### PR TITLE
feat(android): expose API to get current session ID

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -12,6 +12,7 @@ public final class sh/measure/android/Measure {
 	public static final fun clearUserId ()V
 	public final fun createSpanBuilder (Ljava/lang/String;)Lsh/measure/android/tracing/SpanBuilder;
 	public final fun getCurrentTime ()J
+	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getTraceParentHeaderKey ()Ljava/lang/String;
 	public final fun getTraceParentHeaderValue (Lsh/measure/android/tracing/Span;)Ljava/lang/String;
 	public static final fun init (Landroid/content/Context;)V

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -415,6 +415,23 @@ object Measure {
         }
     }
 
+    /**
+     * Returns the session ID for the current session, or null if the SDK has not been initialized.
+     *
+     * A session represents a continuous period of activity in the app. A new session begins
+     * when an app is launched for the first time, or when there's been no activity for a
+     * 20-minute period. A single session can continue across multiple app background and
+     * foreground events; brief interruptions will not cause a new session to be created.
+     *
+     * @return session ID if the SDK is initialized, null otherwise.
+     */
+    fun getSessionId(): String? {
+        if (isInitialized.get()) {
+            return measure.getSessionId()
+        }
+        return null
+    }
+
     internal fun getOkHttpEventCollector(): OkHttpEventCollector? {
         if (isInitialized.get()) {
             return try {

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -216,6 +216,14 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
         return spanCollector.getTraceParentHeaderKey()
     }
 
+    fun getSessionId(): String? {
+        return try {
+            sessionManager.getSessionId()
+        } catch (e: IllegalArgumentException) {
+            return null
+        }
+    }
+
     private fun unregisterCollectors() {
         unhandledExceptionCollector.unregister()
         anrCollector.unregister()

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -287,6 +287,12 @@ or when there's been no activity for a 20-minute period. A single session can co
 foreground events; brief interruptions will not cause a new session to be created. This approach is helpful when reviewing
 session replays, as it shows the app switching between background and foreground states within the same session.
 
+The current session can be retrived by using `getSessionId` method.
+
+```kotlin
+val sessionId = Measure.getSessionId()
+```
+
 
 # Performance Impact
 


### PR DESCRIPTION
# Description

Exposes a new public API to get current session ID.

## Related issue
Fixes #1631 



