### PR TITLE
feat(backend): symbolicate ttid span classes

### DIFF
--- a/backend/api/symbolicator/symbolicator.go
+++ b/backend/api/symbolicator/symbolicator.go
@@ -159,7 +159,9 @@ type Symbolicator struct {
 	// & restoring JVM stacktrace frames before &
 	// after symbolication.
 	stacktraceLUT []stacktraceEntry
-	ttidSpans     []int
+	// ttidSpans stores the index of the TTID span
+	// that needs symbolication.
+	ttidSpans []int
 	// requestJVM contains the payload for JVM
 	// symbolicator request.
 	requestJVM *requestJVM


### PR DESCRIPTION
## Summary

This PR symbolicates span name classes that look like.

- Activity TTID {class_name}
- Fragment TTID {class_name}

## See also

- fixes #1905




