### PR TITLE
fix(android): plugin does not break configuration cache

### DIFF
--- a/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/measure-android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -112,11 +112,9 @@ class MeasurePlugin : Plugin<Project> {
             it.httpClientProvider.set(httpClientProvider)
         }.dependsOn(extractManifestDataProvider).apply {
             configure {
+                val manifestDataFileProvider = manifestDataFileProvider(project, variant)
                 it.onlyIf {
-                    // only run the task if the manifest data file exists, otherwise we assume
-                    // that manifest data extraction failed and we should run the upload task.
-                    val manifestData = manifestDataFileProvider(project, variant).get().asFile
-                    manifestData.exists()
+                    manifestDataFileProvider.get().asFile.exists()
                 }
                 // using dependsOn would not work as apkSizeProvider and aabSizeProvider will both
                 // end up running and overwriting each other's output.


### PR DESCRIPTION
# Summary
`BuildUploadTask` was accessing a file from `ExtractManifestDataTask` in the configuration phase, causing the gradle configuration cache to break. The PR fixes it by accessing the file in execution phase instead of configuration phase.