### PR TITLE
fix(frontend): hide attachment data in session replay event body

### DIFF
--- a/frontend/dashboard/app/components/session_replay_event_accordion.tsx
+++ b/frontend/dashboard/app/components/session_replay_event_accordion.tsx
@@ -133,7 +133,10 @@ export default function SessionReplayEventAccordion({
       if (typeof value === 'object' && value !== null) {
         if (Object.keys(value).length === 0) {
           return `${key}: --`;
-        } else {
+        } else if (key === 'attachments') {
+          return ''
+        }
+        else {
           return `${key}: ${getBodyFromEventDetails(value)}`;
         }
       } else if (value === '' || value === null) {


### PR DESCRIPTION
# Description

Hide attachment data in session replay event body

## Before
<img width="942" alt="before" src="https://github.com/user-attachments/assets/0780ee0e-0bc9-4d2c-a02c-0d15d3675462">

## After
<img width="937" alt="after" src="https://github.com/user-attachments/assets/3c4f9d13-fdad-4e23-b330-b0fce236acc3">


## Related issue
Fixes #1257


