### PR TITLE
fix(android): support java 11

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 agp = "8.7.3"
+# This is the lowest version of AGP supported by the measure gradle plugin
+agp741 = "7.4.1"
 bundletool = "1.17.0"
 # android-tools is used for calculating app size and aab size by the gradle plugin.
 # The version should remain compatible with lower versions of android gradle plugin. New versions
@@ -82,7 +84,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-compose-runtime-android = { module = "androidx.compose.runtime:runtime-android", version.ref = "androidx-runtime-android" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 androidx-orchestrator = { module = "androidx.test:orchestrator", version.ref = "orchestrator" }
-agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+agp741 = { module = "com.android.tools.build:gradle", version.ref = "agp741" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm-util" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm-util" }
 android-tools-bundletool = { module = "com.android.tools.build:bundletool", version.ref = "bundletool" }

--- a/android/measure-android-gradle/build.gradle.kts
+++ b/android/measure-android-gradle/build.gradle.kts
@@ -68,7 +68,7 @@ mavenPublishing {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 extensions.configure<SpotlessExtension>("spotless") {
@@ -113,7 +113,7 @@ fun configureSpotlessKotlin(spotlessExtension: SpotlessExtension) {
 }
 
 dependencies {
-    compileOnly(libs.agp)
+    compileOnly(libs.agp741)
     compileOnly(libs.asm.util)
     compileOnly(libs.asm.commons)
 
@@ -132,7 +132,7 @@ dependencies {
     testImplementation(libs.squareup.okhttp.mockwebserver)
     testImplementation(libs.asm.util)
     testImplementation(libs.asm.commons)
-    testImplementation(libs.agp)
+    testImplementation(libs.agp741)
     testImplementation(libs.mockitokotlin2.mockito.kotlin)
     testImplementationAar(libs.measure.android)
 
@@ -145,7 +145,10 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-    if (this.name.equals("functionalTest")) {
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
+    if (this.name == "functionalTest") {
         useJUnitPlatform()
     }
 }


### PR DESCRIPTION
# Description

This PR changes the Measure gradle plugin default Java version to 11. This should allow apps still on Java 11 to be able to use Measure. Functional test continue to run for Java 17 and all supported AGP versions.

fixes: #1729