### PR TITLE
fix(frontend): add option to handle no data & not onboarded in filters

### DIFF
--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -145,6 +145,8 @@ export default function Apps({ params }: { params: { teamId: string } }) {
         filtersApiType={FiltersApiType.All}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
         showCreateApp={false}
+        showNoData={false}
+        showNotOnboarded={false}
         showAppVersions={false}
         showDates={false}
         showSessionType={false}

--- a/frontend/dashboard/app/[teamId]/overview/page.tsx
+++ b/frontend/dashboard/app/[teamId]/overview/page.tsx
@@ -20,6 +20,8 @@ export default function Overview({ params }: { params: { teamId: string } }) {
         filtersApiType={FiltersApiType.All}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
         showCreateApp={true}
+        showNoData={true}
+        showNotOnboarded={true}
         showAppVersions={true}
         showDates={true}
         showSessionType={false}

--- a/frontend/dashboard/app/[teamId]/sessions/page.tsx
+++ b/frontend/dashboard/app/[teamId]/sessions/page.tsx
@@ -84,6 +84,8 @@ export default function SessionsOverview({ params }: { params: { teamId: string 
                 filtersApiType={FiltersApiType.All}
                 appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
                 showCreateApp={true}
+                showNoData={true}
+                showNotOnboarded={true}
                 showAppVersions={true}
                 showDates={true}
                 showSessionType={true}

--- a/frontend/dashboard/app/components/exceptions_details.tsx
+++ b/frontend/dashboard/app/components/exceptions_details.tsx
@@ -86,6 +86,8 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
         filtersApiType={exceptionsType === ExceptionsType.Crash ? FiltersApiType.Crash : FiltersApiType.Anr}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
         showCreateApp={true}
+        showNoData={true}
+        showNotOnboarded={true}
         showAppVersions={true}
         showDates={true}
         showSessionType={false}

--- a/frontend/dashboard/app/components/exceptions_overview.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview.tsx
@@ -89,6 +89,8 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
         filtersApiType={exceptionsType === ExceptionsType.Crash ? FiltersApiType.Crash : FiltersApiType.Anr}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
         showCreateApp={true}
+        showNoData={true}
+        showNotOnboarded={true}
         showAppVersions={true}
         showDates={true}
         showSessionType={false}

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -21,6 +21,8 @@ interface FiltersProps {
   filtersApiType: FiltersApiType,
   appVersionsInitialSelectionType: AppVersionsInitialSelectionType,
   showCreateApp: boolean
+  showNoData: boolean
+  showNotOnboarded: boolean
   showDates: boolean
   showAppVersions: boolean
   showOsVersions: boolean
@@ -114,6 +116,8 @@ const Filters: React.FC<FiltersProps> = ({
   filtersApiType,
   appVersionsInitialSelectionType,
   showCreateApp,
+  showNoData,
+  showNotOnboarded,
   showAppVersions,
   showDates,
   showSessionType,
@@ -368,8 +372,19 @@ const Filters: React.FC<FiltersProps> = ({
       endDate: selectedEndDate
     }
 
+    let ready = false
+    if (showNoData && showNotOnboarded) {
+      ready = AppsApiStatus.Success && filtersApiStatus === FiltersApiStatus.Success
+    } else if (showNoData) {
+      ready = AppsApiStatus.Success && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NotOnboarded)
+    } else if (showNotOnboarded) {
+      ready = AppsApiStatus.Success && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NoData)
+    } else {
+      ready = AppsApiStatus.Success && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NoData || filtersApiStatus === FiltersApiStatus.NotOnboarded)
+    }
+
     const updatedSelectedFilters: Filters = {
-      ready: appsApiStatus === AppsApiStatus.Success && filtersApiStatus === FiltersApiStatus.Success,
+      ready: ready,
       app: selectedApp,
       startDate: selectedStartDate,
       endDate: selectedEndDate,
@@ -410,10 +425,10 @@ const Filters: React.FC<FiltersProps> = ({
               <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={selectedApp.name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
             </div>
             : null}
-          <div className="py-8" />
+          <div className="py-4" />
           {filtersApiStatus === FiltersApiStatus.Error && <p className="text-lg font-display">Error fetching filters, please refresh page or select a different app to try again</p>}
-          {filtersApiStatus === FiltersApiStatus.NoData && <p className="text-lg font-display">No {filtersApiType === FiltersApiType.Crash ? 'crashes' : filtersApiType === FiltersApiType.Anr ? 'ANRs' : 'data'} received for this app yet</p>}
-          {filtersApiStatus === FiltersApiStatus.NotOnboarded && <CreateApp teamId={teamId} existingAppName={selectedApp.name} existingApiKey={selectedApp.api_key.key} />}
+          {showNoData && filtersApiStatus === FiltersApiStatus.NoData && <p className="text-lg font-display">No {filtersApiType === FiltersApiType.Crash ? 'crashes' : filtersApiType === FiltersApiType.Anr ? 'ANRs' : 'data'} received for this app yet</p>}
+          {showNotOnboarded && filtersApiStatus === FiltersApiStatus.NotOnboarded && <CreateApp teamId={teamId} existingAppName={selectedApp.name} existingApiKey={selectedApp.api_key.key} />}
         </div>
       }
 


### PR DESCRIPTION
# Description

Filters were only considered to be "ready" when filters api is in success status. In pages like apps, we need the option to handle no data and not onboarded ourselves since we need to show app info even when no data is present or app is not onboarded.

## Related issue
Fixes #1296



