### PR TITLE
feat(android): report activity launched with saved state as warm launch

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -191,7 +191,18 @@ internal class LaunchTracker(
                 }
             }
 
+            // Cold launch hasn't completed yet.
+            // However, the activity has a saved state, so it must be a warm launch. The process
+            // was recreated but the system still retained some state. This is not a cold launch as
+            // the process didn't really start from scratch.
+            onCreateRecord.hasSavedState -> "Warm"
+
             processInfo.isForegroundProcess() -> "Cold"
+
+            // While the process was starting in background the system must have decided to create
+            // the activity and it got resumed. This is not a cold start as the system likely got a
+            // chance to warm up before the activity was created. Sadly the system doesn't tell us
+            // when it decided to do so, the data for this can be noisy.
             else -> "Warm"
         }
     }


### PR DESCRIPTION
Fixes incorrect cold launch attribution, closes #1246.

### Breaking Change  
⚠️ After this PR, users might notice a change in cold/warm launch metric even if they haven't made any changes because the attribution for warm/cold launch has changed.