### PR TITLE
chore(backend): symbolication codec

### DIFF
--- a/measure-backend/measure-go/codecmap.go
+++ b/measure-backend/measure-go/codecmap.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/google/uuid"
+)
+
+type CodecMapVal struct {
+	Event         int
+	Type          string
+	ExceptionType string
+	ANR           int
+	Exception     int
+	Thread        int
+	Frames        string
+	Target        string
+	Trace         string
+}
+
+type CodecMap map[uuid.UUID]CodecMapVal
+
+func NewCodecMapVal() *CodecMapVal {
+	return &CodecMapVal{
+		Event:     -1,
+		ANR:       -1,
+		Exception: -1,
+		Thread:    -1,
+	}
+}

--- a/measure-backend/measure-go/events.go
+++ b/measure-backend/measure-go/events.go
@@ -304,18 +304,6 @@ func (e *EventField) isAppExit() bool {
 	return e.Type == "app_exit"
 }
 
-func (e *EventField) symbolicatable() bool {
-	if e.isANR() || e.isException() {
-		return true
-	}
-
-	if e.isAppExit() && e.AppExit.Trace != "" {
-		return true
-	}
-
-	return false
-}
-
 func (e *EventField) validate() error {
 	if len(e.Type) > maxTypeChars {
 		return fmt.Errorf(`"events[].type" exceeds maximum allowed characters of (%d)`, maxTypeChars)

--- a/measure-backend/measure-go/retrace_test.go
+++ b/measure-backend/measure-go/retrace_test.go
@@ -6,36 +6,49 @@ import (
 )
 
 func TestRetraceMarshaling(t *testing.T) {
-	defaultFrame := SymbolFrame{
+	defaultFrame := Frame{
 		ClassName:  "foo.bar.baz",
 		FileName:   "some-file.java",
 		MethodName: "method",
 		LineNum:    10,
 	}
 	defaultExpected := "foo.bar.baz.method(some-file.java:10)"
-	defaultResult := MarshalRetraceFrame(defaultFrame)
+	defaultResult := MarshalRetraceFrame(defaultFrame, "")
 
 	if defaultResult != defaultExpected {
 		t.Errorf("Expected '%s' but got '%s'", defaultExpected, defaultResult)
 	}
 
-	noLineNums := SymbolFrame{
+	prefixFrame := Frame{
+		ClassName:  "foo.bar.baz",
+		FileName:   "some-file.java",
+		MethodName: "method",
+		LineNum:    10,
+	}
+	prefixExpected := "\tat foo.bar.baz.method(some-file.java:10)"
+	prefixResult := MarshalRetraceFrame(prefixFrame, "\tat ")
+
+	if prefixResult != prefixExpected {
+		t.Errorf("Expected '%s' but got '%s'", prefixExpected, prefixResult)
+	}
+
+	noLineNums := Frame{
 		ClassName:  "foo.bar.baz",
 		FileName:   "some-file.java",
 		MethodName: "method",
 	}
 	noLineExpected := "foo.bar.baz.method(some-file.java)"
-	noLineResult := MarshalRetraceFrame(noLineNums)
+	noLineResult := MarshalRetraceFrame(noLineNums, "")
 	if noLineResult != noLineExpected {
 		t.Errorf("Expected '%s' but got '%s'", noLineExpected, noLineResult)
 	}
 
-	noFile := SymbolFrame{
+	noFile := Frame{
 		ClassName:  "foo.bar.baz",
 		MethodName: "method",
 	}
 	noFileExpected := "foo.bar.baz.method"
-	noFileResult := MarshalRetraceFrame(noFile)
+	noFileResult := MarshalRetraceFrame(noFile, "")
 	if noFileResult != noFileExpected {
 		t.Errorf("Expected '%s' but got '%s'", noFileExpected, noFileResult)
 	}
@@ -49,9 +62,21 @@ func TestRetraceUnmarshaling(t *testing.T) {
 		FileName:   "some-file.java",
 		LineNum:    10,
 	}
-	defaultResult, _ := UnmarshalRetraceFrame(defaultFrame)
+	defaultResult, _ := UnmarshalRetraceFrame(defaultFrame, "")
 	if !reflect.DeepEqual(defaultExpected, defaultResult) {
 		t.Errorf("Expected %+v but got %+v", defaultExpected, defaultResult)
+	}
+
+	prefixFrame := "\tat foo.bar.baz.method(some-file.java:10)"
+	prefixExpected := RetraceFrame{
+		ClassName:  "foo.bar.baz",
+		MethodName: "method",
+		FileName:   "some-file.java",
+		LineNum:    10,
+	}
+	prefixResult, _ := UnmarshalRetraceFrame(prefixFrame, "\tat ")
+	if !reflect.DeepEqual(prefixExpected, prefixResult) {
+		t.Errorf("Expected %+v but got %+v", prefixExpected, prefixResult)
 	}
 
 	noLineFrame := "foo.bar.baz.method(some-file.java)"
@@ -60,7 +85,7 @@ func TestRetraceUnmarshaling(t *testing.T) {
 		MethodName: "method",
 		FileName:   "some-file.java",
 	}
-	noLineResult, _ := UnmarshalRetraceFrame(noLineFrame)
+	noLineResult, _ := UnmarshalRetraceFrame(noLineFrame, "")
 	if !reflect.DeepEqual(noLineExpected, noLineResult) {
 		t.Errorf("Expected %+v but got %+v", noLineExpected, noLineResult)
 	}
@@ -70,7 +95,7 @@ func TestRetraceUnmarshaling(t *testing.T) {
 		ClassName:  "foo.bar.baz",
 		MethodName: "method",
 	}
-	noFileResult, _ := UnmarshalRetraceFrame(noFileFrame)
+	noFileResult, _ := UnmarshalRetraceFrame(noFileFrame, "")
 	if !reflect.DeepEqual(noFileExpected, noFileResult) {
 		t.Errorf("Expected %+v but got %+v", noFileExpected, noFileResult)
 	}

--- a/measure-backend/measure-go/symbolicate.go
+++ b/measure-backend/measure-go/symbolicate.go
@@ -2,203 +2,39 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 )
 
-type SymbolFrame Frame
-
-func (sf *SymbolFrame) MarshalJSON() ([]byte, error) {
-	return json.Marshal(MarshalRetraceFrame(*sf))
-}
-
-func (sf *SymbolFrame) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-
-	f, err := UnmarshalRetraceFrame(s)
-	if err != nil {
-		return err
-	}
-
-	sf.ClassName = f.ClassName
-	sf.MethodName = f.MethodName
-	sf.FileName = f.FileName
-	sf.LineNum = f.LineNum
-	return nil
-}
-
-type SymbolExceptionUnit struct {
-	Type    string        `json:"type"`
-	Message string        `json:"message"`
-	Frames  []SymbolFrame `json:"frames"`
-}
-
-type SymbolThread struct {
-	Name   string        `json:"name"`
-	Frames []SymbolFrame `json:"frames"`
-}
-
-type SymbolException struct {
-	ThreadName string                `json:"thread_name"`
-	Exceptions []SymbolExceptionUnit `json:"exceptions"`
-	Threads    []SymbolThread        `json:"threads"`
-}
-
-type SymbolANR struct {
-	ThreadName string                `json:"thread_name"`
-	Exceptions []SymbolExceptionUnit `json:"exceptions"`
-	Threads    []SymbolThread        `json:"threads"`
-}
-
-type SymbolExceptionEvent struct {
-	Type            string          `json:"type"`
-	SymbolException SymbolException `json:"exception"`
-}
-
-type SymbolANREvent struct {
-	Type      string    `json:"type"`
-	SymbolANR SymbolANR `json:"anr"`
-}
-
-type SymbolAppExitEvent struct {
-	Trace string `json:"trace"`
+type SymbolicationUnit struct {
+	ID     uuid.UUID `json:"id"`
+	Values []string  `json:"values"`
 }
 
 type SymbolicationRequest struct {
-	Id                    uuid.UUID              `json:"id"`
-	SessionID             uuid.UUID              `json:"session_id"`
-	MappingType           string                 `json:"mapping_type"`
-	Key                   string                 `json:"key"`
-	SymbolANREvents       []SymbolANREvent       `json:"anr_events"`
-	SymbolExceptionEvents []SymbolExceptionEvent `json:"exception_events"`
-	SymbolAppExitEvents   []SymbolAppExitEvent   `json:"app_exit_events"`
-}
-
-type SymbolicationResult struct {
-	Id              uuid.UUID            `json:"id"`
-	SessionID       uuid.UUID            `json:"session_id"`
-	MappingType     string               `json:"mapping_type"`
-	Key             string               `json:"key"`
-	ANREvents       string               `json:"anr_events"`
-	ExceptionEvents string               `json:"exception_events"`
-	AppExitEvents   []SymbolAppExitEvent `json:"app_exit_events"`
+	Key                string              `json:"key"`
+	SymbolicationUnits []SymbolicationUnit `json:"data"`
 }
 
 func symbolicate(s *Session) error {
-	obfuscatedEvents := s.getObfuscatedEvents()
-	if len(obfuscatedEvents) < 1 {
+	key, err := s.getMappingKey()
+	if err != nil {
+		return err
+	}
+	if key == "" {
 		return nil
 	}
-	var id uuid.UUID
-	var mappingType string
-	var key string
-	if err := server.pgPool.QueryRow(context.Background(), `select id, mapping_type, key from mapping_files where app_id = $1 and version_name = $2 and version_code = $3 limit 1;`, s.Resource.AppUniqueID, s.Resource.AppVersion, s.Resource.AppBuild).Scan(&id, &mappingType, &key); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		} else {
-			return err
-		}
-	}
 
-	var symbolANREvents []SymbolANREvent
-	var symbolExceptionEvents []SymbolExceptionEvent
-	var symbolAppExitEvents []SymbolAppExitEvent
-
-	for _, event := range obfuscatedEvents {
-		if event.isANR() {
-			var symbolExceptionsUnits []SymbolExceptionUnit
-			for _, exceptionUnit := range event.ANR.Exceptions {
-				var symbolFrames []SymbolFrame
-				for _, frame := range exceptionUnit.Frames {
-					symbolFrames = append(symbolFrames, SymbolFrame(frame))
-				}
-				symbolExceptionsUnits = append(symbolExceptionsUnits, SymbolExceptionUnit{
-					Type:    exceptionUnit.Type,
-					Message: exceptionUnit.Message,
-					Frames:  symbolFrames,
-				})
-			}
-			var symbolThreads []SymbolThread
-			for _, thread := range event.ANR.Threads {
-				var symbolFrames []SymbolFrame
-				for _, frame := range thread.Frames {
-					symbolFrames = append(symbolFrames, SymbolFrame(frame))
-				}
-				symbolThreads = append(symbolThreads, SymbolThread{
-					Name:   thread.Name,
-					Frames: symbolFrames,
-				})
-			}
-			symbolANREvents = append(symbolANREvents, SymbolANREvent{
-				Type: event.Type,
-				SymbolANR: SymbolANR{
-					ThreadName: event.ANR.ThreadName,
-					Exceptions: symbolExceptionsUnits,
-					Threads:    symbolThreads,
-				},
-			})
-
-		}
-		if event.isException() {
-			var symbolExceptionsUnits []SymbolExceptionUnit
-			for _, exceptionUnit := range event.Exception.Exceptions {
-				var symbolFrames []SymbolFrame
-				for _, frame := range exceptionUnit.Frames {
-					symbolFrames = append(symbolFrames, SymbolFrame(frame))
-				}
-				symbolExceptionsUnits = append(symbolExceptionsUnits, SymbolExceptionUnit{
-					Type:    exceptionUnit.Type,
-					Message: exceptionUnit.Message,
-					Frames:  symbolFrames,
-				})
-			}
-			var symbolThreads []SymbolThread
-			for _, thread := range event.Exception.Threads {
-				var symbolFrames []SymbolFrame
-				for _, frame := range thread.Frames {
-					symbolFrames = append(symbolFrames, SymbolFrame(frame))
-				}
-				symbolThreads = append(symbolThreads, SymbolThread{
-					Name:   thread.Name,
-					Frames: symbolFrames,
-				})
-			}
-			symbolExceptionEvents = append(symbolExceptionEvents, SymbolExceptionEvent{
-				Type: event.Type,
-				SymbolException: SymbolException{
-					ThreadName: event.Exception.ThreadName,
-					Exceptions: symbolExceptionsUnits,
-					Threads:    symbolThreads,
-				},
-			})
-		}
-
-		if event.isAppExit() {
-			symbolAppExitEvents = append(symbolAppExitEvents, SymbolAppExitEvent{
-				Trace: event.AppExit.Trace,
-			})
-		}
-	}
+	codecMap, symbolicationUnits := s.EncodeForSymbolication()
 
 	payload := &SymbolicationRequest{
-		Id:                    id,
-		SessionID:             s.SessionID,
-		MappingType:           mappingType,
-		Key:                   key,
-		SymbolANREvents:       symbolANREvents,
-		SymbolExceptionEvents: symbolExceptionEvents,
-		SymbolAppExitEvents:   symbolAppExitEvents,
+		Key:                key,
+		SymbolicationUnits: symbolicationUnits,
 	}
 
 	symbolicateUrl, err := url.JoinPath(os.Getenv("SYMBOLICATOR_ORIGIN"), "symbolicate")
@@ -228,117 +64,12 @@ func symbolicate(s *Session) error {
 	defer resp.Body.Close()
 	fmt.Println("symbolicator response status", resp.Status)
 
-	var symbolResult SymbolicationResult
-	err = json.NewDecoder(resp.Body).Decode(&symbolResult)
-	if err != nil {
+	var symbolResult []SymbolicationUnit
+	if err = json.NewDecoder(resp.Body).Decode(&symbolResult); err != nil {
 		fmt.Println("failed to read symbolicator response", err)
 		return err
 	}
-
-	anrEventIdxs := []int{}
-	exceptionEventIdxs := []int{}
-	appExitEventIdxs := []int{}
-	for idx, event := range s.Events {
-		if !event.symbolicatable() {
-			continue
-		}
-		if event.isANR() {
-			anrEventIdxs = append(anrEventIdxs, idx)
-		}
-		if event.isException() {
-			exceptionEventIdxs = append(exceptionEventIdxs, idx)
-		}
-		if event.isAppExit() {
-			appExitEventIdxs = append(appExitEventIdxs, idx)
-		}
-	}
-
-	var symbolANRResultEvents []SymbolANREvent
-	if symbolResult.ANREvents != "" {
-		if err := json.Unmarshal([]byte(symbolResult.ANREvents), &symbolANRResultEvents); err != nil {
-			fmt.Println("failed to unmarshal symbolicated anr events", err)
-			return err
-		}
-	}
-
-	var symbolExceptionResultEvents []SymbolExceptionEvent
-	if symbolResult.ExceptionEvents != "" {
-		if err := json.Unmarshal([]byte(symbolResult.ExceptionEvents), &symbolExceptionResultEvents); err != nil {
-			fmt.Println("failed to unmarshal symbolicated exception events", err)
-			return err
-		}
-	}
-
-	for seq, idx := range anrEventIdxs {
-		symbolicatedANREvent := symbolANRResultEvents[seq]
-		mergeANREvent(&symbolicatedANREvent, &s.Events[idx])
-	}
-
-	for seq, idx := range exceptionEventIdxs {
-		symbolicatedExceptionEvent := symbolExceptionResultEvents[seq]
-		mergeExceptionEvent(&symbolicatedExceptionEvent, &s.Events[idx])
-	}
-
-	for seq, idx := range appExitEventIdxs {
-		symbolicatedAppExitEvent := symbolResult.AppExitEvents[seq]
-		mergeAppExitEvent(&symbolicatedAppExitEvent, &s.Events[idx])
-	}
+	s.DecodeFromSymbolication(codecMap, symbolResult)
 
 	return nil
-}
-
-// mergeEvent copies each field from SymbolFrame to the origin session's
-// underlying Frame struct
-func mergeANREvent(s *SymbolANREvent, d *EventField) {
-	for i, exception := range d.ANR.Exceptions {
-		for j := range exception.Frames {
-			exception.Frames[j].ClassName = s.SymbolANR.Exceptions[i].Frames[j].ClassName
-			exception.Frames[j].FileName = s.SymbolANR.Exceptions[i].Frames[j].FileName
-			exception.Frames[j].MethodName = s.SymbolANR.Exceptions[i].Frames[j].MethodName
-			exception.Frames[j].ModuleName = s.SymbolANR.Exceptions[i].Frames[j].ModuleName
-			exception.Frames[j].LineNum = s.SymbolANR.Exceptions[i].Frames[j].LineNum
-			exception.Frames[j].ColNum = s.SymbolANR.Exceptions[i].Frames[j].ColNum
-		}
-	}
-
-	for i, thread := range d.Exception.Threads {
-		for j := range thread.Frames {
-			thread.Frames[j].ClassName = s.SymbolANR.Threads[i].Frames[j].ClassName
-			thread.Frames[j].FileName = s.SymbolANR.Threads[i].Frames[j].FileName
-			thread.Frames[j].MethodName = s.SymbolANR.Threads[i].Frames[j].MethodName
-			thread.Frames[j].ModuleName = s.SymbolANR.Threads[i].Frames[j].ModuleName
-			thread.Frames[j].LineNum = s.SymbolANR.Threads[i].Frames[j].LineNum
-			thread.Frames[j].ColNum = s.SymbolANR.Threads[i].Frames[j].ColNum
-		}
-	}
-}
-
-// mergeEvent copies each field from SymbolFrame to the origin session's
-// underlying Frame struct
-func mergeExceptionEvent(s *SymbolExceptionEvent, d *EventField) {
-	for i, exception := range d.Exception.Exceptions {
-		for j := range exception.Frames {
-			exception.Frames[j].ClassName = s.SymbolException.Exceptions[i].Frames[j].ClassName
-			exception.Frames[j].FileName = s.SymbolException.Exceptions[i].Frames[j].FileName
-			exception.Frames[j].MethodName = s.SymbolException.Exceptions[i].Frames[j].MethodName
-			exception.Frames[j].ModuleName = s.SymbolException.Exceptions[i].Frames[j].ModuleName
-			exception.Frames[j].LineNum = s.SymbolException.Exceptions[i].Frames[j].LineNum
-			exception.Frames[j].ColNum = s.SymbolException.Exceptions[i].Frames[j].ColNum
-		}
-	}
-
-	for i, thread := range d.Exception.Threads {
-		for j := range thread.Frames {
-			thread.Frames[j].ClassName = s.SymbolException.Threads[i].Frames[j].ClassName
-			thread.Frames[j].FileName = s.SymbolException.Threads[i].Frames[j].FileName
-			thread.Frames[j].MethodName = s.SymbolException.Threads[i].Frames[j].MethodName
-			thread.Frames[j].ModuleName = s.SymbolException.Threads[i].Frames[j].ModuleName
-			thread.Frames[j].LineNum = s.SymbolException.Threads[i].Frames[j].LineNum
-			thread.Frames[j].ColNum = s.SymbolException.Threads[i].Frames[j].ColNum
-		}
-	}
-}
-
-func mergeAppExitEvent(s *SymbolAppExitEvent, d *EventField) {
-	d.AppExit.Trace = s.Trace
 }

--- a/measure-backend/symbolicator-retrace/src/main/kotlin/sh/measure/Symbolicate.kt
+++ b/measure-backend/symbolicator-retrace/src/main/kotlin/sh/measure/Symbolicate.kt
@@ -25,10 +25,10 @@ fun Route.symbolicate() {
     val symbolsAccessKey = env.config.property("s3.symbols_access_key").getString()
     val symbolsSecretKey = env.config.property("s3.symbols_secret_access_key").getString()
 
-    get("/symbolicate") {
+    post("/symbolicate") {
         val request = call.receive<SymbolicateRequest>()
         val s3 = configureS3(s3Region, symbolsAccessKey, symbolsSecretKey)
-        val mappingFile = downloadMappingFile(call, s3, request, s3Bucket) ?: return@get
+        val mappingFile = downloadMappingFile(call, s3, request, s3Bucket) ?: return@post
         val stringRetrace = createStringRetrace(mappingFile.toPath())
         val retraced = request.data.map { dataUnit ->
             dataUnit.copy(


### PR DESCRIPTION
- add a symbolication codec that encodes and decodes symbolicatable events as required
- refactor out old symbolication approach
- change symbolicator-retrace to use `POST` instead of `GET`
- update `retrace` and `retrace_test.go` to reflect the updated behavior

closes #119