### PR TITLE
feat(frontend): show bug reports in session timeline

### DIFF
--- a/backend/api/timeline/bugreport.go
+++ b/backend/api/timeline/bugreport.go
@@ -1,0 +1,50 @@
+package timeline
+
+import (
+	"backend/api/event"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BugReport represents bug report events.
+type BugReport struct {
+	BugReportId uuid.UUID          `json:"bug_report_id"`
+	EventType   string             `json:"event_type"`
+	UDAttribute *event.UDAttribute `json:"user_defined_attribute"`
+	ThreadName  string             `json:"thread_name"`
+	*event.BugReport
+	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
+}
+
+// GetThreadName provides the name of the thread
+// where the bug report event took place.
+func (b BugReport) GetThreadName() string {
+	return b.ThreadName
+}
+
+// GetTimestamp provides the timestamp of
+// the bug report event.
+func (b BugReport) GetTimestamp() time.Time {
+	return b.Timestamp
+}
+
+// ComputeBugReport computes bug report events
+// for session timeline.
+func ComputeBugReport(events []event.EventField) (result []ThreadGrouper) {
+	for _, event := range events {
+		navs := BugReport{
+			event.ID,
+			event.Type,
+			&event.UserDefinedAttribute,
+			event.Attribute.ThreadName,
+			event.BugReport,
+			event.Timestamp,
+			event.Attachments,
+		}
+		result = append(result, navs)
+	}
+
+	return
+}

--- a/frontend/dashboard/app/components/session_replay_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_replay_event_cell.tsx
@@ -32,6 +32,10 @@ export default function SessionReplayEventCell({
       return "bg-red-300"
     }
 
+    if (eventType === "bug_report") {
+      return "bg-red-300"
+    }
+
     if (eventType.includes("gesture")) {
       return "bg-emerald-300"
     }
@@ -58,6 +62,11 @@ export default function SessionReplayEventCell({
   function getTitleFromEventType() {
     if (eventType === "exception" || eventType === "anr") {
       return eventDetails.type + ": " + eventDetails.message
+    }
+
+    if (eventType === "bug_report") {
+      const name = eventDetails.description ? eventDetails.description : eventDetails.bug_report_id
+      return "Bug Report: " + name
     }
 
     if (eventType === "string") {

--- a/frontend/dashboard/app/components/session_replay_event_details.tsx
+++ b/frontend/dashboard/app/components/session_replay_event_details.tsx
@@ -82,8 +82,7 @@ export default function SessionReplayEventDetails({
 
   function getAttachmentsFromEventDetails(): ReactNode {
     if (eventDetails.attachments !== undefined && eventDetails.attachments !== null && eventDetails.attachments.length > 0) {
-      // Return screenshots for exceptions
-      if ((eventType === "exception" && eventDetails.user_triggered === false) || eventType === 'anr' || eventType === 'gesture_click') {
+      if ((eventType === "exception" && eventDetails.user_triggered === false) || eventType === 'anr' || eventType === 'gesture_click' || eventType === 'bug_report') {
         return (
           <div className='flex flex-wrap gap-8 px-4 pt-4 items-center'>
             {eventDetails.attachments.map((attachment: {
@@ -116,10 +115,19 @@ export default function SessionReplayEventDetails({
 
   function getTraceDetailsLinkFromEventDetails(): ReactNode {
     if (eventType === "trace") {
-      console.log("trace_id: " + eventDetails.trace_id)
       return (
         <div className='px-4 pt-8 pb-4'>
           <Link key={eventDetails.id} href={`/${teamId}/traces/${appId}/${eventDetails.trace_id}`} className="outline-none justify-center w-fit hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-white hover:border-black rounded-md text-white hover:text-black font-display transition-colors duration-100 py-2 px-4">View Trace Details</Link>
+        </div>
+      )
+    }
+  }
+
+  function getBugReportDetailsLinkFromEventDetails(): ReactNode {
+    if (eventType === "bug_report") {
+      return (
+        <div className='px-4 pt-8 pb-4'>
+          <Link key={eventDetails.id} href={`/${teamId}/bug_reports/${appId}/${eventDetails.bug_report_id}`} className="outline-none justify-center w-fit hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-white hover:border-black rounded-md text-white hover:text-black font-display transition-colors duration-100 py-2 px-4">View Bug Report Details</Link>
         </div>
       )
     }
@@ -132,6 +140,7 @@ export default function SessionReplayEventDetails({
       {getAttachmentsFromEventDetails()}
       {getExceptionOverviewLinkFromEventDetails()}
       {getTraceDetailsLinkFromEventDetails()}
+      {getBugReportDetailsLinkFromEventDetails()}
       {getBodyFromEventDetails()}
     </div>
   )


### PR DESCRIPTION
# Description

Shows bug reports in session timeline

<img width="1199" alt="Screenshot 2025-02-24 at 5 05 47 PM" src="https://github.com/user-attachments/assets/7494e83a-df50-43e9-9327-769bcda433bc" />

## Related issue
Closes #1827 



