### PR TITLE
chore(android): configure ci to publish to gradle plugin portal and enable automatic releases for maven central

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -129,7 +129,8 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Publish measure-android-gradle
-        run: ./gradlew clean  :measure-android-gradle:publishPluginMavenPublicationToMavenCentralRepository --no-daemon --no-parallel --no-configuration-cache --stacktrace
+        # publish the plugin to Gradle Plugin Portal and Maven Central
+        run: ./gradlew clean :measure-android-gradle:publishPluginMavenPublicationToMavenCentralRepository :measure-android-gradle:publishPlugins --no-daemon --no-parallel --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}

--- a/android/measure-android-gradle/build.gradle.kts
+++ b/android/measure-android-gradle/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.mavenPublish)
 }
 
+@Suppress("UnstableApiUsage")
 gradlePlugin {
     plugins {
         create("plugin") {
@@ -19,6 +20,9 @@ gradlePlugin {
             displayName = "Measure Gradle Plugin"
             description = "A gradle plugin for Measure Android SDK"
             implementationClass = "sh.measure.MeasurePlugin"
+            website = "https://measure.sh"
+            vcsUrl = "https://github.com/measure-sh/measure"
+            tags = listOf("measure")
         }
     }
 }

--- a/android/measure-android-gradle/build.gradle.kts
+++ b/android/measure-android-gradle/build.gradle.kts
@@ -35,7 +35,7 @@ version = properties["MEASURE_PLUGIN_VERSION_NAME"] as String
 
 mavenPublishing {
     coordinates(group as String, artifactId, version as String)
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = false)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     configure(
         GradlePublishPlugin()
     )

--- a/android/measure-android-gradle/gradle.properties
+++ b/android/measure-android-gradle/gradle.properties
@@ -1,4 +1,4 @@
-MEASURE_PLUGIN_GROUP_ID=sh.measure.android.gradle
+MEASURE_PLUGIN_GROUP_ID=sh.measure
 MEASURE_PLUGIN_ARTIFACT_ID=sh.measure.android.gradle.gradle.plugin
 MEASURE_PLUGIN_VERSION_NAME=0.6.0-SNAPSHOT
 

--- a/android/measure/build.gradle.kts
+++ b/android/measure/build.gradle.kts
@@ -19,7 +19,7 @@ private val artifactId = properties["MEASURE_ARTIFACT_ID"] as String
 
 mavenPublishing {
     coordinates(groupId, artifactId, measureSdkVersion)
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = false)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
     configure(
         AndroidSingleVariantLibrary(


### PR DESCRIPTION
# Summary
* Updates github action to publish to gradle plugin portal along with maven central
* Updates group ID for gradle plugin to sh.measure instead of sh.measure.android.gradle. This will change the coordinates for maven, but this is the group ID we want to start using from now onwards.
* Enable automatic release to maven central, we would no longer need to press the publish button on the website.

closes #1068 