### PR TITLE
fix(android): fix serialization of events and attachments

### DIFF
--- a/measure-android/measure/src/main/java/sh/measure/android/exporter/EventPacket.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exporter/EventPacket.kt
@@ -12,8 +12,3 @@ internal data class EventPacket(
     val serializedAttributes: String,
     val serializedUserDefinedAttributes: String?,
 )
-
-internal fun EventPacket.asFormDataPart(): String {
-    require(serializedData?.isNotEmpty() == true) { "serializedData is required for converting the event packet to form data" }
-    return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes}"
-}

--- a/measure-android/measure/src/main/java/sh/measure/android/exporter/LoggingOutputStream.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exporter/LoggingOutputStream.kt
@@ -1,0 +1,41 @@
+package sh.measure.android.exporter
+
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import java.io.OutputStream
+
+internal class LoggingOutputStream(
+    private val outputStream: OutputStream,
+    private val logger: Logger,
+) : OutputStream() {
+    // Divide the logs in chunks as the output can be large, Android logcat truncates
+    // strings which are longer than 500.
+    private val chunkSize: Int = 500
+    private val buffer = StringBuilder()
+
+    override fun write(b: Int) {
+        outputStream.write(b)
+        buffer.append(b.toChar())
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        outputStream.write(b, off, len)
+        buffer.append(String(b, off, len))
+    }
+
+    override fun flush() {
+        outputStream.flush()
+        if (buffer.isNotEmpty()) {
+            val log = buffer.toString()
+            log.chunked(chunkSize).forEach {
+                logger.log(LogLevel.Debug, it)
+            }
+            buffer.clear()
+        }
+    }
+
+    override fun close() {
+        buffer.clear()
+        outputStream.close()
+    }
+}

--- a/measure-android/measure/src/main/java/sh/measure/android/exporter/NetworkClient.kt
+++ b/measure-android/measure/src/main/java/sh/measure/android/exporter/NetworkClient.kt
@@ -18,7 +18,7 @@ private const val PATH_EVENTS = "/events"
 internal class NetworkClientImpl(
     private val logger: Logger,
     private val fileStorage: FileStorage,
-    private val httpClient: HttpClient = HttpUrlConnectionClient(),
+    private val httpClient: HttpClient = HttpUrlConnectionClient(logger),
     private val multipartDataFactory: MultipartDataFactory = MultipartDataFactoryImpl(
         logger,
         fileStorage,

--- a/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
+++ b/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
@@ -7,12 +7,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import sh.measure.android.fakes.NoopLogger
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 class HttpUrlConnectionClientTest {
     private val mockWebServer: MockWebServer = MockWebServer()
-    private val client: HttpUrlConnectionClient = HttpUrlConnectionClient()
+    private val client: HttpUrlConnectionClient = HttpUrlConnectionClient(NoopLogger())
 
     @Before
     fun setup() {
@@ -110,13 +111,12 @@ class HttpUrlConnectionClientTest {
             mockWebServer.url("/").toString(),
             "POST",
             emptyMap(),
-            listOf(MultipartData.FileData("file", "test.txt", "text/plain", inputStream)),
+            listOf(MultipartData.FileData("file", "test.txt", inputStream)),
         )
 
         val request = mockWebServer.takeRequest()
         val body = request.body.readUtf8()
         assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\""))
-        assertTrue(body.contains("Content-Type: text/plain"))
         assertTrue(body.contains("file content"))
         assertEquals(HttpResponse.Success, result)
     }
@@ -133,7 +133,7 @@ class HttpUrlConnectionClientTest {
             listOf(
                 MultipartData.FormField("key1", "value1"),
                 MultipartData.FormField("key2", "value2"),
-                MultipartData.FileData("file", "test.txt", "text/plain", inputStream),
+                MultipartData.FileData("file", "test.txt", inputStream),
             ),
         )
 
@@ -144,7 +144,6 @@ class HttpUrlConnectionClientTest {
         assertTrue(body.contains("Content-Disposition: form-data; name=\"key2\""))
         assertTrue(body.contains("value2"))
         assertTrue(body.contains("Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\""))
-        assertTrue(body.contains("Content-Type: text/plain"))
         assertTrue(body.contains("file content"))
         assertEquals(HttpResponse.Success, result)
     }
@@ -219,7 +218,7 @@ class HttpUrlConnectionClientTest {
             emptyMap(),
             listOf(
                 MultipartData.FormField("key1", "value1"),
-                MultipartData.FileData("file", "test.txt", "text/plain", inputStream),
+                MultipartData.FileData("file", "test.txt", inputStream),
             ),
         )
 
@@ -246,7 +245,6 @@ class HttpUrlConnectionClientTest {
         assertTrue(parts[1].contains("value1"))
 
         assertTrue(parts[2].contains("Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\""))
-        assertTrue(parts[2].contains("Content-Type: text/plain"))
         assertTrue(parts[2].contains("file content"))
     }
 }


### PR DESCRIPTION
Fixes a regression introduced in #980.

* Removes uneeded content type header from multipart request
* Uses `FormField` instead of file for events which are stored in files to match expected format by the server.
* Log request body from `HttpClient` to make debugging easier.