### PR TITLE
chore(backend): remove all app resources in sessionator

### DIFF
--- a/self-host/sessionator/README.md
+++ b/self-host/sessionator/README.md
@@ -11,6 +11,7 @@ Easily ingest test sessions during development.
   - [`--clean-all` flag](#--clean-all-flag)
   - [`--clean` flag](#--clean-flag)
 - [Uploading mappings \& attachments locally](#uploading-mappings--attachments-locally)
+- [Remove apps completely](#remove-apps-completely)
 
 ### Usage and Help
 
@@ -140,3 +141,12 @@ symbols_secret_access_key = "minio123"
 The mapping and attachment files can be either configured to be uploaded to a remote S3 bucket or a local S3-compatible storage service. Like [minio](https://min.io/).
 
 For this to work, make sure `self-host/.env` has the `AWS_ENDPOINT_URL` environment variable pointing to the minio host url. Also, the bucket name, region and access key/secret must be configured correctly. These settings are required for symbolication to work correctly.
+
+### Remove apps completely
+
+With `ingest --clean/--clean-all` commands, only the app's resources are removed, but the apps are not. If you wish to remove an app completely with all its resources also removed. Use the `remove apps` command.
+
+```sh
+# syntax, where xxxx is the id of the app
+go run . remove apps --id xxxx
+```

--- a/self-host/sessionator/cmd/help.go
+++ b/self-host/sessionator/cmd/help.go
@@ -4,24 +4,15 @@ package cmd
 // as a formatted string.
 func DirTree() string {
 	return `
-.
-├── foo-app
-│  └── 1.2.3
+├── foo-app/
+│  └── 1.2.3/
+│     └── blobs/
+│        ├── 8e95922c-2212-49ea-a7ea-f7919c08543c
+│        ├── 1121ffce-e5e7-47af-b22d-1c40f889dc86
 │     ├── 54a0bbb9-e819-47f8-9168-5c201a3f3fc0.json
 │     ├── 203334e1-2a7a-466b-b968-506ec3e23615.json
 │     ├── build.toml
-│     └── mapping.txt
-│  └── 4.5.6
-│     ├── 54a0bbb9-e819-47f8-9168-5c201a3f3fc0.json
-│     ├── 5784a496-0655-4fb5-b51b-2afc23e26cef.json
-│     ├── 203334e1-2a7a-466b-b968-506ec3e23615.json
-│     ├── build.toml
-├── bar-app
-│  └── 1.2.3
-│     ├── 54a0bbb9-e819-47f8-9168-5c201a3f3fc0.json
-│     ├── 203334e1-2a7a-466b-b968-506ec3e23615.json
-│     ├── build.toml
-│     └── mapping.txt`
+│     ├── mapping.txt`
 }
 
 // ValidNote provides note about validity of files

--- a/self-host/sessionator/cmd/metrics.go
+++ b/self-host/sessionator/cmd/metrics.go
@@ -3,7 +3,7 @@ package cmd
 import "time"
 
 // Metrics stores certain metrics used by the program
-// to keep track of progress of ingestion operations.
+// to track of progress of ingestion operations.
 type Metrics struct {
 	AppCount              int
 	EventAndSpanFileCount int

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -41,13 +41,12 @@ func init() {
 	recordCmd.Flags().StringVarP(&outputDir, "path", "p", "../session-data", "path to store event requests")
 	recordCmd.Flags().StringVarP(&port, "port", "P", "8080", "port to run the server")
 	recordCmd.Flags().SortFlags = false
-	rootCmd.AddCommand(recordCmd)
 }
 
 var recordCmd = &cobra.Command{
 	Use:   "record",
-	Short: "Records events & builds",
-	Long: `Records events & builds to disk.
+	Short: "Record events, spans & builds",
+	Long: `Record events & builds to disk.
 
 Structue of "session-data" directory once written:` + "\n" + DirTree() + "\n" + ValidNote(),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/self-host/sessionator/cmd/remove.go
+++ b/self-host/sessionator/cmd/remove.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"sessionator/config"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	removeCmd.AddCommand(newRemoveAppsCmd())
+}
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove resources",
+	Long:  "Remove apps, sessions and so on",
+}
+
+func newRemoveAppsCmd() *cobra.Command {
+	var appId string
+
+	var removeAppsCmd = &cobra.Command{
+		Use:   "apps",
+		Short: "Remove apps",
+		Long:  "Remove apps and all its associated resources",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Reading config at %q\n", configLocation)
+
+			appIds := []uuid.UUID{
+				uuid.MustParse(appId),
+			}
+
+			j := janitor{
+				appIds: appIds,
+			}
+
+			configData, err := config.Init(configLocation)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println("Validating config")
+			if err = configData.ValidateStorage(); err != nil {
+				log.Fatal(err)
+			}
+
+			ctx := cmd.Context()
+			conn, err := pgx.Connect(ctx, configData.Storage["postgres_dsn"])
+			if err != nil {
+				return
+			}
+
+			defer func() {
+				if err := conn.Close(ctx); err != nil {
+					return
+				}
+			}()
+
+			tx, err := conn.Begin(ctx)
+			if err != nil {
+				return
+			}
+
+			defer func() {
+				if err := tx.Rollback(ctx); err != nil {
+					return
+				}
+			}()
+
+			if err = j.rmSessions(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmEventFilters(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmEventMetrics(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmEvents(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmSpanFilters(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmSpanMetrics(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmSpans(ctx); err != nil {
+				return
+			}
+
+			if err = j.rmApps(ctx, &tx); err != nil {
+				return
+			}
+
+			if err = tx.Commit(ctx); err != nil {
+				return
+			}
+		},
+	}
+
+	removeAppsCmd.
+		Flags().
+		StringVarP(&configLocation, "config", "c", "../session-data/config.toml", "location to config.toml")
+
+	removeAppsCmd.
+		Flags().
+		StringVar(&appId, "id", "", "id of the app")
+
+	removeAppsCmd.Flags().SortFlags = false
+
+	return removeAppsCmd
+}

--- a/self-host/sessionator/cmd/root.go
+++ b/self-host/sessionator/cmd/root.go
@@ -8,9 +8,17 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "measure",
-	Short: "measure dev cli",
+	Use:   "sessionator",
+	Short: "measure development cli",
 	Long:  "administer measure backend",
+}
+
+func init() {
+	rootCmd.AddCommand(ingestCmd)
+	rootCmd.AddCommand(recordCmd)
+	rootCmd.AddCommand(removeCmd)
+
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 }
 
 func Execute() {


### PR DESCRIPTION
## Summary

This PR updates sessionator ingest command to clean all resources of an app. Also adds a new subcommand `remove apps` to entirely remove an app. Additionally, refactors all the commands to improve consistency.

## Tasks

- [x] Update sessionator `--clean` & `--clean-all` flags to remove all app resources
- [x] Add new `remove apps` subcommand to completely remove an app and all its resources
- [x] Remove short filters
- [x] Remove sessions
- [x] Remove app metrics
- [x] Remove user defined attributes
- [x] Remove span filters
- [x] Remove span metrics
- [x] :books: Update sessionator documentation

## See also

- fixes #1464
- fixes #1629