### PR TITLE
refactor(backend): move server into its own package

### DIFF
--- a/measure-backend/measure-go/apps.go
+++ b/measure-backend/measure-go/apps.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"measure-backend/measure-go/server"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -95,7 +97,7 @@ func NewApp(teamId uuid.UUID) *App {
 
 func (a *App) add() (*APIKey, error) {
 	a.ID = uuid.New()
-	tx, err := server.PgPool.Begin(context.Background())
+	tx, err := server.Server.PgPool.Begin(context.Background())
 
 	if err != nil {
 		return nil, err
@@ -142,7 +144,7 @@ func (a *App) get(id uuid.UUID) (*App, error) {
 
 	apiKey := new(APIKey)
 
-	if err := server.PgPool.QueryRow(context.Background(), queryGetApp, id, a.TeamId).Scan(&appName, &uniqueId, &platform, &firstVersion, &latestVersion, &firstSeenAt, &onboarded, &onboardedAt, &apiKey.keyPrefix, &apiKey.keyValue, &apiKey.checksum, &apiKeyLastSeen, &apiKeyCreatedAt, &createdAt, &updatedAt); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), queryGetApp, id, a.TeamId).Scan(&appName, &uniqueId, &platform, &firstVersion, &latestVersion, &firstSeenAt, &onboarded, &onboardedAt, &apiKey.keyPrefix, &apiKey.keyValue, &apiKey.checksum, &apiKeyLastSeen, &apiKeyCreatedAt, &createdAt, &updatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		} else {

--- a/measure-backend/measure-go/attachment.go
+++ b/measure-backend/measure-go/attachment.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"measure-backend/measure-go/server"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -54,15 +56,16 @@ func (a *Attachment) Prepare() Attachment {
 }
 
 func (a *Attachment) upload(s *Session) (*s3manager.UploadOutput, error) {
+	config := server.Server.Config
 	b64Decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(a.Blob))
 	awsConfig := &aws.Config{
-		Region:      aws.String(server.Config.AttachmentsBucketRegion),
-		Credentials: credentials.NewStaticCredentials(server.Config.AttachmentsAccessKey, server.Config.AttachmentsSecretAccessKey, ""),
+		Region:      aws.String(config.AttachmentsBucketRegion),
+		Credentials: credentials.NewStaticCredentials(config.AttachmentsAccessKey, config.AttachmentsSecretAccessKey, ""),
 	}
 	awsSession := session.Must(session.NewSession(awsConfig))
 	uploader := s3manager.NewUploader(awsSession)
 	result, err := uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(server.Config.AttachmentsBucket),
+		Bucket: aws.String(config.AttachmentsBucket),
 		Key:    aws.String(a.Key),
 		Body:   b64Decoder,
 		Metadata: map[string]*string{

--- a/measure-backend/measure-go/auth.go
+++ b/measure-backend/measure-go/auth.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"measure-backend/measure-go/server"
 	"net/http"
 	"strings"
 
@@ -56,7 +57,7 @@ func validateAccessToken() gin.HandlerFunc {
 				return nil, err
 			}
 
-			return []byte(server.Config.AuthJWTSecret), nil
+			return []byte(server.Server.Config.AuthJWTSecret), nil
 		})
 
 		if err != nil {

--- a/measure-backend/measure-go/main.go
+++ b/measure-backend/measure-go/main.go
@@ -5,36 +5,33 @@ import (
 	"os"
 	"time"
 
-	srv "measure-backend/measure-go/server"
+	"measure-backend/measure-go/server"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
-var serverConfig srv.ServerConfig
-var server srv.Server
-
 func main() {
-	serverConfig = *srv.NewServerConfig()
+	config := server.NewConfig()
 
 	pgDSN := os.Getenv("POSTGRES_DSN")
 	if pgDSN == "" {
-		log.Printf(`"POSTGRES_DSN" missing, will proceed with default "%s"`, serverConfig.PG.DSN)
+		log.Printf(`"POSTGRES_DSN" missing, will proceed with default "%s"`, config.PG.DSN)
 	} else {
-		serverConfig.PG.DSN = pgDSN
+		config.PG.DSN = pgDSN
 	}
 
 	chDSN := os.Getenv("CLICKHOUSE_DSN")
 	if chDSN == "" {
-		log.Printf(`"CLICKHOUSE_DSN" missing, will proceed with default "%s"`, serverConfig.CH.DSN)
+		log.Printf(`"CLICKHOUSE_DSN" missing, will proceed with default "%s"`, config.CH.DSN)
 	} else {
-		serverConfig.CH.DSN = chDSN
+		config.CH.DSN = chDSN
 	}
 
-	server = *new(srv.Server).Configure(&serverConfig)
+	server.Init(config)
 
-	defer server.PgPool.Close()
-	defer server.ChPool.Close()
+	defer server.Server.PgPool.Close()
+	defer server.Server.ChPool.Close()
 
 	r := gin.Default()
 	cors := cors.New(cors.Config{

--- a/measure-backend/measure-go/mapping.go
+++ b/measure-backend/measure-go/mapping.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"measure-backend/measure-go/server"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,7 +47,7 @@ func (m *MappingFile) shouldUpsert() (bool, *uuid.UUID, error) {
 	var id uuid.UUID
 	var key string
 	var existingHash string
-	if err := server.PgPool.QueryRow(context.Background(), "select id, key, fnv1_hash from mapping_files where app_unique_id = $1 and version_name = $2 and version_code = $3 and mapping_type = $4;", m.AppUniqueID, m.VersionName, m.VersionCode, m.Type).Scan(&id, &key, &existingHash); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), "select id, key, fnv1_hash from mapping_files where app_unique_id = $1 and version_name = $2 and version_code = $3 and mapping_type = $4;", m.AppUniqueID, m.VersionName, m.VersionCode, m.Type).Scan(&id, &key, &existingHash); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return true, nil, nil
 		} else {
@@ -87,7 +89,7 @@ func (m *MappingFile) upload() (*s3manager.UploadOutput, error) {
 }
 
 func (m *MappingFile) insert() error {
-	if _, err := server.PgPool.Exec(context.Background(), "insert into mapping_files (id, app_unique_id, version_name, version_code, mapping_type, key, location, fnv1_hash, file_size, last_updated) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);", m.ID, m.AppUniqueID, m.VersionName, m.VersionCode, m.Type, m.Key, m.Location, m.ContentHash, m.File.Size, time.Now()); err != nil {
+	if _, err := server.Server.PgPool.Exec(context.Background(), "insert into mapping_files (id, app_unique_id, version_name, version_code, mapping_type, key, location, fnv1_hash, file_size, last_updated) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);", m.ID, m.AppUniqueID, m.VersionName, m.VersionCode, m.Type, m.Key, m.Location, m.ContentHash, m.File.Size, time.Now()); err != nil {
 		return err
 	}
 
@@ -95,7 +97,7 @@ func (m *MappingFile) insert() error {
 }
 
 func (m *MappingFile) upsert() error {
-	if _, err := server.PgPool.Exec(context.Background(), `update mapping_files set fnv1_hash = $1, file_size = $2, last_updated = $3 where id = $4;`, m.ContentHash, m.File.Size, time.Now(), m.ID); err != nil {
+	if _, err := server.Server.PgPool.Exec(context.Background(), `update mapping_files set fnv1_hash = $1, file_size = $2, last_updated = $3 where id = $4;`, m.ContentHash, m.File.Size, time.Now(), m.ID); err != nil {
 		return err
 	}
 
@@ -148,8 +150,8 @@ func (m *MappingFile) validate() (int, error) {
 		return http.StatusBadRequest, errors.New(`"mapping_file" does not any contain data`)
 	}
 
-	if m.File.Size > int64(server.Config.MappingFileMaxSize) {
-		return http.StatusRequestEntityTooLarge, fmt.Errorf(`"%s" file size exceeding %d bytes`, m.File.Filename, server.Config.MappingFileMaxSize)
+	if m.File.Size > int64(server.Server.Config.MappingFileMaxSize) {
+		return http.StatusRequestEntityTooLarge, fmt.Errorf(`"%s" file size exceeding %d bytes`, m.File.Filename, server.Server.Config.MappingFileMaxSize)
 	}
 
 	return 0, nil
@@ -229,14 +231,15 @@ func putMapping(c *gin.Context) {
 }
 
 func uploadToStorage(f *multipart.File, k string, m map[string]*string) (*s3manager.UploadOutput, error) {
+	config := server.Server.Config
 	awsConfig := &aws.Config{
-		Region:      aws.String(server.Config.SymbolsBucketRegion),
-		Credentials: credentials.NewStaticCredentials(server.Config.SymbolsAccessKey, server.Config.SymbolsSecretAccessKey, ""),
+		Region:      aws.String(config.SymbolsBucketRegion),
+		Credentials: credentials.NewStaticCredentials(config.SymbolsAccessKey, config.SymbolsSecretAccessKey, ""),
 	}
 	awsSession := session.Must(session.NewSession(awsConfig))
 	uploader := s3manager.NewUploader(awsSession)
 	result, err := uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(server.Config.SymbolsBucket),
+		Bucket: aws.String(config.SymbolsBucket),
 		Key:    aws.String(k),
 		Body:   *f,
 		Metadata: map[string]*string{

--- a/measure-backend/measure-go/sessions.go
+++ b/measure-backend/measure-go/sessions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"measure-backend/measure-go/server"
 	"net/http"
 	"strconv"
 	"strings"
@@ -153,7 +154,7 @@ func (s *Session) uploadAttachments() error {
 
 func (s *Session) saveWithContext(c *gin.Context) error {
 	bytesIn := c.MustGet("bytesIn")
-	tx, err := server.PgPool.Begin(context.Background())
+	tx, err := server.Server.PgPool.Begin(context.Background())
 	if err != nil {
 		return err
 	}
@@ -205,7 +206,7 @@ func (s *Session) saveWithContext(c *gin.Context) error {
 
 func (s *Session) known(id uuid.UUID) (bool, error) {
 	var known string
-	if err := server.PgPool.QueryRow(context.Background(), `select id from sessions where id = $1;`, s.SessionID).Scan(&known); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), `select id from sessions where id = $1;`, s.SessionID).Scan(&known); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil
 		}
@@ -216,7 +217,7 @@ func (s *Session) known(id uuid.UUID) (bool, error) {
 
 func (s *Session) getMappingKey() (string, error) {
 	var key string
-	if err := server.PgPool.QueryRow(context.Background(), `select key from mapping_files where app_unique_id = $1 and version_name = $2 and version_code = $3 and mapping_type = 'proguard' limit 1;`, s.Resource.AppUniqueID, s.Resource.AppVersion, s.Resource.AppBuild).Scan(&key); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), `select key from mapping_files where app_unique_id = $1 and version_name = $2 and version_code = $3 and mapping_type = 'proguard' limit 1;`, s.Resource.AppUniqueID, s.Resource.AppVersion, s.Resource.AppBuild).Scan(&key); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", nil
 		}
@@ -603,7 +604,7 @@ func putSession(c *gin.Context) {
 	}
 
 	query, args := makeInsertQuery("events", columns, session)
-	if err := server.ChPool.AsyncInsert(context.Background(), query, false, args...); err != nil {
+	if err := server.Server.ChPool.AsyncInsert(context.Background(), query, false, args...); err != nil {
 		fmt.Println("clickhouse insert err:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/measure-backend/measure-go/teams.go
+++ b/measure-backend/measure-go/teams.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"measure-backend/measure-go/chrono"
+	"measure-backend/measure-go/server"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -76,7 +77,7 @@ type MemberWithAuthz struct {
 
 func (t *Team) getApps() ([]App, error) {
 	var apps []App
-	rows, err := server.PgPool.Query(context.Background(), queryGetTeamApps, &t.ID)
+	rows, err := server.Server.PgPool.Query(context.Background(), queryGetTeamApps, &t.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (t *Team) getMembers() ([]*Member, error) {
 
 	defer stmt.Close()
 
-	rows, err := server.PgPool.Query(ctx, stmt.String(), t.ID)
+	rows, err := server.Server.PgPool.Query(ctx, stmt.String(), t.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (t *Team) rename() error {
 	defer stmt.Close()
 
 	ctx := context.Background()
-	if _, err := server.PgPool.Exec(ctx, stmt.String(), *t.Name, time.Now(), t.ID); err != nil {
+	if _, err := server.Server.PgPool.Exec(ctx, stmt.String(), *t.Name, time.Now(), t.ID); err != nil {
 		return err
 	}
 
@@ -205,7 +206,7 @@ func (t *Team) removeMember(memberId *uuid.UUID) error {
 
 	ctx := context.Background()
 
-	_, err := server.PgPool.Exec(ctx, stmt.String(), t.ID, memberId)
+	_, err := server.Server.PgPool.Exec(ctx, stmt.String(), t.ID, memberId)
 
 	if err != nil {
 		return err
@@ -225,7 +226,7 @@ func (t *Team) changeRole(memberId *uuid.UUID, role rank) error {
 
 	ctx := context.Background()
 
-	if _, err := server.PgPool.Exec(ctx, stmt.String(), role, time.Now(), t.ID, memberId); err != nil {
+	if _, err := server.Server.PgPool.Exec(ctx, stmt.String(), role, time.Now(), t.ID, memberId); err != nil {
 		return err
 	}
 

--- a/measure-backend/measure-go/users.go
+++ b/measure-backend/measure-go/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"measure-backend/measure-go/server"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -13,7 +14,7 @@ type User struct {
 }
 
 func (u *User) getTeams() ([]map[string]string, error) {
-	rows, err := server.PgPool.Query(context.Background(), "select team_membership.team_id, team_membership.role, teams.name from team_membership left outer join teams on team_membership.team_id = teams.id where team_membership.user_id::uuid = $1;", u.id)
+	rows, err := server.Server.PgPool.Query(context.Background(), "select team_membership.team_id, team_membership.role, teams.name from team_membership left outer join teams on team_membership.team_id = teams.id where team_membership.user_id::uuid = $1;", u.id)
 
 	if err != nil {
 		fmt.Println(err)
@@ -43,7 +44,7 @@ func (u *User) getTeams() ([]map[string]string, error) {
 
 func (u *User) getRole(teamId string) (rank, error) {
 	var role string
-	if err := server.PgPool.QueryRow(context.Background(), "select team_membership.role from team_membership where user_id::uuid = $1 and team_id::uuid = $2;", u.id, teamId).Scan(&role); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), "select team_membership.role from team_membership where user_id::uuid = $1 and team_id::uuid = $2;", u.id, teamId).Scan(&role); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return unknown, nil
 		} else {


### PR DESCRIPTION
- postgres pool now lives as package global
- clickhouse pool now lives as package global
- created a server init function to cache the connection pool objects