### PR TITLE
fix(android): initialization issues

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/NoopPeriodicEventExporter.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/NoopPeriodicEventExporter.kt
@@ -3,11 +3,11 @@ package sh.measure.android
 import sh.measure.android.exporter.PeriodicEventExporter
 
 internal class NoopPeriodicEventExporter : PeriodicEventExporter {
-    override fun onAppForeground() {
+    override fun resume() {
         // No-op
     }
 
-    override fun onAppBackground() {
+    override fun pause() {
         // No-op
     }
 

--- a/android/measure/src/main/java/sh/measure/android/events/EventProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/EventProcessor.kt
@@ -162,7 +162,7 @@ internal class EventProcessorImpl(
             onEventTracked(event)
             sessionManager.markCrashedSession(event.sessionId)
             exceptionExporter.export(event.sessionId)
-            logger.log(LogLevel.Debug, "Event processed: $type, ${event.sessionId}")
+            logger.log(LogLevel.Debug, "Event processed: $type, ${event.id}")
         } ?: logger.log(LogLevel.Debug, "Event dropped: $type")
     }
 
@@ -202,7 +202,7 @@ internal class EventProcessorImpl(
                                 onEventTracked(event)
                                 logger.log(
                                     LogLevel.Debug,
-                                    "Event processed: ${event.type}:${event.id}",
+                                    "Event processed: ${event.type}, ${event.id}",
                                 )
                             })
                         } else {

--- a/android/measure/src/main/java/sh/measure/android/exporter/PeriodicEventExporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/PeriodicEventExporter.kt
@@ -10,8 +10,9 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface PeriodicEventExporter {
-    fun onAppForeground()
-    fun onAppBackground()
+    fun register()
+    fun resume()
+    fun pause()
     fun unregister()
 }
 
@@ -41,7 +42,11 @@ internal class PeriodicEventExporterImpl(
         exportEvents()
     }
 
-    override fun onAppForeground() {
+    override fun register() {
+        heartbeat.start(intervalMs = configProvider.eventsBatchingIntervalMs)
+    }
+
+    override fun resume() {
         heartbeat.start(intervalMs = configProvider.eventsBatchingIntervalMs)
     }
 
@@ -49,7 +54,7 @@ internal class PeriodicEventExporterImpl(
         heartbeat.stop()
     }
 
-    override fun onAppBackground() {
+    override fun pause() {
         heartbeat.stop()
         exportEvents()
     }

--- a/android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangesCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/networkchange/NetworkChangesCollector.kt
@@ -109,11 +109,6 @@ internal class NetworkChangesCollector(
             systemServiceProvider.connectivityManager?.unregisterNetworkCallback(callback)
             networkCallback = null
         }
-        currentNetworkType = NetworkType.UNKNOWN
-        currentNetworkGeneration = NetworkGeneration.UNKNOWN
-        networkStateProvider.setNetworkState(
-            NetworkState(NetworkType.UNKNOWN, NetworkGeneration.UNKNOWN, NetworkProvider.UNKNOWN),
-        )
     }
 
     @RequiresApi(Build.VERSION_CODES.M)

--- a/android/measure/src/test/java/sh/measure/android/exporter/PeriodicEventExporterTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/PeriodicEventExporterTest.kt
@@ -40,7 +40,7 @@ class PeriodicEventExporterTest {
 
     @Test
     fun `starts heartbeat when app comes to foreground with a delay`() {
-        periodicEventExporter.onAppForeground()
+        periodicEventExporter.resume()
 
         verify(heartbeat, atMostOnce()).start(
             configProvider.eventsBatchingIntervalMs,
@@ -57,7 +57,7 @@ class PeriodicEventExporterTest {
 
     @Test
     fun `stops heartbeat when app goes to background`() {
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         verify(heartbeat, atMostOnce()).stop()
     }
@@ -71,7 +71,7 @@ class PeriodicEventExporterTest {
         batches[batch2.first] = batch2.second
         `when`(eventExporter.getExistingBatches()).thenReturn(batches)
 
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         verify(eventExporter).export(batch1.first, batch1.second)
         verify(eventExporter).export(batch2.first, batch2.second)
@@ -92,7 +92,7 @@ class PeriodicEventExporterTest {
             ),
         ).thenReturn(HttpResponse.Error.ServerError(500))
 
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         verify(eventExporter).export(batch1.first, batch1.second)
         verify(eventExporter, never()).export(batch2.first, batch2.second)
@@ -113,7 +113,7 @@ class PeriodicEventExporterTest {
             ),
         ).thenReturn(HttpResponse.Error.RateLimitError())
 
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         verify(eventExporter).export(batch1.first, batch1.second)
         verify(eventExporter, never()).export(batch2.first, batch2.second)
@@ -129,7 +129,7 @@ class PeriodicEventExporterTest {
         )
 
         // When
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         // Then
         verify(eventExporter).export("batchId", listOf("event1", "event2"))
@@ -146,7 +146,7 @@ class PeriodicEventExporterTest {
         testClock.advance(Duration.ofSeconds(29))
 
         // When
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         // Then
         verify(eventExporter, never()).export(any<String>(), any<List<String>>())
@@ -163,7 +163,7 @@ class PeriodicEventExporterTest {
         // forcefully mark an export in progress
         periodicEventExporter.isExportInProgress.set(true)
 
-        periodicEventExporter.onAppBackground()
+        periodicEventExporter.pause()
 
         verify(eventExporter, never()).export(any(), any())
     }


### PR DESCRIPTION
# Description

Fixes and improves initialization logic:

* add reentrant lock to heartbeat to avoid any potential race conditions
* use reentrant lock for SDK start/stop
* disable power state, network changes collection in background
* standardize function names for register/unregister/pause/resume
* unregister AppLifecycleCollector correctly

# Related Issue
#1532  
