### PR TITLE
fix(backend): exception overview mismatch

### DIFF
--- a/measure-backend/measure-go/measure/event.go
+++ b/measure-backend/measure-go/measure/event.go
@@ -386,7 +386,7 @@ func (e eventreq) bucketANRs(ctx context.Context, tx *pgx.Tx) (err error) {
 			continue
 		}
 
-		anrGroups, err := app.GetANRGroups(ctx, nil)
+		anrGroups, err := app.GetANRGroups(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Avoid applying any limit when querying an app's exception groups and let filtering on 
exception events drive the filtering

## Tasks

- [x] :hammer_and_pick: Remove filter in app's exception groups query
- [x] :hammer_and_pick: Remove filter in app's ANR groups query

## Context

For more context, see.

- #819