### PR TITLE
chore: run api server in debug mode

### DIFF
--- a/measure-backend/self-host/docker-compose.yml
+++ b/measure-backend/self-host/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       - POSTGRES_DSN=postgres://postgres:postgres@postgres:5432/postgres
       - CLICKHOUSE_DSN=clickhouse://default:@clickhouse:9000/default
-      - GIN_MODE=release
     depends_on:
       - clickhouse
       - postgres


### PR DESCRIPTION
run the measure api server docker container in debug mode by default to make log tailing easier

closes #40