### PR TITLE
fix(webapp): fix change role being incorrectly enabled

### DIFF
--- a/measure-web-app/app/[teamId]/team/page.tsx
+++ b/measure-web-app/app/[teamId]/team/page.tsx
@@ -298,7 +298,7 @@ export default function Team({ params }: { params: { teamId: string } }) {
                       {/* If roles can be changed for members, add roles to dropdown and set selected role to current role */}
                       {authz.can_change_roles !== null && authz.can_change_roles.length > 0 && <DropdownSelect title="Roles" type={DropdownSelectType.SingleString} items={authz.can_change_roles.map((i) => formatToCamelCase(i))} initialSelected={formatToCamelCase(role)} onChangeSelected={(i) => {
                         const newMap = new Map(selectedDropdownRolesMap)
-                        newMap.set(id, i as string)
+                        newMap.set(id, (i as string).toLocaleLowerCase())
                         setSelectedDropdownRolesMap(newMap)
                       }} />}
                       {/* If roles cannot be changed for current member, just show current role as part of dropdown */}


### PR DESCRIPTION
change role button is only supposed to be enabled when selected role is different from team member's current role. selectedDropdownRolesMap stores a map of team members to selected dropdown roles. These roles are supposed to be stored in lowercase and are used to compare selected role vs actual role to determine change role button disabled state. The roles were being stored in camel case instead of lowercase which was causing the comparison to fail incorrectly leading to incorrect change role button enabled state.