### PR TITLE
ci(backend): tests are being silently skipped

### DIFF
--- a/.github/workflows/measure-go.yml
+++ b/.github/workflows/measure-go.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Test with ${{ matrix.go-version }}
-        run: go test
+        run: go test ./...
 
   deploy:
     name: Deploy API server


### PR DESCRIPTION
- fix issue with how go tests are run in ci. earlier tests were single package, but with earlier changes, tests should be run in a multi-package way.