### PR TITLE
fix(webapp): handle invalid date input in date filters

### DIFF
--- a/measure-web-app/__tests__/utils/time_utils.test.ts
+++ b/measure-web-app/__tests__/utils/time_utils.test.ts
@@ -1,5 +1,5 @@
 
-import { formatDateToHumanReadable, formatMillisToHumanReadable, formatTimeToHumanReadable, formatTimestampToChartFormat } from '@/app/utils/time_utils';
+import { formatDateToHumanReadable, formatMillisToHumanReadable, formatTimeToHumanReadable, formatTimestampToChartFormat, isValidTimestamp } from '@/app/utils/time_utils';
 import { expect, it, describe, beforeEach, afterEach } from '@jest/globals';
 import { Settings, DateTime } from "luxon";
 
@@ -63,7 +63,7 @@ describe('formatDateToHumanReadable', () => {
         expect(formatDateToHumanReadable(timestamp)).toBe(expected);
     });
 
-    it('should handle invalid timestamps', () => {
+    it('should throw on invalid timestamps', () => {
         const timestamp = 'invalid-timestamp';
         expect(() => formatDateToHumanReadable(timestamp)).toThrow();
     });
@@ -91,7 +91,7 @@ describe('formatTimeToHumanReadable', () => {
         expect(formatTimeToHumanReadable(timestamp)).toBe(expected);
     });
 
-    it('should handle invalid timestamps', () => {
+    it('should throw on invalid timestamps', () => {
         const timestamp = 'invalid-timestamp';
         expect(() => formatTimeToHumanReadable(timestamp)).toThrow();
     });
@@ -119,8 +119,29 @@ describe('formatTimestampToChartFormat', () => {
         expect(formatTimestampToChartFormat(timestamp)).toBe(expected);
     });
 
-    it('should handle invalid timestamps', () => {
+    it('should throw on invalid timestamps', () => {
         const timestamp = 'invalid-timestamp';
         expect(() => formatTimestampToChartFormat(timestamp)).toThrow();
+    });
+});
+
+describe('isValidTimestamp', () => {
+    beforeEach(() => {
+        Settings.now = () => 0;
+        Settings.defaultZone = "Asia/Kolkata"
+    });
+
+    afterEach(() => {
+        Settings.now = () => DateTime.now().valueOf();
+    });
+
+    it('should return true on valid timestamp', () => {
+        const timestamp = '2024-04-16T12:00:00Z'; // April 16, 2024, 12:00 PM UTC
+        expect(isValidTimestamp(timestamp)).toBe(true);
+    });
+
+    it('should return false on invalid timestamp', () => {
+        const timestamp = 'invalid-timestamp';
+        expect(isValidTimestamp(timestamp)).toBe(false);
     });
 });

--- a/measure-web-app/app/[teamId]/overview/page.tsx
+++ b/measure-web-app/app/[teamId]/overview/page.tsx
@@ -8,7 +8,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import CreateApp from '@/app/components/create_app';
 import { AppVersion, AppsApiStatus, FiltersApiStatus, FiltersApiType, emptyApp, fetchAppsFromServer, fetchFiltersFromServer } from '@/app/api/api_calls';
 import { updateDateQueryParams } from '@/app/utils/router_utils';
-import { formatDateToHumanReadable } from '@/app/utils/time_utils';
+import { formatDateToHumanReadable, isValidTimestamp } from '@/app/utils/time_utils';
 import DropdownSelect, { DropdownSelectType } from '@/app/components/dropdown_select';
 import { DateTime } from 'luxon';
 
@@ -121,9 +121,17 @@ export default function Overview({ params }: { params: { teamId: string } }) {
             <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={apps[0].name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
             {filtersApiStatus === FiltersApiStatus.Success &&
               <div className="flex flex-row items-center">
-                <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setStartDate(e.target.value)} />
+                <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                  if (isValidTimestamp(e.target.value)) {
+                    setStartDate(e.target.value)
+                  }
+                }} />
                 <p className="font-display px-2">to</p>
-                <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setEndDate(e.target.value)} />
+                <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                  if (isValidTimestamp(e.target.value)) {
+                    setEndDate(e.target.value)
+                  }
+                }} />
               </div>}
             {filtersApiStatus === FiltersApiStatus.Success && <DropdownSelect title="App Version" type={DropdownSelectType.SingleAppVersion} items={versions} initialSelected={selectedVersion} onChangeSelected={(item) => setSelectedVersion(item as AppVersion)} />}
           </div>

