### PR TITLE
refactor(android): implement batch insertions of events and spans in db

### DIFF
--- a/android/docs/internal-documentation.md
+++ b/android/docs/internal-documentation.md
@@ -18,9 +18,8 @@ SQLite database is configured with the following settings:
 * [journal_mode](https://sqlite.org/pragma.html#pragma_journal_mode): WAL
 * [foreign_keys](https://sqlite.org/pragma.html#pragma_foreign_keys): ON
 
-Events are written to the database & file storage (if needed) as soon as they are received. This can be 
-improved in future by adding a queue which batches the inserts. However, as WAL mode enabled, this optimization
-has been ignored for now.
+Batches of events and spans are inserted in database either every 3 seconds or if either the spans or events buffer reaches 30.
+At time of a crash, events and spans are immediately persisted to the db.
 
 # Batching & export
 

--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -55,4 +55,6 @@ class FakeConfigProvider : ConfigProvider {
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64
     override val maxCheckpointsPerSpan: Int = 100
+    override val maxInMemorySignalsQueueSize: Int = 30
+    override val inMemorySignalsQueueFlushRateMs: Long = 3000
 }

--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -66,6 +66,7 @@ import sh.measure.android.storage.Database
 import sh.measure.android.storage.DatabaseImpl
 import sh.measure.android.storage.FileStorage
 import sh.measure.android.storage.FileStorageImpl
+import sh.measure.android.storage.PeriodicSignalStoreScheduler
 import sh.measure.android.storage.PrefsStorage
 import sh.measure.android.storage.PrefsStorageImpl
 import sh.measure.android.storage.SignalStore
@@ -228,6 +229,14 @@ internal class TestMeasureInitializer(
         database = database,
         fileStorage = fileStorage,
         idProvider = idProvider,
+        configProvider = configProvider,
+    ),
+    override val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler = PeriodicSignalStoreScheduler(
+        logger = logger,
+        defaultExecutor = executorServiceRegistry.defaultExecutor(),
+        ioExecutor = executorServiceRegistry.ioExecutor(),
+        signalStore = signalStore,
+        configProvider = configProvider,
     ),
     override val resumedActivityProvider: ResumedActivityProvider = ResumedActivityProviderImpl(
         application,

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -69,6 +69,7 @@ import sh.measure.android.storage.Database
 import sh.measure.android.storage.DatabaseImpl
 import sh.measure.android.storage.FileStorage
 import sh.measure.android.storage.FileStorageImpl
+import sh.measure.android.storage.PeriodicSignalStoreScheduler
 import sh.measure.android.storage.PrefsStorage
 import sh.measure.android.storage.PrefsStorageImpl
 import sh.measure.android.storage.SignalStore
@@ -228,6 +229,14 @@ internal class MeasureInitializerImpl(
         database = database,
         fileStorage = fileStorage,
         idProvider = idProvider,
+        configProvider = configProvider,
+    ),
+    override val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler = PeriodicSignalStoreScheduler(
+        logger = logger,
+        defaultExecutor = executorServiceRegistry.defaultExecutor(),
+        ioExecutor = executorServiceRegistry.ioExecutor(),
+        signalStore = signalStore,
+        configProvider = configProvider,
     ),
     override val resumedActivityProvider: ResumedActivityProvider = ResumedActivityProviderImpl(
         application,
@@ -450,4 +459,5 @@ internal interface MeasureInitializer {
     val powerStateProvider: PowerStateProvider
     val spanCollector: SpanCollector
     val customEventCollector: CustomEventCollector
+    val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler
 }

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -44,6 +44,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
     private val configProvider by lazy { measureInitializer.configProvider }
     private val dataCleanupService by lazy { measureInitializer.dataCleanupService }
     private val powerStateProvider by lazy { measureInitializer.powerStateProvider }
+    private val periodicSignalStoreScheduler by lazy { measureInitializer.periodicSignalStoreScheduler }
     private var isStarted: Boolean = false
     private var startLock = Any()
 
@@ -122,6 +123,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
         periodicExporter.resume()
         spanCollector.register()
         customEventCollector.register()
+        periodicSignalStoreScheduler.register()
     }
 
     override fun onAppForeground() {
@@ -148,6 +150,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
                 periodicExporter.pause()
                 powerStateProvider.unregister()
                 networkChangesCollector.unregister()
+                periodicSignalStoreScheduler.onAppBackground()
                 dataCleanupService.clearStaleData()
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     appExitCollector.collect()
@@ -221,5 +224,6 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
         periodicExporter.unregister()
         spanCollector.unregister()
         customEventCollector.unregister()
+        periodicSignalStoreScheduler.unregister()
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -49,4 +49,6 @@ internal data class Config(
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64
     override val maxCheckpointsPerSpan: Int = 100
+    override val maxInMemorySignalsQueueSize: Int = 30
+    override val inMemorySignalsQueueFlushRateMs: Long = 3000
 }

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -108,6 +108,10 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { customEventNameRegex }
     override val maxUserDefinedAttributesPerEvent: Int
         get() = getMergedConfig { maxUserDefinedAttributesPerEvent }
+    override val maxInMemorySignalsQueueSize: Int
+        get() = getMergedConfig { maxInMemorySignalsQueueSize }
+    override val inMemorySignalsQueueFlushRateMs: Long
+        get() = getMergedConfig { inMemorySignalsQueueFlushRateMs }
 
     override fun shouldTrackHttpBody(url: String, contentType: String?): Boolean {
         if (!trackHttpBody) {

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -106,4 +106,15 @@ internal interface InternalConfig {
      * Max checkpoints per span. Defaults to 100.
      */
     val maxCheckpointsPerSpan: Int
+
+    /**
+     * Maximum number of signals (events and spans) in the in memory queue. Defaults to 30.
+     */
+    val maxInMemorySignalsQueueSize: Int
+
+    /**
+     * The timeout after which signals are attempted to be flushed to disk in milliseconds.
+     * Defaults to 3000ms.
+     */
+    val inMemorySignalsQueueFlushRateMs: Long
 }

--- a/android/measure/src/main/java/sh/measure/android/storage/PeriodicSignalStoreScheduler.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/PeriodicSignalStoreScheduler.kt
@@ -1,0 +1,56 @@
+package sh.measure.android.storage
+
+import sh.measure.android.config.ConfigProvider
+import sh.measure.android.executors.MeasureExecutorService
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+
+internal class PeriodicSignalStoreScheduler(
+    private val logger: Logger,
+    private val defaultExecutor: MeasureExecutorService,
+    private val ioExecutor: MeasureExecutorService,
+    private val signalStore: SignalStore,
+    private val configProvider: ConfigProvider,
+) {
+
+    @Volatile
+    private var future: Future<*>? = null
+
+    fun register() {
+        if (future != null) {
+            return
+        }
+        try {
+            future = defaultExecutor.scheduleAtFixedRate(
+                {
+                    ioExecutor.submit {
+                        signalStore.flush()
+                    }
+                },
+                initialDelay = configProvider.inMemorySignalsQueueFlushRateMs,
+                delayMillis = configProvider.inMemorySignalsQueueFlushRateMs,
+                TimeUnit.MILLISECONDS,
+            )
+        } catch (e: RejectedExecutionException) {
+            logger.log(LogLevel.Error, "Failed to start periodic signal store scheduler", e)
+            return
+        }
+    }
+
+    fun unregister() {
+        future?.cancel(false)
+        future = null
+        ioExecutor.submit {
+            signalStore.flush()
+        }
+    }
+
+    fun onAppBackground() {
+        ioExecutor.submit {
+            signalStore.flush()
+        }
+    }
+}

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -39,17 +39,21 @@ internal class FakeConfigProvider : ConfigProvider {
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64
     override val maxCheckpointsPerSpan: Int = 100
+    override var maxInMemorySignalsQueueSize: Int = 30
+    override val inMemorySignalsQueueFlushRateMs: Long = 3000
 
     var shouldTrackHttpBody = false
 
     override fun shouldTrackHttpBody(url: String, contentType: String?): Boolean {
         return shouldTrackHttpBody
     }
+
     var shouldTrackHttpUrl = false
 
     override fun shouldTrackHttpUrl(url: String): Boolean {
         return shouldTrackHttpUrl
     }
+
     var headerKeysToBlock = emptyList<String>()
 
     override fun shouldTrackHttpHeader(key: String): Boolean {

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
@@ -15,4 +15,8 @@ internal class FakeSignalStore : SignalStore {
     override fun store(spanData: SpanData) {
         trackedSpans.add(spanData)
     }
+
+    override fun flush() {
+        // No-op
+    }
 }

--- a/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -9,10 +9,13 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import sh.measure.android.attributes.StringAttr
 import sh.measure.android.events.EventType
+import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeIdProvider
 import sh.measure.android.fakes.NoopLogger
 import sh.measure.android.fakes.TestData
@@ -24,12 +27,14 @@ internal class SignalStoreTest {
     private val fileStorage = mock<FileStorage>()
     private val database = mock<Database>()
     private val idProvider = FakeIdProvider()
+    private val configProvider = FakeConfigProvider()
 
     private val signalStore: SignalStore = SignalStoreImpl(
         logger,
         fileStorage,
         database,
         idProvider,
+        configProvider,
     )
 
     @Test
@@ -37,7 +42,7 @@ internal class SignalStoreTest {
         // given
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<EventEntity>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
         // when
@@ -48,8 +53,8 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertEvent(eventsCaptor.capture())
+        val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
     }
 
@@ -58,7 +63,7 @@ internal class SignalStoreTest {
         // given
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.ANR)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<EventEntity>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
         // when
@@ -69,68 +74,74 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertEvent(eventsCaptor.capture())
+        val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
     }
 
     @Test
     fun `stores sampled span`() {
         val spanData = TestData.getSpanData(isSampled = true)
-        signalStore.store(spanData)
+        val spansCaptor = argumentCaptor<List<SpanEntity>>()
 
-        verify(database).insertSpan(spanData.toSpanEntity())
+        signalStore.store(spanData)
+        signalStore.flush()
+
+        verify(database).insertSignals(eq(emptyList()), spansCaptor.capture())
+        val spanEntity = spansCaptor.firstValue.first()
+        assertEquals(spanData.toSpanEntity(), spanEntity)
     }
 
     @Test
     fun `does not store non-sampled span`() {
         val spanData = TestData.getSpanData(isSampled = false)
         signalStore.store(spanData)
+        signalStore.flush()
 
-        verify(database, never()).insertSpan(any())
+        verify(database, never()).insertSignals(any(), any())
     }
 
     @Test
     fun `given http event contains request body, stores it in file storage and stores the path in database`() {
         // given
-        val httpData =
-            TestData.getHttpData(requestBody = "request-body", responseBody = null)
+        val httpData = TestData.getHttpData(requestBody = "request-body", responseBody = null)
         val event = httpData.toEvent(type = EventType.HTTP)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
         // when
         signalStore.store(event)
+        signalStore.flush()
 
         // then
         verify(fileStorage).writeEventData(
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertEquals("fake-file-path", eventEntity.filePath)
     }
 
     @Test
     fun `given http event contains response body, stores it in file storage and stores the path in database`() {
         // given
-        val httpData =
-            TestData.getHttpData(requestBody = null, responseBody = "response-body")
+        val httpData = TestData.getHttpData(requestBody = null, responseBody = "response-body")
         val event = httpData.toEvent(type = EventType.HTTP)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
         // when
         signalStore.store(event)
+        signalStore.flush()
 
         // then
         verify(fileStorage).writeEventData(
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertEquals("fake-file-path", eventEntity.filePath)
     }
 
@@ -138,11 +149,12 @@ internal class SignalStoreTest {
     fun `given http event does not contain request or response body, stores it directly in database`() {
         val httpData = TestData.getHttpData(requestBody = null, responseBody = null)
         val event = httpData.toEvent(type = EventType.HTTP)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
         signalStore.store(event)
+        signalStore.flush()
 
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNull(eventEntity.filePath)
         assertNotNull(eventEntity.serializedData)
     }
@@ -152,31 +164,33 @@ internal class SignalStoreTest {
         // given
         val appExit = TestData.getAppExit(trace = "trace")
         val event = appExit.toEvent(type = EventType.APP_EXIT)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
         // when
         signalStore.store(event)
+        signalStore.flush()
 
         // then
         verify(fileStorage).writeEventData(
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
-        assertEquals("fake-file-path", eventEntity.filePath)
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue
+        assertEquals("fake-file-path", eventEntity.first().filePath)
     }
 
     @Test
     fun `given app_exit event does not contain a trace, stores the serialized data in database`() {
         val appExit = TestData.getAppExit(trace = null)
         val event = appExit.toEvent(type = EventType.APP_EXIT)
-        val argumentCaptor = argumentCaptor<EventEntity>()
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
         signalStore.store(event)
+        signalStore.flush()
 
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNull(eventEntity.filePath)
         assertNotNull(eventEntity.serializedData)
     }
@@ -187,16 +201,20 @@ internal class SignalStoreTest {
             bytes = getAttachmentContent().toByteArray(),
             path = null,
         )
-        val event = TestData.getClickData()
-            .toEvent(type = EventType.CLICK, attachments = mutableListOf(attachment), id = idProvider.id)
+        val event = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            attachments = mutableListOf(attachment),
+            id = idProvider.id,
+        )
         `when`(fileStorage.writeAttachment(event.id, attachment.bytes!!)).thenReturn("fake-path")
 
         signalStore.store(event)
+        signalStore.flush()
 
         verify(fileStorage).writeAttachment(event.id, attachment.bytes)
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertEquals(1, eventEntity.attachmentEntities!!.size)
         assertEquals("fake-path", eventEntity.attachmentEntities.first().path)
     }
@@ -207,14 +225,18 @@ internal class SignalStoreTest {
             bytes = null,
             path = "fake-path",
         )
-        val event = TestData.getClickData()
-            .toEvent(type = EventType.CLICK, attachments = mutableListOf(attachment), id = idProvider.id)
+        val event = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            attachments = mutableListOf(attachment),
+            id = idProvider.id,
+        )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertEquals(1, eventEntity.attachmentEntities!!.size)
         assertEquals(attachment.path, eventEntity.attachmentEntities.first().path)
     }
@@ -227,14 +249,18 @@ internal class SignalStoreTest {
             name = "name",
             type = "type",
         )
-        val event = TestData.getClickData()
-            .toEvent(type = EventType.CLICK, attachments = mutableListOf(attachment), id = idProvider.id)
+        val event = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            attachments = mutableListOf(attachment),
+            id = idProvider.id,
+        )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedAttachments)
         assertEquals(
             "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\"}]",
@@ -250,15 +276,24 @@ internal class SignalStoreTest {
             name = "name",
             type = "type",
         )
-        `when`(fileStorage.writeAttachment(idProvider.id, attachment.bytes!!)).thenReturn("fake-path")
-        val event = TestData.getClickData()
-            .toEvent(type = EventType.CLICK, attachments = mutableListOf(attachment), id = idProvider.id)
+        `when`(
+            fileStorage.writeAttachment(
+                idProvider.id,
+                attachment.bytes!!,
+            ),
+        ).thenReturn("fake-path")
+        val event = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            attachments = mutableListOf(attachment),
+            id = idProvider.id,
+        )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedAttachments)
         assertEquals(
             "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\"}]",
@@ -272,10 +307,11 @@ internal class SignalStoreTest {
             .toEvent(type = EventType.CLICK, attachments = mutableListOf(), id = idProvider.id)
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNull(eventEntity.serializedAttachments)
     }
 
@@ -283,17 +319,21 @@ internal class SignalStoreTest {
     fun `given attachments are present, calculates total size and stores it to db`() {
         val attachmentContent = getAttachmentContent()
         val attachment = TestData.getAttachment(bytes = null, path = "fake-path")
-        val event = TestData.getClickData()
-            .toEvent(type = EventType.CLICK, attachments = mutableListOf(attachment), id = idProvider.id)
+        val event = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            attachments = mutableListOf(attachment),
+            id = idProvider.id,
+        )
         val file =
             File.createTempFile("fake-attachment", "txt").apply { writeText(attachmentContent) }
         `when`(fileStorage.getFile(attachment.path!!)).thenReturn(file)
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertEquals(attachmentContent.length.toLong(), eventEntity.attachmentsSize)
     }
 
@@ -306,10 +346,11 @@ internal class SignalStoreTest {
         )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedAttributes)
         assertEquals("{\"key\":\"value\"}", eventEntity.serializedAttributes)
     }
@@ -323,10 +364,11 @@ internal class SignalStoreTest {
         )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedUserDefAttributes)
         assertEquals("{\"key\":\"value\"}", eventEntity.serializedUserDefAttributes)
     }
@@ -340,10 +382,11 @@ internal class SignalStoreTest {
         )
 
         signalStore.store(event)
+        signalStore.flush()
 
-        val argumentCaptor = argumentCaptor<EventEntity>()
-        verify(database).insertEvent(argumentCaptor.capture())
-        val eventEntity = argumentCaptor.firstValue
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
+        val eventEntity = eventsCaptor.firstValue.first()
         assertTrue(eventEntity.userTriggered)
     }
 
@@ -387,9 +430,57 @@ internal class SignalStoreTest {
 
         // when
         signalStore.store(event)
+        signalStore.flush()
 
         // verify that the event is not inserted in the database
         verify(database, never()).insertEvent(any())
+    }
+
+    @Test
+    fun `flushes existing signals and inserts the event which caused queue overflowed, when max events queue size is reached`() {
+        configProvider.maxInMemorySignalsQueueSize = 1
+        val event1 = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            id = "event-1",
+        )
+        val span1 = TestData.getSpanData()
+        val event2 = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            id = "event-2",
+        )
+
+        signalStore.store(event1)
+        signalStore.store(span1)
+        signalStore.store(event2)
+
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        val spansCaptor = argumentCaptor<List<SpanEntity>>()
+        verify(database, times(1)).insertEvent(any())
+        verify(database, times(1)).insertSignals(eventsCaptor.capture(), spansCaptor.capture())
+        assertEquals(1, eventsCaptor.firstValue.size)
+        assertEquals(1, spansCaptor.firstValue.size)
+    }
+
+    @Test
+    fun `flushes existing signals and inserts the span which caused queue overflowed, when max span queue size is reached`() {
+        configProvider.maxInMemorySignalsQueueSize = 1
+        val event1 = TestData.getClickData().toEvent(
+            type = EventType.CLICK,
+            id = "event-1",
+        )
+        val span1 = TestData.getSpanData()
+        val span2 = TestData.getSpanData()
+
+        signalStore.store(event1)
+        signalStore.store(span1)
+        signalStore.store(span2)
+
+        val eventsCaptor = argumentCaptor<List<EventEntity>>()
+        val spansCaptor = argumentCaptor<List<SpanEntity>>()
+        verify(database, times(1)).insertSpan(any())
+        verify(database, times(1)).insertSignals(eventsCaptor.capture(), spansCaptor.capture())
+        assertEquals(1, eventsCaptor.firstValue.size)
+        assertEquals(1, spansCaptor.firstValue.size)
     }
 
     private fun getAttachmentContent(): String {

--- a/android/sample/build.gradle.kts
+++ b/android/sample/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 measure {
     variantFilter {
         if (name.contains("debug")) {
-            enabled = true
+            enabled = false
         }
     }
 }


### PR DESCRIPTION
# Description

* Buffer events and spans in `SignalStore`
* Persist buffer at time of crash, when app goes to background and periodically every 3 seconds.

Closes: https://github.com/measure-sh/measure/issues/1642