### PR TITLE
fix(android): handle exceptions when loading native library

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -250,7 +250,7 @@ internal class TestMeasureInitializer(
         eventProcessor = eventProcessor,
         processInfo = processInfoProvider,
     ),
-    private val nativeBridgeImpl: NativeBridgeImpl = NativeBridgeImpl(),
+    private val nativeBridgeImpl: NativeBridgeImpl = NativeBridgeImpl(logger),
     override val anrCollector: AnrCollector = AnrCollector(
         logger = logger,
         processInfo = processInfoProvider,

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -271,7 +271,7 @@ internal class MeasureInitializerImpl(
         eventProcessor = eventProcessor,
         processInfo = processInfoProvider,
     ),
-    private val nativeBridgeImpl: NativeBridgeImpl = NativeBridgeImpl(),
+    private val nativeBridgeImpl: NativeBridgeImpl = NativeBridgeImpl(logger),
     override val anrCollector: AnrCollector = AnrCollector(
         logger = logger,
         processInfo = processInfoProvider,


### PR DESCRIPTION
- Add try-catch blocks to handle potential exceptions when loading the native library
- Catch all exceptions in enableAnrReporting. This is needed to catch any exception thrown if measure-ndk fails to load.

There is no clean way to write a test for this as the native library load cannot be faked easily. The change is tested manually. 

## Related issue
References: #1174



