### PR TITLE
fix(backend): increase app version character limit

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -120,7 +120,7 @@ func (a Attribute) Validate() error {
 		maxOSNameChars             = 32
 		maxOSVersionChars          = 32
 		maxPlatformChars           = 32
-		maxAppVersionChars         = 64
+		maxAppVersionChars         = 128
 		maxAppBuildChars           = 32
 		maxAppUniqueIDChars        = 128
 		maxMeasureSDKVersion       = 16

--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -120,7 +120,7 @@ func (a Attribute) Validate() error {
 		maxOSNameChars             = 32
 		maxOSVersionChars          = 32
 		maxPlatformChars           = 32
-		maxAppVersionChars         = 32
+		maxAppVersionChars         = 64
 		maxAppBuildChars           = 32
 		maxAppUniqueIDChars        = 128
 		maxMeasureSDKVersion       = 16

--- a/self-host/clickhouse/20241015075419_alter_events_table.sql
+++ b/self-host/clickhouse/20241015075419_alter_events_table.sql
@@ -1,6 +1,6 @@
 -- migrate:up
 alter table default.events
-modify column if exists `attribute.app_version` FixedString(64);
+modify column if exists `attribute.app_version` FixedString(128);
 
 -- migrate:down
 select 1;

--- a/self-host/clickhouse/20241015075419_alter_events_table.sql
+++ b/self-host/clickhouse/20241015075419_alter_events_table.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+alter table default.events
+modify column if exists `attribute.app_version` FixedString(64);
+
+-- migrate:down
+select 1;


### PR DESCRIPTION
## Summary

Increase `attribute.app_version` upper character limit to 64 from 32 to prevent event validation failures during ingestion.