### PR TITLE
ci: add changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,36 @@
+name: Changelog
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  changelog:
+    name: Generate changelog
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog using git-cliff
+        uses: orhun/git-cliff-action@v3
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit the changelog
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          set +e
+          git add CHANGELOG.md
+          git commit -m "ci: update changelog"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPSITORY}.git main
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-notes:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    outputs:
+      release_body: ${{ steps.git-cliff.outputs.content }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog using git-cliff
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: cliff.toml
+          args: --verbose --bump
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit the changelog
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          set +e
+          git add CHANGELOG.md
+          git commit -m "ci: update changelog"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPSITORY}.git main
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v3
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --verbose --github-repo ${{ github.repository }} --current --strip header footer
+
+      - name: Create GitHub release
+        if: ${{ !contains(github.ref, '-' )}}
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.git-cliff.outputs.content }}
+          draft: true
+          prerelease: false
+
+      - name: Create GitHub pre-release
+        if: ${{ contains(github.ref, '-' )}}
+        id: create-prerelease
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.git-cliff.outputs.content }}
+          draft: true
+          prerelease: true

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,86 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# template for the changelog footer
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    {% if commits|length > 0 %}### {{ group | striptags | trim | upper_first }}{% endif -%}
+    {% for scope, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="scope") %}
+        {% for commit in commits %}
+            - {% if commit.scope != "other" %}(**{{ commit.scope }}**): {% endif %}\
+            {{ commit.message | upper_first }}\
+            {% if commit.github.username %} by @{{ commit.github.username }}{%- endif %}\
+            {% if commit.github.pr_number %} in #{{ commit.github.pr_number }}{%- endif -%}
+        {%- endfor -%}
+    {% endfor %}\n
+{% endfor %}
+"""
+# template for the changelog footer
+footer = """
+{% for release in releases -%}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                    /compare/{{ release.previous.version }}..{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+            /compare/{{ release.previous.version }}..HEAD
+    {% endif -%}
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^ci:", skip = true },
+  { message = ".*sessionator.*", skip = true },
+  { message = "^.*\\(android\\):", skip = true },
+  { message = "^.*\\(ios\\):", skip = true },
+  { message = "^docs:", group = "<!-- 5 -->:books: Documentation", default_scope = "other" },
+  { message = "^feat", group = "<!-- 0 -->:sparkles: New features" },
+  { message = "^test", group = "<!-- 3 -->:test_tube: Testing", skip = true },
+  { message = "^fix", group = "<!-- 1 -->:bug: Bug fixes" },
+  { message = "^.*: fix", group = "<!-- 1 -->:bug: Bug fixes" },
+  { message = "^.*: remove", group = "<!-- 4 -->:coffin: Removed" },
+  { message = "^.*: delete", group = "<!-- 4 -->:coffin: Removed" },
+  { message = "^.*", group = "<!-- 2 -->:hammer: Misc" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# regex for matching git tags
+tag_pattern = "v[0-9].*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = "^(android|ios)"
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -182,6 +182,14 @@ All commits landing in any branch are first linted in your local environment and
   exceeding the allowed limit of max characters per line
   ```
 
+## Release process
+
+To trigger a release, create a signed git using [git-cliff](https://git-cliff.org/) and push the tag.
+
+```sh
+VERSION=$(git cliff --bumped-version) git tag -s $VERSION -m $VERSION && git push origin $VERSION
+```
+
 ## Documentation
 - Public facing docs should be in [docs](../README.md) folder - API requests & responses, self host guide, sdk guides and so on
 - Main folder of subproject should link to main guide. ex: [frontend README](../../frontend/README.md) has link to self hosting and local dev guide


### PR DESCRIPTION
## Summary

This PR configures the ability to generate changelog automatically in a consistent manner following [conventionalcommits](https://conventionalcommits.org) but tailored for the project's needs using [git-cliff](https://git-cliff.org). Also, update contributing guide to contain the command to create a new release.

## Tasks

- [x] Add ci changelog generation
- [x] Add ci release that creates a github release automatically
- [x] Update contribution guide to document creating new releases