### PR TITLE
ci: upgrade github action in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Install dependencies
         run: npm ci
       - name: Print versions


### PR DESCRIPTION
- upgrade `setup-node@v3` to `setup-node@v4`

fixes #382