### PR TITLE
fix(backend): support no app version filters

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -1081,13 +1081,6 @@ func (af *AppFilter) GetExcludedVersions(ctx context.Context) (versions Versions
 		return
 	}
 
-	// If no versions are selected, treat it as if all versions were selected
-	if len(af.Versions) == 0 || len(af.VersionCodes) == 0 {
-		af.Versions = allVersions
-		af.VersionCodes = allCodes
-		return
-	}
-
 	count := len(allVersions)
 
 	if count != len(allCodes) {

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -1889,10 +1889,6 @@ func GetIssuesAttributeDistribution(ctx context.Context, g group.IssueGroup, af 
 // GetIssuesPlot aggregates issue free percentage for plotting
 // visually from an ExceptionGroup or ANRGroup.
 func GetIssuesPlot(ctx context.Context, g group.IssueGroup, af *filter.AppFilter) (issueInstances []event.IssueInstance, err error) {
-	if af.Timezone == "" {
-		return nil, errors.New("missing timezone filter")
-	}
-
 	fingerprint := g.GetFingerprint()
 	groupType := event.TypeException
 

--- a/backend/api/pairs/pairs.go
+++ b/backend/api/pairs/pairs.go
@@ -34,6 +34,11 @@ func (p *Pairs[T, U]) Add(first T, second U) {
 	p.second = append(p.second, second)
 }
 
+// Empty indicates if the pair is empty.
+func (p Pairs[T, U]) Empty() bool {
+	return len(p.first) == 0 || len(p.second) == 0
+}
+
 // Parameterize represents Pairs in a slice of clickhouse.GroupSet
 // for direct use in SQL queries.
 func (p Pairs[T, U]) Parameterize() (tuples []clickhouse.GroupSet) {

--- a/frontend/dashboard/app/components/metrics_overview.tsx
+++ b/frontend/dashboard/app/components/metrics_overview.tsx
@@ -42,14 +42,29 @@ const MetricsOverview: React.FC<MetricsOverviewProps> = ({ filters }) => {
 
   return (
     <div className="flex flex-wrap gap-16 w-5/6">
-      <InfoCircleAppAdoption status={metricsApiStatus} title="App adoption" noData={metrics.adoption.nan} value={metrics.adoption.adoption} sessions={metrics.adoption.selected_version} totalSessions={metrics.adoption.all_versions} />
-      <InfoCircleExceptionRate status={metricsApiStatus} title="Crash free sessions" noData={metrics.crash_free_sessions.nan} tooltipMsgLine1="Crash free sessions = (1 - Sessions which experienced a crash in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = Crash free sessions percentage of selected app versions / Crash free sessions percentage of unselected app versions" value={metrics.crash_free_sessions.crash_free_sessions} delta={metrics.crash_free_sessions.delta} />
-      <InfoCircleExceptionRate status={metricsApiStatus} title="Perceived crash free sessions" noData={metrics.perceived_crash_free_sessions.nan} tooltipMsgLine1="Perceived crash free sessions = (1 - Sessions which experienced a visible crash in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = Perceived crash free sessions percentage of selected app versions / Perceived crash free sessions percentage of unselected app versions" value={metrics.perceived_crash_free_sessions.perceived_crash_free_sessions} delta={metrics.perceived_crash_free_sessions.delta} />
+      {/* adoption */}
+      {metrics.adoption && <InfoCircleAppAdoption status={metricsApiStatus} title="App adoption" noData={metrics.adoption.nan} value={metrics.adoption.adoption} sessions={metrics.adoption.selected_version} totalSessions={metrics.adoption.all_versions} />}
+
+      {/* crash free sessions */}
+      {metrics.crash_free_sessions && <InfoCircleExceptionRate status={metricsApiStatus} title="Crash free sessions" noData={metrics.crash_free_sessions.nan} tooltipMsgLine1="Crash free sessions = (1 - Sessions which experienced a crash in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = Crash free sessions percentage of selected app versions / Crash free sessions percentage of unselected app versions" value={metrics.crash_free_sessions.crash_free_sessions} delta={metrics.crash_free_sessions.delta} />}
+
+      {/* perceived crash free sessions */}
+      {metrics.perceived_crash_free_sessions && <InfoCircleExceptionRate status={metricsApiStatus} title="Perceived crash free sessions" noData={metrics.perceived_crash_free_sessions.nan} tooltipMsgLine1="Perceived crash free sessions = (1 - Sessions which experienced a visible crash in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = Perceived crash free sessions percentage of selected app versions / Perceived crash free sessions percentage of unselected app versions" value={metrics.perceived_crash_free_sessions.perceived_crash_free_sessions} delta={metrics.perceived_crash_free_sessions.delta} />}
+
+      {/* anr free sessions */}
       {metrics.anr_free_sessions && <InfoCircleExceptionRate status={metricsApiStatus} title="ANR free sessions" noData={metrics.anr_free_sessions.nan} tooltipMsgLine1="ANR free sessions = (1 - Sessions which experienced an ANR in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = ANR free sessions percentage of selected app versions / ANR free sessions percentage of unselected app versions" value={metrics.anr_free_sessions.anr_free_sessions} delta={metrics.anr_free_sessions.delta} />}
+
+      {/* perceived anr free sessions */}
       {metrics.perceived_anr_free_sessions && <InfoCircleExceptionRate status={metricsApiStatus} title="Perceived ANR free sessions" noData={metrics.perceived_anr_free_sessions.nan} tooltipMsgLine1="Perceived ANR free sessions = (1 - Sessions which experienced a visible ANR in selected app versions / Total sessions of selected app versions) * 100" tooltipMsgLine2="Delta value = Perceived ANR free sessions percentage of selected app versions / Perceived ANR free sessions percentage of unselected app versions" value={metrics.perceived_anr_free_sessions.perceived_anr_free_sessions} delta={metrics.perceived_anr_free_sessions.delta} />}
-      <InfoCircleAppStartTime status={metricsApiStatus} title="App cold launch time" launchType="Cold" noData={metrics.cold_launch.nan} value={metrics.cold_launch.p95} delta={metrics.cold_launch.delta} />
-      <InfoCircleAppStartTime status={metricsApiStatus} title="App warm launch time" launchType="Warm" noData={metrics.warm_launch.nan} value={metrics.warm_launch.p95} delta={metrics.warm_launch.delta} />
-      <InfoCircleAppStartTime status={metricsApiStatus} title="App hot launch time" launchType="Hot" noData={metrics.hot_launch.nan} value={metrics.hot_launch.p95} delta={metrics.hot_launch.delta} />
+
+      {/* cold launch */}
+      {metrics.cold_launch && <InfoCircleAppStartTime status={metricsApiStatus} title="App cold launch time" launchType="Cold" noData={metrics.cold_launch.nan} value={metrics.cold_launch.p95} delta={metrics.cold_launch.delta} />}
+
+      {/* warm launch */}
+      {metrics.warm_launch && <InfoCircleAppStartTime status={metricsApiStatus} title="App warm launch time" launchType="Warm" noData={metrics.warm_launch.nan} value={metrics.warm_launch.p95} delta={metrics.warm_launch.delta} />}
+
+      {/* hot launch */}
+      {metrics.hot_launch && <InfoCircleAppStartTime status={metricsApiStatus} title="App hot launch time" launchType="Hot" noData={metrics.hot_launch.nan} value={metrics.hot_launch.p95} delta={metrics.hot_launch.delta} />}
 
       {/* show app size metrics only on single app version selection && only when app size is available */}
       {filters.versions.length === 1 && metrics.sizes !== null && <InfoCircleAppSize status={metricsApiStatus} title="App size" noData={metrics.sizes.nan} valueInBytes={metrics.sizes.selected_app_size} deltaInBytes={metrics.sizes.delta} />}


### PR DESCRIPTION
## Summary

This PR updates all relevant dashboard APIs to return empty response when requested with no app versions. This allows us to implement a "Clear all" filter option on the dashboard.

## Tasks

- [x] Update dashboard overview metrics page
- [x] Modify GET `/apps/:id/metrics` API to support no app versions
- [x] Modify GET `/apps/:id/journey` API to support no app versions
- [x] Modify GET `/apps/:id/crashGroups` API to support no app versions
- [x] Modify GET `/apps/:id/crashGroups/plots/instances` API to support no app versions
- [x] Modify GET `/apps/:id/crashGroups/:crashGroupId/crashes` API to support no app versions
- [x] Modify GET `/apps/:id/crashGroups/:crashGroupId/plots/instances` API to support no app versions
- [x] Modify GET `/apps/:id/crashGroups/:crashGroupId/plots/distribution` API to support no app versions
- [x] Modify GET `/apps/:id/anrGroups` API to support no app versions
- [x] Modify GET `/apps/:id/anrGroups/plots/instances` API to support no app versions
- [x] Modify GET `/apps/:id/anrGroups/:anrGroupId/anrs` API to support no app versions
- [x] Modify GET `/apps/:id/anrGroups/:anrGroupId/plots/instances` API to support no app versions
- [x] Modify GET `/apps/:id/anrGroups/:anrGroupId/plots/distribution` API to support no app versions
- [x] Update GET `/apps/:id/sessions` API
- [x] Update GET `/apps/:id/sessions/plots/instances` API
- [ ] Update GET `/apps/:id/sessions/:sessionId` API
- [ ] Update GET `/apps/:id/spans/roots/names` API
- [ ] Update GET `/apps/:id/spans/instances` API
- [ ] Update GET `/apps/:id/spans/plot` API
- [ ] Test all endpoints thoroughly
- [ ] :books: Update dashboard API documentation

## See also

- fixes #1725
- #1691 
- #1692