### PR TITLE
add EventProcessor to iOS

### DIFF
--- a/ios/MeasureSDK/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK/MeasureSDK.xcodeproj/project.pbxproj
@@ -27,6 +27,11 @@
 		5202BE592C89603400A3496E /* MockAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE572C89603400A3496E /* MockAttributeProcessor.swift */; };
 		5202BE5B2C89603E00A3496E /* MockConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE5A2C89603E00A3496E /* MockConfigLoader.swift */; };
 		5202BE722C8AFF2800A3496E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE712C8AFF2800A3496E /* Constants.swift */; };
+		5202BE792C8B117900A3496E /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE732C8B117900A3496E /* Attachment.swift */; };
+		5202BE7A2C8B117900A3496E /* AttachmentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE742C8B117900A3496E /* AttachmentType.swift */; };
+		5202BE7B2C8B117900A3496E /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE752C8B117900A3496E /* Event.swift */; };
+		5202BE7C2C8B117900A3496E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE762C8B117900A3496E /* EventProcessor.swift */; };
+		5202BE7D2C8B117900A3496E /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5202BE772C8B117900A3496E /* EventType.swift */; };
 		5224ECE02C88057A00D1B1F7 /* FatalErrorUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5224ECDF2C88057A00D1B1F7 /* FatalErrorUtil.swift */; };
 		5224ECE32C880FA400D1B1F7 /* XCTextCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5224ECE22C880FA300D1B1F7 /* XCTextCase+Extension.swift */; };
 		523287672C85D0AA000EE268 /* SystemTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523287662C85D0AA000EE268 /* SystemTime.swift */; };
@@ -61,6 +66,8 @@
 		52CD91222C7C318C000189BA /* ConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD91212C7C318C000189BA /* ConfigLoader.swift */; };
 		52CD91242C7C3D0F000189BA /* MeasureInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD91232C7C3D0F000189BA /* MeasureInternal.swift */; };
 		52CD91262C7C3D90000189BA /* MeasureInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD91252C7C3D90000189BA /* MeasureInitializer.swift */; };
+		52EB38062C8B4786002D63EC /* MockSystemTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB38052C8B4786002D63EC /* MockSystemTime.swift */; };
+		52EB38082C8B485F002D63EC /* MockSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB38072C8B485F002D63EC /* MockSessionManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +101,11 @@
 		5202BE572C89603400A3496E /* MockAttributeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAttributeProcessor.swift; sourceTree = "<group>"; };
 		5202BE5A2C89603E00A3496E /* MockConfigLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockConfigLoader.swift; sourceTree = "<group>"; };
 		5202BE712C8AFF2800A3496E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		5202BE732C8B117900A3496E /* Attachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attachment.swift; sourceTree = "<group>"; };
+		5202BE742C8B117900A3496E /* AttachmentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentType.swift; sourceTree = "<group>"; };
+		5202BE752C8B117900A3496E /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
+		5202BE762C8B117900A3496E /* EventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventProcessor.swift; sourceTree = "<group>"; };
+		5202BE772C8B117900A3496E /* EventType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventType.swift; sourceTree = "<group>"; };
 		5224ECDF2C88057A00D1B1F7 /* FatalErrorUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorUtil.swift; sourceTree = "<group>"; };
 		5224ECE22C880FA300D1B1F7 /* XCTextCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTextCase+Extension.swift"; sourceTree = "<group>"; };
 		523287662C85D0AA000EE268 /* SystemTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTime.swift; sourceTree = "<group>"; };
@@ -128,6 +140,9 @@
 		52CD91212C7C318C000189BA /* ConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLoader.swift; sourceTree = "<group>"; };
 		52CD91232C7C3D0F000189BA /* MeasureInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureInternal.swift; sourceTree = "<group>"; };
 		52CD91252C7C3D90000189BA /* MeasureInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureInitializer.swift; sourceTree = "<group>"; };
+		52EB38002C8B3688002D63EC /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		52EB38052C8B4786002D63EC /* MockSystemTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemTime.swift; sourceTree = "<group>"; };
+		52EB38072C8B485F002D63EC /* MockSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +207,18 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
+		5202BE782C8B117900A3496E /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				5202BE732C8B117900A3496E /* Attachment.swift */,
+				5202BE742C8B117900A3496E /* AttachmentType.swift */,
+				5202BE752C8B117900A3496E /* Event.swift */,
+				5202BE762C8B117900A3496E /* EventProcessor.swift */,
+				5202BE772C8B117900A3496E /* EventType.swift */,
+			);
+			path = Events;
+			sourceTree = "<group>";
+		};
 		5224ECE12C880F7400D1B1F7 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
