### PR TITLE
feat(android): create core API for tracing

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -68,6 +68,8 @@ import sh.measure.android.storage.FileStorage
 import sh.measure.android.storage.FileStorageImpl
 import sh.measure.android.storage.PrefsStorage
 import sh.measure.android.storage.PrefsStorageImpl
+import sh.measure.android.tracing.MsrTracer
+import sh.measure.android.tracing.Tracer
 import sh.measure.android.utils.AndroidSystemClock
 import sh.measure.android.utils.AndroidTimeProvider
 import sh.measure.android.utils.DebugProvider
@@ -351,6 +353,11 @@ internal class MeasureInitializerImpl(
         sessionManager = sessionManager,
         configProvider = configProvider,
     ),
+    override val tracer: Tracer = MsrTracer(
+        logger = logger,
+        idProvider = idProvider,
+        timeProvider = timeProvider,
+    ),
 ) : MeasureInitializer
 
 internal interface MeasureInitializer {
@@ -380,4 +387,5 @@ internal interface MeasureInitializer {
     val screenshotCollector: ScreenshotCollector
     val dataCleanupService: DataCleanupService
     val processInfoProvider: ProcessInfoProvider
+    val tracer: Tracer
 }

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -20,6 +20,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) :
     val timeProvider by lazy { measureInitializer.timeProvider }
     val httpEventCollector by lazy { measureInitializer.httpEventCollector }
     val processInfoProvider by lazy { measureInitializer.processInfoProvider }
+    val tracer by lazy { measureInitializer.tracer }
     private val userTriggeredEventCollector by lazy { measureInitializer.userTriggeredEventCollector }
     private val resumedActivityProvider by lazy { measureInitializer.resumedActivityProvider }
     private val networkClient by lazy { measureInitializer.networkClient }

