### PR TITLE
fix(frontend): don't update filters on selectedApp change

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -707,7 +707,7 @@ const Filters: React.FC<FiltersProps> = ({
     sessionStorage.setItem(persistedFiltersStorageKey, JSON.stringify(updatedPersistedFilters))
     onFiltersChanged(updatedSelectedFilters)
     // updateUrlWithFilters(updatedSelectedFilters)
-  }, [appsApiStatus, filtersApiStatus, selectedApp, selectedStartDate, selectedEndDate, selectedVersions, selectedSessionType, selectedOsVersions, selectedCountries, selectedNetworkProviders, selectedNetworkTypes, selectedNetworkGenerations, selectedLocales, selectedDeviceManufacturers, selectedDeviceNames, selectedFreeText])
+  }, [filtersApiStatus, selectedStartDate, selectedEndDate, selectedVersions, selectedSessionType, selectedOsVersions, selectedCountries, selectedNetworkProviders, selectedNetworkTypes, selectedNetworkGenerations, selectedLocales, selectedDeviceManufacturers, selectedDeviceNames, selectedFreeText])
 
   return (
     <div>


### PR DESCRIPTION
# Description

Filters was sending a state update on selectedApp change as well as on the actual filter values changing.

This lead to creation of a short code with new app but old filter values causing bugs.

This commit only sends filter updates on filter value changes. Since values always get updated on selectedApp change, we will now get a single update on app + filter value changes.


## Related issue
Fixes #1557 



