### PR TITLE
feat(frontend): show user def attrs in bug report details

### DIFF
--- a/frontend/dashboard/app/[teamId]/bug_reports/[appId]/[bugReportId]/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/[appId]/[bugReportId]/page.tsx
@@ -72,6 +72,14 @@ export default function BugReport({ params }: { params: { teamId: string, appId:
           <p className="font-sans"> Device: {bugReport.attribute.device_manufacturer + bugReport.attribute.device_model}</p>
           <p className="font-sans"> App version: {bugReport.attribute.app_version} ({bugReport.attribute.app_build})</p>
           <p className="font-sans"> Network type: {bugReport.attribute.network_type}</p>
+          {bugReport.user_defined_attribute !== undefined && bugReport.user_defined_attribute !== null && (
+            <div key="user_defined_attribute">
+              {Object.entries(bugReport.user_defined_attribute).map(([attrKey, attrValue]) => (
+                <p key={attrKey + ":" + attrValue} className="font-sans"> {attrKey}: {attrValue?.toString()}</p>
+              ))}
+            </div>
+          )}
+
           <div className="py-6" />
           {bugReport.description && <p className="font-sans text-xl">{bugReport.description}</p>}
           <div className="py-8" />


### PR DESCRIPTION
# Description

show user def attrs in bug report details

<img width="875" alt="Screenshot 2025-02-24 at 4 24 33 PM" src="https://github.com/user-attachments/assets/95ef20ab-80d9-4e86-9769-1a7b97bbcae7" />

## Related issue
Closes #1825



