### PR TITLE
perf(android): improve perf when converting current time to ISO format

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/utils/TimeProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/utils/TimeProvider.kt
@@ -1,7 +1,11 @@
 package sh.measure.android.utils
 
+import android.os.Build
 import android.os.SystemClock
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
@@ -54,10 +58,31 @@ internal class AndroidTimeProvider : TimeProvider {
     }
 }
 
+private val simpleDateFormat by lazy(LazyThreadSafetyMode.NONE) {
+    SimpleDateFormat(
+        "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSS'Z'",
+        Locale.getDefault(),
+    )
+}
+
+private val dateTimeFormatter by lazy(LazyThreadSafetyMode.NONE) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSS'Z'").withZone(ZoneOffset.UTC)
+    } else {
+        throw IllegalStateException("DateTimeFormatter is not supported on this platform")
+    }
+}
+
 internal fun Long.iso8601Timestamp(): String {
-    val calendar: Calendar = Calendar.getInstance(TimeZone.getTimeZone(TimeZone.getDefault().id))
-    calendar.timeInMillis = this
-    val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSS'Z'", Locale.getDefault())
-    dateFormat.timeZone = TimeZone.getTimeZone("UTC")
-    return dateFormat.format(calendar.time)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val formatter = dateTimeFormatter
+        val instant = Instant.ofEpochMilli(this)
+        formatter.format(instant)
+    } else {
+        val calendar: Calendar =
+            Calendar.getInstance(TimeZone.getTimeZone(TimeZone.getDefault().id))
+        calendar.timeInMillis = this
+        simpleDateFormat.timeZone = TimeZone.getTimeZone("UTC")
+        simpleDateFormat.format(calendar.time)
+    }
 }


### PR DESCRIPTION
closes #466 

Comparison of method trace shows that the time to run `iso8601Timestamp` reduced from _14.800ms_ to _0.864ms_ for this instance when running on SDK 33.
<img width="960" alt="Screenshot 2024-03-07 at 7 45 47 PM" src="https://github.com/measure-sh/measure/assets/3646627/72cbf1ae-36b1-4fc9-ae32-960ccd1926e1">
