### PR TITLE
chore(android): remove unnecessary logs for launch tracking

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/AppLaunchCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/AppLaunchCollector.kt
@@ -1,7 +1,6 @@
 package sh.measure.android.applaunch
 
 import android.app.Application
-import android.util.Log
 import sh.measure.android.events.EventProcessor
 import sh.measure.android.events.EventType
 import sh.measure.android.logger.LogLevel
@@ -41,7 +40,6 @@ internal class AppLaunchCollector(
                 ?: return
         val endUptime = coldLaunchData.on_next_draw_uptime
         val duration = endUptime - startUptime
-        Log.e("Measure", "cold: $duration")
         logger.log(LogLevel.Debug, "cold launch duration: $duration ms, start uptime: $startUptime")
         eventProcessor.track(
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
@@ -55,7 +53,6 @@ internal class AppLaunchCollector(
         val startUptime = warmLaunchData.app_visible_uptime
         val endUptime = warmLaunchData.on_next_draw_uptime
         val duration = endUptime - startUptime
-        Log.e("Measure", "warm: $duration, isLukeWarm = ${warmLaunchData.is_lukewarm}")
         logger.log(LogLevel.Debug, "warm launch duration: $duration ms, start uptime: $startUptime")
         eventProcessor.track(
             timestamp = timeProvider.currentTimeSinceEpochInMillis,
@@ -68,7 +65,6 @@ internal class AppLaunchCollector(
         val startUptime = hotLaunchData.app_visible_uptime
         val endUptime = hotLaunchData.on_next_draw_uptime
         val duration = endUptime - startUptime
-        Log.e("Measure", "hot: $duration")
         logger.log(LogLevel.Debug, "hot launch duration: $duration ms, start uptime: $startUptime")
         eventProcessor.track(
             timestamp = timeProvider.currentTimeSinceEpochInMillis,

--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -86,7 +86,7 @@ internal class LaunchTracker(
     private fun appMightBecomeVisible() {
         LaunchState.lastAppVisibleTime = SystemClock.uptimeMillis()
         logger.log(
-            LogLevel.Error,
+            LogLevel.Debug,
             "Updated last app visible time: ${LaunchState.lastAppVisibleTime}",
         )
     }


### PR DESCRIPTION
# Description

Removes unnecessary logs with `level=error` added for launch tracking.