### PR TITLE
fix(android): make gradle plugin compatible with AGP 7.4.1

### DIFF
--- a/android/measure-android-gradle/build.gradle.kts
+++ b/android/measure-android-gradle/build.gradle.kts
@@ -63,7 +63,7 @@ mavenPublishing {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 dependencies {


### PR DESCRIPTION
Use java toolchain 11 for gradle plugin to make it compatible with AGP 7.4.1

closes #1073 