### PR TITLE
ci: update github action

### DIFF
--- a/.github/workflows/measure-go.yml
+++ b/.github/workflows/measure-go.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: measure-backend/measure-go
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy to fly.io


### PR DESCRIPTION
- update to `actions/checkout@v4` for measure-go github workflow