### PR TITLE
chore(android): add cpu architecture as an attribute for all events

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
@@ -13,6 +13,7 @@ internal object Attribute {
     const val DEVICE_HEIGHT_PX_KEY = "device_height_px"
     const val DEVICE_DENSITY_KEY = "device_density"
     const val DEVICE_LOCALE_KEY = "device_locale"
+    const val DEVICE_CPU_ARCH = "device_cpu_arch"
     const val OS_NAME_KEY = "os_name"
     const val OS_VERSION_KEY = "os_version"
     const val PLATFORM_KEY = "platform"

--- a/android/measure/src/main/java/sh/measure/android/attributes/DeviceAttributeProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/DeviceAttributeProcessor.kt
@@ -35,7 +35,17 @@ internal class DeviceAttributeProcessor(
             Attribute.OS_NAME_KEY to "android",
             Attribute.OS_VERSION_KEY to Build.VERSION.SDK_INT.toString(),
             Attribute.PLATFORM_KEY to "android",
+            Attribute.DEVICE_CPU_ARCH to getCpuArchitecture(),
         )
+    }
+
+    private fun getCpuArchitecture(): String? {
+        return try {
+            System.getProperty("os.arch")
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Error getting CPU architecture", e)
+            null
+        }
     }
 
     // Using heuristics from:


### PR DESCRIPTION
# Description

Adds a new attribute - `device_cpu_arch`.

## Related issue
Closes #1126 
Depends on #1212 