### PR TITLE
docs(ios): update readme

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -1,16 +1,17 @@
 # Measure iOS SDK
 
 * [Minimum requirements](#minimum-requirements)
-* [Self host compatibility](#self-host-compatibility)
 * [Quick reference](#quick-reference)
 * [Getting started](#getting-started)
-* [Crash Reporting](#crash-reporting)
-* [Custom events](#custom-events)
+* [Features](#features)
+  * [Automatic collection](#automatic-collection)
+  * [Crash Reporting](#crash-reporting)
+  * [Identify users](#identify-users)
+  * [Custom events](#custom-events)
   * [ScreenView](#screen-view)
   * [SwiftUI Lifecycle](#swiftui-lifecycle)
   * [ViewController Lifecycle](#viewcontroller-lifecycle)
   * [Network Monitoring](#network-monitoring)
-* [Features](#features)
 * [Session](#session)
 
 # Minimum requirements
@@ -20,6 +21,15 @@
 | Xcode                         |     15.0+     |
 | Minimum iOS Deployments       |     12.0+     |
 | Swift Version                 |     5.10+     |
+
+## Self-host compatibility
+
+Before integrating iOS SDK, make sure the deployed self-host version is **atleast 0.6.0**. For more 
+details, checkout the [self-host guide](../hosting/README.md).
+
+| SDK version   | Minimum required self-host version |
+|---------------|------------------------------------|
+| 0.1.0         | 0.6.0                              |
  
 # Getting started
 
@@ -96,21 +106,39 @@ Reopen the app and check the Measure dashboard—you should see the crash report
 
 🎉 Congratulations! You have successfully integrated Measure into your app!
 
-# Crash Reporting  
+# Features
+
+Measure SDK operates on an event-based architecture, automatically collecting key debugging events while letting you track custom events, screen views and layout snapshots, etc. Read along for more details.
+
+## Automatic collection
+
+The following data is automatically collected by Measure. Read the individual docs for more details.
+
+* [App launch](../docs/ios/features/feature_app_launch.md)
+* [Crash tracking](../docs/ios/features/feature_crash_tracking.md)
+* [Network monitoring](../docs/ios/features/feature_network_monitoring.md)
+* [Network changes](../docs/ios/features/feature_network_changes.md)
+* [Gesture tracking](../docs/ios/features/feature_gesture_tracking.md)
+* [Layout Snapshots](../docs/ios/features/feature_layout_snapshots.md)
+* [Navigation & Lifecycle](../docs/ios/features/feature_navigation_and_lifecycle.md)
+* [CPU monitoring](../docs/ios/features/feature_cpu_monitoring.md)
+* [Memory monitoring](../docs/ios/features/feature_memory_monitoring.md)
+
+## Crash Reporting  
 
 MeasureSDK automatically detects and exports crashes. To symbolicate these crashes, DSYM files need to be uploaded to the server. You can upload DSYM files using a standalone shell script or via Xcode’s Build Phases.  
 
-## Using Shell Script  
+### Using Shell Script  
 
-Run the `upload_dsyms.sh` script to manually upload DSYM files after building your app.  
+Run the [`upload_dsyms.sh`](../../ios/Scripts/upload_dsyms.sh) script to manually upload DSYM files after building your app.  
 
 ```sh
 sh upload_dsyms.sh <path_to_ipa> <path_to_dsym_folder> <api_url> <api_key>
 ```
 
-## Using Build Phases  
+### Using Build Phases  
 
-Add the `upload_dsym_build_phases.sh` script as a **New Run Script Phase** in Xcode to upload DSYM files automatically.  
+Add the [`upload_dsym_build_phases.sh`](../../ios/Scripts/upload_dsym_build_phases.sh) script as a **New Run Script Phase** in Xcode to upload DSYM files automatically.  
 
 ```sh
 sh "${SRCROOT}/path/to/upload_dsym_build_phases.sh" <api_url> <api_key>
@@ -119,7 +147,30 @@ sh "${SRCROOT}/path/to/upload_dsym_build_phases.sh" <api_url> <api_key>
 > [!CAUTION]  
 > If you are using Build Phases to upload DSYMs make sure to **upload DSYMs only for release builds**.
 
-# Custom Events
+## Identify users
+
+Correlating sessions with users is critical for debugging certain issues. Measure allows setting a user ID which can
+then be used to query sessions and events on the dashboard. User ID is persisted across app launches.
+
+```swift
+Measure.shared.setUserId("user_id")
+```
+
+```objc
+[[Measure shared] setUserId:@"user_id"]
+```
+
+To clear a user ID. 
+
+```swift
+Measure.shared.clearUserId()
+```
+
+```objc
+[[Measure shared] clearUserId]
+```
+
+## Custom Events
 
 Custom events provide more context on top of automatically collected events. They provide the context specific to the app to debug issues and analyze impact.
 
@@ -144,7 +195,7 @@ Measure.shared.trackEvent(name: "event_name", attributes: ["is_premium_user": .b
 ```
 
 ```objc
-[[Measure shared] trackEvent:@"event_name" attributes:@{@"is_premium_user": @YES}];
+[[Measure shared] trackEvent:@"event_name" attributes:@{@"is_premium_user": YES}];
 ```
 
 If an event occurred before the SDK was initialized, you can track it with a custom timestamp. The timestamp must be in **milliseconds since epoch**.
@@ -153,7 +204,7 @@ If an event occurred before the SDK was initialized, you can track it with a cus
 Measure.shared.trackEvent(name: "event_name", timestamp: 1734443973879)
 ```
 ```objc
-[[Measure shared] trackEvent:@"event_name" timestamp:@(1734443973879)];
+[[Measure shared] trackEvent:@"event_name" timestamp:1734443973879];
 ```
 
 Apart from sending custom events, the following event can be tracked with a predefined schema:
@@ -164,7 +215,7 @@ Apart from sending custom events, the following event can be tracked with a pred
 - [Network Monitoring](#network-monitoring)
 
 
-### Screen View
+## Screen View
 
 Measure SDK automatically tracks view controller [lifecycle events](../docs/ios/features/feature_navigation_and_lifecycle.md). However, if your app uses a custom navigation system, you can manually trigger `screen_view` events to track user flow.
 
@@ -177,13 +228,13 @@ Measure.shared.trackScreenView("Home")
 [[Measure shared] trackScreenView:@"Home"];
 ```
 
-### SwiftUI Lifecycle
+## SwiftUI Lifecycle
 
 Measure can track SwiftUI component's `onAppear` and `onDisappear` if you wrap your view with the `MsrMoniterView`. Measure also provides an extension function on View that wraps the view in an `MsrMoniterView` to monitor its lifecycle events.
 
 To track SwiftUI lifecycle events, you can use the following methods:
 
-#### Using `MsrMoniterView`
+### Using `MsrMoniterView`
 
 ```swift
 struct ContentView: View {
@@ -195,7 +246,7 @@ struct ContentView: View {
 }
 ```
 
-#### Using `moniterWithMsr`
+### Using `moniterWithMsr`
 
 ```swift
 struct ContentView: View {
@@ -206,7 +257,7 @@ struct ContentView: View {
 }
 ```
 
-### ViewController Lifecycle
+## ViewController Lifecycle
 
 Measure automatically tracks the following View Controller lifecycle events:
 
@@ -219,10 +270,10 @@ Measure automatically tracks the following View Controller lifecycle events:
 7. initWithNibName
 8. initWithCoder
 
-You can also track `loadView` and `deinit`/`dealloc` by inheriting from `MeasureViewController` for swift and `MSRViewController` for Objective-C.
+You can also track `loadView` and `deinit`/`dealloc` by inheriting from **`MsrViewController` for swift and `MSRViewController` for Objective-C**.
 
 ```swift
-   class ViewController: MeasureViewController {
+   class ViewController: MsrViewController {
      ...
    }
 ```
@@ -233,43 +284,30 @@ You can also track `loadView` and `deinit`/`dealloc` by inheriting from `Measure
    @end
 ```
 
-### Network Monitoring
+## Network Monitoring
 
 Measure SDK automatically monitors all API calls happening in the app. You can view the collected HTTP data [here](../docs/api/sdk/README.md#http).  
 This is achieved by swizzling `NSURLSessionTask`'s `setState:` method. However, there is one limitation: **response bodies cannot be tracked** using this method.  
 
-If you also want to track response bodies, you can use `MsrNetworkInterceptor`.  
-The `MsrNetworkInterceptor` modifies the provided `URLSessionConfiguration` to inject the `NetworkInterceptorProtocol` into its `protocolClasses`.  
+If you also want to track response bodies, you can use `MSRNetworkInterceptor`.  
+The `MSRNetworkInterceptor` modifies the provided `URLSessionConfiguration` to inject the `NetworkInterceptorProtocol` into its `protocolClasses`.  
 
 If the interceptor is already enabled, subsequent calls to this method will have no effect.  
   
 ```swift
   let config = URLSessionConfiguration.default
-  MsrNetworkInterceptor.enable(on: config)
+  MSRNetworkInterceptor.enable(on: config)
   let session = URLSession(configuration: config)
 ```
 
 ```objc
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-  [MsrNetworkInterceptor enableOn:config];
+  [MSRNetworkInterceptor enableOn:config];
   NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 ```
 
 > [!Note]
 > Ensure you call this method before creating a `URLSession` instance with the given configuration.
-
-# Features
-
-* [App launch](../docs/ios/features/feature_app_launch.md)
-* [Crash tracking](../docs/ios/features/feature_crash_tracking.md)
-* [Network monitoring](../docs/ios/features/feature_network_monitoring.md)
-* [Network changes](../docs/ios/features/feature_network_changes.md)
-* [Gesture tracking](../docs/ios/features/feature_gesture_tracking.md)
-* [Layout Snapshots](../docs/ios/features/feature_layout_snapshots.md)
-* [Navigation & Lifecycle](../docs/ios/features/feature_navigation_and_lifecycle.md)
-* [CPU monitoring](../docs/ios/features/feature_cpu_monitoring.md)
-* [Memory monitoring](../docs/ios/features/feature_memory_monitoring.md)
-
 
 # Session
 

--- a/docs/ios/features/feature_navigation_and_lifecycle.md
+++ b/docs/ios/features/feature_navigation_and_lifecycle.md
@@ -35,7 +35,7 @@ Measure automatically tracks the following View Controller lifecycle events:
 7. initWithNibName
 8. initWithCoder
 
-You can also track `loadView` and `deinit`/`dealloc` by inheriting from `MeasureViewController` for swift and `MSRViewController` for ObjC.
+You can also track `loadView` and `deinit`/`dealloc` by inheriting from `MsrViewController` for swift and `MSRViewController` for ObjC.
 
 ### How it works
 
@@ -46,7 +46,7 @@ Measure SDK uses method swizzling to intercept View Controller lifecycle methods
 #### Swift
 
 ```swift
-   class ViewController: MeasureViewController {
+   class ViewController: MsrViewController {
      ...
    }
 ```

--- a/ios/DemoApp/Controller/ObjcDetailViewController.h
+++ b/ios/DemoApp/Controller/ObjcDetailViewController.h
@@ -6,11 +6,11 @@
 //
 
 #import <UIKit/UIKit.h>
-//#import <MeasureSDK/MeasureSDK-Swift.h>
+#import <Measure/MSRViewController.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ObjcDetailViewController : UIViewController
+@interface ObjcDetailViewController : MSRViewController
 
 @end
 

--- a/ios/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/Controller/ViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SwiftUI
 import Measure
 
-@objc final class ViewController: MeasureViewController, UITableViewDelegate, UITableViewDataSource {
+@objc final class ViewController: MsrViewController, UITableViewDelegate, UITableViewDataSource {
     let crashTypes = [
         "Abort",
         "Bad Pointer",

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		526D185F2D5A1913009A2E90 /* HttpData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17DC2D5A1913009A2E90 /* HttpData.swift */; };
 		526D18602D5A1913009A2E90 /* HttpEventCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17DD2D5A1913009A2E90 /* HttpEventCollector.swift */; };
 		526D18612D5A1913009A2E90 /* HttpInterceptorCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17DE2D5A1913009A2E90 /* HttpInterceptorCallbacks.swift */; };
-		526D18622D5A1913009A2E90 /* MsrNetworkInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17DF2D5A1913009A2E90 /* MsrNetworkInterceptor.swift */; };
+		526D18622D5A1913009A2E90 /* MSRNetworkInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17DF2D5A1913009A2E90 /* MSRNetworkInterceptor.swift */; };
 		526D18632D5A1913009A2E90 /* NetworkInterceptorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E02D5A1913009A2E90 /* NetworkInterceptorProtocol.swift */; };
 		526D18642D5A1913009A2E90 /* URLSessionTaskInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E12D5A1913009A2E90 /* URLSessionTaskInterceptor.swift */; };
 		526D18652D5A1913009A2E90 /* URLSessionTaskSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E22D5A1913009A2E90 /* URLSessionTaskSwizzler.swift */; };
@@ -85,7 +85,7 @@
 		526D18682D5A1913009A2E90 /* LifecycleCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E72D5A1913009A2E90 /* LifecycleCollector.swift */; };
 		526D18692D5A1913009A2E90 /* LifecycleEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */; };
 		526D186A2D5A1913009A2E90 /* LifecycleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E92D5A1913009A2E90 /* LifecycleManager.swift */; };
-		526D186B2D5A1913009A2E90 /* MeasureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EA2D5A1913009A2E90 /* MeasureViewController.swift */; };
+		526D186B2D5A1913009A2E90 /* MsrViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EA2D5A1913009A2E90 /* MsrViewController.swift */; };
 		526D186C2D5A1913009A2E90 /* MsrMoniterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */; };
 		526D186D2D5A1913009A2E90 /* NetworkChangeCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17ED2D5A1913009A2E90 /* NetworkChangeCallback.swift */; };
 		526D186E2D5A1913009A2E90 /* NetworkChangeCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EE2D5A1913009A2E90 /* NetworkChangeCollector.swift */; };
@@ -424,7 +424,7 @@
 		526D17DC2D5A1913009A2E90 /* HttpData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpData.swift; sourceTree = "<group>"; };
 		526D17DD2D5A1913009A2E90 /* HttpEventCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpEventCollector.swift; sourceTree = "<group>"; };
 		526D17DE2D5A1913009A2E90 /* HttpInterceptorCallbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpInterceptorCallbacks.swift; sourceTree = "<group>"; };
-		526D17DF2D5A1913009A2E90 /* MsrNetworkInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrNetworkInterceptor.swift; sourceTree = "<group>"; };
+		526D17DF2D5A1913009A2E90 /* MSRNetworkInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSRNetworkInterceptor.swift; sourceTree = "<group>"; };
 		526D17E02D5A1913009A2E90 /* NetworkInterceptorProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkInterceptorProtocol.swift; sourceTree = "<group>"; };
 		526D17E12D5A1913009A2E90 /* URLSessionTaskInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskInterceptor.swift; sourceTree = "<group>"; };
 		526D17E22D5A1913009A2E90 /* URLSessionTaskSwizzler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskSwizzler.swift; sourceTree = "<group>"; };
@@ -433,7 +433,7 @@
 		526D17E72D5A1913009A2E90 /* LifecycleCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleCollector.swift; sourceTree = "<group>"; };
 		526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleEvents.swift; sourceTree = "<group>"; };
 		526D17E92D5A1913009A2E90 /* LifecycleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleManager.swift; sourceTree = "<group>"; };
-		526D17EA2D5A1913009A2E90 /* MeasureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureViewController.swift; sourceTree = "<group>"; };
+		526D17EA2D5A1913009A2E90 /* MsrViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrViewController.swift; sourceTree = "<group>"; };
 		526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrMoniterView.swift; sourceTree = "<group>"; };
 		526D17ED2D5A1913009A2E90 /* NetworkChangeCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChangeCallback.swift; sourceTree = "<group>"; };
 		526D17EE2D5A1913009A2E90 /* NetworkChangeCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChangeCollector.swift; sourceTree = "<group>"; };
@@ -811,7 +811,7 @@
 				526D17DC2D5A1913009A2E90 /* HttpData.swift */,
 				526D17DD2D5A1913009A2E90 /* HttpEventCollector.swift */,
 				526D17DE2D5A1913009A2E90 /* HttpInterceptorCallbacks.swift */,
-				526D17DF2D5A1913009A2E90 /* MsrNetworkInterceptor.swift */,
+				526D17DF2D5A1913009A2E90 /* MSRNetworkInterceptor.swift */,
 				526D17E02D5A1913009A2E90 /* NetworkInterceptorProtocol.swift */,
 				526D17E12D5A1913009A2E90 /* URLSessionTaskInterceptor.swift */,
 				526D17E22D5A1913009A2E90 /* URLSessionTaskSwizzler.swift */,
@@ -834,7 +834,7 @@
 				526D17E72D5A1913009A2E90 /* LifecycleCollector.swift */,
 				526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */,
 				526D17E92D5A1913009A2E90 /* LifecycleManager.swift */,
-				526D17EA2D5A1913009A2E90 /* MeasureViewController.swift */,
+				526D17EA2D5A1913009A2E90 /* MsrViewController.swift */,
 				526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */,
 			);
 			path = Lifecycle;
@@ -1647,9 +1647,9 @@
 				526D183C2D5A1913009A2E90 /* DataCleanupService.swift in Sources */,
 				526D182F2D5A1913009A2E90 /* UserAttributeProcessor.swift in Sources */,
 				526D18482D5A1913009A2E90 /* CustomEventCollector.swift in Sources */,
-				526D18622D5A1913009A2E90 /* MsrNetworkInterceptor.swift in Sources */,
+				526D18622D5A1913009A2E90 /* MSRNetworkInterceptor.swift in Sources */,
 				526D18472D5A1913009A2E90 /* AttachmentType.swift in Sources */,
-				526D186B2D5A1913009A2E90 /* MeasureViewController.swift in Sources */,
+				526D186B2D5A1913009A2E90 /* MsrViewController.swift in Sources */,
 				526D18292D5A1913009A2E90 /* AttributeProcessor.swift in Sources */,
 				526D18382D5A1913009A2E90 /* EventEntity.swift in Sources */,
 				526D18632D5A1913009A2E90 /* NetworkInterceptorProtocol.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -76,10 +76,10 @@ extension SwiftUICore.View {
   @objc final public func clearUserId()
   @objc deinit
 }
-public struct MsrNetworkInterceptor {
+public struct MSRNetworkInterceptor {
   public static func enable(on sessionConfiguration: Foundation.URLSessionConfiguration)
 }
-@objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency open class MeasureViewController : UIKit.UIViewController {
+@objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency open class MsrViewController : UIKit.UIViewController {
   @_Concurrency.MainActor @preconcurrency @objc override dynamic open func loadView()
   @objc deinit
   @_Concurrency.MainActor @preconcurrency @objc override dynamic public init(nibName nibNameOrNil: Swift.String?, bundle nibBundleOrNil: Foundation.Bundle?)

--- a/ios/PublicApi/MeasureSDK.swiftinterface
+++ b/ios/PublicApi/MeasureSDK.swiftinterface
@@ -76,7 +76,7 @@ extension SwiftUICore.View {
   @objc final public func clearUserId()
   @objc deinit
 }
-public struct MsrNetworkInterceptor {
+public struct MSRNetworkInterceptor {
   public static func enable(on sessionConfiguration: Foundation.URLSessionConfiguration)
 }
 @objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency open class MeasureViewController : UIKit.UIViewController {

--- a/ios/Sources/MeasureSDK/Objc/include/MSRViewController.h
+++ b/ios/Sources/MeasureSDK/Objc/include/MSRViewController.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// A view controller that monitors the `loadView` and `dealloc` lifecycle events of the view controller.
 /// This class is intended to be subclassed by view controllers that need to monitor the view controller lifecycle.
 ///
-/// - Example:
 ///   ```objc
 ///   @interface ObjcDetailViewController : MSRViewController
 ///

--- a/ios/Sources/MeasureSDK/Swift/Http/MSRNetworkInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/MSRNetworkInterceptor.swift
@@ -1,5 +1,5 @@
 //
-//  MsrNetworkInterceptor.swift
+//  MSRNetworkInterceptor.swift
 //  MeasureSDK
 //
 //  Created by Adwin Ross on 18/12/24.
@@ -7,11 +7,11 @@
 
 import Foundation
 
-public struct MsrNetworkInterceptor {
+public struct MSRNetworkInterceptor {
     static var isEnabled = false
     private static let lock = NSLock()
 
-    /// Enables the `MsrNetworkInterceptor` by modifying the provided `URLSessionConfiguration`.
+    /// Enables the `MSRNetworkInterceptor` by modifying the provided `URLSessionConfiguration`.
     ///
     /// This method injects the `NetworkInterceptorProtocol` into the `protocolClasses` of the given
     /// `URLSessionConfiguration`. If the interceptor is already enabled, subsequent calls to this
@@ -25,14 +25,14 @@ public struct MsrNetworkInterceptor {
     ///   - Swift:
     ///   ```swift
     ///   let config = URLSessionConfiguration.default
-    ///   MsrNetworkInterceptor.enable(on: config)
+    ///   MSRNetworkInterceptor.enable(on: config)
     ///   let session = URLSession(configuration: config)
     ///   ```
     ///
     ///   - Objective-C:
     ///   ```objc
     ///   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    ///   [MsrNetworkInterceptor enableOn:config];
+    ///   [MSRNetworkInterceptor enableOn:config];
     ///   NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
     ///   ```
     ///

--- a/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
@@ -44,7 +44,7 @@ final class URLSessionTaskInterceptor {
     }
 
     func urlSessionTask(_ task: URLSessionTask, setState state: URLSessionTask.State) { // swiftlint:disable:this cyclomatic_complexity
-        guard !MsrNetworkInterceptor.isEnabled else { return }
+        guard !MSRNetworkInterceptor.isEnabled else { return }
 
         guard let httpInterceptorCallbacks = self.httpInterceptorCallbacks,
               let timeProvider = self.timeProvider,

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/MsrViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/MsrViewController.swift
@@ -9,13 +9,12 @@ import UIKit
 /// A view controller that monitors the `loadView` and `deinit` lifecycle events of the view controller.
 /// This class is intended to be subclassed by view controllers that need to monitor the view controller lifecycle.
 /// 
-/// - Example:
 ///   ```swift
-///   class ViewController: MeasureViewController {
+///   class ViewController: MsrViewController {
 ///     ...
 ///   }
 ///   ```
-open class MeasureViewController: UIViewController {
+open class MsrViewController: UIViewController {
     open override func loadView() {
         super.loadView()
         LifecycleManager.shared.sendLifecycleEvent(.loadView, for: self)

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -93,18 +93,15 @@ import Foundation
     /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
     /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
     /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
-    func getSessionId() -> String? {
+    @objc func getSessionId() -> String? {
         guard let sessionId = measureInternal?.sessionManager.sessionId else { return nil }
 
         return sessionId
     }
 
     /// Tracks an event with optional timestamp.
+    /// Event names should be clear and consistent to aid in dashboard searches
     ///
-    /// Usage Notes:
-    /// - Event names should be clear and consistent to aid in dashboard searches
-    ///
-    ///   /// - Example:
     ///   ```swift
     ///   Measure.shared.trackEvent(name: "event-name", attributes:["user_name": .string("Alice")], timestamp: nil)
     ///   ```
@@ -120,11 +117,11 @@ import Foundation
     }
 
     /// Tracks an event with optional timestamp.
+    /// Event names should be clear and consistent to aid in dashboard searches
     ///
-    /// Usage Notes:
-    /// - Event names should be clear and consistent to aid in dashboard searches
+    /// Note:
+    /// This method is primarily intended for Objective-C use..
     ///
-    ///   /// - Example:
     ///   ```objc
     ///   [[Measure shared] trackEvent:@"event-name" attributes:@{@"user_name": @"Alice"} timestamp:nil];
     ///   ```

--- a/ios/TestApp/ViewController.swift
+++ b/ios/TestApp/ViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import Measure
 
-final class ViewController: MeasureViewController, UITableViewDelegate, UITableViewDataSource {
+final class ViewController: MsrViewController, UITableViewDelegate, UITableViewDataSource {
     let crashTypes = [
         "Abort",
         "Bad Pointer",


### PR DESCRIPTION
# Description

Updated the below things in iOS docs.

- Updated table of content and restructured the ios README.
- Rename `MsrNetworkInterceptor` to `MSRNetworkInterceptor`.
- Links for upload dsym scripts added.
- Rename `MeasureViewController` to `MsrViewController`.
- Clarification on the usages of `MsrViewController` and `MSRViewController` marked as bold.

## Related issue
Closes #1954 
