### PR TITLE
fix(android): serialize numbers as numbers instead of string in user def attrs

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/attributes/AttributeValue.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/AttributeValue.kt
@@ -67,9 +67,9 @@ internal object AttributeValueSerializer : KSerializer<AttributeValue> {
             is StringAttr -> JsonPrimitive(value.value)
             is BooleanAttr -> JsonPrimitive(value.value)
             is IntAttr -> JsonPrimitive(value.value)
-            is LongAttr -> JsonPrimitive(value.value.toString())
+            is LongAttr -> JsonPrimitive(value.value)
             is FloatAttr -> JsonPrimitive(value.value)
-            is DoubleAttr -> JsonPrimitive(value.value.toString())
+            is DoubleAttr -> JsonPrimitive(value.value)
         }
         jsonEncoder.encodeJsonElement(jsonElement)
     }

--- a/android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
@@ -4,6 +4,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import sh.measure.android.attributes.DoubleAttr
+import sh.measure.android.attributes.FloatAttr
+import sh.measure.android.attributes.IntAttr
+import sh.measure.android.attributes.LongAttr
 import sh.measure.android.events.EventType
 import sh.measure.android.fakes.TestData
 import sh.measure.android.fakes.TestData.toEvent
@@ -12,22 +16,21 @@ class EventExtensionsKtTest {
 
     @Test
     fun `returns null if attributes are empty`() {
-        val event = TestData.getClickData()
-            .toEvent(attributes = mutableMapOf(), type = EventType.CLICK)
+        val event =
+            TestData.getClickData().toEvent(attributes = mutableMapOf(), type = EventType.CLICK)
 
         assertNull(event.serializeAttributes())
     }
 
     @Test
     fun `returns serialized attributes if attributes are not empty`() {
-        val event = TestData.getClickData()
-            .toEvent(
-                attributes = mutableMapOf(
-                    "key1" to "value1",
-                    "key2" to "value2",
-                ),
-                type = EventType.CLICK,
-            )
+        val event = TestData.getClickData().toEvent(
+            attributes = mutableMapOf(
+                "key1" to "value1",
+                "key2" to "value2",
+            ),
+            type = EventType.CLICK,
+        )
 
         val serializedAttributes = event.serializeAttributes()
         assertEquals(
@@ -53,16 +56,20 @@ class EventExtensionsKtTest {
         val scrollEvent = TestData.getScrollData().toEvent(type = EventType.SCROLL)
         assert(scrollEvent.serializeDataToString().isNotEmpty())
 
-        val lifecycleActivityEvent = TestData.getActivityLifecycleData().toEvent(type = EventType.LIFECYCLE_ACTIVITY)
+        val lifecycleActivityEvent =
+            TestData.getActivityLifecycleData().toEvent(type = EventType.LIFECYCLE_ACTIVITY)
         assert(lifecycleActivityEvent.serializeDataToString().isNotEmpty())
 
-        val lifecycleFragmentEvent = TestData.getFragmentLifecycleData().toEvent(type = EventType.LIFECYCLE_FRAGMENT)
+        val lifecycleFragmentEvent =
+            TestData.getFragmentLifecycleData().toEvent(type = EventType.LIFECYCLE_FRAGMENT)
         assert(lifecycleFragmentEvent.serializeDataToString().isNotEmpty())
 
-        val applicationLifecycleEvent = TestData.getApplicationLifecycleData().toEvent(type = EventType.LIFECYCLE_APP)
+        val applicationLifecycleEvent =
+            TestData.getApplicationLifecycleData().toEvent(type = EventType.LIFECYCLE_APP)
         assert(applicationLifecycleEvent.serializeDataToString().isNotEmpty())
 
-        val networkChangeEvent = TestData.getNetworkChangeData().toEvent(type = EventType.NETWORK_CHANGE)
+        val networkChangeEvent =
+            TestData.getNetworkChangeData().toEvent(type = EventType.NETWORK_CHANGE)
         assert(networkChangeEvent.serializeDataToString().isNotEmpty())
 
         val httpEvent = TestData.getHttpData().toEvent(type = EventType.HTTP)
@@ -109,5 +116,25 @@ class EventExtensionsKtTest {
         assertThrows(ClassCastException::class.java) {
             event.serializeDataToString()
         }
+    }
+
+    @Test
+    fun `user defined attributes with large and small numbers`() {
+        val expectedSerializedAttributes = "{\"largest_integer\":2147483647,\"largest_long\":9223372036854775807,\"largest_double\":1.7976931348623157E308,\"largest_float\":3.4028235E38,\"smallest_integer\":-2147483648,\"smallest_long\":-9223372036854775808,\"smallest_double\":4.9E-324,\"smallest_float\":1.4E-45}"
+        val event = TestData.getScreenViewData().toEvent(
+            type = EventType.CLICK,
+            userDefinedAttributes = mapOf(
+                "largest_integer" to IntAttr(Int.MAX_VALUE),
+                "largest_long" to LongAttr(Long.MAX_VALUE),
+                "largest_double" to DoubleAttr(Double.MAX_VALUE),
+                "largest_float" to FloatAttr(Float.MAX_VALUE),
+                "smallest_integer" to IntAttr(Int.MIN_VALUE),
+                "smallest_long" to LongAttr(Long.MIN_VALUE),
+                "smallest_double" to DoubleAttr(Double.MIN_VALUE),
+                "smallest_float" to FloatAttr(Float.MIN_VALUE),
+            ),
+        )
+        val serializedAttributes = event.serializeUserDefinedAttributes()
+        assertEquals(expectedSerializedAttributes, serializedAttributes)
     }
 }


### PR DESCRIPTION
# Description

Updates serialization of user defined attributes to always serialize numbers as _numbers_ instead of strings.

References #1620