### PR TITLE
fix(webapp): select all versions on filters fetch in Crashes page

### DIFF
--- a/measure-web-app/app/[teamId]/crashes/page.tsx
+++ b/measure-web-app/app/[teamId]/crashes/page.tsx
@@ -84,7 +84,7 @@ export default function Crashes({ params }: { params: { teamId: string } }) {
       case FiltersApiStatus.Success:
         setFiltersApiStatus(FiltersApiStatus.Success)
         setVersions(result.data.versions)
-        setSelectedVersions(result.data.versions[0])
+        setSelectedVersions(result.data.versions)
         break
     }
   }


### PR DESCRIPTION
When the filters api call succeeds, we need to set the selected versions state field to mark all versions as selected. Only the first version was being set instead of all versions which this commit rectifies.