@@ -220,6 +247,8 @@
 				523287782C8619EF000EE268 /* MockRandomizer.swift */,
 				5232877A2C861A14000EE268 /* MockTimeProvider.swift */,
 				5202BE562C89603400A3496E /* MockUserDefaultStorage.swift */,
+				52EB38052C8B4786002D63EC /* MockSystemTime.swift */,
+				52EB38072C8B485F002D63EC /* MockSessionManager.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -230,6 +259,7 @@
 				524CC5BC2C6A4B11001AB506 /* MeasureSDK */,
 				524CC5C62C6A4B12001AB506 /* MeasureSDKTests */,
 				524CC5BB2C6A4B11001AB506 /* Products */,
+				52EB37FF2C8B3688002D63EC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -249,6 +279,7 @@
 				524CC5DA2C6A4B48001AB506 /* Config */,
 				524CC5D32C6A4B48001AB506 /* CoreData */,
 				524CC5D82C6A4B48001AB506 /* CrashReporter */,
+				5202BE782C8B117900A3496E /* Events */,
 				5202BE412C895FD600A3496E /* FrameworkInfo.swift */,
 				524CC5D92C6A4B48001AB506 /* Measure.swift */,
 				52CD91252C7C3D90000189BA /* MeasureInitializer.swift */,
