### PR TITLE
Support user defined attributes

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -50,6 +50,9 @@ const (
 	maxNavigationToChars                      = 128
 	maxNavigationFromChars                    = 128
 	maxNavigationSourceChars                  = 128
+	maxUseDefAttrsCount                       = 100
+	maxUseDefAttrsKeyChars                    = 256
+	maxUseDefAttrsValChars                    = 256
 )
 
 const TypeANR = "anr"
@@ -360,6 +363,7 @@ type EventField struct {
 	Type              string             `json:"type" binding:"required"`
 	UserTriggered     bool               `json:"user_triggered" binding:"required"`
 	Attribute         Attribute          `json:"attribute" binding:"required"`
+	UseDefAttrs       UDAttribute        `json:"user_defined_attributes" binding:"required"`
 	Attachments       []Attachment       `json:"attachments" binding:"required"`
 	ANR               *ANR               `json:"anr,omitempty"`
 	Exception         *Exception         `json:"exception,omitempty"`

--- a/backend/api/event/usedefattr.go
+++ b/backend/api/event/usedefattr.go
@@ -1,0 +1,137 @@
+package event
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+type attr_type int
+
+const (
+	attr_unknown attr_type = iota
+	attr_string
+	attr_number
+	attr_bool
+)
+
+// type AttrNumber interface {
+// 	int | float64
+// }
+
+// type AttrVal interface {
+// 	string | bool | AttrNumber
+// }
+
+// type UDKey struct {
+// 	Type int
+// 	Val  string
+// }
+
+// type UDVal[T AttrVal] struct {
+// 	Val T
+// }
+
+// type UDAttribute map[string]any
+
+// type rawAttrs map[string]any
+
+// UDAttribute defines User Defined Attributes designed
+// to be attached to each event. An event can have multiple
+// user defined attributes.
+type UDAttribute struct {
+	rawAttrs    map[string]any
+	keyTypes    map[string]string
+	keys        []string
+	types       []string
+	stringVals  []string
+	boolVals    []bool
+	int64Vals   []int
+	float64Vals []float64
+}
+
+// UnmarshalJSON unmarshals bytes resembling user defined
+// attributes to an internal representation.
+func (u *UDAttribute) UnmarshalJSON(data []byte) (err error) {
+	return json.Unmarshal(data, &u.rawAttrs)
+}
+
+// MarshalJSON marshals internal representation of user defined
+// attributes to JSON.
+func (u UDAttribute) MarshalJSON() (data []byte, err error) {
+	return json.Marshal(u.rawAttrs)
+}
+
+// Validate validate the user defined attributes bag.
+func (u *UDAttribute) Validate() (err error) {
+	if u.rawAttrs == nil {
+		return errors.New("user defined attribute must not be empty")
+	}
+
+	count := len(u.rawAttrs)
+
+	if count > maxUseDefAttrsCount {
+		return fmt.Errorf("user defined attributes must not exceed %d items", maxUseDefAttrsCount)
+	}
+
+	if u.keyTypes == nil {
+		u.keyTypes = make(map[string]string)
+	}
+
+	index := -1
+
+	for k, v := range u.rawAttrs {
+		if len(k) > maxUseDefAttrsKeyChars {
+			return fmt.Errorf("user defined attribute keys must not exceed %d characters", maxUseDefAttrsKeyChars)
+		}
+
+		index += 1
+
+		switch value := v.(type) {
+		case string:
+			if len(v.(string)) > maxUseDefAttrsValChars {
+				return fmt.Errorf("user defined attributes string values must not exceed %d characters", maxUseDefAttrsValChars)
+			}
+			u.keyTypes[k] = "string"
+			u.types = append(u.types, "string")
+
+			continue
+		case bool:
+			u.keyTypes[k] = "bool"
+			u.types = append(u.types, "bool")
+			continue
+		case float64:
+			if reflect.TypeOf(v).Kind() == reflect.Float64 {
+				if v == float64(int(value)) {
+					u.keyTypes[k] = "int64"
+					u.types = append(u.types, "int64")
+				} else {
+					u.keyTypes[k] = "float64"
+					u.types = append(u.types, "float64")
+				}
+			}
+			continue
+		default:
+			return fmt.Errorf("user defined attribute values can be only string, number or boolean")
+		}
+	}
+
+	return
+}
+
+func (u *UDAttribute) HasItems() bool {
+	return len(u.rawAttrs) > 0
+}
+
+func (u UDAttribute) GetKeys() (keys []string) {
+	return u.keys
+}
+
+func (u UDAttribute) GetTypes() (types []string) {
+	return u.types
+}
+
+func (u UDAttribute) BuildArgs() (err error) {
+	return
+}

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -416,7 +416,12 @@ func (e eventreq) validate() error {
 		if err := e.events[i].Validate(); err != nil {
 			return err
 		}
+
 		if err := e.events[i].Attribute.Validate(); err != nil {
+			return err
+		}
+
+		if err := e.events[i].UseDefAttrs.Validate(); err != nil {
 			return err
 		}
 
@@ -527,6 +532,11 @@ func (e eventreq) ingest(ctx context.Context) error {
 
 			// attachments
 			Set(`attachments`, attachments)
+
+		// user defined attributes
+		if e.events[i].UseDefAttrs.HasItems() {
+			e.events[i].UseDefAttrs.BuildArgs()
+		}
 
 		// anr
 		if e.events[i].IsANR() {
@@ -1776,6 +1786,10 @@ func PutEvents(c *gin.Context) {
 		})
 		return
 	}
+
+	// temporary
+	// c.JSON(http.StatusOK, gin.H{"events": eventReq.events})
+	// return
 
 	if seen, err := eventReq.seen(ctx); err != nil {
 		msg := `failed to check existing event request`

--- a/go.work.sum
+++ b/go.work.sum
@@ -258,6 +258,7 @@ golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
 golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/self-host/clickhouse/20240903022512_add_usedef_attrs_keys_column.sql
+++ b/self-host/clickhouse/20240903022512_add_usedef_attrs_keys_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.keys` Array(String) after `navigation.source`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.keys`;

--- a/self-host/clickhouse/20240903103401_add_usedef_attrs_types_column.sql
+++ b/self-host/clickhouse/20240903103401_add_usedef_attrs_types_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.types` Array(String) after `usedef_attrs.keys`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.types`;

--- a/self-host/clickhouse/20240903103423_add_usedef_string_vals_column.sql
+++ b/self-host/clickhouse/20240903103423_add_usedef_string_vals_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.string_vals` Array(String) after `usedef_attrs.types`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.string_vals`;

--- a/self-host/clickhouse/20240903103435_add_usedef_bool_vals_column.sql
+++ b/self-host/clickhouse/20240903103435_add_usedef_bool_vals_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.bool_vals` Array(Bool) after `usedef_attrs.string_vals`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.bool_vals`;

--- a/self-host/clickhouse/20240903103443_add_usedef_int64_vals_column.sql
+++ b/self-host/clickhouse/20240903103443_add_usedef_int64_vals_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.int64_vals` Array(Int64) after `usedef_attrs.bool_vals`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.int64_vals`;

--- a/self-host/clickhouse/20240903103450_add_usedef_float64_vals_column.sql
+++ b/self-host/clickhouse/20240903103450_add_usedef_float64_vals_column.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table events add column if not exists `usedef_attrs.float64_vals` Array(Float64) after `usedef_attrs.int64_vals`;
+
+-- migrate:down
+drop column if exists `usedef_attrs.float64_vals`;


### PR DESCRIPTION
## Summary

Add ability to ingest, query and fetch user defined attributes for events.

## Tasks

- [x] Create ClickHouse migrations to add new columns for user defined attributes
- [ ] Update PUT `/events` API to read, validate, process and store user defined attributes
- [ ] Build a common comparison expression system that will apply to all APIs that filter using user defined attributes
- [ ] Update GET `/apps/:id/crashGroups/:id/crashes` API to return user defined attributes (if present)
- [ ] Update GET `/apps/:id/crashGroups/:id/plots/instances` to support filtering via user defined attributes
- [ ] Update GET `/apps/:id/crashGroups/:id/plots/journey` to support filtering via user defined attributes
- [ ] Update GET `/apps/:id/anrGroups/:id/anrs` API to return user defined attributes (if present)
- [ ] Update GET `/apps/:id/anrGroups/:id/plots/instances` to support filtering via user defined attributes
- [ ] Update GET `/apps/:id/anrGroups/:id/plots/journey` to support filtering via user defined attributes
- [ ] Update GET `/apps/:id/sessions/:id` API to return user defined attributes (if present)
- [ ] Update GET `/apps/:id/filters` API to return list of unique user defined attribute keys and their types
- [ ] Inject user defined attributes in session data events using random sampling and make sure event ingestion (via sessionator) works as expected
- [ ] 📚 Update SDK API docs
- [ ] 📚 Update dashboard API docs

## Linked Issues

- Fixes #1143