### PR TITLE
feat(backend): support ios event ingestion

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -86,6 +86,10 @@ type Attribute struct {
 	// is running with thermal throttling enabled.
 	DeviceThermalThrottlingEnabled bool `json:"device_thermal_throttling_enabled"`
 
+	// DeviceCPUArch describes the CPU architecture
+	// of the device if available.
+	DeviceCPUArch string `json:"device_cpu_arch"`
+
 	// OSName is the operating system's name
 	OSName string `json:"os_name"`
 
@@ -136,7 +140,14 @@ func (a Attribute) Validate() error {
 		maxNetworkGenerationChars  = 8
 		maxNetworkProviderChars    = 64
 		maxDeviceLocaleChars       = 64
+		maxDeviceCPUArchChars      = 16
 	)
+
+	switch a.Platform {
+	case platform.Android, platform.IOS:
+	default:
+		return fmt.Errorf(`%q does not contain a valid platform value`, `attribute.platform`)
+	}
 
 	if len(a.AppVersion) > maxAppVersionChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_version`, maxAppVersionChars)
@@ -152,9 +163,6 @@ func (a Attribute) Validate() error {
 	}
 	if len(a.MeasureSDKVersion) > maxMeasureSDKVersion {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.measure_sdk_version`, maxMeasureSDKVersion)
-	}
-	if a.Platform != platform.Android && a.Platform != platform.IOS {
-		return fmt.Errorf(`%q does not contain a valid platform value`, `attribute.platform`)
 	}
 	if len(a.ThreadName) > maxThreadNameChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.thread_name`, maxThreadNameChars)
@@ -176,6 +184,9 @@ func (a Attribute) Validate() error {
 	}
 	if len(a.DeviceLocale) > maxDeviceLocaleChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_locale`, maxDeviceLocaleChars)
+	}
+	if len(a.DeviceCPUArch) > maxDeviceCPUArchChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.device_cpu_arch`, maxDeviceCPUArchChars)
 	}
 	if len(a.OSName) > maxOSNameChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.os_name`, maxOSNameChars)

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -646,6 +646,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			Set(`attribute.device_locale`, e.events[i].Attribute.DeviceLocale).
 			Set(`attribute.device_low_power_mode`, e.events[i].Attribute.DeviceLowPowerMode).
 			Set(`attribute.device_thermal_throttling_enabled`, e.events[i].Attribute.DeviceThermalThrottlingEnabled).
+			Set(`attribute.device_cpu_arch`, e.events[i].Attribute.DeviceCPUArch).
 			Set(`attribute.os_name`, e.events[i].Attribute.OSName).
 			Set(`attribute.os_version`, e.events[i].Attribute.OSVersion).
 			Set(`attribute.os_page_size`, e.events[i].Attribute.OSPageSize).
@@ -824,6 +825,28 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				Set(`lifecycle_fragment.tag`, nil)
 		}
 
+		// lifecycle view controller
+		if e.events[i].IsLifecycleViewController() {
+			row.
+				Set(`lifecycle_view_controller.type`, e.events[i].LifecycleViewController.Type).
+				Set(`lifecycle_view_controller.class_name`, e.events[i].LifecycleViewController.ClassName)
+		} else {
+			row.
+				Set(`lifecycle_view_controller.type`, nil).
+				Set(`lifecycle_view_controller.class_name`, nil)
+		}
+
+		// lifecycle swift ui
+		if e.events[i].IsLifecycleSwiftUI() {
+			row.
+				Set(`lifecycle_swift_ui.type`, e.events[i].LifecycleSwiftUI.Type).
+				Set(`lifecycle_swift_ui.class_name`, e.events[i].LifecycleSwiftUI.ClassName)
+		} else {
+			row.
+				Set(`lifecycle_swift_ui.type`, nil).
+				Set(`lifecycle_swift_ui.class_name`, nil)
+		}
+
 		// lifecycle app
 		if e.events[i].IsLifecycleApp() {
 			row.
@@ -971,6 +994,19 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				Set(`memory_usage.native_total_heap`, nil).
 				Set(`memory_usage.native_free_heap`, nil).
 				Set(`memory_usage.interval`, nil)
+		}
+
+		// memory usage absolute
+		if e.events[i].IsMemoryUsageAbs() {
+			row.
+				Set(`memory_usage_absolute.max_memory`, e.events[i].MemoryUsageAbs.MaxMemory).
+				Set(`memory_usage_absolute.used_memory`, e.events[i].MemoryUsageAbs.UsedMemory).
+				Set(`memory_usage.interval`, e.events[i].MemoryUsageAbs.Interval)
+		} else {
+			row.
+				Set(`memory_usage_absolute.max_memory`, nil).
+				Set(`memory_usage_absolute.used_memory`, nil).
+				Set(`memory_usage_absolute.interval`, nil)
 		}
 
 		// low memory

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -332,8 +332,8 @@ Events can contain the following attributes, some of which are mandatory.
 | `device_height_px`                  | uint16  | Yes      | Screen height                                                               |
 | `device_density`                    | float32 | Yes      | Device density                                                              |
 | `device_locale`                     | string  | Yes      | Locale based on RFC 5646, eg. en-US                                         |
