### PR TITLE
feat(backend): update alert perfs to be per user per app

### DIFF
--- a/measure-backend/measure-go/measure/alertprefs_test.go
+++ b/measure-backend/measure-go/measure/alertprefs_test.go
@@ -13,33 +13,28 @@ import (
 
 func TestNewAlertPref(t *testing.T) {
 	// Setup
-	appID := uuid.New()
+	appId := uuid.New()
+	userId := uuid.New()
 	now := time.Now()
 
 	// Act
-	pref := newAlertPref(appID)
+	pref := newAlertPref(appId, userId)
 
 	// Assert
-	if pref.AppId != appID {
-		t.Errorf("appId mismatch: expected %v, got %v", appID, pref.AppId)
+	if pref.AppId != appId {
+		t.Errorf("appId mismatch: expected %v, got %v", appId, pref.AppId)
+	}
+	if pref.UserId != userId {
+		t.Errorf("userId mismatch: expected %v, got %v", userId, pref.UserId)
 	}
 	if !pref.CrashRateSpikeEmail {
 		t.Errorf("crashRateSpikeEmail should be true")
 	}
-	if pref.CrashRateSpikeSlack {
-		t.Errorf("crashRateSpikeSlack should be false")
-	}
 	if !pref.AnrRateSpikeEmail {
 		t.Errorf("anrRateSpikeEmail should be true")
 	}
-	if pref.AnrRateSpikeSlack {
-		t.Errorf("anrRateSpikeSlack should be false")
-	}
 	if !pref.LaunchTimeSpikeEmail {
 		t.Errorf("launchTimeSpikeEmail should be true")
-	}
-	if pref.LaunchTimeSpikeSlack {
-		t.Errorf("launchTimeSpikeSlack should be false")
 	}
 	if pref.CreatedAt.Sub(now) > time.Second {
 		t.Errorf("createdAt should be around current time")
@@ -51,34 +46,30 @@ func TestNewAlertPref(t *testing.T) {
 
 func TestAlertPrefMarshalJSON(t *testing.T) {
 	// Setup
-	appID := uuid.New()
+	appId := uuid.New()
+	userId := uuid.New()
 	createdAt := time.Date(2023, 4, 4, 12, 0, 0, 0, time.UTC)
 	updatedAt := time.Date(2023, 4, 5, 12, 0, 0, 0, time.UTC)
 
 	pref := AlertPref{
-		AppId:                appID,
+		AppId:                appId,
+		UserId:               userId,
 		CrashRateSpikeEmail:  true,
-		CrashRateSpikeSlack:  false,
 		AnrRateSpikeEmail:    false,
-		AnrRateSpikeSlack:    true,
 		LaunchTimeSpikeEmail: false,
-		LaunchTimeSpikeSlack: false,
 		CreatedAt:            createdAt,
 		UpdatedAt:            updatedAt,
 	}
 
 	expectedJSON := `{
         "crash_rate_spike": {
-            "email": true,
-            "slack": false
+            "email": true
         },
         "anr_rate_spike": {
-            "email": false,
-            "slack": true
+            "email": false
         },
         "launch_time_spike": {
-            "email": false,
-            "slack": false
+            "email": false
         },
         "created_at": "2023-04-04T12:00:00Z",
         "updated_at": "2023-04-05T12:00:00Z"
@@ -110,23 +101,22 @@ func TestAlertPrefMarshalJSON(t *testing.T) {
 
 func TestAlertPrefString(t *testing.T) {
 	// Setup
-	appID := uuid.New()
+	appId := uuid.New()
+	userId := uuid.New()
 	createdAt := time.Date(2023, 4, 4, 12, 0, 0, 0, time.UTC)
 	updatedAt := time.Date(2023, 4, 5, 12, 0, 0, 0, time.UTC)
 
 	pref := AlertPref{
-		AppId:                appID,
+		AppId:                appId,
+		UserId:               userId,
 		CrashRateSpikeEmail:  true,
-		CrashRateSpikeSlack:  false,
 		AnrRateSpikeEmail:    false,
-		AnrRateSpikeSlack:    true,
 		LaunchTimeSpikeEmail: true,
-		LaunchTimeSpikeSlack: false,
 		CreatedAt:            createdAt,
 		UpdatedAt:            updatedAt,
 	}
 
-	expectedString := fmt.Sprintf("AlertPref - appId: %s, crash_rate_spike_email: true, crash_rate_spike_slack: false, anr_rate_spike_email: false, anr_rate_spike_slack: true, launch_time_spike_email: true, launch_time_spike_slack: false, created_at: %s, updated_at: %s", appID, createdAt, updatedAt)
+	expectedString := fmt.Sprintf("AlertPref - appId: %s, userId: %s, crash_rate_spike_email: true, anr_rate_spike_email: false, launch_time_spike_email: true, created_at: %s, updated_at: %s", appId, userId, createdAt, updatedAt)
 
 	// Act
 	actualString := pref.String()

--- a/measure-web-app/app/[teamId]/alerts/page.tsx
+++ b/measure-web-app/app/[teamId]/alerts/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import CreateApp from '@/app/components/create_app';
 import { AppsApiStatus, FetchAlertPrefsApiStatus, UpdateAlertPrefsApiStatus, emptyAlertPrefs, emptyApp, fetchAlertPrefsFromServer, fetchAppsFromServer, updateAlertPrefsFromServer } from '@/app/api/api_calls';
 import DropdownSelect, { DropdownSelectType } from '@/app/components/dropdown_select';
-import Link from 'next/link';
 
 export default function Overview({ params }: { params: { teamId: string } }) {
   const router = useRouter()
@@ -17,8 +16,6 @@ export default function Overview({ params }: { params: { teamId: string } }) {
   const [apps, setApps] = useState([] as typeof emptyApp[]);
   const [selectedApp, setSelectedApp] = useState(emptyApp);
 
-  const [slackConnected, setSlackConnected] = useState(false)
-
   const [alertPrefs, setAlertPrefs] = useState(emptyAlertPrefs);
   const [updatedAlertPrefs, setUpdatedAlertPrefs] = useState(emptyAlertPrefs);
 
@@ -26,7 +23,6 @@ export default function Overview({ params }: { params: { teamId: string } }) {
 
   interface AlertState {
     email: boolean;
-    slack: boolean;
   }
 
   interface UpdatedAlertsState {
@@ -38,9 +34,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
   interface AlertRowProps {
     rowTitle: string;
     emailChecked: boolean;
-    slackChecked: boolean;
     handleEmailChange: () => void;
-    handleSlackChange: () => void;
   }
 
   const handleEmailChange = (alertKey: keyof UpdatedAlertsState) => {
@@ -53,22 +47,10 @@ export default function Overview({ params }: { params: { teamId: string } }) {
     }));
   };
 
-  const handleSlackChange = (alertKey: keyof UpdatedAlertsState) => {
-    setUpdatedAlertPrefs((prevAlertPrefs) => ({
-      ...prevAlertPrefs,
-      [alertKey]: {
-        ...prevAlertPrefs[alertKey],
-        slack: !prevAlertPrefs[alertKey].slack,
-      },
-    }));
-  };
-
   const AlertRow: React.FC<AlertRowProps> = ({
     rowTitle,
     emailChecked,
-    slackChecked,
     handleEmailChange,
-    handleSlackChange,
   }) => {
 
     const checkboxStyle = "appearance-none border-black rounded-sm font-display checked:bg-neutral-950 checked:hover:bg-neutral-950 focus:ring-offset-yellow-200 focus:ring-0 checked:focus:bg-neutral-950"
@@ -93,22 +75,12 @@ export default function Overview({ params }: { params: { teamId: string } }) {
     if (a.anr_rate_spike.email != b.anr_rate_spike.email) {
       return false
     }
-    if (a.anr_rate_spike.slack != b.anr_rate_spike.slack) {
-      return false
-    }
     if (a.crash_rate_spike.email != b.crash_rate_spike.email) {
-      return false
-    }
-    if (a.crash_rate_spike.slack != b.crash_rate_spike.slack) {
       return false
     }
     if (a.launch_time_spike.email != b.launch_time_spike.email) {
       return false
     }
-    if (a.launch_time_spike.slack != b.launch_time_spike.slack) {
-      return false
-    }
-
     return true
   }
 
@@ -196,9 +168,6 @@ export default function Overview({ params }: { params: { teamId: string } }) {
       {appsApiStatus === AppsApiStatus.Success &&
         <div className="flex flex-col items-start">
           <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={apps[0].name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
-          {/* <div className="py-4" />
-          {slackConnected && <p className="px-3 py-1 text-emerald-600 font-display text-sm border border-emerald-600 rounded-full outline-none">Slack connected</p>}
-          {!slackConnected && <Link href={`https://slack.com/apps/placeholderId`} className="outline-none justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black disabled:border-gray-400 rounded-md font-display disabled:text-gray-400 transition-colors duration-100 py-2 px-4">Connect Slack</Link>} */}
           <div className="py-4" />
 
           {fetchAlertPrefsApiStatus === FetchAlertPrefsApiStatus.Loading && <p className='font-sans'> Fetching alert preferences...</p>}
@@ -215,23 +184,17 @@ export default function Overview({ params }: { params: { teamId: string } }) {
                 <AlertRow
                   rowTitle="Crash Rate Spike"
                   emailChecked={updatedAlertPrefs.crash_rate_spike.email}
-                  slackChecked={updatedAlertPrefs.crash_rate_spike.slack}
                   handleEmailChange={() => handleEmailChange('crash_rate_spike')}
-                  handleSlackChange={() => handleSlackChange('crash_rate_spike')}
                 />
                 <AlertRow
                   rowTitle="ANR Rate Spike"
                   emailChecked={updatedAlertPrefs.anr_rate_spike.email}
-                  slackChecked={updatedAlertPrefs.anr_rate_spike.slack}
                   handleEmailChange={() => handleEmailChange('anr_rate_spike')}
-                  handleSlackChange={() => handleSlackChange('anr_rate_spike')}
                 />
                 <AlertRow
                   rowTitle="Launch Time Spike"
                   emailChecked={updatedAlertPrefs.launch_time_spike.email}
-                  slackChecked={updatedAlertPrefs.launch_time_spike.slack}
                   handleEmailChange={() => handleEmailChange('launch_time_spike')}
-                  handleSlackChange={() => handleSlackChange('launch_time_spike')}
                 />
               </div>
               <div className="py-4" />

--- a/measure-web-app/app/api/api_calls.ts
+++ b/measure-web-app/app/api/api_calls.ts
@@ -543,16 +543,13 @@ export const emptySessionReplay = {
 
 export const emptyAlertPrefs = {
     crash_rate_spike: {
-        email: true,
-        slack: false
+        email: true
     },
     anr_rate_spike: {
-        email: true,
-        slack: false
+        email: true
     },
     launch_time_spike: {
-        email: true,
-        slack: false
+        email: true
     }
 }
 

--- a/self-host/postgres/20240404122712_create_alert_prefs_table.sql
+++ b/self-host/postgres/20240404122712_create_alert_prefs_table.sql
@@ -1,23 +1,20 @@
 -- migrate:up
 create table if not exists public.alert_prefs (
-    app_id uuid primary key not null references public.apps(id) on delete cascade,
+    app_id uuid not null references public.apps(id) on delete cascade,
+    user_id uuid not null references auth.users(id) on delete cascade,
     crash_rate_spike_email boolean not null,
-    crash_rate_spike_slack boolean not null,
     anr_rate_spike_email boolean not null,
-    anr_rate_spike_slack boolean not null,
     launch_time_spike_email boolean not null,
-    launch_time_spike_slack boolean not null,
     created_at timestamptz not null default now(),
-    updated_at timestamptz not null default now()
+    updated_at timestamptz not null default now(),
+    primary key (app_id, user_id)
 );
 
 comment on column public.alert_prefs.app_id is 'linked app id';
+comment on column public.alert_prefs.user_id is 'linked user id';
 comment on column public.alert_prefs.crash_rate_spike_email is 'team admin/owner set pref for enabling email on crash rate spike';
-comment on column public.alert_prefs.crash_rate_spike_slack is 'team admin/owner set pref for enabling slack message on crash rate spike';
 comment on column public.alert_prefs.anr_rate_spike_email is 'team admin/owner set pref for enabling email on ANR rate spike';
-comment on column public.alert_prefs.anr_rate_spike_slack is 'team admin/owner set pref for enabling slack message on ANR rate spike';
 comment on column public.alert_prefs.launch_time_spike_email is 'team admin/owner set pref for enabling email on launch time spike';
-comment on column public.alert_prefs.launch_time_spike_slack is 'team admin/owner set pref for enabling slack message on launch time spike';
 comment on column public.alert_prefs.created_at is 'utc timestamp at the time of record creation';
 comment on column public.alert_prefs.updated_at is 'utc timestamp at the time of record update';
 

--- a/self-host/postgres/schema.sql
+++ b/self-host/postgres/schema.sql
@@ -96,12 +96,10 @@ CREATE TABLE dbmate.schema_migrations (
 
 CREATE TABLE public.alert_prefs (
     app_id uuid NOT NULL,
+    user_id uuid NOT NULL,
     crash_rate_spike_email boolean NOT NULL,
-    crash_rate_spike_slack boolean NOT NULL,
     anr_rate_spike_email boolean NOT NULL,
-    anr_rate_spike_slack boolean NOT NULL,
     launch_time_spike_email boolean NOT NULL,
-    launch_time_spike_slack boolean NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -115,17 +113,17 @@ COMMENT ON COLUMN public.alert_prefs.app_id IS 'linked app id';
 
 
 --
+-- Name: COLUMN alert_prefs.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.alert_prefs.user_id IS 'linked user id';
+
+
+--
 -- Name: COLUMN alert_prefs.crash_rate_spike_email; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.alert_prefs.crash_rate_spike_email IS 'team admin/owner set pref for enabling email on crash rate spike';
-
-
---
--- Name: COLUMN alert_prefs.crash_rate_spike_slack; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.alert_prefs.crash_rate_spike_slack IS 'team admin/owner set pref for enabling slack message on crash rate spike';
 
 
 --
@@ -136,24 +134,10 @@ COMMENT ON COLUMN public.alert_prefs.anr_rate_spike_email IS 'team admin/owner s
 
 
 --
--- Name: COLUMN alert_prefs.anr_rate_spike_slack; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.alert_prefs.anr_rate_spike_slack IS 'team admin/owner set pref for enabling slack message on ANR rate spike';
-
-
---
 -- Name: COLUMN alert_prefs.launch_time_spike_email; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.alert_prefs.launch_time_spike_email IS 'team admin/owner set pref for enabling email on launch time spike';
-
-
---
--- Name: COLUMN alert_prefs.launch_time_spike_slack; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.alert_prefs.launch_time_spike_slack IS 'team admin/owner set pref for enabling slack message on launch time spike';
 
 
 --
@@ -818,7 +802,7 @@ ALTER TABLE ONLY dbmate.schema_migrations
 --
 
 ALTER TABLE ONLY public.alert_prefs
-    ADD CONSTRAINT alert_prefs_pkey PRIMARY KEY (app_id);
+    ADD CONSTRAINT alert_prefs_pkey PRIMARY KEY (app_id, user_id);
 
 
 --
@@ -915,6 +899,14 @@ ALTER TABLE ONLY public.unhandled_exception_groups
 
 ALTER TABLE ONLY public.alert_prefs
     ADD CONSTRAINT alert_prefs_app_id_fkey FOREIGN KEY (app_id) REFERENCES public.apps(id) ON DELETE CASCADE;
+
+
+--
+-- Name: alert_prefs alert_prefs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.alert_prefs
+    ADD CONSTRAINT alert_prefs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -1019,4 +1011,5 @@ INSERT INTO dbmate.schema_migrations (version) VALUES
     ('20231228044339'),
     ('20240311054505'),
     ('20240404122712'),
-    ('20240502060117');
+    ('20240502060117'),
+    ('20240516155840');


### PR DESCRIPTION
Alert prefs were app wide so far. i.e. Only admins could set alert prefs and it would apply to every team member. A single user could not change their own preference.

This commit makes alert prefs per user per app. Users will now be able to set their alert prefs for every app without affecting anyone else.

Changes:
1. Removes unused slack prefs
2. Adds a user_id column to alert_prefs table
3. If alert perfs are queried for a given app + user, server checks if row exists, otherwise creates and returns it with default prefs

We went with "create row when asked for" strategy due to:
1. We would have to have multiple points where rows would have to be created otherwise (new app creation, new team member addition etc)
2. Idempotency of GET API is not affected. If prefs don't exist, prefs are created and returned which has the same effect as prepopulating prefs with default values and returning them.