### PR TITLE
ci: enable lint and unit tests for Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,63 @@
+name: Android CI
+
+on:
+  push:
+    pull_request:
+      branches:
+        - main
+      paths:
+        - 'measure-android/**'
+
+env:
+  JAVA_VERSION: 17
+  CACHE_VERSION: 1
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: measure-android
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+      - run: ./ci-scripts/ci_clear_gradle_cache.sh
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.CACHE_VERSION }}-${{ hashFiles('**/**.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties', '**/libs.versions.toml') }}
+
+      - name: Check Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Check lint
+        run: ./gradlew :measure:lint
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: measure-android
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+      - run: ./ci-scripts/ci_clear_gradle_cache.sh
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ env.CACHE_VERSION }}-${{ hashFiles('**/**.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties', '**/libs.versions.toml') }}
+      - name: Unit tests
+        run: ./gradlew :measure:testDebugUnitTest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # macOS
 .DS_Store
 
+# .idea
+.idea/
+
 # node/bun
 node_modules

--- a/measure-android/ci-scripts/ci_clear_gradle_cache.sh
+++ b/measure-android/ci-scripts/ci_clear_gradle_cache.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mv ~/.gradle ~/.invalid || true

--- a/measure-android/measure/src/test/java/sh/measure/android/storage/StorageImplTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/storage/StorageImplTest.kt
@@ -96,8 +96,9 @@ internal class StorageImplTest {
     fun `Storage writes the event to event log, when event log file is empty`() {
         val sessionId = "id"
         val data: JsonElement = Json.encodeToJsonElement("data")
+        val timestamp = 9876543210.iso8601Timestamp()
         val event = Event(
-            timestamp = 9876543210.iso8601Timestamp(), type = "event", data = data
+            timestamp = timestamp, type = "event", data = data
         )
         `when`(fileHelper.isEventLogEmpty(sessionId)).thenReturn(true)
         val eventLogFile = File(tempDirPath, "event_log")
@@ -111,7 +112,7 @@ internal class StorageImplTest {
         // Then
         assertEquals(
             """
-                {"timestamp": "1970-04-25T12:59:03.000000210Z","type": "event","event": "data"}
+                {"timestamp": "$timestamp","type": "event","event": "data"}
             """.trimIndent(), eventLogFile.readText()
         )
     }
@@ -120,8 +121,9 @@ internal class StorageImplTest {
     fun `Storage appends event to event log, when event log file is not empty`() {
         val sessionId = "id"
         val data: JsonElement = Json.encodeToJsonElement("data")
+        val timestamp = 9876543210.iso8601Timestamp()
         val event = Event(
-            timestamp = 9876543210.iso8601Timestamp(), type = "event", data = data
+            timestamp = timestamp, type = "event", data = data
         )
         `when`(fileHelper.isEventLogEmpty(sessionId)).thenReturn(false)
         val eventLogFile = File(tempDirPath, "event_log")
@@ -136,7 +138,7 @@ internal class StorageImplTest {
         assertEquals(
             """
                
-               {"timestamp": "1970-04-25T12:59:03.000000210Z","type": "event","event": "data"}
+               {"timestamp": "$timestamp","type": "event","event": "data"}
             """.trimIndent(), eventLogFile.readText()
         )
     }


### PR DESCRIPTION
Enables a lint and unit test step on CI for measure-android.
This will run each time a PR is raised or updated, when targeted to `main` branch.

This PR also fixes two tests which were failing on CI due to dependence on time.

Resolves #75 