### PR TITLE
fix(backend): metrics api sometimes returns 500

### DIFF
--- a/measure-backend/measure-go/measure/app.go
+++ b/measure-backend/measure-go/measure/app.go
@@ -216,7 +216,11 @@ func (a App) GetSizeMetrics(ctx context.Context, af *filter.AppFilter) (size *me
 
 	ctx = context.Background()
 	if err := server.Server.PgPool.QueryRow(ctx, sizeStmt.String(), args...).Scan(&size.AverageAppSize, &size.SelectedAppSize, &size.Delta); err != nil {
-		return nil, err
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
 	}
 
 	return


### PR DESCRIPTION
## Summary

- [x] Fix a condition where metrics api could incorrectly return a 500 when build sizes do not exist for an app

fixes #764