### PR TITLE
chore(backend): remove eventIds array from crash + anr groups

### DIFF
--- a/self-host/postgres/20231228033348_create_unhandled_exception_groups_table.sql
+++ b/self-host/postgres/20231228033348_create_unhandled_exception_groups_table.sql
@@ -8,7 +8,6 @@ create table if not exists public.unhandled_exception_groups (
     file_name text not null,
     line_number int not null,
     fingerprint varchar(32) not null,
-    event_ids uuid[] not null,
     first_event_timestamp timestamptz not null,
     created_at timestamptz not null default now(),
     updated_at timestamptz not null default now()
@@ -22,7 +21,6 @@ comment on column public.unhandled_exception_groups.method_name is 'method name 
 comment on column public.unhandled_exception_groups.file_name is 'file name where the exception occured';
 comment on column public.unhandled_exception_groups.line_number is 'line number where the exception occured';
 comment on column public.unhandled_exception_groups.fingerprint is 'fingerprint of the unhandled exception';
-comment on column public.unhandled_exception_groups.event_ids is 'list of associated event ids';
 comment on column public.unhandled_exception_groups.first_event_timestamp is 'utc timestamp of the oldest event in the group';
 comment on column public.unhandled_exception_groups.created_at is 'utc timestamp at the time of record creation';
 comment on column public.unhandled_exception_groups.updated_at is 'utc timestamp at the time of record updation';

--- a/self-host/postgres/20231228044339_create_anr_groups_table.sql
+++ b/self-host/postgres/20231228044339_create_anr_groups_table.sql
@@ -8,7 +8,6 @@ create table if not exists public.anr_groups (
     file_name text not null,
     line_number int not null,
     fingerprint varchar(32) not null,
-    event_ids uuid[] not null,
     first_event_timestamp timestamptz not null,
     created_at timestamptz not null default now(),
     updated_at timestamptz not null default now()
@@ -22,7 +21,6 @@ comment on column public.anr_groups.method_name is 'method name where the anr oc
 comment on column public.anr_groups.file_name is 'file name where the anr occured';
 comment on column public.anr_groups.line_number is 'line number where the anr occured';
 comment on column public.anr_groups.fingerprint is 'fingerprint of the anr';
-comment on column public.anr_groups.event_ids is 'list of associated event ids';
 comment on column public.anr_groups.first_event_timestamp is 'utc timestamp of the oldest event in the group';
 comment on column public.anr_groups.created_at is 'utc timestamp at the time of record creation';
 comment on column public.anr_groups.updated_at is 'utc timestamp at the time of record updation';


### PR DESCRIPTION
# Description

Crash and ANR groups have a list of event ids associated with them which are stored as an array in the 'event_ids' column in Postgres. Postgres fields have a [limit of 1GB](https://www.postgresql.org/docs/current/limits.html) and this list can get quite large in high scale environments.

To improve this situation, this commit:
1. Removes the event_ids column from postgres
2. Fetches event ids of crash + anr groups from clickhouse based on the event's fingeprint
3. Updates the ingest algorithm to no longer append event_ids to crash & anr groups and only update updated_at and first_seen_event timestamps
4. Updates the cleanup service to no longer delete event_ids from postgres on stale event cleanup

## Related issue
Closes #1027



