### PR TITLE
fix(backend): remove mapping file size validation

### DIFF
--- a/backend/api/measure/mapping.go
+++ b/backend/api/measure/mapping.go
@@ -69,7 +69,6 @@ func (bm BuildMapping) hasMapping() bool {
 // validate validates build mapping details.
 func (bm BuildMapping) validate(app *App) (code int, err error) {
 	code = http.StatusBadRequest
-	maxSize := int64(server.Server.Config.MappingFileMaxSize)
 
 	for i, mf := range bm.MappingFiles {
 		// none of the mapping files
@@ -81,14 +80,6 @@ func (bm BuildMapping) validate(app *App) (code int, err error) {
 
 		if mf.Header.Size < 1 {
 			err = fmt.Errorf("%q at %d index has zero or invalid size", "mapping_file", i)
-		}
-
-		// none of the mapping files
-		// should exceed maximum allowed
-		// size limit
-		if mf.Header.Size > maxSize {
-			code = http.StatusRequestEntityTooLarge
-			err = fmt.Errorf("%q at %d index exceeds max allowed size in %d bytes", "mapping_file", i, maxSize)
 		}
 	}
 

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -42,7 +41,6 @@ type ClickhouseConfig struct {
 type ServerConfig struct {
 	PG                         PostgresConfig
 	CH                         ClickhouseConfig
-	MappingFileMaxSize         uint64
 	SymbolsBucket              string
 	SymbolsBucketRegion        string
 	SymbolsAccessKey           string
@@ -65,12 +63,6 @@ type ServerConfig struct {
 }
 
 func NewConfig() *ServerConfig {
-	mappingFileMaxSize, err := strconv.ParseUint(os.Getenv("MAPPING_FILE_MAX_SIZE"), 10, 64)
-	if err != nil {
-		log.Println("using default value of MAPPING_FILE_MAX_SIZE")
-		mappingFileMaxSize = 524_288_000
-	}
-
 	symbolsBucket := os.Getenv("SYMBOLS_S3_BUCKET")
 	if symbolsBucket == "" {
 		log.Println("SYMBOLS_S3_BUCKET env var not set, mapping file uploads won't work")
@@ -180,7 +172,6 @@ func NewConfig() *ServerConfig {
 		CH: ClickhouseConfig{
 			DSN: clickhouseDSN,
 		},
-		MappingFileMaxSize:         mappingFileMaxSize,
 		SymbolsBucket:              symbolsBucket,
 		SymbolsBucketRegion:        symbolsBucketRegion,
 		SymbolsAccessKey:           symbolsAccessKey,

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -238,7 +238,6 @@ List of all the fields of the multipart request.
 | `build_type`   | string | No       | Type of the build.<br />- `aab` for Android<br />- `ipa` for iOS              |
 | `platform`     | string | Yes      | Platform of the app.<br />- `android` for Android<br />- `ios` for iOS        |
 
-- Mapping file size should not exceed **512 MiB**.
 - `mapping_type` &amp; `mapping_file` are optional. Both need to be present for mapping file uploads to work.
 - `version_name`, `version_code`, `build_size` &amp; `build_type` are required and cannot be skipped.
 - Uploading a previously uploaded mapping file with exact contents for the same combination of `version_name`, `version_code`, `mapping_type` replaces the older mapping file(s).


### PR DESCRIPTION
## Summary

This PR removes mapping file maximum size validation in PUT `/builds` API.

## Tasks

- [x] Remove config from `server.go`
- [x] Remove validation in PUT `/builds` API
- [x] Update SDK API docs

## See also

- fixes #1930
