### PR TITLE
ci: update secret for git push of auto generated changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,5 +34,4 @@ jobs:
           set +e
           git add CHANGELOG.md
           git commit -m "ci: update changelog"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git main
-
+          git push https://${{ secrets.CHANGELOG_PUSH_TOKEN }}@github.com/${{ github.repository }}.git main


### PR DESCRIPTION
## Summary

Trying to push auto generated changelog with a fine-grained Personal Access Token (PAT). This unlocks simplified & unobtrusive changelog generation.

## Tasks

- [x] Use a fine-grained PAT for git push of auto generated changelog