### PR TITLE
fix(webapp): upadte apps fetch API error msg

### DIFF
--- a/measure-web-app/app/[teamId]/apps/page.tsx
+++ b/measure-web-app/app/[teamId]/apps/page.tsx
@@ -80,7 +80,7 @@ export default function Apps({ params }: { params: { teamId: string } }) {
       {appsApiStatus === AppsApiStatus.Loading && <p className="text-lg font-display">Updating Apps...</p>}
 
       {/* Error message for apps fetch error */}
-      {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please refresh page to try again</p>}
+      {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please check if Team ID is valid or refresh page to try again</p>}
 
       {/* Show list of apps if app fetch succeeds */}
       {appsApiStatus === AppsApiStatus.Success &&

--- a/measure-web-app/app/[teamId]/crashes/page.tsx
+++ b/measure-web-app/app/[teamId]/crashes/page.tsx
@@ -220,7 +220,7 @@ export default function Crashes({ params }: { params: { teamId: string } }) {
         {appsApiStatus === AppsApiStatus.Loading && <p className="text-lg font-display">Updating Apps...</p>}
 
         {/* Error message for apps fetch error */}
-        {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please refresh page to try again</p>}
+        {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please check if Team ID is valid or refresh page to try again</p>}
 
         {/* Create app when no apps exist */}
         {appsApiStatus === AppsApiStatus.NoApps && <p className="text-lg font-display">Looks like you don&apos;t have any apps yet. Get started by creating your first app!</p>}

--- a/measure-web-app/app/[teamId]/overview/page.tsx
+++ b/measure-web-app/app/[teamId]/overview/page.tsx
@@ -153,7 +153,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
         {appsApiStatus === AppsApiStatus.Loading && <p className="text-lg font-display">Updating Apps...</p>}
 
         {/* Error message for apps fetch error */}
-        {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please refresh page to try again</p>}
+        {appsApiStatus === AppsApiStatus.Error && <p className="text-lg font-display">Error fetching apps, please check if Team ID is valid or refresh page to try again</p>}
 
         {/* Create app when no apps exist */}
         {appsApiStatus === AppsApiStatus.NoApps && <p className="text-lg font-display">Looks like you don&apos;t have any apps yet. Get started by creating your first app!</p>}


### PR DESCRIPTION
A common cause of app fetch API failing could be that the team ID for which the apps are being fetched is invalid. This commit updates the user facing error message UI to reflect this