### PR TITLE
feat(backend): add support for iOS exceptions

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -291,23 +291,6 @@ type Thread struct {
 	ThreadiOS
 }
 
-func whatever() {
-	threadAndroid := Thread{
-		Name:   "android-thread-name",
-		Frames: Frames{},
-	}
-
-	threadiOS := Thread{
-		Name: "iOS-thread-name",
-		ThreadiOS: ThreadiOS{
-			Sequence: 0,
-		},
-	}
-
-	fmt.Println("android thread", threadAndroid)
-	fmt.Println("iOS thread", threadiOS)
-}
-
 type Threads []Thread
 
 type ANR struct {
@@ -318,17 +301,12 @@ type ANR struct {
 	Foreground  bool           `json:"foreground" binding:"required"`
 }
 
-type ExceptioniOS struct {
-	Signal string `json:"signal" binding:"required"`
-}
-
 type Exception struct {
 	Handled     bool           `json:"handled" binding:"required"`
 	Exceptions  ExceptionUnits `json:"exceptions" binding:"required"`
 	Threads     Threads        `json:"threads" binding:"required"`
 	Fingerprint string         `json:"fingerprint"`
 	Foreground  bool           `json:"foreground" binding:"required"`
-	ExceptioniOS
 }
 
 // FingerprintComputer describes the behavior

--- a/backend/api/event/frame.go
+++ b/backend/api/event/frame.go
@@ -14,13 +14,34 @@ const FramePrefix = "\tat "
 // that appears in Android stacktraces.
 const GenericPrefix = ": "
 
+type FrameiOS struct {
+	// BinaryName is the name of the iOS binary image.
+	BinaryName string `json:"binary_name"`
+	// BinaryAddress is the binary load address.
+	BinaryAddress string `json:"binary_address"`
+	// SymbolAddress is the address to symbolicate.
+	SymbolAddress string `json:"symbol_address"`
+	// Offset is the byte offset.
+	Offset int `json:"offset"`
+	// InApp is `true` if the frame originates
+	// from the app module.
+	InApp bool `json:"in_app"`
+}
+
 type Frame struct {
-	LineNum    int    `json:"line_num"`
-	ColNum     int    `json:"col_num"`
+	// LineNum is the line number of the method.
+	LineNum int `json:"line_num"`
+	// ColNum is the column number of the method.
+	ColNum int `json:"col_num"`
+	// ModuleName is the name of the originating module.
 	ModuleName string `json:"module_name"`
-	FileName   string `json:"file_name"`
-	ClassName  string `json:"class_name"`
+	// FileName is the name of the originating file.
+	FileName string `json:"file_name"`
+	// ClassName is the name of the originating class.
+	ClassName string `json:"class_name"`
+	// MethodName is the name of the originating method.
 	MethodName string `json:"method_name"`
+	FrameiOS
 }
 
 type Frames []Frame

--- a/backend/api/event/frame.go
+++ b/backend/api/event/frame.go
@@ -15,6 +15,8 @@ const FramePrefix = "\tat "
 const GenericPrefix = ": "
 
 type FrameiOS struct {
+	// FrameIndex is the sequence of the frame.
+	FrameIndex int `json:"frame_index"`
 	// BinaryName is the name of the iOS binary image.
 	BinaryName string `json:"binary_name"`
 	// BinaryAddress is the binary load address.

--- a/backend/api/journey/android.go
+++ b/backend/api/journey/android.go
@@ -519,7 +519,7 @@ func NewJourneyAndroid(events []event.EventField, opts *Options) (journey *Journ
 
 		} else if issue {
 			// find the previous activity node
-			// and attach the issue to the node.
+			// and attach the issue to that node.
 			c := i
 			for {
 				c--

--- a/backend/api/journey/ios.go
+++ b/backend/api/journey/ios.go
@@ -370,7 +370,7 @@ func NewJourneyiOS(events []event.EventField, opts *Options) (journey *JourneyiO
 			node.IsSwiftUI = true
 		} else if issue {
 			// find the previous view node and
-			// attach the issue to the node.
+			// attach the issue to that node.
 			c := i
 			for {
 				c--
@@ -381,7 +381,7 @@ func NewJourneyiOS(events []event.EventField, opts *Options) (journey *JourneyiO
 				}
 
 				// we only add issues to view nodes
-				if journey.Nodes[i].IsViewController || journey.Nodes[i].IsSwiftUI {
+				if journey.Nodes[c].IsViewController || journey.Nodes[c].IsSwiftUI {
 					addIssue := false
 
 					// only add exception if requested and if the issue exists

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -1446,6 +1446,11 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 		`gesture_scroll.end_x`,
 		`gesture_scroll.end_y`,
 		`toString(gesture_scroll.direction)`,
+		`exception.handled`,
+		`exception.fingerprint`,
+		`exception.foreground`,
+		`exception.exceptions`,
+		`exception.threads`,
 		`toString(lifecycle_app.type)`,
 		`cold_launch.process_start_uptime`,
 		`cold_launch.process_start_requested_uptime`,
@@ -1509,11 +1514,6 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			`anr.foreground`,
 			`anr.exceptions`,
 			`anr.threads`,
-			`exception.handled`,
-			`exception.fingerprint`,
-			`exception.foreground`,
-			`exception.exceptions`,
-			`exception.threads`,
 			`toString(app_exit.reason)`,
 			`toString(app_exit.importance)`,
 			`app_exit.trace`,
@@ -1692,6 +1692,13 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			&gestureScroll.EndY,
 			&gestureScroll.Direction,
 
+			// excpetion
+			&exception.Handled,
+			&exception.Fingerprint,
+			&exception.Foreground,
+			&exceptionExceptions,
+			&exceptionThreads,
+
 			// lifecycle app
 			&lifecycleApp.Type,
 
@@ -1773,13 +1780,6 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 				&anr.Foreground,
 				&anrExceptions,
 				&anrThreads,
-
-				// excpetion
-				&exception.Handled,
-				&exception.Fingerprint,
-				&exception.Foreground,
-				&exceptionExceptions,
-				&exceptionThreads,
 
 				// app exit
 				&appExit.Reason,

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -17,6 +17,7 @@ import (
 	"backend/api/group"
 	"backend/api/journey"
 	"backend/api/metrics"
+	"backend/api/numeric"
 	"backend/api/paginate"
 	"backend/api/platform"
 	"backend/api/server"
@@ -690,7 +691,7 @@ func (a App) GetSizeMetrics(ctx context.Context, af *filter.AppFilter, versions 
 func (a App) GetIssueFreeMetrics(
 	ctx context.Context,
 	af *filter.AppFilter,
-	versions filter.Versions,
+	unselectedVersions filter.Versions,
 ) (
 	crashFree *metrics.CrashFreeSession,
 	perceivedCrashFree *metrics.PerceivedCrashFreeSession,
@@ -775,13 +776,13 @@ func (a App) GetIssueFreeMetrics(
 			perceivedANRFree.ANRFreeSessions = math.NaN()
 		}
 	} else {
-		crashFree.CrashFreeSessions = math.Round(1-float64(crashSelected/selected)) * 100
-		perceivedCrashFree.CrashFreeSessions = math.Round(1-float64(perceivedCrashSelected/selected)) * 100
+		crashFree.CrashFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(crashSelected) / float64(selected))) * 100)
+		perceivedCrashFree.CrashFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedCrashSelected) / float64(selected))) * 100)
 
 		switch a.Platform {
 		case platform.Android:
-			anrFree.ANRFreeSessions = math.Round(1-float64(anrSelected/selected)) * 100
-			perceivedANRFree.ANRFreeSessions = math.Round(1-float64(perceivedANRSelected/selected)) * 100
+			anrFree.ANRFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(anrSelected) / float64(selected))) * 100)
+			perceivedANRFree.ANRFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedANRSelected) / float64(selected))) * 100)
 		}
 	}
 
