### PR TITLE
docs: improve self host guide

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -68,6 +68,11 @@ git clone https://github.com/measure-sh/measure.git && cd measure
 
 Checkout to git a tag. Replace `GIT-TAG` with an existing git tag. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
 
+> [!IMPORTANT]
+
+> Always choose a tag matching the format `v[MAJOR].[MINOR].[PATCH]`, for example: `v1.2.3`.
+> These tags are tailored for self host deployments.
+
 ```sh
 git checkout GIT-TAG
 ```

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -63,8 +63,7 @@ cd ~
 Clone the repository with git and change to the `measure` directory.
 
 ```sh
-git clone https://github.com/measure-sh/measure.git
-cd measure
+git clone https://github.com/measure-sh/measure.git && cd measure
 ```
 
 Checkout to git a tag. Replace `GIT-TAG` with an existing git tag. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
@@ -142,10 +141,10 @@ cd ~
 Run the following commands to install caddy.
 
 ```sh
-sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-sudo apt update
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl && \
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg && \
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list && \
+sudo apt update && \
 sudo apt install caddy
 ```
 
@@ -169,10 +168,10 @@ EOF
 > 
 > In the above Caddyfile, we have used the example domains from above, but make sure you replace with your actual domain names.
 
-Next, run `sudo caddy start` to make sure caddy picks up our newly generated config.
+Next, reload caddy to make sure caddy picks up our newly generated config.
 
 ```sh
-sudo caddy start
+caddy reload
 ```
 
 ### 6. Setup DNS A records

--- a/frontend/dashboard/README.md
+++ b/frontend/dashboard/README.md
@@ -1,3 +1,3 @@
 # Measure frontend dashboard app
 
-The `self-host` directory contains all resources required for local development and self hosting. [Read the official self hosting guide](../docs/hosting/README.md)
+The `self-host` directory contains all resources required for local development and self hosting. [Read the official self hosting guide](../../docs/hosting/README.md)


### PR DESCRIPTION
## Summary

Organize and format few commands in the self host guide so that they are easier to copy. Added information around how to choose the correct tag for self hosting and fixed a broken link in dashboard's readme.

## Tasks

- [x] :books: Organize and format commands so that they are easier to copy
- [x] :books: Change the caddy reload command
- [x] :books: Add alert on choose the right format for tags
- [x] :books: Fix a broken link in dashboard README