### PR TITLE
fix(backend): handle no selected versions for app journey & metrics

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -706,6 +706,13 @@ func (af *AppFilter) GetExcludedVersions(ctx context.Context) (versions Versions
 		return
 	}
 
+	// If no versions are selected, treat it as if all versions were selected
+	if len(af.Versions) == 0 || len(af.VersionCodes) == 0 {
+		af.Versions = allVersions
+		af.VersionCodes = allCodes
+		return
+	}
+
 	count := len(allVersions)
 
 	if count != len(allCodes) {

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -1888,13 +1888,15 @@ func GetAppJourney(c *gin.Context) {
 		return
 	}
 
-	if err := af.ValidateVersions(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
+	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
+		if err := af.ValidateVersions(); err != nil {
+			fmt.Println(msg, err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   msg,
+				"details": err.Error(),
+			})
+			return
+		}
 	}
 
 	if !af.HasTimeRange() {
@@ -2118,13 +2120,15 @@ func GetAppMetrics(c *gin.Context) {
 		return
 	}
 
-	if err := af.ValidateVersions(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
+	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
+		if err := af.ValidateVersions(); err != nil {
+			fmt.Println(msg, err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   msg,
+				"details": err.Error(),
+			})
+			return
+		}
 	}
 
 	if !af.HasTimeRange() {
@@ -2201,7 +2205,7 @@ func GetAppMetrics(c *gin.Context) {
 	}
 
 	var sizes *metrics.SizeMetric = nil
-	if !af.HasMultiVersions() {
+	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 && !af.HasMultiVersions() {
 		sizes, err = app.GetSizeMetrics(ctx, &af, excludedVersions)
 		if err != nil {
 			fmt.Println(msg, err)


### PR DESCRIPTION
# Description

- App journey attempts to validate versions without checking if any versions are present. This commit adds that missing check.

- App metrics has multiple queries where at least one version is expected to be present. In case no versions are present, this commit assings all versions as selected to achieve the expected behaviour.

## Related issue
Fixes #1157



