### PR TITLE
chore: expose clickhouse http port

### DIFF
--- a/measure-backend/self-host/docker-compose.yml
+++ b/measure-backend/self-host/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     image: clickhouse/clickhouse-server
     ports:
       - "9000:9000/tcp"
+      - "8123:8123"
     ulimits:
       nofile: 262144
     volumes:


### PR DESCRIPTION
- expose http port from container to make it easy for external database clients to connect while in development