@@ -795,28 +796,28 @@ func (a App) GetIssueFreeMetrics(
 			perceivedANRFreeUnselected = math.NaN()
 		}
 	} else {
-		crashFreeUnselected = math.Round(1-float64(crashUnselected/unselected)) * 100
-		perceivedCrashFreeUnselected = math.Round(1-float64(perceivedCrashUnselected/unselected)) * 100
+		crashFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(crashUnselected) / float64(unselected))) * 100)
+		perceivedCrashFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedCrashUnselected) / float64(unselected))) * 100)
 
 		switch a.Platform {
 		case platform.Android:
-			anrFreeUnselected = math.Round(1-float64(anrUnselected/unselected)) * 100
-			perceivedANRFreeUnselected = math.Round(1-float64(perceivedANRUnselected/unselected)) * 100
+			anrFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(anrUnselected) / float64(unselected))) * 100)
+			perceivedANRFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedANRUnselected) / float64(unselected))) * 100)
 		}
 	}
 
 	// compute delta
-	if versions.HasVersions() {
+	if unselectedVersions.HasVersions() {
 		// avoid division by zero
 		if crashFreeUnselected != 0 {
 			// Round to two decimal places
-			crashFree.Delta = math.Round(crashFree.CrashFreeSessions/crashFreeUnselected*100) / 100
+			crashFree.Delta = numeric.RoundTwoDecimalsFloat64(crashFree.CrashFreeSessions / crashFreeUnselected)
 		} else {
 			crashFree.Delta = 1
 		}
 
 		if perceivedCrashFreeUnselected != 0 {
-			crashFree.Delta = math.Round(perceivedCrashFree.CrashFreeSessions/perceivedCrashFreeUnselected*100) / 100
+			crashFree.Delta = numeric.RoundTwoDecimalsFloat64(perceivedCrashFree.CrashFreeSessions / perceivedCrashFreeUnselected)
 		} else {
 			perceivedCrashFree.Delta = 1
 		}
@@ -824,13 +825,13 @@ func (a App) GetIssueFreeMetrics(
 		switch a.Platform {
 		case platform.Android:
 			if anrFreeUnselected != 0 {
-				anrFree.Delta = math.Round(anrFree.ANRFreeSessions/anrFreeUnselected*100) / 100
+				anrFree.Delta = numeric.RoundTwoDecimalsFloat64(anrFree.ANRFreeSessions / anrFreeUnselected)
 			} else {
 				anrFree.Delta = 1
 			}
 
 			if perceivedANRFreeUnselected != 0 {
-				perceivedANRFree.Delta = math.Round(perceivedANRFree.ANRFreeSessions/perceivedANRFreeUnselected*100) / 100
+				perceivedANRFree.Delta = numeric.RoundTwoDecimalsFloat64(perceivedANRFree.ANRFreeSessions / perceivedANRFreeUnselected)
 			} else {
 				perceivedANRFree.Delta = 1
 			}

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -62,6 +62,7 @@ type eventreq struct {
 	id                     uuid.UUID
 	appId                  uuid.UUID
 	status                 status
+	platform               string
 	symbolicate            map[uuid.UUID]int
 	exceptionIds           []int
 	anrIds                 []int
@@ -2013,6 +2014,7 @@ func PutEvents(c *gin.Context) {
 	msg := `failed to parse event request payload`
 	eventReq := eventreq{
 		appId:       appId,
+		platform:    app.Platform,
 		symbolicate: make(map[uuid.UUID]int),
 		attachments: make(map[uuid.UUID]*attachment),
 		createdAt:   time.Now(),

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -627,7 +627,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				return err
 			}
 			anrThreads = string(marshalledThreads)
-			if err := e.events[i].ANR.ComputeANRFingerprint(); err != nil {
+			if err := e.events[i].ANR.ComputeFingerprint(); err != nil {
 				return err
 			}
 		}
@@ -643,7 +643,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				return err
 			}
 			exceptionThreads = string(marshalledThreads)
-			if err := e.events[i].Exception.ComputeExceptionFingerprint(); err != nil {
+			if err := e.events[i].Exception.ComputeFingerprint(); err != nil {
 				return err
 			}
 		}

--- a/backend/api/numeric/numeric.go
+++ b/backend/api/numeric/numeric.go
@@ -1,5 +1,7 @@
 package numeric
 
+import "math"
+
 // AbsInt returns the absolute
 // value of int n.
 //
@@ -13,4 +15,10 @@ func AbsInt(n int) int {
 		return -n
 	}
 	return n
+}
+
+// RoundTwoDecimalsFloat64 rounds the precision
+// part of a float64 value to 2 decimals.
+func RoundTwoDecimalsFloat64(x float64) float64 {
+	return math.Ceil(x*100) / 100
 }

--- a/backend/api/platform/platform.go
+++ b/backend/api/platform/platform.go
@@ -3,4 +3,5 @@ package platform
 const (
 	IOS     = "ios"
 	Android = "android"
+	Unknown = "unknown"
 )

--- a/self-host/sessionator/README.md
+++ b/self-host/sessionator/README.md
@@ -144,9 +144,11 @@ For this to work, make sure `self-host/.env` has the `AWS_ENDPOINT_URL` environm
 
 ### Remove apps completely
 
-With `ingest --clean/--clean-all` commands, only the app's resources are removed, but the apps are not. If you wish to remove an app completely with all its resources also removed. Use the `remove apps` command.
+The `ingest --clean/--clean-all` commands only removes the app's resources, but the apps themselves are not removed. If you wish to remove an app completely, use the `remove apps` command. Like below.
 
 ```sh
 # syntax, where xxxx is the id of the app
 go run . remove apps --id xxxx
 ```
+
+You would need to get the id of the app from the `apps` table in Measure's Postgres database.


### PR DESCRIPTION
## Summary

This PR adds support for **validating**, **grouping**, **fingerprinting**, **ingesting**, **storing** and **retrieving** iOS exceptions throughout the system surface. Android exceptions and ANRs should continue to work without regression.

> [!NOTE]
> _Builds, mappings and symbolication would be implemented in a different PR._

## Tasks

- [x] Extend exception related structs to support iOS exceptions without regression
- [x] Validate iOS exceptions during ingestion
- [x] Group iOS exceptions during ingestion
- [x] Fingerprint iOS exceptions during ingestion
- [x] Store iOS exceptions during ingestion
- [x] Update GET `/apps/:id/filters` API to support iOS exceptions
- [x] Update GET `/apps/:id/crashGroups` API to support iOS exceptions
- [x] Update GET `/apps/:id/sessions/:id` API to support iOS exceptions
- [x] Fixed incorrect metrics compute in GET `/apps/:id/metrics` API

## See also

- fixes #1724