### PR TITLE
refactor(android): improve config usage

### DIFF
--- a/measure-android/measure/api/measure.api
+++ b/measure-android/measure/api/measure.api
@@ -25,21 +25,8 @@ public final class sh/measure/android/config/MeasureConfig : sh/measure/android/
 	public fun <init> ()V
 	public fun <init> (ZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Z)V
 	public synthetic fun <init> (ZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getDefaultHttpHeadersBlocklist ()Ljava/util/List;
-	public fun getDefaultHttpUrlBlocklist ()Ljava/util/List;
-	public fun getDefaultMaxUserDefinedAttributeKeyLength ()I
-	public fun getDefaultMaxUserDefinedAttributeValueLength ()I
-	public fun getDefaultSessionEndThresholdMs ()J
-	public fun getDefaultSessionsTableTtlMs ()J
-	public fun getDefaultUserDefinedAttributeKeyWithSpaces ()Z
-	public fun getEventsBatchingIntervalMs ()J
-	public fun getHttpContentTypeAllowlist ()Ljava/util/List;
 	public fun getHttpHeadersBlocklist ()Ljava/util/List;
 	public fun getHttpUrlBlocklist ()Ljava/util/List;
-	public fun getMaxAttachmentSizeInEventsBatchInBytes ()I
-	public fun getMaxEventsInBatch ()I
-	public fun getScreenshotCompressionQuality ()I
-	public fun getScreenshotMaskHexColor ()Ljava/lang/String;
 	public fun getScreenshotMaskLevel ()Lsh/measure/android/config/ScreenshotMaskLevel;
 	public fun getTrackActivityIntentData ()Z
 	public fun getTrackHttpBody ()Z

--- a/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -40,7 +40,7 @@ object Measure {
     fun init(context: Context, measureConfig: MeasureConfig = MeasureConfig()) {
         if (isInitialized.compareAndSet(false, true)) {
             val application = context.applicationContext as Application
-            val initializer = MeasureInitializerImpl(application, defaultConfig = measureConfig)
+            val initializer = MeasureInitializerImpl(application, inputConfig = measureConfig)
             measure = MeasureInternal(initializer)
             measure.init()
         }

--- a/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -14,6 +14,7 @@ import sh.measure.android.attributes.NetworkStateAttributeProcessor
 import sh.measure.android.attributes.UserAttributeProcessor
 import sh.measure.android.attributes.UserDefinedAttribute
 import sh.measure.android.attributes.UserDefinedAttributeImpl
+import sh.measure.android.config.Config
 import sh.measure.android.config.ConfigLoaderImpl
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.config.ConfigProviderImpl
@@ -91,7 +92,7 @@ import sh.measure.android.utils.UUIDProvider
 
 internal class MeasureInitializerImpl(
     private val application: Application,
-    private val defaultConfig: MeasureConfig,
+    inputConfig: MeasureConfig,
     override val logger: Logger = AndroidLogger(),
     override val timeProvider: TimeProvider = AndroidTimeProvider(),
     private val executorServiceRegistry: ExecutorServiceRegistry = ExecutorServiceRegistryImpl(),
@@ -106,7 +107,15 @@ internal class MeasureInitializerImpl(
         fileStorage = fileStorage,
     ),
     override val configProvider: ConfigProvider = ConfigProviderImpl(
-        defaultConfig = defaultConfig,
+        defaultConfig = Config(
+            trackScreenshotOnCrash = inputConfig.trackScreenshotOnCrash,
+            screenshotMaskLevel = inputConfig.screenshotMaskLevel,
+            trackHttpHeaders = inputConfig.trackHttpHeaders,
+            trackHttpBody = inputConfig.trackHttpBody,
+            httpHeadersBlocklist = inputConfig.httpHeadersBlocklist,
+            httpUrlBlocklist = inputConfig.httpUrlBlocklist,
+            trackActivityIntentData = inputConfig.trackActivityIntentData,
+        ),
         configLoader = ConfigLoaderImpl(),
     ),
     private val idProvider: IdProvider = UUIDProvider(),

--- a/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -35,6 +35,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) :
     private val periodicEventExporter by lazy { measureInitializer.periodicEventExporter }
     private val userAttributeProcessor by lazy { measureInitializer.userAttributeProcessor }
     private val userDefinedAttribute by lazy { measureInitializer.userDefinedAttribute }
+    private val configProvider by lazy { measureInitializer.configProvider }
 
     fun init() {
         logger.log(LogLevel.Debug, "Starting Measure SDK")
@@ -54,6 +55,9 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) :
                 )
                 return
             }
+            // This is not very elegant, but can't find a better way to do this given the way the
+            // SDK is initialized.
+            configProvider.setMeasureUrl(it.url)
             networkClient.init(baseUrl = it.url, apiKey = it.apiKey)
         }
         registerCollectors()