@@ -264,12 +295,12 @@
 		524CC5C62C6A4B12001AB506 /* MeasureSDKTests */ = {
 			isa = PBXGroup;
 			children = (
-				5202BE542C89601A00A3496E /* Config */,
 				5202BE4E2C89601200A3496E /* Attribute */,
+				5202BE542C89601A00A3496E /* Config */,
 				5224ECE12C880F7400D1B1F7 /* Helper */,
 				523287712C861928000EE268 /* Mocks */,
-				5232876A2C85E277000EE268 /* Utils */,
 				523287722C86195E000EE268 /* SessionManagerTests.swift */,
+				5232876A2C85E277000EE268 /* Utils */,
 			);
 			path = MeasureSDKTests;
 			sourceTree = "<group>";
@@ -328,6 +359,14 @@
 				5202BE452C89600200A3496E /* UserDefaultStorage.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		52EB37FF2C8B3688002D63EC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				52EB38002C8B3688002D63EC /* CoreTelephony.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -461,8 +500,11 @@
 				5202BE3C2C895FC800A3496E /* ComputeOnceAttributeProcessor.swift in Sources */,
 				5202BE3D2C895FC800A3496E /* DeviceAttributeProcessor.swift in Sources */,
 				5224ECE02C88057A00D1B1F7 /* FatalErrorUtil.swift in Sources */,
+				5202BE7B2C8B117900A3496E /* Event.swift in Sources */,
+				5202BE7C2C8B117900A3496E /* EventProcessor.swift in Sources */,
 				5202BE482C89600200A3496E /* UserDefaultStorage.swift in Sources */,
 				524CC5EE2C6A55F0001AB506 /* CrashReportManager.swift in Sources */,
+				5202BE7A2C8B117900A3496E /* AttachmentType.swift in Sources */,
 				528EAB8D2C80824200CB1574 /* Logger.swift in Sources */,
 				528EAB8F2C81B4C700CB1574 /* TimeProvider.swift in Sources */,
 				52CD91222C7C318C000189BA /* ConfigLoader.swift in Sources */,
@@ -474,7 +516,9 @@
 				528EAB982C845AF400CB1574 /* Randomizer.swift in Sources */,
 				524CC5DF2C6A4B48001AB506 /* Measure.swift in Sources */,
 				5202BE3F2C895FC800A3496E /* NetworkStateAttributeProcessor.swift in Sources */,
+				5202BE792C8B117900A3496E /* Attachment.swift in Sources */,
 				528EAB962C84553500CB1574 /* LifecycleObserver.swift in Sources */,
+				5202BE7D2C8B117900A3496E /* EventType.swift in Sources */,
 				52CD911E2C7B397C000189BA /* BaseConfigProvider.swift in Sources */,
 				52CD91202C7B39AE000189BA /* Config.swift in Sources */,
 				52CD911A2C7B2C77000189BA /* DefaultConfig.swift in Sources */,
@@ -494,10 +538,12 @@
 				5202BE592C89603400A3496E /* MockAttributeProcessor.swift in Sources */,
 				5202BE4F2C89601200A3496E /* AttributeProcessorTests.swift in Sources */,
 				523287752C8619C4000EE268 /* MockIdProvider.swift in Sources */,
+				52EB38082C8B485F002D63EC /* MockSessionManager.swift in Sources */,
 				5202BE582C89603400A3496E /* MockUserDefaultStorage.swift in Sources */,
 				5202BE522C89601200A3496E /* UserAttributeProcessorTests.swift in Sources */,
 				5224ECE32C880FA400D1B1F7 /* XCTextCase+Extension.swift in Sources */,
 				5202BE552C89601A00A3496E /* BaseConfigProviderTests.swift in Sources */,
+				52EB38062C8B4786002D63EC /* MockSystemTime.swift in Sources */,
 				523287732C86195E000EE268 /* SessionManagerTests.swift in Sources */,
 				5202BE5B2C89603E00A3496E /* MockConfigLoader.swift in Sources */,
 				523287692C85E07B000EE268 /* LifecycleObserverTests.swift in Sources */,

--- a/ios/MeasureSDK/MeasureSDK/Events/Attachment.swift
+++ b/ios/MeasureSDK/MeasureSDK/Events/Attachment.swift
@@ -1,0 +1,35 @@
+//
+//  Attachment.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 05/09/24.
+//
+
+import Foundation
+
+struct Attachment: Codable {
+    /// The name of the attachment, e.g. "screenshot.png".
+    let name: String
+
+    /// The type of the attachment.
+    let type: AttachmentType
+
+    /// An optional byte array representing the attachment (not encoded).
+    var bytes: Data?
+
+    /// An optional path to the attachment (not encoded).
+    var path: String?
+
+    init(name: String,
+         type: AttachmentType,
+         bytes: Data? = nil,
+         path: String? = nil) {
+        precondition(bytes != nil || path != nil, "Failed to create Attachment. Either bytes or path must be provided")
+        precondition(bytes == nil || path == nil, "Failed to create Attachment. Only one of bytes or path must be provided")
+
+        self.name = name
+        self.type = type
+        self.bytes = bytes
+        self.path = path
+    }
+}

--- a/ios/MeasureSDK/MeasureSDK/Events/AttachmentType.swift
+++ b/ios/MeasureSDK/MeasureSDK/Events/AttachmentType.swift
@@ -1,0 +1,12 @@
+//
+//  AttachmentType.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 05/09/24.
+//
+
+import Foundation
+
+enum AttachmentType: String, Codable {
+    case screenshot
+}

--- a/ios/MeasureSDK/MeasureSDK/Events/Event.swift
+++ b/ios/MeasureSDK/MeasureSDK/Events/Event.swift
@@ -1,0 +1,63 @@
+//
+//  Event.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 05/09/24.
+//
+
+import Foundation
+
+/// Represents an event in Measure. This object maps closely to the event object in the Measure API.
+final class Event<T: Codable>: Codable {
+    /// A unique identifier for the event.
+    let id: String
+
+    /// The session id of the event. This is the session id of the session in which the event was triggered.
+    let sessionId: String
+
+    /// The timestamp of the event. The time when the event was triggered, measured in milliseconds since epoch.
+    let timestamp: String
+
+    /// The type of the event.
+    let type: EventType
+
+    /// The data collected. This can be any object that conforms to `Codable`.
+    let data: T
+
+    /// Attachments that can be added to the event.
+    var attachments: [Attachment]
+
+    /// Additional key-value pairs that can be added to the event.
+    var attributes: Attributes?
+
+    /// A flag to indicate if the event is triggered by the user or the SDK.
+    let userTriggered: Bool
+
+    init(id: String, sessionId: String, timestamp: String, type: EventType, data: T, attachments: [Attachment], attributes: Attributes?, userTriggered: Bool) {
+        self.id = id
+        self.sessionId = sessionId
+        self.timestamp = timestamp
+        self.type = type
+        self.data = data
+        self.attachments = attachments
+        self.attributes = attributes
+        self.userTriggered = userTriggered
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case sessionId = "session_id"
+        case timestamp
+        case type
+        case data
+        case attachments
+        case attributes
+        case userTriggered = "user_triggered"
+    }
+
+    func appendAttributes(_ attributeProcessors: [AttributeProcessor]) {
+        attributeProcessors.forEach { processor in
+            processor.appendAttributes(&self.attributes!)
+        }
+    }
+}

--- a/ios/MeasureSDK/MeasureSDK/Events/EventProcessor.swift
+++ b/ios/MeasureSDK/MeasureSDK/Events/EventProcessor.swift
@@ -1,0 +1,137 @@
+//
+//  EventProcessor.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 05/09/24.
+//
+
+import Foundation
+
+/// A protocol for processing events. Responsible for tracking events, processing them by applying
+/// various attributes and transformations, and then eventually storing them or sending them to the server.
+protocol EventProcessor {
+    /// Tracks an event with the given data, timestamp, and type.
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType
+    )
+
+    /// Tracks an event with the given data, timestamp, type, and sessionId.
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        sessionId: String
+    )
+
+    /// Tracks an event with the given data, timestamp, type, attributes, and attachments.
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        attributes: Attributes?,
+        attachments: [Attachment]
+    )
+}
+
+/// A concrete implementation of the `EventProcessor` protocol, responsible for tracking and
+/// processing events.
+internal class BaseEventProcessor: EventProcessor {
+    private let logger: Logger
+    private let idProvider: IdProvider
+    private let sessionManager: SessionManager
+    private let attributeProcessors: [AttributeProcessor]
+    private let configProvider: ConfigProvider
+    private let systemTime: SystemTime
+
+    init(
+        logger: Logger,
+        idProvider: IdProvider,
+        sessionManager: SessionManager,
+        attributeProcessors: [AttributeProcessor],
+        configProvider: ConfigProvider,
+        systemTime: SystemTime
+    ) {
+        self.logger = logger
+        self.idProvider = idProvider
+        self.sessionManager = sessionManager
+        self.attributeProcessors = attributeProcessors
+        self.configProvider = configProvider
+        self.systemTime = systemTime
+    }
+
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType
+    ) {
+        track(data: data, timestamp: timestamp, type: type, attributes: Attributes(), attachments: [])
+    }
+
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        sessionId: String
+    ) {
+        track(data: data, timestamp: timestamp, type: type, attributes: Attributes(), attachments: [], sessionId: sessionId)
+    }
+
+    func track<T: Codable>(
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        attributes: Attributes?,
+        attachments: [Attachment]
+    ) {
+        track(data: data, timestamp: timestamp, type: type, attributes: attributes, attachments: attachments, sessionId: nil)
+    }
+
+    private func track<T: Codable>( // swiftlint:disable:this function_parameter_count
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        attributes: Attributes?,
+        attachments: [Attachment],
+        sessionId: String?
+    ) {
+        let threadName = Thread.current.name ?? "unknown"
+        let event = createEvent(
+            data: data,
+            timestamp: timestamp,
+            type: type,
+            attachments: attachments,
+            attributes: attributes,
+            userTriggered: false,
+            sessionId: sessionId
+        )
+        event.attributes?.threadName = threadName
+        event.appendAttributes(self.attributeProcessors)
+
+        logger.log(level: .debug, message: "Event processed: \(type), \(event.sessionId)", error: nil)
+    }
+
+    private func createEvent<T: Codable>( // swiftlint:disable:this function_parameter_count
+        data: T,
+        timestamp: Int64,
+        type: EventType,
+        attachments: [Attachment],
+        attributes: Attributes?,
+        userTriggered: Bool,
+        sessionId: String?
+    ) -> Event<T> {
+        let id = idProvider.createId()
+        let resolvedSessionId = sessionId ?? sessionManager.sessionId
+        return Event(
+            id: id,
+            sessionId: resolvedSessionId,
+            timestamp: systemTime.iso8601Timestamp(timeInMillis: timestamp),
+            type: type,
+            data: data,
+            attachments: attachments,
+            attributes: attributes,
+            userTriggered: userTriggered
+        )
+    }
+}

