### PR TITLE
chore(android): upgrade AGP and downgrade androidx.core

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.9.0"
 # This is the lowest version of AGP supported by the measure gradle plugin
 agp741 = "7.4.1"
 bundletool = "1.17.0"
@@ -15,7 +15,7 @@ measure-android = "0.10.0-SNAPSHOT"
 androidx-activity-compose = "1.7.2"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"
-androidx-core-ktx = "1.15.0"
+androidx-core-ktx = "1.13.1"
 androidx-junit = "1.1.5"
 androidx-compose-ui = "1.4.3"
 androidx-compose-material3 = "1.0.1"
@@ -50,7 +50,7 @@ kolinx-binary-compatibility-validator = "0.13.2"
 diffplug-spotless = "6.24.0"
 compose-plugin = "1.5.11"
 gradle-plugin-publish = "1.2.0"
-autonomousapps-testkit = "0.10"
+autonomousapps-testkit = "0.12"
 mavenPublish = "0.29.0"
 
 [libraries]

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 14 14:48:04 IST 2023
+#Mon Mar 17 10:37:45 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
+++ b/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
@@ -157,6 +157,8 @@ class MeasurePluginTest {
                 Arguments.of(SemVer(8, 5, 2), GradleVersion.version("8.7")),
                 Arguments.of(SemVer(8, 6, 1), GradleVersion.version("8.7")),
                 Arguments.of(SemVer(8, 7, 3), GradleVersion.version("8.9")),
+                Arguments.of(SemVer(8, 8, 0), GradleVersion.version("8.10.2")),
+                Arguments.of(SemVer(8, 9, 0), GradleVersion.version("8.11.1")),
             )
         }
     }


### PR DESCRIPTION
# Description

Version changes:

AGP -> 8.9.0
androidx.core -> 1.13.1 to remain compatible with apps on Android 34

## Related issue
Fixes #1921 


