### PR TITLE
chore(android): add binary-compatibility-validator

### DIFF
--- a/measure-android/build.gradle.kts
+++ b/measure-android/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.10" apply false
     id("com.android.library") version "8.2.1" apply false
     kotlin("plugin.serialization") version "1.9.10" apply false
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2" apply false
 }

--- a/measure-android/measure/api/measure.api
+++ b/measure-android/measure/api/measure.api
@@ -1,0 +1,19 @@
+public final class sh/measure/android/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field MEASURE_SDK_VERSION Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class sh/measure/android/Measure {
+	public static final field INSTANCE Lsh/measure/android/Measure;
+	public final fun init (Landroid/content/Context;)V
+}
+
+public final class sh/measure/android/okhttp/MeasureEventListenerFactory : okhttp3/EventListener$Factory {
+	public fun <init> (Lokhttp3/EventListener$Factory;)V
+	public synthetic fun <init> (Lokhttp3/EventListener$Factory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun create (Lokhttp3/Call;)Lokhttp3/EventListener;
+}
+

--- a/measure-android/measure/build.gradle.kts
+++ b/measure-android/measure/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     kotlin("plugin.serialization")
+    id("binary-compatibility-validator")
 }
 apply(from = "publish_local.gradle")
 

--- a/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExit.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExit.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Transient
  */
 @Serializable
 @RequiresApi(Build.VERSION_CODES.R)
