### PR TITLE
fix(android): crash when app visible time isn't available to calculate launch time

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -158,7 +158,7 @@ internal class LaunchTracker(
                         }
 
                         else -> {
-                            throw IllegalStateException("Unknown preLaunchState: $launchType")
+                            logger.log(LogLevel.Error, "Unknown launch type: $launchType")
                         }
                     }
                 }

--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -122,26 +122,36 @@ internal class LaunchTracker(
                     }
 
                     "Hot" -> {
-                        callbacks.onHotLaunch(
-                            HotLaunchData(
-                                app_visible_uptime = LaunchState.lastAppVisibleTime!!,
-                                on_next_draw_uptime = onNextDrawUptime,
-                                launched_activity = onCreateRecord.activityName,
-                                has_saved_state = onCreateRecord.hasSavedState,
-                                intent_data = onCreateRecord.intentData,
-                            ),
+                        LaunchState.lastAppVisibleTime?.let {
+                            callbacks.onHotLaunch(
+                                HotLaunchData(
+                                    app_visible_uptime = it,
+                                    on_next_draw_uptime = onNextDrawUptime,
+                                    launched_activity = onCreateRecord.activityName,
+                                    has_saved_state = onCreateRecord.hasSavedState,
+                                    intent_data = onCreateRecord.intentData,
+                                ),
+                            )
+                        } ?: logger.log(
+                            LogLevel.Error,
+                            "lastAppVisibleTime is null, cannot calculate hot launch time",
                         )
                     }
 
                     "Warm" -> {
-                        callbacks.onWarmLaunch(
-                            WarmLaunchData(
-                                app_visible_uptime = LaunchState.lastAppVisibleTime!!,
-                                on_next_draw_uptime = onNextDrawUptime,
-                                launched_activity = onCreateRecord.activityName,
-                                has_saved_state = onCreateRecord.hasSavedState,
-                                intent_data = onCreateRecord.intentData,
-                            ),
+                        LaunchState.lastAppVisibleTime?.let {
+                            callbacks.onWarmLaunch(
+                                WarmLaunchData(
+                                    app_visible_uptime = it,
+                                    on_next_draw_uptime = onNextDrawUptime,
+                                    launched_activity = onCreateRecord.activityName,
+                                    has_saved_state = onCreateRecord.hasSavedState,
+                                    intent_data = onCreateRecord.intentData,
+                                ),
+                            )
+                        } ?: logger.log(
+                            LogLevel.Error,
+                            "lastAppVisibleTime is null, cannot calculate warm launch time",
                         )
                     }
 
@@ -177,6 +187,7 @@ internal class LaunchTracker(
                     "Hot"
                 }
             }
+
             processInfo.isForegroundProcess() -> "Cold"
             else -> "Warm"
         }


### PR DESCRIPTION
# Description

On certain devices we're detecting a warm/hot launch without having the `lastAppVisibleTime` set, which is unusual. This causes a NPE. This PR discards the event and logs an error instead of crashing in such a case.

This PR also adds two more safe checks to LaunchTracker:
1. Removes usage of getValue when accessing maps which can potentially throw.
2. Removes an explicit throw and replaces it with an error log.

## Related issue
#1180 


