### PR TITLE
fix(backend): improve ios support

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -38,7 +38,7 @@ const (
 	maxLifecycleFragmentTypeChars             = 32
 	maxLifecycleFragmentClassNameChars        = 128
 	maxLifecycleViewControllerTypeChars       = 32
-	maxLifecycleViewControllerClassNameChars  = 128
+	maxLifecycleViewControllerClassNameChars  = 256
 	maxLifecycleSwiftUITypeChars              = 32
 	maxLifecycleSwiftUIClassNameChars         = 128
 	maxLifecycleAppTypeChars                  = 32
@@ -159,6 +159,7 @@ var iOSValidTypes = []string{
 	TypeException,
 	TypeGestureLongClick, TypeGestureScroll, TypeGestureClick,
 	TypeLifecycleViewController, TypeLifecycleSwiftUI,
+	TypeLifecycleApp,
 	TypeColdLaunch, TypeWarmLaunch, TypeHotLaunch,
 	TypeNetworkChange, TypeHttp,
 	TypeMemoryUsageAbs,

--- a/backend/api/measure/mapping.go
+++ b/backend/api/measure/mapping.go
@@ -211,7 +211,7 @@ type BuildSize struct {
 	VersionName string `form:"version_name" binding:"required"`
 	VersionCode string `form:"version_code" binding:"required"`
 	BuildSize   int    `form:"build_size" binding:"required_with=BuildType,gt=100"`
-	BuildType   string `form:"build_type" binding:"required_with=BuildSize,oneof=aab apk"`
+	BuildType   string `form:"build_type" binding:"required_with=BuildSize,oneof=aab apk ipa"`
 	CreatedAt   chrono.ISOTime
 }
 

--- a/self-host/clickhouse/20241210052709_alter_events_table.sql
+++ b/self-host/clickhouse/20241210052709_alter_events_table.sql
@@ -2,9 +2,9 @@
 alter table events
     add column if not exists `attribute.device_cpu_arch` LowCardinality(FixedString(16)) after `attribute.device_thermal_throttling_enabled`,
     add column if not exists `lifecycle_view_controller.type` LowCardinality(FixedString(32)) after `lifecycle_fragment.tag`,
-    add column if not exists `lifecycle_view_controller.class_name` LowCardinality(FixedString(128)) after `lifecycle_view_controller.type`,
+    add column if not exists `lifecycle_view_controller.class_name` LowCardinality(FixedString(256)) after `lifecycle_view_controller.type`,
     add column if not exists `lifecycle_swift_ui.type` LowCardinality(FixedString(16)) after `lifecycle_view_controller.class_name`,
-    add column if not exists `lifecycle_swift_ui.class_name` LowCardinality(FixedString(128)) after `lifecycle_swift_ui.type`,
+    add column if not exists `lifecycle_swift_ui.class_name` LowCardinality(FixedString(256)) after `lifecycle_swift_ui.type`,
     add column if not exists `memory_usage_absolute.max_memory` UInt64 after `memory_usage.interval`,
     add column if not exists `memory_usage_absolute.used_memory` UInt64 after `memory_usage_absolute.max_memory`,
     add column if not exists `memory_usage_absolute.interval` UInt64 after `memory_usage_absolute.used_memory`,


### PR DESCRIPTION
## Summary

Improve upon a couple of parts of the iOS ingestion pipeline to be compatible with idiosyncrasies of iOS.

## Tasks

- [x] Support ipa build type in PUT `/builds` API
- [x] Increase `lifecycle_view_controller.class_name` character size to 256
- [x] Increase `lifecycle_swift_ui.class_name` character size to 256