### PR TITLE
fix(frontend): handle empty file/method name

### DIFF
--- a/frontend/dashboard/app/components/exceptions_overview.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview.tsx
@@ -150,9 +150,9 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
             </div>
             <div className="table-row-group font-sans">
               {exceptionsOverview.results.map(({ id, type, message, method_name, file_name, line_number, count, percentage_contribution }) => (
-                <Link key={id} href={`/${teamId}/${exceptionsType === ExceptionsType.Crash ? 'crashes' : 'anrs'}/${filters.app.id}/${id}/${type + file_name !== "" ? "@" + file_name : ""}`} className="table-row border-b-2 border-black hover:bg-yellow-200 focus:bg-yellow-200 active:bg-yellow-300 ">
+                <Link key={id} href={`/${teamId}/${exceptionsType === ExceptionsType.Crash ? 'crashes' : 'anrs'}/${filters.app.id}/${id}/${type + (file_name !== "" ? "@" + file_name : "")}`} className="table-row border-b-2 border-black hover:bg-yellow-200 focus:bg-yellow-200 active:bg-yellow-300 ">
                   <div className="table-cell p-4">
-                    <p className='truncate'>{file_name !== "" ? file_name : "--" + ": " + method_name !== "" ? method_name : "--" + "()"}</p>
+                    <p className='truncate'>{(file_name !== "" ? file_name : "unknown_file") + ": " + (method_name !== "" ? method_name : "unknown_method") + "()"}</p>
                     <div className='py-1' />
                     <p className='text-xs truncate text-gray-500'>{type + ":" + message}</p>
                   </div>


### PR DESCRIPTION
# Description

Handle empty file/method name in exceptions overview and details components

## Related issue
Fixes #1346 



