### PR TITLE
fix(frontend): use whole int left axes for crash + anr instances plots

### DIFF
--- a/frontend/dashboard/app/components/exceptions_details_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_details_plot.tsx
@@ -108,6 +108,7 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ appId, ex
           axisLeft={{
             tickSize: 1,
             tickPadding: 5,
+            format: value => Number.isInteger(value) ? value : '',
             legend: exceptionsType === ExceptionsType.Crash ? 'Crash instances' : 'ANR instances',
             legendOffset: -80,
             legendPosition: 'middle'

--- a/frontend/dashboard/app/components/exceptions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview_plot.tsx
@@ -116,6 +116,7 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ appId, 
           axisLeft={{
             tickSize: 1,
             tickPadding: 5,
+            format: value => Number.isInteger(value) ? value : '',
             legend: exceptionsType === ExceptionsType.Crash ? '% Crash free sessions ' : '% ANR free sessions',
             legendOffset: -80,
             legendPosition: 'middle'


### PR DESCRIPTION
# Description

Use whole integer left axes for crash + anr instances plots instead of having decimals

## Related issue
Fixes #1216



