### PR TITLE
feat(ios): expose API to get current session ID

### DIFF
--- a/ios/MeasureSDK/Measure.swift
+++ b/ios/MeasureSDK/Measure.swift
@@ -82,4 +82,15 @@ import Foundation
             }
         }
     }
+
+    /// Returns the session ID for the current session, or nil if the SDK has not been initialized.
+    ///
+    /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
+    /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
+    /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
+    func getSessionId() -> String? {
+        guard let sessionId = measureInternal?.sessionManager.sessionId else { return nil }
+
+        return sessionId
+    }
 }


### PR DESCRIPTION
# Description

Exposes a public API to get current session ID.

## Related issue
Closes #1635
