### PR TITLE
fix(webapp): make filter end date include all day

### DIFF
--- a/measure-web-app/__tests__/utils/time_utils.test.ts
+++ b/measure-web-app/__tests__/utils/time_utils.test.ts
@@ -1,5 +1,5 @@
 
-import { formatDateToHumanReadable, formatMillisToHumanReadable, formatTimeToHumanReadable, formatTimestampToChartFormat, isValidTimestamp } from '@/app/utils/time_utils';
+import { UserInputDateType, formatDateToHumanReadable, formatMillisToHumanReadable, formatTimeToHumanReadable, formatTimestampToChartFormat, formatUserInputDateToServerFormat, isValidTimestamp } from '@/app/utils/time_utils';
 import { expect, it, describe, beforeEach, afterEach } from '@jest/globals';
 import { Settings, DateTime } from "luxon";
 
@@ -117,6 +117,34 @@ describe('formatTimestampToChartFormat', () => {
         const timestamp = '2024-04-15T03:44:00Z'; // April 15, 2024, 03:44 PM UTC
         const expected = '2024-04-15 09:14:00:000 AM';
         expect(formatTimestampToChartFormat(timestamp)).toBe(expected);
+    });
+
+    it('should throw on invalid timestamps', () => {
+        const timestamp = 'invalid-timestamp';
+        expect(() => formatTimestampToChartFormat(timestamp)).toThrow();
+    });
+});
+
+describe('formatUserSelectedDateToServerFormat', () => {
+    beforeEach(() => {
+        Settings.now = () => 0;
+        Settings.defaultZone = "Asia/Kolkata"
+    });
+
+    afterEach(() => {
+        Settings.now = () => DateTime.now().valueOf();
+    });
+
+    it('should format a From user input date to server format', () => {
+        const timestamp = '2024-04-16'; // April 16, 2024
+        const expected = '2024-04-15T18:30:00.000Z';
+        expect(formatUserInputDateToServerFormat(timestamp, UserInputDateType.From)).toBe(expected);
+    });
+
+    it('should format a To user input date to server format', () => {
+        const timestamp = '2024-04-16'; // April 16
+        const expected = '2024-04-16T18:29:59.999Z';
+        expect(formatUserInputDateToServerFormat(timestamp, UserInputDateType.To)).toBe(expected);
     });
 
     it('should throw on invalid timestamps', () => {

--- a/measure-web-app/app/api/api_calls.ts
+++ b/measure-web-app/app/api/api_calls.ts
@@ -1,8 +1,8 @@
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime"
 import { getAccessTokenOrRedirectToAuth, logoutIfAuthError } from "../utils/auth_utils"
-import { DateTime } from "luxon"
 import { supabase } from "@/utils/supabase/browser"
 import { JourneyType } from "../components/journey"
+import { UserInputDateType, formatUserInputDateToServerFormat } from "../utils/time_utils"
 
 export enum TeamsApiStatus {
     Loading,
@@ -702,8 +702,8 @@ export const fetchJourneyFromServer = async (appId: string, journeyType: Journey
     }
 
     // Append dates
-    const serverFormattedStartDate = DateTime.fromFormat(startDate, 'yyyy-MM-dd').toUTC().toISO();
-    const serverFormattedEndDate = DateTime.fromFormat(endDate, 'yyyy-MM-dd').toUTC().toISO();
+    const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate, UserInputDateType.From)
+    const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate, UserInputDateType.To)
     url = url + `?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
 
     // Append versions
@@ -769,8 +769,8 @@ export const fetchMetricsFromServer = async (appId: string, startDate: string, e
         }
     };
 
-    const serverFormattedStartDate = DateTime.fromFormat(startDate, 'yyyy-MM-dd').toUTC().toISO();
-    const serverFormattedEndDate = DateTime.fromFormat(endDate, 'yyyy-MM-dd').toUTC().toISO();
+    const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate, UserInputDateType.From)
+    const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate, UserInputDateType.To)
 
     let url = `${origin}/apps/${appId}/metrics?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
 
@@ -799,8 +799,8 @@ export const fetchCrashOrAnrGroupsFromServer = async (crashOrAnrType: CrashOrAnr
         }
     };
 
-    const serverFormattedStartDate = DateTime.fromFormat(startDate, 'yyyy-MM-dd').toUTC().toISO();
-    const serverFormattedEndDate = DateTime.fromFormat(endDate, 'yyyy-MM-dd').toUTC().toISO();
+    const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate, UserInputDateType.From)
+    const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate, UserInputDateType.To)
 
     var url = ""
     if (crashOrAnrType === CrashOrAnrType.Crash) {
@@ -842,8 +842,8 @@ export const fetchCrashOrAnrGroupDetailsFromServer = async (crashOrAnrType: Cras
         }
     };
 
-    const serverFormattedStartDate = DateTime.fromFormat(startDate, 'yyyy-MM-dd').toUTC().toISO();
-    const serverFormattedEndDate = DateTime.fromFormat(endDate, 'yyyy-MM-dd').toUTC().toISO();
+    const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate, UserInputDateType.From)
+    const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate, UserInputDateType.To)
 
     var url = ""
     if (crashOrAnrType === CrashOrAnrType.Crash) {
@@ -925,8 +925,8 @@ export const fetchCrashOrAnrGroupDetailsPlotFromServer = async (appId: string, c
         }
     };
 
-    const serverFormattedStartDate = DateTime.fromFormat(startDate, 'yyyy-MM-dd').toUTC().toISO();
-    const serverFormattedEndDate = DateTime.fromFormat(endDate, 'yyyy-MM-dd').toUTC().toISO();
+    const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate, UserInputDateType.From)
+    const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate, UserInputDateType.To)
 
     var url = ""
     if (crashOrAnrType === CrashOrAnrType.Crash) {

--- a/measure-web-app/app/utils/time_utils.ts
+++ b/measure-web-app/app/utils/time_utils.ts
@@ -68,6 +68,28 @@ export function formatTimestampToChartFormat(timestamp: string): string {
   return formattedDate
 }
 
+export enum UserInputDateType {
+  From,
+  To
+}
+
+export function formatUserInputDateToServerFormat(date: string, inputDateType: UserInputDateType): string {
+  // Parse date string, time will be 00:00:00 
+  let localDateTime = DateTime.fromFormat(date, 'yyyy-MM-dd')
+
+  // Throw error if invalid
+  if (!localDateTime.isValid) {
+    throw (localDateTime.invalidReason)
+  }
+
+  // If "To" date, set time to end of day to include whole of the day
+  if (inputDateType === UserInputDateType.To) {
+    localDateTime = localDateTime.plus({ hours: 23, minutes: 59, seconds: 59, milliseconds: 999 })
+  }
+
+  return localDateTime.toUTC().toISO()!
+}
+
 export function isValidTimestamp(timestamp: string): boolean {
   const utcDateTime = DateTime.fromISO(timestamp, { zone: 'utc' });
   return utcDateTime.isValid


### PR DESCRIPTION
end date was being converted to a timestamp with time set to 00:00:00 which would exclude the day from
queries. This commit sets the time value of end date to include the whole day.

fixes #722