### PR TITLE
fix(backend): nil pointer dereference in remove apps

### DIFF
--- a/self-host/sessionator/cmd/remove.go
+++ b/self-host/sessionator/cmd/remove.go
@@ -34,13 +34,14 @@ func newRemoveAppsCmd() *cobra.Command {
 				uuid.MustParse(appId),
 			}
 
-			j := janitor{
-				appIds: appIds,
-			}
-
 			configData, err := config.Init(configLocation)
 			if err != nil {
 				log.Fatal(err)
+			}
+
+			j := janitor{
+				appIds: appIds,
+				config: configData,
 			}
 
 			fmt.Println("Validating config")

--- a/self-host/sessionator/cmd/rm.go
+++ b/self-host/sessionator/cmd/rm.go
@@ -392,7 +392,8 @@ func (j *janitor) rmApps(ctx context.Context, tx *pgx.Tx) (err error) {
 	placeholders, args := parameterize(j.appIds)
 	deleteApps := fmt.Sprintf("delete from apps where id in (%s);", placeholders)
 
-	fmt.Println("removing apps")
+	fmt.Println("removing app(s)")
+	fmt.Printf("  %s\n", args)
 	_, err = (*tx).Exec(ctx, deleteApps, args...)
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

This PR fixes a nil pointer deference issue happening when removing apps using `sessionator remove apps` command.
