### PR TITLE
fix(android): fix events request schema

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/exporter/NetworkClient.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exporter/NetworkClient.kt
@@ -136,5 +136,5 @@ internal fun EventPacket.asFormDataPart(fileStorage: FileStorage): String {
     } else {
         throw IllegalStateException("EventPacket must have either serializedData or serializedDataFilePath")
     }
-    return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":\"$userTriggered\",\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes}"
+    return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes}"
 }

--- a/measure-android/measure/src/test/java/sh/measure/android/exporter/NetworkClientTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/exporter/NetworkClientTest.kt
@@ -88,7 +88,7 @@ class NetworkClientTest {
         val formDataPart = eventPacket.asFormDataPart(fileStorage)
 
         val expectedData =
-            "{\"id\":\"${eventEntity.id}\",\"session_id\":\"${eventEntity.sessionId}\",\"user_triggered\":\"${eventEntity.userTriggered}\",\"timestamp\":\"${eventEntity.timestamp}\",\"type\":\"${eventEntity.type}\",\"${eventEntity.type}\":serialized-data,\"attachments\":${eventEntity.serializedAttachments},\"attribute\":${eventEntity.serializedAttributes}}"
+            "{\"id\":\"${eventEntity.id}\",\"session_id\":\"${eventEntity.sessionId}\",\"user_triggered\":${eventEntity.userTriggered},\"timestamp\":\"${eventEntity.timestamp}\",\"type\":\"${eventEntity.type}\",\"${eventEntity.type}\":serialized-data,\"attachments\":${eventEntity.serializedAttachments},\"attribute\":${eventEntity.serializedAttributes}}"
         assertEquals(expectedData, formDataPart)
     }
 
@@ -100,7 +100,7 @@ class NetworkClientTest {
         val formDataPart = eventPacket.asFormDataPart(fileStorage)
 
         val expectedData =
-            "{\"id\":\"${eventEntity.id}\",\"session_id\":\"${eventEntity.sessionId}\",\"user_triggered\":\"${eventEntity.userTriggered}\",\"timestamp\":\"${eventEntity.timestamp}\",\"type\":\"${eventEntity.type}\",\"${eventEntity.type}\":serialized-data,\"attachments\":${eventEntity.serializedAttachments},\"attribute\":${eventEntity.serializedAttributes}}"
+            "{\"id\":\"${eventEntity.id}\",\"session_id\":\"${eventEntity.sessionId}\",\"user_triggered\":${eventEntity.userTriggered},\"timestamp\":\"${eventEntity.timestamp}\",\"type\":\"${eventEntity.type}\",\"${eventEntity.type}\":serialized-data,\"attachments\":${eventEntity.serializedAttachments},\"attribute\":${eventEntity.serializedAttributes}}"
         assertEquals(expectedData, formDataPart)
     }
 


### PR DESCRIPTION
# Summary 
`user_triggered` boolean was being wrapped around quotes and breaking the ingestion. This PR fixes the issue.