### PR TITLE
chore(frontend): rename session 'replay' to 'timeline'

### DIFF
--- a/frontend/dashboard/app/[teamId]/sessions/[appId]/[sessionId]/page.tsx
+++ b/frontend/dashboard/app/[teamId]/sessions/[appId]/[sessionId]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { SessionReplayApiStatus, emptySessionReplay, fetchSessionReplayFromServer } from "@/app/api/api_calls";
-import SessionReplay from "@/app/components/session_replay";
+import { SessionTimelineApiStatus, emptySessionTimeline, fetchSessionTimelineFromServer } from "@/app/api/api_calls";
+import SessionTimeline from "@/app/components/session_timeline";
 import { formatMillisToHumanReadable } from "@/app/utils/time_utils";
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from "react";
@@ -9,27 +9,27 @@ import { useEffect, useState } from "react";
 export default function Session({ params }: { params: { teamId: string, appId: string, sessionId: string } }) {
   const router = useRouter()
 
-  const [sessionReplay, setSessionReplay] = useState(emptySessionReplay);
-  const [sessionReplayApiStatus, setSessionReplayApiStatus] = useState(SessionReplayApiStatus.Loading);
+  const [sessionTimeline, setSessionTimeline] = useState(emptySessionTimeline);
+  const [sessionTimelineApiStatus, setSessionTimelineApiStatus] = useState(SessionTimelineApiStatus.Loading);
 
-  const getSessionReplay = async () => {
-    setSessionReplayApiStatus(SessionReplayApiStatus.Loading)
+  const getSessionTimeline = async () => {
+    setSessionTimelineApiStatus(SessionTimelineApiStatus.Loading)
 
-    const result = await fetchSessionReplayFromServer(params.appId, params.sessionId, router)
+    const result = await fetchSessionTimelineFromServer(params.appId, params.sessionId, router)
 
     switch (result.status) {
-      case SessionReplayApiStatus.Error:
-        setSessionReplayApiStatus(SessionReplayApiStatus.Error)
+      case SessionTimelineApiStatus.Error:
+        setSessionTimelineApiStatus(SessionTimelineApiStatus.Error)
         break
-      case SessionReplayApiStatus.Success:
-        setSessionReplayApiStatus(SessionReplayApiStatus.Success)
-        setSessionReplay(result.data)
+      case SessionTimelineApiStatus.Success:
+        setSessionTimelineApiStatus(SessionTimelineApiStatus.Success)
+        setSessionTimeline(result.data)
         break
     }
   }
 
   useEffect(() => {
-    getSessionReplay()
+    getSessionTimeline()
   }, []);
 
   return (
@@ -38,19 +38,19 @@ export default function Session({ params }: { params: { teamId: string, appId: s
       <p className="font-display text-4xl">Session: {params.sessionId}</p>
       <div className="py-2" />
 
-      {sessionReplayApiStatus === SessionReplayApiStatus.Loading && <p className="text-lg font-display">Fetching session replay...</p>}
+      {sessionTimelineApiStatus === SessionTimelineApiStatus.Loading && <p className="text-lg font-display">Fetching session timeline...</p>}
 
-      {sessionReplayApiStatus === SessionReplayApiStatus.Error && <p className="text-lg font-display">Error fetching session replay, please refresh page try again</p>}
+      {sessionTimelineApiStatus === SessionTimelineApiStatus.Error && <p className="text-lg font-display">Error fetching session timeline, please refresh page try again</p>}
 
-      {sessionReplayApiStatus === SessionReplayApiStatus.Success &&
+      {sessionTimelineApiStatus === SessionTimelineApiStatus.Success &&
         <div>
-          <p className="font-sans"> User ID: {sessionReplay.attribute.user_id !== "" ? sessionReplay.attribute.user_id : "N/A"}</p>
-          <p className="font-sans"> Duration: {formatMillisToHumanReadable(sessionReplay.duration as unknown as number)}</p>
-          <p className="font-sans"> Device: {sessionReplay.attribute.device_manufacturer + sessionReplay.attribute.device_model}</p>
-          <p className="font-sans"> App version: {sessionReplay.attribute.app_version} ({sessionReplay.attribute.app_build})</p>
-          <p className="font-sans"> Network type: {sessionReplay.attribute.network_type}</p>
+          <p className="font-sans"> User ID: {sessionTimeline.attribute.user_id !== "" ? sessionTimeline.attribute.user_id : "N/A"}</p>
+          <p className="font-sans"> Duration: {formatMillisToHumanReadable(sessionTimeline.duration as unknown as number)}</p>
+          <p className="font-sans"> Device: {sessionTimeline.attribute.device_manufacturer + sessionTimeline.attribute.device_model}</p>
+          <p className="font-sans"> App version: {sessionTimeline.attribute.app_version} ({sessionTimeline.attribute.app_build})</p>
+          <p className="font-sans"> Network type: {sessionTimeline.attribute.network_type}</p>
           <div className="py-6" />
-          <SessionReplay teamId={params.teamId} appId={params.appId} sessionReplay={sessionReplay} />
+          <SessionTimeline teamId={params.teamId} appId={params.appId} sessionTimeline={sessionTimeline} />
         </div>}
     </div>
 

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -206,7 +206,7 @@ export enum AuthzAndMembersApiStatus {
   Cancelled
 }
 
-export enum SessionReplayApiStatus {
+export enum SessionTimelineApiStatus {
   Loading,
   Success,
   Error,
@@ -622,7 +622,7 @@ export const defaultAuthzAndMembers = {
   ]
 }
 
-export const emptySessionReplay = {
+export const emptySessionTimeline = {
   "app_id": "2b7ddad4-40a6-42a7-9e21-a90577e08263",
   "attribute": {
     "installation_id": "",
@@ -1569,21 +1569,21 @@ export const fetchAuthzAndMembersFromServer = async (teamId: string, router: App
   }
 }
 
-export const fetchSessionReplayFromServer = async (appId: string, sessionId: string, router: AppRouterInstance) => {
+export const fetchSessionTimelineFromServer = async (appId: string, sessionId: string, router: AppRouterInstance) => {
   const origin = process.env.NEXT_PUBLIC_API_BASE_URL
 
   try {
     const res = await fetchMeasure(`${origin}/apps/${appId}/sessions/${sessionId}`);
     if (!res.ok) {
       logoutIfAuthError(auth, router, res)
-      return { status: SessionReplayApiStatus.Error, data: null }
+      return { status: SessionTimelineApiStatus.Error, data: null }
     }
 
     const data = await res.json()
 
-    return { status: SessionReplayApiStatus.Success, data: data }
+    return { status: SessionTimelineApiStatus.Success, data: data }
   } catch {
-    return { status: SessionReplayApiStatus.Cancelled, data: null }
+    return { status: SessionTimelineApiStatus.Cancelled, data: null }
   }
 }
 

--- a/frontend/dashboard/app/components/session_timeline_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_cell.tsx
@@ -3,7 +3,7 @@
 import { formatDateToHumanReadableDateTime } from '../utils/time_utils'
 import { formatToCamelCase } from '../utils/string_utils'
 
-type SessionReplayEventCellProps = {
+type SessionTimelineEventCellProps = {
   eventType: string
   eventDetails: any
   threadName: string
@@ -13,7 +13,7 @@ type SessionReplayEventCellProps = {
   onClick: (index: number) => void
 }
 
-export default function SessionReplayEventCell({
+export default function SessionTimelineEventCell({
   eventType,
   eventDetails,
   threadName,
@@ -21,7 +21,7 @@ export default function SessionReplayEventCell({
   index,
   selected,
   onClick
-}: SessionReplayEventCellProps) {
+}: SessionTimelineEventCellProps) {
 
   function getColorFromEventType() {
     if ((eventType === "exception" || eventType === "anr") && eventDetails.user_triggered === true) {

--- a/frontend/dashboard/app/components/session_timeline_event_details.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_details.tsx
@@ -5,19 +5,19 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { formatDateToHumanReadableDateTime, formatMillisToHumanReadable } from '../utils/time_utils'
 
-type SessionReplayEventDetailsProps = {
+type SessionTimelineEventDetailsProps = {
   teamId: string
   appId: string
   eventType: string
   eventDetails: any
 }
 
-export default function SessionReplayEventDetails({
+export default function SessionTimelineEventDetails({
   teamId,
   appId,
   eventType,
   eventDetails
-}: SessionReplayEventDetailsProps) {
+}: SessionTimelineEventDetailsProps) {
 
   function getBodyFromEventDetails(): ReactNode {
     // Remove user defined attrs. In case of http event, remove start_time and end_time as well since they represent uptime in ms and not timestamps.

--- a/frontend/dashboard/app/components/session_timeline_seekbar.tsx
+++ b/frontend/dashboard/app/components/session_timeline_seekbar.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 
-interface SessionReplaySeekBarProps {
+interface SessionTimelineSeekBarProps {
   value: number;
   onChange: (value: number) => void;
 }
@@ -14,7 +14,7 @@ interface CSSProperties extends React.CSSProperties {
   '--progress-percent'?: string;
 }
 
-const SessionReplaySeekBar: React.FC<SessionReplaySeekBarProps> = ({ value, onChange }) => {
+const SessionTimelineSeekBar: React.FC<SessionTimelineSeekBarProps> = ({ value, onChange }) => {
   const rangeRef = useRef<HTMLInputElement>(null);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -107,4 +107,4 @@ const SessionReplaySeekBar: React.FC<SessionReplaySeekBarProps> = ({ value, onCh
   );
 };
 
-export default SessionReplaySeekBar;
+export default SessionTimelineSeekBar;


### PR DESCRIPTION
# Description

Renames session 'replay' to 'timeline'

## Related issue
Closes #1835