--- a/ios/MeasureSDK/MeasureSDK/Events/EventType.swift
+++ b/ios/MeasureSDK/MeasureSDK/Events/EventType.swift
@@ -1,0 +1,12 @@
+//
+//  EventType.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 05/09/24.
+//
+
+import Foundation
+
+enum EventType: String, Codable {
+    case exception
+}

--- a/ios/MeasureSDK/MeasureSDK/MeasureInitializer.swift
+++ b/ios/MeasureSDK/MeasureSDK/MeasureInitializer.swift
@@ -23,6 +23,7 @@ protocol MeasureInitializer {
     var networkStateAttributeProcessor: NetworkStateAttributeProcessor { get }
     var userAttributeProcessor: UserAttributeProcessor { get }
     var attributeProcessors: [AttributeProcessor] { get }
+    var eventProcessor: EventProcessor { get }
 }
 
 /// `BaseMeasureInitializer` is responsible for setting up the internal configuration
@@ -58,6 +59,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
     let networkStateAttributeProcessor: NetworkStateAttributeProcessor
     let userAttributeProcessor: UserAttributeProcessor
     let attributeProcessors: [AttributeProcessor]
+    let eventProcessor: EventProcessor
 
     init(config: MeasureConfig,
          client: Client) {
@@ -87,7 +89,12 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                     installationIdAttributeProcessor,
                                     networkStateAttributeProcessor,
                                     userAttributeProcessor]
