### PR TITLE
feat(android): apply bytecode transformation only for supported dependency versions

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
@@ -1,0 +1,50 @@
+package sh.measure
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.result.DependencyResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.provider.MapProperty
+import sh.measure.asm.ModuleInfo
+
+/**
+ * Checks if the version of the library is compatible with the given range.
+ *
+ * @param group The group of the library.
+ * @param name The name of the library.
+ * @param minVersion The minimum version of the library that is compatible. This version is inclusive.
+ * @param maxVersion The maximum version of the library that is compatible. This version is exclusive.
+ */
+fun Map<ModuleInfo, SemVer>.isVersionCompatible(
+    group: String,
+    name: String,
+    minVersion: SemVer,
+    maxVersion: SemVer,
+): Boolean {
+    val version: SemVer = this.getOrDefault(ModuleInfo(group, name), SemVer())
+    return version >= minVersion && version < maxVersion
+}
+
+/**
+ * Extracts the versions of the dependencies from the [ResolvedComponentResult] and returns a map
+ * of [ModuleInfo] to [SemVer]. Ignores the dependency if it is not a valid SemVer.
+ */
+fun ResolvedComponentResult.versionsMap(project: Project): MapProperty<ModuleInfo, SemVer> {
+    val versionsMap = project.objects.mapProperty(ModuleInfo::class.java, SemVer::class.java)
+    dependencies.forEach { dependency: DependencyResult ->
+        when (val requested = dependency.requested) {
+            is ModuleComponentSelector -> {
+                val version = try {
+                    SemVer.parse(requested.version)
+                } catch (e: IllegalArgumentException) {
+                    SemVer()
+                }
+                versionsMap.put(
+                    ModuleInfo(requested.group, requested.module),
+                    version,
+                )
+            }
+        }
+    }
+    return versionsMap
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/SemVer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/SemVer.kt
@@ -1,0 +1,171 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Eric Li
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sh.measure
+
+import java.io.Serializable
+
+/**
+ * Adapted from: https://github.com/swiftzer/semver as we require the data class to be serializable.
+ *
+ * Version number in [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) specification (SemVer).
+ *
+ * @property major major version, increment it when you make incompatible API changes.
+ * @property minor minor version, increment it when you add functionality in a backwards-compatible manner.
+ * @property patch patch version, increment it when you make backwards-compatible bug fixes.
+ * @property preRelease pre-release version.
+ * @property buildMetadata build metadata.
+ */
+data class SemVer(
+    val major: Int = 0,
+    val minor: Int = 0,
+    val patch: Int = 0,
+    val preRelease: String? = null,
+    val buildMetadata: String? = null,
+) : Comparable<SemVer>, Serializable {
+    companion object {
+        /**
+         * Parse the version string to [SemVer] data object.
+         * @param version version string.
+         * @throws IllegalArgumentException if the version is not valid.
+         */
+        @JvmStatic
+        fun parse(version: String): SemVer {
+            val pattern =
+                Regex("""(0|[1-9]\d*)?(?:\.)?(0|[1-9]\d*)?(?:\.)?(0|[1-9]\d*)?(?:-([\dA-z\-]+(?:\.[\dA-z\-]+)*))?(?:\+([\dA-z\-]+(?:\.[\dA-z\-]+)*))?""")
+            val result = pattern.matchEntire(version)
+                ?: throw IllegalArgumentException("Invalid version string [$version]")
+            return SemVer(
+                major = if (result.groupValues[1].isEmpty()) 0 else result.groupValues[1].toInt(),
+                minor = if (result.groupValues[2].isEmpty()) 0 else result.groupValues[2].toInt(),
+                patch = if (result.groupValues[3].isEmpty()) 0 else result.groupValues[3].toInt(),
+                preRelease = if (result.groupValues[4].isEmpty()) null else result.groupValues[4],
+                buildMetadata = if (result.groupValues[5].isEmpty()) null else result.groupValues[5]
+            )
+        }
+    }
+
+    init {
+        require(major >= 0) { "Major version must be a positive number" }
+        require(minor >= 0) { "Minor version must be a positive number" }
+        require(patch >= 0) { "Patch version must be a positive number" }
+        if (preRelease != null) require(preRelease.matches(Regex("""[\dA-z\-]+(?:\.[\dA-z\-]+)*"""))) { "Pre-release version is not valid" }
+        if (buildMetadata != null) require(buildMetadata.matches(Regex("""[\dA-z\-]+(?:\.[\dA-z\-]+)*"""))) { "Build metadata is not valid" }
+    }
+
+    /**
+     * Build the version name string.
+     * @return version name string in Semantic Versioning 2.0.0 specification.
+     */
+    override fun toString(): String = buildString {
+        append("$major.$minor.$patch")
+        if (preRelease != null) {
+            append('-')
+            append(preRelease)
+        }
+        if (buildMetadata != null) {
+            append('+')
+            append(buildMetadata)
+        }
+    }
+
+    /**
+     * Check the version number is in initial development.
+     * @return true if it is in initial development.
+     */
+    fun isInitialDevelopmentPhase(): Boolean = major == 0
+
+    /**
+     * Compare two SemVer objects using major, minor, patch and pre-release version as specified in SemVer specification.
+     *
+     * For comparing the whole SemVer object including build metadata, use [equals] instead.
+     *
+     * @return a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object.
+     */
+    override fun compareTo(other: SemVer): Int {
+        if (major > other.major) return 1
+        if (major < other.major) return -1
+        if (minor > other.minor) return 1
+        if (minor < other.minor) return -1
+        if (patch > other.patch) return 1
+        if (patch < other.patch) return -1
+
+        if (preRelease == null && other.preRelease == null) return 0
+        if (preRelease != null && other.preRelease == null) return -1
+        if (preRelease == null && other.preRelease != null) return 1
+
+        val parts = preRelease.orEmpty().split(".")
+        val otherParts = other.preRelease.orEmpty().split(".")
+
+        val endIndex = Math.min(parts.size, otherParts.size) - 1
+        for (i in 0..endIndex) {
+            val part = parts[i]
+            val otherPart = otherParts[i]
+            if (part == otherPart) continue
+
+            val partIsNumeric = part.isNumeric()
+            val otherPartIsNumeric = otherPart.isNumeric()
+
+            when {
+                partIsNumeric && !otherPartIsNumeric -> {
+                    // lower priority
+                    return -1
+                }
+
+                !partIsNumeric && otherPartIsNumeric -> {
+                    // higher priority
+                    return 1
+                }
+
+                !partIsNumeric && !otherPartIsNumeric -> {
+                    if (part > otherPart) return 1
+                    if (part < otherPart) return -1
+                }
+
+                else -> {
+                    try {
+                        val partInt = part.toInt()
+                        val otherPartInt = otherPart.toInt()
+                        if (partInt > otherPartInt) return 1
+                        if (partInt < otherPartInt) return -1
+                    } catch (_: NumberFormatException) {
+                        // When part or otherPart doesn't fit in an Int, compare as strings
+                        return part.compareTo(otherPart)
+                    }
+                }
+            }
+        }
+
+        return if (parts.size == endIndex + 1 && otherParts.size > endIndex + 1) {
+            // parts is ended and otherParts is not ended
+            -1
+        } else if (parts.size > endIndex + 1 && otherParts.size == endIndex + 1) {
+            // parts is not ended and otherParts is ended
+            1
+        } else {
+            0
+        }
+    }
+
+    private fun String.isNumeric(): Boolean = this.matches(Regex("""\d+"""))
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/AsmBytecodeTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/AsmBytecodeTransformer.kt
@@ -1,0 +1,59 @@
+package sh.measure.asm
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.FramesComputationMode
+import com.android.build.api.instrumentation.InstrumentationScope
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+import sh.measure.SemVer
+import sh.measure.versionsMap
+
+/**
+ * A bytecode transformer that uses ASM to transform classes using
+ * Android Gradle Plugin's [com.android.build.api.variant.Instrumentation] API.
+ *
+ * This class is meant to be subclassed to provide the necessary configuration for
+ * the transformation including the [visitorFactoryClass], [minVersion], and [maxVersion].
+ *
+ * Example usage:
+ *
+ * ```kotlin
+ * class MyTransformer : AsmBytecodeTransformer() {
+ *    override val visitorFactoryClass = MyVisitorFactory::class.java
+ *    override val minVersion = SemVer(1, 0, 0)
+ *    override val maxVersion = SemVer(2, 0, 0)
+ * }
+ * ```
+ *
+ * @property visitorFactoryClass The [AsmClassVisitorFactory] class that will be used to create
+ * the [org.objectweb.asm.ClassVisitor] instances.
+ * @property minVersion The minimum version of the library that this transformer is compatible with.
+ * @property maxVersion The maximum version of the library that this transformer is compatible with.
+ */
+abstract class AsmBytecodeTransformer : BytecodeTransformer {
+    abstract val visitorFactoryClass: Class<out AsmClassVisitorFactory<TransformerParameters>>
+    abstract val minVersion: SemVer
+    abstract val maxVersion: SemVer
+
+    override fun transform(
+        variant: Variant,
+        project: Project,
+    ) {
+        variant.instrumentation.transformClassesWith(
+            visitorFactoryClass, InstrumentationScope.ALL
+        ) {
+            it.minVersion.set(minVersion)
+            it.maxVersion.set(maxVersion)
+            project.configurations.named("${variant.name}RuntimeClasspath")
+                .configure { configuration ->
+                    val map = configuration.incoming.resolutionResult.rootComponent.map { result ->
+                        result.versionsMap(project)
+                    }
+                    it.versions.set(map)
+                }
+        }
+        variant.instrumentation.setAsmFramesComputationMode(
+            FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
+        )
+    }
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformationPipeline.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformationPipeline.kt
@@ -1,0 +1,20 @@
+package sh.measure.asm
+
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+
+/**
+ * Applies multiple bytecode transformers to a variant. Transformers are applied in
+ * the order they were added to the pipeline.
+ */
+class BytecodeTransformationPipeline : BytecodeTransformer {
+    private val transformers = mutableListOf<BytecodeTransformer>()
+
+    fun addTransformer(transformer: BytecodeTransformer) {
+        transformers.add(transformer)
+    }
+
+    override fun transform(variant: Variant, project: Project) {
+        transformers.forEach { it.transform(variant, project) }
+    }
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformationPipelineBuilder.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformationPipelineBuilder.kt
@@ -1,0 +1,15 @@
+package sh.measure.asm
+
+/**
+ * Allows for construction multiple [BytecodeTransformer]s.
+ */
+class BytecodeTransformationPipelineBuilder {
+    private val pipeline = BytecodeTransformationPipeline()
+
+    fun addTransformer(transformer: BytecodeTransformer): BytecodeTransformationPipelineBuilder {
+        pipeline.addTransformer(transformer)
+        return this
+    }
+
+    fun build(): BytecodeTransformer = pipeline
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/BytecodeTransformer.kt
@@ -1,0 +1,14 @@
+package sh.measure.asm
+
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+
+/**
+ * Defines a bytecode transformer that can be applied to a variant.
+ */
+interface BytecodeTransformer {
+    fun transform(
+        variant: Variant,
+        project: Project,
+    )
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/ModuleInfo.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/ModuleInfo.kt
@@ -1,0 +1,16 @@
+package sh.measure.asm
+
+import java.io.Serializable
+
+/**
+ * Represents a dependency module.
+ *
+ * @property group The group of the module, example for `com.google.dagger:dagger:2.35`
+ * the group is `com.google.dagger`.
+ * @property name The name of the module, example for `com.google.dagger:dagger:2.35` the name
+ * is `dagger`.
+ */
+data class ModuleInfo(
+    val group: String,
+    val name: String,
+) : Serializable

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
@@ -1,19 +1,37 @@
-package sh.measure.navigation
+package sh.measure.asm
 
 import com.android.build.api.instrumentation.AsmClassVisitorFactory
-import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
-import com.android.build.api.instrumentation.InstrumentationParameters
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.commons.AdviceAdapter
+import sh.measure.SemVer
+import sh.measure.isVersionCompatible
 
-abstract class NavigationVisitorFactory : AsmClassVisitorFactory<InstrumentationParameters.None> {
+class NavigationTransformer : AsmBytecodeTransformer() {
+    override val visitorFactoryClass = NavigationVisitorFactory::class.java
 
-    override fun createClassVisitor(
-        classContext: ClassContext, nextClassVisitor: ClassVisitor
-    ): ClassVisitor {
+    // Tested from 2.4.0, 2.3.5 does not have navigation-compose package
+    override val minVersion = SemVer(2, 4, 0)
+
+    // Tested up-to 2.8.0-beta06, 2.8.0-beta07 requires compile SDK 35
+    override val maxVersion = SemVer(2, 8, 0, "-beta06")
+}
+
+abstract class NavigationVisitorFactory : AsmClassVisitorFactory<TransformerParameters>,
+    VersionAwareVisitor<TransformerParameters> {
+    override fun isVersionCompatible(
+        versions: Map<ModuleInfo, SemVer>,
+        minVersion: SemVer,
+        maxVersion: SemVer,
+    ): Boolean {
+        return versions.isVersionCompatible(
+            "androidx.navigation", "navigation-compose", minVersion, maxVersion
+        )
+    }
+
+    override fun createClassVisitor(nextClassVisitor: ClassVisitor): ClassVisitor {
         return NavigationClassVisitor(nextClassVisitor)
     }
 
@@ -64,7 +82,7 @@ class NavigationClassVisitor(classVisitor: ClassVisitor) :
  * ```
  */
 class NavigationMethodVisitor(
-    apiVersion: Int, originalVisitor: MethodVisitor, access: Int, name: String, descriptor: String
+    apiVersion: Int, originalVisitor: MethodVisitor, access: Int, name: String, descriptor: String,
 ) : AdviceAdapter(
     apiVersion, originalVisitor, access, name, descriptor
 ) {

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/TransformerParameters.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/TransformerParameters.kt
@@ -1,0 +1,18 @@
+package sh.measure.asm
+
+import com.android.build.api.instrumentation.InstrumentationParameters
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import sh.measure.SemVer
+
+interface TransformerParameters : InstrumentationParameters {
+    @get:Input
+    val versions: Property<Provider<Map<ModuleInfo, SemVer>>>
+
+    @get:Input
+    val minVersion: Property<SemVer>
+
+    @get:Input
+    val maxVersion: Property<SemVer>
+}

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/VersionAwareVisitor.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/VersionAwareVisitor.kt
@@ -1,0 +1,36 @@
+package sh.measure.asm
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.ClassContext
+import org.objectweb.asm.ClassVisitor
+import sh.measure.SemVer
+
+/**
+ * A common base class for creating [AsmClassVisitorFactory] depending on the version of the
+ * dependency being instrumented. It applies the class visitor only if the version of the dependency
+ * is within the specified range.
+ */
+interface VersionAwareVisitor<T : TransformerParameters> : AsmClassVisitorFactory<T> {
+    fun isVersionCompatible(
+        versions: Map<ModuleInfo, SemVer>,
+        minVersion: SemVer,
+        maxVersion: SemVer,
+    ): Boolean
+
+    override fun createClassVisitor(
+        classContext: ClassContext,
+        nextClassVisitor: ClassVisitor,
+    ): ClassVisitor {
+        val versions = parameters.get().versions.get().get()
+        val minVersion = parameters.get().minVersion.get()
+        val maxVersion = parameters.get().maxVersion.get()
+
+        return if (isVersionCompatible(versions, minVersion, maxVersion)) {
+            createClassVisitor(nextClassVisitor)
+        } else {
+            nextClassVisitor
+        }
+    }
+
+    fun createClassVisitor(nextClassVisitor: ClassVisitor): ClassVisitor
+}

--- a/docs/android/features/feature_navigation_and_lifecycle.md
+++ b/docs/android/features/feature_navigation_and_lifecycle.md
@@ -5,7 +5,7 @@ Measure SDK captures lifecycle and navigation events automatically, this include
 1. [Application foregrounded/backgrounded](#application-foregroundedbackgrounded)
 2. [Activity lifecycle](#activity-lifecycle)
 3. [Fragment lifecycle](#fragment-lifecycle)
-4. [Compose navigation](#compose-navigation)
+4. [Navigation](#navigation)
 
 ## Application foregrounded/backgrounded
 
@@ -84,7 +84,7 @@ using [ASM](https://asm.ow2.io/) by automatically tracking all
 navigation events by
 registering [NavController.OnDestinationChangedListener](https://developer.android.com/reference/androidx/navigation/NavController.OnDestinationChangedListener)
 This is done using the Measure gradle plugin, read more details about
-it [here](../../../android/measure-android-gradle/README.md#androidx-navigation).
+it [here](/docs/android/gradle-plugin.md).
 
 ### Data collected
 

--- a/docs/android/gradle-plugin.md
+++ b/docs/android/gradle-plugin.md
@@ -25,6 +25,9 @@ We apply the following transformations to your app, provided your app uses these
 
 ### OkHttp
 
+* Minimum supported version: `4.7.0`
+* Maximum supported version: `5.0.0-alpha.14`
+
 Enables tracking network requests and metrics from OkHttp.
 This is done by injecting an [Interceptor](https://square.github.io/okhttp/features/interceptors/)
 and an [EventListener](https://square.github.io/okhttp/features/events/#eventlistener) into
@@ -35,6 +38,9 @@ you already set one, it will continue working as is. Measure plugin does not ove
 to it.
 
 ### AndroidX Navigation
+
+* Minimum supported version: `2.4.0`
+* Maximum supported version: `2.8.0-beta06`
 
 Automatically tracks screen transition events from
 the [AndroidX Navigation](https://developer.android.com/guide/navigation)


### PR DESCRIPTION
# Summary
 Bytecode transformation now requires configuring min and max supported versions for the library being transformed. The transformation is applied only when the resolved version lies within the constraints provided. This makes the SDK more robust and reduces the chances of crashes at runtime when changing library versions.

This PR fixes the issues which were present in https://github.com/measure-sh/measure/pull/1053:
* Dependencies declared via BOM or version catalog bundles are now parsed correctly.
* Resolved dependencies are read lazily, ensuring we always have them available when class visitor needs to be created (which is where we make the version check).