### PR TITLE
chore(backend): consistent healthcheck

### DIFF
--- a/measure-backend/measure-go/main.go
+++ b/measure-backend/measure-go/main.go
@@ -64,8 +64,9 @@ func main() {
 		MaxAge:           12 * time.Hour,
 	})
 
+	// health check
 	r.GET("/ping", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"message": "pong"})
+		c.String(http.StatusOK, "pong")
 	})
 
 	// Auth routes

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -64,7 +64,7 @@ services:
         - path: ../measure-backend/measure-go
           action: rebuild
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/ping"]
+      test: ["CMD", "wget", "-q", "http://localhost:8080/ping"]
       interval: 5s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary

Made healthcheck behavior consistent across services.

## Tasks

- [x] Made healthcheck response of measure-go match with symbolicator-retrace
- [x] Update healthcheck test for api service to send `GET` requests only