### PR TITLE
fix(frontend): handle empty attr distributions

### DIFF
--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1108,7 +1108,7 @@ export const fetchExceptionsDistributionPlotFromServer = async (exceptionsType: 
 
         const data = await res.json()
 
-        if (data === null) {
+        if (data === null || Object.values(data).every(value => typeof value === 'object' && value !== null && Object.keys(value).length === 0)) {
             return { status: ExceptionsDistributionPlotApiStatus.NoData, data: null }
         }
 


### PR DESCRIPTION
# Description

Handles empty attribute distributions

Before:
<img width="1114" alt="before" src="https://github.com/user-attachments/assets/37cc6e53-27f9-4eb6-b6bf-2b66b7303c87">

After:
<img width="1151" alt="after" src="https://github.com/user-attachments/assets/a0d9f539-2c64-4996-9db0-11019cf12c1d">

## Related issue
Fixes #1475 



