### PR TITLE
fix(android): add limits to size of stack trace and number of threads

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/exceptions/TrimStackTrace.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exceptions/TrimStackTrace.kt
@@ -1,0 +1,53 @@
+package sh.measure.android.exceptions
+
+/**
+ * The maximum number of threads to include in the exception.
+ */
+internal const val MAX_THREADS_IN_EXCEPTION = 16
+
+/**
+ * The maximum number of frames to include in a stacktrace.
+ */
+private const val MAX_FRAMES_IN_STACKTRACE = 64
+
+/**
+ * The maximum number of consecutive repeats of a frame allowed in a stacktrace.
+ */
+private const val MAX_CONSECUTIVE_FRAME_REPEATS = 5
+
+/**
+ * Trims stacktrace to remove consecutive repeats and reduce the size of the stacktrace.
+ *
+ * @param maxRepeats The maximum number of consecutive repeats allowed.
+ * @param maxSize The maximum size of the stacktrace allowed.
+ */
+internal fun Array<StackTraceElement>.trimStackTrace(
+    maxRepeats: Int = MAX_CONSECUTIVE_FRAME_REPEATS, maxSize: Int = MAX_FRAMES_IN_STACKTRACE
+): Array<StackTraceElement> {
+    val result = mutableListOf<StackTraceElement>()
+    var currentElement: StackTraceElement? = null
+    var currentCount = 0
+
+    for (element in this) {
+        if (element == currentElement) {
+            currentCount++
+            if (currentCount <= maxRepeats) {
+                result.add(element)
+            }
+        } else {
+            currentElement = element
+            currentCount = 1
+            result.add(element)
+        }
+    }
+
+    // Check if the result list is larger than maxSize
+    if (result.size > maxSize) {
+        val middleIndex = result.size / 2
+        val startIndex = middleIndex - maxSize / 2
+        val endIndex = middleIndex + maxSize / 2
+        result.subList(startIndex, endIndex).clear()
+    }
+
+    return result.toTypedArray()
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
@@ -11,7 +11,7 @@ class ExceptionFactoryTest {
     private val timeProvider = FakeTimeProvider()
 
     @Test
-    fun `creates a single exception in MeasureException when exception has no cause`() {
+    fun `creates a single exception when exception has no cause`() {
         // Given
         val exception = IllegalArgumentException("Test exception")
         val thread = Thread.currentThread()
@@ -32,7 +32,7 @@ class ExceptionFactoryTest {
     }
 
     @Test
-    fun `creates two exceptions in MeasureException when exception has a cause`() {
+    fun `creates two exceptions when exception has a cause`() {
         // Given
         val exception =
             IllegalArgumentException("Test exception").initCause(RuntimeException("Cause"))
@@ -56,24 +56,6 @@ class ExceptionFactoryTest {
         assertEquals("java.lang.RuntimeException", causeException.type)
         assertEquals("Cause", causeException.message)
         assertTrue(causeException.frames.isNotEmpty())
-    }
-
-
-    @Test
-    fun `creates frames in MeasureException equal to the size of stacktrace`() {
-        // Given
-        val exception = IllegalArgumentException("Test exception")
-        val framesSize = exception.stackTrace.size
-        val thread = Thread.currentThread()
-
-        // When
-        val measureException = ExceptionFactory.createMeasureException(
-            exception, handled = true, timeProvider.currentTimeSinceEpochInMillis, thread
-        )
-
-        // Then
-        val frames = measureException.exceptions.first().frames
-        assertEquals(framesSize, frames.size)
     }
 
     @Test

--- a/measure-android/measure/src/test/java/sh/measure/android/exceptions/TrimStackTraceTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/exceptions/TrimStackTraceTest.kt
@@ -1,0 +1,69 @@
+package sh.measure.android.exceptions
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class TrimStackTraceKtTest {
+
+    @Test
+    fun `when stacktrace is empty, returns empty stacktrace`() {
+        val stackTrace = emptyArray<StackTraceElement>()
+        val trimmedStackTrace = stackTrace.trimStackTrace()
+        assertArrayEquals(stackTrace, trimmedStackTrace)
+    }
+
+    @Test
+    fun `when stacktrace is within maxSize and no repeats, returns the stacktrace unchanged`() {
+        val stackTrace = arrayOf(
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class2", "method2", "file2", 2),
+            StackTraceElement("Class3", "method3", "file3", 3)
+        )
+        val trimmedStackTrace = stackTrace.trimStackTrace(maxRepeats = 1, maxSize = 3)
+        assertArrayEquals(stackTrace, trimmedStackTrace)
+    }
+
+    @Test
+    fun `when stacktrace contains consecutive repeats more than maxRepeats, trims the stacktrace`() {
+        val stackTrace = arrayOf(
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class2", "method2", "file2", 2),
+            StackTraceElement("Class2", "method2", "file2", 2),
+            StackTraceElement("Class2", "method2", "file2", 2),
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class1", "method1", "file1", 1)
+        )
+        val trimmedStackTrace = stackTrace.trimStackTrace(maxRepeats = 2)
+        assertArrayEquals(
+            arrayOf(
+                stackTrace[0],
+                stackTrace[1],
+                stackTrace[3],
+                stackTrace[4],
+                stackTrace[6],
+                stackTrace[7]
+            ),
+            trimmedStackTrace,
+        )
+    }
+
+    @Test
+    fun `when stacktrace exceeds maxSize, removes the middle frames`() {
+        val stackTrace = arrayOf(
+            StackTraceElement("Class1", "method1", "file1", 1),
+            StackTraceElement("Class2", "method2", "file2", 2),
+            StackTraceElement("Class3", "method3", "file3", 3),
+            StackTraceElement("Class4", "method4", "file4", 4),
+            StackTraceElement("Class5", "method5", "file5", 5)
+        )
+        val trimmedStackTrace = stackTrace.trimStackTrace(maxSize = 3)
+        assertArrayEquals(
+            arrayOf(
+                stackTrace[0], stackTrace[3], stackTrace[4]
+            ),
+            trimmedStackTrace,
+        )
+    }
+}

--- a/measure-android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
+++ b/measure-android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
@@ -13,7 +13,6 @@ class ExceptionDemoActivity : AppCompatActivity() {
         findViewById<Button>(R.id.btn_single_exception).setOnClickListener {
             throw IllegalAccessException("This is a new exception")
         }
-
         findViewById<Button>(R.id.btn_chained_exception).setOnClickListener {
             throw IOException("This is a test exception").initCause(
                 CustomException(message = "This is a nested custom exception")
@@ -26,6 +25,13 @@ class ExceptionDemoActivity : AppCompatActivity() {
                 list.add(byteArray)
             }
         }
+        findViewById<Button>(R.id.btn_stack_overflow_exception).setOnClickListener {
+            recursiveFunction()
+        }
+    }
+
+    private fun recursiveFunction() {
+        recursiveFunction()
     }
 }
 

--- a/measure-android/sample/src/main/res/layout/activity_exception_demo.xml
+++ b/measure-android/sample/src/main/res/layout/activity_exception_demo.xml
@@ -25,4 +25,10 @@
         android:layout_height="wrap_content"
         android:text="@string/oom_exception" />
 
+    <Button
+        android:id="@+id/btn_stack_overflow_exception"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/stack_overflow_exception" />
+
 </LinearLayout>

--- a/measure-android/sample/src/main/res/values/strings.xml
+++ b/measure-android/sample/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="single_exception">Raise single exception</string>
     <string name="chained_exceptions">Raise chained exception</string>
     <string name="oom_exception">Raise OOM exception</string>
+    <string name="stack_overflow_exception">Raise StackOverflow exception</string>
 </resources>


### PR DESCRIPTION
Partly fixes #49 

Stack frames and the number of threads can be very large in an exception. We put some hard limits by trimming the stack trace using the following limits:

**Maximum consecutively repeated frames: 5** — This ensures there are no more than 5 consecutive repeated frames in each stacktrace.

**Maximum threads in an exception: 16** — This ensures max 16 threads are reported in the exception.threads array.

**Maximum frames in each stacktrace: 64** — Trims the frames from the middle, keeping the start and end of the array,  such that the maximum number of frames per stacktrace is no more than 64.