### PR TITLE
chore: improve automated changelog formatting

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,18 +17,17 @@ body = """
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
     ## [Unreleased]
-{% endif -%}
+{% endif -%}\n
 {% for group, commits in commits | group_by(attribute="group") %}
-    {% if commits|length > 0 %}### {{ group | striptags | trim | upper_first }}{% endif -%}
-    {% for scope, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="scope") %}
-        {% for commit in commits %}
+    {% if commits|length > 0 %}### {{ group | striptags | trim | upper_first }}\n{% endif -%}
+    {% for scope, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="scope") %}{% for commit in commits %}
             - {% if commit.scope != "other" %}(**{{ commit.scope }}**): {% endif %}\
             {{ commit.message | upper_first }}\
             {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
             {% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{%- endif -%}
         {%- endfor -%}
-    {% endfor %}\n
-{% endfor %}
+    {% endfor %}
+{% endfor %}\n
 """
 # template for the changelog footer
 footer = """
@@ -64,6 +63,7 @@ commit_parsers = [
   { message = "^.*\\(flutter\\):", skip = true },
   { message = "^.*\\(rn\\):", skip = true },
   { message = "^docs", group = "<!-- 7 -->:books: Documentation", default_scope = "other" },
+  { message = "^chore", group = "<!-- 2 -->:hammer: Misc", default_scope = "other" },
   { message = "^feat", group = "<!-- 0 -->:sparkles: New features" },
   { message = "^test", group = "<!-- 3 -->:test_tube: Testing", skip = true },
   { message = "^fix", group = "<!-- 1 -->:bug: Bug fixes" },


### PR DESCRIPTION
## Summary

This PR improves the overall formatting of automated change logs.

## Tasks

- [x] Fix and remove extra newlines that looked awful
- [x] Add support for scope-less commits to show up
- [x] Improve overall formatting

## See also

- fixes #1293
