### PR TITLE
feat(backend): improve session explorer

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -45,6 +45,10 @@ type AppFilter struct {
 	// the filter time range.
 	To time.Time `form:"to" time_format:"2006-01-02T15:04:05.000Z" time_utc:"1"`
 
+	// Timezone represents the timezone of the
+	// client
+	Timezone string `form:"timezone"`
+
 	// Versions is the list of version string
 	// to be matched & filtered on.
 	Versions []string `form:"versions"`

--- a/frontend/dashboard/app/[teamId]/sessions/page.tsx
+++ b/frontend/dashboard/app/[teamId]/sessions/page.tsx
@@ -64,8 +64,8 @@ export default function SessionsOverview({ params }: { params: { teamId: string 
 
     // Reset pagination range if not in default if any filters change
     useEffect(() => {
-        // If we reset pagination range even if values haven't change, we will trigger
-        // and unnecessary getSessionsOverview effect
+        // If we reset pagination range even if values haven't changed, we will trigger
+        // an unnecessary getSessionsOverview effect
         if (paginationRange.start === 1 && paginationRange.end === paginationOffset) {
             return
         }
@@ -162,7 +162,7 @@ export default function SessionsOverview({ params }: { params: { teamId: string 
                                         <div className='py-1' />
                                         <p className='text-xs truncate'>{formatDateToHumanReadable(first_event_time).split(',').slice(2).join(',').trim()}</p>
                                     </div>
-                                    <div className="table-cell w-48 p-4 truncate text-center">{formatMillisToHumanReadable(duration as unknown as number)}</div>
+                                    <div className="table-cell w-48 p-4 truncate text-center">{(duration as unknown as number) === 0 ? 'N/A' : formatMillisToHumanReadable(duration as unknown as number)}</div>
                                 </Link>
                             ))}
                         </div>

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1,7 +1,7 @@
 import { auth, fetchAuth, logoutIfAuthError } from "@/app/utils/auth/auth";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime"
 import { JourneyType } from "../components/journey"
-import { formatUserInputDateToServerFormat } from "../utils/time_utils"
+import { formatUserInputDateToServerFormat, getTimeZoneForServer } from "../utils/time_utils"
 
 export enum TeamsApiStatus {
     Loading,
@@ -867,8 +867,9 @@ export const fetchSessionsOverviewPlotFromServer = async (appId: string, startDa
 
     const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate)
     const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate)
+    const timezone = getTimeZoneForServer()
 
-    var url = `${origin}/apps/${appId}/sessions/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
+    var url = `${origin}/apps/${appId}/sessions/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}&timezone=${timezone}`
 
     // Append versions if present
     if (appVersions.length > 0) {

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -429,7 +429,7 @@ const Filters: React.FC<FiltersProps> = ({
             {showLocales && locales.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Locale" items={locales} initialSelected={locales} onChangeSelected={(items) => setSelectedLocales(items as string[])} />}
             {showDeviceManufacturers && deviceManufacturers.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Device Manufacturer" items={deviceManufacturers} initialSelected={deviceManufacturers} onChangeSelected={(items) => setSelectedDeviceManufacturers(items as string[])} />}
             {showDeviceNames && deviceNames.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Device Name" items={deviceNames} initialSelected={deviceNames} onChangeSelected={(items) => setSelectedDeviceNames(items as string[])} />}
-            {showFreeText && <DebounceTextInput id="free-text" placeholder="Search User ID, Session ID, Logs, Class names or Exception Traces..." onChange={(input) => setSelectedFreeText(input)} />}
+            {showFreeText && <DebounceTextInput id="free-text" placeholder="Search User/Session ID, Logs, Event Type, Target View ID, File/Class name or Exception Traces..." onChange={(input) => setSelectedFreeText(input)} />}
           </div>
           <div className="py-4" />
           <div className="flex flex-wrap gap-2 items-center">

--- a/frontend/dashboard/app/components/sessions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/sessions_overview_plot.tsx
@@ -151,7 +151,7 @@ const SessionsOverviewPlot: React.FC<SessionsOverviewPlotProps> = ({ appId, star
           sliceTooltip={({ slice }) => {
             return (
               <div className="bg-neutral-950 text-white flex flex-col p-2 text-xs">
-                <p className='p-2'>Date: {formatDateToHumanReadable(slice.points[0].data.xFormatted.toString())}</p>
+                <p className='p-2'>Date: {formatDateToHumanReadable(slice.points[0].data.xFormatted.toString()).split(',').slice(0, 2).join(',')}</p>
                 {slice.points.map((point) => (
                   <div className="flex flex-row items-center p-2" key={point.id}>
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />

--- a/frontend/dashboard/app/utils/time_utils.ts
+++ b/frontend/dashboard/app/utils/time_utils.ts
@@ -1,5 +1,9 @@
 import { DateTime } from 'luxon';
 
+export function getTimeZoneForServer(): string {
+  return DateTime.now().zone.name
+}
+
 export function formatMillisToHumanReadable(millis: number) {
   if (millis <= 0) {
     return '0ms'


### PR DESCRIPTION
# Description

- Show "N/A" for 0 duration
- Fix some sessions show 0 duration even if it has more events
- Add event id target as searchable property
- Placeholder: add all searchable properties
- Show only date in instances plot and not time
- Fix plot sessions calculating first_time_time for session over filtered events instead of whole session
- Fix plot grouping happening on server timezone instead of client time zone

## Related issue
Closes #1209 if not bug fix task


