### PR TITLE
chore(backend): add data skipping indexes for fingerprints

### DIFF
--- a/self-host/clickhouse/20241031172411_alter_events_table.sql
+++ b/self-host/clickhouse/20241031172411_alter_events_table.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+alter table default.events
+  add index if not exists exception_fingerprint_bloom_idx `exception.fingerprint` type bloom_filter granularity 4,
+  add index if not exists anr_fingerprint_bloom_idx `anr.fingerprint` type bloom_filter granularity 4,
+  materialize index if exists exception_fingerprint_bloom_idx,
+  materialize index if exists anr_fingerprint_bloom_idx;
+
+-- migrate:down
+alter table default.events
+  drop index if exists exception_fingerprint_bloom_idx,
+  drop index if exists anr_fingerprint_bloom_idx;
+


### PR DESCRIPTION
## Summary

Added new migration to create/drop data skipping indexes for Crash/ANR fingerprints. These indexes use bloom filter with a granularity value of 4.

## Tasks

- [x] Add data skipping index for exception fingerprint
- [x] Add data skipping index for ANR fingerprint
- [x] Add ClickHouse migration

## See also

- fixes #1454 