### PR TITLE
chore(backend): update symbolicator-retrace docker

### DIFF
--- a/measure-backend/symbolicator-retrace/Dockerfile
+++ b/measure-backend/symbolicator-retrace/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle buildFatJar --no-daemon
+RUN --mount=type=cache,target=/root/.gradle gradle buildFatJar --no-daemon
 
 FROM eclipse-temurin:17
 EXPOSE 8181:8181


### PR DESCRIPTION
## Summary

- [x] Add build cache for symbolicator-retrace dockerfile

## Details

Added a docker build cache for speeding up subsequent gradle fatjar builds in symbolicator-retrace's dockerfile.