### PR TITLE
chore(backend): enable sessionator parallel ingest

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -111,6 +111,8 @@ services:
       context: ../backend/cleanup
     ports:
       - "8081:8081"
+    profiles:
+      - cleanup
     environment:
       - POSTGRES_DSN=${POSTGRES_DSN}
       - CLICKHOUSE_DSN=${CLICKHOUSE_DSN}

--- a/self-host/sessionator/cmd/rm.go
+++ b/self-host/sessionator/cmd/rm.go
@@ -83,6 +83,10 @@ func deleteAllObjects(ctx context.Context, bucket *string, client *s3.Client) (e
 // rmEvents removes all data associated with
 // the apps in config.
 func rmEvents(ctx context.Context, c *config.Config) (err error) {
+	if dryRun {
+		return nil
+	}
+
 	hasApps := len(c.Apps) > 0
 
 	if !hasApps {
@@ -157,6 +161,10 @@ func rmEvents(ctx context.Context, c *config.Config) (err error) {
 // rmAll removes all data regardless of apps configuration
 // in config.
 func rmAll(ctx context.Context, c *config.Config) (err error) {
+	if dryRun {
+		return nil
+	}
+
 	pgconn, err := pgx.Connect(ctx, c.Storage["postgres_dsn"])
 	if err != nil {
 		return

--- a/self-host/sessionator/cmd/virtual.go
+++ b/self-host/sessionator/cmd/virtual.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// virtualizer provides settings
+// for virtualizing event ingestion.
+type virtualizer struct {
+	virtualEvents   bool
+	virtualSessions bool
+	sessionIdMap    map[string]uuid.UUID
+}
+
+// NewVirtualizer creates a new virtualizer.
+func NewVirtualizer() *virtualizer {
+	return &virtualizer{
+		virtualEvents:   false,
+		virtualSessions: false,
+		sessionIdMap:    make(map[string]uuid.UUID),
+	}
+}
+
+// doubleQuoteID wraps a UUID in double
+// quotes.
+func doubleQuoteID(id uuid.UUID) string {
+	return "\"" + id.String() + "\""
+}
+
+// rawEvent replaces the raw json event's
+// id.
+func rawEventId(rm *json.RawMessage) (err error) {
+	id := uuid.New()
+	quotedId := doubleQuoteID(id)
+	opts := sjson.Options{
+		Optimistic:     true,
+		ReplaceInPlace: true,
+	}
+	_, err = sjson.SetRawBytesOptions(*rm, "id", []byte(quotedId), &opts)
+
+	return
+}
+
+// rawEvent replaces the raw json session's
+// id.
+func rawSessionId(v *virtualizer, rm *json.RawMessage) (err error) {
+	result := gjson.GetBytes(*rm, "session_id")
+
+	opts := sjson.Options{
+		Optimistic:     true,
+		ReplaceInPlace: true,
+	}
+
+	sessionId, ok := v.sessionIdMap[result.Str]
+	if !ok {
+		id := uuid.New()
+		v.sessionIdMap[result.Str] = id
+		quotedId := doubleQuoteID(id)
+		_, err = sjson.SetRawBytesOptions(*rm, "id", []byte(quotedId), &opts)
+		return
+	}
+
+	quotedId := doubleQuoteID(sessionId)
+	_, err = sjson.SetRawBytesOptions(*rm, "id", []byte(quotedId), &opts)
+
+	return
+}
+
+// Event enables virtualization of events.
+func (v *virtualizer) Event() *virtualizer {
+	v.virtualEvents = true
+	return v
+}
+
+// Event enables virtualization of sessions.
+func (v *virtualizer) Session() *virtualizer {
+	v.virtualSessions = true
+	return v
+}
+
+// Virtualize virtualizes a single json raw event.
+func (v *virtualizer) Virtualize(rm *json.RawMessage) (err error) {
+	if v.virtualEvents {
+		if err = rawEventId(rm); err != nil {
+			return
+		}
+	}
+
+	if v.virtualSessions {
+		if err = rawSessionId(v, rm); err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/self-host/sessionator/go.mod
+++ b/self-host/sessionator/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/spf13/cobra v1.8.0
+	github.com/tidwall/gjson v1.17.3
+	github.com/tidwall/sjson v1.2.5
 )
 
 require (
@@ -54,6 +56,8 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect

--- a/self-host/sessionator/go.sum
+++ b/self-host/sessionator/go.sum
@@ -142,7 +142,17 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.17.3 h1:bwWLZU7icoKRG+C+0PNwIKC6FCJO/Q3p2pZvuP0jN94=
+github.com/tidwall/gjson v1.17.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=


### PR DESCRIPTION
## Summary

Equip sessionator to virtualize existing session data events and send multiple request in parallel with the ability to control the ingestion rate.

## Tasks

- [x] Add `--dry-run` flag to simulate ingestion
- [x] Add `--frequency` flag to control parallel ingest frequency
- [x] Add `--duration` flag to control parallel ingest upper bound duration

fixes #1193