### PR TITLE
fix(backend): improve crash/anr detail experience

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -212,6 +212,18 @@ func (af *AppFilter) VersionPairs() (versions *pairs.Pairs[string, string], err 
 	return
 }
 
+// OSVersionPairs provides a convinient wrapper over OS name
+// and OS version representing them in paired-up way, like
+// tuples. For many cases, a paired up version is more useful
+// than individual OS names and versions.
+func (af *AppFilter) OSVersionPairs() (osVersions *pairs.Pairs[string, string], err error) {
+	osVersions, err = pairs.NewPairs(af.OsNames, af.OsVersions)
+	if err != nil {
+		return
+	}
+	return
+}
+
 // Expand expands comma separated fields to slice
 // of strings
 func (af *AppFilter) Expand() {
@@ -298,8 +310,7 @@ func (af *AppFilter) ExtendLimit() int {
 	if af.HasPositiveLimit() {
 		return af.Limit + 1
 	} else {
-		limit := -af.Limit
-		return limit + 1
+		return af.Limit - 1
 	}
 }
 

--- a/backend/api/group/group.go
+++ b/backend/api/group/group.go
@@ -16,6 +16,13 @@ import (
 	"github.com/leporo/sqlf"
 )
 
+// IssueGroup interface represents
+// common interface for issue group
+// types like ExceptionGroup & ANRGroup.
+type IssueGroup interface {
+	GetFingerprint() string
+}
+
 type ExceptionGroup struct {
 	ID              uuid.UUID              `json:"id" db:"id"`
 	AppID           uuid.UUID              `json:"app_id" db:"app_id"`
@@ -54,6 +61,12 @@ type ANRGroup struct {
 
 func (e ExceptionGroup) GetID() uuid.UUID {
 	return e.ID
+}
+
+// GetFingerprint provides the exception's
+// fingerprint.
+func (e ExceptionGroup) GetFingerprint() string {
+	return e.Fingerprint
 }
 
 // GetDisplayTitle provides a user friendly display
@@ -129,6 +142,12 @@ func (e *ExceptionGroup) Insert(ctx context.Context, tx *pgx.Tx) (err error) {
 
 func (a ANRGroup) GetID() uuid.UUID {
 	return a.ID
+}
+
+// GetFingerprint provides the ANR's
+// fingerprint.
+func (a ANRGroup) GetFingerprint() string {
+	return a.Fingerprint
 }
 
 // GetDisplayTitle provides a user friendly display

--- a/backend/api/numeric/numeric.go
+++ b/backend/api/numeric/numeric.go
@@ -1,0 +1,16 @@
+package numeric
+
+// AbsInt returns the absolute
+// value of int n.
+//
+// Go's math.Abs() function
+// expects float64 type.
+// This function follows a
+// simpler approach without
+// resorting to convert types.
+func AbsInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

Made pagination of Crash/ANR detail crashes duplication free. Improved overall performance and experience of Crash/ANR Overview and detail APIs.

## Tasks

- [x] Improve pagination of crashes on crash detail page
- [x] Improve pagination of anrs on anr detail page
- [x] Optimize performance of crash overview and detail page
- [x] Optimize performance of anr over and detail page

## See also

- fixes #1418