### PR TITLE
chore(backend): sort exception/anr groups

### DIFF
--- a/measure-backend/measure-go/measure/app.go
+++ b/measure-backend/measure-go/measure/app.go
@@ -122,6 +122,7 @@ func (a App) GetANRGroups(af *AppFilter) ([]ANRGroup, error) {
 	stmt := sqlf.PostgreSQL.
 		Select("id, app_id, app_version, name, fingerprint, count, events, created_at, updated_at").
 		From("public.anr_groups").
+		OrderBy("count desc").
 		Where("app_id = ?", nil)
 
 	args := []any{a.ID}


### PR DESCRIPTION
## Summary

- Sort the response of `GET apps/:id/crashGroups` by `count` field in descending fashion.
- Sort the response of `GET apps/:id/anrGroups` by `count` field in descending fashion.