-
+        self.eventProcessor = BaseEventProcessor(logger: logger,
+                                                 idProvider: idProvider,
+                                                 sessionManager: sessionManager,
+                                                 attributeProcessors: attributeProcessors,
+                                                 configProvider: configProvider,
+                                                 systemTime: systemTime)
         self.client = client
     }
 }

--- a/ios/MeasureSDK/MeasureSDK/MeasureInternal.swift
+++ b/ios/MeasureSDK/MeasureSDK/MeasureInternal.swift
@@ -26,6 +26,33 @@ final class MeasureInternal {
     private var configProvider: ConfigProvider {
         return measureInitializer.configProvider
     }
+    private var systemTime: SystemTime {
+        return measureInitializer.systemTime
+    }
+    private var appAttributeProcessor: AppAttributeProcessor {
+        return measureInitializer.appAttributeProcessor
+    }
+    private var deviceAttributeProcessor: DeviceAttributeProcessor {
+        return measureInitializer.deviceAttributeProcessor
+    }
+    private var installationIdAttributeProcessor: InstallationIdAttributeProcessor {
+        return measureInitializer.installationIdAttributeProcessor
+    }
+    private var networkStateAttributeProcessor: NetworkStateAttributeProcessor {
+        return measureInitializer.networkStateAttributeProcessor
+    }
+    private var userAttributeProcessor: UserAttributeProcessor {
+        return measureInitializer.userAttributeProcessor
+    }
+    private var userDefaultStorage: UserDefaultStorage {
+        return measureInitializer.userDefaultStorage
+    }
+    private var attributeProcessors: [AttributeProcessor] {
+        return measureInitializer.attributeProcessors
+    }
+    private var eventProcessor: EventProcessor {
+        return measureInitializer.eventProcessor
+    }
     private let lifecycleObserver: LifecycleObserver
 
     init(_ measureInitializer: MeasureInitializer) {
@@ -36,6 +63,16 @@ final class MeasureInternal {
         self.lifecycleObserver.applicationDidEnterBackground = applicationDidEnterBackground
         self.lifecycleObserver.applicationWillEnterForeground = applicationWillEnterForeground
         self.lifecycleObserver.applicationWillTerminate = applicationWillTerminate
+        let dic = ["2": "B", "1": "A", "3": "C"]
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: dic, options: .prettyPrinted)
+            // here "jsonData" is the dictionary encoded in JSON data
+
+            self.eventProcessor.track(data: jsonData, timestamp: 1_000_000_000_000, type: .exception)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 
     private func applicationDidEnterBackground() {

--- a/ios/MeasureSDK/MeasureSDKTests/Mocks/MockLogger.swift
+++ b/ios/MeasureSDK/MeasureSDKTests/Mocks/MockLogger.swift
@@ -9,11 +9,7 @@ import Foundation
 @testable import MeasureSDK
 
 final class MockLogger: Logger {
-    var enabled: Bool
-
-    init(enabled: Bool) {
-        self.enabled = enabled
-    }
+    var enabled: Bool = false
 
     func log(level: MeasureSDK.LogLevel, message: String, error: (any Error)?) {}
 }

--- a/ios/MeasureSDK/MeasureSDKTests/Mocks/MockSessionManager.swift
+++ b/ios/MeasureSDK/MeasureSDKTests/Mocks/MockSessionManager.swift
@@ -1,0 +1,25 @@
+//
+//  MockSessionManager.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 06/09/24.
+//
+
+import Foundation
+@testable import MeasureSDK
+
+class MockSessionManager: SessionManager {
+    var sessionId: String
+
+    func start() {}
+
+    func applicationDidEnterBackground() {}
+
+    func applicationWillEnterForeground() {}
+
+    func applicationWillTerminate() {}
+
+    init(sessionId: String) {
+        self.sessionId = sessionId
+    }
+}

--- a/ios/MeasureSDK/MeasureSDKTests/Mocks/MockSystemTime.swift
+++ b/ios/MeasureSDK/MeasureSDKTests/Mocks/MockSystemTime.swift
@@ -1,0 +1,25 @@
+//
+//  MockSystemTime.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 06/09/24.
+//
+
+import Foundation
+@testable import MeasureSDK
+
+final class MockSystemTime: SystemTime {
+    var timeIntervalSince1970: Int64
+    var systemUptime: Int64
+    var timeInMillis: String
+
+    init(timeIntervalSince1970: Int64, systemUptime: Int64, timeInMillis: String) {
+        self.timeIntervalSince1970 = timeIntervalSince1970
+        self.systemUptime = systemUptime
+        self.timeInMillis = timeInMillis
+    }
+
+    func iso8601Timestamp(timeInMillis: Int64) -> String {
+        return self.timeInMillis
+    }
+}

--- a/ios/MeasureSDK/MeasureSDKTests/SessionManagerTests.swift
+++ b/ios/MeasureSDK/MeasureSDKTests/SessionManagerTests.swift
@@ -19,7 +19,7 @@ final class SessionManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         idProvider = MockIdProvider("test-session-id-1")
-        logger = MockLogger(enabled: false)
+        logger = MockLogger()
         timeProvider = MockTimeProvider(currentTimeSinceEpochInMillis: 1_000_000_000,
                                             currentTimeSinceEpochInNanos: 1_000_000_000_000,
                                             uptimeInMillis: 1_000_000,


### PR DESCRIPTION
# Description

events processor added to the iOS SDK.

## Related issue
closes #1204 

## Note

Tests are currently not added as there is no public api to access events. Tests will be added once EventStore is created. Related issue: #1205 



