### PR TITLE
chore(android): add max session duration config

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -39,7 +39,8 @@ class FakeConfigProvider : ConfigProvider {
     override var maxEventsInBatch: Int = 1_000_000
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
-    override var sessionEndThresholdMs: Long = 1_000_000
+    override var sessionEndLastEventThresholdMs: Long = 1_000_000
+    override var maxSessionDurationMs: Long = 6_000_000
     override var maxUserDefinedAttributeKeyLength: Int = 1_000_000
     override var maxUserDefinedAttributeValueLength: Int = 1_000_000
     override var userDefinedAttributeKeyWithSpaces: Boolean = true

--- a/android/measure/src/androidTest/java/sh/measure/android/SessionTest.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/SessionTest.kt
@@ -50,7 +50,7 @@ class SessionTest {
             // When
             it.moveToState(Lifecycle.State.RESUMED)
             robot.moveAppToBackground()
-            robot.incrementTimeBeyondSessionThreshold()
+            robot.incrementTimeBeyondLastEventThreshold()
             robot.openAppFromRecent()
             it.moveToState(Lifecycle.State.RESUMED)
 
@@ -88,6 +88,26 @@ class SessionTest {
             robot.simulateAppCrash()
             robot.moveAppToBackground()
             robot.incrementTimeWithinSessionThreshold()
+            robot.openAppFromRecent()
+            it.moveToState(Lifecycle.State.RESUMED)
+
+            // Then
+            val sessionCount = robot.getSessionCount()
+            Assert.assertEquals(2, sessionCount)
+        }
+    }
+
+    @Test
+    fun createsNewSessionOnInitializationWhenMaxSessionDurationForPreviousSessionHasBeenReached() {
+        // Given
+        robot.initializeMeasure(MeasureConfig(enableLogging = true))
+        robot.setSessionMaxDurationConfig(5000L)
+        robot.setSessionEndThresholdConfig(10000L)
+        ActivityScenario.launch(TestActivity::class.java).use {
+            // When
+            it.moveToState(Lifecycle.State.RESUMED)
+            robot.moveAppToBackground()
+            robot.incrementTimeBeyondMaxSessionDuration()
             robot.openAppFromRecent()
             it.moveToState(Lifecycle.State.RESUMED)
 

--- a/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
@@ -47,12 +47,16 @@ class SessionTestRobot {
         }
     }
 
-    fun incrementTimeBeyondSessionThreshold() {
-        timeProvider.elapsedRealtime += configProvider.sessionEndThresholdMs + 1000
+    fun incrementTimeBeyondLastEventThreshold() {
+        timeProvider.elapsedRealtime += configProvider.sessionEndLastEventThresholdMs + 1000
     }
 
     fun incrementTimeWithinSessionThreshold() {
-        timeProvider.elapsedRealtime += configProvider.sessionEndThresholdMs - 1000
+        timeProvider.elapsedRealtime += configProvider.sessionEndLastEventThresholdMs - 1000
+    }
+
+    fun incrementTimeBeyondMaxSessionDuration() {
+        timeProvider.elapsedRealtime += configProvider.maxSessionDurationMs + 100
     }
 
     fun moveAppToBackground() {
@@ -86,5 +90,13 @@ class SessionTestRobot {
             attributes = mutableMapOf(),
             attachments = mutableListOf(),
         )
+    }
+
+    fun setSessionMaxDurationConfig(maxDuration: Long) {
+        configProvider.maxSessionDurationMs = maxDuration
+    }
+
+    fun setSessionEndThresholdConfig(threshold: Long) {
+        configProvider.sessionEndLastEventThresholdMs = threshold
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -68,7 +68,7 @@ internal interface SessionManager {
  * Manages creation of sessions.
  *
  * A new session is created when [getSessionId] is first called. A session ends when the app comes
- * back to foreground after being in background for more than [ConfigProvider.sessionEndThresholdMs].
+ * back to foreground after being in background for more than [ConfigProvider.sessionEndLastEventThresholdMs].
  */
 internal class SessionManagerImpl(
     private val logger: Logger,
@@ -198,11 +198,16 @@ internal class SessionManagerImpl(
             return false
         }
 
+        val sessionDuration = timeProvider.elapsedRealtime - recentSession.createdAt
+        if (sessionDuration >= configProvider.maxSessionDurationMs) {
+            return false
+        }
+
         // Continue session if no event have been tracked yet.
         if (recentSession.hasTrackedEvent()) {
             val elapsedTime =
                 timeProvider.elapsedRealtime - recentSession.lastEventTime
-            return elapsedTime <= configProvider.sessionEndThresholdMs
+            return elapsedTime <= configProvider.sessionEndLastEventThresholdMs
         }
         return true
     }

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -28,7 +28,8 @@ internal data class Config(
         "WWW-Authenticate",
         "X-Api-Key",
     )
-    override val sessionEndThresholdMs: Long = 20 * 60 * 1000 // 20 minutes
+    override val sessionEndLastEventThresholdMs: Long = 20 * 60 * 1000 // 20 minutes
+    override val maxSessionDurationMs: Long = 6 * 60 * 60 * 1000 // 6 hours
     override val maxUserDefinedAttributeKeyLength: Int = 64 // 64 chars
     override val maxUserDefinedAttributeValueLength: Int = 256 // 256 chars
     override val userDefinedAttributeKeyWithSpaces: Boolean = false

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -82,8 +82,10 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { httpContentTypeAllowlist }
     override val defaultHttpHeadersBlocklist: List<String>
         get() = getMergedConfig { defaultHttpHeadersBlocklist }
-    override val sessionEndThresholdMs: Long
-        get() = getMergedConfig { sessionEndThresholdMs }
+    override val sessionEndLastEventThresholdMs: Long
+        get() = getMergedConfig { sessionEndLastEventThresholdMs }
+    override val maxSessionDurationMs: Long
+        get() = getMergedConfig { maxSessionDurationMs }
     override val maxAttachmentSizeInEventsBatchInBytes: Int
         get() = getMergedConfig { maxAttachmentSizeInEventsBatchInBytes }
     override val maxUserDefinedAttributeKeyLength: Int

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -32,7 +32,15 @@ internal interface InternalConfig {
     /**
      * The threshold after which a session is considered ended. Defaults to 20 minutes.
      */
-    val sessionEndThresholdMs: Long
+    val sessionEndLastEventThresholdMs: Long
+
+    /**
+     * The maximum duration for a session. Used when the app comes to foreground, sessions which
+     * remain in foreground for more than this time will still continue.
+     *
+     * Defaults to 6 hours.
+     */
+    val maxSessionDurationMs: Long
 
     /**
      * The maximum length of user defined attribute key. Defaults to 64 chars.

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -27,7 +27,8 @@ internal class FakeConfigProvider : ConfigProvider {
     override var maxEventsInBatch: Int = 100
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
-    override var sessionEndThresholdMs: Long = 60 * 1000 // 1 minute
+    override var sessionEndLastEventThresholdMs: Long = 60 * 1000 // 1 minute
+    override var maxSessionDurationMs: Long = 6 * 60 * 60 * 1000 // 6 hours
     override var maxUserDefinedAttributeKeyLength: Int = 64
     override var maxUserDefinedAttributeValueLength: Int = 256
     override var userDefinedAttributeKeyWithSpaces: Boolean = false


### PR DESCRIPTION
# Description

- [x] Add a config for max session duration, defaults to 6 hours.
- [x] Create a new session - in both cases - when app comes back to foreground or when the sdk is initialized if the last session has crossed the max session duration config.
- [x] Update unit and instrumentation tests  

closes #1391
