### PR TITLE
fix(android): use process death time instead of current time for AppExit timestamp

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -275,7 +275,6 @@ internal class MeasureInitializerImpl(
         systemServiceProvider = systemServiceProvider,
     ),
     override val appExitCollector: AppExitCollector = AppExitCollector(
-        timeProvider = timeProvider,
         appExitProvider = appExitProvider,
         ioExecutor = executorServiceRegistry.ioExecutor(),
         eventProcessor = eventProcessor,

--- a/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExit.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExit.kt
@@ -3,6 +3,7 @@ package sh.measure.android.appexit
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Represents the data that is collected when an application exits.
@@ -28,6 +29,12 @@ internal data class AppExit(
      * @see [ApplicationExitInfo.getProcessName]
      */
     val process_name: String,
+
+    /**
+     * @see [ApplicationExitInfo.getTimestamp]
+     */
+    @Transient
+    val app_exit_time_ms: Long = 0,
 
     /**
      * @see [ApplicationExitInfo.getPid]

--- a/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
@@ -4,13 +4,11 @@ import sh.measure.android.SessionManager
 import sh.measure.android.events.EventProcessor
 import sh.measure.android.events.EventType
 import sh.measure.android.executors.MeasureExecutorService
-import sh.measure.android.utils.TimeProvider
 
 internal class AppExitCollector(
     private val appExitProvider: AppExitProvider,
     private val ioExecutor: MeasureExecutorService,
     private val eventProcessor: EventProcessor,
-    private val timeProvider: TimeProvider,
     private val sessionManager: SessionManager,
 ) {
     fun onColdLaunch() {
@@ -28,7 +26,9 @@ internal class AppExitCollector(
             appExitsToTrack.forEach {
                 eventProcessor.track(
                     it.third,
-                    timeProvider.currentTimeSinceEpochInMillis,
+                    // For app exit, the time at which the app exited is more relevant
+                    // than the current time.
+                    it.third.app_exit_time_ms,
                     EventType.APP_EXIT,
                     sessionId = it.second,
                 )

--- a/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitProvider.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitProvider.kt
@@ -41,6 +41,7 @@ internal class AppExitProviderImpl(
             importance = getImportanceName(importance),
             trace = getTraceString(traceInputStream),
             process_name = processName,
+            app_exit_time_ms = timestamp,
             pid = pid.toString(),
         )
     }

--- a/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
@@ -12,21 +12,18 @@ import sh.measure.android.SessionManager
 import sh.measure.android.events.EventProcessor
 import sh.measure.android.events.EventType
 import sh.measure.android.fakes.FakeAppExitProvider
-import sh.measure.android.fakes.FakeTimeProvider
 import sh.measure.android.fakes.ImmediateExecutorService
 
 class AppExitCollectorTest {
     private val appExitProvider = FakeAppExitProvider()
     private val executorService = ImmediateExecutorService(ResolvableFuture.create<Any>())
     private val eventProcessor = mock<EventProcessor>()
-    private val timeProvider = FakeTimeProvider()
     private val sessionManager = mock<SessionManager>()
 
     private val appExitCollector = AppExitCollector(
         appExitProvider,
         executorService,
         eventProcessor,
-        timeProvider,
         sessionManager,
     )
 
@@ -119,6 +116,7 @@ class AppExitCollectorTest {
             trace = null,
             process_name = "com.example.app",
             importance = "IMPORTANCE_VISIBLE",
+            app_exit_time_ms = 1234567890,
         )
         appExitProvider.appExits = mapOf(pid to appExit)
         `when`(sessionManager.getSessionsForPids()).thenReturn(mapOf(pid to listOf(sessionId)))
@@ -127,7 +125,7 @@ class AppExitCollectorTest {
 
         verify(eventProcessor).track(
             data = appExit,
-            timestamp = timeProvider.currentTimeSinceEpochInMillis,
+            timestamp = appExit.app_exit_time_ms,
             type = EventType.APP_EXIT,
             sessionId = sessionId,
         )


### PR DESCRIPTION
# Summary
The time at which the AppExit event is collected is not useful. We're more interested in the time at which the app actually exited. This PR uses the app exit time as the `AppExit` event timestamp instead of the time at which the event was collected.

This also fixes #953, a related issue in session replay, where session duration for sessions with app exit event was incorrect. 