-data class AppExit(
+internal data class AppExit(
     /**
      * @see [ApplicationExitInfo.getReason]
      */

--- a/measure-android/measure/src/main/java/sh/measure/android/events/Event.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/Event.kt
@@ -24,7 +24,7 @@ import sh.measure.android.performance.MemoryUsage
 import sh.measure.android.performance.TrimMemory
 import sh.measure.android.utils.iso8601Timestamp
 
-data class Event(
+internal data class Event(
     val timestamp: String,
     val type: String,
     val data: JsonElement,

--- a/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -1,6 +1,6 @@
 package sh.measure.android.events
 
-object EventType {
+internal object EventType {
     const val STRING = "string"
     const val EXCEPTION = "exception"
     const val ANR = "anr"

--- a/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 
-interface MeasureExecutorService {
+internal interface MeasureExecutorService {
     val isClosed: Boolean
     fun submit(runnable: Runnable): Future<*>
     fun schedule(runnable: Runnable, delayMillis: Long): Future<*>

--- a/measure-android/measure/src/main/java/sh/measure/android/lifecycle/LifecycleEvents.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/lifecycle/LifecycleEvents.kt
@@ -7,7 +7,7 @@ import sh.measure.android.events.Event
 import sh.measure.android.events.EventType
 
 @Serializable
-data class ActivityLifecycleEvent(
+internal data class ActivityLifecycleEvent(
     val type: String,
     val class_name: String,
     val intent: String? = null,
@@ -17,7 +17,7 @@ data class ActivityLifecycleEvent(
 )
 
 @Serializable
-data class FragmentLifecycleEvent(
+internal data class FragmentLifecycleEvent(
     val type: String,
     val class_name: String,
     val parent_activity: String?,
@@ -27,25 +27,25 @@ data class FragmentLifecycleEvent(
 )
 
 @Serializable
-data class ApplicationLifecycleEvent(
+internal data class ApplicationLifecycleEvent(
     val type: String,
     @Transient val timestamp: String = "",
     @Transient val thread_name: String = "",
 )
 
-object AppLifecycleType {
+internal object AppLifecycleType {
     const val FOREGROUND = "foreground"
     const val BACKGROUND = "background"
 }
 
-object ActivityLifecycleType {
+internal object ActivityLifecycleType {
     const val CREATED = "created"
     const val RESUMED = "resumed"
     const val PAUSED = "paused"
     const val DESTROYED = "destroyed"
 }
 
-object FragmentLifecycleType {
+internal object FragmentLifecycleType {
     const val ATTACHED = "attached"
     const val RESUMED = "resumed"
     const val PAUSED = "paused"

--- a/measure-android/measure/src/main/java/sh/measure/android/network/SecretTokenHeaderInterceptor.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/network/SecretTokenHeaderInterceptor.kt
@@ -4,7 +4,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 
-class SecretTokenHeaderInterceptor(
+internal class SecretTokenHeaderInterceptor(
     private val secretToken: String
 ) : Interceptor {
 

--- a/measure-android/measure/src/main/java/sh/measure/android/performance/CpuUsage.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/performance/CpuUsage.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @Serializable
-data class CpuUsage(
+internal data class CpuUsage(
     /**
      * Number of active cores in the device.
      */

--- a/measure-android/measure/src/main/java/sh/measure/android/performance/MemoryEvents.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/performance/MemoryEvents.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @Serializable
-data class MemoryUsage(
+internal data class MemoryUsage(
     val java_max_heap: Long,
     val java_total_heap: Long,
     val java_free_heap: Long,
@@ -18,7 +18,7 @@ data class MemoryUsage(
 )
 
 @Serializable
-data class LowMemory(
+internal data class LowMemory(
     @Transient
     val timestamp: Long = 0L,
     @Transient
@@ -26,7 +26,7 @@ data class LowMemory(
 )
 
 @Serializable
-data class TrimMemory(
+internal data class TrimMemory(
     val level: String,
     @Transient
     val timestamp: Long = 0L,

--- a/measure-android/measure/src/main/java/sh/measure/android/session/Resource.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/session/Resource.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * identifiers, etc.
  */
 @Serializable
-data class Resource(
+internal data class Resource(
     // device info
     val device_name: String? = null,
     val device_model: String? = null,

--- a/measure-android/measure/src/main/java/sh/measure/android/session/ResourceFactory.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/session/ResourceFactory.kt
@@ -9,7 +9,7 @@ import sh.measure.android.logger.Logger
 import sh.measure.android.network_change.NetworkInfoProvider
 import sh.measure.android.utils.LocaleProvider
 
-interface ResourceFactory {
+internal interface ResourceFactory {
     fun create(): Resource
 }
 

--- a/measure-android/measure/src/main/java/sh/measure/android/utils/ClassUtil.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/utils/ClassUtil.kt
@@ -1,6 +1,6 @@
 package sh.measure.android.utils
 
-fun isClassAvailable(clazz: String) : Boolean {
+internal fun isClassAvailable(clazz: String) : Boolean {
     return loadClass(clazz) != null
 }
 

--- a/measure-android/measure/src/main/java/sh/measure/android/utils/StrictMode.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/utils/StrictMode.kt
@@ -5,7 +5,7 @@ import android.os.StrictMode
 /**
  * Runs the given [block] with [StrictMode.allowThreadDiskWrites] enabled.
  */
-inline fun runAllowDiskWrites(block: () -> Unit) {
+internal inline fun runAllowDiskWrites(block: () -> Unit) {
     val oldPolicy = StrictMode.getThreadPolicy()
     StrictMode.setThreadPolicy(StrictMode.allowThreadDiskWrites())
     try {

--- a/measure-android/measure/src/main/java/sh/measure/android/utils/TimeProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/utils/TimeProvider.kt
@@ -9,7 +9,7 @@ import java.util.TimeZone
 /**
  * Provides time from different clocks.
  */
-interface TimeProvider {
+internal interface TimeProvider {
     val currentTimeSinceEpochInMillis: Long
     val currentTimeSinceEpochInNanos: Long
     val uptimeInMillis: Long

--- a/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeResourceFactory.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeResourceFactory.kt
@@ -5,7 +5,7 @@ import sh.measure.android.network_change.NetworkType
 import sh.measure.android.session.Resource
 import sh.measure.android.session.ResourceFactory
 
-class FakeResourceFactory(
+internal class FakeResourceFactory(
     val resource: Resource = fakeResource()
 ) : ResourceFactory {
     override fun create(): Resource {


### PR DESCRIPTION
Adds [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file) plugin.
This allows dumping the public API and ensures that the public binary API hasn't changed in a way that makes this change binary incompatible.

This PR uses the output generated by _binary-compatibility-validator_ to clean up the public API by adding necessary visibility modifiers across the codebase. 