### PR TITLE
chore(backend): add `--skip-apps` option

### DIFF
--- a/self-host/sessionator/README.md
+++ b/self-host/sessionator/README.md
@@ -10,6 +10,7 @@ Easily ingest test sessions during development.
 - [Repeat ingestion of sessions](#repeat-ingestion-of-sessions)
   - [`--clean-all` flag](#--clean-all-flag)
   - [`--clean` flag](#--clean-flag)
+- [Skipping apps from ingestion](#skipping-apps-from-ingestion)
 - [Uploading mappings \& attachments locally](#uploading-mappings--attachments-locally)
 - [Remove apps completely](#remove-apps-completely)
 
@@ -135,6 +136,17 @@ symbols_s3_bucket_region = "us-east-1"
 symbols_access_key = "minio"
 symbols_secret_access_key = "minio123"
 ```
+
+### Skipping apps from ingestion
+
+You can skip certain apps during ingestion using the `--skip-apps` option. This can be useful in scenarios when you to ingest some apps partially.
+
+```sh
+go run . ingest --skip-apps com.example.appOne,com.example.appTwo
+```
+
+Sessionator will not scan the `com.example.appOne` and `com.example.appTwo` apps for the above. Note the app name must match the directory name under the `session-data` directory.
+
 
 ### Uploading mappings & attachments locally
 

--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -15,10 +16,16 @@ func hidden(name string) bool {
 	return strings.HasPrefix(name, ".")
 }
 
+// ScanOpts holds the options for
+// configuring app scanning on disk.
+type ScanOpts struct {
+	SkipApps []string
+}
+
 // Scan reads and validates session data directory
 // and sets up internal data structures for apps,
 // builds, events and blobs.
-func Scan(rootPath string) (apps *Apps, err error) {
+func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 	apps = &Apps{}
 	rootbase := filepath.Base(rootPath)
 	if err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
@@ -32,6 +39,12 @@ func Scan(rootPath string) (apps *Apps, err error) {
 		}
 
 		parts := strings.Split(rel, "/")
+
+		// don't process apps marked
+		// to skip
+		if slices.Contains(opts.SkipApps, parts[0]) {
+			return fs.SkipDir
+		}
 
 		if d.IsDir() {
 			// not top-level directory

--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -63,6 +63,10 @@ var duration time.Duration
 // parallel is used to enable virtualization.
 var parallel bool
 
+// skipApps is used to skip processing
+// of specified apps.
+var skipApps []string
+
 // metrics is used to store progress of ingestion
 // operations.
 var metrics Metrics
@@ -99,6 +103,10 @@ func init() {
 	ingestCmd.
 		Flags().
 		BoolVarP(&cleanAll, "clean-all", "X", false, "remove all builds, events & attachments before ingestion")
+
+	ingestCmd.
+		Flags().
+		StringSliceVar(&skipApps, "skip-apps", nil, "list of apps to skip ingestion")
 
 	ingestCmd.Flags().SortFlags = false
 }
@@ -568,7 +576,9 @@ Structure of "session-data" directory:` + "\n" + DirTree() + "\n" + ValidNote(),
 			os.Exit(1)
 		}
 
-		apps, err := app.Scan(sourceDir)
+		apps, err := app.Scan(sourceDir, &app.ScanOpts{
+			SkipApps: skipApps,
+		})
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)


### PR DESCRIPTION
## Summary

This PR adds a new `--skip-apps` option to sessionator's ingest command allowing us to skip certain apps from ingestion.

## Tasks

- [x] Add `--skip-apps` option to skip certain apps from ingestion
- [x] :books: Update sessionator README documentation

## See also

- fixes #1743