### PR TITLE
chore(ios): update plcrashreporter config

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CoreData/CoreDataManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/CoreDataManager.swift
@@ -27,6 +27,7 @@ final class BaseCoreDataManager: CoreDataManager {
         guard let modelURL = Bundle.module.url(forResource: "MeasureModel", withExtension: "momd"),
               let model = NSManagedObjectModel(contentsOf: modelURL) else {
             logger.log(level: .fatal, message: "Error loading model from Swift Package bundle", error: nil, data: nil)
+            return
         }
         #else
         // Use `Bundle(for:)` for CocoaPods or direct integration

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
@@ -19,12 +19,21 @@ protocol SystemCrashReporter {
 
 final class BaseSystemCrashReporter: SystemCrashReporter {
     private let crashReporter: PLCrashReporter
+    private let logger: Logger
     var hasPendingCrashReport: Bool {
         return crashReporter.hasPendingCrashReport()
     }
 
-    init() {
-        crashReporter = PLCrashReporter()
+    init(logger: Logger) {
+        self.logger = logger
+        let config = PLCrashReporterConfig(signalHandlerType: .BSD, symbolicationStrategy: [], shouldRegisterUncaughtExceptionHandler: false)
+        guard let crashReporter = PLCrashReporter(configuration: config) else {
+            logger.log(level: .error, message: "Could not create an instance of PLCrashReporter with config.", error: nil, data: nil)
+            logger.log(level: .info, message: "Initialising PLCrashReporter with default config.", error: nil, data: nil)
+            self.crashReporter = PLCrashReporter()
+            return
+        }
+        self.crashReporter = crashReporter
     }
 
     func setCrashCallback(_ handleSignal: PLCrashReporterPostCrashSignalCallback) {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -212,7 +212,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                                  timeProvider: timeProvider,
                                                  crashDataPersistence: crashDataPersistence,
                                                  eventStore: eventStore)
-        self.systemCrashReporter = BaseSystemCrashReporter()
+        self.systemCrashReporter = BaseSystemCrashReporter(logger: logger)
         self.crashReportManager = CrashReportingManager(logger: logger,
                                                         eventProcessor: eventProcessor,
                                                         crashDataPersistence: crashDataPersistence,

--- a/ios/TestApp/MockMeasureInitializer.swift
+++ b/ios/TestApp/MockMeasureInitializer.swift
@@ -113,7 +113,7 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                  timeProvider: timeProvider,
                                                  crashDataPersistence: crashDataPersistence,
                                                  eventStore: eventStore)
-        self.systemCrashReporter = BaseSystemCrashReporter()
+        self.systemCrashReporter = BaseSystemCrashReporter(logger: logger)
         self.crashReportManager = CrashReportingManager(logger: logger,
                                                         eventProcessor: eventProcessor,
                                                         crashDataPersistence: crashDataPersistence,


### PR DESCRIPTION
# Description

## Update PLCrashReporter config

When `PLCrashReporter` is initalized in its default configuration, it handles unhandled exception and then manually aborts the application. This results in PLCrashReporter.m showing up in stacktraces instead of the original crash stacktrace.

Setting `shouldRegisterUncaughtExceptionHandler` to `false` lets us skip this behaviour and unhandled exceptions crash in their respective classes.

## Related issue
Closes #1934 
