### PR TITLE
fix(backend): filter versions and os versions securely

### DIFF
--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -1091,8 +1091,8 @@ func GetExceptionsWithFilter(ctx context.Context, group *group.ExceptionGroup, a
 		Select("attachments").
 		Select(fmt.Sprintf("row_number() over (order by timestamp %s, id) as row_num", order)).
 		Clause(prewhere, af.AppID, group.Fingerprint).
-		Where(fmt.Sprintf("(attribute.app_version, attribute.app_build) in (%s)", selectedVersions.String())).
-		Where(fmt.Sprintf("(attribute.os_name, attribute.os_version) in (%s)", selectedOSVersions.String())).
+		Where("(attribute.app_version, attribute.app_build) in (?)", selectedVersions.Parameterize()).
+		Where("(attribute.os_name, attribute.os_version) in (?)", selectedOSVersions.Parameterize()).
 		Where("type = ?", event.TypeException).
 		Where("exception.handled = false").
 		Where("inet.country_code in ?", af.Countries).
@@ -1361,8 +1361,8 @@ func GetANRsWithFilter(ctx context.Context, group *group.ANRGroup, af *filter.Ap
 		Select("attachments").
 		Select(fmt.Sprintf("row_number() over (order by timestamp %s, id) as row_num", order)).
 		Clause(prewhere, af.AppID, group.Fingerprint).
-		Where(fmt.Sprintf("(attribute.app_version, attribute.app_build) in (%s)", selectedVersions.String())).
-		Where(fmt.Sprintf("(attribute.os_name, attribute.os_version) in (%s)", selectedOSVersions.String())).
+		Where("(attribute.app_version, attribute.app_build) in (?)", selectedVersions.Parameterize()).
+		Where("(attribute.os_name, attribute.os_version) in (?)", selectedOSVersions.Parameterize()).
 		Where("type = ?", event.TypeANR).
 		Where("inet.country_code in ?", af.Countries).
 		Where("attribute.device_name in ?", af.DeviceNames).

--- a/backend/api/measure/session.go
+++ b/backend/api/measure/session.go
@@ -147,7 +147,7 @@ func GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter) (sessio
 			return nil, err
 		}
 
-		base.Where(fmt.Sprintf("app_version in (%s)", selectedVersions.String()))
+		base.Where("app_version in (?)", selectedVersions.Parameterize())
 	}
 
 	if af.HasOSVersions() {
@@ -156,7 +156,7 @@ func GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter) (sessio
 			return nil, err
 		}
 
-		base.Where(fmt.Sprintf("os_version in (%s)", selectedOSVersions.String()))
+		base.Where("os_version in (?)", selectedOSVersions.Parameterize())
 	}
 
 	if af.HasCountries() {
@@ -316,7 +316,7 @@ func GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (sessions 
 			return sessions, next, previous, err
 		}
 
-		stmt.Where(fmt.Sprintf("app_version in (%s)", selectedVersions.String()))
+		stmt.Where("app_version in (?)", selectedVersions.Parameterize())
 	}
 
 	if af.HasOSVersions() {
@@ -325,7 +325,7 @@ func GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (sessions 
 			return sessions, next, previous, err
 		}
 
-		stmt.Where(fmt.Sprintf("os_version in (%s)", selectedOSVersions.String()))
+		stmt.Where("os_version in (?)", selectedOSVersions.Parameterize())
 	}
 
 	if af.HasCountries() {

--- a/backend/api/pairs/pairs.go
+++ b/backend/api/pairs/pairs.go
@@ -2,6 +2,8 @@ package pairs
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -32,6 +34,27 @@ func NewPairs[T, U any](first []T, second []U) (*Pairs[T, U], error) {
 func (p *Pairs[T, U]) Add(first T, second U) {
 	p.first = append(p.first, first)
 	p.second = append(p.second, second)
+}
+
+// String returns a string representation of
+// a pairs.
+func (p Pairs[T, U]) String() string {
+	var b strings.Builder
+
+	// if there are no elements, return empty string
+	if len(p.first) == 0 {
+		return ""
+	}
+
+	for i := 0; i < len(p.first); i++ {
+		b.WriteString(fmt.Sprintf("('%v','%v')", p.first[i], p.second[i]))
+		// add separator between pairs, except the last pair
+		if i < len(p.first)-1 {
+			b.WriteString(",")
+		}
+	}
+
+	return b.String()
 }
 
 // Parameterize represents Pairs in a slice of clickhouse.GroupSet

--- a/backend/api/pairs/pairs.go
+++ b/backend/api/pairs/pairs.go
@@ -2,8 +2,8 @@ package pairs
 
 import (
 	"errors"
-	"fmt"
-	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 // Pairs is a tuple-like data structure
@@ -34,23 +34,17 @@ func (p *Pairs[T, U]) Add(first T, second U) {
 	p.second = append(p.second, second)
 }
 
-// String returns a string representation of
-// a pairs.
-func (p Pairs[T, U]) String() string {
-	var b strings.Builder
-
-	// if there are no elements, return empty string
+// Parameterize represents Pairs in a slice of clickhouse.GroupSet
+// for direct use in SQL queries.
+func (p Pairs[T, U]) Parameterize() (tuples []clickhouse.GroupSet) {
 	if len(p.first) == 0 {
-		return ""
+		return
 	}
 
 	for i := 0; i < len(p.first); i++ {
-		b.WriteString(fmt.Sprintf("('%v','%v')", p.first[i], p.second[i]))
-		// add separator between pairs, except the last pair
-		if i < len(p.first)-1 {
-			b.WriteString(",")
-		}
+		tuple := clickhouse.GroupSet{Value: []any{p.first[i], p.second[i]}}
+		tuples = append(tuples, tuple)
 	}
 
-	return b.String()
+	return
 }


### PR DESCRIPTION
## Summary

Handle versions & OS versions securely using database parameters when filtering.

## See also

- fixes #1562 