### PR TITLE
fix(android): handle un-parsable dependency versions

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
@@ -44,9 +44,15 @@ fun Project.versionsMap(variant: Variant): MapProperty<ModuleInfo, SemVer> {
             dependencies.forEach { dependency: DependencyResult ->
                 when (val requested = dependency.requested) {
                     is ModuleComponentSelector -> {
+                        val parse = try {
+                            SemVer.parse(requested.version)
+                        } catch (e: IllegalArgumentException) {
+                            logger.info("[Measure] unable to parse version: ${requested.version}")
+                            SemVer()
+                        }
                         versionsMap.put(
                             ModuleInfo(requested.group, requested.module),
-                            SemVer.parse(requested.version),
+                            parse,
                         )
                     }
                 }


### PR DESCRIPTION
Some dependency versions (like BOMs) don't follow SemVer. This causes errors when parsing versions for bytecode transformations

This commit fixes the issue by catching the exception when parsing versions. Additionally, BOM dependency versions are now parsed correctly.

closes #1072