### PR TITLE
chore(backend): capture more details in otel traces

### DIFF
--- a/backend/api/go.mod
+++ b/backend/api/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
+	go.opentelemetry.io/otel/trace v1.28.0
 	google.golang.org/api v0.188.0
 	google.golang.org/grpc v1.65.0
 )
@@ -72,7 +73,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
-	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect

--- a/backend/api/server/middleware.go
+++ b/backend/api/server/middleware.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// buffer to write current req's response
+// body.
+type bodyWriter struct {
+	gin.ResponseWriter
+	body *bytes.Buffer
+}
+
+func (w bodyWriter) Write(b []byte) (int, error) {
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+
+// CaptureRequest is a middleware that captures
+// request parameters like host and referer.
+func CaptureRequest() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		span := trace.SpanFromContext(c.Request.Context())
+
+		if span.IsRecording() {
+			span.SetAttributes(
+				attribute.String("http.host", c.Request.Host),
+				attribute.String("http.referer", c.Request.Referer()),
+			)
+		}
+
+		c.Next()
+	}
+}
+
+// CaptureErrorBody is a middleware that captures
+// error response bodies and attaches to the OTel
+// trace.
+func CaptureErrorBody() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// create a buffer to hold response body
+		bw := &bodyWriter{
+			body:           bytes.NewBufferString(""),
+			ResponseWriter: c.Writer,
+		}
+		c.Writer = bw
+
+		// continue to process the request
+		c.Next()
+
+		statusCode := c.Writer.Status()
+		if statusCode < 399 {
+			return
+		}
+
+		// only capture error body for 4xx
+		// and higher
+		responseBody := bw.body.String()
+
+		span := trace.SpanFromContext(c.Request.Context())
+		if span != nil {
+			span.SetAttributes(
+				attribute.Int("http.status_code", statusCode),
+				attribute.String("http.response.body", responseBody),
+			)
+		}
+
+	}
+}
+
+// CapturePanic is a middlware that captures runtime
+// errors like panic and stacktrace, recovers and
+// attaches to the OTel trace.
+func CapturePanic() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				// log and capture stack trace
+				stacktrace := string(debug.Stack())
+				err := err.(error)
+
+				log.Printf("Panic occurred: %v\nStack trace: %s", err, stacktrace)
+				statusCode := http.StatusInternalServerError
+
+				// retrieve current otel span
+				// and populate details
+				span := trace.SpanFromContext(c.Request.Context())
+				if span != nil {
+					span.SetAttributes(
+						attribute.String("error", "true"),
+						attribute.String("panic.error", err.Error()),
+						attribute.String("panic.stacktrace", stacktrace),
+						attribute.Int("http.status_code", statusCode),
+					)
+
+					span.SetStatus(codes.Error, err.Error())
+				}
+
+				c.JSON(statusCode, gin.H{
+					"error": "Internal Server Error",
+				})
+
+				c.Abort()
+			}
+		}()
+
+		c.Next()
+	}
+}


### PR DESCRIPTION
## Summary

Capture additional details like error response body, stacktrace for runtime errors and HTTP host and referer values from request in OpenTelemetry traces.

## Tasks

- [x] Capture response body for error responses
- [x] Capture error and stacktrace for runtime errors and panics
- [x] Capture `http.host` header in otel traces
- [x] Capture `http.referer` header in otel traces
- [x] Refactor otel init code

fixes #1163
fixes #1278