### PR TITLE
chore: change commitlint config

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -10,6 +10,10 @@ export default {
      * - feat(backend): attachments is now available
      * 
      */
-    "scope-enum": [2, "always", ["android", "backend", "webapp"]]
+    "scope-enum": [2, "always", ["android", "backend", "webapp"]],
+    /**
+     * reduce header max length violation to a warning
+     */
+    "header-max-length": [1, "always", 72]
   }
 }


### PR DESCRIPTION
reduce `header-max-length` violations to only raise warnings

closes #51