### PR TITLE
chore(frontend): truncate class names in session timeline event titles

### DIFF
--- a/frontend/dashboard/app/components/session_replay_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_replay_event_cell.tsx
@@ -57,15 +57,18 @@ export default function SessionReplayEventCell({
     }
 
     if (eventType === "gesture_long_click") {
-      return 'Long Click: ' + eventDetails.target
+      const name = eventDetails.target.includes(".") ? eventDetails.target.split('.').pop()! : eventDetails.target
+      return 'Long Click: ' + name
     }
 
     if (eventType === "gesture_scroll") {
-      return 'Scroll: ' + eventDetails.target
+      const name = eventDetails.target.includes(".") ? eventDetails.target.split('.').pop()! : eventDetails.target
+      return 'Scroll: ' + name
     }
 
     if (eventType === "gesture_click") {
-      return 'Click: ' + eventDetails.target
+      const name = eventDetails.target.includes(".") ? eventDetails.target.split('.').pop()! : eventDetails.target
+      return 'Click: ' + name
     }
 
     if (eventType === "http") {
@@ -73,11 +76,13 @@ export default function SessionReplayEventCell({
     }
 
     if (eventType === "lifecycle_activity") {
-      return 'Activity ' + formatToCamelCase(eventDetails.type) + ': ' + eventDetails.class_name
+      const name = eventDetails.class_name.includes(".") ? eventDetails.class_name.split('.').pop()! : eventDetails.class_name
+      return 'Activity ' + formatToCamelCase(eventDetails.type) + ': ' + name
     }
 
     if (eventType === "lifecycle_fragment") {
-      return 'Fragment ' + formatToCamelCase(eventDetails.type) + ': ' + eventDetails.class_name
+      const name = eventDetails.class_name.includes(".") ? eventDetails.class_name.split('.').pop()! : eventDetails.class_name
+      return 'Fragment ' + formatToCamelCase(eventDetails.type) + ': ' + name
     }
 
     if (eventType === "lifecycle_app") {


### PR DESCRIPTION
# Description

Truncates class names in session timeline event titles

<img width="1165" alt="Screenshot 2024-12-09 at 3 08 14 PM" src="https://github.com/user-attachments/assets/aaab97ef-636e-40b4-89e2-9d372850dfd2">

## Related issue
Closes #1561 



