### PR TITLE
fix(android): handle session management when elapsed time gets reset

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/RecentSession.kt
+++ b/android/measure/src/main/java/sh/measure/android/RecentSession.kt
@@ -10,9 +10,21 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 internal data class RecentSession(
+    /**
+     * The session id.
+     */
     val id: String,
+    /**
+     * The time since boot when the session was created at.
+     */
     val createdAt: Long,
+    /**
+     * The time since boot when the last event was tracked.
+     */
     val lastEventTime: Long = 0,
+    /**
+     * Whether this session crashed or not.
+     */
     val crashed: Boolean = false,
 ) {
     fun hasTrackedEvent(): Boolean {

--- a/android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -207,6 +207,14 @@ internal class SessionManagerImpl(
         if (recentSession.hasTrackedEvent()) {
             val elapsedTime =
                 timeProvider.elapsedRealtime - recentSession.lastEventTime
+
+            // Elapsed time can be negative as we're using [timeProvider.elapsedRealtime]
+            // which can get reset to 0 when the device boots. In such a case we create a new
+            // session.
+            if (elapsedTime < 0) {
+                return false
+            }
+
             return elapsedTime <= configProvider.sessionEndLastEventThresholdMs
         }
         return true

--- a/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -151,7 +151,8 @@ class SessionManagerTest {
                 crashed = false,
             ),
         )
-        timeProvider.fakeElapsedRealtime = recentSessionCreatedAtTime + configProvider.maxSessionDurationMs
+        timeProvider.fakeElapsedRealtime =
+            recentSessionCreatedAtTime + configProvider.maxSessionDurationMs
 
         // When
         sessionManager.init()
@@ -326,17 +327,22 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `continues session when app comes to foreground for first time`() {
-        // Given
+    fun `creates new session if elapsed time is zero due to device boot`() {
+        // Given a recent session
+        val initialSessionId = "initial-session-id"
+        idProvider.id = initialSessionId
+        val initialTime = 1000L
+        timeProvider.fakeElapsedRealtime = initialTime
+        `when`(prefsStorage.getRecentSession()).thenReturn(
+            RecentSession(initialSessionId, createdAt = initialTime, lastEventTime = initialTime),
+        )
+
+        val expectedSessionId = "new-session-id"
+        idProvider.id = expectedSessionId
+        timeProvider.fakeElapsedRealtime = 0
         sessionManager.init()
-        val initialSessionId = sessionManager.getSessionId()
 
-        idProvider.id = "new-session-id"
-
-        // When
-        sessionManager.onAppForeground()
-
-        assertEquals(initialSessionId, sessionManager.getSessionId())
+        assertEquals(expectedSessionId, sessionManager.getSessionId())
     }
 
     @Test


### PR DESCRIPTION
# Summary 
We're using elapsed time since boot to store createdAt and lastEventTime for recent session. This allows us to ensure that session management does not get affected by any change in wall clock time.

However, we didn't handle the case where the device get rebooted and the atomic clock is reset. This PR fixes that.

## Related issue
closes #1393