### PR TITLE
fix(frontend): round millis to nearest int

### DIFF
--- a/frontend/dashboard/__tests__/utils/time_utils.test.ts
+++ b/frontend/dashboard/__tests__/utils/time_utils.test.ts
@@ -31,6 +31,10 @@ describe('formatMillisToHumanReadable', () => {
         expect(formatMillisToHumanReadable(604799999)).toBe('6d, 23h, 59min, 59s, 999ms')
     })
 
+    it('should round decimal milliseconds to nearest int', () => {
+        expect(formatMillisToHumanReadable(500.920473)).toBe('501ms')
+    })
+
     it('should handle zero input', () => {
         expect(formatMillisToHumanReadable(0)).toBe('0ms')
     })

--- a/frontend/dashboard/app/utils/time_utils.ts
+++ b/frontend/dashboard/app/utils/time_utils.ts
@@ -31,7 +31,7 @@ export function formatMillisToHumanReadable(millis: number) {
   if (hours > 0) output += `${hours}h, `;
   if (minutes > 0) output += `${minutes}min, `;
   if (seconds > 0) output += `${seconds}s, `;
-  if (millis > 0) output += `${millis}ms`;
+  if (millis > 0) output += `${Math.round(millis)}ms`;
 
   return output.trim().replace(/,\s*$/, ''); // Remove trailing comma if any
 }


### PR DESCRIPTION
# Description

Rounds milliseconds to nearest int

## Related issue
Fixes #1574 



