### PR TITLE
fix(android): resolve crash when OkHttp is not a runtime dependency

### DIFF
--- a/android/measure/consumer-rules.pro
+++ b/android/measure/consumer-rules.pro
@@ -1,3 +1,6 @@
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
 -keep class sh.measure.android.NativeBridgeImpl { *; }
+
+# Required to check if okhttp is present in runtime classpath
+-keepnames class okhttp3.OkHttpClient

--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -46,7 +46,7 @@ import sh.measure.android.networkchange.InitialNetworkStateProviderImpl
 import sh.measure.android.networkchange.NetworkChangesCollector
 import sh.measure.android.networkchange.NetworkStateProvider
 import sh.measure.android.networkchange.NetworkStateProviderImpl
-import sh.measure.android.okhttp.OkHttpEventCollector
+import sh.measure.android.okhttp.HttpEventCollector
 import sh.measure.android.okhttp.OkHttpEventCollectorImpl
 import sh.measure.android.performance.ComponentCallbacksCollector
 import sh.measure.android.performance.CpuUsageCollector
@@ -244,11 +244,6 @@ internal class TestMeasureInitializer(
     ),
     override val periodicEventExporter: PeriodicEventExporter = NoopPeriodicEventExporter(),
     private val osSysConfProvider: OsSysConfProvider = OsSysConfProviderImpl(),
-    override val okHttpEventCollector: OkHttpEventCollector = OkHttpEventCollectorImpl(
-        logger = logger,
-        timeProvider = timeProvider,
-        eventProcessor = eventProcessor,
-    ),
     override val unhandledExceptionCollector: UnhandledExceptionCollector = UnhandledExceptionCollector(
         logger = logger,
         timeProvider = timeProvider,
@@ -328,5 +323,10 @@ internal class TestMeasureInitializer(
         ioExecutor = executorServiceRegistry.ioExecutor(),
         sessionManager = sessionManager,
         configProvider = configProvider,
+    ),
+    override val httpEventCollector: HttpEventCollector = OkHttpEventCollectorImpl(
+        logger = logger,
+        eventProcessor = eventProcessor,
+        timeProvider = timeProvider,
     ),
 ) : MeasureInitializer

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -49,8 +49,8 @@ import sh.measure.android.networkchange.InitialNetworkStateProviderImpl
 import sh.measure.android.networkchange.NetworkChangesCollector
 import sh.measure.android.networkchange.NetworkStateProvider
 import sh.measure.android.networkchange.NetworkStateProviderImpl
-import sh.measure.android.okhttp.OkHttpEventCollector
-import sh.measure.android.okhttp.OkHttpEventCollectorImpl
+import sh.measure.android.okhttp.HttpEventCollector
+import sh.measure.android.okhttp.HttpEventCollectorFactory
 import sh.measure.android.performance.ComponentCallbacksCollector
 import sh.measure.android.performance.CpuUsageCollector
 import sh.measure.android.performance.DefaultMemoryReader
@@ -259,11 +259,12 @@ internal class MeasureInitializerImpl(
         eventExporter = eventExporter,
     ),
     private val osSysConfProvider: OsSysConfProvider = OsSysConfProviderImpl(),
-    override val okHttpEventCollector: OkHttpEventCollector = OkHttpEventCollectorImpl(
+    private val httpEventCollectorFactory: HttpEventCollectorFactory = HttpEventCollectorFactory(
         logger = logger,
-        timeProvider = timeProvider,
         eventProcessor = eventProcessor,
+        timeProvider = timeProvider,
     ),
+    override val httpEventCollector: HttpEventCollector = httpEventCollectorFactory.create(),
     override val unhandledExceptionCollector: UnhandledExceptionCollector = UnhandledExceptionCollector(
         logger = logger,
         timeProvider = timeProvider,
@@ -355,7 +356,7 @@ internal interface MeasureInitializer {
     val resumedActivityProvider: ResumedActivityProvider
     val eventProcessor: EventProcessor
     val userTriggeredEventCollector: UserTriggeredEventCollector
-    val okHttpEventCollector: OkHttpEventCollector
+    val httpEventCollector: HttpEventCollector
     val sessionManager: SessionManager
     val unhandledExceptionCollector: UnhandledExceptionCollector
     val anrCollector: AnrCollector

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -16,7 +16,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) :
     val logger by lazy { measureInitializer.logger }
     val eventProcessor by lazy { measureInitializer.eventProcessor }
     val timeProvider by lazy { measureInitializer.timeProvider }
-    val okHttpEventCollector by lazy { measureInitializer.okHttpEventCollector }
+    val httpEventCollector by lazy { measureInitializer.httpEventCollector }
     private val userTriggeredEventCollector by lazy { measureInitializer.userTriggeredEventCollector }
     private val sessionManager by lazy { measureInitializer.sessionManager }
     private val resumedActivityProvider by lazy { measureInitializer.resumedActivityProvider }

--- a/android/measure/src/main/java/sh/measure/android/okhttp/HttpEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/okhttp/HttpEventCollector.kt
@@ -1,0 +1,8 @@
+package sh.measure.android.okhttp
+
+internal interface HttpEventCollector
+
+/**
+ * No-op implementation of [HttpEventCollector] when OkHttp is not available as a runtime dependency.
+ */
+internal class NoOpHttpEventCollector : HttpEventCollector

--- a/android/measure/src/main/java/sh/measure/android/okhttp/HttpEventCollectorFactory.kt
+++ b/android/measure/src/main/java/sh/measure/android/okhttp/HttpEventCollectorFactory.kt
@@ -1,0 +1,24 @@
+package sh.measure.android.okhttp
+
+import sh.measure.android.events.EventProcessor
+import sh.measure.android.logger.Logger
+import sh.measure.android.utils.TimeProvider
+import sh.measure.android.utils.isClassAvailable
+
+/**
+ * Factory for creating [HttpEventCollector] instances. This is required to
+ * avoid accessing [OkHttpEventCollectorImpl] when OkHttp is not available as a runtime dependency.
+ */
+internal class HttpEventCollectorFactory(
+    private val logger: Logger,
+    private val eventProcessor: EventProcessor,
+    private val timeProvider: TimeProvider,
+) {
+    fun create(): HttpEventCollector {
+        return if (isClassAvailable("okhttp3.OkHttpClient")) {
+            OkHttpEventCollectorImpl(logger, eventProcessor, timeProvider)
+        } else {
+            NoOpHttpEventCollector()
+        }
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/okhttp/OkHttpEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/okhttp/OkHttpEventCollector.kt
@@ -14,7 +14,7 @@ import sh.measure.android.logger.Logger
 import sh.measure.android.utils.TimeProvider
 import java.io.IOException
 
-internal abstract class OkHttpEventCollector : EventListener() {
+internal abstract class OkHttpEventCollector : EventListener(), HttpEventCollector {
     open fun request(call: Call, request: Request) {}
     open fun response(call: Call, request: Request, response: Response) {}
 }


### PR DESCRIPTION
This commit addresses a crash that occurred when instantiating `OkHttpEventCollectorImpl` without verifying the presence of OkHttp as a runtime dependency. The issue was introduced in #980 when OkHttp was changed to a compile-time dependency.

Changes:

* Implement runtime checks for OkHttp availability before accessing OkHttp-dependent classes
* Add ProGuard rule to preserve ability to check for OkHttp presence

This solution ensures the SDK functions correctly regardless of whether OkHttp is available at runtime.

closes: [#1066](https://github.com/measure-sh/measure/issues/1066)