### PR TITLE
fix(backend): fix network type validation

### DIFF
--- a/measure-backend/measure-go/event/event.go
+++ b/measure-backend/measure-go/event/event.go
@@ -80,6 +80,7 @@ const NetworkGenerationUnknown = "unknown"
 const NetworkTypeCellular = "cellular"
 const NetworkTypeWifi = "wifi"
 const NetworkTypeVpn = "vpn"
+const NetworkTypeNoNetwork = "no_network"
 const NetworkTypeUnknown = "unknown"
 
 const LifecycleActivityTypeCreated = "created"
@@ -130,6 +131,7 @@ var ValidNetworkTypes = []string{
 	NetworkTypeCellular,
 	NetworkTypeWifi,
 	NetworkTypeVpn,
+	NetworkTypeNoNetwork,
 	NetworkTypeUnknown,
 }
 

--- a/self-host/clickhouse/20231117020810_create-events-table.sql
+++ b/self-host/clickhouse/20231117020810_create-events-table.sql
@@ -31,7 +31,7 @@ create table if not exists default.events
   `attribute.os_name` FixedString(32) comment 'name of the operating system',
   `attribute.os_version` FixedString(32) comment 'version of the operating system',
   `attribute.network_type` LowCardinality(FixedString(16)) comment 'either - wifi, cellular, vpn, unknown, no_network',
-  `attribute.network_generation` LowCardinality(FixedString(8)) comment 'either - 2g, 3g, 4g, 5g',
+  `attribute.network_generation` LowCardinality(FixedString(8)) comment 'either - 2g, 3g, 4g, 5g, unknown',
   `attribute.network_provider` FixedString(64) comment 'name of the network service provider',
   `anr.handled` Bool comment 'anr was handled by the application code',
   `anr.fingerprint` FixedString(16) comment 'fingerprint for anr similarity classification',


### PR DESCRIPTION
# Summary 

#726 introduced two issues which are fixed as part of this PR:
1. The `network_type` validation ignored `no_network` due to which ingestion of events failed
2. A comment was added directly to `clickhouse/schema.sql` instead of to the migration file.

Change is tested by ingesting all events using sessionator.