### PR TITLE
fix(android): ignore duplicate inserts to app exit

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -459,7 +459,12 @@ internal class DatabaseImpl(
                     put(AppExitTable.COL_PID, session.pid)
                     put(AppExitTable.COL_CREATED_AT, session.createdAt)
                 }
-                writableDatabase.insert(AppExitTable.TABLE_NAME, null, appExitValues)
+                writableDatabase.insertWithOnConflict(
+                    AppExitTable.TABLE_NAME,
+                    null,
+                    appExitValues,
+                    SQLiteDatabase.CONFLICT_IGNORE,
+                )
             } else {
                 0
             }
@@ -505,10 +510,11 @@ internal class DatabaseImpl(
                     put(AppExitTable.COL_PID, pid)
                     put(AppExitTable.COL_CREATED_AT, createdAt)
                 }
-                writableDatabase.insert(
+                writableDatabase.insertWithOnConflict(
                     AppExitTable.TABLE_NAME,
                     null,
                     appExitValues,
+                    SQLiteDatabase.CONFLICT_IGNORE,
                 )
             } else {
                 0


### PR DESCRIPTION
# Description

App exit table can get an update or insert query for the same session-pid when a session is continued. This PR makes the insertion safe by ignoring them. Otherwise this would silently cause an exception on the I/O thread. 

## Related issue
References #1333 



