### PR TITLE
chore(android): update sdk version to 35 and agp to 8.6

### DIFF
--- a/android/benchmarks/app/build.gradle.kts
+++ b/android/benchmarks/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "sh.measure.test.benchmark"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "sh.measure.test.benchmark"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/android/benchmarks/benchmark/build.gradle.kts
+++ b/android/benchmarks/benchmark/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "sh.measure.benchmark"
-    compileSdk = 34
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         minSdk = 23
-        targetSdk = 34
+        targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.6.0"
 benchmarkJunit4 = "1.2.4"
 bundletool = "1.17.0"
 # android-tools is used for calculating app size and aab size by the gradle plugin.

--- a/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
+++ b/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
@@ -146,6 +146,8 @@ class MeasurePluginTest {
                 Arguments.of(SemVer(8, 2, 1), GradleVersion.version("8.2")),
                 Arguments.of(SemVer(8, 3, 2), GradleVersion.version("8.5")),
                 Arguments.of(SemVer(8, 4, 1), GradleVersion.version("8.6")),
+                Arguments.of(SemVer(8, 5, 2), GradleVersion.version("8.7")),
+                Arguments.of(SemVer(8, 6, 0), GradleVersion.version("8.7")),
             )
         }
     }

--- a/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/fixtures/MeasurePluginFixture.kt
+++ b/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/fixtures/MeasurePluginFixture.kt
@@ -54,7 +54,7 @@ class MeasurePluginFixture(
             defaultConfig = DefaultConfig(
                 applicationId = "com.example",
                 minSdkVersion = 21,
-                targetSdkVersion = 34,
+                targetSdkVersion = 35,
                 versionCode = 1,
                 versionName = "1.0",
             )
@@ -64,6 +64,7 @@ class MeasurePluginFixture(
     // Ref: https://developer.android.com/build/releases/gradle-plugin#api-level-support
     private fun computeCompileSdkVersion(agpVersion: SemVer): Int {
         return when {
+            agpVersion >= SemVer(8, 4, 0) -> 35
             agpVersion >= SemVer(8, 1, 1) -> 34
             else -> 33
         }

--- a/android/measure/build.gradle.kts
+++ b/android/measure/build.gradle.kts
@@ -57,7 +57,7 @@ mavenPublishing {
 
 android {
     namespace = "sh.measure.android"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21

--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -133,12 +133,14 @@ internal class TestMeasureInitializer(
     private val procProvider: ProcProvider = ProcProviderImpl(),
     private val debugProvider: DebugProvider = DefaultDebugProvider(),
     private val runtimeProvider: RuntimeProvider = DefaultRuntimeProvider(),
+    private val osSysConfProvider: OsSysConfProvider = OsSysConfProviderImpl(),
     private val memoryReader: MemoryReader = DefaultMemoryReader(
         logger = logger,
         processInfo = processInfoProvider,
         procProvider = procProvider,
         debugProvider = debugProvider,
         runtimeProvider = runtimeProvider,
+        osSysConfProvider = osSysConfProvider,
     ),
     private val localeProvider: LocaleProvider = LocaleProviderImpl(),
     private val prefsStorage: PrefsStorage = PrefsStorageImpl(context = application),
@@ -166,6 +168,7 @@ internal class TestMeasureInitializer(
         logger,
         context = application,
         localeProvider = localeProvider,
+        osSysConfProvider = osSysConfProvider,
     ),
     private val appAttributeProcessor: AppAttributeProcessor = AppAttributeProcessor(
         context = application,
@@ -243,7 +246,6 @@ internal class TestMeasureInitializer(
         processInfoProvider = processInfoProvider,
     ),
     override val periodicEventExporter: PeriodicEventExporter = NoopPeriodicEventExporter(),
-    private val osSysConfProvider: OsSysConfProvider = OsSysConfProviderImpl(),
     override val unhandledExceptionCollector: UnhandledExceptionCollector = UnhandledExceptionCollector(
         logger = logger,
         timeProvider = timeProvider,

--- a/android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -688,6 +688,9 @@ internal class DatabaseImpl(
     }
 
     override fun getEventsForSessions(sessions: List<String>): List<String> {
+        if (sessions.isEmpty()) {
+            return emptyList()
+        }
         val eventIds = mutableListOf<String>()
         readableDatabase.rawQuery(Sql.getEventsForSessions(sessions), null).use {
             while (it.moveToNext()) {

--- a/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
@@ -298,10 +298,7 @@ internal object Sql {
         """.trimIndent()
     }
 
-    fun getEventsForSessions(sessions: List<String>): String? {
-        if (sessions.isEmpty()) {
-            return null
-        }
+    fun getEventsForSessions(sessions: List<String>): String {
         return """
             SELECT ${EventTable.COL_ID}
             FROM ${EventTable.TABLE_NAME}

--- a/android/sample/build.gradle.kts
+++ b/android/sample/build.gradle.kts
@@ -14,12 +14,12 @@ measure {
 
 android {
     namespace = "sh.measure.sample"
-    compileSdk = 34
+    compileSdk = 35
     val measureSdkVersion = libs.versions.measure.android.get()
     defaultConfig {
         applicationId = "sh.measure.sample"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = computeVersionCode(measureSdkVersion)
         versionName = measureSdkVersion
 


### PR DESCRIPTION
# Description

Version updates for compile sdk, target sdk and AGP to latest.

## Related issue
closes #1248 