-| `device_low_power_mode`             | string  | Yes      | `true` when low power mode is enabled                                       |
-| `device_thermal_throttling_enabled` | string  | Yes      | `true` when thermal throttling is enabled                                   |
+| `device_low_power_mode`             | bool    | Yes      | `true` when low power mode is enabled                                       |
+| `device_thermal_throttling_enabled` | bool    | Yes      | `true` when thermal throttling is enabled                                   |
 | `os_name`                           | string  | Yes      | Operating system name                                                       |
 | `os_version`                        | string  | Yes      | Operating system version                                                    |
 | `os_page_size`                      | uint8   | Yes      | Operating system memory page size                                           |
@@ -652,10 +652,10 @@ Use the `lifecycle_view_controller` type for iOS ViewController lifecycle events
 
 Use the `lifecycle_swift_ui` type for iOS SwiftUI view lifecycle events.
 
-| Field       | Type   | Optional | Comment                                                        |
-| ----------- | ------ | -------- | -------------------------------------------------------------- |
-| `type`      | string | No       | One of the following:<br />- `on_appear`<br />- `on_disappear` |
-| `view_name` | string | No       | SwiftUI View class name                                        |
+| Field        | Type   | Optional | Comment                                                        |
+| ------------ | ------ | -------- | -------------------------------------------------------------- |
+| `type`       | string | No       | One of the following:<br />- `on_appear`<br />- `on_disappear` |
+| `class_name` | string | No       | SwiftUI View class name                                        |
 
 #### **`lifecycle_app`**
 

--- a/self-host/clickhouse/20241210052709_alter_events_table.sql
+++ b/self-host/clickhouse/20241210052709_alter_events_table.sql
@@ -1,0 +1,30 @@
+-- migrate:up
+alter table events
+    add column if not exists `attribute.device_cpu_arch` LowCardinality(FixedString(16)) after `attribute.device_thermal_throttling_enabled`,
+    add column if not exists `lifecycle_view_controller.type` LowCardinality(FixedString(32)) after `lifecycle_fragment.tag`,
+    add column if not exists `lifecycle_view_controller.class_name` LowCardinality(FixedString(128)) after `lifecycle_view_controller.type`,
+    add column if not exists `lifecycle_swift_ui.type` LowCardinality(FixedString(16)) after `lifecycle_view_controller.class_name`,
+    add column if not exists `lifecycle_swift_ui.class_name` LowCardinality(FixedString(128)) after `lifecycle_swift_ui.type`,
+    add column if not exists `memory_usage_absolute.max_memory` UInt64 after `memory_usage.interval`,
+    add column if not exists `memory_usage_absolute.used_memory` UInt64 after `memory_usage_absolute.max_memory`,
+    add column if not exists `memory_usage_absolute.interval` UInt64 after `memory_usage_absolute.used_memory`,
+    comment column `attribute.device_cpu_arch` 'cpu architecture like arm64 and so on',
+    comment column `lifecycle_view_controller.type` 'type of the iOS ViewController lifecycle event',
+    comment column `lifecycle_view_controller.class_name` 'class name of the iOS ViewController lifecycle event',
+    comment column `lifecycle_swift_ui.type` 'type of the iOS SwiftUI view lifecycle event',
+    comment column `lifecycle_swift_ui.class_name` 'class name of the iOS SwiftUI view lifecycle event',
+    comment column `memory_usage_absolute.max_memory` 'maximum memory available to the application, in KiB',
+    comment column `memory_usage_absolute.used_memory` 'used memory by the application, in KiB',
+    comment column `memory_usage_absolute.interval` 'interval between two consecutive readings';
+
+
+-- migrate:down
+alter table events
+  drop column if exists `attribute.device_cpu_arch`,
+  drop column if exists `lifecycle_view_controller.type`,
+  drop column if exists `lifecycle_view_controller.class_name`,
+  drop column if exists `lifecycle_swift_ui.type`,
+  drop column if exists `lifecycle_swift_ui.class_name`,
+  drop column if exists `memory_usage_absolute.max_memory`,
+  drop column if exists `memory_usage_absolute.used_memory`,
+  drop column if exists `memory_usage_absolute.interval`;

