### PR TITLE
fix(android): use uptime millis for cold launch instead of realtime elapsed

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInitProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitProvider.kt
@@ -25,7 +25,7 @@ internal class MeasureInitProvider : ContentProvider() {
         check(MeasureInitProvider::class.java.name != info.authority) {
             "An applicationId is required to fulfill the manifest placeholder."
         }
-        LaunchState.contentLoaderAttachUptime = SystemClock.elapsedRealtime()
+        LaunchState.contentLoaderAttachUptime = SystemClock.uptimeMillis()
         super.attachInfo(context, info)
     }
 

--- a/android/measure/src/main/java/sh/measure/android/applaunch/AppLaunchCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/AppLaunchCollector.kt
@@ -26,7 +26,7 @@ internal class AppLaunchCollector(
     fun register() {
         logger.log(LogLevel.Debug, "Registering AppLaunchCollector")
         application.registerActivityLifecycleCallbacks(
-            LaunchTracker(logger, timeProvider, this),
+            LaunchTracker(logger, this),
         )
     }
 

--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -9,7 +9,6 @@ import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.mainHandler
 import sh.measure.android.postAtFrontOfQueueAsync
-import sh.measure.android.utils.TimeProvider
 
 internal interface LaunchCallbacks {
     fun onColdLaunch(coldLaunchData: ColdLaunchData)
@@ -23,7 +22,6 @@ internal interface LaunchCallbacks {
  */
 internal class LaunchTracker(
     private val logger: Logger,
-    private val timeProvider: TimeProvider,
     private val callbacks: LaunchCallbacks,
 ) : ActivityLifecycleAdapter {
 
@@ -85,7 +83,7 @@ internal class LaunchTracker(
     }
 
     private fun appMightBecomeVisible() {
-        LaunchState.lastAppVisibleTime = timeProvider.millisTime
+        LaunchState.lastAppVisibleTime = android.os.SystemClock.uptimeMillis()
         logger.log(
             LogLevel.Debug,
             "Updated last app visible time: ${LaunchState.lastAppVisibleTime}",
@@ -103,7 +101,7 @@ internal class LaunchTracker(
                 if (!launchInProgress) return@postAtFrontOfQueueAsync
                 launchInProgress = false
 
-                val onNextDrawUptime = timeProvider.millisTime
+                val onNextDrawUptime = android.os.SystemClock.uptimeMillis()
                 onCreateRecord?.let { onCreateRecord ->
                     when (val launchType = computeLaunchType(onCreateRecord)) {
                         "Cold" -> {


### PR DESCRIPTION
# Description

The system APIs return uptime millis, using realtime elapsed will lead to wrong time calculation. This was changed as part of #1402. Reverting launch time to continue using uptime millis. 

## Related issue
Fixes #1437


