### PR TITLE
chore(webapp): remove unnecessary logout call from route

### DIFF
--- a/measure-web-app/app/auth/logout/route.ts
+++ b/measure-web-app/app/auth/logout/route.ts
@@ -1,17 +1,9 @@
-import { createRouteClient } from '@/utils/supabase/route'
 import { NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
-  const supabase = createRouteClient()
-
-  const { error } = await supabase.auth.signOut()
-
-  if (error) {
-    console.log(`logout failed with error`, error)
-  }
 
   return NextResponse.redirect(`${requestUrl.origin}/auth/login`, {
     // using temporary redirect, so that browsers don't cache this


### PR DESCRIPTION
We are calling supabase logout API from client side. We do not need to call this on server logout route.