### PR TITLE
chore(backend): change index type in sessions table

### DIFF
--- a/self-host/clickhouse/20241107074128_alter_sessions_table.sql
+++ b/self-host/clickhouse/20241107074128_alter_sessions_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+alter table sessions
+    drop index if exists user_id_bloom_idx;
+
+
+-- migrate:down
+alter table sessions
+    add index if not exists user_id_bloom_idx `user_id` type minmax granularity 2,
+    materialize index if exists user_id_bloom_idx;

--- a/self-host/clickhouse/20241107074259_alter_sessions_table.sql
+++ b/self-host/clickhouse/20241107074259_alter_sessions_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+alter table sessions
+    add index if not exists user_id_bloom_idx `user_id` type bloom_filter granularity 2,
+    materialize index if exists user_id_bloom_idx;
+
+
+-- migrate:down
+alter table sessions
+    drop index if exists user_id_bloom_idx;
+


### PR DESCRIPTION
> [!NOTE]
> 
> **Maintainers**, please [run ClickHouse migrations](https://github.com/measure-sh/measure/tree/main/self-host/clickhouse#running-clickhouse-migrations).

## Summary

Changed skip index type of `user_id` field in sessions table from `minmax` to `bloom_filter`.

## See also

- fixes #1504 