### PR TITLE
Render attachments for `gesture_scroll` & `gesture_long_click` events in session timeline

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -1891,15 +1891,36 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			ev.LogString = &logString
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureLongClick:
+			// only unmarshal attachments if more than
+			// 8 characters
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			ev.GestureLongClick = &gestureLongClick
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureClick:
+			// only unmarshal attachments if more than
+			// 8 characters
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
 				return nil, err
 			}
 			ev.GestureClick = &gestureClick
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureScroll:
+			// only unmarshal attachments if more than
+			// 8 characters
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			ev.GestureScroll = &gestureScroll
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleActivity:

--- a/backend/api/timeline/gesture.go
+++ b/backend/api/timeline/gesture.go
@@ -46,6 +46,7 @@ type GestureLongClick struct {
 	X           float32            `json:"x"`
 	Y           float32            `json:"y"`
 	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
 }
 
 // GetThreadName provides the name of the thread
@@ -74,6 +75,7 @@ type GestureScroll struct {
 	EndY        float32            `json:"end_y"`
 	Direction   string             `json:"direction"`
 	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
 }
 
 // GetThreadName provides the name of the thread
@@ -126,6 +128,7 @@ func ComputeGestureLongClicks(events []event.EventField) (result []ThreadGrouper
 			event.GestureLongClick.X,
 			event.GestureLongClick.Y,
 			event.Timestamp,
+			event.Attachments,
 		}
 		result = append(result, gestureLongClicks)
 	}
@@ -149,6 +152,7 @@ func ComputeGestureScrolls(events []event.EventField) (result []ThreadGrouper) {
 			event.GestureScroll.EndY,
 			event.GestureScroll.Direction,
 			event.Timestamp,
+			event.Attachments,
 		}
 		result = append(result, gestureScrolls)
 	}

--- a/frontend/dashboard/app/components/session_timeline_event_details.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_details.tsx
@@ -82,7 +82,7 @@ export default function SessionTimelineEventDetails({
 
   function getAttachmentsFromEventDetails(): ReactNode {
     if (eventDetails.attachments !== undefined && eventDetails.attachments !== null && eventDetails.attachments.length > 0) {
-      if ((eventType === "exception" && eventDetails.user_triggered === false) || eventType === 'anr' || eventType === 'gesture_click' || eventType === 'bug_report') {
+      if ((eventType === "exception" && eventDetails.user_triggered === false) || eventType === 'anr' || eventType === 'gesture_click' || eventType === 'gesture_long_click' || eventType === 'gesture_scroll' || eventType === 'bug_report') {
         return (
           <div className='flex flex-wrap gap-8 px-4 pt-4 items-center'>
             {eventDetails.attachments.map((attachment: {


### PR DESCRIPTION
## Summary

In Session Timeline view, we only render attachments for `gesture_click` gesture events. This behavior works as expected with respect to Android platform, but for iOS platform, we capture attachments like layout snapshots for `gesture_long_click` and `gesture_scroll` events along with `gesture_click` events.

This PR modifies the GET `/apps/:id/sessions/:sessionId` API to return attachment data for `gesture_scroll` and `gesture_long_click` events when available.

Additionally, the Session Timeline details page has been modified to render these attachments.

## Tasks

- [x] Modify `/apps/:id/sessions/:sessionId` API to return attachments for `gesture_scroll` & `gesture_long_click` events
- [x] Modify `session_timeline_event_details.tsx` to support rendering of attachments for the above events

## See also

- fixes #1909 