### PR TITLE
chore: fix self host and google signin

### DIFF
--- a/frontend/dashboard/app/auth/login/google-sign-in.tsx
+++ b/frontend/dashboard/app/auth/login/google-sign-in.tsx
@@ -38,7 +38,7 @@ export default function GoogleSignIn() {
       <div id="g_id_onload"
         data-client_id={googleClientID}
         data-context="signin"
-        data-ux_mode="redirect"
+        data-ux_mode="popup"
         data-nonce={hashedNonce}
         data-login_uri={`${origin}/auth/callback/google?nonce=${encodeURIComponent(nonce)}&state=${encodeURIComponent(state)}`}
         data-auto_prompt="false"

--- a/frontend/dashboard/dockerfile
+++ b/frontend/dashboard/dockerfile
@@ -7,6 +7,5 @@ RUN npm install
 
 FROM base
 WORKDIR /app
-RUN apk add --no-cache curl
 COPY --from=builder /app/node_modules ./node_modules
 CMD ["npm", "run", "dev"]

--- a/frontend/dashboard/dockerfile.prod
+++ b/frontend/dashboard/dockerfile.prod
@@ -9,7 +9,6 @@ RUN npm run build
 
 FROM base
 WORKDIR /app
-RUN apk add --no-cache curl
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static

--- a/self-host/compose.prod.yml
+++ b/self-host/compose.prod.yml
@@ -4,6 +4,7 @@ services:
       dockerfile: dockerfile.prod
     environment:
       - NODE_ENV=production
+      - HOSTNAME=0.0.0.0
     volumes: !reset null
 
   api:

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -37,7 +37,7 @@ services:
       - NODE_ENV=development
       - NEXT_TELEMETRY_DISABLED=1
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:3000 || exit 1"]
+      test: ["CMD", "wget", "-q", "-O", "-", "http://0.0.0.0:3000"]
       interval: 5s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary

This PR reverts the ux mode of Google SignIn to `popup` instead of `redirect` because otherwise Google SignIn fails on production with the following error.

```
GSI_LOGGER]: The given login_uri is not allowed for the given client ID.
```

Verified that Google Signin on iOS (17.6.1) Safari works in popup mode on production.

Also, healthcheck for dashboard service was failing because next.js binds the production server on the `HOSTNAME` environment variable if present. This PR, adds a suitable `HOSTNAME` environment variable for the production dockerfile of dashboard.

## Tasks

- [x] Revert to using `popup` ux mode in Google Signin
- [x] Fix healthcheck for dashboard service using `HOSTNAME` in production
- [x] Update dashboard service healthcheck test accordingly
- [x] Remove installation of `curl` from dashboard's dev and production dockerfiles