### PR TITLE
fix(frontend): place span durations above bar

### DIFF
--- a/frontend/dashboard/app/components/trace_viz.tsx
+++ b/frontend/dashboard/app/components/trace_viz.tsx
@@ -345,37 +345,48 @@ const TraceViz: React.FC<TraceVizProps> = ({ inputTrace }) => {
         {/* spans column */}
         <div className='flex flex-col w-[800px] select-none'>
           {trace.spans.filter((span) => span.visibility !== SpanVisibility.Hidden).map((span, spanIndex) => (
-            <div key={span.span_id} className={`w-full ${spanIndex % 2 === 0 ? 'bg-zinc-50' : ''}`}>
-              {/* span */}
-              <div style={{
-                marginLeft: `${span.leftOffset}px`,
-                width: `${span.width}px`,
-              }}
-                className={`h-6 mt-2 ${bgSpanColorMap.get(span.span_id)} ${span === selectedSpan ? "bg-neutral-800 hover:bg-neutral-950 text-white" : ""} select-none`}
-                onClick={() => {
-                  if (selectedSpan === undefined || selectedSpan !== span) {
-                    setSelectedSpan(span)
-                  } else {
-                    setSelectedSpan(undefined)
-                    setSelectedCheckpoint(undefined)
-                  }
+            <div key={span.span_id} className={`w-full h-12 ${spanIndex % 2 === 0 ? 'bg-zinc-50' : ''}`}>
+              {/* span and duration container */}
+              <div>
+
+                {/* duration */}
+                <p className={`text-xs mt-1 pr-1 overflow-x-auto`}
+                  style={{
+                    marginLeft: `${span.leftOffset}px`,
+                  }}>
+                  {span.duration}ms
+                </p>
+
+                {/* span */}
+                <div style={{
+                  marginLeft: `${span.leftOffset}px`,
+                  width: `${span.width}px`,
                 }}
-              >
-                <p className={`text-xs pl-2 py-1`}>{span.duration}ms</p>
+                  className={`h-3 mt-1 ${bgSpanColorMap.get(span.span_id)} ${span === selectedSpan ? "bg-neutral-800 hover:bg-neutral-950" : ""} select-none`}
+                  onClick={() => {
+                    if (selectedSpan === undefined || selectedSpan !== span) {
+                      setSelectedSpan(span)
+                    } else {
+                      setSelectedSpan(undefined)
+                      setSelectedCheckpoint(undefined)
+                    }
+                  }}
+                >
+                </div>
               </div>
 
               {/* checkpoints */}
               <div style={{
                 marginLeft: `${span.leftOffset}px`,
                 width: `${span.width}px`,
-              }} className="relative h-2 mb-2">
+              }} className="relative">
                 {span.checkpoints.map((checkpoint, _) => (
                   <div
                     key={span.span_id + checkpoint.name}
                     style={{
                       left: `${checkpoint.leftOffset}px`,
                       top: '0px'
-                    }} className={`w-0.5 h-2 rounded-full absolute mt-1 ${bgCheckPointColorMap.get(span.span_id)} ${checkpoint === selectedCheckpoint ? "bg-neutral-800 hover:bg-neutral-950" : ""}`}
+                    }} className={`w-0.5 h-2 rounded-full absolute mt-0.5 mb-0.5 ${bgCheckPointColorMap.get(span.span_id)} ${checkpoint === selectedCheckpoint ? "bg-neutral-800 hover:bg-neutral-950" : ""}`}
                     onClick={() => {
                       if (selectedCheckpoint === undefined) {
                         setSelectedSpan(span)


### PR DESCRIPTION
# Description

Span duration display on bar had several issues:

- text overflowing the span bar
- text color change in selected state not being visible in the overflowing part
- spans at end of trace not having enough space to render text

In this commit, we render the text above the bar.
Now, text color does not need to change in selected state and for spans near the end of the trace, text becomes horizontally scrollable.

<img width="1195" alt="Screenshot 2024-12-12 at 4 15 17 PM" src="https://github.com/user-attachments/assets/160a2ea8-5968-46f1-bace-6a938887056c" />

## Related issue
Fixes #1595 



