### PR TITLE
chore(backend): handle not found condition

### DIFF
--- a/measure-backend/measure-go/teams.go
+++ b/measure-backend/measure-go/teams.go
@@ -127,5 +127,11 @@ func getTeamApps(c *gin.Context) {
 		return
 	}
 
+	if len(apps) < 1 {
+		msg := fmt.Sprintf("no apps exists under team: %s", teamId)
+		c.JSON(http.StatusNotFound, gin.H{"error": msg})
+		return
+	}
+
 	c.JSON(http.StatusOK, apps)
 }


### PR DESCRIPTION
- return 404 when no app exists for a team for GET `/teams/:id/apps` API