### PR TITLE
fix(backend): auth nonce issue with google signin

### DIFF
--- a/measure-web-app/app/auth/login/page.tsx
+++ b/measure-web-app/app/auth/login/page.tsx
@@ -17,8 +17,14 @@ export default async function Login({ searchParams }: { searchParams: { [key: st
   const error = searchParams["error"]
   const message = searchParams["message"]
   const initial = !Boolean(error || message)
-  const { nonce, hashedNonce } = await genNonce()
-  console.log(`created nonce: [${nonce}] & hashedNonce: [${hashedNonce}]`)
+  let nonce = ""
+  let hashedNonce = ""
+  if (initial) {
+    const result = await genNonce()
+    nonce = result.nonce
+    hashedNonce = result.hashedNonce
+    console.log(`created nonce: [${nonce}] & hashedNonce: [${hashedNonce}]`)
+  }
   const origin = process?.env?.NEXT_PUBLIC_SITE_URL
 
   return (


### PR DESCRIPTION
## Summary

- encode the nonce before google oauth form submit
- only generate the nonce when needed