### PR TITLE
fix(android): truncate TTID span names to fit max span length

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -292,7 +292,12 @@ internal class LaunchTracker(
         if (!isActivityTtidSpanEnabled()) {
             return null
         }
-        val span = tracer.spanBuilder(SpanName.activityTtidSpan(activity)).startSpan()
+        val span = tracer.spanBuilder(
+            SpanName.activityTtidSpan(
+                activity.javaClass.name,
+                configProvider.maxSpanNameLength,
+            ),
+        ).startSpan()
         span.setCheckpoint(CheckpointName.ACTIVITY_CREATED)
         return span
     }

--- a/android/measure/src/main/java/sh/measure/android/lifecycle/FragmentLifecycleCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/lifecycle/FragmentLifecycleCollector.kt
@@ -110,7 +110,12 @@ internal class FragmentLifecycleCollector(
             return
         }
         val identityHash = getIdentityHash(f)
-        val fragmentTtidSpan = tracer.spanBuilder(SpanName.fragmentTtidSpan(f)).startSpan()
+        val fragmentTtidSpan = tracer.spanBuilder(
+            SpanName.fragmentTtidSpan(
+                f.javaClass.name,
+                configProvider.maxSpanNameLength,
+            ),
+        ).startSpan()
             .setCheckpoint(CheckpointName.FRAGMENT_ATTACHED)
         attachedFragmentSpans[identityHash] = fragmentTtidSpan
     }

--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanConstants.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanConstants.kt
@@ -1,18 +1,39 @@
 package sh.measure.android.tracing
 
-import android.app.Activity
-import androidx.fragment.app.Fragment
-
 /**
  * Centralized definitions of span names created by the Measure SDK.
  */
 internal object SpanName {
-    fun activityTtidSpan(activity: Activity): String {
-        return "Activity TTID ${activity.javaClass.name}"
+    private const val ACTIVITY_TTID_PREFIX = "Activity TTID"
+    private const val FRAGMENT_TTID_PREFIX = "Fragment TTID"
+
+    fun activityTtidSpan(className: String, maxLength: Int): String {
+        return truncateClassNameIfNeeded(ACTIVITY_TTID_PREFIX, className, maxLength)
     }
 
-    fun fragmentTtidSpan(fragment: Fragment): String {
-        return "Fragment TTID ${fragment.javaClass.name}"
+    fun fragmentTtidSpan(className: String, maxLength: Int): String {
+        return truncateClassNameIfNeeded(FRAGMENT_TTID_PREFIX, className, maxLength)
+    }
+
+    /**
+     * Truncates the class name to fit within the specified maximum length, including the prefix.
+     * @param prefix The prefix to be included in the truncated string.
+     * @param className The full class name to be truncated.
+     * @param maxLength The maximum length of the resulting string.
+     */
+    private fun truncateClassNameIfNeeded(
+        prefix: String,
+        className: String,
+        maxLength: Int,
+    ): String {
+        val fullString = "$prefix $className"
+        return if (fullString.length <= maxLength) {
+            fullString
+        } else {
+            val availableSpace = maxLength - prefix.length - 1
+            val truncatedClassName = className.takeLast(availableSpace)
+            "$prefix $truncatedClassName"
+        }
     }
 }
 

--- a/android/measure/src/test/java/sh/measure/android/tracing/SpanNameTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/tracing/SpanNameTest.kt
@@ -1,0 +1,115 @@
+package sh.measure.android.tracing
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpanNameTest {
+
+    @Test
+    fun `activityTtidSpan returns full string when within max length`() {
+        // Given
+        val className = "com.example.MyActivity"
+        val maxLength = 50
+
+        // When
+        val result = SpanName.activityTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Activity TTID com.example.MyActivity", result)
+    }
+
+    @Test
+    fun `activityTtidSpan truncates class name when over max length`() {
+        // Given
+        val className = "com.example.very.long.package.name.MyActivity"
+        val maxLength = 25
+
+        // When
+        val result = SpanName.activityTtidSpan(className, maxLength)
+
+        // Then
+        // "Activity TTID " is 14 characters
+        // So we can fit 11 more characters (25 - 14)
+        assertEquals("Activity TTID .MyActivity", result)
+    }
+
+    @Test
+    fun `fragmentTtidSpan returns full string when under max length`() {
+        // Given
+        val className = "com.example.MyFragment"
+        val maxLength = 50
+
+        // When
+        val result = SpanName.fragmentTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Fragment TTID com.example.MyFragment", result)
+    }
+
+    @Test
+    fun `fragmentTtidSpan truncates class name when over max length`() {
+        // Given
+        val className = "com.example.very.long.package.name.MyFragment"
+        val maxLength = 26
+
+        // When
+        val result = SpanName.fragmentTtidSpan(className, maxLength)
+
+        // Then
+        // "Fragment TTID " is 14 characters
+        // So we can fit 12 more characters (26 - 14)
+        assertEquals("Fragment TTID e.MyFragment", result)
+    }
+
+    @Test
+    fun `activityTtidSpan handles exact length match`() {
+        // Given
+        val className = "MyActivity"
+        val maxLength = 24 // Exact length of "Activity TTID MyActivity"
+
+        // When
+        val result = SpanName.activityTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Activity TTID MyActivity", result)
+    }
+
+    @Test
+    fun `fragmentTtidSpan handles exact length match`() {
+        // Given
+        val className = "MyFragment"
+        val maxLength = 24 // Exact length of "Fragment TTID MyFragment"
+
+        // When
+        val result = SpanName.fragmentTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Fragment TTID MyFragment", result)
+    }
+
+    @Test
+    fun `activityTtidSpan handles empty class name`() {
+        // Given
+        val className = ""
+        val maxLength = 50
+
+        // When
+        val result = SpanName.activityTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Activity TTID ", result)
+    }
+
+    @Test
+    fun `fragmentTtidSpan handles empty class name`() {
+        // Given
+        val className = ""
+        val maxLength = 50
+
+        // When
+        val result = SpanName.fragmentTtidSpan(className, maxLength)
+
+        // Then
+        assertEquals("Fragment TTID ", result)
+    }
+}


### PR DESCRIPTION
# Description

Truncate the TTID span names to always fit within the max span name length.

## Related issue
Fixes #1951
