### PR TITLE
fix(backend): handle error when no teams

### DIFF
--- a/measure-web-app/app/auth/callback/github/route.ts
+++ b/measure-web-app/app/auth/callback/github/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
   })
 
   const teams = await res.json()
-  if (!teams.length) {
+  if (!teams?.length) {
     console.log(`no teams found for user: ${session?.user?.id}`)
     return NextResponse.redirect(errRedirectUrl, { status: 302 })
   }


### PR DESCRIPTION
- handle error and redirect to error page if, for some reason, teams is null

fixes #497