### PR TITLE
fix(android): remove unneeded view id prefix in gesture events

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutInspector.kt
+++ b/android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutInspector.kt
@@ -216,7 +216,7 @@ internal object LayoutInspector {
         if (id != View.NO_ID && resources != null) {
             try {
                 val resourceName = resources.getResourceEntryName(id)
-                return "id:$resourceName"
+                return resourceName
             } catch (_: NotFoundException) {
                 // Ignore
             }


### PR DESCRIPTION
# Description

Since #1551 the target id in gesture click events incorrectly contained a hardcoded "id:" prefix. This has been removed.


