### PR TITLE
fix(android): use scheduleWithFixedDelay instead of scheduleWithFixedRate

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
@@ -39,6 +39,6 @@ internal class MeasureExecutorServiceImpl @TestOnly constructor(private val exec
         delayMillis: Long,
         delayUnit: TimeUnit,
     ): Future<*> {
-        return executorService.scheduleAtFixedRate(runnable, initialDelay, delayMillis, delayUnit)
+        return executorService.scheduleWithFixedDelay(runnable, initialDelay, delayMillis, delayUnit)
     }
 }


### PR DESCRIPTION
Fixes the lint warning:
Use of `scheduleAtFixedRate` is strongly discouraged because it can lead to unexpected behavior when Android processes become cached (tasks may unexpectedly execute hundreds or thousands of times in quick succession when a process changes from cached to uncached); prefer using `scheduleWithFixedDelay`.