### PR TITLE
chore(backend): sessionator `--clean-all` flag

### DIFF
--- a/self-host/sessionator/README.md
+++ b/self-host/sessionator/README.md
@@ -1,19 +1,16 @@
-## Sessionator
+## Sessionator <!-- omit in toc -->
 
-This tool is used to ingest test sessions for local development.
+Easily ingest test sessions during development.
 
-### Ingesting Sessions
+## Contents <!-- omit in toc -->
 
-To ingest sessions from a local directory,
-
-1. Navigate to the local directory
-2. Copy example config - `cp config.toml.example config.toml`
-3. Edit `config.toml` to list your apps and their api keys and configure other settings.
-4. Navigate to `./self-host/sessionator` and run.
-
-```sh
-go run . ingest
-```
+- [Usage and Help](#usage-and-help)
+- [Recording sessions and mappings](#recording-sessions-and-mappings)
+- [Ingesting Sessions](#ingesting-sessions)
+- [Repeat ingestion of sessions](#repeat-ingestion-of-sessions)
+  - [`--clean-all` flag](#--clean-all-flag)
+  - [`--clean` flag](#--clean-flag)
+- [Uploading mappings \& attachments locally](#uploading-mappings--attachments-locally)
 
 ### Usage and Help
 
@@ -28,45 +25,85 @@ To see usage of a subcommand.
 ```sh
 go run . ingest --help
 ```
-
 For a clean ingest, run.
 
 ```sh
-go run . ingest --clean
+go run . ingest --clean-all
 ```
+
+### Recording sessions and mappings
+
+To record sessions and mappings to a local directory, navigate to `./self-host/sessionator` and run
+
+```sh
+go run . record
+```
+
+* to record sessions from an Android emulator, set following in `~/.gradle.properties`:
+
+```sh
+measure_url=http://10.0.2.2:8080
+```
+
+* to record sessions from an Android device, use a service like [tunnelmole](https://tunnelmole.com/) to forward requests from the device to localhost.
+
+* to record mappings, run a assemble task, the mapping will be added to the local directory, `self-host/session-data`.
+
+### Ingesting Sessions
+
+To ingest sessions from a local directory,
+
+1. Navigate to the local directory
+2. Copy example config - `cp config.toml.example config.toml`
+3. Edit `config.toml` to list your apps and their api keys and configure other settings.
+4. Navigate to `./self-host/sessionator` and run.
+
+    ```sh
+    go run . ingest
+    ```
 
 5. Make sure the name of the directories under `self-host/session-data` matches the app names in the `self-host/session-data/config.toml` file.
 
-For example:
+    For example:
 
-```toml
-[apps.sample-app]
-api-key = "msrsh_xxxxxx_xxxx"
+    ```toml
+    [apps.sample-app]
+    api-key = "msrsh_xxxxxx_xxxx"
 
-[apps.wikipedia]
-api-key = "msrsh_xxxxxx_xxxx"
-```
+    [apps.wikipedia]
+    api-key = "msrsh_xxxxxx_xxxx"
+    ```
 
-For the above configuration to work, the app directory names must match.
+    For the above configuration to work, the app directory names must match.
 
-```
-self-host/
-├─ session-data/
-├─ ├─ sample-app/
-├─ ├─ wikipedia/
-```
+    ```
+    self-host/
+    ├─ session-data/
+    ├─ ├─ sample-app/
+    ├─ ├─ wikipedia/
+    ```
 
 ### Repeat ingestion of sessions
 
-During development, you will often want to clear the sessions data and re-ingest sessions again and again. Using `--clean` on ingest will remove all data for the apps added in `session-data/config.toml` and re-ingest.
+During development, you will often want to clear the sessions data and re-ingest sessions again and again. There are 2 ways to clean old data.
+
+#### `--clean-all` flag
+
+```sh
+go run . ingest --clean-all
+```
+
+The `--clean-all` flag would remove all old data for **all** apps regardless of your settings in `config.toml`. Use this if you want to clean ingest from scratch.
+
+#### `--clean` flag
 
 ```sh
 go run . ingest --clean
 ```
 
-For `--clean` to work, you would need to configure the following settings in your `session-data/config.toml` file.
+The `--clean` flag would remove all old data for **only** matching apps in `config.toml`. Use this if you want to clear data for certain apps.
 
-When ingesting events for newly created apps along with `--clean` flag, please mention the app name in the `name` field per app. The value of the `name` field must match exactly the name given when creating apps in Measure dashboard.
+Additionally, when using `--clean` mention the app name in the `name` field per app, like this.
 
 ```toml
 [apps.sample-app]
@@ -76,7 +113,11 @@ api-key = "msrsh_xxxxxx_xxxx"
 [apps.wikipedia]
 name = "your-app-name-2"
 api-key = "msrsh_xxxxxx_xxxx"
+```
 
+Regardless of which method you choose, the `session-data/config.toml` needs the **`[storage]`** section to perform cleanups.
+
+```toml
 [storage]
 postgres_dsn = "postgresql://postgres:postgres@127.0.0.1:5432/postgres"
 clickhouse_dsn = "clickhouse://default:@127.0.0.1:9000/default"
@@ -94,7 +135,7 @@ symbols_access_key = "minio"
 symbols_secret_access_key = "minio123"
 ```
 
-3. Local uploading of files
+### Uploading mappings & attachments locally
 
 When sessionator is running, the mapping and attachments files can be either configured to be uploaded to a remote S3 bucket or a local S3-compatible storage service. Like [minio](https://min.io/).
 
@@ -103,22 +144,3 @@ Make sure the `self-host/docker-compose.yml` file has the correct environment va
 Make sure `backend/api/.env` file has the `AWS_ENDPOINT_URL` environment variable pointing to the minio host url. Also, the bucket name, region and access key/secret must be configured correctly.
 
 For symbolication to work, make sure `backend/symbolicator-android/.env` file has the `AWS_ENDPONT_URL` variable pointing to the minio host. Also, the bucket name, region and access key/secret must be configured correctly.
-
-### Recording sessions or mappings
-
-To record sessions or mappings to a local directory, navigate to `./self-host/sessionator` and run
-
-```sh
-go run . record
-```
-
-* to record sessions from an Android emulator, set following in `~/.gradle.properties`:
-
-```sh
-measure_url=http://10.0.2.2:8080
-```
-
-* to record sessions from an Android device, use a service like [tunnelmole](https://tunnelmole.com/) to forward requests from the device to localhost.
-
-
-* to record mappings, run a assemble task, the mapping will be added to the local directory, `self-host/session-data`.

--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -42,9 +42,12 @@ var configLocation string
 // `config.toml` file.
 var configData *config.Config
 
-// clean is used to decide if existing events and
-// attachments will be cleared.
+// clean if true is used to remove data for matching
+// apps in config.
 var clean bool
+
+// cleanAll if true is used to clear all the data.
+var cleanAll bool
 
 // metrics is used to store progress of ingestion
 // operations.
@@ -65,7 +68,11 @@ func init() {
 
 	ingestCmd.
 		Flags().
-		BoolVarP(&clean, "clean", "x", false, "clear all events and attachments before ingestion")
+		BoolVarP(&clean, "clean", "x", false, "remove builds, events & attachments for configured apps before ingestion")
+
+	ingestCmd.
+		Flags().
+		BoolVarP(&cleanAll, "clean-all", "X", false, "remove all builds, events & attachments before ingestion")
 
 	ingestCmd.Flags().SortFlags = false
 
@@ -400,7 +407,15 @@ Structure of "session-data" directory:` + "\n" + DirTree() + "\n" + ValidNote(),
 			}
 			ctx := context.Background()
 			if err := rmEvents(ctx, configData); err != nil {
-				log.Fatal("failed to cleanup old data", err)
+				log.Fatal("failed to clean old data", err)
+			}
+		} else if cleanAll {
+			if err := configData.ValidateStorage(); err != nil {
+				log.Fatal(err)
+			}
+			ctx := context.Background()
+			if err := rmAll(ctx, configData); err != nil {
+				log.Fatal("failed to clean all old data", err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR adds a `--clean-all` flag to clean all old data regardless of app settings in `config.toml`. Running sessionator with this new flag address the mismatching of crash/ANR instances in #1171.

## Tasks

- [x] Add `--clean-all` flag in Sesionator
- [x] :books: Update Sessionator README.md

fixes #1171