### PR TITLE
chore(backend): support .dylib mapping files in ios

### DIFF
--- a/backend/api/measure/mapping.go
+++ b/backend/api/measure/mapping.go
@@ -432,9 +432,9 @@ func (bm *BuildMapping) extractDif() (err error) {
 				return errExtract
 			}
 
-			for k, v := range entities {
-				if k == symbol.TypeDsymDebug {
-					bm.MappingFiles[i].Difs = append(bm.MappingFiles[i].Difs, v...)
+			for _, entity := range entities {
+				for _, difs := range entity {
+					bm.MappingFiles[i].Difs = append(bm.MappingFiles[i].Difs, difs)
 				}
 			}
 		}

--- a/backend/api/symbol/dif.go
+++ b/backend/api/symbol/dif.go
@@ -66,7 +66,7 @@ type Dif struct {
 // ExtractDsymEntities extracts data from Mach-O
 // binary by reading a gzipped tarball while
 // matching a caller provided predicate.
-func ExtractDsymEntities(file io.Reader, filter func(string) (DsymType, bool)) (entities map[DsymType][]*Dif, err error) {
+func ExtractDsymEntities(file io.Reader, filter func(string) (DsymType, bool)) (entities [][]*Dif, err error) {
 	gzipReader, err := gzip.NewReader(file)
 	if err != nil {
 		return
@@ -93,11 +93,7 @@ func ExtractDsymEntities(file io.Reader, filter func(string) (DsymType, bool)) (
 			continue
 		}
 
-		if dSYMType, ok := filter(header.Name); ok {
-			if entities == nil {
-				entities = make(map[DsymType][]*Dif)
-			}
-
+		if _, ok := filter(header.Name); ok {
 			debugBytes, err := io.ReadAll(tarReader)
 			if err != nil {
 				return nil, err
@@ -160,7 +156,7 @@ func ExtractDsymEntities(file io.Reader, filter func(string) (DsymType, bool)) (
 				},
 			}
 
-			entities[dSYMType] = difs
+			entities = append(entities, difs)
 		}
 	}
 

--- a/backend/api/symbol/dif_test.go
+++ b/backend/api/symbol/dif_test.go
@@ -3,7 +3,6 @@ package symbol
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -49,7 +48,6 @@ func TestExtractDsymEntities(t *testing.T) {
 			symbolCondition := strings.Count(name, "Contents/Resources/") == 1 && !strings.HasSuffix(name, ".dSYM") && len(parts) == 5 && !strings.HasPrefix(last, "._")
 
 			if symbolCondition {
-				fmt.Println("name", name)
 				return TypeDsymDebug, true
 			}
 
@@ -75,8 +73,8 @@ func TestExtractDsymEntities(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		expected := map[DsymType][]*Dif{
-			TypeDsymDebug: {
+		expected := [][]*Dif{
+			{
 				{
 					Data: debugBytes,
 					Meta: false,
@@ -91,33 +89,33 @@ func TestExtractDsymEntities(t *testing.T) {
 		}
 
 		// assertions for debuginfo
-		if len(expected[TypeDsymDebug][0].Data) != len(got[TypeDsymDebug][0].Data) {
-			t.Errorf("Expected %d length, but got %d", len(expected[TypeDsymDebug][0].Data), len(got[TypeDsymDebug][0].Data))
+		if len(expected[0][0].Data) != len(got[0][0].Data) {
+			t.Errorf("Expected %d length, but got %d", len(expected[0][0].Data), len(got[0][0].Data))
 		}
 
-		if !bytes.Equal(expected[TypeDsymDebug][0].Data, got[TypeDsymDebug][0].Data) {
-			t.Errorf("Expected debuginfo bytes %v, but got %v", expected[TypeDsymDebug][0].Data, got[TypeDsymDebug][0].Data)
+		if !bytes.Equal(expected[0][0].Data, got[0][0].Data) {
+			t.Errorf("Expected debuginfo bytes %v, but got %v", expected[0][0].Data, got[0][0].Data)
 		}
 
-		if expected[TypeDsymDebug][0].Meta != got[TypeDsymDebug][0].Meta {
-			t.Errorf("Expected meta %v, but got %v", expected[TypeDsymDebug][0].Meta, got[TypeDsymDebug][0].Meta)
+		if expected[0][0].Meta != got[0][0].Meta {
+			t.Errorf("Expected meta %v, but got %v", expected[0][0].Meta, got[0][0].Meta)
 		}
 
-		if expected[TypeDsymDebug][0].Key != got[TypeDsymDebug][0].Key {
-			t.Errorf("Expected debuginfo key %v, but got %v", expected[TypeDsymDebug][0].Key, got[TypeDsymDebug][0].Key)
+		if expected[0][0].Key != got[0][0].Key {
+			t.Errorf("Expected debuginfo key %v, but got %v", expected[0][0].Key, got[0][0].Key)
 		}
 
 		// assertions for meta file
-		if !bytes.Equal(expected[TypeDsymDebug][1].Data, got[TypeDsymDebug][1].Data) {
-			t.Errorf("Expected meta bytes %v, but got %v", expected[TypeDsymDebug][1].Data, got[TypeDsymDebug][1].Data)
+		if !bytes.Equal(expected[0][1].Data, got[0][1].Data) {
+			t.Errorf("Expected meta bytes %v, but got %v", expected[0][1].Data, got[0][1].Data)
 		}
 
-		if expected[TypeDsymDebug][1].Meta != got[TypeDsymDebug][1].Meta {
-			t.Errorf("Expected meta %v, but got %v", expected[TypeDsymDebug][1].Meta, got[TypeDsymDebug][1].Meta)
+		if expected[0][1].Meta != got[0][1].Meta {
+			t.Errorf("Expected meta %v, but got %v", expected[0][1].Meta, got[0][1].Meta)
 		}
 
-		if expected[TypeDsymDebug][1].Key != got[TypeDsymDebug][1].Key {
-			t.Errorf("Expected key %v, but got %v", expected[TypeDsymDebug][1].Key, got[TypeDsymDebug][1].Key)
+		if expected[0][1].Key != got[0][1].Key {
+			t.Errorf("Expected key %v, but got %v", expected[0][1].Key, got[0][1].Key)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR modfies the PUT `/builds` API to accept `.dylib` binary files for iOS along with regular non-dylib binaries. This change ensures that users who are producing debug builds in newer Xcode versions also enjoy iOS symbolication.

## Tasks

- [x] Modify the put `/builds` API to accept and treat `.dylib` mach-o binary files like regular non-dylib binaries

## See also

- fixes #1913