### PR TITLE
chore(backend): format log line

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -401,7 +401,7 @@ func (cl *ColdLaunch) Compute() {
 	cl.Duration = time.Duration(onNextDrawUptime-uptime) * time.Millisecond
 
 	if cl.Duration >= NominalColdLaunchThreshold {
-		fmt.Printf(`anomaly in cold_launch duration compute. nominal threshold: < %v . actual value: %f\n`, NominalColdLaunchThreshold, cl.Duration.Seconds())
+		fmt.Printf("anomaly in cold_launch duration compute. nominal threshold: < %v . actual value: %f\n", NominalColdLaunchThreshold, cl.Duration.Seconds())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes formatting of a log line for logging `cold_launch` duration anomalies. The `\n` was not getting printed correctly.

## Tasks

- [x] Format log line for logging `cold_launch` duration anomalies.

fixes #1181