### PR TITLE
chore(android): fix publish command for gradle plugin on CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -130,7 +130,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Publish measure-android-gradle
         # publish the plugin to Gradle Plugin Portal and Maven Central
-        run: ./gradlew clean :measure-android-gradle:publishPluginMavenPublicationToMavenCentralRepository :measure-android-gradle:publishPlugins --no-daemon --no-parallel --no-configuration-cache --stacktrace
+        run: ./gradlew clean :measure-android-gradle:publish :measure-android-gradle:publishPlugins --no-daemon --no-parallel --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
Use `:measure-gradle-plugin:publish` instead of `publishPluginMavenPublicationToMavenCentralRepository` to ensure the [plugin marker artefact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) is also published.