### PR TITLE
fix(frontend): fix root span names api call

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -323,7 +323,7 @@ const Filters: React.FC<FiltersProps> = ({
 
   useEffect(() => {
     // Don't try to fetch trace names if selected app is not yet set or if FilterType is not span
-    if (selectedApp.id === "" && filtersApiType === FiltersApiType.Span) {
+    if (selectedApp.id === "" || filtersApiType !== FiltersApiType.Span) {
       return
     }
 


### PR DESCRIPTION
# Description

root span names api was being called on non-span filter type. This commit fixes the if condition to prevent this.

## Related issue
Fixes #1568 



