### PR TITLE
fix(backend): validate required event & span attributes

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -149,6 +149,26 @@ func (a Attribute) Validate() error {
 		return fmt.Errorf(`%q does not contain a valid platform value`, `attribute.platform`)
 	}
 
+	if a.InstallationID == uuid.Nil {
+		return fmt.Errorf(`%q must not be empty`, `attribute.installation_id`)
+	}
+
+	if a.MeasureSDKVersion == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.measure_sdk_version`)
+	}
+
+	if a.AppVersion == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_version`)
+	}
+
+	if a.AppBuild == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_build`)
+	}
+
+	if a.AppUniqueID == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_unique_id`)
+	}
+
 	if len(a.AppVersion) > maxAppVersionChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_version`, maxAppVersionChars)
 	}

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -198,6 +198,26 @@ func (s *SpanField) Validate() error {
 		return fmt.Errorf(`%q must be a valid ISO 8601 timestamp`, `end_time`)
 	}
 
+	if s.Attributes.InstallationID == uuid.Nil {
+		return fmt.Errorf(`%q must be a valid UUID`, `attribute.installation_id`)
+	}
+
+	if s.Attributes.MeasureSDKVersion == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.measure_sdk_version`)
+	}
+
+	if s.Attributes.AppVersion == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_version`)
+	}
+
+	if s.Attributes.AppBuild == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_build`)
+	}
+
+	if s.Attributes.AppUniqueID == "" {
+		return fmt.Errorf(`%q must not be empty`, `attribute.app_unique_id`)
+	}
+
 	if len(s.Attributes.AppUniqueID) > maxAppUniqueIDChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
 	}
@@ -234,8 +254,10 @@ func (s *SpanField) Validate() error {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `platform`, maxPlatformChars)
 	}
 
-	if s.Attributes.Platform != platform.Android && s.Attributes.Platform != platform.IOS {
-		return fmt.Errorf(`%q does not contain a valid platform value`, `platform`)
+	switch s.Attributes.Platform {
+	case platform.Android, platform.IOS:
+	default:
+		return fmt.Errorf(`%q does not contain a valid platform value`, `attribute.platform`)
 	}
 
 	if len(s.Attributes.ThreadName) > maxThreadNameChars {


### PR DESCRIPTION
## Summary

Validate all required event & span attributes before ingestion.

## Tasks

- [x] Refactor `attribute.platform` validation to be consistent between event and span attributes.
- [x] Validate `attribute.installation_id`
- [x] Validate `attribute.measure_sdk_version`
- [x] Validate `attribute.app_version`
- [x] Validate `attribute.app_build`
- [x] Validate `attribute.app_unique_id`

## See also

- fixes #1589