### PR TITLE
fix(backend): intermittent login failure with google auth

### DIFF
--- a/measure-web-app/app/auth/login/google-sign-in.tsx
+++ b/measure-web-app/app/auth/login/google-sign-in.tsx
@@ -38,12 +38,12 @@ export default function GoogleSignIn() {
       <div id="g_id_onload"
         data-client_id={googleClientID}
         data-context="signin"
-        data-ux_mode="popup"
+        data-ux_mode="redirect"
         data-nonce={hashedNonce}
         data-login_uri={`${origin}/auth/callback/google?nonce=${encodeURIComponent(nonce)}&state=${encodeURIComponent(state)}`}
-        data-auto_select="false"
         data-auto_prompt="false"
-        data-itp_support="true">
+        data-itp_support="true"
+        data-use_fedcm_for_prompt="true">
       </div>
 
       <div className="g_id_signin"


### PR DESCRIPTION
> [!Important]
> The Google OAuth consent screen settings is configured in testing mode. This effectively means only login attempts from whitelisted Google accounts will succeed. **We need to publish the OAuth app before launch, otherwise non-whitelisted users won't be able to login using Google.**
>
> ![image](https://github.com/user-attachments/assets/f1eb2a1a-54fa-4e8f-824e-c339834c6c25)
>
> ![image](https://github.com/user-attachments/assets/0b339c6f-3053-4290-8a2a-e83318c80649)

## Summary

Login with Google would fail intermittently on Chromium and repeatedly fail on Safari. In this PR, we turn on FedCM so that sign in with Google works on browsers that block third-party cookies. We also implement a bypass on nonce checking on Safari browsers while implementing logs for further monitoring this particular situation. Overall, authentication with Google should be more robust with this PR.

## Tasks 
- [x] Fix intermittent login issues with google
- [x] Modify sign in with google settings to use `redirect` ux mode
- [x] Modify sign in with google settings to use fedCM
- [x] Modify google auth stack to work around issues with safari



## References

For more context, see below.

- https://github.com/google/google-api-javascript-client/issues/843
- https://developers.google.com/identity/gsi/web/guides/fedcm-migration
- https://developers.google.com/identity/gsi/web/reference/html-reference