### PR TITLE
fix(backend): dashboard no longer depends on api service

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -44,10 +44,6 @@ services:
     volumes:
       - ../frontend/dashboard:/app
       - ../frontend/dashboard/public:/app/public
-    depends_on:
-      api:
-        condition: service_healthy
-        restart: false
 
   api:
     build:


### PR DESCRIPTION
## Summary

On Docker Desktop for Mac, dashboard service would not auto-restart on compose restarts of its dependent service - `api`. This PR, removes the `depends_on` element from dashboard service thereby untethering the ordering of container creation of dashboard service from rest of the compose services.

For regular development, this change should not be a blocker - in fact, this leads to a faster developer feedback cycle, as developers do not need to wait for restart of the dashboard service. But on production if the `dashboard` service is started before `api` service, for a brief moment network requests to `api` service will fail while the service is coming up.

If users report this to be an issue, we can override the behavior on production using compose overrides, but for now, we'll continue with a simpler no `depends_on` approach.

## Tasks

- [x] Remove `depends_on` element from dashboard service

## See also

- fixes #1652
