### PR TITLE
feat(android): implement ANR watchdog to track ANRs

### DIFF
--- a/measure-android/measure/build.gradle.kts
+++ b/measure-android/measure/build.gradle.kts
@@ -57,6 +57,7 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            isReturnDefaultValues = true
         }
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -41,14 +41,13 @@ class Measure {
             val idProvider = UUIDProvider()
             val config = Config
             val resourceFactory = ResourceFactoryImpl(logger, context, config)
-            val sessionProvider = SessionProvider(
-                logger, timeProvider, idProvider, resourceFactory
-            )
+            val sessionProvider = SessionProvider(timeProvider, idProvider, resourceFactory)
             val sessionController: SessionController = SessionControllerImpl(
                 logger, sessionProvider, storage, transport, executorService
             )
             MeasureClient(
                 logger,
+                context = context,
                 timeProvider = timeProvider,
                 eventTracker = MeasureEventTracker(logger, sessionController),
                 sessionController = sessionController,

--- a/measure-android/measure/src/main/java/sh/measure/android/MeasureClient.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/MeasureClient.kt
@@ -1,5 +1,7 @@
 package sh.measure.android
 
+import android.content.Context
+import sh.measure.android.anr.AnrCollector
 import sh.measure.android.events.EventTracker
 import sh.measure.android.exceptions.UnhandledExceptionCollector
 import sh.measure.android.logger.LogLevel
@@ -13,6 +15,7 @@ import sh.measure.android.utils.TimeProvider
  */
 internal class MeasureClient(
     private val logger: Logger,
+    private val context: Context,
     private val timeProvider: TimeProvider,
     private val eventTracker: EventTracker,
     private val sessionController: SessionController
@@ -30,6 +33,7 @@ internal class MeasureClient(
 
     private fun onSessionCreated() {
         UnhandledExceptionCollector(logger, eventTracker, timeProvider).register()
+        AnrCollector(logger, context, timeProvider, eventTracker).register()
         sessionController.syncSessions()
         sessionController.deleteSyncedSessions()
     }

--- a/measure-android/measure/src/main/java/sh/measure/android/anr/ANRWatchDog.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/anr/ANRWatchDog.kt
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Salomon BRYS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package sh.measure.android.anr
+
+import android.app.ActivityManager
+import android.app.ActivityManager.ProcessErrorStateInfo
+import android.content.Context
+import android.os.Debug
+import android.os.Handler
+import android.os.Looper
+import android.os.Process
+import sh.measure.android.utils.TimeProvider
+
+/**
+ * A watchdog timer thread that detects when the UI thread has frozen.
+ */
+internal class ANRWatchDog(
+    private val context: Context,
+    private val timeoutInterval: Int,
+    private val timeProvider: TimeProvider,
+    private val anrListener: ANRListener,
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
+) : Thread() {
+    interface ANRListener {
+        fun onAppNotResponding(error: AnrError)
+    }
+
+    @Volatile
+    private var tick: Long = 0
+
+    @Volatile
+    private var reported = false
+    private val ticker = Runnable {
+        tick = 0
+        reported = false
+    }
+
+    /**
+     * @noinspection BusyWait
+     */
+    override fun run() {
+        var interval = timeoutInterval.toLong()
+        while (!isInterrupted) {
+            val needPost = tick == 0L
+            tick += interval
+            if (needPost) {
+                mainHandler.post(ticker)
+            }
+            try {
+                sleep(interval)
+            } catch (e: InterruptedException) {
+                currentThread().interrupt()
+                return
+            }
+
+            // Ignore if the ANR is already reported.
+            if (tick == 0L || reported) {
+                continue
+            }
+            // If the debugger is connected, ignore ANR.
+            if (Debug.isDebuggerConnected() || Debug.waitingForDebugger()) {
+                reported = true
+                continue
+            }
+
+            // Verify ANR state by checking activity manager ProcessErrorStateInfo.
+            // Don't report an ANR if the process error state is not ANR.
+            val activityManager =
+                context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            val pid = Process.myPid()
+            val processErrorState = captureProcessErrorState(activityManager, pid)
+            if (processErrorState != null && processErrorState.condition != ProcessErrorStateInfo.NOT_RESPONDING) {
+                continue
+            }
+
+            // If the main thread has not handled ticker, it is blocked. ANR.
+            val message = "Application Not Responding for at least $timeoutInterval ms."
+            val error = AnrError(
+                mainHandler.looper.thread, timeProvider.currentTimeSinceEpochInMillis, message
+            )
+            anrListener.onAppNotResponding(error)
+            interval = timeoutInterval.toLong()
+            reported = true
+        }
+    }
+
+    private fun captureProcessErrorState(am: ActivityManager?, pid: Int): ProcessErrorStateInfo? {
+        return try {
+            val processes = am?.processesInErrorState ?: emptyList()
+            processes.firstOrNull { it.pid == pid }
+        } catch (exc: RuntimeException) {
+            null
+        }
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/anr/Anr.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/anr/Anr.kt
@@ -1,0 +1,7 @@
+package sh.measure.android.anr
+
+internal class AnrError(val thread: Thread, val timestamp: Long, message: String) : RuntimeException(message) {
+    init {
+        stackTrace = thread.stackTrace
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -1,0 +1,42 @@
+package sh.measure.android.anr
+
+import android.content.Context
+import sh.measure.android.events.EventTracker
+import sh.measure.android.exceptions.ExceptionFactory
+import sh.measure.android.exceptions.MeasureException
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import sh.measure.android.utils.TimeProvider
+
+private const val ANR_TIMEOUT_MILLIS = 5000
+
+internal class AnrCollector(
+    private val logger: Logger,
+    private val context: Context,
+    private val timeProvider: TimeProvider,
+    private val tracker: EventTracker
+) : ANRWatchDog.ANRListener {
+    fun register() {
+        ANRWatchDog(
+            context = context,
+            timeoutInterval = ANR_TIMEOUT_MILLIS,
+            timeProvider = timeProvider,
+            anrListener = this
+        ).start()
+    }
+
+    override fun onAppNotResponding(error: AnrError) {
+        logger.log(LogLevel.Error, "ANR detected", error)
+        tracker.trackUnhandledException(toMeasureException(error))
+    }
+
+    private fun toMeasureException(anr: AnrError): MeasureException {
+        return ExceptionFactory.createMeasureException(
+            throwable = anr,
+            handled = false,
+            timestamp = anr.timestamp,
+            thread = anr.thread,
+            isAnr = true
+        )
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/events/Event.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/Event.kt
@@ -13,7 +13,7 @@ data class Event(
 
 internal fun MeasureException.toEvent(): Event {
     return Event(
-        type = EventType.EXCEPTION,
+        type = if (isAnr) EventType.ANR else EventType.EXCEPTION,
         timestamp = timestamp.iso8601Timestamp(),
         data = Json.encodeToJsonElement(MeasureException.serializer(), this)
     )

--- a/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -3,4 +3,5 @@ package sh.measure.android.events
 object EventType {
     const val STRING = "string"
     const val EXCEPTION = "exception"
+    const val ANR = "anr"
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
@@ -8,7 +8,11 @@ internal object ExceptionFactory {
      * @param handled Whether the exception was handled or not.
      */
     fun createMeasureException(
-        throwable: Throwable, handled: Boolean, timestamp: Long, thread: Thread
+        throwable: Throwable,
+        handled: Boolean,
+        timestamp: Long,
+        thread: Thread,
+        isAnr: Boolean = false
     ): MeasureException {
         val exceptions = mutableListOf<ExceptionUnit>()
         var error: Throwable? = throwable
@@ -49,6 +53,6 @@ internal object ExceptionFactory {
             }
             count++
         }
-        return MeasureException(timestamp, thread.name, exceptions, threads, handled)
+        return MeasureException(timestamp, thread.name, exceptions, threads, handled, isAnr)
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/exceptions/MeasureException.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exceptions/MeasureException.kt
@@ -32,7 +32,13 @@ internal data class MeasureException(
     /**
      * Whether the exception was handled or not.
      */
-    val handled: Boolean
+    val handled: Boolean,
+
+    /**
+     * Whether is exception represents an ANR or not.
+     */
+    @Transient
+    val isAnr: Boolean = false,
 )
 
 @Serializable

--- a/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -1,0 +1,40 @@
+package sh.measure.android.anr
+
+import android.content.Context
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import sh.measure.android.events.EventTracker
+import sh.measure.android.exceptions.ExceptionFactory
+import sh.measure.android.fakes.FakeTimeProvider
+import sh.measure.android.fakes.NoopLogger
+
+class AnrCollectorTest {
+    private val logger = NoopLogger()
+    private val timeProvider = FakeTimeProvider()
+    private val eventTracker = mock<EventTracker>()
+    private val context = mock<Context>()
+
+    @Test
+    fun `AnrCollector tracks exception using event tracker, when ANR is detected`() {
+        val anrCollector = AnrCollector(logger, context, timeProvider, eventTracker)
+        val thread = Thread.currentThread()
+        val message = "ANR"
+        val timestamp = timeProvider.currentTimeSinceEpochInMillis
+        val anrError = AnrError(thread, timestamp, message)
+
+        // When
+        anrCollector.onAppNotResponding(anrError)
+
+        // Then
+        verify(eventTracker).trackUnhandledException(
+            ExceptionFactory.createMeasureException(
+                throwable = anrError,
+                handled = false,
+                timestamp = anrError.timestamp,
+                thread = thread,
+                isAnr = true
+            )
+        )
+    }
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/events/EventKtTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/events/EventKtTest.kt
@@ -1,0 +1,33 @@
+package sh.measure.android.events
+
+import org.junit.Test
+import sh.measure.android.exceptions.ExceptionFactory
+
+class EventKtTest {
+
+    @Test
+    fun `MeasureException toEvent() returns an event of type Exception, when exception is not an ANR`() {
+        val event = ExceptionFactory.createMeasureException(
+            throwable = Exception("Test exception"),
+            handled = false,
+            timestamp = 0L,
+            thread = Thread.currentThread(),
+            isAnr = false
+        ).toEvent()
+
+        assert(event.type == EventType.EXCEPTION)
+    }
+
+    @Test
+    fun `MeasureException toEvent() returns an event of type ANR, when exception is an ANR`() {
+        val event = ExceptionFactory.createMeasureException(
+            throwable = Exception("Test exception"),
+            handled = false,
+            timestamp = 0L,
+            thread = Thread.currentThread(),
+            isAnr = true
+        ).toEvent()
+
+        assert(event.type == EventType.ANR)
+    }
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/session/SessionProviderTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/session/SessionProviderTest.kt
@@ -10,7 +10,6 @@ import sh.measure.android.fakes.NoopLogger
 
 class SessionProviderTest {
     private lateinit var sessionProvider: SessionProvider
-    private val logger = NoopLogger()
     private val idProvider = FakeIdProvider()
     private val timeProvider = FakeTimeProvider()
     private val resourceFactory = FakeResourceFactory()
@@ -18,7 +17,6 @@ class SessionProviderTest {
     @Before
     fun setup() {
         sessionProvider = SessionProvider(
-            logger = logger,
             idProvider = idProvider,
             resourceFactory = resourceFactory,
             timeProvider = timeProvider,

--- a/measure-android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
+++ b/measure-android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
@@ -1,11 +1,17 @@
 package sh.measure.sample
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import java.io.IOException
 
+
 class ExceptionDemoActivity : AppCompatActivity() {
+    private val _mutex = Any()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_exception_demo)
@@ -28,10 +34,51 @@ class ExceptionDemoActivity : AppCompatActivity() {
         findViewById<Button>(R.id.btn_stack_overflow_exception).setOnClickListener {
             recursiveFunction()
         }
+        findViewById<Button>(R.id.btn_infinite_loop).setOnClickListener {
+            infiniteLoop()
+        }
+        findViewById<Button>(R.id.btn_deadlock).setOnClickListener {
+            deadLock()
+        }
+    }
+
+    private fun infiniteLoop() {
+        while (true) {
+            // Do nothing
+        }
     }
 
     private fun recursiveFunction() {
         recursiveFunction()
+    }
+
+    private fun deadLock() {
+        LockerThread().start()
+        Handler(Looper.getMainLooper()).postDelayed(Runnable {
+            synchronized(_mutex) {
+                Log.e(
+                    "Measure", "There should be a dead lock before this message"
+                )
+            }
+        }, 1000)
+    }
+
+    inner class LockerThread internal constructor() : Thread() {
+        init {
+            name = "APP: Locker"
+        }
+
+        override fun run() {
+            synchronized(_mutex) { while (true) sleep() }
+        }
+    }
+
+    private fun sleep() {
+        try {
+            Thread.sleep((8 * 1000).toLong())
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
     }
 }
 

--- a/measure-android/sample/src/main/res/layout/activity_exception_demo.xml
+++ b/measure-android/sample/src/main/res/layout/activity_exception_demo.xml
@@ -31,4 +31,16 @@
         android:layout_height="wrap_content"
         android:text="@string/stack_overflow_exception" />
 
+    <Button
+        android:id="@+id/btn_infinite_loop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/infinite_loop" />
+
+    <Button
+        android:id="@+id/btn_deadlock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/deadlock" />
+
 </LinearLayout>

--- a/measure-android/sample/src/main/res/values/strings.xml
+++ b/measure-android/sample/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="chained_exceptions">Raise chained exception</string>
     <string name="oom_exception">Raise OOM exception</string>
     <string name="stack_overflow_exception">Raise StackOverflow exception</string>
+    <string name="infinite_loop">Infinite Loop</string>
+    <string name="deadlock">Deadlock</string>
 </resources>


### PR DESCRIPTION
* Introduces a new event type: `anr`.
* `AnrCollector` detects ANRs by frequently posting a runnable to main thread and checking if it runs within 5s.
* If the runnable fails to run within 5s and Activity Manager reports that the process is in not responding, an exception along with all threads stacktrace is prepared to be sent to measure servers.

resolves #68