### PR TITLE
chore(android): collect all crashed session events and only launch & journey events for non-crashed sessions

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -37,6 +37,9 @@ internal data class Config(
         EventType.COLD_LAUNCH,
         EventType.HOT_LAUNCH,
         EventType.WARM_LAUNCH,
+        EventType.LIFECYCLE_ACTIVITY,
+        EventType.LIFECYCLE_FRAGMENT,
+        EventType.SCREEN_VIEW,
     )
     override val maxEventsInDatabase: Int = 50_000
 }

--- a/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
@@ -10,5 +10,5 @@ internal object DefaultConfig {
     val HTTP_URL_BLOCKLIST: List<String> = emptyList()
     val HTTP_URL_ALLOWLIST: List<String> = emptyList()
     const val TRACK_ACTIVITY_INTENT_DATA: Boolean = false
-    const val SESSION_SAMPLING_RATE: Float = 1.0f
+    const val SESSION_SAMPLING_RATE: Float = 0.0f
 }

--- a/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
@@ -108,8 +108,8 @@ class MeasureConfig(
     override val trackActivityIntentData: Boolean = DefaultConfig.TRACK_ACTIVITY_INTENT_DATA,
 
     /**
-     * Allows setting a sampling rate for non-crashed sessions. By default, all non-crashed
-     * sessions are always exported. Non-crashed sessions are ones which did not end due to an
+     * Allows setting a sampling rate for non-crashed sessions. By default, no non-crashed
+     * sessions are exported. Non-crashed sessions are ones which did not end due to an
      * unhandled exception or ANR.
      *
      * The sampling rate is a value between 0 and 1. For example, a value of `0.5` will export only 50%


### PR DESCRIPTION
# Description

* Update default session sampling rate to 0, meaning all events for non-crashed sessions will not be exported by default.
* Add `eventTypeExportAllowList` to include screen view, lifecycle activity and fragment events.

## Related issue
#1480


