### PR TITLE
fix(webapp): handle invalid selected app in persisted filters

### DIFF
--- a/measure-web-app/app/components/filters.tsx
+++ b/measure-web-app/app/components/filters.tsx
@@ -146,11 +146,17 @@ const Filters: React.FC<FiltersProps> = ({
         setAppsApiStatus(AppsApiStatus.Success)
         setApps(result.data)
         // If appId is provided, set selected app to given appId. If no app Id is provided but we have a saved appId from
-        // saved filters, set selected app to the one from saved filters. If not, set to the first app id.
+        // saved filters and we can find the corresponding app in the results, set selected app to the one from saved filters.
+        // If not, set to the first app id.
         if (appId !== undefined) {
           setSelectedApp(result.data.find((e: typeof emptyApp) => e.id === appId))
         } else if (persistedFilters !== null) {
-          setSelectedApp(result.data.find((e: typeof emptyApp) => e.id === persistedFilters.selectedAppId))
+          const appMatchingPersisted = result.data.find((e: typeof emptyApp) => e.id === persistedFilters.selectedAppId)
+          if (appMatchingPersisted !== undefined) {
+            setSelectedApp(appMatchingPersisted)
+          } else {
+            setSelectedApp(result.data[0])
+          }
         } else {
           setSelectedApp(result.data[0])
         }
@@ -229,7 +235,7 @@ const Filters: React.FC<FiltersProps> = ({
   }
 
   useEffect(() => {
-    // Don't try to fetch filters if app id is not yet set
+    // Don't try to fetch filters if selected app is not yet set
     if (selectedApp.id === "") {
       return
     }
@@ -238,6 +244,11 @@ const Filters: React.FC<FiltersProps> = ({
   }, [selectedApp]);
 
   useEffect(() => {
+    // Don't persist filters or fire change listener if selected app is not yet set
+    if (selectedApp.id === "") {
+      return
+    }
+
     const updatedPersistedFilters: PersistedFilters = {
       selectedAppId: selectedApp.id,
       selectedStartDate: startDate,


### PR DESCRIPTION
In some cases, persisted filters could have a selected app id that does not match any apps  in the apps fetch results (an app being deleted or app id being empty for example). This leads to an undefined selected app being set causing downstream issues in the filters component.

This commit:
- persists filters only when a selected app is present
- handles an invalid selected app id in persisted filters

fixes #914