### PR TITLE
fix(backend): retrace frame parsing

### DIFF
--- a/measure-backend/measure-go/measure/retrace.go
+++ b/measure-backend/measure-go/measure/retrace.go
@@ -75,7 +75,18 @@ func UnmarshalRetraceFrame(i string, p string) (retraceFrame RetraceFrame, err e
 
 	className := codeInfo[:strings.LastIndex(codeInfo, ".")]
 	methodName := codeInfo[strings.LastIndex(codeInfo, ".")+1:]
-	fileName, lineNumStr, _ := strings.Cut(fileInfo, ":")
+	lastIndexSep := strings.LastIndex(fileInfo, ":")
+
+	var fileName string
+	var lineNumStr string
+
+	if lastIndexSep < 0 {
+		fileName = fileInfo
+		lineNumStr = ""
+	} else {
+		fileName = fileInfo[:lastIndexSep]
+		lineNumStr = fileInfo[lastIndexSep+1:]
+	}
 
 	var lineNum int
 


### PR DESCRIPTION
- support an edge case where a filename inside a frame may contain multiple colon `:` characters

fix #299