### PR TITLE
ci(android): run publish only for releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -108,6 +108,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_ARTIFACT_SIGNING_PASSWORD }}
   publish-android-gradle:
     runs-on: ubuntu-latest
+    needs: [ checks ]
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/measure-android-') && !startsWith(github.ref, 'refs/tags/measure-android-gradle-')
     defaults:
       run:
         working-directory: measure-android


### PR DESCRIPTION
* Fixes a issue introduced in #862 which made publish measure-android-gradle task to run all the time.