### PR TITLE
chore(backend): add new scopes to commitlint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -10,7 +10,7 @@ export default {
      * - feat(backend): attachments is now available
      *
      */
-    "scope-enum": [2, "always", ["android", "ios", "flutter", "react-native", "backend", "frontend", "deps"]],
+    "scope-enum": [2, "always", ["android", "ios", "flutter", "rn", "backend", "frontend", "deps"]],
     /**
      * reduce header max length violation to a warning
      */

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -3,14 +3,14 @@ export default {
   rules: {
     /**
      * allowed scopes when committing
-     * 
+     *
      * e.g.
-     * 
+     *
      * - fix(android): consumes less energy now
      * - feat(backend): attachments is now available
-     * 
+     *
      */
-    "scope-enum": [2, "always", ["android", "ios", "backend", "frontend"]],
+    "scope-enum": [2, "always", ["android", "ios", "flutter", "react-native", "backend", "frontend", "deps"]],
     /**
      * reduce header max length violation to a warning
      */


### PR DESCRIPTION
## Summary

This PR extends commitlint's config to support additional scopes.

## Tasks

- [x] Add `flutter` as valid commitlint scope
- [x] Add `rn` as valid commitlint scope
- [x] Add `deps` as valid commitlint scope

## See also

- fixes #1702 