### PR TITLE
refactor(android): avoid accessing thermal status change for older APIs

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/NoopThermalStateManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/NoopThermalStateManager.kt
@@ -1,0 +1,20 @@
+package sh.measure.android
+
+import android.os.PowerManager
+
+/**
+ * A no-op implementation of [ThermalStateManager], used for API < Q
+ * which do not have [PowerManager.OnThermalStatusChangedListener].
+ */
+internal class NoopThermalStateManager : ThermalStateManager {
+    override fun register(powerManager: PowerManager?) {
+        // No-op
+    }
+
+    override fun unregister(powerManager: PowerManager?) {
+        // No-op
+    }
+
+    override val thermalThrottlingEnabled: Boolean
+        get() = false
+}

--- a/android/measure/src/main/java/sh/measure/android/ThermalStateManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/ThermalStateManager.kt
@@ -1,0 +1,10 @@
+package sh.measure.android
+
+import android.os.PowerManager
+
+// Base interface for thermal state management
+internal interface ThermalStateManager {
+    fun register(powerManager: PowerManager?)
+    fun unregister(powerManager: PowerManager?)
+    val thermalThrottlingEnabled: Boolean
+}

--- a/android/measure/src/main/java/sh/measure/android/ThermalStateManagerImpl.kt
+++ b/android/measure/src/main/java/sh/measure/android/ThermalStateManagerImpl.kt
@@ -1,0 +1,43 @@
+package sh.measure.android
+
+import android.os.Build
+import android.os.PowerManager
+import androidx.annotation.RequiresApi
+
+/**
+ * An implementation of [ThermalStateManager] for API > Q where
+ * [PowerManager.OnThermalStatusChangedListener] is available.
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+internal class ThermalStateManagerImpl : ThermalStateManager {
+    private var currentThermalThrottlingState: Boolean = false
+
+    private val thermalListener = PowerManager.OnThermalStatusChangedListener { status ->
+        currentThermalThrottlingState = isThermalThrottlingEnabled(status)
+    }
+
+    override fun register(powerManager: PowerManager?) {
+        powerManager?.let {
+            it.addThermalStatusListener(thermalListener)
+            currentThermalThrottlingState = isThermalThrottlingEnabled(it.currentThermalStatus)
+        }
+    }
+
+    override fun unregister(powerManager: PowerManager?) {
+        powerManager?.removeThermalStatusListener(thermalListener)
+    }
+
+    override val thermalThrottlingEnabled: Boolean
+        get() = currentThermalThrottlingState
+
+    private fun isThermalThrottlingEnabled(status: Int?) = when (status) {
+        PowerManager.THERMAL_STATUS_NONE -> false
+        PowerManager.THERMAL_STATUS_LIGHT -> false
+        PowerManager.THERMAL_STATUS_MODERATE -> false
+        PowerManager.THERMAL_STATUS_SEVERE -> true
+        PowerManager.THERMAL_STATUS_CRITICAL -> true
+        PowerManager.THERMAL_STATUS_EMERGENCY -> true
+        PowerManager.THERMAL_STATUS_SHUTDOWN -> true
+        else -> false
+    }
+}


### PR DESCRIPTION
# Description

PowerManager.OnThermalStatusChangedListener is available only for API 29 and above. This PR makes sure that this class is only accessed for APIs when it's available.

## Related issue
Closes #1660



