### PR TITLE
fix(backend): add authz in metrics

### DIFF
--- a/measure-backend/measure-go/measure/app.go
+++ b/measure-backend/measure-go/measure/app.go
@@ -1608,6 +1608,42 @@ func GetAppMetrics(c *gin.Context) {
 		ID: &id,
 	}
 
+	team, err := app.getTeam(ctx)
+	if err != nil {
+		msg := "failed to get team from app id"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+	if team == nil {
+		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	userId := c.GetString("userId")
+	okTeam, err := PerformAuthz(userId, team.ID.String(), *ScopeTeamRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	if !okTeam || !okApp {
+		msg := `you are not authorized to access this app`
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
 	msg = `failed to fetch app metrics`
 
 	launch, err := app.GetLaunchMetrics(ctx, &af)


### PR DESCRIPTION
- add standard rbac authorization checks for get `/apps/:id/metrics` api

fixes #657