### PR TITLE
chore(backend): made span queries secure

### DIFF
--- a/backend/api/pairs/pairs.go
+++ b/backend/api/pairs/pairs.go
@@ -2,8 +2,6 @@ package pairs
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -34,27 +32,6 @@ func NewPairs[T, U any](first []T, second []U) (*Pairs[T, U], error) {
 func (p *Pairs[T, U]) Add(first T, second U) {
 	p.first = append(p.first, first)
 	p.second = append(p.second, second)
-}
-
-// String returns a string representation of
-// a pairs.
-func (p Pairs[T, U]) String() string {
-	var b strings.Builder
-
-	// if there are no elements, return empty string
-	if len(p.first) == 0 {
-		return ""
-	}
-
-	for i := 0; i < len(p.first); i++ {
-		b.WriteString(fmt.Sprintf("('%v','%v')", p.first[i], p.second[i]))
-		// add separator between pairs, except the last pair
-		if i < len(p.first)-1 {
-			b.WriteString(",")
-		}
-	}
-
-	return b.String()
 }
 
 // Parameterize represents Pairs in a slice of clickhouse.GroupSet

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -353,7 +353,7 @@ func GetSpanInstancesWithFilter(ctx context.Context, spanName string, af *filter
 			return rootSpans, next, previous, err
 		}
 
-		stmt.Where(fmt.Sprintf("attribute.app_version in (%s)", selectedVersions.String()))
+		stmt.Where("attribute.app_version in (?)", selectedVersions.Parameterize())
 	}
 
 	if af.HasOSVersions() {
@@ -362,7 +362,7 @@ func GetSpanInstancesWithFilter(ctx context.Context, spanName string, af *filter
 			return rootSpans, next, previous, err
 		}
 
-		stmt.Where(fmt.Sprintf("attribute.os_version in (%s)", selectedOSVersions.String()))
+		stmt.Where("attribute.os_version in (?)", selectedOSVersions.Parameterize())
 	}
 
 	if af.HasCountries() {
@@ -452,7 +452,7 @@ func GetSpanMetricsPlotWithFilter(ctx context.Context, spanName string, af *filt
 			return nil, err
 		}
 
-		stmt.Where(fmt.Sprintf("app_version in (%s)", selectedVersions.String()))
+		stmt.Where("app_version in (?)", selectedVersions.Parameterize())
 	}
 
 	if af.HasOSVersions() {
@@ -461,7 +461,7 @@ func GetSpanMetricsPlotWithFilter(ctx context.Context, spanName string, af *filt
 			return nil, err
 		}
 
-		stmt.Where(fmt.Sprintf("os_version in (%s)", selectedOSVersions.String()))
+		stmt.Where("os_version in (?)", selectedOSVersions.Parameterize())
 	}
 
 	if af.HasCountries() {

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -105,7 +105,7 @@ services:
       mc:
         condition: service_completed_successfully
         required: false
-  
+
   cleanup:
     build:
       context: ../backend/cleanup


### PR DESCRIPTION
## Summary

Update all references of previous Pairs.String method with Pairs.Parameterize method which prevents potential SQL security issues.