### PR TITLE
fix(backend): overview instance plot would not load for some cases

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -2751,8 +2751,8 @@ func GetCrashOverviewPlotInstances(c *gin.Context) {
 		if ok {
 			instances[ndx].Data = append(instances[ndx].Data, instance.Data...)
 		} else {
-			lut[crashInstances[i].Version] = i
 			instances = append(instances, instance)
+			lut[crashInstances[i].Version] = len(instances) - 1
 		}
 	}
 
@@ -3483,8 +3483,8 @@ func GetANROverviewPlotInstances(c *gin.Context) {
 		if ok {
 			instances[ndx].Data = append(instances[ndx].Data, instance.Data...)
 		} else {
-			lut[anrInstances[i].Version] = i
 			instances = append(instances, instance)
+			lut[anrInstances[i].Version] = len(instances) - 1
 		}
 	}
 
@@ -4510,8 +4510,8 @@ func GetSessionsOverviewPlot(c *gin.Context) {
 		if ok {
 			instances[ndx].Data = append(instances[ndx].Data, instance.Data...)
 		} else {
-			lut[sessionInstances[i].Version] = i
 			instances = append(instances, instance)
+			lut[sessionInstances[i].Version] = len(instances) - 1
 		}
 	}
 


### PR DESCRIPTION
## Summary

For cases when multiple app versions are available, crash/ANR/session overview instance plot was throwing an index of out range error

fixes #1287