### PR TITLE
fix(webapp): use slices tooltips for exceptions plots

### DIFF
--- a/measure-web-app/app/components/exceptions_details_plot.tsx
+++ b/measure-web-app/app/components/exceptions_details_plot.tsx
@@ -142,11 +142,18 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ appId, ex
               symbolBorderColor: 'rgba(0, 0, 0, .5)',
             }
           ]}
-          tooltip={({ point }) => {
+          enableSlices="x"
+          sliceTooltip={({ slice }) => {
             return (
-              <div className='bg-neutral-950 text-white flex flex-col p-2 text-xs'>
-                <p>Date: {formatDateToHumanReadable(point.data.xFormatted.toString())}</p>
-                <p>No of {exceptionsType === ExceptionsType.Crash ? 'Crashes' : 'ANRs'}: {point.data.y.toString()}</p>
+              <div className="bg-neutral-950 text-white flex flex-col p-2 text-xs">
+                <p className='p-2'>Date: {formatDateToHumanReadable(slice.points[0].data.xFormatted.toString())}</p>
+                {slice.points.map((point) => (
+                  <div className="flex flex-row items-center p-2" key={point.id}>
+                    <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />
+                    <div className="px-2" />
+                    <p>{point.data.y.toString()} {point.data.y.valueOf() as number > 1 ? 'instances' : 'instance'}</p>
+                  </div>
+                ))}
               </div>
             )
           }}

--- a/measure-web-app/app/components/exceptions_overview_plot.tsx
+++ b/measure-web-app/app/components/exceptions_overview_plot.tsx
@@ -150,12 +150,18 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ appId, 
               symbolBorderColor: 'rgba(0, 0, 0, .5)',
             }
           ]}
-          tooltip={({ point }) => {
+          enableSlices="x"
+          sliceTooltip={({ slice }) => {
             return (
-              <div className='bg-neutral-950 text-white flex flex-col p-2 text-xs'>
-                <p>Date: {formatDateToHumanReadable(point.data.xFormatted.toString())}</p>
-                <p>{exceptionsType === ExceptionsType.Crash ? 'Crash' : 'ANR'} free sessions: {point.data.yFormatted}%</p>
-                <p>No of {exceptionsType === ExceptionsType.Crash ? 'Crashes' : 'ANRs'}: {pointIdToInstanceMap.get(point.id)}</p>
+              <div className="bg-neutral-950 text-white flex flex-col p-2 text-xs">
+                <p className='p-2'>Date: {formatDateToHumanReadable(slice.points[0].data.xFormatted.toString())}</p>
+                {slice.points.map((point) => (
+                  <div className="flex flex-row items-center p-2" key={point.id}>
+                    <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />
+                    <div className="px-2" />
+                    <p>{point.data.yFormatted}% {exceptionsType === ExceptionsType.Crash ? 'Crash' : 'ANR'} free sessions, {pointIdToInstanceMap.get(point.id)} {exceptionsType === ExceptionsType.Crash ? (pointIdToInstanceMap.get(point.id)! > 1 ? 'Crashes' : 'Crash') : (pointIdToInstanceMap.get(point.id)! > 1 ? 'ANRs' : 'ANR')} </p>
+                  </div>
+                ))}
               </div>
             )
           }}


### PR DESCRIPTION
point tooltips don't work in case of overlapping points since only the top point is visible. Slices tooltips show values for all points in a slice solving this issue.

fixes #808