### PR TITLE
Ios session logic update & time provider refactor

### DIFF
--- a/ios/MeasureSDK/Exporter/BatchCreator.swift
+++ b/ios/MeasureSDK/Exporter/BatchCreator.swift
@@ -45,7 +45,7 @@ final class BaseBatchCreator: BatchCreator {
         }
 
         let batchId = idProvider.createId()
-        let isBatchInsertionSuccessful = batchStore.insertBatch(BatchEntity(batchId: batchId, eventIds: eventIds, createdAt: timeProvider.currentTimeSinceEpochInMillis))
+        let isBatchInsertionSuccessful = batchStore.insertBatch(BatchEntity(batchId: batchId, eventIds: eventIds, createdAt: timeProvider.now()))
 
         if !isBatchInsertionSuccessful {
             logger.log(level: .error, message: "Failed to insert batched event IDs", error: nil, data: nil)

--- a/ios/MeasureSDK/Exporter/PeriodicEventExporter.swift
+++ b/ios/MeasureSDK/Exporter/PeriodicEventExporter.swift
@@ -96,9 +96,9 @@ final class BasePeriodicEventExporter: PeriodicEventExporter, HeartbeatListener 
     }
 
     private func processNewBatchIfTimeElapsed() {
-        if timeProvider.uptimeInMillis - lastBatchCreationUptimeMs >= configProvider.eventsBatchingIntervalMs {
+        if timeProvider.millisTime - lastBatchCreationUptimeMs >= configProvider.eventsBatchingIntervalMs {
             if let result = eventExporter.createBatch(nil) {
-                lastBatchCreationUptimeMs = timeProvider.uptimeInMillis
+                lastBatchCreationUptimeMs = timeProvider.millisTime
                 processExistingBatches([BatchEntity(batchId: result.batchId,
                                                     eventIds: result.eventIds,
                                                     createdAt: lastBatchCreationUptimeMs)])

--- a/ios/MeasureSDK/Gestures/GestureCollector.swift
+++ b/ios/MeasureSDK/Gestures/GestureCollector.swift
@@ -69,7 +69,7 @@ final class BaseGestureCollector: GestureCollector {
                                  y: FloatNumber(y),
                                  touchDownTime: touchDownTime,
                                  touchUpTime: touchUpTime)
-            eventProcessor.track(data: data, timestamp: timeProvider.currentTimeSinceEpochInMillis, type: .gestureClick, attributes: nil, sessionId: nil, attachments: nil)
+            eventProcessor.track(data: data, timestamp: timeProvider.now(), type: .gestureClick, attributes: nil, sessionId: nil, attachments: nil)
         case .longClick(let x, let y, let touchDownTime, let touchUpTime, let target, let targetId, let targetFrame):
             let gestureTargetFinderData = gestureTargetFinder.findClickable(x: x, y: y, window: window)
             let width = Number((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0)
@@ -83,7 +83,7 @@ final class BaseGestureCollector: GestureCollector {
                                      y: FloatNumber(y),
                                      touchDownTime: touchDownTime,
                                      touchUpTime: touchUpTime)
-            eventProcessor.track(data: data, timestamp: timeProvider.currentTimeSinceEpochInMillis, type: .gestureLongClick, attributes: nil, sessionId: nil, attachments: nil)
+            eventProcessor.track(data: data, timestamp: timeProvider.now(), type: .gestureLongClick, attributes: nil, sessionId: nil, attachments: nil)
         case .scroll(let startX, let startY, let endX, let endY, let direction, let touchDownTime, let touchUpTime, let target, let targetId):
             let startScrollPoint = CGPoint(x: startX, y: startY)
             let endScrollPoint = CGPoint(x: endX, y: endY)
@@ -97,7 +97,7 @@ final class BaseGestureCollector: GestureCollector {
                                       direction: direction,
                                       touchDownTime: touchDownTime,
                                       touchUpTime: touchUpTime)
-                eventProcessor.track(data: data, timestamp: timeProvider.currentTimeSinceEpochInMillis, type: .gestureScroll, attributes: nil, sessionId: nil, attachments: nil)
+                eventProcessor.track(data: data, timestamp: timeProvider.now(), type: .gestureScroll, attributes: nil, sessionId: nil, attachments: nil)
             }
         }
         // swiftlint:enable identifier_name

--- a/ios/MeasureSDK/Gestures/GestureDetector.swift
+++ b/ios/MeasureSDK/Gestures/GestureDetector.swift
@@ -72,7 +72,7 @@ struct GestureDetector {
         case .began:
             startTouchX = location.x
             startTouchY = location.y
-            startTouchEventTime = timeProvider.uptimeInMillis
+            startTouchEventTime = timeProvider.millisTime
             isScrolling = false
         case .moved:
             // Movement detected, check if it is a scroll gesture
@@ -94,7 +94,7 @@ struct GestureDetector {
                             x: location.x,
                             y: location.y,
                             touchDownTime: startTouchEventTime,
-                            touchUpTime: timeProvider.uptimeInMillis,
+                            touchUpTime: timeProvider.millisTime,
                             target: target,
                             targetId: targetId,
                             targetFrame: targetFrame)
@@ -106,7 +106,7 @@ struct GestureDetector {
                             x: location.x,
                             y: location.y,
                             touchDownTime: startTouchEventTime,
-                            touchUpTime: timeProvider.uptimeInMillis,
+                            touchUpTime: timeProvider.millisTime,
                             target: target,
                             targetId: targetId,
                             targetFrame: targetFrame)
@@ -123,7 +123,7 @@ struct GestureDetector {
                     endY: location.y,
                     direction: calculateScrollDirection(endX: location.x, endY: location.y, startX: startTouchX, startY: startTouchY),
                     touchDownTime: startTouchEventTime,
-                    touchUpTime: timeProvider.uptimeInMillis,
+                    touchUpTime: timeProvider.millisTime,
                     target: target,
                     targetId: targetId)
                 target = nil

--- a/ios/MeasureSDK/Lifecycle/LifecycleCollector.swift
+++ b/ios/MeasureSDK/Lifecycle/LifecycleCollector.swift
@@ -35,7 +35,7 @@ class BaseLifecycleCollector: LifecycleCollector {
 
     func applicationDidEnterBackground() {
         eventProcessor.track(data: ApplicationLifecycleData(type: .background),
-                             timestamp: timeProvider.currentTimeSinceEpochInMillis,
+                             timestamp: timeProvider.now(),
                              type: .lifecycleApp,
                              attributes: nil,
                              sessionId: nil,
@@ -44,7 +44,7 @@ class BaseLifecycleCollector: LifecycleCollector {
 
     func applicationWillEnterForeground() {
         eventProcessor.track(data: ApplicationLifecycleData(type: .foreground),
-                             timestamp: timeProvider.currentTimeSinceEpochInMillis,
+                             timestamp: timeProvider.now(),
                              type: .lifecycleApp,
                              attributes: nil,
                              sessionId: nil,
@@ -55,7 +55,7 @@ class BaseLifecycleCollector: LifecycleCollector {
         let className = String(describing: type(of: viewController))
 
         eventProcessor.track(data: VCLifecycleData(type: vcLifecycleType.stringValue, className: className),
-                             timestamp: timeProvider.currentTimeSinceEpochInMillis,
+                             timestamp: timeProvider.now(),
                              type: .lifecycleViewController,
                              attributes: nil,
                              sessionId: nil,
@@ -64,7 +64,7 @@ class BaseLifecycleCollector: LifecycleCollector {
 
     func processSwiftUILifecycleEvent(_ swiftUILifecycleType: SwiftUILifecycleType, for viewName: String) {
         eventProcessor.track(data: SwiftUILifecycleData(type: swiftUILifecycleType, viewName: viewName),
-                             timestamp: timeProvider.currentTimeSinceEpochInMillis,
+                             timestamp: timeProvider.now(),
                              type: .lifecycleSwiftUI,
                              attributes: nil,
                              sessionId: nil,

--- a/ios/MeasureSDK/MeasureInitializer.swift
+++ b/ios/MeasureSDK/MeasureInitializer.swift
@@ -132,7 +132,8 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                                  timeProvider: timeProvider,
                                                  configProvider: configProvider,
                                                  sessionStore: sessionStore,
-                                                 userDefaultStorage: userDefaultStorage)
+                                                 userDefaultStorage: userDefaultStorage,
+                                                 versionCode: FrameworkInfo.version)
         self.appAttributeProcessor = AppAttributeProcessor()
         self.deviceAttributeProcessor = DeviceAttributeProcessor()
         self.installationIdAttributeProcessor = InstallationIdAttributeProcessor(userDefaultStorage: userDefaultStorage,

--- a/ios/MeasureSDK/RecentSession.swift
+++ b/ios/MeasureSDK/RecentSession.swift
@@ -12,12 +12,18 @@ struct RecentSession {
     let createdAt: Int64
     var lastEventTime: Int64
     var crashed: Bool
+    let versionCode: String
 
-    init(id: String, createdAt: Int64, lastEventTime: Int64 = 0, crashed: Bool = false) {
+    init(id: String,
+         createdAt: Int64,
+         lastEventTime: Int64 = 0,
+         crashed: Bool = false,
+         versionCode: String) {
         self.id = id
         self.createdAt = createdAt
         self.lastEventTime = lastEventTime
         self.crashed = crashed
+        self.versionCode = versionCode
     }
 
     func hasTrackedEvent() -> Bool {

--- a/ios/MeasureSDK/SessionManager.swift
+++ b/ios/MeasureSDK/SessionManager.swift
@@ -33,6 +33,7 @@ final class BaseSessionManager: SessionManager {
     private let sessionStore: SessionStore
     private let userDefaultStorage: UserDefaultStorage
     private var previousSessionCrashed = false
+    private let versionCode: String
 
     /// The current session ID.
     var sessionId: String {
@@ -49,7 +50,8 @@ final class BaseSessionManager: SessionManager {
          configProvider: ConfigProvider,
          randomizer: Randomizer = BaseRandomizer(),
          sessionStore: SessionStore,
-         userDefaultStorage: UserDefaultStorage) {
+         userDefaultStorage: UserDefaultStorage,
+         versionCode: String) {
         self.appBackgroundTimeMs = 0
         self.idProvider = idProvider
         self.logger = logger
@@ -58,6 +60,7 @@ final class BaseSessionManager: SessionManager {
         self.randomizer = randomizer
         self.sessionStore = sessionStore
         self.userDefaultStorage = userDefaultStorage
+        self.versionCode = versionCode
     }
 
     private func createNewSession() {
@@ -70,7 +73,8 @@ final class BaseSessionManager: SessionManager {
                                     crashed: false)
         sessionStore.insertSession(session)
         let recentSession = RecentSession(id: session.sessionId,
-                                          createdAt: session.createdAt)
+                                          createdAt: session.createdAt,
+                                          versionCode: versionCode)
         userDefaultStorage.setRecentSession(recentSession)
     }
 
@@ -101,8 +105,19 @@ final class BaseSessionManager: SessionManager {
         return (timeProvider.now() - recentSession.createdAt) >= configProvider.maxSessionDurationMs
     }
 
+    private func isFrameworkVersionUpdated() -> Bool {
+        if let recentSession = userDefaultStorage.getRecentSession(),
+           recentSession.versionCode == self.versionCode {
+            return false
+        }
+        return true
+    }
+
     func start() {
-        if isSessonDurationThreadholdReached() {
+        if isFrameworkVersionUpdated() {
+            logger.log(level: .info, message: "Ending previous session as SDK version has been updated.", error: nil, data: nil)
+            createNewSession()
+        } else if isSessonDurationThreadholdReached() {
             logger.log(level: .info, message: "Ending previous session as maxSessionDurationMs threshold is reached.", error: nil, data: nil)
             createNewSession()
         } else if let recentSessionId = getRecentSessionId() {

--- a/ios/MeasureSDK/SessionManager.swift
+++ b/ios/MeasureSDK/SessionManager.swift
@@ -65,7 +65,7 @@ final class BaseSessionManager: SessionManager {
         logger.log(level: .info, message: "New session created", error: nil, data: nil)
         let session = SessionEntity(sessionId: sessionId,
                                     pid: ProcessInfo.processInfo.processIdentifier,
-                                    createdAt: Number(timeProvider.currentTimeSinceEpochInMillis),
+                                    createdAt: Number(timeProvider.now()),
                                     needsReporting: true,
                                     crashed: false)
         sessionStore.insertSession(session)
@@ -80,7 +80,7 @@ final class BaseSessionManager: SessionManager {
         }
 
         if let recentSession = userDefaultStorage.getRecentSession(), recentSession.lastEventTime != 0 {
-            let elapsedTime = timeProvider.currentTimeSinceEpochInMillis - recentSession.lastEventTime
+            let elapsedTime = timeProvider.now() - recentSession.lastEventTime
             if elapsedTime <= configProvider.sessionEndLastEventThresholdMs {
                 return recentSession.id
             }
@@ -94,11 +94,11 @@ final class BaseSessionManager: SessionManager {
         }
 
         // Check negative time to handle clock skew
-        guard (timeProvider.currentTimeSinceEpochInMillis - recentSession.createdAt) > 0 else {
+        guard (timeProvider.now() - recentSession.createdAt) > 0 else {
             return false
         }
 
-        return (timeProvider.currentTimeSinceEpochInMillis - recentSession.createdAt) >= configProvider.maxSessionDurationMs
+        return (timeProvider.now() - recentSession.createdAt) >= configProvider.maxSessionDurationMs
     }
 
     func start() {
@@ -114,7 +114,7 @@ final class BaseSessionManager: SessionManager {
     }
 
     func applicationDidEnterBackground() {
-        self.appBackgroundTimeMs = timeProvider.uptimeInMillis
+        self.appBackgroundTimeMs = timeProvider.millisTime
         logger.log(level: .info, message: "applicationDidEnterBackground", error: nil, data: nil)
     }
 
@@ -142,7 +142,7 @@ final class BaseSessionManager: SessionManager {
     }
 
     private func shouldEndSession() -> Bool {
-        let durationInBackground = timeProvider.uptimeInMillis - appBackgroundTimeMs
+        let durationInBackground = timeProvider.millisTime - appBackgroundTimeMs
 
         if durationInBackground >= configProvider.sessionEndLastEventThresholdMs {
             logger.log(level: .info, message: "Ending session as app was relaunched after being in background for \(durationInBackground) ms", error: nil, data: nil)

--- a/ios/MeasureSDK/Utils/Constants.swift
+++ b/ios/MeasureSDK/Utils/Constants.swift
@@ -30,6 +30,7 @@ let recentSessionIdKey = "recent_session_id"
 let recentSessionEventTimeKey = "recent_session_event_time"
 let recentSessionCreatedAtKey = "recent_session_created_at"
 let recentSessionCrashedKey = "recent_session_crashed_key"
+let recentSessionVersionCodeKey = "recent_session_version_code"
 
 struct AttributeConstants {
     static let deviceManufacturer = "Apple"

--- a/ios/MeasureSDK/Utils/UserDefaultStorage.swift
+++ b/ios/MeasureSDK/Utils/UserDefaultStorage.swift
@@ -47,6 +47,7 @@ final class BaseUserDefaultStorage: UserDefaultStorage {
         userDefaults.set(recentSession.lastEventTime, forKey: recentSessionEventTimeKey)
         userDefaults.set(recentSession.createdAt, forKey: recentSessionCreatedAtKey)
         userDefaults.set(recentSession.crashed, forKey: recentSessionCrashedKey)
+        userDefaults.set(recentSession.versionCode, forKey: recentSessionVersionCodeKey)
     }
 
     func setRecentSessionEventTime(_ timestamp: Number) {
@@ -54,7 +55,8 @@ final class BaseUserDefaultStorage: UserDefaultStorage {
     }
 
     func getRecentSession() -> RecentSession? {
-        guard let sessionId = userDefaults.string(forKey: recentSessionIdKey) else {
+        guard let sessionId = userDefaults.string(forKey: recentSessionIdKey),
+              let versionCode = userDefaults.string(forKey: recentSessionVersionCodeKey) else {
             return nil
         }
         let eventTime = Number(userDefaults.integer(forKey: recentSessionEventTimeKey))
@@ -65,7 +67,8 @@ final class BaseUserDefaultStorage: UserDefaultStorage {
             id: sessionId,
             createdAt: createdAt,
             lastEventTime: eventTime,
-            crashed: crashed
+            crashed: crashed,
+            versionCode: versionCode
         )
     }
 }

--- a/ios/MeasureSDKTests/Exporter/BatchCreatorTests.swift
+++ b/ios/MeasureSDKTests/Exporter/BatchCreatorTests.swift
@@ -76,7 +76,7 @@ final class BatchCreatorTests: XCTestCase {
         configProvider.maxAttachmentSizeInEventsBatchInBytes = 300
         configProvider.maxEventsInBatch = 2
         idProvider.idString = "batch1"
-        timeProvider.currentTimeSinceEpochInMillis = 1727272496000
+        timeProvider.current = 1727272496000
 
         let result = batchCreator.create(sessionId: nil)
 

--- a/ios/MeasureSDKTests/Exporter/PeriodicEventExporterTests.swift
+++ b/ios/MeasureSDKTests/Exporter/PeriodicEventExporterTests.swift
@@ -69,7 +69,7 @@ final class PeriodicEventExporterTests: XCTestCase {
 
     func testProcessNewBatchIfTimeElapsed_createsAndExportsBatch() {
         let batchingIntervalMs: Int64 = 1000
-        timeProvider.uptimeInMillis = 2000
+        timeProvider.millisTime = 2000
         configProvider.eventsBatchingIntervalMs = batchingIntervalMs
         eventExporter.createBatchResult = BatchCreationResult(batchId: "testBatch", eventIds: ["event1", "event2"])
 
@@ -82,7 +82,7 @@ final class PeriodicEventExporterTests: XCTestCase {
 
     func testProcessNewBatchIfTimeElapsed_doesNotCreateBatchIfIntervalNotElapsed() {
         let batchingIntervalMs: Int64 = 1000
-        timeProvider.uptimeInMillis = 1500
+        timeProvider.millisTime = 1500
         periodicEventExporter.lastBatchCreationUptimeMs = 1000
         configProvider.eventsBatchingIntervalMs = batchingIntervalMs
 

--- a/ios/MeasureSDKTests/Mocks/MockTimeProvider.swift
+++ b/ios/MeasureSDKTests/Mocks/MockTimeProvider.swift
@@ -9,25 +9,15 @@ import Foundation
 @testable import MeasureSDK
 
 final class MockTimeProvider: TimeProvider {
-    var elapsedRealtime: Number
-    var currentTimeSinceEpochInMillis: Number
-    var currentTimeSinceEpochInNanos: Number
-    var uptimeInMillis: Number
-    private let iso8601Timestamp: String
+    var millisTime: Number = 0
+    var current: Number = 0
+    var iso8601Timestamp: String = ""
+
+    func now() -> MeasureSDK.Number {
+        return current
+    }
 
     func iso8601Timestamp(timeInMillis: Number) -> String {
         return iso8601Timestamp
-    }
-
-    init(currentTimeSinceEpochInMillis: Number = 0,
-         currentTimeSinceEpochInNanos: Number = 0,
-         uptimeInMillis: Number = 0,
-         iso8601Timestamp: String = "",
-         elapsedRealtime: Number = 0) {
-        self.currentTimeSinceEpochInMillis = currentTimeSinceEpochInMillis
-        self.currentTimeSinceEpochInNanos = currentTimeSinceEpochInNanos
-        self.uptimeInMillis = uptimeInMillis
-        self.iso8601Timestamp = iso8601Timestamp
-        self.elapsedRealtime = elapsedRealtime
     }
 }

--- a/ios/MeasureSDKTests/SessionManagerTests.swift
+++ b/ios/MeasureSDKTests/SessionManagerTests.swift
@@ -41,7 +41,8 @@ final class SessionManagerTests: XCTestCase {
                                             configProvider: configProvider,
                                             randomizer: randomizer,
                                             sessionStore: sessionStore,
-                                            userDefaultStorage: userDefaultStorage)
+                                            userDefaultStorage: userDefaultStorage,
+                                            versionCode: "1.0.0")
     }
 
     override func tearDown() {
@@ -63,6 +64,32 @@ final class SessionManagerTests: XCTestCase {
     func testSessionStart() {
         sessionManager.start()
         XCTAssertEqual(sessionManager.sessionId, "test-session-id-1", "Expected session ID to be 'test-session-id-1' after initialisation.")
+    }
+
+    func testSessionContinues_WhenFrameworkVersionNotUpdated() {
+        let expectedSessionId = "previous-session-id"
+        idProvider.idString = "new-session-id"
+        let lastEventTime: Int64 = 1000
+        let recentSession = RecentSession(id: expectedSessionId, createdAt: 9876544331, lastEventTime: lastEventTime, versionCode: "1.0.0")
+        userDefaultStorage.recentSession = recentSession
+        timeProvider.current = lastEventTime + 1000
+        configProvider.sessionEndLastEventThresholdMs = 10000
+
+        sessionManager.start()
+        XCTAssertEqual(sessionManager.sessionId, "previous-session-id", "Expected a new session to be created when the framework version is updated.")
+    }
+
+    func testCreatesNewSession_WhenFrameworkVersionUpdated() {
+        let expectedSessionId = "previous-session-id"
+        idProvider.idString = "new-session-id"
+        let lastEventTime: Int64 = 1000
+        let recentSession = RecentSession(id: expectedSessionId, createdAt: 9876544331, lastEventTime: lastEventTime, versionCode: "2.0.0")
+        userDefaultStorage.recentSession = recentSession
+        timeProvider.current = lastEventTime + 1000
+        configProvider.sessionEndLastEventThresholdMs = 10000
+
+        sessionManager.start()
+        XCTAssertEqual(sessionManager.sessionId, "new-session-id", "Expected a new session to be created when the framework version is updated.")
     }
 
     func testSessionContinues_WhenEnteringForegroundBeforeThreshold() {
@@ -90,7 +117,8 @@ final class SessionManagerTests: XCTestCase {
                                             configProvider: configProvider,
                                             randomizer: randomizer,
                                             sessionStore: sessionStore,
-                                            userDefaultStorage: userDefaultStorage)
+                                            userDefaultStorage: userDefaultStorage,
+                                            versionCode: "1.0.0")
         sessionManager.start()
 
         let expectation = self.expectation(description: "New session created after entering foreground after threshold")
@@ -137,7 +165,7 @@ final class SessionManagerTests: XCTestCase {
         let expectedSessionId = "new-session-id"
         idProvider.idString = expectedSessionId
         let lastEventTime: Int64 = 1000
-        let recentSession = RecentSession(id: "previous-session-id", createdAt: 9876544331, lastEventTime: lastEventTime)
+        let recentSession = RecentSession(id: "previous-session-id", createdAt: 9876544331, lastEventTime: lastEventTime, versionCode: "1.0.0")
         userDefaultStorage.recentSession = recentSession
         timeProvider.current = lastEventTime + 5000
         configProvider.sessionEndLastEventThresholdMs = 1000
@@ -152,7 +180,7 @@ final class SessionManagerTests: XCTestCase {
         let expectedSessionId = "previous-session-id"
         idProvider.idString = "new-session-id"
         let lastEventTime: Int64 = 1000
-        let recentSession = RecentSession(id: expectedSessionId, createdAt: 9876544331, lastEventTime: lastEventTime)
+        let recentSession = RecentSession(id: expectedSessionId, createdAt: 9876544331, lastEventTime: lastEventTime, versionCode: "1.0.0")
         userDefaultStorage.recentSession = recentSession
         timeProvider.current = lastEventTime + 1000
         configProvider.sessionEndLastEventThresholdMs = 10000
@@ -168,7 +196,7 @@ final class SessionManagerTests: XCTestCase {
         idProvider.idString = expectedSessionId
         configProvider.maxSessionDurationMs = 500
         let recentSessionCreatedAtTime: Int64 = 1000
-        let recentSession = RecentSession(id: "previous-session-id", createdAt: recentSessionCreatedAtTime)
+        let recentSession = RecentSession(id: "previous-session-id", createdAt: recentSessionCreatedAtTime, versionCode: "1.0.0")
         userDefaultStorage.recentSession = recentSession
         timeProvider.current = recentSessionCreatedAtTime + configProvider.maxSessionDurationMs
 

--- a/ios/MeasureSDKTests/SessionManagerTests.swift
+++ b/ios/MeasureSDKTests/SessionManagerTests.swift
@@ -139,7 +139,7 @@ final class SessionManagerTests: XCTestCase {
         let lastEventTime: Int64 = 1000
         let recentSession = RecentSession(id: "previous-session-id", createdAt: 9876544331, lastEventTime: lastEventTime)
         userDefaultStorage.recentSession = recentSession
-        timeProvider.currentTimeSinceEpochInMillis = lastEventTime + 5000
+        timeProvider.current = lastEventTime + 5000
         configProvider.sessionEndLastEventThresholdMs = 1000
 
         sessionManager.start()
@@ -154,7 +154,7 @@ final class SessionManagerTests: XCTestCase {
         let lastEventTime: Int64 = 1000
         let recentSession = RecentSession(id: expectedSessionId, createdAt: 9876544331, lastEventTime: lastEventTime)
         userDefaultStorage.recentSession = recentSession
-        timeProvider.currentTimeSinceEpochInMillis = lastEventTime + 1000
+        timeProvider.current = lastEventTime + 1000
         configProvider.sessionEndLastEventThresholdMs = 10000
 
         sessionManager.start()
@@ -170,7 +170,7 @@ final class SessionManagerTests: XCTestCase {
         let recentSessionCreatedAtTime: Int64 = 1000
         let recentSession = RecentSession(id: "previous-session-id", createdAt: recentSessionCreatedAtTime)
         userDefaultStorage.recentSession = recentSession
-        timeProvider.currentTimeSinceEpochInMillis = recentSessionCreatedAtTime + configProvider.maxSessionDurationMs
+        timeProvider.current = recentSessionCreatedAtTime + configProvider.maxSessionDurationMs
 
         sessionManager.start()
         let sessionId = sessionManager.sessionId
@@ -181,12 +181,12 @@ final class SessionManagerTests: XCTestCase {
     func testCreatesNewSession_IfLastSessionCrashedWithinThresholdTime() {
         configProvider.sessionEndLastEventThresholdMs = 100000
         let sessionCreatedAt: Int64 = 1000
-        timeProvider.currentTimeSinceEpochInMillis = sessionCreatedAt
+        timeProvider.current = sessionCreatedAt
         sessionManager.start()
         let newSessionId = "new-session-id"
         idProvider.idString = newSessionId
         let lastEventTime: Int64 = sessionCreatedAt + 1000
-        timeProvider.currentTimeSinceEpochInMillis = lastEventTime + 1000
+        timeProvider.current = lastEventTime + 1000
 
         sessionManager.setPreviousSessionCrashed(true)
         sessionManager.start()

--- a/ios/MeasureSDKTests/Utils/TimeProviderTests.swift
+++ b/ios/MeasureSDKTests/Utils/TimeProviderTests.swift
@@ -31,7 +31,7 @@ class TimeProviderTests: XCTestCase {
     }
 
     func testIso8601Timestamp_withCurrentTime() {
-        let timestamp = timeProvider.currentTimeSinceEpochInMillis
+        let timestamp = timeProvider.now()
         let isoTimestamp = timeProvider.iso8601Timestamp(timeInMillis: timestamp)
 
         XCTAssertTrue(isoTimestamp.matchesIso8601Pattern(), "The iso8601Timestamp should return a valid ISO 8601 formatted string.")

--- a/ios/TestApp/MockMeasureInitializer.swift
+++ b/ios/TestApp/MockMeasureInitializer.swift
@@ -63,7 +63,8 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                  timeProvider: timeProvider,
                                                  configProvider: configProvider,
                                                  sessionStore: sessionStore,
-                                                 userDefaultStorage: userDefaultStorage)
+                                                 userDefaultStorage: userDefaultStorage,
+                                                 versionCode: "1.0.0")
         self.appAttributeProcessor = AppAttributeProcessor()
         self.deviceAttributeProcessor = DeviceAttributeProcessor()
         self.installationIdAttributeProcessor = InstallationIdAttributeProcessor(userDefaultStorage: userDefaultStorage,


### PR DESCRIPTION
# Description

- update time creation logic to accommodate for clock skew
- create a new session if SDK version has been updated

## Related issue
Closes #1477 



