### PR TITLE
feat(android): capture application exit info for all sessions when available

### DIFF
--- a/measure-android/measure/build.gradle.kts
+++ b/measure-android/measure/build.gradle.kts
@@ -65,6 +65,7 @@ android {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 
+    implementation("androidx.annotation:annotation:1.7.0")
     implementation("com.squareup.okio:okio:3.5.0")
     implementation(platform("com.squareup.okhttp3:okhttp-bom:4.11.0"))
     implementation("com.squareup.okhttp3:okhttp")

--- a/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -27,7 +27,7 @@ internal class AnrCollector(
 
     override fun onAppNotResponding(error: AnrError) {
         logger.log(LogLevel.Error, "ANR detected", error)
-        tracker.trackUnhandledException(toMeasureException(error))
+        tracker.trackAnr(toMeasureException(error))
     }
 
     private fun toMeasureException(anr: AnrError): MeasureException {

--- a/measure-android/measure/src/main/java/sh/measure/android/events/EventTracker.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/EventTracker.kt
@@ -7,6 +7,7 @@ import sh.measure.android.session.SessionController
 
 internal interface EventTracker {
     fun trackUnhandledException(measureException: MeasureException)
+    fun trackAnr(measureException: MeasureException)
 }
 
 internal class MeasureEventTracker(
@@ -17,6 +18,11 @@ internal class MeasureEventTracker(
         assert(!measureException.handled)
         logger.log(LogLevel.Debug, "Tracking unhandled exception")
         sessionController.storeEventSync(measureException.toEvent())
-        sessionController.syncActiveSession()
+    }
+
+    override fun trackAnr(measureException: MeasureException) {
+        assert(measureException.isAnr)
+        logger.log(LogLevel.Debug, "Tracking ANR")
+        sessionController.storeEventSync(measureException.toEvent())
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -4,4 +4,5 @@ object EventType {
     const val STRING = "string"
     const val EXCEPTION = "exception"
     const val ANR = "anr"
+    const val EXIT_INFO = "application_exit_info"
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/exitinfo/ExitInfo.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exitinfo/ExitInfo.kt
@@ -1,0 +1,44 @@
+package sh.measure.android.exitinfo
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.os.Build
+import androidx.annotation.RequiresApi
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the data that is collected when an application exits.
+ */
+@Serializable
+@RequiresApi(Build.VERSION_CODES.R)
+data class ExitInfo(
+    /**
+     * @see [ApplicationExitInfo.getReason]
+     */
+    val reason: String,
+
+    /**
+     * @see [ActivityManager.RunningAppProcessInfo.importance]
+     */
+    val importance: String,
+
+    /**
+     * @see [ApplicationExitInfo.getTimestamp]
+     */
+    val timestamp: Long,
+
+    /**
+     * @see [ApplicationExitInfo.getTraceInputStream]
+     */
+    val trace: String?,
+
+    /**
+     * @see [ApplicationExitInfo.getProcessName]
+     */
+    val process_name: String,
+
+    /**
+     * @see [ApplicationExitInfo.getPid]
+     */
+    val pid: String,
+)

--- a/measure-android/measure/src/main/java/sh/measure/android/exitinfo/ExitInfoProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exitinfo/ExitInfoProvider.kt
@@ -1,0 +1,116 @@
+package sh.measure.android.exitinfo
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import okio.Buffer
+import okio.BufferedSource
+import okio.buffer
+import okio.source
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import java.io.InputStream
+
+internal interface ExitInfoProvider {
+    fun get(pid: Int): ExitInfo?
+}
+
+internal class ExitInfoProviderImpl(private val context: Context, private val logger: Logger) :
+    ExitInfoProvider {
+
+    override fun get(pid: Int): ExitInfo? {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+            return null
+        }
+        return try {
+            val activityManager =
+                context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val historicalExitReason =
+                activityManager.getHistoricalProcessExitReasons(null, pid, 1).firstOrNull()
+            historicalExitReason?.toExitInfo()
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Failed to get exit info for pid: $pid", e)
+            null
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun ApplicationExitInfo.toExitInfo(): ExitInfo {
+        return ExitInfo(
+            reason = getReasonName(reason),
+            importance = getImportanceName(importance),
+            timestamp = timestamp,
+            trace = getTraceString(traceInputStream),
+            process_name = processName,
+            pid = pid.toString(),
+        )
+    }
+
+    private fun getTraceString(traceInputStream: InputStream?): String? {
+        if (traceInputStream == null) {
+            return null
+        }
+        logger.log(LogLevel.Debug, "Adding ApplicationExitInfo trace")
+        return traceInputStream.extractContent().bufferedReader().useLines { lines ->
+            lines.joinToString("\n")
+        }
+    }
+
+    private fun InputStream.extractContent(): InputStream {
+        val source: BufferedSource = source().buffer()
+        val buffer = Buffer()
+        var insideSection = false
+        while (!source.exhausted()) {
+            val line = source.readUtf8Line() ?: break
+
+            if (line.startsWith("DALVIK THREADS (")) {
+                insideSection = true
+            } else if (line.startsWith("----- Waiting Channels:")) {
+                insideSection = false
+            }
+
+            if (insideSection) {
+                if (line.startsWith("  | ")) {
+                    continue
+                }
+                buffer.writeUtf8(line)
+                buffer.writeUtf8("\n")
+            }
+        }
+        return buffer.inputStream()
+    }
+
+    private fun getImportanceName(importance: Int): String {
+        return when (importance) {
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED -> "CACHED"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "CANT_SAVE_STATE"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND -> "FOREGROUND"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "GONE"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "PERCEPTIBLE"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "SERVICE"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "TOP_SLEEPING"
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "VISIBLE"
+            else -> "UNKNOWN"
+        }
+    }
+
+    private fun getReasonName(reason: Int): String {
+        return when (reason) {
+            ApplicationExitInfo.REASON_ANR -> "ANR"
+            ApplicationExitInfo.REASON_CRASH -> "CRASH"
+            ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+            ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "DEPENDENCY_DIED"
+            ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "EXCESSIVE_RESOURCE_USAGE"
+            ApplicationExitInfo.REASON_EXIT_SELF -> "EXIT_SELF"
+            ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "INITIALIZATION_FAILURE"
+            ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+            ApplicationExitInfo.REASON_OTHER -> "OTHER"
+            ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+            ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+            ApplicationExitInfo.REASON_UNKNOWN -> "UNKNOWN"
+            else -> "UNKNOWN"
+        }
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/session/Session.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/session/Session.kt
@@ -20,4 +20,9 @@ internal data class Session(
      * Whether the session has been synced or not.
      */
     val synced: Boolean = false,
+
+    /**
+     * The process id of the session.
+     */
+    val pid: Int = 0,
 )

--- a/measure-android/measure/src/main/java/sh/measure/android/session/SessionProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/session/SessionProvider.kt
@@ -1,6 +1,7 @@
 package sh.measure.android.session
 
 import sh.measure.android.utils.IdProvider
+import sh.measure.android.utils.PidProvider
 import sh.measure.android.utils.TimeProvider
 
 internal interface ISessionProvider {
@@ -11,6 +12,7 @@ internal interface ISessionProvider {
 internal class SessionProvider(
     private val timeProvider: TimeProvider,
     private val idProvider: IdProvider,
+    private val pidProvider: PidProvider,
     private val resourceFactory: ResourceFactory,
 ) : ISessionProvider {
     override lateinit var session: Session
@@ -20,7 +22,8 @@ internal class SessionProvider(
         session = Session(
             id = idProvider.createId(),
             startTime = timeProvider.currentTimeSinceEpochInMillis,
-            resource = resourceFactory.create()
+            resource = resourceFactory.create(),
+            pid = pidProvider.getPid()
         )
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/session/SessionReportGenerator.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/session/SessionReportGenerator.kt
@@ -1,0 +1,83 @@
+package sh.measure.android.session
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToStream
+import okio.BufferedSink
+import okio.buffer
+import okio.sink
+import okio.source
+import okio.use
+import sh.measure.android.events.EventType
+import sh.measure.android.exitinfo.ExitInfo
+import sh.measure.android.exitinfo.ExitInfoProvider
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import sh.measure.android.storage.Storage
+import sh.measure.android.storage.UnsyncedSession
+import sh.measure.android.utils.iso8601Timestamp
+import java.io.File
+
+internal class SessionReportGenerator(
+    private val logger: Logger,
+    private val storage: Storage,
+    private val exitInfoProvider: ExitInfoProvider
+) {
+
+    fun getSessionReport(session: UnsyncedSession): SessionReport {
+        logger.log(LogLevel.Debug, "Getting session report for session: ${session.id}")
+        val sessionStartTime = getSessionStartTime(session.id)
+        val exitInfo = exitInfoProvider.get(session.processId)
+        val eventsFile = createEventsJsonFile(session.id, exitInfo)
+        val resourceFile = storage.getResourceFile(session.id)
+        return SessionReport(
+            session_id = session.id,
+            timestamp = sessionStartTime.iso8601Timestamp(),
+            eventsFile = eventsFile,
+            resourceFile = resourceFile
+        )
+    }
+
+    private fun getSessionStartTime(sessionId: String): Long {
+        return storage.getSessionStartTime(sessionId)
+    }
+
+    private fun createEventsJsonFile(sessionId: String, exitInfo: ExitInfo?): File {
+        logger.log(LogLevel.Debug, "Creating events.json file for session: $sessionId")
+        val eventsFile = storage.getEventsFile(sessionId)
+        storage.getEventLogFile(sessionId).source().buffer().use { source ->
+            eventsFile.sink().buffer().use { sink ->
+                sink.writeUtf8("[")
+                var line = source.readUtf8Line()
+                while (line != null) {
+                    sink.writeUtf8(line)
+                    line = source.readUtf8Line()
+                    if (line != null) {
+                        sink.writeUtf8(",")
+                        continue
+                    }
+                    if (exitInfo != null) {
+                        addExitInfo(sink, exitInfo)
+                    }
+                }
+                sink.writeUtf8("]")
+            }
+        }
+        logger.log(LogLevel.Debug, "Created events.json file for session: $sessionId")
+        return eventsFile
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun addExitInfo(sink: BufferedSink, exitInfo: ExitInfo) {
+        sink.writeUtf8(",")
+        sink.writeUtf8("{")
+        sink.writeUtf8("\"timestamp\": \"${exitInfo.timestamp}\",")
+        sink.writeUtf8("\"type\": \"${EventType.EXIT_INFO}\",")
+        sink.writeUtf8("\"${EventType.EXIT_INFO}\": ")
+        Json.encodeToStream(
+            Json.encodeToJsonElement(ExitInfo.serializer(), exitInfo),
+            sink.outputStream()
+        )
+        sink.writeUtf8("}")
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/storage/DatabaseConstants.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/storage/DatabaseConstants.kt
@@ -11,13 +11,15 @@ internal object SessionDbConstants {
         const val COLUMN_SESSION_ID = "session_id"
         const val COLUMN_SESSION_START_TIME = "session_start_time"
         const val COLUMN_SYNCED = "synced"
+        const val COLUMN_PROCESS_ID = "pid"
     }
 
     const val CREATE_SESSION_TABLE = """
         CREATE TABLE ${SessionTable.TABLE_NAME} (
             ${SessionTable.COLUMN_SESSION_ID} TEXT PRIMARY KEY NOT NULL,
             ${SessionTable.COLUMN_SESSION_START_TIME} TEXT NOT NULL,
-            ${SessionTable.COLUMN_SYNCED} INTEGER NOT NULL
+            ${SessionTable.COLUMN_SYNCED} INTEGER NOT NULL,
+            ${SessionTable.COLUMN_PROCESS_ID} INTEGER NOT NULL
         )
     """
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/storage/UnsyncedSession.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/storage/UnsyncedSession.kt
@@ -1,0 +1,7 @@
+package sh.measure.android.storage
+
+data class UnsyncedSession(
+    val id: String,
+    val startTime: String,
+    val processId: Int,
+)

--- a/measure-android/measure/src/main/java/sh/measure/android/utils/PidProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/utils/PidProvider.kt
@@ -1,0 +1,13 @@
+package sh.measure.android.utils
+
+import android.os.Process
+
+internal interface PidProvider {
+    fun getPid(): Int
+}
+
+internal class PidProviderImpl : PidProvider {
+    override fun getPid(): Int {
+        return Process.myPid()
+    }
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -27,7 +27,7 @@ class AnrCollectorTest {
         anrCollector.onAppNotResponding(anrError)
 
         // Then
-        verify(eventTracker).trackUnhandledException(
+        verify(eventTracker).trackAnr(
             ExceptionFactory.createMeasureException(
                 throwable = anrError,
                 handled = false,

--- a/measure-android/measure/src/test/java/sh/measure/android/fakes/FakePidProvider.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/fakes/FakePidProvider.kt
@@ -1,0 +1,9 @@
+package sh.measure.android.fakes
+
+import sh.measure.android.utils.PidProvider
+
+internal class FakePidProvider(val id: Int = 0): PidProvider {
+    override fun getPid(): Int {
+        return id
+    }
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/session/SessionProviderTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/session/SessionProviderTest.kt
@@ -4,15 +4,16 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import sh.measure.android.fakes.FakeIdProvider
+import sh.measure.android.fakes.FakePidProvider
 import sh.measure.android.fakes.FakeResourceFactory
 import sh.measure.android.fakes.FakeTimeProvider
-import sh.measure.android.fakes.NoopLogger
 
 class SessionProviderTest {
     private lateinit var sessionProvider: SessionProvider
     private val idProvider = FakeIdProvider()
     private val timeProvider = FakeTimeProvider()
     private val resourceFactory = FakeResourceFactory()
+    private val pidProvider = FakePidProvider()
 
     @Before
     fun setup() {
@@ -20,6 +21,7 @@ class SessionProviderTest {
             idProvider = idProvider,
             resourceFactory = resourceFactory,
             timeProvider = timeProvider,
+            pidProvider = pidProvider
         )
     }
 


### PR DESCRIPTION
[ApplicationExitInfo](https://developer.android.com/reference/android/app/ApplicationExitInfo) is a system API which provides reason for application exit and an optional stacktrace which is useful for debugging and categorizing ANRs.

Tracking ANR free rate using this API is more accurate than the ANR event, which is collected using the `ANRWatchDog` approach. However, this API is only available in [Android 11 (API 30)](https://apilevels.com/). Also, in different scenarios, the stacktrace from either `ApplicationExitInfo` or `ANRWatchDog` can be useful. Hence, we're capturing both as of now as separate events.

### Other changes
Apart from capturing exit info as a event, this PR also modifies the syncing logic:

Now sessions are synced only on next cold launch. Earlier, an attempt was made to sync the session as soon as a crash is encountered. This is required because `ApplicationExitInfo` is available only on next cold launch.

Resolves #76 