### PR TITLE
fix(backend): codeql integer conversion error

### DIFF
--- a/self-host/sessionator/app/build.go
+++ b/self-host/sessionator/app/build.go
@@ -7,7 +7,7 @@ import (
 // BuildInfo represents build metadata for an
 // app version's build.
 type BuildInfo struct {
-	Size uint32 `toml:"size"`
+	Size uint   `toml:"size"`
 	Type string `toml:"type"`
 }
 

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -427,7 +427,7 @@ func writeBuild(c *gin.Context) {
 	defer out.Close()
 
 	buildInfo := app.BuildInfo{
-		Size: uint32(buildSize),
+		Size: uint(buildSize),
 		Type: buildType,
 	}
 


### PR DESCRIPTION
## Summary

Fix a CodeQL alert in `sessionator record` command. The error occurred in the code path of creating build size toml object while reading and writing `build.toml` files.

[See the alert](https://github.com/measure-sh/measure/security/code-scanning/35)

## Tasks

- [x] Fix incorrect integer correction error when create build size files in sessionator

