### PR TITLE
chore(backend): upgrade clickhouse docker image

### DIFF
--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
   clickhouse:
     container_name: clickhouse
-    image: clickhouse/clickhouse-server:23
+    image: clickhouse/clickhouse-server:24
     ports:
       - "9000:9000/tcp"
       - "8123:8123"


### PR DESCRIPTION
## Summary

- [x] Upgrade docker image to clickhouse:24

Refer to [release notes](https://clickhouse.com/docs/en/whats-new/changelog#-clickhouse-release-245-2024-05-30) of Clickhouse v24