### PR TITLE
fix(webapp): add key id + timestamp only when pagination has actually…

### DIFF
--- a/measure-web-app/app/components/crash_or_anr_group_details.tsx
+++ b/measure-web-app/app/components/crash_or_anr_group_details.tsx
@@ -164,7 +164,7 @@ export const CrashOrAnrGroupDetails: React.FC<CrashOrAnrGroupDetailsProps> = ({ 
     // Set key id if user has paginated
     var keyId = null
     var keyTimestamp = null
-    if (crashOrAnrGroupDetails.results !== null && crashOrAnrGroupDetails?.results.length > 0) {
+    if (paginationDirection != PaginationDirection.None && crashOrAnrGroupDetails.results !== null && crashOrAnrGroupDetails?.results.length > 0) {
       keyId = crashOrAnrGroupDetails.results[0].id
       keyTimestamp = crashOrAnrGroupDetails.results[0].timestamp
     }


### PR DESCRIPTION
… occured

When first request to Crash/ANR group details returns a result, the results array becomes non-empty. Any subsequent calls to the group details API results in appending keyID and timestamp to the API regardless of whether pagination has occured or not because there is no check for pagination actually occuring and the only check is to see if the results array is non-empty.

This results in keyID and timestamp being sent when it shouldn't be. This commit adds a check to see if pagination direction is not None which guarantees that user has actually paginated before sending keyID and timestamp.