### PR TITLE
chore(backend): update go toolchain version

### DIFF
--- a/backend/api/go.mod
+++ b/backend/api/go.mod
@@ -1,6 +1,6 @@
 module backend/api
 
-go 1.24
+go 1.24.1
 
 toolchain go1.24.0
 

--- a/backend/cleanup/go.mod
+++ b/backend/cleanup/go.mod
@@ -1,6 +1,6 @@
 module backend/cleanup
 
-go 1.24
+go 1.24.1
 
 toolchain go1.24.0
 

--- a/backend/migrator/go.mod
+++ b/backend/migrator/go.mod
@@ -1,6 +1,6 @@
 module migrator
 
-go 1.24
+go 1.24.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.24.0
+go 1.24.1
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 use (
 	./backend/api


### PR DESCRIPTION
## Summary

The go toolchain version is not in the updated format. It should be go 1.N.P while they were in 1.N format. This will ensure go tools in CI and local environments pick the correct tooling versions.

## Tasks

- [x] Update to go 1.24.1 toolchain version for all go services
