### PR TITLE
fix(backend): query all user defined attributes

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -1041,7 +1041,7 @@ func (af *AppFilter) getUDAttrKeys(ctx context.Context) (keytypes []event.UDKeyT
 	stmt := sqlf.From("user_def_attrs").
 		Select("distinct key").
 		Select("toString(type) type").
-		Clause("prewhere app_id = toUUID(?) and end_of_month <= ?", af.AppID, af.To).
+		Clause("prewhere app_id = toUUID(?)", af.AppID).
 		OrderBy("key")
 
 	defer stmt.Close()


### PR DESCRIPTION
## Summary

This PR removes the datetime from the filters read query for user defined attributes.

## Tasks

- [x] Query all user defined attributes in GET `/apps/:id/filters` API

## See also

- fixes #1737
