### PR TITLE
Configure API_KEY and API_URL to initialise the SDK

### DIFF
--- a/ios/MeasureDemo/MeasureDemo/AppDelegate.swift
+++ b/ios/MeasureDemo/MeasureDemo/AppDelegate.swift
@@ -13,7 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        Measure.shared.initialize()
+        let clientInfo = ClientInfo(apiKey: "apiKey", apiUrl: "api.measure.com")
+        Measure.shared.initialize(with: clientInfo)
         return true
     }
 

--- a/ios/MeasureDemo/MeasureDemo/MeasureManager.h
+++ b/ios/MeasureDemo/MeasureDemo/MeasureManager.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) Measure *measure;
 
-- (void)initializeMeasureSDKWithConfig:(nullable BaseMeasureConfig *)config;
+- (void)initializeMeasureSDKWithConfig:(nullable BaseMeasureConfig *)config clientInfo:(nullable ClientInfo *)clientInfo;
 
 @end
 

--- a/ios/MeasureDemo/MeasureDemo/MeasureManager.m
+++ b/ios/MeasureDemo/MeasureDemo/MeasureManager.m
@@ -9,9 +9,9 @@
 
 @implementation MeasureManager
 
-- (void)initializeMeasureSDKWithConfig:(nullable BaseMeasureConfig *)config {
+- (void)initializeMeasureSDKWithConfig:(nullable BaseMeasureConfig *)config clientInfo:(nullable ClientInfo *)clientInfo {
     _measure = [Measure shared];
-    [_measure initializeWith:config];
+    [_measure initializeWith:clientInfo config:config];
 }
 
 @end

--- a/ios/MeasureSDK/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK/MeasureSDK.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		523C1AC52C6B1B850081D1CC /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 523C1AC42C6B1B850081D1CC /* CrashReporter */; };
+		5242B2A02C7F4AF600BE19F7 /* ClientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5242B29F2C7F4AF600BE19F7 /* ClientInfo.swift */; };
 		524CC5C32C6A4B12001AB506 /* MeasureSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524CC5BA2C6A4B11001AB506 /* MeasureSDK.framework */; };
 		524CC5C82C6A4B12001AB506 /* MeasureSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524CC5C72C6A4B12001AB506 /* MeasureSDKTests.swift */; };
 		524CC5C92C6A4B12001AB506 /* MeasureSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 524CC5BD2C6A4B11001AB506 /* MeasureSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5242B29F2C7F4AF600BE19F7 /* ClientInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientInfo.swift; sourceTree = "<group>"; };
 		524CC5BA2C6A4B11001AB506 /* MeasureSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MeasureSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		524CC5BD2C6A4B11001AB506 /* MeasureSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeasureSDK.h; sourceTree = "<group>"; };
 		524CC5C22C6A4B12001AB506 /* MeasureSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MeasureSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,8 +139,8 @@
 		524CC5D82C6A4B48001AB506 /* CrashReporter */ = {
 			isa = PBXGroup;
 			children = (
-				524CC5D72C6A4B48001AB506 /* MeasureCrashReporter.swift */,
 				524CC5ED2C6A55F0001AB506 /* CrashReportManager.swift */,
+				524CC5D72C6A4B48001AB506 /* MeasureCrashReporter.swift */,
 			);
 			path = CrashReporter;
 			sourceTree = "<group>";
@@ -146,12 +148,13 @@
 		524CC5DA2C6A4B48001AB506 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				52CD91172C7B2B4E000189BA /* MeasureConfig.swift */,
-				52CD91192C7B2C77000189BA /* DefaultConfig.swift */,
-				52CD911B2C7B388B000189BA /* InternalConfig.swift */,
 				52CD911D2C7B397C000189BA /* BaseConfigProvider.swift */,
+				5242B29F2C7F4AF600BE19F7 /* ClientInfo.swift */,
 				52CD911F2C7B39AE000189BA /* Config.swift */,
 				52CD91212C7C318C000189BA /* ConfigLoader.swift */,
+				52CD91192C7B2C77000189BA /* DefaultConfig.swift */,
+				52CD911B2C7B388B000189BA /* InternalConfig.swift */,
+				52CD91172C7B2B4E000189BA /* MeasureConfig.swift */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 				524CC5DE2C6A4B48001AB506 /* MeasureCrashReporter.swift in Sources */,
 				52CD911C2C7B388B000189BA /* InternalConfig.swift in Sources */,
 				52CD91242C7C3D0F000189BA /* MeasureInternal.swift in Sources */,
+				5242B2A02C7F4AF600BE19F7 /* ClientInfo.swift in Sources */,
 				524CC5DD2C6A4B48001AB506 /* MeasureModel.xcdatamodeld in Sources */,
 				524CC5EE2C6A55F0001AB506 /* CrashReportManager.swift in Sources */,
 				52CD91222C7C318C000189BA /* ConfigLoader.swift in Sources */,

--- a/ios/MeasureSDK/MeasureSDK/Config/ClientInfo.swift
+++ b/ios/MeasureSDK/MeasureSDK/Config/ClientInfo.swift
@@ -1,0 +1,42 @@
+//
+//  ClientInfo.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 27/08/24.
+//
+
+import Foundation
+
+/// Client Info identifiers for the Measure SDK.
+protocol Client {
+    var apiKey: String { get }
+    var apiUrl: URL { get }
+}
+
+/// Client Info identifiers for the Measure SDK.
+///
+/// Properties:
+/// - `apiKey`: `API Key` from the Measure dashboard.
+/// - `apiUrl`: `API URL` from the Measure dashboard.
+///
+@objc public class ClientInfo: NSObject, Client {
+    let apiKey: String
+    let apiUrl: URL
+
+    /// Client info
+    /// - Parameters:
+    ///   - apiKey: `API Key` from the Measure dashboard.
+    ///   - apiUrl: `API URL` from the Measure dashboard.
+    @objc public init(apiKey: String,
+                      apiUrl: String) {
+        guard !apiKey.isEmpty else {
+            fatalError("apiKey cannot be empty.")
+        }
+        guard let apiUrl = URL(string: apiUrl) else {
+            fatalError("Invalid apiUrl: \(apiUrl).")
+        }
+
+        self.apiKey = apiKey
+        self.apiUrl = apiUrl
+    }
+}

--- a/ios/MeasureSDK/MeasureSDK/Measure.swift
+++ b/ios/MeasureSDK/MeasureSDK/Measure.swift
@@ -24,11 +24,12 @@ import Foundation
     /// - Example:
     ///   - Swift:
     ///   ```swift
-    ///   Measure.shared.initialize()
+    ///   let clientInfo = ClientInfo(apiKey: "apiKey", apiUrl: "apiUrl")
+    ///   Measure.shared.initialize(with: clientInfo)
     ///   ```
     ///   - Objective-C:
     ///   ```objc
-    ///   [[Measure shared] initializeWith:nil];
+    ///   [[Measure shared] initializeWith:clientInfo config:config];
     ///   ```
     @objc public static let shared: Measure = {
         let instance = Measure()
@@ -50,24 +51,28 @@ import Foundation
     ///
     /// Initializing the SDK multiple times will have no effect.
     /// - Parameter config: The configuration for the Measure SDK.
+    /// - Parameter client: `ClientInfo` object consisting the api-key and api-url
     ///
     /// - Example:
     ///   - Swift:
     ///   ```swift
     ///   let config = BaseMeasureConfig()
-    ///   Measure.shared.initialize(with: config)
+    ///   let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
+    ///   Measure.shared.initialize(with: clientInfo, config: config)
     ///   ```
     ///   - Objective-C:
     ///   ```objc
     ///   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
-    ///   [[Measure shared] initializeWith:config];
+    ///   ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
+    ///   [[Measure shared] initializeWith:clientInfo config:config];
     ///   ```
-    @objc public func initialize(with config: BaseMeasureConfig? = nil) {
+    @objc public func initialize(with client: ClientInfo, config: BaseMeasureConfig? = nil) {
         initializationQueue.sync {
             // Ensure initialization is done only once
             guard measure == nil else { return }
 
-            let initializer = BaseMeasureInitializer(config ?? BaseMeasureConfig())
+            let initializer = BaseMeasureInitializer(config: config ?? BaseMeasureConfig(),
+                                                     client: client)
             measure = MeasureInternal(initializer)
         }
     }

--- a/ios/MeasureSDK/MeasureSDK/MeasureInitializer.swift
+++ b/ios/MeasureSDK/MeasureSDK/MeasureInitializer.swift
@@ -10,21 +10,26 @@ import Foundation
 /// Protocol defining the requirements for initializing the Measure SDK.
 protocol MeasureInitializer {
     var configProvider: ConfigProvider { get }
+    var client: Client { get }
 }
 
 /// `BaseMeasureInitializer` is responsible for setting up the internal configuration
 ///
 /// Properties:
 /// - `configProvider`: `ConfigProvider` object managing the `Config` for the MeasureSDK.
-/// 
+/// - `client`: `Client` object managing the `Config` for the MeasureSDK.
+///
 struct BaseMeasureInitializer: MeasureInitializer {
     let configProvider: ConfigProvider
+    let client: Client
 
-    init(_ config: MeasureConfig) {
+    init(config: MeasureConfig,
+         client: Client) {
         let defaultConfig = Config(enableLogging: config.enableLogging,
                                    trackScreenshotOnCrash: config.trackScreenshotOnCrash,
                                    sessionSamplingRate: config.sessionSamplingRate)
 
-        configProvider = BaseConfigProvider(defaultConfig: defaultConfig, configLoader: BaseConfigLoader())
+        self.configProvider = BaseConfigProvider(defaultConfig: defaultConfig, configLoader: BaseConfigLoader())
+        self.client = client
     }
 }


### PR DESCRIPTION
# Description

This PR updates the iOS SDK initialisation to accept API-KEY and API-URL as parameters.

SDK initialisation code will look something like this.

```
- Swift:
let config = BaseMeasureConfig()
let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
Measure.shared.initialize(with: clientInfo, config: config)

- Objective-C:

BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
[[Measure shared] initializeWith:clientInfo config:config];
```

## Related issue
Closes #1120



