### PR TITLE
fix(backend): sessionator record & ingest errors

### DIFF
--- a/backend/api/codec/codec.go
+++ b/backend/api/codec/codec.go
@@ -12,7 +12,7 @@ import (
 
 // IsTarGz validates that the expected file
 // is a valid gzipped tarball.
-func IsTarGz(file io.Reader) (err error) {
+func IsTarGz(file io.ReadSeeker) (err error) {
 	// check if gzip file
 	gzipReader, err := gzip.NewReader(file)
 	if err != nil {
@@ -31,6 +31,12 @@ func IsTarGz(file io.Reader) (err error) {
 	_, err = tarReader.Next()
 	if err != nil {
 		err = errors.Join(errors.New("not a valid tar file"), err)
+		return
+	}
+
+	// important to seek the file pointer
+	// to the very start
+	if _, err = file.Seek(0, 0); err != nil {
 		return
 	}
 

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -257,7 +257,7 @@ func (e *eventreq) read(c *gin.Context, appId uuid.UUID) error {
 		// if we haven't figured out
 		// platform already.
 		if e.platform == "" {
-			e.platform = e.events[0].Attribute.Platform
+			e.platform = ev.Attribute.Platform
 		}
 
 		e.events = append(e.events, ev)

--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -89,9 +89,13 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				if info.Size() < 1 {
 					return fmt.Errorf("%q has empty build.toml. check %q", app.FullName(), rel)
 				}
-				build := &Build{
-					VersionCode: code,
+				_, ok := app.Builds[code]
+				if !ok {
+					app.Builds[code] = &Build{
+						VersionCode: code,
+					}
 				}
+				build := app.Builds[code]
 				if err := app.ReadBuild(path, &build.BuildInfo); err != nil {
 					return err
 				}
@@ -101,8 +105,6 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				if build.BuildInfo.Type == "" {
 					return fmt.Errorf("%q has empty build type. check %q", app.FullName(), rel)
 				}
-
-				app.Builds[code] = build
 			}
 
 			proguardMapping, err := filepath.Match("*/*/*/mapping.txt", rel)
@@ -117,6 +119,13 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 				if info.Size() < 1 {
 					return fmt.Errorf("%q has empty mapping.txt file. check %q", app.FullName(), rel)
+				}
+
+				_, ok := app.Builds[code]
+				if !ok {
+					app.Builds[code] = &Build{
+						VersionCode: code,
+					}
 				}
 
 				app.Builds[code].MappingFiles = append(app.Builds[code].MappingFiles, path)
@@ -137,7 +146,9 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 				_, ok := app.Builds[code]
 				if !ok {
-					return fmt.Errorf("failed to create build for code: %s", code)
+					app.Builds[code] = &Build{
+						VersionCode: code,
+					}
 				}
 
 				app.Builds[code].MappingFiles = append(app.Builds[code].MappingFiles, path)


### PR DESCRIPTION
## Summary

This PR fixes some of the issues discovered in sessionator record and ingest operations during our recent testing.

## Tasks

- [x] Fix the way builds were read when scanning before ingestion
- [x] Fix an issue where gzip check would fail with an eof error
- [x] Fix an issue where platform was not being sent during ingest
- [x] Fix an issue where platform was being not being read correctly