### PR TITLE
fix(backend): unexpected shortcodes gets created sometimes

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -6,8 +6,6 @@ import (
 	"backend/api/server"
 	"backend/api/text"
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -186,20 +184,6 @@ type FilterList struct {
 	UDExpressionRaw     string            `json:"ud_expression"`
 }
 
-// Hash generates an MD5 hash of the FilterList struct.
-func (f *FilterList) Hash() (string, error) {
-	data, err := json.Marshal(f)
-	if err != nil {
-		return "", err
-	}
-
-	// Compute MD5 hash
-	md5Hash := md5.Sum(data)
-
-	// Convert hash to hex string
-	return hex.EncodeToString(md5Hash[:]), nil
-}
-
 // Versions represents a list of
 // (version, code) pairs.
 type Versions struct {
@@ -313,6 +297,7 @@ func (af *AppFilter) Expand(ctx context.Context) (err error) {
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return
 		}
+
 		// it's critical to set err to nil
 		err = nil
 	}

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -5180,9 +5180,12 @@ func CreateShortFilters(c *gin.Context) {
 		return
 	}
 
-	shortFilters, err := filter.NewShortFilters(appId, payload.Filters)
+	// embed app id in filter payload
+	payload.AppID = appId
+
+	shortFilters, err := filter.NewShortFilters(payload)
 	if err != nil {
-		msg := `failed to create generate filter hash`
+		msg := `failed to create filter hash`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": msg,


### PR DESCRIPTION
## Summary

When there are 2 apps with the exact same filter structure and values, the POST `/apps/:id/shortFilters` API mistakenly returns the matching short code which can be associated incorrectly with a different app. When this incorrect short code is then used in further APIs like GET `/apps/:id/metrics` and so on, they raise further errors.

This PR, includes the `appId` in the filter short code generation. This way, the generated code always remains unique for each app and hence can be safely used as the primary key of the `short_filters` table.

## Tasks

- [x] Include `app_id` in the short code hash generation

## See also

- fixes #1602