### PR TITLE
chore(backend): support `flutter` & `rn` in cliff config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -61,6 +61,8 @@ commit_parsers = [
   { message = ".*sessionator.*", skip = true },
   { message = "^.*\\(android\\):", skip = true },
   { message = "^.*\\(ios\\):", skip = true },
+  { message = "^.*\\(flutter\\):", skip = true },
+  { message = "^.*\\(react-native\\):", skip = true },
   { message = "^docs", group = "<!-- 7 -->:books: Documentation", default_scope = "other" },
   { message = "^feat", group = "<!-- 0 -->:sparkles: New features" },
   { message = "^test", group = "<!-- 3 -->:test_tube: Testing", skip = true },
@@ -80,7 +82,7 @@ tag_pattern = "v[0-9].*"
 # regex for skipping tags
 skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags
-ignore_tags = "^(android|ios)"
+ignore_tags = "^(android|ios|flutter|react-native)"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order

--- a/cliff.toml
+++ b/cliff.toml
@@ -62,7 +62,7 @@ commit_parsers = [
   { message = "^.*\\(android\\):", skip = true },
   { message = "^.*\\(ios\\):", skip = true },
   { message = "^.*\\(flutter\\):", skip = true },
-  { message = "^.*\\(react-native\\):", skip = true },
+  { message = "^.*\\(rn\\):", skip = true },
   { message = "^docs", group = "<!-- 7 -->:books: Documentation", default_scope = "other" },
   { message = "^feat", group = "<!-- 0 -->:sparkles: New features" },
   { message = "^test", group = "<!-- 3 -->:test_tube: Testing", skip = true },
@@ -82,7 +82,7 @@ tag_pattern = "v[0-9].*"
 # regex for skipping tags
 skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags
-ignore_tags = "^(android|ios|flutter|react-native)"
+ignore_tags = "^(android|ios|flutter|rn)"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order


### PR DESCRIPTION
## Summary

This PR adds support for `flutter` & `react-native` to git cliff for generating appropriate changelogs during releases.

## Tasks

- [x] Add `flutter` platform support in cliff config
- [x] Add `rn` platform support in cliff config

## See also

- fixes #1704