### PR TITLE
fix(frontend): make user def attr dropdown stay in viewport

### DIFF
--- a/frontend/dashboard/app/components/user_def_attr_selector.tsx
+++ b/frontend/dashboard/app/components/user_def_attr_selector.tsx
@@ -204,7 +204,7 @@ const UserDefAttrSelector: React.FC<UserDefAttrSelectorProps> = ({ attrs, ops, o
       </div>
 
       {isOpen && (
-        <div className="z-50 origin-top-right absolute left-0 mt-2 w-[600px] max-h-96 overflow-auto rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
+        <div className="z-50 origin-top-right absolute right-0 mt-2 w-[600px] max-h-96 overflow-auto rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
           <div
             role="menu"
             aria-orientation="vertical"


### PR DESCRIPTION
# Description

Makes user def attr dropdown stay in viewport

<img width="1501" alt="Screenshot 2025-01-31 at 5 04 31 PM" src="https://github.com/user-attachments/assets/8748d16b-3d3c-4803-aec4-b3681ddde903" />


## Related issue
Fixes #1783 



