### PR TITLE
feat(frontend): add "Copy AI context" button

### DIFF
--- a/frontend/dashboard/app/components/copy_ai_context.tsx
+++ b/frontend/dashboard/app/components/copy_ai_context.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { emptyAnrExceptionsDetailsResponse, emptyCrashExceptionsDetailsResponse, ExceptionsType } from '../api/api_calls';
+import { formatDateToHumanReadable, formatTimeToHumanReadable } from '../utils/time_utils';
+
+interface CopyAiContextProps {
+  appName: string,
+  exceptionsType: ExceptionsType
+  exceptionsDetails: typeof emptyCrashExceptionsDetailsResponse | typeof emptyAnrExceptionsDetailsResponse
+}
+
+const CopyAiContext: React.FC<CopyAiContextProps> = ({ appName, exceptionsType, exceptionsDetails }) => {
+  const formatExceptionDetails = () => {
+    let formatted = ""
+
+    formatted = formatted + "App Name: " + appName + "\n"
+    formatted = formatted + "App version: " + exceptionsDetails.results[0].attribute.app_version + "\n"
+    formatted = formatted + "Date & time: " + formatDateToHumanReadable(exceptionsDetails.results[0].timestamp) + ", " + formatTimeToHumanReadable(exceptionsDetails.results[0].timestamp) + "\n"
+    formatted = formatted + "Platform: " + exceptionsDetails.results[0].attribute.platform + "\n"
+    formatted = formatted + "Device: " + exceptionsDetails.results[0].attribute.device_manufacturer + exceptionsDetails.results[0].attribute.device_model + "\n"
+    formatted = formatted + "Network type: " + exceptionsDetails.results[0].attribute.network_type + "\n"
+
+    formatted = formatted + "\nSTACK TRACES:\n"
+    let stacktrace = exceptionsType === ExceptionsType.Crash ? (exceptionsDetails as typeof emptyCrashExceptionsDetailsResponse).results[0].exception.stacktrace : (exceptionsDetails as typeof emptyAnrExceptionsDetailsResponse).results[0].anr.stacktrace
+    let indentedStackTrace = stacktrace.split("\n").map(line => "    " + line).join("\n")
+
+    formatted = formatted + "Thread: " + exceptionsDetails.results[0].attribute.thread_name + "\nStacktrace:\n" + indentedStackTrace + "\n\n"
+
+    exceptionsDetails.results[0].threads.forEach((e) => {
+      formatted = formatted + "Thread: " + e.name + "\n"
+      formatted = formatted + "Stacktrace:\n    " + e.frames.join("\n    ")
+      formatted = formatted + "\n\n"
+    })
+
+    return formatted
+  }
+
+  const llmContext =
+    "I am trying to fix an exception in my app. The details are as follows: \n\n"
+    + formatExceptionDetails() + "\n\n"
+    + "Please help me debug this."
+
+  return (
+    <button className="flex group relative outline-none justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4" onClick={() => navigator.clipboard.writeText(llmContext)}>
+      Copy AI Context
+      <span className="pointer-events-none z-50 max-w-xl absolute font-sans text-sm text-white rounded-md p-2 bg-neutral-800 -bottom-12 left-0 w-max opacity-0 transition-opacity group-hover:opacity-100">
+        Copy full exception context for easy pasting in your favorite LLM
+      </span>
+    </button>
+  );
+}
+
+export default CopyAiContext;

--- a/frontend/dashboard/app/components/exceptions_details.tsx
+++ b/frontend/dashboard/app/components/exceptions_details.tsx
@@ -11,6 +11,7 @@ import ExceptionspDetailsPlot from './exceptions_details_plot';
 import Filters, { AppVersionsInitialSelectionType, defaultSelectedFilters } from './filters';
 import Journey, { JourneyType } from './journey';
 import Image from 'next/image';
+import CopyAiContext from './copy_ai_context';
 
 interface ExceptionsDetailsProps {
   exceptionsType: ExceptionsType,
@@ -180,7 +181,11 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
                   ))}
                 </div>}
               <div className="py-4" />
