### PR TITLE
chore: prevent unnecessary service restarts

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -30,6 +30,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
+        restart: false
 
   api:
     build:


### PR DESCRIPTION
## Summary

In this PR, we update docker compose behavior to not restart the web service when api service restarts. The web & the api service are decoupled by nature and hence web service do not need to be restarted always. This slightly improves developer feedback cycle time.

## Tasks

- [x] Prevent compose web service to restart always when service api restarts