### PR TITLE
fix(backend): detect bogon addresses locally

### DIFF
--- a/backend/api/go.mod
+++ b/backend/api/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/uuid v1.6.0
-	github.com/ipinfo/go/v2 v2.10.0
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/leporo/sqlf v1.4.0
 	github.com/oschwald/maxminddb-golang v1.13.1
@@ -61,7 +60,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect

--- a/backend/api/go.sum
+++ b/backend/api/go.sum
@@ -106,8 +106,6 @@ github.com/googleapis/gax-go/v2 v2.12.5 h1:8gw9KZK8TiVKB6q3zHY3SBzLnrGp6HQjyfYBY
 github.com/googleapis/gax-go/v2 v2.12.5/go.mod h1:BUDKcWo+RaKq5SC9vVYL0wLADa3VcfswbOMMRmB9H3E=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
-github.com/ipinfo/go/v2 v2.10.0 h1:v9sFjaxnVVD+JVgpWpjgwols18Tuu4SgBDaHHaw0IXo=
-github.com/ipinfo/go/v2 v2.10.0/go.mod h1:tRDkYfM20b1XzNqorn1Q1O6Xtg7uzw3Wn3I2R0SyJh4=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
@@ -154,8 +152,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/oschwald/maxminddb-golang v1.13.1 h1:G3wwjdN9JmIK2o/ermkHM+98oX5fS+k5MbwsmL4MRQE=
 github.com/oschwald/maxminddb-golang v1.13.1/go.mod h1:K4pgV9N/GcK694KSTmVSDTODk4IsCNThNdTmnaBZ/F8=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=
 github.com/paulmach/orb v0.11.1/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
@@ -266,7 +262,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/backend/api/inet/ipinfo.go
+++ b/backend/api/inet/ipinfo.go
@@ -39,7 +39,7 @@ func Init() (err error) {
 		"172.16.0.0/12",  // private
 		"192.168.0.0/16", // private
 		"169.254.0.0/16", // subnet, link-local addresses
-		"127.0.0.0/8",    //loopback
+		"127.0.0.0/8",    // loopback
 		"224.0.0.0/4",    // multicast (former Class D)
 		"240.0.0.0/4",    // reserved (former Class E)
 	}

--- a/backend/api/inet/ipinfo.go
+++ b/backend/api/inet/ipinfo.go
@@ -13,7 +13,15 @@ var mmdbFile embed.FS
 // geodb is the mmdb reader instance
 var geodb *maxminddb.Reader
 
-// Init initializes the mmdb database.
+// ipv4Nets defines a list of
+// bogon ipv4 ranges.
+var ipv4Nets []*net.IPNet
+
+// ipv6Nets defines a list of
+// bogon ipv6 ranges.
+var ipv6Nets []*net.IPNet
+
+// Init initializes the inet geoip system.
 func Init() (err error) {
 	dbFile, err := mmdbFile.ReadFile("country.mmdb")
 	if err != nil {
@@ -24,6 +32,45 @@ func Init() (err error) {
 		return
 	}
 	geodb = db
+
+	// See more: https://en.wikipedia.org/wiki/Reserved_IP_addresses
+	ipv4Bogons := []string{
+		"10.0.0.0/8",     // private
+		"172.16.0.0/12",  // private
+		"192.168.0.0/16", // private
+		"169.254.0.0/16", // subnet, link-local addresses
+		"127.0.0.0/8",    //loopback
+		"224.0.0.0/4",    // multicast (former Class D)
+		"240.0.0.0/4",    // reserved (former Class E)
+	}
+
+	ipv6Bogons := []string{
+		"::1/128",   // loopback
+		"fe80::/10", // link-local addresses
+		"ff00::/8",  // multicast
+		"fc00::/7",  // private internets, unique local address
+	}
+
+	// cache ipv4 bogon nets
+	for _, cidr := range ipv4Bogons {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return err
+		}
+
+		ipv4Nets = append(ipv4Nets, network)
+	}
+
+	// cache ipv6 bogon nets
+	for _, cidr := range ipv6Bogons {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return err
+		}
+
+		ipv6Nets = append(ipv6Nets, network)
+	}
+
 	return
 }
 
@@ -40,6 +87,27 @@ func Close() (err error) {
 	}
 
 	return
+}
+
+// IsBogon returns true if the IP
+// is not routable via public
+// internet.
+func IsBogon(ip net.IP) bool {
+	if ip.To4() != nil {
+		for _, network := range ipv4Nets {
+			if network.Contains(ip) {
+				return true
+			}
+		}
+	} else if ip.To16() != nil {
+		for _, network := range ipv6Nets {
+			if network.Contains(ip) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // CountryCode looks up the country code for

--- a/backend/api/inet/ipinfo_test.go
+++ b/backend/api/inet/ipinfo_test.go
@@ -1,0 +1,36 @@
+package inet
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsBogon(t *testing.T) {
+	Init()
+
+	ipOne := net.ParseIP("127.0.0.1")
+	ipTwo := net.ParseIP("192.168.1.10")
+	ipThree := net.ParseIP("::1")
+	ipFour := net.ParseIP("8.8.8.8")
+	ipFive := net.ParseIP("2001:4860:4860::8888")
+
+	if IsBogon(ipOne) != true {
+		t.Errorf("Expected %q to be bogon, but got false", ipOne)
+	}
+
+	if IsBogon(ipTwo) != true {
+		t.Errorf("Expected %q to be bogon, but got false", ipTwo)
+	}
+
+	if IsBogon(ipThree) != true {
+		t.Errorf("Expected %q to be bogon, but got false", ipThree)
+	}
+
+	if IsBogon(ipFour) == true {
+		t.Errorf("Expected %q to be not bogon, but got true", ipFour)
+	}
+
+	if IsBogon(ipFive) == true {
+		t.Errorf("Expected %q to be not bogon, but got true", ipFive)
+	}
+}

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/ipinfo/go/v2/ipinfo"
 	"github.com/jackc/pgx/v5"
 	"github.com/leporo/sqlf"
 	"go.opentelemetry.io/otel"
@@ -197,11 +196,6 @@ func (e *eventreq) infuseInet(rawIP string) error {
 		return err
 	}
 
-	bogon, err := ipinfo.GetIPBogon(ip)
-	if err != nil {
-		return err
-	}
-
 	v4 := inet.Isv4(ip)
 
 	for i := range e.events {
@@ -211,12 +205,12 @@ func (e *eventreq) infuseInet(rawIP string) error {
 			e.events[i].IPv6 = ip
 		}
 
-		if bogon {
-			e.events[i].CountryCode = "bogon"
-		} else if country != "" {
+		if country != "" {
 			e.events[i].CountryCode = country
+		} else if inet.IsBogon(ip) {
+			e.events[i].CountryCode = "bogon"
 		} else {
-			e.events[i].CountryCode = "not available"
+			e.events[i].CountryCode = "n/a"
 		}
 	}
 


### PR DESCRIPTION
## Summary

Bogon filtering of IPs during ingestion was still contacting remote IPInfo servers and thus was hitting IPInfo's rate limits thereby failing ingestion. This PR detects bogon IPs locally without depending on any remote servers. The newer implementation looks up country code first and checks for bogon addresses if a valid country code is not found. If IP is not bogon, we set country code as `n/a`.

## Tasks

- [x] Detect bogon addresses by inspecting the ip locally
- [x] Remove dependency on IPInfo
- [x] Optimized detection of country codes
- [x] Add tests for bogon address detection

fixes #1178