### PR TITLE
fix(backend): increase thread name character limit

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -111,7 +111,7 @@ type Attribute struct {
 // Validate validates an event's attributes.
 func (a Attribute) Validate() error {
 	const (
-		maxThreadNameChars         = 64
+		maxThreadNameChars         = 128
 		maxUserIDChars             = 128
 		maxDeviceNameChars         = 32
 		maxDeviceModelChars        = 32
@@ -131,64 +131,64 @@ func (a Attribute) Validate() error {
 	)
 
 	if len(a.AppVersion) > maxAppVersionChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.app_version`, maxAppVersionChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_version`, maxAppVersionChars)
 	}
 	if len(a.AppBuild) > maxAppBuildChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.app_build`, maxAppBuildChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_build`, maxAppBuildChars)
 	}
 	if len(a.AppUniqueID) > maxAppUniqueIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubutes.app_unique_id`, maxAppUniqueIDChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
 	}
 	if len(a.Platform) > maxPlatformChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.platform`, maxPlatformChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.platform`, maxPlatformChars)
 	}
 	if len(a.MeasureSDKVersion) > maxMeasureSDKVersion {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.measure_sdk_version`, maxMeasureSDKVersion)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.measure_sdk_version`, maxMeasureSDKVersion)
 	}
 	if a.Platform != platform.Android && a.Platform != platform.IOS {
-		return fmt.Errorf(`%q does not contain a valid platform value`, `attributes.platform`)
+		return fmt.Errorf(`%q does not contain a valid platform value`, `attribute.platform`)
 	}
 	if len(a.ThreadName) > maxThreadNameChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.thread_name`, maxThreadNameChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.thread_name`, maxThreadNameChars)
 	}
 	if len(a.UserID) > maxUserIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.user_id`, maxUserIDChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.user_id`, maxUserIDChars)
 	}
 	if len(a.DeviceName) > maxDeviceNameChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.device_name`, maxDeviceNameChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_name`, maxDeviceNameChars)
 	}
 	if len(a.DeviceModel) > maxDeviceModelChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.device_model`, maxDeviceModelChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_model`, maxDeviceModelChars)
 	}
 	if len(a.DeviceManufacturer) > maxDeviceManufacturerChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.device_manufacturer`, maxDeviceManufacturerChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_manufacturer`, maxDeviceManufacturerChars)
 	}
 	if len(a.DeviceType) > maxDeviceTypeChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.device_type`, maxDeviceTypeChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_type`, maxDeviceTypeChars)
 	}
 	if len(a.DeviceLocale) > maxDeviceLocaleChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.device_locale`, maxDeviceLocaleChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_locale`, maxDeviceLocaleChars)
 	}
 	if len(a.OSName) > maxOSNameChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.os_name`, maxOSNameChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.os_name`, maxOSNameChars)
 	}
 	if len(a.OSVersion) > maxOSVersionChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.os_version`, maxOSVersionChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.os_version`, maxOSVersionChars)
 	}
 	if len(a.NetworkType) > maxNetworkTypeChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.network_type`, maxNetworkTypeChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.network_type`, maxNetworkTypeChars)
 	}
 	if len(a.NetworkGeneration) > maxNetworkGenerationChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.network_generation`, maxNetworkGenerationChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.network_generation`, maxNetworkGenerationChars)
 	}
 	if len(a.NetworkProvider) > maxNetworkProviderChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.network_provider`, maxNetworkProviderChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.network_provider`, maxNetworkProviderChars)
 	}
 	if !slices.Contains(ValidNetworkTypes, a.NetworkType) {
-		return fmt.Errorf(`%q contains invalid network type`, `attributes.network_type`)
+		return fmt.Errorf(`%q contains invalid network type`, `attribute.network_type`)
 	}
 	if !slices.Contains(ValidNetworkGenerations, a.NetworkGeneration) {
-		return fmt.Errorf(`%q contains invalid network geenration`, `attributes.network_generation`)
+		return fmt.Errorf(`%q contains invalid network geenration`, `attribute.network_generation`)
 	}
 	return nil
 }

--- a/self-host/clickhouse/20241015073422_alter_events_table.sql
+++ b/self-host/clickhouse/20241015073422_alter_events_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table default.events
+modify column if exists `attribute.thread_name` FixedString(128);
+
+
+-- migrate:down
+select 1;


### PR DESCRIPTION
## Summary

Increase `attribute.thread_name` upper character limit to 128 from 64 to prevent event validation failures during ingestion.