### PR TITLE
feat(android): use URL from manifest for uploading builds

### DIFF
--- a/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -26,6 +26,7 @@ private const val BUILD_TYPE = "build_type"
 private const val MAPPING_TYPE = "mapping_type"
 private const val TYPE_PROGUARD = "proguard"
 private const val MAPPING_FILE = "mapping_file"
+private const val BUILDS_PATH = "builds"
 
 private const val ERROR_MSG_401 =
     "Failed to upload mapping file to Measure, please check the api-key in manifest"
@@ -42,9 +43,6 @@ abstract class BuildUploadTask : DefaultTask() {
 
     @get:Internal
     abstract val httpClientProvider: Property<MeasureHttpClient>
-
-    @get:Input
-    abstract val mappingEndpointProperty: Property<String>
 
     @get:Optional
     @get:InputFile
@@ -82,8 +80,8 @@ abstract class BuildUploadTask : DefaultTask() {
             addFormDataPart(BUILD_SIZE, appSize)
             addFormDataPart(BUILD_TYPE, buildType)
         }.build()
-
-        val request: Request = Request.Builder().url(mappingEndpointProperty.get())
+        val url = "${manifestData.apiUrl}/${BUILDS_PATH}"
+        val request: Request = Request.Builder().url(url)
             .header(HEADER_AUTHORIZATION, "Bearer ${manifestData.apiKey}").put(requestBody).build()
         try {
             val response = client.newCall(request).execute()

--- a/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/ExtractManifestDataTask.kt
+++ b/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/ExtractManifestDataTask.kt
@@ -18,6 +18,7 @@ private const val KEY_VERSION_CODE = "android:versionCode"
 private const val KEY_VERSION_NAME = "android:versionName"
 private const val KEY_PACKAGE = "package"
 private const val KEY_API_KEY = "sh.measure.android.API_KEY"
+private const val KEY_API_URL = "sh.measure.android.API_URL"
 private const val TAG_MANIFEST = "manifest"
 private const val TAG_META_DATA = "meta-data"
 private const val ATTR_ANDROID_NAME = "android:name"
@@ -52,12 +53,14 @@ abstract class ExtractManifestDataTask : DefaultTask() {
         val packageName =
             extractPackageName(doc) ?: throw GradleException("$KEY_PACKAGE not found in manifest")
         val apiKey = extractApiKey(doc) ?: throw GradleException("$KEY_API_KEY not set in manifest")
+        val apiUrl = extractApiUrl(doc) ?: throw GradleException("$KEY_API_URL not set in manifest")
         @Suppress("OPT_IN_USAGE") Json.encodeToStream(
             ManifestData(
                 versionCode = versionCode,
                 versionName = versionName,
                 appUniqueId = packageName,
-                apiKey = apiKey
+                apiKey = apiKey,
+                apiUrl = apiUrl
             ), outputFile.outputStream()
         )
     }
@@ -76,6 +79,14 @@ abstract class ExtractManifestDataTask : DefaultTask() {
         return (0 until metaDataNodes.length).asSequence().map { metaDataNodes.item(it) }
             .filter { it.nodeType == Node.ELEMENT_NODE }.map { it as Element }
             .firstOrNull { it.getAttribute(ATTR_ANDROID_NAME) == KEY_API_KEY }
+            ?.getAttribute(ATTR_ANDROID_VALUE)
+    }
+
+    private fun extractApiUrl(doc: Document): String? {
+        val metaDataNodes = doc.getElementsByTagName(TAG_META_DATA)
+        return (0 until metaDataNodes.length).asSequence().map { metaDataNodes.item(it) }
+            .filter { it.nodeType == Node.ELEMENT_NODE }.map { it as Element }
+            .firstOrNull { it.getAttribute(ATTR_ANDROID_NAME) == KEY_API_URL }
             ?.getAttribute(ATTR_ANDROID_VALUE)
     }
 }

--- a/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/ManifestData.kt
+++ b/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/ManifestData.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ManifestData(
     val apiKey: String,
+    val apiUrl: String,
     val versionCode: String,
     val appUniqueId: String,
     val versionName: String

--- a/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -21,8 +21,6 @@ class MeasurePlugin : Plugin<Project> {
     companion object {
         const val GROUP_NAME = "measure"
         const val SHARED_SERVICE_HTTP_CLIENT = "measure-http-client"
-        const val DEFAULT_ENDPOINT = "http://localhost:8080"
-        const val ROUTE_BUILDS = "/builds"
         const val DEFAULT_TIMEOUT_MS = 60_000L
         const val DEFAULT_RETRIES = 3
     }
@@ -102,7 +100,6 @@ class MeasurePlugin : Plugin<Project> {
             it.manifestDataProperty.set(manifestDataFileProvider(project, variant))
             it.mappingFileProperty.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
             it.appSizeFileProperty.set(appSizeFileProvider(project, variant))
-            it.mappingEndpointProperty.set(DEFAULT_ENDPOINT + ROUTE_BUILDS)
             it.retriesProperty.set(DEFAULT_RETRIES)
             it.usesService(httpClientProvider)
             it.httpClientProvider.set(httpClientProvider)

--- a/measure-android/measure-android-gradle/src/test/kotlin/sh/measure/ExtractManifestDataTaskTest.kt
+++ b/measure-android/measure-android-gradle/src/test/kotlin/sh/measure/ExtractManifestDataTaskTest.kt
@@ -33,7 +33,7 @@ internal class ExtractManifestDataTaskTest {
         configureTask()
         task.extractManifestData()
         val validManifestOutput = """
-                {"apiKey":"api-key","versionCode":"100","appUniqueId":"sh.measure.sample","versionName":"1.0.0"}
+                {"apiKey":"api-key","apiUrl":"api-url","versionCode":"100","appUniqueId":"sh.measure.sample","versionName":"1.0.0"}
             """.trimIndent()
         Assert.assertEquals(validManifestOutput, outputFile.readText())
     }
@@ -41,6 +41,15 @@ internal class ExtractManifestDataTaskTest {
     @Test
     fun `ExtractManifestDataTask throws when API key is missing in manifest`() {
         manifestFile.writeText(manifestWithoutApiKey)
+        configureTask()
+        Assert.assertThrows(GradleException::class.java) {
+            task.extractManifestData()
+        }
+    }
+
+    @Test
+    fun `ExtractManifestDataTask throws when API url is missing in manifest`() {
+        manifestFile.writeText(manifestWithoutApiUrl)
         configureTask()
         Assert.assertThrows(GradleException::class.java) {
             task.extractManifestData()
@@ -65,6 +74,10 @@ internal class ExtractManifestDataTaskTest {
                     <meta-data
                         android:name="sh.measure.android.API_KEY"
                         android:value="api-key" />
+                        
+                    <meta-data
+                        android:name="sh.measure.android.API_URL"
+                        android:value="api-url" />
                 </application>
             </manifest>
         """.trimIndent()
@@ -75,7 +88,25 @@ internal class ExtractManifestDataTaskTest {
                 package="sh.measure.sample"
                 android:versionCode="100"
                 android:versionName="1.0.0">
-                <application></application>
+                <application>
+                      <meta-data
+                        android:name="sh.measure.android.API_URL"
+                        android:value="api-url" />
+                </application>
+            </manifest>
+        """.trimIndent()
+
+    private val manifestWithoutApiUrl = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="sh.measure.sample"
+                android:versionCode="100"
+                android:versionName="1.0.0">
+                <application>
+                      <meta-data
+                        android:name="sh.measure.android.API_KEY"
+                        android:value="api-key" />
+                </application>
             </manifest>
         """.trimIndent()
 }


### PR DESCRIPTION
Measure gradle plugin was using a hardcoded URL to upload build information. This has now been updated to use the `sh.measure.android.API_URL` set in the Android manifest.