### PR TITLE
feat(frontend): add build number to session replay attr display

### DIFF
--- a/frontend/dashboard/app/[teamId]/sessions/[appId]/[sessionId]/page.tsx
+++ b/frontend/dashboard/app/[teamId]/sessions/[appId]/[sessionId]/page.tsx
@@ -47,7 +47,7 @@ export default function Session({ params }: { params: { teamId: string, appId: s
           <p className="font-sans"> User ID: {sessionReplay.attribute.user_id !== "" ? sessionReplay.attribute.user_id : "N/A"}</p>
           <p className="font-sans"> Duration: {formatMillisToHumanReadable(sessionReplay.duration as unknown as number)}</p>
           <p className="font-sans"> Device: {sessionReplay.attribute.device_manufacturer + sessionReplay.attribute.device_model}</p>
-          <p className="font-sans"> App version: {sessionReplay.attribute.app_version}</p>
+          <p className="font-sans"> App version: {sessionReplay.attribute.app_version} ({sessionReplay.attribute.app_build})</p>
           <p className="font-sans"> Network type: {sessionReplay.attribute.network_type}</p>
           <div className="py-6" />
           <SessionReplay teamId={params.teamId} appId={params.appId} sessionReplay={sessionReplay} />


### PR DESCRIPTION
# Description

Adds build number to session replay attr display

<img width="836" alt="Screenshot 2025-02-24 at 4 05 09 PM" src="https://github.com/user-attachments/assets/23d87adb-8e9b-405a-9750-f64f0d88dadf" />

## Related issue
Closes #1829



