### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # node/bun
 node_modules
+
+# vscode multi-root workspace
+*.code-workspace


### PR DESCRIPTION
## Summary

VSCode's [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) feature is useful when working with monorepos. This PR ignores the `.code-workspace` file extension so that contributors may choose to maintain their local copies of the project however they see fit.

## Tasks

- [x] Add vscode mult-root workspace file