### PR TITLE
chore(android): add thread name to exception

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
@@ -53,6 +53,11 @@ internal data class ExceptionUnit(
      * A list of stack frames for the exception.
      */
     val frames: List<Frame>,
+
+    /**
+     * The thread name where the exception occurred.
+     */
+    val thread_name: String,
 )
 
 /**

--- a/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
@@ -27,6 +27,7 @@ internal object ExceptionFactory {
                         line_num = it.lineNumber,
                     )
                 },
+                thread_name = thread.name,
             )
             exceptions.add(exception)
             error = error.cause

--- a/android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
@@ -4,12 +4,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import sh.measure.android.fakes.FakeTimeProvider
 
 class ExceptionFactoryTest {
-
-    private val timeProvider = FakeTimeProvider()
-
     @Test
     fun `ExceptionFactory creates a single exception when exception has no cause`() {
         // Given


### PR DESCRIPTION
# Description

Adds thread name to exception object. This allows the server to pick the thread name directly from the event instead of relying on attributes. Using the thread name from attributes was not a issue on Android, but on iOS the thread name of the event can be different from where the exception actually occurred. This change makes things consistent between the two platforms to avoid platform checks on backend.

## Related issue
Closes #1127  
Relates to https://github.com/measure-sh/measure/issues/1047

