### PR TITLE
refactor(android): improve internal SDK traces

### DIFF
--- a/measure-android/benchmarks/benchmark/src/main/java/sh/measure/benchmark/ComposeTargetFinderBenchmark.kt
+++ b/measure-android/benchmarks/benchmark/src/main/java/sh/measure/benchmark/ComposeTargetFinderBenchmark.kt
@@ -23,7 +23,7 @@ class ComposeTargetFinderBenchmark {
             packageName = "sh.measure.test.benchmark",
             metrics = listOf(
                 TraceSectionMetric(
-                    sectionName = "GestureCollector.getTarget",
+                    sectionName = "msr-click-getTarget",
                     mode = TraceSectionMetric.Mode.Sum,
                 )
             ),

--- a/measure-android/benchmarks/benchmark/src/main/java/sh/measure/benchmark/ViewTargetFinderBenchmark.kt
+++ b/measure-android/benchmarks/benchmark/src/main/java/sh/measure/benchmark/ViewTargetFinderBenchmark.kt
@@ -22,7 +22,7 @@ class ViewTargetFinderBenchmark {
         benchmarkRule.measureRepeated(packageName = "sh.measure.test.benchmark",
             metrics = listOf(
                 TraceSectionMetric(
-                    sectionName = "GestureCollector.getTarget",
+                    sectionName = "msr-click-getTarget",
                     mode = TraceSectionMetric.Mode.Sum,
                 )
             ),

--- a/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -6,6 +6,7 @@ import androidx.annotation.VisibleForTesting
 import sh.measure.android.config.MeasureConfig
 import sh.measure.android.events.EventProcessor
 import sh.measure.android.okhttp.OkHttpEventCollector
+import sh.measure.android.tracing.InternalTrace
 import sh.measure.android.utils.TimeProvider
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -39,10 +40,15 @@ object Measure {
     @JvmOverloads
     fun init(context: Context, measureConfig: MeasureConfig = MeasureConfig()) {
         if (isInitialized.compareAndSet(false, true)) {
-            val application = context.applicationContext as Application
-            val initializer = MeasureInitializerImpl(application, inputConfig = measureConfig)
-            measure = MeasureInternal(initializer)
-            measure.init()
+            InternalTrace.trace(
+                label = { "msr-init" },
+                block = {
+                    val application = context.applicationContext as Application
+                    val initializer = MeasureInitializerImpl(application, inputConfig = measureConfig)
+                    measure = MeasureInternal(initializer)
+                    measure.init()
+                },
+            )
         }
     }
 

--- a/measure-android/measure/src/main/java/sh/measure/android/attributes/ComputeOnceAttributeProcessor.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/attributes/ComputeOnceAttributeProcessor.kt
@@ -1,7 +1,5 @@
 package sh.measure.android.attributes
 
-import sh.measure.android.tracing.InternalTrace
-
 /**
  * Generates the attributes once and then caches them. Subsequent calls to [appendAttributes] will return the
  * cached attributes. This is useful for attributes that are expensive to compute and are not
@@ -15,14 +13,12 @@ internal abstract class ComputeOnceAttributeProcessor : AttributeProcessor {
     private lateinit var cachedAttrs: Map<String, Any?>
 
     override fun appendAttributes(attributes: MutableMap<String, Any?>) {
-        InternalTrace.beginSection("ComputeOnceAttributeProcessor.appendAttributes")
         if (!isComputed) {
             this.cachedAttrs = computeAttributes()
             attributes.putAll(this.cachedAttrs)
             isComputed = true
         }
         attributes.putAll(cachedAttrs)
-        InternalTrace.endSection()
     }
 
     /**

--- a/measure-android/measure/src/main/java/sh/measure/android/attributes/NetworkStateAttributeProcessor.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/attributes/NetworkStateAttributeProcessor.kt
@@ -4,7 +4,6 @@ import sh.measure.android.networkchange.NetworkGeneration
 import sh.measure.android.networkchange.NetworkProvider
 import sh.measure.android.networkchange.NetworkStateProvider
 import sh.measure.android.networkchange.NetworkType
-import sh.measure.android.tracing.InternalTrace
 
 /**
  * Generates the network state attributes. These attributes are expected to change during the
@@ -18,14 +17,12 @@ internal class NetworkStateAttributeProcessor(
     private var networkProviderName: String = NetworkProvider.UNKNOWN
 
     override fun appendAttributes(attributes: MutableMap<String, Any?>) {
-        InternalTrace.beginSection("NetworkStateAttributeProcessor.appendAttributes")
         computeAttributes()
         attributes.apply {
             put(Attribute.NETWORK_TYPE_KEY, networkType)
             put(Attribute.NETWORK_GENERATION_KEY, networkGeneration)
             put(Attribute.NETWORK_PROVIDER_NAME_KEY, networkProviderName)
         }
-        InternalTrace.endSection()
     }
 
     private fun computeAttributes() {

--- a/measure-android/measure/src/main/java/sh/measure/android/gestures/GestureTargetFinder.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/gestures/GestureTargetFinder.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
-import sh.measure.android.tracing.InternalTrace
 import sh.measure.android.utils.ComposeHelper
 
 internal data class Target(
@@ -25,7 +24,6 @@ internal object GestureTargetFinder {
     fun findScrollable(view: ViewGroup, event: MotionEvent): Target? {
         val foundView = findScrollableRecursively(view, event.x, event.y) ?: return null
 
-        InternalTrace.beginSection("GestureTargetFinder.findScrollable")
         val target = when {
             ComposeHelper.isComposeView(foundView) -> findComposeTarget(
                 foundView,
@@ -35,14 +33,12 @@ internal object GestureTargetFinder {
 
             else -> foundView.toTarget()
         }
-        InternalTrace.endSection()
         return target
     }
 
     fun findClickable(view: ViewGroup, event: MotionEvent): Target? {
         val foundView = findClickableViewRecursively(view, event) ?: return null
 
-        InternalTrace.beginSection("GestureTargetFinder.findClickable")
         val target = when {
             ComposeHelper.isComposeView(foundView) -> findComposeTarget(
                 foundView,
@@ -52,7 +48,6 @@ internal object GestureTargetFinder {
 
             else -> foundView.toTarget()
         }
-        InternalTrace.endSection()
         return target
     }
 

--- a/measure-android/measure/src/main/java/sh/measure/android/screenshot/ScreenshotCollector.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/screenshot/ScreenshotCollector.kt
@@ -18,7 +18,6 @@ import sh.measure.android.config.ConfigProvider
 import sh.measure.android.isMainThread
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
-import sh.measure.android.tracing.InternalTrace
 import sh.measure.android.utils.LowMemoryCheck
 import sh.measure.android.utils.ResumedActivityProvider
 import java.io.ByteArrayOutputStream
@@ -103,9 +102,7 @@ internal class ScreenshotCollectorImpl(
             return null
         }
 
-        InternalTrace.beginSection("find-rects-to-mask")
         val rectsToMask = ScreenshotMask(config).findRectsToMask(view)
-        InternalTrace.endSection()
         val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             captureBitmapUsingPixelCopy(window, bitmap)?.apply {

--- a/measure-android/measure/src/main/java/sh/measure/android/tracing/InternalTrace.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/tracing/InternalTrace.kt
@@ -2,34 +2,54 @@ package sh.measure.android.tracing
 
 import android.os.Build
 import android.os.Trace
-import androidx.annotation.RequiresApi
+import androidx.annotation.ChecksSdkIntAtLeast
+import sh.measure.android.tracing.InternalTrace.MAX_LABEL_LENGTH
 
 /**
- * A simple wrapper over [Trace] to allow enabling & disabling tracing.
+ * A simple wrapper over [Trace] to allow tracing of code blocks. There is no impact on performance
+ * if a trace is not being collected.
+ *
+ * The label for the trace is always truncated to [MAX_LABEL_LENGTH] characters as
+ * [android.os.Trace.beginSection] throws IllegalArgumentException if the label is longer
+ * than 127 characters. The labels must be prefixed with `msr-` to make it easy to find any trace
+ * from the SDK.
  */
 internal object InternalTrace {
-    @Volatile
-    var enabled = true
+    /**
+     * [android.os.Trace.beginSection] throws IllegalArgumentException if the
+     * label is longer than 127 characters.
+     */
+    private const val MAX_LABEL_LENGTH = 127
 
-    fun beginSection(name: String) {
-        if (!enabled) return
-        Trace.beginSection(name)
+    /**
+     * Allows tracing of a block of code.
+     *
+     * [label] a string producing lambda if the label is computed dynamically. If the label isn't
+     * dynamic, use the [trace] which directly takes a string instead.
+     */
+    inline fun <T> trace(
+        crossinline label: () -> String,
+        crossinline block: () -> T,
+    ): T {
+        if (!isEnabled()) {
+            return block()
+        }
+        try {
+            Trace.beginSection(label().take(MAX_LABEL_LENGTH))
+            return block()
+        } finally {
+            Trace.endSection()
+        }
     }
 
-    fun endSection() {
-        if (!enabled) return
-        Trace.endSection()
-    }
+    /**
+     * Allows tracing of a block of code. The label is truncated to [MAX_LABEL_LENGTH] characters
+     */
+    inline fun <T> trace(
+        label: String,
+        crossinline block: () -> T,
+    ): T = trace({ label }, block)
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    fun beginAsyncSection(name: String, cookie: Int) {
-        if (!enabled) return
-        Trace.beginAsyncSection(name, cookie)
-    }
-
-    @RequiresApi(Build.VERSION_CODES.Q)
-    fun endAsyncSection(name: String, cookie: Int) {
-        if (!enabled) return
-        Trace.endAsyncSection(name, cookie)
-    }
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    private fun isEnabled(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 }


### PR DESCRIPTION
# Summary

* End traces for gestures correctly.
* Improve the `InternalTrace` implementation by ensuring the trace always ends correctly.
* Standardize naming convention for traces.
* Update benchmarks relying on trace names.
* Add a new trace for Measure SDK initialization. 

closes #868