### PR TITLE
chore(backend): change docker registry

### DIFF
--- a/measure-backend/measure-go/Dockerfile
+++ b/measure-backend/measure-go/Dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM golang:alpine AS builder
+FROM public.ecr.aws/docker/library/golang:alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /go/src/app
 COPY go.mod go.sum ./
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go build -o /go/bin/app -v .
 
 #final stage
-FROM alpine:latest
+FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app
 ENTRYPOINT /app

--- a/measure-backend/symbolicator-retrace/Dockerfile
+++ b/measure-backend/symbolicator-retrace/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:8-jdk17 AS build
+FROM public.ecr.aws/docker/library/gradle:8-jdk17 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN --mount=type=cache,target=/root/.gradle gradle buildFatJar --no-daemon
 
-FROM eclipse-temurin:17
+FROM public.ecr.aws/docker/library/eclipse-temurin:17
 EXPOSE 8181:8181
 RUN mkdir /app
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/app.jar


### PR DESCRIPTION
## Summary

Use AWS public docker registry (public.ecr.aws) for pulling images. The default docker hub registry is throwing 503 Service Unavailable errors for some reason. We don't need to depend on docker hub, we can use any of the other publicly available popular registry.

## Tasks

- [x] Use aws ecr public registry to pull docker images