### PR TITLE
chore(backend): update migration script

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -1,6 +1,6 @@
 # Self Hosting Guide <!-- omit in toc -->
 
-Measure is designed from the ground up for easy self-hosting. Follow along to run Measure on your own infrastructure.
+measure.sh is designed from the ground up for easy self-hosting. Follow along to run measure.sh on your own infrastructure.
 
 ## Contents <!-- omit in toc -->
 
@@ -14,12 +14,11 @@ Measure is designed from the ground up for easy self-hosting. Follow along to ru
   - [4. Configure and start your self hosted measure instance](#4-configure-and-start-your-self-hosted-measure-instance)
   - [5. Setup a reverse proxy server](#5-setup-a-reverse-proxy-server)
   - [6. Setup DNS A records](#6-setup-dns-a-records)
-  - [7. Access your Measure dashboard](#7-access-your-measure-dashboard)
+  - [7. Access your measure.sh dashboard](#7-access-your-measuresh-dashboard)
 - [Upgrade a Self Hosted Installation](#upgrade-a-self-hosted-installation)
 - [Run on macOS locally](#run-on-macos-locally)
   - [System Requirements](#system-requirements-1)
   - [1. Clone the measure repo](#1-clone-the-measure-repo)
-  - [2. Install dependencies](#2-install-dependencies)
   - [2. Run `config.sh` script to configure](#2-run-configsh-script-to-configure)
   - [3. Start the containers](#3-start-the-containers)
   - [4. Access your Measure dashboard](#4-access-your-measure-dashboard)
@@ -56,7 +55,7 @@ Measure is designed from the ground up for easy self-hosting. Follow along to ru
 
 ## Deploy on a Linux virtual machine
 
-Follow these step-by-step instructions to deploy Measure on a single Linux VM instance.
+Follow these step-by-step instructions to deploy measure.sh on a single Linux VM instance.
 
 ### 1. SSH into your VM
 
@@ -101,7 +100,7 @@ Run the install script with `sudo`.
 sudo ./install.sh
 ```
 
-The measure install script will check your system's requirements and start the installation. It can take a few minutes to complete.
+The measure.sh install script will check your system's requirements and start the installation. It can take a few minutes to complete.
 
 ### 4. Configure and start your self hosted measure instance
 
@@ -113,7 +112,7 @@ For the first prompt, it'll ask for a namespace for your company or team. This t
   <img src="https://github.com/user-attachments/assets/70e5aa2c-8916-4b84-930a-e57a5c020e2a" alt="Measure Configuration Wizard" />
 </p>
 
-For the next prompt, you'll be asked to enter the URL to access Measure's web dashboard. Typically, this might look like a subdomain on your primary domain, for example, if your domain is `yourcompany.com`, enter `https://measure.yourcompany.com`.
+For the next prompt, you'll be asked to enter the URL to access measure.sh's web dashboard. Typically, this might look like a subdomain on your primary domain, for example, if your domain is `yourcompany.com`, enter `https://measure.yourcompany.com`.
 
 Next, you'll be asked to enter the URL to access Measure's REST API endpoint. Typically, this might look like, `https://measure-api.yourcompany.com`.
 
@@ -123,7 +122,7 @@ Next, you'll be asked to enter the URL to access Measure's REST API endpoint. Ty
 
 Later in this guide, you'll be setting DNS A records for the above subdomains you entered. For now, let's move on to the next prompt.
 
-For the next few prompts, you'll need to obtain a Google & GitHub OAuth Application's credentials. This is required to setup authentication in Measure dashboard. Follow the below links to obtain Google & GitHub OAuth credentials.
+For the next few prompts, you'll need to obtain a Google & GitHub OAuth Application's credentials. This is required to setup authentication in measure.sh dashboard. Follow the below links to obtain Google & GitHub OAuth credentials.
 
 - [Create a Google OAuth App](./google-oauth.md)
 - [Create a GitHub OAuth App](./github-oauth.md)
@@ -202,13 +201,13 @@ measure-api.yourcompany.com     IN A        101.102.103.104
 
 Depending on your domain provider, it might take a few mins to couple of hours for the above DNS records to take effect.
 
-### 7. Access your Measure dashboard
+### 7. Access your measure.sh dashboard
 
 Visit `https://measure.yourcompany.com` to access your dashboard and sign in to continue. Replace `yourcompany.com` with your domain.
 
 ## Upgrade a Self Hosted Installation
 
-To upgrade to a specific or latest version of Measure, SSH to your VM instance first and run these commands.
+To upgrade to a specific or latest version of measure.sh, SSH to your VM instance first and run these commands.
 
 For certain target versions, you will need to run extra migration scripts. Check out our [Migration Guides](../hosting/migration-guides/README.md).
 
@@ -244,20 +243,11 @@ Change to `self-host` directory and run `sudo ./install.sh` to perform the upgra
 # change to `self-host` directory
 cd self-host
 
-# bring down all containers
-sudo docker compose -f compose.yml -f compose.prod.yml \
-  --profile init \
-  --profile migrate \
-  down
-
-# pull fresh images
-sudo docker compose pull
-
-# bring up all containers
+# run the `install.sh` script
 sudo ./install.sh
 ```
 
-It'll take a few seconds for the containers to come back up.
+It'll take a few minutes for the upgrade to complete.
 
 > [!NOTE]
 >
@@ -265,7 +255,7 @@ It'll take a few seconds for the containers to come back up.
 
 ## Run on macOS locally
 
-You can run Measure locally on macOS for trying it out quickly, but keep in mind that not all features may not work as expected on macOS.
+You can run measure.sh locally on macOS for trying it out quickly, but keep in mind that not all features may not work as expected on macOS.
 
 > [!WARNING]
 >
@@ -300,15 +290,7 @@ Checkout to git a tag. Replace `GIT-TAG` with an existing git tag. You can find 
 git checkout GIT-TAG
 ```
 
-### 2. Install dependencies
-
-Install frontend dashboard app's dependencies.
-
-```sh
-npm --prefix frontend/dashboard install
-```
-
-Next, change into the `self-host` directory. All commands will be run mostly from the `self-host` directory after this point.
+Next, change to the `self-host` directory. All commands will be run from the `self-host` directory after this point.
 
 ```sh
 cd self-host

--- a/self-host/config.sh
+++ b/self-host/config.sh
@@ -10,7 +10,8 @@ ENV_FILE=.env
 ENV_WEB_FILE=../frontend/dashboard/.env.local
 
 # Measure insignia
-ENV_HEADER=$(cat <<'EOF'
+ENV_HEADER=$(
+  cat <<'EOF'
 #                                                            ( )
 #   ___ ___     __     _ _   ___  _   _  _ __   __       ___ | |__
 # /' _ ` _ `\ /'__`\ /'_` )/',__)( ) ( )( '__)/'__`\   /',__)|  _ `\
@@ -49,7 +50,6 @@ validate_name() {
     return 1
   fi
 
-
   # must not contain spaces
   if [[ "$1" =~ \  ]]; then
     return 1
@@ -86,20 +86,20 @@ to manually enter: " choice
 
   while true; do
     case "$choice" in
-      a)
-        password=$(generate_password "$length" "$passprompt")
-        break
-        ;;
-      m)
-        read -p "$passprompt" password
-        if [[ -z "$password" ]]; then
-          continue
-        fi
-        break
-        ;;
-      *)
-        echo "Invalid choice. Please try again."
-        ;;
+    a)
+      password=$(generate_password "$length" "$passprompt")
+      break
+      ;;
+    m)
+      read -p "$passprompt" password
+      if [[ -z "$password" ]]; then
+        continue
+      fi
+      break
+      ;;
+    *)
+      echo "Invalid choice. Please try again."
+      ;;
     esac
   done
 
@@ -152,7 +152,7 @@ create_ns() {
 
 # Writes environment file for development
 write_dev_env() {
-  cat <<EOF > "$ENV_FILE"
+  cat <<EOF >"$ENV_FILE"
 $ENV_HEADER
 
 # 🚨 Attention 🚨
@@ -230,7 +230,7 @@ EOF
 }
 
 write_web_dev_env() {
-  cat <<EOF > "$ENV_WEB_FILE"
+  cat <<EOF >"$ENV_WEB_FILE"
 $ENV_HEADER
 
 # 🚨 Attention 🚨
@@ -268,7 +268,7 @@ EOF
 
 # Writes environment file for production
 write_prod_env() {
-  cat <<EOF > "$ENV_FILE"
+  cat <<EOF >"$ENV_FILE"
 $ENV_HEADER
 
 # 🚨 Attention 🚨
@@ -343,7 +343,7 @@ EOF
 }
 
 write_web_prod_env() {
-  cat <<EOF > "$ENV_WEB_FILE"
+  cat <<EOF >"$ENV_WEB_FILE"
 $ENV_HEADER
 
 # 🚨 Attention 🚨
@@ -495,12 +495,12 @@ END
 
   echo -e "\nSet Google OAuth"
   echo -e "To create a Google OAuth app, visit: https://support.google.com/cloud/answer/6158849?hl=en"
-  OAUTH_GOOGLE_KEY=$(prompt_value_manual "Enter Google oauth app key: ")
+  OAUTH_GOOGLE_KEY=$(prompt_value_manual "Enter Google OAuth app key: ")
 
   echo -e "\nSet GitHub OAuth"
   echo -e "To create a GitHub OAuth app, visit: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app"
-  OAUTH_GITHUB_KEY=$(prompt_value_manual "Enter GitHub oauth app key: ")
-  OAUTH_GITHUB_SECRET=$(prompt_password_manual "Enter GitHub oauth app secret: ")
+  OAUTH_GITHUB_KEY=$(prompt_value_manual "Enter GitHub OAuth app key: ")
+  OAUTH_GITHUB_SECRET=$(prompt_password_manual "Enter GitHub OAuth app secret: ")
   SESSION_ACCESS_SECRET=$(generate_password 44)
   SESSION_REFRESH_SECRET=$(generate_password 44)
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -481,5 +481,5 @@ start_docker
 ensure_config
 detect_compose_command
 update_symbolicator_origin
-cleanup
 start_docker_compose
+cleanup

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -401,7 +401,6 @@ set_package_manager() {
       PKGMAN="zypper"
     fi
   fi
-
 }
 
 # ------------------------------------------------------------------------------
@@ -474,7 +473,7 @@ init() {
   info "Package manager: $PKGMAN"
 }
 
-# kickstart installation
+# kickstart
 init
 ensure_docker
 start_docker

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -309,7 +309,6 @@ detect_compose_command() {
 # ------------------------------------------------------------------------------
 update_symbolicator_origin() {
   update_env_variable SYMBOLICATOR_ORIGIN "http://symbolicator:3021"
-  info "Updated SYMBOLICATOR_ORIGIN in $env_file to http://symbolicator:3021"
 }
 
 # ------------------------------------------------------------------------------

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -308,22 +308,8 @@ detect_compose_command() {
 # update_symbolicator_origin updates value of a variable in .env file.
 # ------------------------------------------------------------------------------
 update_symbolicator_origin() {
-  # local env_file="./.env"
-
-  # if [[ ! -f "$env_file" ]]; then
-  #   warn "'.env' file not found in current directory. Please manually update .env file."
-  #   info "SYMBOLICATOR_ORIGIN=http://symbolicator:3021"
-  #   return 0
-  # fi
-
-  # if is_macOS; then
-  #   sed -i '' 's|^SYMBOLICATOR_ORIGIN=.*|SYMBOLICATOR_ORIGIN=http://symbolicator:3021|' "$env_file"
-  # else
-  #   sed -i 's|^SYMBOLICATOR_ORIGIN=.*|SYMBOLICATOR_ORIGIN=http://symbolicator:3021|' "$env_file"
-  # fi
-
-  # info "Updated SYMBOLICATOR_ORIGIN in $env_file to http://symbolicator:3021"
   update_env_variable SYMBOLICATOR_ORIGIN "http://symbolicator:3021"
+  info "Updated SYMBOLICATOR_ORIGIN in $env_file to http://symbolicator:3021"
 }
 
 # ------------------------------------------------------------------------------
@@ -343,7 +329,7 @@ stop_docker_compose() {
 # start_docker_compose starts services using docker compose.
 # ------------------------------------------------------------------------------
 start_docker_compose() {
-  info "Starting Measure docker containers"
+  info "Starting measure.sh docker containers"
 
   $DOCKER_COMPOSE_CMD \
     --progress plain \
@@ -496,5 +482,5 @@ start_docker
 ensure_config
 detect_compose_command
 update_symbolicator_origin
-start_docker_compose
 cleanup
+start_docker_compose

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -365,7 +365,7 @@ start_docker_compose() {
     --file compose.prod.yml \
     up \
     --build \
-    --pull \
+    --pull policy \
     --detach \
     --remove-orphans \
     --wait


### PR DESCRIPTION
## Summary

This PR updates the `self-host/install.sh` script to accommodate recent symbolicator service migration, environment variable migration and other such similar updates.

## Tasks

- [x] Add detection of docker compose command
- [x] Add updating existing environment variable value
- [x] Pull fresh images before starting compose
- [x] Remove orphans before starting compose
- [x] Update self hosting guide

## See also

- fixes #1886