### PR TITLE
feat(backend): migrate to self-hosted postgres

### DIFF
--- a/measure-backend/measure-go/.env.example
+++ b/measure-backend/measure-go/.env.example
@@ -11,6 +11,8 @@
 # Databases #
 #############
 
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
 POSTGRES_DSN=postgresql://postgres:postgres@postgres:5432/postgres
 CLICKHOUSE_DSN=clickhouse://default:@clickhouse:9000/default
 

--- a/measure-backend/measure-go/main.go
+++ b/measure-backend/measure-go/main.go
@@ -38,7 +38,7 @@ func main() {
 	r := gin.Default()
 	cors := cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:3000", "https://www.measure.sh"},
-		AllowMethods:     []string{"GET", "OPTIONS", "PATCH", "DELETE"},
+		AllowMethods:     []string{"GET", "OPTIONS", "PATCH", "DELETE", "PUT"},
 		AllowHeaders:     []string{"Authorization"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
@@ -54,6 +54,11 @@ func main() {
 
 	// Dashboard rotues
 	r.Use(cors).Use(measure.ValidateAccessToken())
+	users := r.Group("/users")
+	{
+		users.PUT("", measure.CreateUser)
+	}
+
 	apps := r.Group("/apps")
 	{
 		apps.GET(":id/journey", measure.GetAppJourney)

--- a/measure-backend/measure-go/measure/authz.go
+++ b/measure-backend/measure-go/measure/authz.go
@@ -134,7 +134,7 @@ func newScope(resource, perm string) *scope {
 
 func PerformAuthz(uid string, rid string, scope scope) (bool, error) {
 	u := &User{
-		id: uid,
+		ID: &uid,
 	}
 
 	role, err := u.getRole(rid)

--- a/measure-backend/measure-go/measure/user.go
+++ b/measure-backend/measure-go/measure/user.go
@@ -5,16 +5,130 @@ import (
 	"errors"
 	"fmt"
 	"measure-backend/measure-go/server"
+	"net/http"
 	"strings"
+	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/leporo/sqlf"
 )
 
 type User struct {
-	id    string
-	email string
+	ID              *string    `json:"id"`
+	Name            *string    `json:"name"`
+	Email           *string    `json:"email"`
+	InvitedByUserId *string    `json:"invited_by_user_id"`
+	InvitedToTeamId *string    `json:"invited_to_team_id"`
+	InvitedAsRole   *string    `json:"invited_as_role"`
+	ConfirmedAt     *time.Time `json:"confirmed_at"`
+	LastSignInAt    *time.Time `json:"last_sign_in_at"`
+	CreatedAt       *time.Time `json:"created_at"`
+	UpdatedAt       *time.Time `json:"updated_at"`
+}
+
+func (u User) String() string {
+	return fmt.Sprintf(
+		"ID: %s, Name: %s, Email: %s,Email: %s,InvitedByUserId: %s,InvitedToTeamId: %s InvitedAsRole: %v, LastSignInAt: %v, CreatedAt: %v, UpdatedAt: %v",
+		stringOrNil(u.ID),
+		stringOrNil(u.Name),
+		stringOrNil(u.Email),
+		stringOrNil(u.InvitedByUserId),
+		stringOrNil(u.InvitedToTeamId),
+		stringOrNil(u.InvitedAsRole),
+		timeOrNil(u.ConfirmedAt),
+		timeOrNil(u.LastSignInAt),
+		timeOrNil(u.CreatedAt),
+		timeOrNil(u.UpdatedAt),
+	)
+}
+
+// Helper functions to handle nil pointers
+func stringOrNil(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}
+
+func timeOrNil(t *time.Time) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.Format(time.RFC3339)
+}
+
+func CreateUser(c *gin.Context) {
+	var user User
+
+	if err := c.ShouldBindJSON(&user); err != nil {
+		msg := "failed to parse user payload"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	selectStmt := sqlf.PostgreSQL.
+		Select("id").
+		From("public.users").
+		Where("id = ?", user.ID)
+	defer selectStmt.Close()
+
+	var userIdFromDb string
+	err := server.Server.PgPool.QueryRow(context.Background(), selectStmt.String(), selectStmt.Args()...).Scan(&userIdFromDb)
+
+	// If there is no user for given userID, we create one
+	if err != nil && err == pgx.ErrNoRows {
+		insertStmt := sqlf.PostgreSQL.
+			InsertInto("public.users").
+			Set("id", user.ID).
+			Set("name", user.Name).
+			Set("email", user.Email).
+			Set("invited_by_user_id", user.InvitedByUserId).
+			Set("invited_to_team_id", user.InvitedToTeamId).
+			Set("invited_as_role", user.InvitedAsRole).
+			Set("confirmed_at", user.ConfirmedAt).
+			Set("last_sign_in_at", user.LastSignInAt).
+			Set("created_at", user.CreatedAt).
+			Set("updated_at", user.UpdatedAt)
+		defer insertStmt.Close()
+
+		if _, err := server.Server.PgPool.Exec(context.Background(), insertStmt.String(), insertStmt.Args()...); err != nil {
+			msg := "failed to create user in database"
+			fmt.Println(msg, err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+			return
+		}
+
+		c.JSON(http.StatusCreated, user)
+		return
+	}
+
+	// If user exists for given userID, we updated the record
+	updateStmt := sqlf.PostgreSQL.
+		Update("public.users").
+		Set("name", user.Name).
+		Set("email", user.Email).
+		Set("invited_by_user_id", user.InvitedByUserId).
+		Set("invited_to_team_id", user.InvitedToTeamId).
+		Set("invited_as_role", user.InvitedAsRole).
+		Set("confirmed_at", user.ConfirmedAt).
+		Set("last_sign_in_at", user.LastSignInAt).
+		Set("created_at", user.CreatedAt).
+		Set("updated_at", user.UpdatedAt).
+		Where("id = ?", user.ID)
+	defer updateStmt.Close()
+
+	ctx := context.Background()
+	if _, err := server.Server.PgPool.Exec(ctx, updateStmt.String(), updateStmt.Args()...); err != nil {
+		msg := "failed to update user in database"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	c.JSON(http.StatusCreated, user)
 }
 
 func (u *User) getTeams() ([]map[string]string, error) {
@@ -26,7 +140,7 @@ func (u *User) getTeams() ([]map[string]string, error) {
 
 	defer stmt.Close()
 
-	rows, err := server.Server.PgPool.Query(context.Background(), stmt.String(), u.id)
+	rows, err := server.Server.PgPool.Query(context.Background(), stmt.String(), u.ID)
 
 	if err != nil {
 		return nil, err
@@ -64,7 +178,7 @@ func (u *User) getOwnTeam() (*Team, error) {
 
 	team := &Team{}
 
-	if err := server.Server.PgPool.QueryRow(context.Background(), stmt.String(), u.id).Scan(&team.ID, &team.Name); err != nil {
+	if err := server.Server.PgPool.QueryRow(context.Background(), stmt.String(), u.ID).Scan(&team.ID, &team.Name); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +196,7 @@ func (u *User) getRole(teamId string) (rank, error) {
 	defer stmt.Close()
 
 	ctx := context.Background()
-	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), u.id, teamId).Scan(&role); err != nil {
+	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), u.ID, teamId).Scan(&role); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return unknown, nil
 		} else {
@@ -96,8 +210,8 @@ func (u *User) getRole(teamId string) (rank, error) {
 // GetUsersByInvitees provides existing & new invitees by matching
 // each user's and invitee's email.
 //
-// Only confirmed, not banned and not deleted users are considered as
-// viable candidates for team invitation.
+// Only confirmed users are considered as viable candidates for
+// team invitation.
 func GetUsersByInvitees(invitees []Invitee) ([]Invitee, []Invitee, error) {
 	var oldUsers []Invitee
 	var newUsers []Invitee
@@ -111,18 +225,16 @@ func GetUsersByInvitees(invitees []Invitee) ([]Invitee, []Invitee, error) {
 
 	stmt := sqlf.PostgreSQL.
 		Select("id, email").
-		From("auth.users").
+		From("public.users").
 		Where(fmt.Sprintf("email in (%s)", emailList)).
-		Where("confirmed_at is not null").
-		Where("deleted_at is null").
-		Where("banned_until is null")
+		Where("confirmed_at is not null")
 
 	defer stmt.Close()
 
 	rows, _ := server.Server.PgPool.Query(context.Background(), stmt.String())
 	users, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (User, error) {
 		var user User
-		err := row.Scan(&user.id, &user.email)
+		err := row.Scan(&user.ID, &user.Email)
 		return user, err
 	})
 	if err != nil {
@@ -131,8 +243,8 @@ func GetUsersByInvitees(invitees []Invitee) ([]Invitee, []Invitee, error) {
 
 	for _, invitee := range invitees {
 		for _, user := range users {
-			if strings.EqualFold(user.email, invitee.Email) {
-				uuid, err := uuid.Parse(user.id)
+			if strings.EqualFold(*user.Email, invitee.Email) {
+				uuid, err := uuid.Parse(*user.ID)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -142,7 +254,7 @@ func GetUsersByInvitees(invitees []Invitee) ([]Invitee, []Invitee, error) {
 		}
 		newInvitee := true
 		for _, user := range users {
-			if strings.EqualFold(user.email, invitee.Email) {
+			if strings.EqualFold(*user.Email, invitee.Email) {
 				newInvitee = false
 			}
 		}

--- a/measure-web-app/app/auth/callback/github/route.ts
+++ b/measure-web-app/app/auth/callback/github/route.ts
@@ -1,5 +1,6 @@
 import { createRouteClient } from '@/utils/supabase/route'
 import { NextResponse } from 'next/server'
+import { syncSupabaseUserToMeasureServerFromServer } from '@/utils/supabase/sync_user_server'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,6 +28,11 @@ export async function GET(request: Request) {
 
   if (!accessToken || !refreshToken) {
     return NextResponse.redirect(errRedirectUrl)
+  }
+
+  const userCreationRes = await syncSupabaseUserToMeasureServerFromServer()
+  if (!userCreationRes.ok) {
+    return NextResponse.redirect(errRedirectUrl, { status: 302 })
   }
 
   const apiOrigin = process?.env?.NEXT_PUBLIC_API_BASE_URL

--- a/measure-web-app/app/auth/callback/google/route.ts
+++ b/measure-web-app/app/auth/callback/google/route.ts
@@ -1,5 +1,6 @@
 import { createRouteClient } from '@/utils/supabase/route'
 import { NextResponse } from 'next/server'
+import { syncSupabaseUserToMeasureServerFromServer } from '@/utils/supabase/sync_user_server'
 
 export const dynamic = 'force-dynamic'
 
@@ -31,6 +32,11 @@ export async function POST(request: Request) {
   }
 
   const accessToken = data.session.access_token
+
+  const userCreationRes = await syncSupabaseUserToMeasureServerFromServer()
+  if (!userCreationRes.ok) {
+    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+  }
 
   const origin = process?.env?.NEXT_PUBLIC_API_BASE_URL
 

--- a/measure-web-app/app/auth/callback/route.ts
+++ b/measure-web-app/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { createRouteClient } from '@/utils/supabase/route'
 import { NextResponse } from 'next/server'
+import { syncSupabaseUserToMeasureServerFromServer } from '@/utils/supabase/sync_user_server'
 
 export const dynamic = 'force-dynamic'
 
@@ -22,6 +23,11 @@ export async function GET(request: Request) {
   }
 
   const accessToken = data.session.access_token
+
+  const userCreationRes = await syncSupabaseUserToMeasureServerFromServer()
+  if (!userCreationRes.ok) {
+    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+  }
 
   const origin = process?.env?.NEXT_PUBLIC_API_BASE_URL
 

--- a/measure-web-app/app/auth/invite/route.ts
+++ b/measure-web-app/app/auth/invite/route.ts
@@ -49,16 +49,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: `invited ${email}` })
   }
 
-  const redirectUrl = `${requestUrl.origin}/${teamId}/overview`
+  const redirectUrl = `${requestUrl.origin}/auth/login/invited`
 
   const { error } = await supabase.auth.admin.inviteUserByEmail(email, {
     redirectTo: redirectUrl,
     data: {
-      invite: {
-        userId: session?.user.id,
-        teamId,
-        role
-      }
+      invited_by_user_id: session?.user.id,
+      invited_to_team_id: teamId,
+      invited_as_role: role
     }
   })
 

--- a/measure-web-app/app/auth/login/invited/page.tsx
+++ b/measure-web-app/app/auth/login/invited/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/utils/supabase/browser';
+import { syncSupabaseUserToMeasureServerFromBrowser } from '@/utils/supabase/sync_user_browser';
+
+export default function Invited() {
+  const router = useRouter()
+
+  const loginUserWithInvitedUserCreds = async () => {
+    const errRedirectUrl = `/auth/login?error=Could not sign in with email`
+
+    const hash = window.location.hash.substring(1); // Remove the leading '#'
+    const hashParams = new URLSearchParams(hash);
+
+    const accessToken = hashParams.get('access_token')!
+    const refreshToken = hashParams.get('refresh_token')!
+
+    const { data, error } = await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken })
+
+    if (error) {
+      const msg = `failed to retrieve user session`
+      console.log(msg, error)
+      router.push(errRedirectUrl)
+      return
+    }
+
+    const userCreationRes = await syncSupabaseUserToMeasureServerFromBrowser()
+    if (!userCreationRes.ok) {
+      router.push(errRedirectUrl)
+      return
+    }
+
+    const invitedToTeamId = data.user!.user_metadata.invited_to_team_id
+    console.log("invited to team id: " + invitedToTeamId)
+    router.push(`/${invitedToTeamId}/overview`)
+  }
+
+  useEffect(() => {
+    loginUserWithInvitedUserCreds()
+  }, []);
+
+
+  return (
+    <div className="flex flex-col min-h-screen selection:bg-yellow-200/75 items-center justify-center p-24 pt-8">
+      <div className="py-4" />
+      <p className="font-display font-regular text-2xl max-w-6xl text-center">Welcome to Measure</p>
+      <div className="py-4" />
+      <p className="font-sans font-regular max-w-6xl text-center">Setting up your account...</p>
+    </div>
+  )
+}

--- a/measure-web-app/app/auth/sign-up/messages.tsx
+++ b/measure-web-app/app/auth/sign-up/messages.tsx
@@ -17,8 +17,9 @@ export default function Messages() {
       )}
       {message && (
         <>
-          <p className="mt-2 p-4">We&apos;ve sent a magic link to your inbox.</p>
-          <p className="mt-2 p-4 text-black">{message}</p>
+          <p className="font-display font-regular text-2xl text-center">We&apos;ve sent a magic link to your inbox</p>
+          <div className="py-4" />
+          <p className="font-sans font-regular text-center">{message}</p>
         </>
       )}
     </div>

--- a/measure-web-app/utils/supabase/sync_user.ts
+++ b/measure-web-app/utils/supabase/sync_user.ts
@@ -1,0 +1,31 @@
+import { Session, SupabaseClient } from "@supabase/supabase-js"
+
+export async function syncSupabaseUserToMeasureServer(session: Session, supabase: SupabaseClient) {
+    const authToken = session!.access_token
+    const user = (await supabase.auth.getUser()).data.user!
+
+    const payload = {
+        id: user.id,
+        email: user.email,
+        name: user.user_metadata.name,
+        invited_by_user_id: user.user_metadata.invited_by_user_id,
+        invited_to_team_id: user.user_metadata.invited_to_team_id,
+        invited_as_role: user.user_metadata.invited_as_role,
+        confirmed_at: user.confirmed_at,
+        last_sign_in_at: user.last_sign_in_at,
+        created_at: user.created_at,
+        updated_at: user.updated_at,
+    }
+
+    const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+    const opts = {
+        method: 'PUT',
+        headers: {
+            "Authorization": `Bearer ${authToken}`
+        },
+        body: JSON.stringify(payload)
+    }
+
+    const res = await fetch(`${origin}/users`, opts)
+    return { res, user }
+}

--- a/measure-web-app/utils/supabase/sync_user_browser.ts
+++ b/measure-web-app/utils/supabase/sync_user_browser.ts
@@ -1,0 +1,22 @@
+import { supabase } from "@/utils/supabase/browser"
+import { syncSupabaseUserToMeasureServer } from "./sync_user"
+
+export const syncSupabaseUserToMeasureServerFromBrowser = async () => {
+    const { data: { session }, error: sessionErr } = await supabase.auth.getSession()
+
+    if (sessionErr) {
+        const msg = `Could not create/update user, failed to fetch supabase session`
+        console.log(msg, sessionErr)
+        return Response.error()
+    }
+
+    const { res, user } = await syncSupabaseUserToMeasureServer(session!, supabase)
+
+    if (!res.ok) {
+        console.log("Could not create/update user with payload: ", user)
+        return Response.error()
+    }
+
+    console.log("Created/Updated user with payload: ", user)
+    return Response.json({ msg: "Created/Updated user with payload: " + user, status: 201 })
+}

--- a/measure-web-app/utils/supabase/sync_user_server.ts
+++ b/measure-web-app/utils/supabase/sync_user_server.ts
@@ -1,0 +1,25 @@
+import { createAdminClient } from "@/utils/supabase/admin"
+import { NextResponse } from "next/server"
+import { syncSupabaseUserToMeasureServer } from "./sync_user"
+
+export const syncSupabaseUserToMeasureServerFromServer = async () => {
+    const supabase = createAdminClient()
+
+    const { data: { session }, error: sessionErr } = await supabase.auth.getSession()
+
+    if (sessionErr) {
+        const msg = `Could not create/update user, failed to fetch supabase session`
+        console.log(msg, sessionErr)
+        return NextResponse.json({ error: msg }, { status: 500 })
+    }
+
+    const { res, user } = await syncSupabaseUserToMeasureServer(session!, supabase)
+
+    if (!res.ok) {
+        console.log("Could not create/update user with payload: ", user)
+        return Response.error()
+    }
+
+    console.log("Created/Updated user with payload: ", user)
+    return Response.json({ msg: "Created/Updated user with payload: " + user, status: 201 })
+}

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -16,6 +16,23 @@ services:
       - clickhouse
       - minio
       - symbolicator-retrace
+      - postgres
+  
+  postgres:
+    image: postgres:16.3-alpine
+    restart: always
+    command: ["postgres", "-c", "log_statement=all"]
+    env_file:
+      - ../measure-backend/measure-go/.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
 
   symbolicator-retrace:
     container_name: symbolicator-retrace
@@ -76,3 +93,4 @@ volumes:
   clickhouse-volume:
   symbolicator-volume:
   minio-data:
+  pgdata:

--- a/self-host/postgres/20231117010311_create_users_table.sql
+++ b/self-host/postgres/20231117010311_create_users_table.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+create table if not exists public.users (
+    id uuid primary key not null,
+    name varchar(256),
+    email varchar(256) not null,
+    invited_by_user_id uuid,
+    invited_to_team_id uuid,
+    invited_as_role varchar(256),
+    confirmed_at timestamptz,
+    last_sign_in_at timestamptz not null,
+    created_at timestamptz not null,
+    updated_at timestamptz not null
+);
+
+comment on column public.users.id is 'unique id for each user';
+comment on column public.users.name is 'name of the user';
+comment on column public.users.invited_by_user_id is 'id of user who invited this user';
+comment on column public.users.invited_to_team_id is 'id of team to which this user was invited';
+comment on column public.users.invited_as_role is 'role as which this user was invited';
+comment on column public.users.confirmed_at is 'utc timestamp at which user was confirmed';
+comment on column public.users.last_sign_in_at is 'utc timestamp at the time of last user sign in';
+comment on column public.users.created_at is 'utc timestamp at the time of user creation';
+comment on column public.users.updated_at is 'utc timestmap at the time of user update';
+
+-- migrate:down
+drop table if exists public.users;

--- a/self-host/postgres/20231117012219_create-team_membership-relation.sql
+++ b/self-host/postgres/20231117012219_create-team_membership-relation.sql
@@ -2,7 +2,7 @@
 create table if not exists public.team_membership (
     id uuid primary key not null default gen_random_uuid(),
     team_id uuid references public.teams(id) on delete cascade,
-    user_id uuid references auth.users(id) on delete cascade,
+    user_id uuid references public.users(id) on delete cascade,
     role varchar(256) references public.roles(name) on delete cascade,
     role_updated_at timestamptz not null,
     created_at timestamptz not null default current_timestamp

--- a/self-host/postgres/20231117012557_create-create_team-function.sql
+++ b/self-host/postgres/20231117012557_create-create_team-function.sql
@@ -8,7 +8,7 @@ create
 or replace function public.create_team()
 returns trigger
 language plpgsql
-security definer set search_path = auth,public
+security definer set search_path = public
 as $$
 declare
   team_id uuid;
@@ -24,7 +24,7 @@ begin
   end if;
 
   -- prepare new user's team name
-  user_name = new.raw_user_meta_data->>'name';
+  user_name = new.name;
   if user_name is not null then
     team_name = substring(user_name from 1 for position(' ' in user_name) - 1);
   else
@@ -32,8 +32,8 @@ begin
   end if;
 
   -- get invite details
-  inviter_team_id = new.raw_user_meta_data->'invite'->>'teamId';
-  invitee_role = new.raw_user_meta_data->'invite'->>'role';
+  inviter_team_id = new.invited_to_team_id;
+  invitee_role = new.invited_as_role;
 
   -- update tables
   time_now = now();

--- a/self-host/postgres/20231117012726_create-create_team_for_user-trigger.sql
+++ b/self-host/postgres/20231117012726_create-create_team_for_user-trigger.sql
@@ -4,8 +4,8 @@
  * team
  */
 create or replace trigger create_team_for_user
-after update on auth.users
+after insert on public.users
 for each row execute function create_team();
 
 -- migrate:down
-drop trigger if exists create_team_for_user on auth.users;
+drop trigger if exists create_team_for_user on public.users;

--- a/self-host/postgres/20240404122712_create_alert_prefs_table.sql
+++ b/self-host/postgres/20240404122712_create_alert_prefs_table.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 create table if not exists public.alert_prefs (
     app_id uuid not null references public.apps(id) on delete cascade,
-    user_id uuid not null references auth.users(id) on delete cascade,
+    user_id uuid not null references public.users(id) on delete cascade,
     crash_rate_spike_email boolean not null,
     anr_rate_spike_email boolean not null,
     launch_time_spike_email boolean not null,


### PR DESCRIPTION
We were using supabase auth postgres for all db data. This commit changes the following:

1. Sets up a vanilla postgres in docker compose
2. Creates a users table in the new postgres
3. On login, syncs user data from supabase to users table
4. Updates email invite metadata to make sure invited users are set up properly on logging in

closes #650