### PR TITLE
fix(backend): incorrect pagination when no data

### DIFF
--- a/backend/api/measure/session.go
+++ b/backend/api/measure/session.go
@@ -497,15 +497,15 @@ func GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (sessions 
 
 	resultLen := len(sessions)
 
-	// handle pagination
+	// set pagination next & previous
+	// flags
 	if resultLen > af.Limit {
 		sessions = sessions[:resultLen-1]
 		next = true
 		if af.Offset >= af.Limit {
 			previous = true
 		}
-	} else if resultLen <= af.Limit {
-		next = false
+	} else if resultLen > 0 && resultLen <= af.Limit {
 		previous = true
 	}
 


### PR DESCRIPTION
## Summary

Fix an edge condition where `previous` would be set incorrectly to false when there are no results.

## See also

- fixes #1497 