--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -135,7 +135,7 @@ func ValidateFlags() bool {
 func IngestSerial(apps *app.Apps, origin string) {
 	startTime := time.Now()
 	eventURL := fmt.Sprintf("%s/events", origin)
-	mappingURL := fmt.Sprintf("%s/builds", origin)
+	buildURL := fmt.Sprintf("%s/builds", origin)
 	virtualizer := NewVirtualizer()
 
 	for _, app := range apps.Items {
@@ -149,7 +149,7 @@ func IngestSerial(apps *app.Apps, origin string) {
 		apiKey := configData.Apps[app.Name].ApiKey
 
 		fmt.Printf("Uploading build info...")
-		status, err := UploadBuild(mappingURL, apiKey, app)
+		status, err := UploadBuild(buildURL, apiKey, app)
 		if err != nil {
 			if status == "" {
 				status = err.Error()
@@ -196,7 +196,7 @@ func IngestSerial(apps *app.Apps, origin string) {
 func IngestParallel(apps *app.Apps, origin string) {
 	startTime := time.Now()
 	eventURL := fmt.Sprintf("%s/events", origin)
-	mappingURL := fmt.Sprintf("%s/builds", origin)
+	buildURL := fmt.Sprintf("%s/builds", origin)
 
 	var logResults = func(results *[]string) {
 		for _, result := range *results {
@@ -216,7 +216,7 @@ func IngestParallel(apps *app.Apps, origin string) {
 		apiKey := configData.Apps[app.Name].ApiKey
 
 		fmt.Printf("Uploading build info...")
-		status, err := UploadBuild(mappingURL, apiKey, app)
+		status, err := UploadBuild(buildURL, apiKey, app)
 		if err != nil {
 			if status == "" {
 				status = err.Error()
@@ -426,12 +426,12 @@ func prepareEventsAndSpans(eventAndSpanFile string, virtualizer *virtualizer) (d
 	}
 
 	if len(rawEvents) != len(fileData.Events) {
-		err = fmt.Errorf("mismatch found in number of events while preparing events request")
+		err = errors.New("mismatch found in number of events while preparing events request")
 		return
 	}
 
 	if len(rawSpans) != len(fileData.Spans) {
-		err = fmt.Errorf("mismatch found in number of spans while preparing spans request")
+		err = errors.New("mismatch found in number of spans while preparing spans request")
 		return
 	}
 

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -48,7 +48,7 @@ var recordCmd = &cobra.Command{
 	Use:   "record",
 	Short: "Records events & builds",
 	Long: `Records events & builds to disk.
-	
+
 Structue of "session-data" directory once written:` + "\n" + DirTree() + "\n" + ValidNote(),
 	Run: func(cmd *cobra.Command, args []string) {
 		r := gin.Default()


### PR DESCRIPTION
## Summary

Support ingesting iOS events in the PUT `/events` API.

## Tasks

- [x] Add support for `attribute.device_cpu_arch` event attribute
- [x] Add `lifecycle_view_controller` iOS event
- [x] Add `lifecycle_swift_ui` iOS event
- [x] Add `memory_usage_absolute` iOS event
- [x] Refactor & improve event ingestion validation
- [x] :books: Update SDK API documentation

## See also

- fixes #1586
- #1118
- #1139