### PR TITLE
fix(webapp): use 'onboarded' flag in apps API response to set filter …

### DIFF
--- a/measure-web-app/app/[teamId]/overview/page.tsx
+++ b/measure-web-app/app/[teamId]/overview/page.tsx
@@ -103,7 +103,12 @@ export default function Overview({ params }: { params: { teamId: string } }) {
     getApps(params.teamId)
   }, []);
 
-  const getFilters = async (appId: string,) => {
+  const getFilters = async (selectedApp: typeof emptyApp) => {
+    if (!selectedApp.onboarded) {
+      setFiltersApiStatus(FiltersApiStatus.NoData)
+      return
+    }
+
     setFiltersApiStatus(FiltersApiStatus.Loading)
 
     const authToken = await getAccessTokenOrRedirectToAuth(router)
@@ -114,7 +119,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
       }
     };
 
-    const res = await fetch(`${origin}/apps/${appId}/filters`, opts);
+    const res = await fetch(`${origin}/apps/${selectedApp.id}/filters`, opts);
 
     if (!res.ok && res.status == 404) {
       setFiltersApiStatus(FiltersApiStatus.NoData)
@@ -134,7 +139,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
   }
 
   useEffect(() => {
-    getFilters(selectedApp.id)
+    getFilters(selectedApp)
   }, [selectedApp]);
 
   return (


### PR DESCRIPTION
…status

We were depending on the value of the filters API response to determine if the selected app is onboarded or not in Overview page. This was a brittle implementation leading to checks on each filter value to determine "No data" state. This commit uses the 'onboarded' flag from apps API response to accurately determine whether selected app is onboarded or not and update the UI accordingly.