### PR TITLE
fix(backend): fix issue with sessionator clean-all flag

### DIFF
--- a/self-host/sessionator/cmd/rm.go
+++ b/self-host/sessionator/cmd/rm.go
@@ -286,7 +286,7 @@ func rmAll(ctx context.Context, c *config.Config) (err error) {
 
 	symbolsClient := j.getSymbolsClient(options...)
 	symbolsBucket := aws.String(j.config.Storage["symbols_s3_bucket"])
-	attachmentsClient := j.getAttachmentsClient()
+	attachmentsClient := j.getAttachmentsClient(options...)
 	attachmentsBucket := aws.String(j.config.Storage["attachments_s3_bucket"])
 
 	fmt.Println("removing all app resources")


### PR DESCRIPTION
## Summary

This PR fixes ingest `--clean-all` flag to work as expected. An optional parameter was missed when creating an S3 client for operating on attachments bucket.

## Tasks

- [x] `--clean-all` flag in sessionator ingest command would throw an error

## See also

- fixes #1923
