### PR TITLE
fix(backend): handle large numbers in user defined attributes gracefully

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.23.x"]
+        go-version: ["1.22.x", "1.23.x"]
     defaults:
       run:
         working-directory: backend/api
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.23.x"]
+        go-version: ["1.22.x", "1.23.x"]
     defaults:
       run:
         working-directory: backend/api

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22.x"]
+        go-version: ["1.23.x"]
     defaults:
       run:
         working-directory: backend/api
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22.x"]
+        go-version: ["1.23.x"]
     defaults:
       run:
         working-directory: backend/api
@@ -73,7 +73,7 @@ jobs:
         run: go get .
       - name: Test with ${{ matrix.go-version }}
         run: go test ./...
-  
+
   push:
     name: Build and push image
     runs-on: ubuntu-latest

--- a/backend/api/event/userdefattr.go
+++ b/backend/api/event/userdefattr.go
@@ -567,13 +567,16 @@ func (u *UDAttribute) Parameterize() (attr map[string]string) {
 
 	val := ""
 
+	fmt.Println("maxInt64", math.MaxInt64)
+	fmt.Println("minInt64", math.MinInt64)
+
 	for k, v := range u.rawAttrs {
 		switch v := v.(type) {
 		case bool:
 			val = strconv.FormatBool(v)
 		case float64:
 			var intVal int64
-			if math.Trunc(v) == v && v >= math.MinInt64 && v <= math.MaxInt64 {
+			if v == float64(int64(v)) && v >= math.MinInt64 && v <= math.MaxInt64 {
 				// if v >= math.MaxInt64 {
 				// 	intVal = math.MaxInt64
 				// } else if v <= math.MinInt64 {

--- a/backend/api/event/userdefattr.go
+++ b/backend/api/event/userdefattr.go
@@ -572,12 +572,24 @@ func (u *UDAttribute) Parameterize() (attr map[string]string) {
 		case bool:
 			val = strconv.FormatBool(v)
 		case float64:
-			if math.Trunc(v) == v && v <= math.MaxInt64 && v >= math.MinInt64 {
+			var intVal int64
+			if math.Trunc(v) == v && v >= math.MinInt64 && v <= math.MaxInt64 {
+				// if v >= math.MaxInt64 {
+				// 	intVal = math.MaxInt64
+				// } else if v <= math.MinInt64 {
+				// 	intVal = math.MinInt64
+				// } else {
+				// 	intVal = int64(v)
+				// }
+				// if (v >= math.MinInt64 && v <= math.MaxInt64)
 				// only base 10 numbers are supported
 				// right now
-				val = strconv.FormatInt(int64(v), 10)
+				intVal = int64(v)
+				val = strconv.FormatInt(intVal, 10)
+				fmt.Println("int parsed", val)
 			} else {
 				val = strconv.FormatFloat(v, 'g', -1, 64)
+				fmt.Println("float parsed", val)
 			}
 		case int64:
 			// usually, this case won't hit

--- a/backend/api/event/userdefattr_test.go
+++ b/backend/api/event/userdefattr_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -654,6 +655,202 @@ func TestAugmentExpression(t *testing.T) {
 
 		if !reflect.DeepEqual(expectedArgs, gotArgs) {
 			t.Errorf("Expected %+#v args, got %+#v", expectedArgs, gotArgs)
+		}
+	}
+}
+
+func TestParameterize(t *testing.T) {
+	udAttr := &UDAttribute{
+		rawAttrs: map[string]any{
+			"max_int32":                float64(2147483647),
+			"min_int32":                float64(-2147483648),
+			"max_int64":                float64(9223372036854775807),
+			"min_int64":                float64(-9223372036854775808),
+			"max_float64":              float64(1.7976931348623157e+308),
+			"min_float64":              float64(5e-324),
+			"max_safe_integer":         float64(9007199254740991),
+			"min_safe_integer":         float64(-9007199254740991),
+			"regular_negative_float64": float64(-3.141519),
+			"regular_positive_float64": float64(3.141519),
+			"regular_negative_int64":   float64(-4200),
+			"regular_positive_int64":   float64(4200),
+			"zero_float64":             float64(0.0),
+			"zero_int64":               float64(0),
+			"regular_bool":             true,
+			"regular_string":           "lorem ipsum",
+		},
+		keyTypes: map[string]AttrType{
+			"max_int32":                AttrInt64,
+			"min_int32":                AttrInt64,
+			"max_int64":                AttrInt64,
+			"min_int64":                AttrInt64,
+			"max_float64":              AttrFloat64,
+			"min_float64":              AttrFloat64,
+			"max_safe_integer":         AttrInt64,
+			"min_safe_integer":         AttrInt64,
+			"regular_negative_float64": AttrFloat64,
+			"regular_positive_float64": AttrFloat64,
+			"regular_negative_int64":   AttrInt64,
+			"regular_positive_int64":   AttrInt64,
+			"zero_float64":             AttrInt64,
+			"zero_int64":               AttrInt64,
+			"regular_bool":             AttrBool,
+			"regular_string":           AttrString,
+		},
+	}
+
+	expected := map[string]string{
+		"max_int32":                fmt.Sprintf(`('%s', '2147483647')`, AttrInt64.String()),
+		"min_int32":                fmt.Sprintf(`('%s', '-2147483648')`, AttrInt64.String()),
+		"max_int64":                fmt.Sprintf(`('%s', '9223372036854775807')`, AttrInt64.String()),
+		"min_int64":                fmt.Sprintf(`('%s', '-9223372036854775808')`, AttrInt64.String()),
+		"max_float64":              fmt.Sprintf(`('%s', '1.7976931348623157e+308')`, AttrFloat64.String()),
+		"min_float64":              fmt.Sprintf(`('%s', '5e-324')`, AttrFloat64.String()),
+		"max_safe_integer":         fmt.Sprintf(`('%s', '9007199254740991')`, AttrInt64.String()),
+		"min_safe_integer":         fmt.Sprintf(`('%s', '-9007199254740991')`, AttrInt64.String()),
+		"regular_negative_float64": fmt.Sprintf(`('%s', '-3.141519')`, AttrFloat64.String()),
+		"regular_positive_float64": fmt.Sprintf(`('%s', '3.141519')`, AttrFloat64.String()),
+		"regular_negative_int64":   fmt.Sprintf(`('%s', '-4200')`, AttrInt64.String()),
+		"regular_positive_int64":   fmt.Sprintf(`('%s', '4200')`, AttrInt64.String()),
+		"zero_float64":             fmt.Sprintf(`('%s', '0')`, AttrInt64.String()),
+		"zero_int64":               fmt.Sprintf(`('%s', '0')`, AttrInt64.String()),
+		"regular_bool":             fmt.Sprintf(`('%s', 'true')`, AttrBool.String()),
+		"regular_string":           fmt.Sprintf(`('%s', 'lorem ipsum')`, AttrString.String()),
+	}
+	got := udAttr.Parameterize()
+
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Expected %+#v args, got %+#v", expected, got)
+	}
+}
+
+func TestScan(t *testing.T) {
+	attrMap := map[string][]any{
+		"max_int32":                {AttrInt64.String(), 2147483647},
+		"min_int32":                {AttrInt64.String(), -2147483648},
+		"max_int64":                {AttrInt64.String(), 9223372036854775807},
+		"min_int64":                {AttrInt64.String(), -9223372036854775808},
+		"max_float64":              {AttrFloat64.String(), 1.7976931348623157e+308},
+		"min_float64":              {AttrFloat64.String(), 5e-324},
+		"max_safe_integer":         {AttrInt64.String(), 9007199254740991},
+		"min_safe_integer":         {AttrInt64.String(), -9007199254740991},
+		"regular_negative_float64": {AttrFloat64.String(), -3.141519},
+		"regular_positive_float64": {AttrFloat64.String(), 3.141519},
+		"regular_negative_int64":   {AttrInt64.String(), -4200},
+		"regular_positive_int64":   {AttrInt64.String(), 4200},
+		"zero_float64":             {AttrInt64.String(), 0},
+		"zero_int64":               {AttrInt64.String(), 0},
+		"regular_bool":             {AttrBool.String(), true},
+		"regular_string":           {AttrString.String(), "lorem ipsum"},
+	}
+	var udAttr UDAttribute
+
+	expectedKeyTypes := map[string]AttrType{
+		"max_int32":                AttrInt64,
+		"min_int32":                AttrInt64,
+		"max_int64":                AttrInt64,
+		"min_int64":                AttrInt64,
+		"max_float64":              AttrFloat64,
+		"min_float64":              AttrFloat64,
+		"max_safe_integer":         AttrInt64,
+		"min_safe_integer":         AttrInt64,
+		"regular_negative_float64": AttrFloat64,
+		"regular_positive_float64": AttrFloat64,
+		"regular_negative_int64":   AttrInt64,
+		"regular_positive_int64":   AttrInt64,
+		"zero_float64":             AttrInt64,
+		"zero_int64":               AttrInt64,
+		"regular_bool":             AttrBool,
+		"regular_string":           AttrString,
+	}
+	expectedRawAttrs := map[string]any{
+		"max_int32":                2147483647,
+		"min_int32":                -2147483648,
+		"max_int64":                9223372036854775807,
+		"min_int64":                -9223372036854775808,
+		"max_float64":              1.7976931348623157e+308,
+		"min_float64":              5e-324,
+		"max_safe_integer":         9007199254740991,
+		"min_safe_integer":         -9007199254740991,
+		"regular_negative_float64": -3.141519,
+		"regular_positive_float64": 3.141519,
+		"regular_negative_int64":   -4200,
+		"regular_positive_int64":   4200,
+		"zero_float64":             0,
+		"zero_int64":               0,
+		"regular_bool":             true,
+		"regular_string":           "lorem ipsum",
+	}
+
+	udAttr.Scan(attrMap)
+
+	if !reflect.DeepEqual(expectedKeyTypes, udAttr.keyTypes) {
+		t.Errorf("Expected %+#v args, got %+#v", expectedKeyTypes, udAttr.keyTypes)
+	}
+
+	if !reflect.DeepEqual(expectedRawAttrs, udAttr.rawAttrs) {
+		t.Errorf("Expected %+#v args, got %+#v", expectedRawAttrs, udAttr.rawAttrs)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	{
+		udAttrEmpty := UDAttribute{}
+		err := udAttrEmpty.Validate()
+		if err == nil {
+			t.Errorf("Expected an error, but got nil")
+		}
+	}
+	{
+		udAttrCount := UDAttribute{
+			rawAttrs: map[string]any{},
+		}
+
+		for i := range maxUserDefAttrsCount + 10 {
+			key := fmt.Sprintf("key-%d", i)
+			value := fmt.Sprintf("value-%d", i)
+			udAttrCount.rawAttrs[key] = value
+		}
+
+		err := udAttrCount.Validate()
+		if err == nil {
+			t.Errorf("Expected an error, but got nil")
+		}
+	}
+	{
+		udAttrHugeKey := UDAttribute{
+			rawAttrs: map[string]any{
+				"apple-banana-cherry-dog-42-elephant-frog-giraffe-87-honey-iguana-jump-kite-lion-monkey-nest-orange-99-penguin-queen-rabbit-snake-tiger-umbrella-violet-whale-xray-yak-zebra-12345-balloon-cactus-daisy-forest-galaxy-hippo-jungle-koala-ladder-77-mountain-ocean-polar": "some value",
+			},
+		}
+
+		err := udAttrHugeKey.Validate()
+		if err == nil {
+			t.Errorf("Expected an error, but got nil")
+		}
+	}
+	{
+		udAttrInvalidKey := UDAttribute{
+			rawAttrs: map[string]any{
+				"key contains spaces": "some value",
+			},
+		}
+
+		err := udAttrInvalidKey.Validate()
+		if err == nil {
+			t.Errorf("Expected an error, but got nil")
+		}
+	}
+	{
+		udAttrHugeValue := UDAttribute{
+			rawAttrs: map[string]any{
+				"some-key": "apple-banana-cherry-dog-42-elephant-frog-giraffe-87-honey-iguana-jump-kite-lion-monkey-nest-orange-99-penguin-queen-rabbit-snake-tiger-umbrella-violet-whale-xray-yak-zebra-12345-balloon-cactus-daisy-forest-galaxy-hippo-jungle-koala-ladder-77-mountain-ocean-polar",
+			},
+		}
+
+		err := udAttrHugeValue.Validate()
+		if err == nil {
+			t.Errorf("Expected an error, but got nil")
 		}
 	}
 }

--- a/backend/api/event/userdefattr_test.go
+++ b/backend/api/event/userdefattr_test.go
@@ -660,7 +660,7 @@ func TestAugmentExpression(t *testing.T) {
 }
 
 func TestParameterize(t *testing.T) {
-	udAttr := &UDAttribute{
+	udAttr := UDAttribute{
 		rawAttrs: map[string]any{
 			"max_int32":                float64(2147483647),
 			"min_int32":                float64(-2147483648),

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -354,6 +354,8 @@ Events can optionally contain attributes defined by the SDK user. A `user_define
 - Key names must be unique in a user defined attribute key/value object.
 - Key names must only contain alphabets, numbers, underscores and hyphens.
 - Value can be regular String, Boolean or Number JSON types only.
+- Number values when integer should be within the range of typical **int64** type. `-9223372036854775808` and `9223372036854775807`.
+- Number values when float should not exceed maximum value of typical **float64** type. `1.7976931348623157e+308`.
 - String values should not exceed 256 characters.
 
 ```jsonc
@@ -808,7 +810,7 @@ Use the `custom` type for custom events.
 
 ### Traces
 
-A **span** is the fundamental building block of a *trace*. Spans have the following shape illustrated with an 
+A **span** is the fundamental building block of a *trace*. Spans have the following shape illustrated with an
 example of a `app_startup` span:
 
 ```jsonc


### PR DESCRIPTION
## Summary

This PR fixes and improves support for number(both integers and floats) for user defined attributes.

## Tasks

- [x] support huge or tiny integer values in user defined attributes within the bounds of the int64 type
- [x] Support huge float values in user defined attributes within the bounds of the float64 type
- [x] Improve parsing and error handling for user defined attributes
- [x] Handle float64 to int64 conversions in safe architecture (aarch64/arm64/amd64) agnostic way
- [x] Update sdk API docs
- [x] Add and update tests

## See also

- fixes #1620