### PR TITLE
fix(backend): invalid error format

### DIFF
--- a/measure-backend/measure-go/main.go
+++ b/measure-backend/measure-go/main.go
@@ -57,7 +57,7 @@ func main() {
 	r.Use(cors).GET("/apps/:id/metrics", authorize(), getAppMetrics)
 	r.Use(cors).GET("/apps/:id/filters", authorize(), getAppFilters)
 	r.Use(cors).GET("/teams", authorize(), getTeams)
-	r.Use(cors).GET("/teams/:id/apps", authorize(), getApps)
+	r.Use(cors).GET("/teams/:id/apps", authorize(), getTeamApps)
 
 	r.Run(":8080") // listen and serve on 0.0.0.0:8080
 }

--- a/measure-backend/measure-go/teams.go
+++ b/measure-backend/measure-go/teams.go
@@ -27,7 +27,7 @@ func getTeams(c *gin.Context) {
 	c.Data(http.StatusOK, "application/json", []byte(teams))
 }
 
-func getApps(c *gin.Context) {
+func getTeamApps(c *gin.Context) {
 	appMap := map[string]string{
 		"6c0f7001-1e81-4cb0-a08c-2a29e94e36da": `[
 			{
@@ -78,7 +78,8 @@ func getApps(c *gin.Context) {
 	if err != nil {
 		msg := `team id is invalid or missing`
 		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg, "details": err.Error()})
+		return
 	}
 
 	app := appMap[teamId.String()]


### PR DESCRIPTION
- fix invalid error format in `teams/:id/apps` api response
- improve function names