### PR TITLE
chore(backend): change postgres compose config

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -247,7 +247,7 @@ services:
 
   postgres:
     image: postgres:16.3-alpine
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Summary

Changed the configuration of `restart` setting of `postgres` compose service to restart unless stopped explicitly. This enables self host-ers to perform maintenance tasks when necessary.

## See also

- fixes #1508 