### PR TITLE
feat(frontend): add memory usage absolute plot in session timeline

### DIFF
--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -635,6 +635,14 @@ export const emptySessionReplay = {
             "timestamp": ""
         }
     ],
+    "memory_usage_absolute": [
+        {
+            "max_memory": 0,
+            "used_memory": 0,
+            "interval": 0,
+            "timestamp": ""
+        }
+    ],
     "session_id": "",
     "threads": {
         "main": [


### PR DESCRIPTION
## Summary

This PR adds a memory usage plot for `memory_usage_abolute` events in session timeline detail page. Additionally, it fixes the legend to say 'KB' instead of 'MB'.

## Tasks

- [x] Add `memory_usage_absolute` events on session timeline plot
- [x] Change plot legend to say 'KB' instead of 'MB'

## See also

- fixes #1619