### PR TITLE
fix(frontend): made api key input read only to fix warnings

### DIFF
--- a/frontend/dashboard/app/components/create_app.tsx
+++ b/frontend/dashboard/app/components/create_app.tsx
@@ -20,7 +20,7 @@ export enum CreateAppStatus {
 //
 // If only teamId is passed in, it will show
 // the UI for new app creation first and show following app setup steps after
-// successfull app creation. 
+// successfull app creation.
 //
 // If existingAppName and existingApiKey are passed in, it will skip the new app
 // creation UI and only show the following app setup steps with the api key and
@@ -82,7 +82,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ teamId, existingAppName = null, e
           <div className="py-4" />
           <p className="font-display font-regular text-xl max-w-6xl">API key</p>
           <div className="flex flex-row items-center">
-            <input id="api-key-input" type="text" value={existingApiKey !== null ? existingApiKey : data.api_key.key} className="w-96 border border-black rounded-md outline-none focus-visible:outline-yellow-300 py-2 px-4 font-sans placeholder:text-neutral-400" />
+            <input id="api-key-input" readOnly={true} type="text" value={existingApiKey !== null ? existingApiKey : data.api_key.key} className="w-96 border border-black rounded-md outline-none focus-visible:outline-yellow-300 py-2 px-4 font-sans placeholder:text-neutral-400" />
             <button className="m-4 outline-none flex justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4" onClick={() => navigator.clipboard.writeText(existingApiKey !== null ? existingApiKey : data.api_key.key)}>Copy</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

This PR makes the API key text input field read only in the `<CreateApp />` component so that React warnings about controlled/uncontrolled component is not triggered.

## See also

- fixes #1656
