### PR TITLE
fix(android): make network attributes (provider, type and generation) non-nullable

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/attributes/NetworkStateAttributeProcessor.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/attributes/NetworkStateAttributeProcessor.kt
@@ -1,6 +1,7 @@
 package sh.measure.android.attributes
 
 import sh.measure.android.networkchange.NetworkGeneration
+import sh.measure.android.networkchange.NetworkProvider
 import sh.measure.android.networkchange.NetworkStateProvider
 import sh.measure.android.networkchange.NetworkType
 import sh.measure.android.tracing.InternalTrace
@@ -12,10 +13,9 @@ import sh.measure.android.tracing.InternalTrace
 internal class NetworkStateAttributeProcessor(
     private val networkStateProvider: NetworkStateProvider,
 ) : AttributeProcessor {
-    private val networkProviderUnknown = "unknown"
     private var networkType: String = NetworkType.UNKNOWN
     private var networkGeneration: String = NetworkGeneration.UNKNOWN
-    private var networkProviderName: String = networkProviderUnknown
+    private var networkProviderName: String = NetworkProvider.UNKNOWN
 
     override fun appendAttributes(attributes: MutableMap<String, Any?>) {
         InternalTrace.beginSection("NetworkStateAttributeProcessor.appendAttributes")
@@ -32,6 +32,6 @@ internal class NetworkStateAttributeProcessor(
         val networkState = networkStateProvider.getNetworkState()
         networkType = networkState?.networkType ?: NetworkType.UNKNOWN
         networkGeneration = networkState?.networkGeneration ?: NetworkGeneration.UNKNOWN
-        networkProviderName = networkState?.networkProvider ?: networkProviderUnknown
+        networkProviderName = networkState?.networkProvider ?: NetworkProvider.UNKNOWN
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangeData.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangeData.kt
@@ -8,7 +8,7 @@ internal data class NetworkChangeData(
      * The [NetworkType] of the network that was previously active. This is null if there was no
      * previously active network.
      */
-    val previous_network_type: String?,
+    val previous_network_type: String,
 
     /**
      * The [NetworkType] of the network that is now active.
@@ -19,15 +19,15 @@ internal data class NetworkChangeData(
      * The [NetworkGeneration] of the network that was previously active. Only set for cellular
      * networks.
      */
-    val previous_network_generation: String?,
+    val previous_network_generation: String,
 
     /**
      * The [NetworkGeneration] of the network that is now active.
      */
-    val network_generation: String?,
+    val network_generation: String,
 
     /**
      * The name of the network provider that is now active. Only set for cellular networks.
      */
-    val network_provider: String?,
+    val network_provider: String,
 )

--- a/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangesCollector.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangesCollector.kt
@@ -52,8 +52,8 @@ internal class NetworkChangesCollector(
     private val timeProvider: TimeProvider,
     private val networkStateProvider: NetworkStateProvider,
 ) {
-    private var currentNetworkType: String? = null
-    private var currentNetworkGeneration: String? = null
+    private var currentNetworkType: String = NetworkType.UNKNOWN
+    private var currentNetworkGeneration: String = NetworkGeneration.UNKNOWN
     private val telephonyManager: TelephonyManager? by lazy(mode = LazyThreadSafetyMode.NONE) {
         systemServiceProvider.telephonyManager
     }
@@ -108,8 +108,9 @@ internal class NetworkChangesCollector(
             val newNetworkType = getNetworkType(networkCapabilities)
             val previousNetworkType = currentNetworkType
             val previousNetworkGeneration = currentNetworkGeneration
-            val newNetworkGeneration = getNetworkGenerationIfAvailable(newNetworkType)
-            val networkProvider = getNetworkOperatorName(newNetworkType)
+            val newNetworkGeneration =
+                getNetworkGenerationIfAvailable(newNetworkType) ?: NetworkGeneration.UNKNOWN
+            val networkProvider = getNetworkOperatorName(newNetworkType) ?: NetworkProvider.UNKNOWN
             networkStateProvider.setNetworkState(
                 NetworkState(newNetworkType, newNetworkGeneration, networkProvider),
             )
@@ -119,7 +120,7 @@ internal class NetworkChangesCollector(
             // This also means, the first change event will contain non-null previous states
             // for Android O+.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                if (currentNetworkType == null) {
+                if (currentNetworkType == NetworkType.UNKNOWN) {
                     currentNetworkType = newNetworkType
                     currentNetworkGeneration = newNetworkGeneration
                     return
@@ -157,7 +158,7 @@ internal class NetworkChangesCollector(
             val previousNetworkGeneration = currentNetworkGeneration
             val newNetworkType = NetworkType.NO_NETWORK
             networkStateProvider.setNetworkState(
-                NetworkState(newNetworkType, null, null),
+                NetworkState(newNetworkType, NetworkGeneration.UNKNOWN, NetworkProvider.UNKNOWN),
             )
             if (previousNetworkType == newNetworkType) {
                 return
@@ -169,12 +170,12 @@ internal class NetworkChangesCollector(
                     previous_network_type = previousNetworkType,
                     network_type = newNetworkType,
                     previous_network_generation = previousNetworkGeneration,
-                    network_generation = null,
-                    network_provider = null,
+                    network_generation = NetworkGeneration.UNKNOWN,
+                    network_provider = NetworkGeneration.UNKNOWN,
                 ),
             )
             currentNetworkType = newNetworkType
-            currentNetworkGeneration = null
+            currentNetworkGeneration = NetworkGeneration.UNKNOWN
         }
     }
 

--- a/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkState.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkState.kt
@@ -2,6 +2,6 @@ package sh.measure.android.networkchange
 
 internal data class NetworkState(
     val networkType: String,
-    val networkGeneration: String?,
-    val networkProvider: String?,
+    val networkGeneration: String,
+    val networkProvider: String,
 )

--- a/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkStateProviderImpl.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkStateProviderImpl.kt
@@ -27,8 +27,8 @@ internal class NetworkStateProviderImpl(
 
     fun init() {
         initialNetworkStateProvider.getNetworkType()?.let {
-            val networkGen = initialNetworkStateProvider.getNetworkGeneration(it)
-            val networkProvider = initialNetworkStateProvider.getNetworkProvider(it)
+            val networkGen = initialNetworkStateProvider.getNetworkGeneration(it) ?: NetworkGeneration.UNKNOWN
+            val networkProvider = initialNetworkStateProvider.getNetworkProvider(it) ?: "unknown"
             networkState = NetworkState(it, networkGen, networkProvider)
         }
     }

--- a/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkType.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/networkchange/NetworkType.kt
@@ -15,3 +15,7 @@ internal object NetworkGeneration {
     const val FIFTH_GEN = "5g"
     const val UNKNOWN = "unknown"
 }
+
+internal object NetworkProvider {
+    const val UNKNOWN = "unknown"
+}

--- a/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeEventFactory.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeEventFactory.kt
@@ -20,6 +20,7 @@ import sh.measure.android.lifecycle.FragmentLifecycleData
 import sh.measure.android.lifecycle.FragmentLifecycleType
 import sh.measure.android.navigation.NavigationData
 import sh.measure.android.networkchange.NetworkChangeData
+import sh.measure.android.networkchange.NetworkGeneration
 import sh.measure.android.okhttp.HttpData
 import sh.measure.android.performance.CpuUsageData
 import sh.measure.android.performance.LowMemoryData
@@ -180,11 +181,11 @@ internal object FakeEventFactory {
     }
 
     fun getNetworkChangeData(
-        previousNetworkType: String? = "cellular",
+        previousNetworkType: String = "cellular",
         networkType: String = "wifi",
-        previousNetworkGeneration: String? = "2g",
-        networkGeneration: String? = null,
-        networkProvider: String? = "t-mobile",
+        previousNetworkGeneration: String = "2g",
+        networkGeneration: String = NetworkGeneration.UNKNOWN,
+        networkProvider: String = "t-mobile",
     ): NetworkChangeData {
         return NetworkChangeData(
             previousNetworkType,

--- a/measure-android/measure/src/test/java/sh/measure/android/networkchange/NetworkChangesCollectorTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/networkchange/NetworkChangesCollectorTest.kt
@@ -103,7 +103,7 @@ class NetworkChangesCollectorTest {
         shadowOf(context as Application).grantPermissions(Manifest.permission.READ_PHONE_STATE)
         shadowOf(telephonyManager).setNetworkOperatorName("Test Provider")
         setNetworkTypeInTelephonyManager(networkType = TelephonyManager.NETWORK_TYPE_NR)
-        var previousNetworkType: String? = null
+        var previousNetworkType: String = NetworkType.UNKNOWN
 
         NetworkChangesCollector(
             context = context,
@@ -127,7 +127,7 @@ class NetworkChangesCollectorTest {
             data = NetworkChangeData(
                 previous_network_type = previousNetworkType,
                 network_type = NetworkType.CELLULAR,
-                previous_network_generation = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
                 network_generation = NetworkGeneration.FIFTH_GEN,
                 network_provider = "Test Provider",
             ),
@@ -156,10 +156,10 @@ class NetworkChangesCollectorTest {
             type = EventType.NETWORK_CHANGE,
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
             data = NetworkChangeData(
-                previous_network_type = null,
+                previous_network_type = NetworkType.UNKNOWN,
                 network_type = NetworkType.CELLULAR,
-                previous_network_generation = null,
-                network_generation = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
+                network_generation = NetworkGeneration.UNKNOWN,
                 network_provider = "Test Provider",
             ),
         )
@@ -193,7 +193,7 @@ class NetworkChangesCollectorTest {
             data = NetworkChangeData(
                 previous_network_type = NetworkType.WIFI,
                 network_type = NetworkType.CELLULAR,
-                previous_network_generation = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
                 network_generation = NetworkGeneration.FIFTH_GEN,
                 network_provider = "Test Provider",
             ),
@@ -244,8 +244,8 @@ class NetworkChangesCollectorTest {
         verify(networkStateProvider).setNetworkState(
             NetworkState(
                 networkType = NetworkType.WIFI,
-                networkGeneration = null,
-                networkProvider = null,
+                networkGeneration = NetworkGeneration.UNKNOWN,
+                networkProvider = NetworkProvider.UNKNOWN,
             ),
         )
 
@@ -279,11 +279,11 @@ class NetworkChangesCollectorTest {
             type = EventType.NETWORK_CHANGE,
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
             data = NetworkChangeData(
-                previous_network_type = null,
+                previous_network_type = NetworkGeneration.UNKNOWN,
                 network_type = NetworkType.WIFI,
-                previous_network_generation = null,
-                network_generation = null,
-                network_provider = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
+                network_generation = NetworkGeneration.UNKNOWN,
+                network_provider = NetworkProvider.UNKNOWN,
             ),
         )
     }
@@ -428,11 +428,11 @@ class NetworkChangesCollectorTest {
             type = EventType.NETWORK_CHANGE,
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
             data = NetworkChangeData(
-                previous_network_type = null,
+                previous_network_type = NetworkType.UNKNOWN,
                 network_type = NetworkType.VPN,
-                previous_network_generation = null,
-                network_generation = null,
-                network_provider = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
+                network_generation = NetworkGeneration.UNKNOWN,
+                network_provider = NetworkProvider.UNKNOWN,
             ),
         )
     }
@@ -460,11 +460,11 @@ class NetworkChangesCollectorTest {
             type = EventType.NETWORK_CHANGE,
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
             data = NetworkChangeData(
-                previous_network_type = null,
+                previous_network_type = NetworkType.UNKNOWN,
                 network_type = NetworkType.NO_NETWORK,
-                previous_network_generation = null,
-                network_generation = null,
-                network_provider = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
+                network_generation = NetworkGeneration.UNKNOWN,
+                network_provider = NetworkProvider.UNKNOWN,
             ),
         )
     }
@@ -491,8 +491,8 @@ class NetworkChangesCollectorTest {
         verify(networkStateCache).setNetworkState(
             NetworkState(
                 networkType = NetworkType.NO_NETWORK,
-                networkGeneration = null,
-                networkProvider = null,
+                networkGeneration = NetworkGeneration.UNKNOWN,
+                networkProvider = NetworkProvider.UNKNOWN,
             ),
         )
     }
@@ -523,9 +523,9 @@ class NetworkChangesCollectorTest {
             type = EventType.NETWORK_CHANGE,
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
             data = NetworkChangeData(
-                previous_network_type = null,
+                previous_network_type = NetworkType.UNKNOWN,
                 network_type = NetworkType.CELLULAR,
-                previous_network_generation = null,
+                previous_network_generation = NetworkGeneration.UNKNOWN,
                 network_generation = NetworkGeneration.FIFTH_GEN,
                 network_provider = "Test Provider",
             ),


### PR DESCRIPTION
Use "unknown" instead of null for network attributes: network provider, network type and network generation instead of null. This makes it clearer about the state of network in the backend and on the dashboard.

closes: #656 