### PR TITLE
fix(backend): fix partial android symbolication

### DIFF
--- a/backend/api/symbolicator/payload.go
+++ b/backend/api/symbolicator/payload.go
@@ -1,6 +1,8 @@
 package symbolicator
 
-import "slices"
+import (
+	"slices"
+)
 
 type frameNative struct {
 	Status          string `json:"status"`
@@ -66,6 +68,16 @@ type responseJVM struct {
 	Stacktraces []stacktraceJVM   `json:"stacktraces"`
 	Classes     map[string]string `json:"classes"`
 	Errors      []moduleJVM       `json:"errors"`
+}
+
+// rewriteClass is a helper method to provide a mapped
+// class if found or return the fallback.
+func (r responseJVM) rewriteClass(needle, fallback string) string {
+	if value, ok := r.Classes[needle]; ok {
+		return value
+	}
+
+	return fallback
 }
 
 // requestJVM represents the payload sent

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -43,9 +43,9 @@ services:
       retries: 5
     develop:
       watch:
-      - path: ../frontend/dashboard
-        action: sync
-        target: /app
+        - path: ../frontend/dashboard
+          action: sync
+          target: /app
 
   api:
     build:
@@ -76,6 +76,7 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}
       - OTEL_INSECURE_MODE=${OTEL_INSECURE_MODE}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+      - SYMBOLICATE_JVM_LAMBDA_REWRITE=true
     develop:
       watch:
         - path: ../backend/api


### PR DESCRIPTION
## Summary

This PR works around a bug in Sentry's Symbolicator JVM symbolication response where it would produce unexpected symbolication outcomes for certain stacktraces containing lambda functions.

## Tasks

- [x] Fix an issue where for some jvm stacktraces containing lambda functions, symbolication would be incomplete or non-sensical
- [x] Add `SYMBOLICATE_JVM_LAMBDA_REWRITE` config to api service in `compose.yml`

## See also

- fixes #1920