### PR TITLE
chore(backend): add lifecycle app type for ios

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -130,6 +130,9 @@ const LifecycleSwiftUITypeOnDisappear = "on_disappear"
 const LifecycleAppTypeBackground = "background"
 const LifecycleAppTypeForeground = "foreground"
 
+// LifecycleAppTypeTerminated is used only for iOS
+const LifecycleAppTypeTerminated = "terminated"
+
 // NominalColdLaunchThreshold defines the upper bound
 // of a nominal cold launch duration.
 const NominalColdLaunchThreshold = 30 * time.Second
@@ -188,13 +191,6 @@ var ValidLifecycleFragmentTypes = []string{
 	LifecycleFragmentTypeDetached,
 }
 
-// ValidLifecycleAppTypes defines allowed
-// `lifecycle_app.type` values.
-var ValidLifecycleAppTypes = []string{
-	LifecycleAppTypeBackground,
-	LifecycleAppTypeForeground,
-}
-
 // ValidLifecycleViewControllerTypes defines allowed
 // `lifecycle_view_controller.type` values.
 var ValidLifecycleViewControllerTypes = []string{
@@ -235,6 +231,27 @@ var ValidNetworkGenerations = []string{
 	NetworkGeneration4G,
 	NetworkGeneration5G,
 	NetworkGenerationUnknown,
+}
+
+// getValidLifecycleAppTypes defines valid
+// `lifecycle_app.type` values according
+// to the platform.
+func getValidLifecycleAppTypes(p string) (types []string) {
+	switch p {
+	case platform.Android:
+		types = []string{
+			LifecycleAppTypeBackground,
+			LifecycleAppTypeForeground,
+		}
+	case platform.IOS:
+		types = []string{
+			LifecycleAppTypeBackground,
+			LifecycleAppTypeForeground,
+			LifecycleAppTypeTerminated,
+		}
+	}
+
+	return types
 }
 
 // makeTitle appends the message to the type
@@ -980,7 +997,10 @@ func (e *EventField) Validate() error {
 		if len(e.LifecycleApp.Type) > maxLifecycleAppTypeChars {
 			return fmt.Errorf(`%q exceeds maximum allowed characters of (%d)`, `lifecycle_app.type`, maxLifecycleAppTypeChars)
 		}
-		if !slices.Contains(ValidLifecycleAppTypes, e.LifecycleApp.Type) {
+
+		validTypes := getValidLifecycleAppTypes(e.Attribute.Platform)
+
+		if !slices.Contains(validTypes, e.LifecycleApp.Type) {
 			return fmt.Errorf(`%q contains invalid lifecycle app type`, `lifecycle_app.type`)
 		}
 	}

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -665,11 +665,11 @@ Use the `lifecycle_swift_ui` type for iOS SwiftUI view lifecycle events.
 
 #### **`lifecycle_app`**
 
-Use the `lifecycle_app` type for Android's app lifecycle events.
+Use the `lifecycle_app` type for app's lifecycle events.
 
 | Field  | Type   | Optional | Comment                                                       |
 | ------ | ------ | -------- | ------------------------------------------------------------- |
-| `type` | string | No       | One of the following:<br />- `background`<br />- `foreground`<br />- `terminated` |
+| `type` | string | No       | One of the following:<br />- `background`<br />- `foreground`<br />- `terminated`. `terminated` option is only supported on iOS. |
 
 #### **`cold_launch`**
 


### PR DESCRIPTION
## Summary

This PR adds a new `terminated` type for `lifecycle_app.type` for iOS platforms.

## Tasks

- [x] Add new `terminated` type for `lifecycle_app.type` for iOS

## See also

- fixes #1754