### PR TITLE
ci: add cleanup workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -75,7 +75,7 @@ jobs:
   push:
     name: Build and push image
     runs-on: ubuntu-latest
-    #if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'v')
     needs: [build, test]
     permissions:
       contents: read

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -75,7 +75,7 @@ jobs:
   push:
     name: Build and push image
     runs-on: ubuntu-latest
-    # if: github.ref_type == 'tag' && startsWith(github.ref, 'v')
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'v')
     needs: [build, test]
     permissions:
       contents: read

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -42,7 +42,7 @@ jobs:
   push:
     name: Build and push image
     runs-on: ubuntu-latest
-    #if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'v')
     needs: [unit-test]
     permissions:
       contents: read

--- a/.github/workflows/symbolicator-android.yml
+++ b/.github/workflows/symbolicator-android.yml
@@ -64,7 +64,7 @@ jobs:
   push:
     name: Build Docker image
     runs-on: ubuntu-latest
-    #if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'v')
     needs: [build-and-test]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

This PR adds a GitHub Workflow for the `cleanup` service. All build and push OCI image jobs now runs for new git tags starting with `v`.

## Tasks

- [x] Add GitHub Workflow for cleanup service
- [x] Change trigger for api workflow to git tag starting with `v`
- [x] Change trigger for cleanup workflow to git tag starting with `v`
- [x] Change trigger for dashboard workflow to git tag starting with `v`
- [x] Change trigger for symbolicator-android workflow to git tag starting
with `v`