### PR TITLE
fix(backend): fix an issue where clock_speed validation was failing

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -535,7 +535,7 @@ type TrimMemory struct {
 
 type CPUUsage struct {
 	NumCores        uint8   `json:"num_cores" binding:"required"`
-	ClockSpeed      uint32  `json:"clock_speed" binding:"required"`
+	ClockSpeed      uint64  `json:"clock_speed" binding:"required"`
 	StartTime       uint64  `json:"start_time" binding:"required"`
 	Uptime          uint64  `json:"uptime" binding:"required"`
 	UTime           uint64  `json:"utime" binding:"required"`

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -774,7 +774,7 @@ Use the `cpu_usage` type for CPU usage of a Linux based OS.
 | Field              | Type    | Optional | Description                                                         |
 | ------------------ | :------ | :------- | ------------------------------------------------------------------- |
 | `num_cores`        | uint8   | No       | Number of cores in the device.                                      |
-| `clock_speed`      | uint32  | No       | Clock speed of the device, in Hz.                                   |
+| `clock_speed`      | uint64  | No       | Clock speed of the device, in Hz.                                   |
 | `uptime`           | uint64  | No       | Time since the device booted, in ms.                                |
 | `utime`            | uint64  | No       | Time spent executing code in user mode, in Jiffies.                 |
 | `stime`            | uint64  | No       | Time spent executing code in kernel mode, in Jiffies.               |

--- a/self-host/clickhouse/20250315090713_alter_events_table.sql
+++ b/self-host/clickhouse/20250315090713_alter_events_table.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+alter table events
+modify column if exists `cpu_usage.clock_speed` UInt64;
+
+-- migrate:down
+select 1;


### PR DESCRIPTION
> [!NOTE]
>
> ## To Maintainers
>
> Please run ClickHouse migrations by [following this guide.](https://github.com/measure-sh/measure/blob/main/self-host/clickhouse/README.md)

## Summary

This PR modifies the column width of `cpu_usage.clock_speed` in ClickHouse events table and in server code from `uint32` to `uint64`. iOS necessitates this otherwise `cpu_usage.clock_speed` could become 0 which is not acceptable by the event ingestion pipeline.

## Tasks

- [x] Modify the type of `cpu_usage.clock_speed` column to `UInt64`
- [x] Modify the type of `CPUUsge.ClockSpeed` struct field to `uint64`
- [x] Update SDK API documentation

## See also

- fixes #1903