--- a/measure-web-app/app/components/crash_or_anr_group_details.tsx
+++ b/measure-web-app/app/components/crash_or_anr_group_details.tsx
@@ -10,7 +10,7 @@ import { AppsApiStatus, CrashOrAnrGroupDetailsApiStatus, CrashOrAnrType, Filters
 import { useRouter, useSearchParams } from 'next/navigation';
 import Paginator, { PaginationDirection } from '@/app/components/paginator';
 import { updateDateQueryParams } from '../utils/router_utils';
-import { formatDateToHumanReadable, formatTimeToHumanReadable } from '../utils/time_utils';
+import { formatDateToHumanReadable, formatTimeToHumanReadable, isValidTimestamp } from '../utils/time_utils';
 import DropdownSelect, { DropdownSelectType } from './dropdown_select';
 import { DateTime } from 'luxon';
 
@@ -230,9 +230,17 @@ export const CrashOrAnrGroupDetails: React.FC<CrashOrAnrGroupDetailsProps> = ({ 
         <div>
           <div className="flex flex-wrap gap-8 items-center w-5/6">
             <div className="flex flex-row items-center">
-              <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setStartDate(e.target.value)} />
+              <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                if (isValidTimestamp(e.target.value)) {
+                  setStartDate(e.target.value)
+                }
+              }} />
               <p className="font-display px-2">to</p>
-              <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setEndDate(e.target.value)} />
+              <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                if (isValidTimestamp(e.target.value)) {
+                  setEndDate(e.target.value)
+                }
+              }} />
             </div>
             <DropdownSelect title="App versions" type={DropdownSelectType.MultiAppVersion} items={versions} initialSelected={selectedVersions} onChangeSelected={(items) => setSelectedVersions(items as AppVersion[])} />
             {countries.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Country" items={countries} initialSelected={countries} onChangeSelected={(items) => setSelectedCountries(items as string[])} />}

--- a/measure-web-app/app/components/crashes_or_anrs_overview.tsx
+++ b/measure-web-app/app/components/crashes_or_anrs_overview.tsx
@@ -9,7 +9,7 @@ import CreateApp from '@/app/components/create_app';
 import { AppVersion, AppsApiStatus, CrashOrAnrGroupsApiStatus, CrashOrAnrType, FiltersApiStatus, FiltersApiType, emptyApp, emptyCrashOrAnrGroupsResponse, fetchAppsFromServer, fetchCrashOrAnrGroupsFromServer, fetchFiltersFromServer } from '@/app/api/api_calls';
 import Paginator, { PaginationDirection } from '@/app/components/paginator';
 import { updateDateQueryParams } from '../utils/router_utils';
-import { formatDateToHumanReadable } from '../utils/time_utils';
+import { formatDateToHumanReadable, isValidTimestamp } from '../utils/time_utils';
 import DropdownSelect, { DropdownSelectType } from './dropdown_select';
 import { DateTime } from 'luxon';
 
@@ -181,9 +181,17 @@ export const CrashesOrAnrsOverview: React.FC<CrashOrAnrsOverviewProps> = ({ cras
             <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={apps[0].name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
             {filtersApiStatus === FiltersApiStatus.Success &&
               <div className="flex flex-row items-center">
-                <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setStartDate(e.target.value)} />
+                <input type="date" defaultValue={startDate} max={endDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                  if (isValidTimestamp(e.target.value)) {
+                    setStartDate(e.target.value)
+                  }
+                }} />
                 <p className="font-display px-2">to</p>
-                <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => setEndDate(e.target.value)} />
+                <input type="date" defaultValue={endDate} min={startDate} max={todayDate} className="font-display border border-black rounded-md p-2" onChange={(e) => {
+                  if (isValidTimestamp(e.target.value)) {
+                    setEndDate(e.target.value)
+                  }
+                }} />
               </div>}
             {filtersApiStatus === FiltersApiStatus.Success && <DropdownSelect title="App versions" type={DropdownSelectType.MultiAppVersion} items={versions} initialSelected={selectedVersions} onChangeSelected={(items) => setSelectedVersions(items as AppVersion[])} />}
           </div>

--- a/measure-web-app/app/utils/time_utils.ts
+++ b/measure-web-app/app/utils/time_utils.ts
@@ -67,3 +67,8 @@ export function formatTimestampToChartFormat(timestamp: string): string {
   const formattedDate = localDateTime.toFormat('yyyy-MM-dd HH:mm:ss:SSS a');
   return formattedDate
 }
+
+export function isValidTimestamp(timestamp: string): boolean {
+  const utcDateTime = DateTime.fromISO(timestamp, { zone: 'utc' });
+  return utcDateTime.isValid
+}


### PR DESCRIPTION
On invalid date input via keyboard, time utils was throwing an error. This commit adds a check to only pass in valid dates for futher processing after user input. If entered date is invalid, previous valid
value is maintained and selected dates states aren't updated.

fixes #694