### PR TITLE
ci(flutter): disable ios tests for flutter

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -64,5 +64,5 @@ jobs:
         with:
           version: latest
           directory: ios
-      - name: Run iOS tests
-        run: xcodebuild test -workspace example/ios/Runner.xcworkspace -scheme Runner -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16 Pro Max"
+      # - name: Run iOS tests
+      #  run: xcodebuild test -workspace example/ios/Runner.xcworkspace -scheme Runner -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16 Pro Max"


### PR DESCRIPTION
# Description

Unit tests for iOS are failing on CI due to code signing issues. Disabling tests temporarily.

## Related issue
References #1847 