-              <Link key={exceptionsDetails.results[0].id} href={`/${teamId}/sessions/${appId}/${exceptionsDetails.results[0].session_id}`} className="outline-none justify-center w-fit hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4">View Session </Link>
+              <div className='flex flex-row items-center'>
+                <Link key={exceptionsDetails.results[0].id} href={`/${teamId}/sessions/${appId}/${exceptionsDetails.results[0].session_id}`} className="outline-none justify-center w-fit hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4">View Session</Link>
+                <div className='px-2' />
+                <CopyAiContext appName={selectedFilters.selectedApp.name} exceptionsType={exceptionsType} exceptionsDetails={exceptionsDetails} />
+              </div>
               <div className="py-2" />
               {exceptionsType === ExceptionsType.Crash &&
                 <Accordion key='crash-thread' title={'Thread: ' + exceptionsDetails.results[0].attribute.thread_name} id='crash' active={true}>


### PR DESCRIPTION
closes #1025

This commit adds a "Copy AI context" button to crash/ANR details page.

This button copies key attributes and stack traces to the clipboard along with a prompt.

The intention is to make it easy for developers
to paste this context into an LLM of their choice and get help in debugging.

Sample context that gets copied:

```
I am trying to fix an exception in my Android app. The details of the exception are as follows: 

App Name: Sample
App version: 1.0
Date & time: Thu, 25 Jul, 2024, 12:14:07:239 PM
Platform: android
Device: Googlesdk_gphone64_arm64
Network type: wifi

STACK TRACES:
Thread: main
Stacktrace:
    java.lang.IllegalAccessException: This is a new exception
        at sh.measure.sample.ExceptionDemoActivity.onCreate$lambda$0(ExceptionDemoActivity.kt:21)
        at sh.measure.sample.ExceptionDemoActivity.$r8$lambda$Q_ui1nZ8w7tXFl-UGrB13ccXmnU
        at sh.measure.sample.ExceptionDemoActivity$$ExternalSyntheticLambda3.onClick(D8$$SyntheticClass)
        at android.view.View.performClick(View.java:7506)
        at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1218)
        at android.view.View.performClickInternal(View.java:7483)
        at android.view.View.-$$Nest$mperformClickInternal
        at android.view.View$PerformClick.run(View.java:29334)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7872)
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
    Caused by: java.lang.IllegalAccessException: This is a new exception
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
    Caused by: java.lang.reflect.InvocationTargetException
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:558)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)

Thread: Okio Watchdog
Stacktrace:
    jdk.internal.misc.Unsafe.park(Unsafe.java:-2)
    java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
    java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2211)
    okio.AsyncTimeout$Companion.awaitTimeout(AsyncTimeout.kt:370)
    okio.AsyncTimeout$Watchdog.run(AsyncTimeout.kt:211)

Thread: msr-default
Stacktrace:
    jdk.internal.misc.Unsafe.park(Unsafe.java:-2)
    java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
    java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2123)
    java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1188)
    java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:905)
    java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1063)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1123)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
    java.lang.Thread.run(Thread.java:1012)

Thread: LeakCanary-Heap-Dump
Stacktrace:
    android.os.MessageQueue.nativePollOnce(MessageQueue.java:-2)
    android.os.MessageQueue.next(MessageQueue.java:335)
    android.os.Looper.loopOnce(Looper.java:161)
    android.os.Looper.loop(Looper.java:288)
    android.os.HandlerThread.run(HandlerThread.java:67)

Thread: FinalizerDaemon
Stacktrace:
    java.lang.Object.wait(Object.java:-2)
    java.lang.Object.wait(Object.java:442)
    java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:203)
    java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:224)
    java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:300)
    java.lang.Daemons$Daemon.run(Daemons.java:140)
    java.lang.Thread.run(Thread.java:1012)

Thread: OkHttp TaskRunner
Stacktrace:
    java.lang.Object.wait(Object.java:-2)
    okhttp3.internal.concurrent.TaskRunner$RealBackend.coordinatorWait(TaskRunner.kt:294)
    okhttp3.internal.concurrent.TaskRunner.awaitTaskToRun(TaskRunner.kt:218)
    okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:59)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
    java.lang.Thread.run(Thread.java:1012)

Thread: ReferenceQueueDaemon
Stacktrace:
    java.lang.Object.wait(Object.java:-2)
    java.lang.Object.wait(Object.java:442)
    java.lang.Object.wait(Object.java:568)
    java.lang.Daemons$ReferenceQueueDaemon.runInternal(Daemons.java:232)
    java.lang.Daemons$Daemon.run(Daemons.java:140)
    java.lang.Thread.run(Thread.java:1012)

Thread: msr-io
Stacktrace:
    jdk.internal.misc.Unsafe.park(Unsafe.java:-2)
    java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
    java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)
    java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1176)
    java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:905)
    java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1063)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1123)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
    java.lang.Thread.run(Thread.java:1012)

Thread: FinalizerWatchdogDaemon
Stacktrace:
    java.lang.Object.wait(Object.java:-2)
    java.lang.Object.wait(Object.java:442)
    java.lang.Object.wait(Object.java:568)
    java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded(Daemons.java:385)
    java.lang.Daemons$FinalizerWatchdogDaemon.runInternal(Daemons.java:365)
    java.lang.Daemons$Daemon.run(Daemons.java:140)
    java.lang.Thread.run(Thread.java:1012)

Thread: queued-work-looper
Stacktrace:
    android.os.MessageQueue.nativePollOnce(MessageQueue.java:-2)
    android.os.MessageQueue.next(MessageQueue.java:335)
    android.os.Looper.loopOnce(Looper.java:161)
    android.os.Looper.loop(Looper.java:288)
    android.os.HandlerThread.run(HandlerThread.java:67)



Please help me debug this issue
```