### PR TITLE
fix(backend): broken session pagination with user defined attrs

### DIFF
--- a/backend/api/measure/session.go
+++ b/backend/api/measure/session.go
@@ -367,7 +367,7 @@ func GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (sessions 
 			Select("distinct session_id").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
-		stmt.Clause("AND session_id in").SubQuery("(", ")", subQuery)
+		stmt.SubQuery("session_id in (", ")", subQuery)
 	}
 
 	applyGroupBy := af.Crash ||


### PR DESCRIPTION
## Summary

This PR fixes an issue where paginating GET `/apps/:id/sessions` API would fail when combined with any user defined attributes.

## See also

- fixes #1946