### PR TITLE
fix(backend): use specific clickhouse image version

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -263,7 +263,7 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24
+    image: clickhouse/clickhouse-server:24.10-alpine
     environment:
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
## Summary

Modified compose configuration to use a more specific `clickhouse/clickhouser-server:24.10-alpine` image version. This fixes issues when running backfills using `clickhouse-client` as the older `clickhouse-client` does not support multiline queries.

Pinning to a more specific version ensures that docker compose will always attempt to pull this version before starting the containers.