### PR TITLE
fix(backend): sessionator would fail deleting objects

### DIFF
--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -642,11 +642,11 @@ Structure of "session-data" directory:` + "\n" + DirTree() + "\n" + ValidNote(),
 
 		if clean {
 			if err := rmAppResources(ctx, configData); err != nil {
-				log.Fatal("failed to clean old data", err)
+				log.Fatal("failed to clean old data: ", err)
 			}
 		} else if cleanAll {
 			if err := rmAll(ctx, configData); err != nil {
-				log.Fatal("failed to clean all old data", err)
+				log.Fatal("failed to clean all old data: ", err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Recent versions of aws-sdk-go-v2 require the client to manually inject a `Content-Md5` header containing the hash of the request body, otherwise the remote server would reject bulk deletion of objects

## Tasks

- [x] Created a common stack middleware function that can be passed as options when creating customized S3 clients.
- [x] Fixed an issue where `getAttachmentsClient` was incorrectly using the symbols bucket values instead of attachment bucket values.

## See also

- fixes #1888