### PR TITLE
chore(android): implement Exponential Backoff for events API

### DIFF
--- a/android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
@@ -95,8 +95,10 @@ class HttpUrlConnectionClientTest {
     }
 
     @Test
-    fun `test client error`() {
-        mockWebServer.enqueue(MockResponse().setResponseCode(400))
+    fun `test client error for all 3 retries`() {
+        repeat(4) {//1(initial Failure) + 3(retry failure)
+            mockWebServer.enqueue(MockResponse().setResponseCode(400))
+        }
 
         val result = client.sendMultipartRequest(
             mockWebServer.url("/").toString(),
@@ -109,8 +111,16 @@ class HttpUrlConnectionClientTest {
     }
 
     @Test
-    fun `test client error with body`() {
-        mockWebServer.enqueue(MockResponse().setResponseCode(400).setBody("error-body"))
+    fun `test success in retry after client error`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(400))//Simulate Failure
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))//Simulate Success
+    }
+
+    @Test
+    fun `test client error with body for all 3 retries`() {
+        repeat(4) {
+            mockWebServer.enqueue(MockResponse().setResponseCode(400).setBody("error-body"))
+        }
 
         val result = client.sendMultipartRequest(
             mockWebServer.url("/").toString(),


### PR DESCRIPTION
# Description

Introduced exponential backoff for Events API retries to handle transient failures. The exponential backoff is applied when a client error (4xx) is encountered, allowing the request to be retried with increasing delays. Note: For Error 429 (Rate Limit Error) I haven't considered it as Client Error so it won't be counted in retry.

## Changes Made
- Currently retryLimit is set as 3. We might want to change this as per product requirements
- Use Thread.sleep() for 200 ms, 400 ms, 800 ms waiting period before new API call
- Add retry functionality in `sendMultiPartRequestWithRedirects()` fun in  `HttpUrlConnectionClient` class
- Add/ Update Test cases

## Related issue
Closes (https://github.com/measure-sh/measure/issues/893)



