### PR TITLE
fix(backend): use client timezone for plots

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -4338,7 +4338,7 @@ func GetSessionsOverviewPlot(c *gin.Context) {
 
 	sessionInstances, err := GetSessionsPlot(ctx, &af)
 	if err != nil {
-		msg := `failed to query exception instances`
+		msg := `failed to query data for sessions overview plot`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": msg,

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1061,12 +1061,13 @@ export const fetchExceptionsOverviewPlotFromServer = async (appId: string, excep
 
     const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate)
     const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate)
+    const timezone = getTimeZoneForServer()
 
     var url = ""
     if (exceptionsType === ExceptionsType.Crash) {
-        url = `${origin}/apps/${appId}/crashGroups/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
+        url = `${origin}/apps/${appId}/crashGroups/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}&timezone=${timezone}`
     } else {
-        url = `${origin}/apps/${appId}/anrGroups/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
+        url = `${origin}/apps/${appId}/anrGroups/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}&timezone=${timezone}`
     }
 
     // Append versions if present
@@ -1097,12 +1098,13 @@ export const fetchExceptionsDetailsPlotFromServer = async (appId: string, except
 
     const serverFormattedStartDate = formatUserInputDateToServerFormat(startDate)
     const serverFormattedEndDate = formatUserInputDateToServerFormat(endDate)
+    const timezone = getTimeZoneForServer()
 
     var url = ""
     if (exceptionsType === ExceptionsType.Crash) {
-        url = `${origin}/apps/${appId}/crashGroups/${exceptionsGroupdId}/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
+        url = `${origin}/apps/${appId}/crashGroups/${exceptionsGroupdId}/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}&timezone=${timezone}`
     } else {
-        url = `${origin}/apps/${appId}/anrGroups/${exceptionsGroupdId}/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`
+        url = `${origin}/apps/${appId}/anrGroups/${exceptionsGroupdId}/plots/instances?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}&timezone=${timezone}`
     }
 
     // Append versions if present


### PR DESCRIPTION
# Description

Use client timezones for grouping instances in Crash and ANR plots

## Related issue
Fixes #1215


