### PR TITLE
fix(android): track fragment lifecycle events when r8 is enabled

### DIFF
--- a/android/measure/consumer-rules.pro
+++ b/android/measure/consumer-rules.pro
@@ -4,3 +4,6 @@
 
 # Required to check if okhttp is present in runtime classpath
 -keepnames class okhttp3.OkHttpClient
+
+# Required to check if androidx-fragment is present in runtime classpath
+-keepnames class androidx.fragment.app.FragmentActivity


### PR DESCRIPTION
# Description
Fragment lifecycle events were not being tracked when r8 was enabled due to a missing ProGuard rule. This PR adds the necessary ProGuard rule to address this issue.

## How is this tested

Manually using sample app, on a release build with `minifyEnabled = true` — fragment lifecycle events are tracked.
On an app without `androidx.fragment` dependency — no impact.

## Related issue
closes #1326