--- a/android/measure/src/main/java/sh/measure/android/tracing/InvalidSpan.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/InvalidSpan.kt
@@ -1,0 +1,42 @@
+package sh.measure.android.tracing
+
+internal class InvalidSpan : Span {
+    override val traceId: String = "invalid-trace-id"
+    override val spanId: String = "invalid-span-id"
+    override val name: String = "invalid"
+
+    override val parentId: String? = null
+    override val startTime: Long = 0
+
+    override fun getStatus(): SpanStatus {
+        return SpanStatus.Unset
+    }
+
+    override fun setStatus(status: SpanStatus): Span {
+        return this
+    }
+
+    override fun end(): Span {
+        return this
+    }
+
+    override fun end(timestamp: Long): Span {
+        return this
+    }
+
+    override fun hasEnded(): Boolean {
+        return false
+    }
+
+    override fun getDuration(): Long {
+        return 0
+    }
+
+    override fun makeCurrent(): Scope {
+        return NoopScope()
+    }
+
+    override fun <T> withScope(block: () -> T): T {
+        return block()
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/MsrSpan.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/MsrSpan.kt
@@ -1,0 +1,130 @@
+package sh.measure.android.tracing
+
+import android.util.Log
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import sh.measure.android.utils.IdProvider
+import sh.measure.android.utils.TimeProvider
+
+/**
+ * A thread safe implementation of [Span].
+ */
+internal class MsrSpan(
+    private val logger: Logger,
+    private val timeProvider: TimeProvider,
+    override val name: String,
+    override val spanId: String,
+    override val traceId: String,
+    override val parentId: String?,
+    override val startTime: Long,
+) : Span {
+    private val lock = Any()
+    private var status = SpanStatus.Unset
+    private var endTime = 0L
+    private var hasEnded: EndState = EndState.NotEnded
+    private var duration: Long = 0
+
+    companion object {
+        fun startSpan(
+            name: String,
+            logger: Logger,
+            timeProvider: TimeProvider,
+            idProvider: IdProvider,
+            parentSpan: Span?,
+            timestamp: Long? = null,
+        ): Span {
+            val startTime = timestamp ?: timeProvider.now()
+            val spanId: String = idProvider.createId()
+            val traceId = parentSpan?.traceId ?: idProvider.createId()
+            return MsrSpan(
+                logger = logger,
+                timeProvider = timeProvider,
+                name = name,
+                spanId = spanId,
+                traceId = traceId,
+                parentId = parentSpan?.spanId,
+                startTime = startTime,
+            )
+        }
+    }
+
+    override fun getStatus(): SpanStatus {
+        return this.status
+    }
+
+    override fun setStatus(status: SpanStatus): Span {
+        synchronized(lock) {
+            this.status = status
+        }
+        return this
+    }
+
+    override fun end(): Span {
+        endSpanInternal(timeProvider.now())
+        return this
+    }
+
+    override fun end(timestamp: Long): Span {
+        endSpanInternal(timestamp)
+        return this
+    }
+
+    override fun hasEnded(): Boolean {
+        synchronized(lock) {
+            return hasEnded != EndState.NotEnded
+        }
+    }
+
+    private fun endSpanInternal(timestamp: Long) {
+        synchronized(lock) {
+            if (hasEnded != EndState.NotEnded) {
+                logger.log(LogLevel.Warning, "Attempt to end a span($name) that has already ended")
+                return
+            }
+            endTime = timestamp
+            hasEnded = EndState.Ending
+        }
+
+        // trigger onEnding
+        synchronized(lock) {
+            hasEnded = EndState.Ended
+        }
+
+        // trigger onEnded
+        Log.i("MsrSpan", "${this.toSpanData()}")
+    }
+
+    override fun makeCurrent(): Scope {
+        return SpanStorage.instance.makeCurrent(this)
+    }
+
+    override fun <T> withScope(block: () -> T): T {
+        return makeCurrent().use { block() }
+    }
+
+    override fun getDuration(): Long {
+        return duration
+    }
+
+    private enum class EndState {
+        NotEnded,
+        Ending,
+        Ended,
+    }
+
+    private fun toSpanData(): SpanData {
+        synchronized(lock) {
+            this.duration = (endTime - startTime).coerceAtLeast(0)
+            return SpanData(
+                spanId = spanId,
+                name = name,
+                startTime = startTime,
+                endTime = endTime,
+                status = status,
+                hasEnded = hasEnded == EndState.Ended,
+                parentId = parentId,
+                duration = duration,
+            )
+        }
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/MsrSpanBuilder.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/MsrSpanBuilder.kt
@@ -1,0 +1,58 @@
+package sh.measure.android.tracing
+
+import sh.measure.android.logger.Logger
+import sh.measure.android.utils.IdProvider
+import sh.measure.android.utils.TimeProvider
+
+internal class MsrSpanBuilder(
+    val name: String,
+    private val idProvider: IdProvider,
+    private val timeProvider: TimeProvider,
+    private val logger: Logger,
+) : SpanBuilder {
+    private var parentSpan: Span? = null
+    private var setNoParent: Boolean = false
+
+    override fun setParent(span: Span): SpanBuilder {
+        this.parentSpan = span
+        return this
+    }
+
+    override fun setNoParent(): SpanBuilder {
+        setNoParent = true
+        return this
+    }
+
+    override fun startSpan(): Span {
+        val parent = findSpanParent()
+        return MsrSpan.startSpan(
+            name,
+            logger,
+            timeProvider,
+            idProvider,
+            parentSpan = parent,
+        )
+    }
+
+    override fun startSpan(timestamp: Long): Span {
+        val parent = findSpanParent()
+        return MsrSpan.startSpan(
+            name = name,
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = parent,
+            timestamp = timestamp,
+        )
+    }
+
+    private fun findSpanParent(): Span? {
+        if (setNoParent) {
+            return null
+        }
+        if (parentSpan != null) {
+            return parentSpan
+        }
+        return Span.current()
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/MsrTracer.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/MsrTracer.kt
@@ -1,0 +1,15 @@
+package sh.measure.android.tracing
+
+import sh.measure.android.logger.Logger
+import sh.measure.android.utils.IdProvider
+import sh.measure.android.utils.TimeProvider
+
+internal class MsrTracer(
+    private val logger: Logger,
+    private val idProvider: IdProvider,
+    private val timeProvider: TimeProvider,
+) : Tracer {
+    override fun spanBuilder(name: String): SpanBuilder {
+        return MsrSpanBuilder(name, idProvider, timeProvider, logger)
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/Scope.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/Scope.kt
@@ -1,0 +1,28 @@
+package sh.measure.android.tracing
+
+/**
+ * Scope is the mechanism used to maintain current span context.
+ *
+ * A scope is created when a span is made as current using [Span.makeCurrent], once the scope
+ * is closed, the current span will be replaced with the earlier one if any.
+ *
+ * Failure to close a scope correctly can break tracing and cause memory leaks.
+ *
+ * It is recommended to use scopes in a try-with-resources block in java or with [use] function
+ * in Kotlin to ensure the scopes are closed correctly. Example:
+ *
+ * ```kotlin
+ * span.makeCurrent().use {
+ *   // do work here
+ * }
+ * ``
+ *
+ * or,
+ *
+ * ```kotlin
+ * Measure.withScope(span) {
+ *   // do work here
+ * }
+ * ```
+ */
+internal interface Scope : AutoCloseable

--- a/android/measure/src/main/java/sh/measure/android/tracing/Span.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/Span.kt
@@ -1,0 +1,96 @@
+package sh.measure.android.tracing
+
+/**
+ * Represents a span in a trace.
+ */
+internal interface Span {
+    /**
+     * Unique identifier for the trace this span is part of. Created when a root span
+     * is created.
+     */
+    val traceId: String
+
+    /**
+     * Unique identifier for a span in the trace. Created when a new span is started.
+     */
+    val spanId: String
+
+    /**
+     * The name of the span.
+     */
+    val name: String
+
+    /**
+     * The span id of the parent.
+     */
+    val parentId: String?
+
+    /**
+     * The time since epoch when the span started.
+     */
+    val startTime: Long
+
+    /**
+     * Returns the status of the span.
+     */
+    fun getStatus(): SpanStatus
+
+    /**
+     * Updates the status of the span. Behaviour is undefined if the span has ended.
+     */
+    fun setStatus(status: SpanStatus): Span
+
+    /**
+     * Ends the span.
+     *
+     * A span can only be ended once. Attempt to end an already ended span is no-op.
+     */
+    fun end(): Span
+
+    /**
+     * Ends the span and sets the [timestamp] as it's end time. Useful if a span is being collected
+     * for an operation that already ended.
+     *
+     * A span can only be ended once. Attempt to end an already ended span is a no-op.
+     *
+     * @param timestamp The milliseconds since epoch when the span ended.
+     */
+    fun end(timestamp: Long): Span
+
+    /**
+     * Returns whether the span has ended or not.
+     */
+    fun hasEnded(): Boolean
+
+    /**
+     * Puts this span in scope. Putting in scope means putting the span in thread local. Any spans
+     * created on this thread will now have this span set as it's parent automatically.
+     */
+    fun makeCurrent(): Scope
+
+    /**
+     * Runs the [block] of code in this span's scope. Any spans
+     * created within this block on the same thread will have this span set as it's parent
+     * automatically.
+     */
+    fun <T> withScope(block: () -> T): T
+
+    /**
+     * The duration of the span once it ends. If the span has not ended, returns 0.
+     */
+    fun getDuration(): Long
+
+    companion object {
+
+        /**
+         * Returns the current span from thread local if any.
+         */
+        internal fun current(): Span? {
+            return SpanStorage.instance.current()
+        }
+
+        internal fun invalid(): Span {
+            return InvalidSpan()
+        }
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanBuilder.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanBuilder.kt
@@ -1,0 +1,32 @@
+package sh.measure.android.tracing
+
+/**
+ * Used to construct a [Span].
+ */
+internal interface SpanBuilder {
+    /**
+     * Sets the parent span. If not set, the current span in scope will be automatically set
+     * as parent. If no span is available in scope, this span will be a root span.
+     */
+    fun setParent(span: Span): SpanBuilder
+
+    /**
+     * Force this span to be a root span, regardless of the current span in scope.
+     */
+    fun setNoParent(): SpanBuilder
+
+    /**
+     * Starts a new span.
+     *
+     * Once the span is started, any other function in the span builder will be ignored.
+     */
+    fun startSpan(): Span
+
+    /**
+     * Starts a new span at the specified [timeMs]. Use when the operation to be traced has already
+     * started.
+     *
+     * @param timeMs The milliseconds since epoch when the span started.
+     */
+    fun startSpan(timeMs: Long): Span
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanData.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanData.kt
@@ -1,0 +1,12 @@
+package sh.measure.android.tracing
+
+internal data class SpanData(
+    val name: String,
+    val spanId: String,
+    val parentId: String?,
+    val startTime: Long,
+    val endTime: Long,
+    val duration: Long,
+    val status: SpanStatus,
+    val hasEnded: Boolean,
+)

--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanStatus.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanStatus.kt
@@ -1,0 +1,21 @@
+package sh.measure.android.tracing
+
+/**
+ * Specifies the status of the operation for which the span has been created.
+ */
+internal enum class SpanStatus {
+    /**
+     * The operation completed successfully.
+     */
+    Ok,
+
+    /**
+     * The operation ended in a failure.
+     */
+    Error,
+
+    /**
+     * Default value for all spans.
+     */
+    Unset,
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanStorage.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanStorage.kt
@@ -1,0 +1,36 @@
+package sh.measure.android.tracing
+
+/**
+ * Stores current span as a thread local variable.
+ */
+internal class SpanStorage private constructor() {
+    private val currentSpan = ThreadLocal<Span?>()
+
+    internal companion object {
+        val instance = SpanStorage()
+    }
+
+    fun makeCurrent(span: Span): Scope {
+        val scope = ScopeImpl()
+        currentSpan.set(span)
+        return scope
+    }
+
+    fun current(): Span? {
+        return currentSpan.get()
+    }
+
+    internal inner class ScopeImpl : Scope {
+        private val previousSpan = currentSpan.get()
+
+        override fun close() {
+            currentSpan.set(previousSpan)
+        }
+    }
+}
+
+internal class NoopScope : Scope {
+    override fun close() {
+        // No-op
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/tracing/Tracer.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/Tracer.kt
@@ -1,0 +1,8 @@
+package sh.measure.android.tracing
+
+/**
+ * An interface to create a span.
+ */
+internal interface Tracer {
+    fun spanBuilder(name: String): SpanBuilder
+}

--- a/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanBuilderTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanBuilderTest.kt
@@ -1,0 +1,45 @@
+package sh.measure.android.tracing
+
+import org.junit.Assert
+import org.junit.Test
+import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.TestClock
+import sh.measure.android.utils.UUIDProvider
+
+class MsrSpanBuilderTest {
+    private val idProvider = UUIDProvider()
+    private val testClock = TestClock.create()
+    private val timeProvider = AndroidTimeProvider(testClock)
+    private val logger = NoopLogger()
+
+    @Test
+    fun `setsParent sets span parent`() {
+        val parentSpan = MsrSpanBuilder("parent-name", idProvider, timeProvider, logger).startSpan()
+        val span =
+            MsrSpanBuilder("span-name", idProvider, timeProvider, logger).setParent(parentSpan)
+                .startSpan()
+
+        Assert.assertEquals(parentSpan.spanId, span.parentId)
+    }
+
+    @Test
+    fun `sets parent from thread local storage`() {
+        val parentSpan = MsrSpanBuilder("parent-name", idProvider, timeProvider, logger).startSpan()
+        parentSpan.makeCurrent().use {
+            val span =
+                MsrSpanBuilder("span-name", idProvider, timeProvider, logger).startSpan()
+            Assert.assertEquals(parentSpan.spanId, span.parentId)
+        }
+    }
+
+    @Test
+    fun `setNoParent forces no parent to be set`() {
+        val parentSpan = MsrSpanBuilder("parent-name", idProvider, timeProvider, logger).startSpan()
+        parentSpan.makeCurrent().use {
+            val span =
+                MsrSpanBuilder("span-name", idProvider, timeProvider, logger).setNoParent().startSpan()
+            Assert.assertNull(span.parentId)
+        }
+    }
+}

--- a/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanTest.kt
@@ -1,0 +1,145 @@
+package sh.measure.android.tracing
+
+import org.junit.Assert
+import org.junit.Test
+import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.TestClock
+import sh.measure.android.utils.UUIDProvider
+import java.time.Duration
+
+class MsrSpanTest {
+    private val logger = NoopLogger()
+    private val testClock = TestClock.create()
+    private val timeProvider = AndroidTimeProvider(testClock)
+    private val idProvider = UUIDProvider()
+
+    @Test
+    fun `startSpan sets parent span if provided`() {
+        val parentSpan = MsrSpan(
+            logger,
+            timeProvider,
+            "parent-span",
+            "span-id",
+            "trace-id",
+            parentId = null,
+            startTime = 1000,
+        )
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = parentSpan,
+            timestamp = null,
+        )
+
+        Assert.assertEquals(parentSpan.spanId, span.parentId)
+    }
+
+    @Test
+    fun `startSpan sets current timestamp`() {
+        val epochTime = testClock.epochTime()
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+            timestamp = null,
+        )
+        Assert.assertEquals(epochTime, span.startTime)
+    }
+
+    @Test
+    fun `startSpan sets timestamp if provided`() {
+        val timestamp = 10000L
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+            timestamp = timestamp,
+        )
+        Assert.assertEquals(timestamp, span.startTime)
+    }
+
+    @Test
+    fun `default span status is unset`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        )
+        Assert.assertEquals(SpanStatus.Unset, span.getStatus())
+    }
+
+    @Test
+    fun `setStatus updates the span status`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        ).setStatus(SpanStatus.Ok)
+        Assert.assertEquals(SpanStatus.Ok, span.getStatus())
+    }
+
+    @Test
+    fun `hasEnded for active span`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        )
+        Assert.assertEquals(false, span.hasEnded())
+    }
+
+    @Test
+    fun `hasEnded for ended span`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        ).end()
+        Assert.assertEquals(true, span.hasEnded())
+    }
+
+    @Test
+    fun `end updates the span duration`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        )
+        testClock.advance(Duration.ofMillis(1000))
+        val duration = span.end().getDuration()
+
+        Assert.assertEquals(1000, duration)
+    }
+
+    @Test
+    fun `duration is 0 for active span`() {
+        val span = MsrSpan.startSpan(
+            "span-name",
+            logger = logger,
+            timeProvider = timeProvider,
+            idProvider = idProvider,
+            parentSpan = null,
+        )
+        testClock.advance(Duration.ofMillis(1000))
+        val duration = span.getDuration()
+
+        Assert.assertEquals(0, duration)
+    }
+}

--- a/android/measure/src/test/java/sh/measure/android/tracing/SpanStorageTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/tracing/SpanStorageTest.kt
@@ -1,0 +1,41 @@
+package sh.measure.android.tracing
+
+import org.junit.Assert
+import org.junit.Test
+import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.TestClock
+import sh.measure.android.utils.UUIDProvider
+
+class SpanStorageTest {
+    private val idProvider = UUIDProvider()
+    private val testClock = TestClock.create()
+    private val timeProvider = AndroidTimeProvider(testClock)
+    private val logger = NoopLogger()
+
+    @Test
+    fun `current returns null by default`() {
+        Assert.assertNull(SpanStorage.instance.current())
+    }
+
+    @Test
+    fun `makeCurrent sets span as current`() {
+        val span = MsrSpanBuilder("span-name", idProvider, timeProvider, logger).startSpan()
+        val scope = span.makeCurrent()
+        Assert.assertEquals(span, SpanStorage.instance.current())
+        scope.close()
+    }
+
+    @Test
+    fun `closing the scope resets the current span`() {
+        val spanA = MsrSpanBuilder("span-A", idProvider, timeProvider, logger).startSpan()
+        val spanB = MsrSpanBuilder("span-B", idProvider, timeProvider, logger).startSpan()
+        val spanAScope = spanA.makeCurrent()
+        val spanBScope = spanB.makeCurrent()
+        Assert.assertEquals(spanB, SpanStorage.instance.current())
+        spanBScope.close()
+        Assert.assertEquals(spanA, SpanStorage.instance.current())
+        spanAScope.close()
+        Assert.assertEquals(null, SpanStorage.instance.current())
+    }
+}


### PR DESCRIPTION
# Description

* Implements create span API
* Implements start span API
* Implement end span API
* Implement set status API
* Implement an invalid span and no-op scope.
* Implement thread local storage for spans, scopes and helper functions to manage scopes
* Calculate duration of span.
* Document the public API

## Related issue
closes #1396

