### PR TITLE
Fix ingestion related integer overflow errors

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -204,8 +204,8 @@ type LogString struct {
 type GestureLongClick struct {
 	Target        string  `json:"target"`
 	TargetID      string  `json:"target_id"`
-	TouchDownTime uint32  `json:"touch_down_time"`
-	TouchUpTime   uint32  `json:"touch_up_time"`
+	TouchDownTime uint64  `json:"touch_down_time"`
+	TouchUpTime   uint64  `json:"touch_up_time"`
 	Width         uint16  `json:"width"`
 	Height        uint16  `json:"height"`
 	X             float32 `json:"x" binding:"required"`
@@ -215,8 +215,8 @@ type GestureLongClick struct {
 type GestureScroll struct {
 	Target        string  `json:"target"`
 	TargetID      string  `json:"target_id"`
-	TouchDownTime uint32  `json:"touch_down_time"`
-	TouchUpTime   uint32  `json:"touch_up_time"`
+	TouchDownTime uint64  `json:"touch_down_time"`
+	TouchUpTime   uint64  `json:"touch_up_time"`
 	X             float32 `json:"x"`
 	Y             float32 `json:"y"`
 	EndX          float32 `json:"end_x"`
@@ -227,8 +227,8 @@ type GestureScroll struct {
 type GestureClick struct {
 	Target        string  `json:"target"`
 	TargetID      string  `json:"target_id"`
-	TouchDownTime uint32  `json:"touch_down_time"`
-	TouchUpTime   uint32  `json:"touch_up_time"`
+	TouchDownTime uint64  `json:"touch_down_time"`
+	TouchUpTime   uint64  `json:"touch_up_time"`
 	Width         uint16  `json:"width"`
 	Height        uint16  `json:"height"`
 	X             float32 `json:"x"`
@@ -254,10 +254,10 @@ type LifecycleApp struct {
 }
 
 type ColdLaunch struct {
-	ProcessStartUptime          uint32        `json:"process_start_uptime"`
-	ProcessStartRequestedUptime uint32        `json:"process_start_requested_uptime"`
-	ContentProviderAttachUptime uint32        `json:"content_provider_attach_uptime"`
-	OnNextDrawUptime            uint32        `json:"on_next_draw_uptime" binding:"required"`
+	ProcessStartUptime          uint64        `json:"process_start_uptime"`
+	ProcessStartRequestedUptime uint64        `json:"process_start_requested_uptime"`
+	ContentProviderAttachUptime uint64        `json:"content_provider_attach_uptime"`
+	OnNextDrawUptime            uint64        `json:"on_next_draw_uptime" binding:"required"`
 	LaunchedActivity            string        `json:"launched_activity" binding:"required"`
 	HasSavedState               bool          `json:"has_saved_state" binding:"required"`
 	IntentData                  string        `json:"intent_data"`
@@ -265,8 +265,8 @@ type ColdLaunch struct {
 }
 
 type WarmLaunch struct {
-	AppVisibleUptime uint32        `json:"app_visible_uptime"`
-	OnNextDrawUptime uint32        `json:"on_next_draw_uptime" binding:"required"`
+	AppVisibleUptime uint64        `json:"app_visible_uptime"`
+	OnNextDrawUptime uint64        `json:"on_next_draw_uptime" binding:"required"`
 	LaunchedActivity string        `json:"launched_activity" binding:"required"`
 	HasSavedState    bool          `json:"has_saved_state" binding:"required"`
 	IntentData       string        `json:"intent_data"`
@@ -274,8 +274,8 @@ type WarmLaunch struct {
 }
 
 type HotLaunch struct {
-	AppVisibleUptime uint32        `json:"app_visible_uptime"`
-	OnNextDrawUptime uint32        `json:"on_next_draw_uptime" binding:"required"`
+	AppVisibleUptime uint64        `json:"app_visible_uptime"`
+	OnNextDrawUptime uint64        `json:"on_next_draw_uptime" binding:"required"`
 	LaunchedActivity string        `json:"launched_activity" binding:"required"`
 	HasSavedState    bool          `json:"has_saved_state" binding:"required"`
 	IntentData       string        `json:"intent_data"`
@@ -313,7 +313,7 @@ type MemoryUsage struct {
 	RSS             uint64 `json:"rss"`
 	NativeTotalHeap uint64 `json:"native_total_heap" binding:"required"`
 	NativeFreeHeap  uint64 `json:"native_free_heap" binding:"required"`
-	Interval        uint32 `json:"interval" binding:"required"`
+	Interval        uint64 `json:"interval" binding:"required"`
 }
 
 type LowMemory struct {
@@ -339,7 +339,7 @@ type CPUUsage struct {
 	CUTime          uint64  `json:"cutime" binding:"required"`
 	STime           uint64  `json:"stime" binding:"required"`
 	CSTime          uint64  `json:"cstime" binding:"required"`
-	Interval        uint32  `json:"interval" binding:"required"`
+	Interval        uint64  `json:"interval" binding:"required"`
 	PercentageUsage float64 `json:"percentage_usage" binding:"required"`
 }
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -447,8 +447,8 @@ Use the `gesture_long_click` body type for longer press and hold gestures.
 |-------------------|---------|----------|---------------------------------------------|
 | `target`          | string  | Yes      | Class/Instance name of the originating view |
 | `target_id`       | string  | Yes      | Unique identifier for the target            |
-| `touch_down_time` | string  | Yes      | System uptime when target was pressed       |
-| `touch_up_time`   | string  | Yes      | System uptime when target was released      |
+| `touch_down_time` | uint64  | Yes      | System uptime when target was pressed       |
+| `touch_up_time`   | uint64  | Yes      | System uptime when target was released      |
 | `width`           | uint16  | Yes      | Width of the target view in pixels          |
 | `height`          | uint16  | Yes      | Height of the target view in pixels         |
 | `x`               | float32 | No       | X coordinate of the target view             |
@@ -462,8 +462,8 @@ Use the `gesture_scroll` body type for scroll events.
 |-------------------|---------|----------|-----------------------------------------------------|
 | `target`          | string  | Yes      | Class/Instance name of the originating view         |
 | `target_id`       | string  | Yes      | Unique identifier for the target                    |
-| `touch_down_time` | uint32  | Yes      | System uptime when target scroll started            |
-| `touch_up_time`   | uint32  | Yes      | System uptime when target scroll ended              |
+| `touch_down_time` | uint64  | Yes      | System uptime when target scroll started            |
+| `touch_up_time`   | uint64  | Yes      | System uptime when target scroll ended              |
 | `x`               | float32 | No       | X coordinate of the target where scroll started     |
 | `y`               | float32 | No       | Y coordinate of the target where scroll started     |
 | `end_x`           | float32 | No       | X coordinate of the target where scroll ended       |
@@ -478,8 +478,8 @@ Use the `gesture_click` body type for taps or clicks.
 |-------------------|---------|----------|-------------------------------------------------|
 | `target`          | string  | Yes      | Class/Instance name of the originating view     |
 | `target_id`       | string  | Yes      | Unique identifier for the target                |
-| `touch_down_time` | string  | Yes      | System uptime when target was pressed           |
-| `touch_up_time`   | string  | Yes      | System uptime when target was released          |
+| `touch_down_time` | uint64  | Yes      | System uptime when target was pressed           |
+| `touch_up_time`   | uint64  | Yes      | System uptime when target was released          |
 | `width`           | uint16  | Yes      | Width of the target view in pixels              |
 | `height`          | uint16  | Yes      | Height of the target view in pixels             |
 | `x`               | float32 | No       | X coordinate of the target where click happened |
@@ -494,8 +494,8 @@ Use the `http` body type for tracking a single HTTP network.
 | `url`                 | string | No       | Complete URL of the HTTP request                                                |
 | `method`              | string | No       | Any of the common HTTP method like, `GET` or `POST`                             |
 | `status_code`         | int    | Yes      | Any of the common HTTP response codes.                                          |
-| `start_time`          | uint32 | Yes      | The uptime at which the http call started, in ms.                               |
-| `end_time`            | uint32 | Yes      | The uptime at which the http call ended, in ms.                                 |
+| `start_time`          | uint64 | Yes      | The uptime at which the http call started, in ms.                               |
+| `end_time`            | uint64 | Yes      | The uptime at which the http call ended, in ms.                                 |
 | `failure_reason`      | string | Yes      | The reason for failure. For Android, typically the IOException class name.      |
 | `failure_description` | string | Yes      | The description of the failure. For Android, Typically the IOException message. |
 | `request_headers`     | map    | Yes      | The request headers.                                                            |
@@ -567,10 +567,10 @@ Use the `cold_launch` type for Android cold app launch time.
 
 | Field                            | Type    | Optional | Comment                                                                |
 | -------------------------------- | ------- | -------- | ---------------------------------------------------------------------- |
-| `process_start_uptime`           | uint32  | Yes      | The start uptime, measure in ms.                                       |
-| `process_start_requested_uptime` | uint32  | Yes      | The start uptime, measure in ms.                                       |
-| `content_provider_attach_uptime` | uint32  | Yes      | The start uptime, measure in ms.                                       |
-| `on_next_draw_uptime`            | uint32  | No       | The time at which the app became visible to the user.                  |
+| `process_start_uptime`           | uint64  | Yes      | The start uptime, measure in ms.                                       |
+| `process_start_requested_uptime` | uint64  | Yes      | The start uptime, measure in ms.                                       |
+| `content_provider_attach_uptime` | uint64  | Yes      | The start uptime, measure in ms.                                       |
+| `on_next_draw_uptime`            | uint64  | No       | The time at which the app became visible to the user.                  |
 | `launched_activity`              | string  | No       | The activity which drew the first frame during cold launch.            |
 | `has_saved_state`                | boolean | No       | Whether the _launched_activity_ was created with a saved state bundle. |
 | `intent_data`                    | string  | Yes      | The Intent data used to launch the _launched_activity_.                |
@@ -581,8 +581,8 @@ Use the `warm_launch` type for Android warm app launch time.
 
 | Field               | Type    | Optional | Comment                                                                |
 | ------------------- | ------- | -------- | ---------------------------------------------------------------------- |
-| app_visible_uptime  | uint32  | Yes      | The time since the app became visible to the user, in ms.              |
-| on_next_draw_uptime | uint32  | No       | The time at which the app became visible to the user, in ms.           |
+| app_visible_uptime  | uint64  | Yes      | The time since the app became visible to the user, in ms.              |
+| on_next_draw_uptime | uint64  | No       | The time at which the app became visible to the user, in ms.           |
 | launched_activity   | string  | No       | The activity which drew the first frame during launch                  |
 | has_saved_state     | boolean | No       | Whether the _launched_activity_ was created with a saved state bundle. |
 | intent_data         | string  | Yes      | The Intent data used to launch the _launched_activity_.                |
@@ -593,8 +593,8 @@ Use the `hot_launch` type for Android hot app launch time.
 
 | Field               | Type    | Optional | Comment                                                           |
 | ------------------- | ------- | -------- | ----------------------------------------------------------------- |
-| app_visible_uptime  | uint32  | Yes      | The time elapsed since the app became visible to the user, in ms. |
-| on_next_draw_uptime | uint32  | No       | The time at which the app became visible to the user, in ms.      |
+| app_visible_uptime  | uint64  | Yes      | The time elapsed since the app became visible to the user, in ms. |
+| on_next_draw_uptime | uint64  | No       | The time at which the app became visible to the user, in ms.      |
 | launched_activity   | string  | No       | The activity which drew the first frame during launch             |
 | has_saved_state     | boolean | No       | Whether the _launched_activity_ was created with a saved state.   |
 | intent_data         | string  | Yes      | The Intent data used to launch the _launched_activity_.           |
@@ -612,7 +612,7 @@ Use the `cpu_usage` type for CPU usage of a Linux based OS.
 | `stime`            | uint64  | No       | Time spent executing code in kernel mode, in Jiffies.               |
 | `cutime`           | uint64  | No       | Time spent executing code in user mode with children, in Jiffies.   |
 | `cstime`           | uint64  | No       | Time spent executing code in kernel mode with children, in Jiffies. |
-| `interval`         | uint32  | No       | The interval between two collections, in ms.                        |
+| `interval`         | uint64  | No       | The interval between two collections, in ms.                        |
 | `percentage_usage` | float64 | No       | The percentage CPU usage in the interval.                           |
 | `start_time`       | uint64  | No       | The process start time, in Jiffies.                                 |
 

--- a/self-host/clickhouse/20240905133723_alter_events_table.sql
+++ b/self-host/clickhouse/20240905133723_alter_events_table.sql
@@ -1,0 +1,38 @@
+-- migrate:up
+alter table default.events
+modify column if exists `gesture_long_click.touch_down_time` UInt64,
+modify column if exists `gesture_long_click.touch_up_time` UInt64,
+modify column if exists `gesture_click.touch_down_time` UInt64,
+modify column if exists `gesture_click.touch_up_time` UInt64,
+modify column if exists `gesture_scroll.touch_down_time` UInt64,
+modify column if exists `gesture_scroll.touch_up_time` UInt64,
+modify column if exists `cold_launch.process_start_uptime` UInt64,
+modify column if exists `cold_launch.process_start_requested_uptime` UInt64,
+modify column if exists `cold_launch.content_provider_attach_uptime` UInt64,
+modify column if exists `cold_launch.on_next_draw_uptime` UInt64,
+modify column if exists `warm_launch.app_visible_uptime` UInt64,
+modify column if exists `warm_launch.on_next_draw_uptime` UInt64,
+modify column if exists `hot_launch.app_visible_uptime` UInt64,
+modify column if exists `hot_launch.on_next_draw_uptime` UInt64,
+modify column if exists `memory_usage.interval` UInt64,
+modify column if exists `cpu_usage.interval` UInt64;
+
+-- migrate:down
+alter table default.events
+modify column if exists `gesture_long_click.touch_down_time` UInt32,
+modify column if exists `gesture_long_click.touch_up_time` UInt32,
+modify column if exists `gesture_click.touch_down_time` UInt32,
+modify column if exists `gesture_click.touch_up_time` UInt32,
+modify column if exists `gesture_scroll.touch_down_time` UInt32,
+modify column if exists `gesture_scroll.touch_up_time` UInt32,
+modify column if exists `cold_launch.process_start_uptime` UInt32,
+modify column if exists `cold_launch.process_start_requested_uptime` UInt32,
+modify column if exists `cold_launch.content_provider_attach_uptime` UInt32,
+modify column if exists `cold_launch.on_next_draw_uptime` UInt32,
+modify column if exists `warm_launch.app_visible_uptime` UInt32,
+modify column if exists `warm_launch.on_next_draw_uptime` UInt32,
+modify column if exists `hot_launch.app_visible_uptime` UInt32,
+modify column if exists `hot_launch.on_next_draw_uptime` UInt32,
+modify column if exists `memory_usage.interval` UInt32,
+modify column if exists `cpu_usage.interval` UInt32;
+


### PR DESCRIPTION
## Summary

Addresses an issue where for certain events ingestion would fail with a `400 Bad Request` due to integer overflow errors.

## Tasks

- [x] Add ClickHouse migration to update data types of the following columns
  - `gesture_click.touch_down_time`
  - `gesture_click.touch_up_time`
  - `gesture_long_click.touch_down_time`
  - `gesture_long_click.touch_up_time`
  - `gesture_scroll.touch_down_time`
  - `gesture_scroll.touch_up_time`
  - `cold_launch.process_start_uptime`
  - `cold_launch.process_start_requested_uptime`
  - `cold_launch.content_provider_attach_uptime`
  - `cold_launch.on_next_draw_uptime`
  - `warm_launch.app_visible_uptime`
  - `warm_launch.on_next_draw_uptime`
  - `hot_launch.app_visible_uptime`
  - `hot_launch.on_next_draw_uptime`
  - `cpu_usage.interval`
  - `memory_usage.interval`
- [x] Modified the data types of the corresponding event types
- [x] 📚 Update SDK API docs

## Issues

- Fixes #1184 