### PR TITLE
fix(backend): journey graph build crash

### DIFF
--- a/measure-backend/measure-go/journey/journey.go
+++ b/measure-backend/measure-go/journey/journey.go
@@ -207,12 +207,22 @@ func (j *JourneyAndroid) computeIssues() {
 // journey.
 func (j *JourneyAndroid) buildGraph() {
 	j.Graph = graph.New(len(j.nodelut))
+
 	if j.metalut == nil {
 		j.metalut = make(map[string]*set.UUIDSet)
 	}
+
 	lastActivity := -1
 
+	var nodeidxs []int
+
 	for i := range j.Nodes {
+		if j.Nodes[i].IsActivity || j.Nodes[i].IsFragment {
+			nodeidxs = append(nodeidxs, i)
+		}
+	}
+
+	for _, i := range nodeidxs {
 		first := i == 0
 		last := i == len(j.Nodes)-1
 
@@ -542,7 +552,6 @@ func NewJourneyAndroid(events []event.EventField, opts *Options) (journey Journe
 				journey.nodelutinverse[vertex] = node.Name
 			}
 		}
-
 	}
 
 	journey.computeIssues()


### PR DESCRIPTION
## Summary

- [x] Fix an issue where while building journey graph, sometimes non-activity & non-fragment nodes were mistakenly being used.

fixes #789