### PR TITLE
chore(android): support latest stable compose-navigation

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
@@ -15,8 +15,8 @@ class NavigationTransformer : AsmBytecodeTransformer() {
     // Tested from 2.4.0, 2.3.5 does not have navigation-compose package
     override val minVersion = SemVer(2, 4, 0)
 
-    // Tested up-to 2.8.0-beta06, 2.8.0-beta07 requires compile SDK 35
-    override val maxVersion = SemVer(2, 8, 0, "-beta06")
+    // Tested up-to 2.9.0-alpha01
+    override val maxVersion = SemVer(2, 9, 0)
 }
 
 abstract class NavigationVisitorFactory : AsmClassVisitorFactory<TransformerParameters>,


### PR DESCRIPTION
# Description

Updates `NavigationTransformer` to apply ASM transformation to latest `navigation-compose` library at the moment (8.3.0)