--- a/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -49,7 +49,7 @@ internal interface SessionManager {
  * Manages creation of sessions.
  *
  * A new session is created when [getSessionId] is first called. A session ends when the app comes
- * back to foreground after being in background for more than [ConfigProvider.defaultSessionEndThresholdMs].
+ * back to foreground after being in background for more than [ConfigProvider.sessionEndThresholdMs].
  */
 internal class SessionManagerImpl(
     private val logger: Logger,
@@ -91,7 +91,7 @@ internal class SessionManagerImpl(
     // clear up resources associated with a session in future or take any other action.
     private fun endSessionIfNeeded() {
         val durationInBackground = timeProvider.uptimeInMillis - appBackgroundedUptimeMs
-        if (durationInBackground >= configProvider.defaultSessionEndThresholdMs) {
+        if (durationInBackground >= configProvider.sessionEndThresholdMs) {
             logger.log(
                 LogLevel.Debug,
                 "Ending session as app was relaunched after being in background for $durationInBackground ms",
@@ -103,7 +103,7 @@ internal class SessionManagerImpl(
     override fun clearOldSessions() {
         ioExecutor.submit {
             val clearUpToTimeSinceEpoch =
-                timeProvider.currentTimeSinceEpochInMillis - configProvider.defaultSessionsTableTtlMs
+                timeProvider.currentTimeSinceEpochInMillis - configProvider.sessionsTableTtlMs
             database.clearOldSessions(clearUpToTimeSinceEpoch)
         }
     }

--- a/measure-android/measure/src/main/java/sh/measure/android/attributes/UserDefinedAttribute.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/attributes/UserDefinedAttribute.kt
@@ -96,10 +96,10 @@ internal class UserDefinedAttributeImpl(
     }
 
     private fun validateKey(key: String): Boolean {
-        if (key.length > configProvider.defaultMaxUserDefinedAttributeKeyLength) {
+        if (key.length > configProvider.maxUserDefinedAttributeKeyLength) {
             logger.log(
                 LogLevel.Warning,
-                "Attribute key: $key length is longer than the maximum allowed length of ${configProvider.defaultMaxUserDefinedAttributeKeyLength}. This attribute will be dropped.",
+                "Attribute key: $key length is longer than the maximum allowed length of ${configProvider.maxUserDefinedAttributeKeyLength}. This attribute will be dropped.",
             )
             return false
         } else if (!key.isLowerCase()) {
@@ -120,10 +120,10 @@ internal class UserDefinedAttributeImpl(
 
     private fun validateValue(value: Any?): Boolean {
         if (value is String) {
-            if (value.length > configProvider.defaultMaxUserDefinedAttributeValueLength) {
+            if (value.length > configProvider.maxUserDefinedAttributeValueLength) {
                 logger.log(
                     LogLevel.Warning,
-                    "Attribute value: $value length is longer than the maximum allowed length of ${configProvider.defaultMaxUserDefinedAttributeValueLength}. This attribute will be dropped.",
+                    "Attribute value: $value length is longer than the maximum allowed length of ${configProvider.maxUserDefinedAttributeValueLength}. This attribute will be dropped.",
                 )
                 return false
             }

--- a/measure-android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -1,0 +1,31 @@
+package sh.measure.android.config
+
+internal data class Config(
+    override val trackScreenshotOnCrash: Boolean = DefaultConfig.TRACK_SCREENSHOT_ON_CRASH,
+    override val screenshotMaskLevel: ScreenshotMaskLevel = DefaultConfig.SCREENSHOT_MASK_LEVEL,
+    override val trackHttpHeaders: Boolean = DefaultConfig.TRACK_HTTP_HEADERS,
+    override val trackHttpBody: Boolean = DefaultConfig.TRACK_HTTP_BODY,
+    override val httpHeadersBlocklist: List<String> = DefaultConfig.HTTP_HEADERS_BLOCKLIST,
+    override val httpUrlBlocklist: List<String> = DefaultConfig.HTTP_URL_BLOCKLIST,
+    override val trackActivityIntentData: Boolean = DefaultConfig.TRACK_ACTIVITY_INTENT_DATA,
+) : InternalConfig, IMeasureConfig {
+    override val screenshotMaskHexColor: String = "#222222"
+    override val screenshotCompressionQuality: Int = 25
+    override val maxAttachmentSizeInEventsBatchInBytes: Int = 3_000_000 // 3 MB
+    override val eventsBatchingIntervalMs: Long = 30_000 // 30 seconds
+    override val maxEventsInBatch: Int = 500
+    override val httpContentTypeAllowlist: List<String> = listOf("application/json")
+    override val defaultHttpHeadersBlocklist: List<String> = listOf(
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "Proxy-Authorization",
+        "WWW-Authenticate",
+        "X-Api-Key",
+    )
+    override val sessionsTableTtlMs: Long = 15 * 24 * 60 * 60 * 1000 // 15 days
+    override val sessionEndThresholdMs: Long = 60 * 1000 // 1 minute
+    override val maxUserDefinedAttributeKeyLength: Int = 64 // 64 chars
+    override val maxUserDefinedAttributeValueLength: Int = 256 // 256 chars
+    override val userDefinedAttributeKeyWithSpaces: Boolean = false
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
@@ -5,22 +5,22 @@ internal interface ConfigLoader {
      * Returns the cached config synchronously, if available. Returns `null` if cached config is
      * unavailable or failed to load.
      */
-    fun getCachedConfig(): MeasureConfig?
+    fun getCachedConfig(): Config?
 
     /**
      * Fetches a fresh config from the server asynchronously and calls [onSuccess] with the result,
      * if successful. Ignores the result if the fetch fails.
      */
-    fun getNetworkConfig(onSuccess: (MeasureConfig) -> Unit)
+    fun getNetworkConfig(onSuccess: (Config) -> Unit)
 }
 
 internal class ConfigLoaderImpl : ConfigLoader {
-    override fun getCachedConfig(): MeasureConfig? {
+    override fun getCachedConfig(): Config? {
         // TODO:  Load the cached config from disk.
         return null
     }
 
-    override fun getNetworkConfig(onSuccess: (MeasureConfig) -> Unit) {
+    override fun getNetworkConfig(onSuccess: (Config) -> Unit) {
         // TODO: fetch the config from the server, write it to disk and call onSuccess.
     }
 }

--- a/measure-android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
@@ -1,0 +1,11 @@
+package sh.measure.android.config
+
+internal object DefaultConfig {
+    const val TRACK_SCREENSHOT_ON_CRASH: Boolean = false
+    val SCREENSHOT_MASK_LEVEL: ScreenshotMaskLevel = ScreenshotMaskLevel.AllTextAndMedia
+    const val TRACK_HTTP_HEADERS: Boolean = false
+    const val TRACK_HTTP_BODY: Boolean = false
+    val HTTP_HEADERS_BLOCKLIST: List<String> = emptyList()
+    val HTTP_URL_BLOCKLIST: List<String> = emptyList()
+    const val TRACK_ACTIVITY_INTENT_DATA: Boolean = false
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -1,0 +1,66 @@
+package sh.measure.android.config
+
+internal interface InternalConfig {
+    /**
+     * The maximum size of attachments allowed in a single batch. Defaults to 3MB
+     */
+    val maxAttachmentSizeInEventsBatchInBytes: Int
+
+    /**
+     * The interval at which to create a batch for export.
+     */
+    val eventsBatchingIntervalMs: Long
+
+    /**
+     * The maximum number of events to export in /events API. Defaults to 500.
+     */
+    val maxEventsInBatch: Int
+
+    /**
+     * When `httpBodyCapture` is enabled, this determines whether to capture the body or not based
+     * on the content type of the request/response. Defaults to `application/json`.
+     */
+    val httpContentTypeAllowlist: List<String>
+
+    /**
+     * Default list of HTTP headers to not capture for network request and response.
+     */
+    val defaultHttpHeadersBlocklist: List<String>
+
+    /* The TTL for data in the sessions table after which it will be cleared. Defaults to
+     * 15 days.
+     */
+    val sessionsTableTtlMs: Long
+
+    /**
+     * The threshold after which a session is considered ended. Defaults to 1 minute.
+     */
+    val sessionEndThresholdMs: Long
+
+    /**
+     * The maximum length of user defined attribute key. Defaults to 64 chars.
+     */
+    val maxUserDefinedAttributeKeyLength: Int
+
+    /**
+     * The maximum length of a user defined attribute value. Defaults to 256 chars.
+     */
+    val maxUserDefinedAttributeValueLength: Int
+
+    /**
+     * Whether user defined attribute keys can have spaces or not. Defaults to `false`.
+     */
+    val userDefinedAttributeKeyWithSpaces: Boolean
+
+    /**
+     * The color of the mask to apply to the screenshot. The value should be a hex color string.
+     * For example, "#222222".
+     */
+    val screenshotMaskHexColor: String
+
+    /**
+     * The compression quality of the screenshot. Must be between 0 and 100, where 0 is lowest quality
+     * and smallest size while 100 is highest quality and largest size.
+     */
+    val screenshotCompressionQuality: Int
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
@@ -1,61 +1,63 @@
 package sh.measure.android.config
 
 /**
- * Defines all the configuration options for the Measure SDK.
+ * Configuration for the Measure SDK. See [MeasureConfig] for details.
  */
 internal interface IMeasureConfig {
+    val trackScreenshotOnCrash: Boolean
+    val screenshotMaskLevel: ScreenshotMaskLevel
+    val trackHttpHeaders: Boolean
+    val trackHttpBody: Boolean
+    val httpHeadersBlocklist: List<String>
+    val httpUrlBlocklist: List<String>
+    val trackActivityIntentData: Boolean
+}
+
+/**
+ * Configuration options for the Measure SDK. Used to customize the behavior of the SDK on
+ * initialization.
+ */
+class MeasureConfig(
     /**
      * Whether to capture a screenshot of the app when it crashes due to an unhandled exception or
      * ANR. Defaults to `true`.
      */
-    val trackScreenshotOnCrash: Boolean
+    override val trackScreenshotOnCrash: Boolean = DefaultConfig.TRACK_SCREENSHOT_ON_CRASH,
 
     /**
      * Allows changing the masking level of screenshots to prevent sensitive information from leaking.
      * Defaults to [ScreenshotMaskLevel.AllTextAndMedia].
      */
-    val screenshotMaskLevel: ScreenshotMaskLevel
-
-    /**
-     * The color of the mask to apply to the screenshot. The value should be a hex color string.
-     * For example, "#222222".
-     */
-    val screenshotMaskHexColor: String
-
-    /**
-     * The compression quality of the screenshot. Must be between 0 and 100, where 0 is lowest quality
-     * and smallest size while 100 is highest quality and largest size.
-     */
-    val screenshotCompressionQuality: Int
+    override val screenshotMaskLevel: ScreenshotMaskLevel = DefaultConfig.SCREENSHOT_MASK_LEVEL,
 
     /**
      * Whether to capture http headers of a network request and response. Defaults to `false`.
      */
-    val trackHttpHeaders: Boolean
+    override val trackHttpHeaders: Boolean = DefaultConfig.TRACK_HTTP_HEADERS,
 
     /**
      * Whether to capture http body of a network request and response. Defaults to `false`.
      */
-    val trackHttpBody: Boolean
+    override val trackHttpBody: Boolean = DefaultConfig.TRACK_HTTP_BODY,
 
     /**
-     * List of HTTP headers to not capture for network request and response. Defaults to an empty
-     * list.
-     *
-     * Internally, this list is combined with [defaultHttpHeadersBlocklist] to form the final
-     * blocklist.
+     * List of HTTP headers to not collect with the `http` event for both request and response.
+     * Defaults to an empty list. The following headers are always excluded:
+     * * Authorization
+     * * Cookie
+     * * Set-Cookie
+     * * Proxy-Authorization
+     * * WWW-Authenticate
+     * * X-Api-Key
      */
-    val httpHeadersBlocklist: List<String>
+    override val httpHeadersBlocklist: List<String> = DefaultConfig.HTTP_HEADERS_BLOCKLIST,
 
     /**
      * Allows disabling collection of `http` events for certain URLs. This is useful to setup if you do not
-     * want to collect data for certain endpoints or third party domains. By default, Measure endpoints
-     * are always disabled.
+     * want to collect data for certain endpoints or third party domains.
      *
-     * The check is made in order of the list and uses a simple `contains` check to see if the URL
-     * contains any of the strings in the list.
-     *
-     * Internally, this list is combined with [defaultHttpUrlBlocklist] to form the final blocklist.
+     * The check is made using [String.contains] to see if the URL contains any of the strings in
+     * the list.
      *
      * Example:
      *
@@ -69,98 +71,10 @@ internal interface IMeasureConfig {
      * )
      * ```
      */
-    val httpUrlBlocklist: List<String>
+    override val httpUrlBlocklist: List<String> = DefaultConfig.HTTP_URL_BLOCKLIST,
 
     /**
-     * Whether to capture lifecycle activity intent data. Defaults to `false`.
+     * Whether to capture intent data used to launch an Activity. Defaults to `false`.
      */
-    val trackActivityIntentData: Boolean
-
-    /**
-     * The maximum size of attachments allowed in a single batch. Defaults to 3MB
-     */
-    val maxAttachmentSizeInEventsBatchInBytes: Int
-
-    /**
-     * The interval at which to create a batch for export.
-     */
-    val eventsBatchingIntervalMs: Long
-
-    /**
-     * The maximum number of events to export in /events API. Defaults to 500.
-     */
-    val maxEventsInBatch: Int
-
-    /**
-     * When `httpBodyCapture` is enabled, this determines whether to capture the body or not based
-     * on the content type of the request/response. Defaults to `application/json`.
-     */
-    val httpContentTypeAllowlist: List<String>
-
-    /**
-     * Default list of HTTP headers to not capture for network request and response.
-     */
-    val defaultHttpHeadersBlocklist: List<String>
-
-    /**
-     * Default list of HTTP URLs to not capture for network request and response.
-     */
-    val defaultHttpUrlBlocklist: List<String>
-
-    // The TTL for data in the sessions table after which it will be cleared. Defaults to
-    // 15 days.
-    val defaultSessionsTableTtlMs: Long
-
-    // The threshold after which a session is considered ended. Defaults to 1 minute.
-    val defaultSessionEndThresholdMs: Long
-
-    /**
-     * The maximum length of user defined attribute key. Defaults to 64 chars.
-     */
-    val defaultMaxUserDefinedAttributeKeyLength: Int
-
-    /**
-     * The maximum length of a user defined attribute value. Defaults to 256 chars.
-     */
-    val defaultMaxUserDefinedAttributeValueLength: Int
-
-    /**
-     * Whether user defined attribute keys can have spaces or not. Defaults to `false`.
-     */
-    val defaultUserDefinedAttributeKeyWithSpaces: Boolean
-}
-
-class MeasureConfig(
-    override val trackScreenshotOnCrash: Boolean = false,
-    override val screenshotMaskLevel: ScreenshotMaskLevel = ScreenshotMaskLevel.AllTextAndMedia,
-    override val trackHttpHeaders: Boolean = false,
-    override val trackHttpBody: Boolean = false,
-    override val httpHeadersBlocklist: List<String> = emptyList(),
-    override val httpUrlBlocklist: List<String> = emptyList(),
-    override val trackActivityIntentData: Boolean = false,
-) : IMeasureConfig {
-    override val screenshotMaskHexColor: String = "#222222"
-    override val screenshotCompressionQuality: Int = 25
-    override val maxAttachmentSizeInEventsBatchInBytes: Int = 3_000_000 // 3 MB
-    override val eventsBatchingIntervalMs: Long = 30_000 // 30 seconds
-    override val maxEventsInBatch: Int = 500
-    override val httpContentTypeAllowlist: List<String> = listOf("application/json")
-    override val defaultHttpHeadersBlocklist: List<String> = listOf(
-        "Authorization",
-        "Cookie",
-        "Set-Cookie",
-        "Proxy-Authorization",
-        "WWW-Authenticate",
-        "X-Api-Key",
-    )
-    override val defaultHttpUrlBlocklist: List<String> = listOf(
-        // TODO(abhay): review this list to block all measure API endpoints.
-        "api.measure.sh",
-        "10.0.2.2:8080/events",
-    )
-    override val defaultSessionsTableTtlMs: Long = 15 * 24 * 60 * 60 * 1000 // 15 days
-    override val defaultSessionEndThresholdMs: Long = 60 * 1000 // 1 minute
-    override val defaultMaxUserDefinedAttributeKeyLength: Int = 64 // 64 chars
-    override val defaultMaxUserDefinedAttributeValueLength: Int = 256 // 256 chars
-    override val defaultUserDefinedAttributeKeyWithSpaces: Boolean = false
-}
+    override val trackActivityIntentData: Boolean = DefaultConfig.TRACK_ACTIVITY_INTENT_DATA,
+) : IMeasureConfig

--- a/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -63,7 +63,7 @@ class SessionManagerTest {
         sessionManager.currentSessionId = initialSessionId
 
         idProvider.id = updatedSessionId
-        simulateAppRelaunch(configProvider.defaultSessionEndThresholdMs)
+        simulateAppRelaunch(configProvider.sessionEndThresholdMs)
 
         val sessionId = sessionManager.getSessionId()
         assertEquals(updatedSessionId, sessionId)
@@ -78,10 +78,10 @@ class SessionManagerTest {
 
     @Test
     fun `delegates to database to delete old sessions by calculating the time to clear up to`() {
-        val currentTime = configProvider.defaultSessionsTableTtlMs + 1000
+        val currentTime = configProvider.sessionsTableTtlMs + 1000
         timeProvider.fakeCurrentTimeSinceEpochInMillis = currentTime
         sessionManager.clearOldSessions()
-        verify(database).clearOldSessions(currentTime - configProvider.defaultSessionsTableTtlMs)
+        verify(database).clearOldSessions(currentTime - configProvider.sessionsTableTtlMs)
     }
 
     private fun simulateAppRelaunch(durationMs: Long) {

--- a/measure-android/measure/src/test/java/sh/measure/android/attributes/UserDefinedAttributeTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/attributes/UserDefinedAttributeTest.kt
@@ -78,7 +78,7 @@ class UserDefinedAttributeTest {
 
     @Test
     fun `discards attribute if key length is more than configured maximum length`() {
-        configProvider.defaultMaxUserDefinedAttributeKeyLength = 3
+        configProvider.maxUserDefinedAttributeKeyLength = 3
         userDefinedAttribute.put("key", "value1", false)
         userDefinedAttribute.put("longer-length-key", "value2", false)
 
@@ -87,7 +87,7 @@ class UserDefinedAttributeTest {
 
     @Test
     fun `discards attribute if value length is more than configured maximum length`() {
-        configProvider.defaultMaxUserDefinedAttributeValueLength = 5
+        configProvider.maxUserDefinedAttributeValueLength = 5
         userDefinedAttribute.put("key1", "value", false)
         userDefinedAttribute.put("key2", "longer-length-value", false)
 
@@ -96,7 +96,7 @@ class UserDefinedAttributeTest {
 
     @Test
     fun `discards attribute if key contains spaces`() {
-        configProvider.defaultUserDefinedAttributeKeyWithSpaces = false
+        configProvider.userDefinedAttributeKeyWithSpaces = false
         userDefinedAttribute.put("key1", "value1", false)
         userDefinedAttribute.put("key with spaces", "value2", false)
 

--- a/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -22,12 +22,11 @@ internal class FakeConfigProvider : ConfigProvider {
     override var maxEventsInBatch: Int = 100
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
-    override var defaultHttpUrlBlocklist: List<String> = emptyList()
-    override var defaultSessionsTableTtlMs: Long = 15 * 24 * 60 * 60 * 1000 // 15 days
-    override var defaultSessionEndThresholdMs: Long = 60 * 1000 // 1 minute
-    override var defaultMaxUserDefinedAttributeKeyLength: Int = 64
-    override var defaultMaxUserDefinedAttributeValueLength: Int = 256
-    override var defaultUserDefinedAttributeKeyWithSpaces: Boolean = false
+    override var sessionsTableTtlMs: Long = 15 * 24 * 60 * 60 * 1000 // 15 days
+    override var sessionEndThresholdMs: Long = 60 * 1000 // 1 minute
+    override var maxUserDefinedAttributeKeyLength: Int = 64
+    override var maxUserDefinedAttributeValueLength: Int = 256
+    override var userDefinedAttributeKeyWithSpaces: Boolean = false
 
     var shouldTrackHttpBody = false
     override fun shouldTrackHttpBody(url: String, contentType: String?): Boolean {
@@ -42,5 +41,9 @@ internal class FakeConfigProvider : ConfigProvider {
     var headerKeysToBlock = emptyList<String>()
     override fun shouldTrackHttpHeader(key: String): Boolean {
         return !headerKeysToBlock.any { key.contains(it, ignoreCase = true) }
+    }
+
+    override fun setMeasureUrl(url: String) {
+        // no-op
     }
 }


### PR DESCRIPTION
* avoid leaking internal configs in public API.
* block collection of measure APIs in `http` events.

closes #847, #852