### PR TITLE
chore(backend): fix a sessionator edge case

### DIFF
--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -400,7 +400,7 @@ Structure of "session-data" directory:` + "\n" + DirTree() + "\n" + ValidNote(),
 			}
 			ctx := context.Background()
 			if err := rmEvents(ctx, configData); err != nil {
-				log.Fatal(err)
+				log.Fatal("failed to cleanup old data", err)
 			}
 		}
 

--- a/self-host/sessionator/config/config.go
+++ b/self-host/sessionator/config/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type App struct {
+	Name   string `toml:"name"`
 	ApiKey string `toml:"api-key"`
 }
 


### PR DESCRIPTION
## Summary

Sessionator ingest would fail if apps in the database has empty unique identifier. To mitigate, this PR adds support for a `name` field in `config.toml` which the janitor module uses to resolve app ids accordingly.

## Tasks

- [x] Fix an edge case in sessionator where ingest would fail if apps in the database lack unique identifier
- [x] Add support for `name` field in `config.toml` for janitor to read and resolve app ids accordingly