### PR TITLE
feat(android): add attribute to track accessibility status

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -7,6 +7,7 @@ import sh.measure.android.appexit.AppExitProvider
 import sh.measure.android.appexit.AppExitProviderImpl
 import sh.measure.android.applaunch.AppLaunchCollector
 import sh.measure.android.applaunch.LaunchTracker
+import sh.measure.android.attributes.A11yAttributesProcessor
 import sh.measure.android.attributes.AppAttributeProcessor
 import sh.measure.android.attributes.AttributeProcessor
 import sh.measure.android.attributes.DeviceAttributeProcessor
@@ -193,6 +194,9 @@ internal class TestMeasureInitializer(
         localeProvider = localeProvider,
         osSysConfProvider = osSysConfProvider,
     ),
+    private val a11yAttributesProcessor: A11yAttributesProcessor = A11yAttributesProcessor(
+        systemServiceProvider = systemServiceProvider,
+    ),
     private val appAttributeProcessor: AppAttributeProcessor = AppAttributeProcessor(
         context = application,
         packageInfoProvider = packageInfoProvider,
@@ -219,6 +223,7 @@ internal class TestMeasureInitializer(
         installationIdAttributeProcessor,
         networkStateAttributeProcessor,
         powerStateAttributeProcessor,
+        a11yAttributesProcessor,
     ),
     private val eventTransformer: EventTransformer = DefaultEventTransformer(
         configProvider = configProvider,

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -7,6 +7,7 @@ import sh.measure.android.appexit.AppExitProvider
 import sh.measure.android.appexit.AppExitProviderImpl
 import sh.measure.android.applaunch.AppLaunchCollector
 import sh.measure.android.applaunch.LaunchTracker
+import sh.measure.android.attributes.A11yAttributesProcessor
 import sh.measure.android.attributes.AppAttributeProcessor
 import sh.measure.android.attributes.AttributeProcessor
 import sh.measure.android.attributes.DeviceAttributeProcessor
@@ -206,6 +207,9 @@ internal class MeasureInitializerImpl(
         localeProvider = localeProvider,
         osSysConfProvider = osSysConfProvider,
     ),
+    private val a11yAttributesProcessor: A11yAttributesProcessor = A11yAttributesProcessor(
+        systemServiceProvider = systemServiceProvider,
+    ),
     private val appAttributeProcessor: AppAttributeProcessor = AppAttributeProcessor(
         context = application,
         packageInfoProvider = packageInfoProvider,
@@ -227,6 +231,7 @@ internal class MeasureInitializerImpl(
         installationIdAttributeProcessor,
         networkStateAttributeProcessor,
         powerStateAttributeProcessor,
+        a11yAttributesProcessor,
     ),
     private val eventTransformer: EventTransformer = DefaultEventTransformer(
         configProvider = configProvider,
@@ -373,6 +378,7 @@ internal class MeasureInitializerImpl(
             installationIdAttributeProcessor,
             networkStateAttributeProcessor,
             powerStateAttributeProcessor,
+            a11yAttributesProcessor,
         ),
         configProvider,
     ),

--- a/android/measure/src/main/java/sh/measure/android/attributes/A11yAttributesProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/A11yAttributesProcessor.kt
@@ -1,0 +1,18 @@
+package sh.measure.android.attributes
+
+import sh.measure.android.utils.SystemServiceProvider
+
+/**
+ * Generates the accessibility attributes. These attributes are expected to change during the
+ * session. This class computes the attributes every time [appendAttributes] is called.
+ */
+internal class A11yAttributesProcessor(
+    private val systemServiceProvider: SystemServiceProvider,
+) : AttributeProcessor {
+    override fun appendAttributes(attributes: MutableMap<String, Any?>) {
+        val isEnabled = systemServiceProvider.accessibilityManager?.isEnabled
+        attributes.apply {
+            put(Attribute.ACCESSIBILITY_ENABLED, isEnabled)
+        }
+    }
+}

--- a/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
@@ -24,4 +24,5 @@ internal object Attribute {
     const val USER_ID_KEY = "user_id"
     const val DEVICE_LOW_POWER_ENABLED = "device_low_power_mode"
     const val DEVICE_THERMAL_THROTTLING_ENABLED = "device_thermal_throttling_enabled"
+    const val ACCESSIBILITY_ENABLED = "accessibility_enabled"
 }

--- a/android/measure/src/main/java/sh/measure/android/utils/SystemServiceProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/utils/SystemServiceProvider.kt
@@ -6,6 +6,7 @@ import android.hardware.SensorManager
 import android.net.ConnectivityManager
 import android.os.PowerManager
 import android.telephony.TelephonyManager
+import android.view.accessibility.AccessibilityManager
 
 internal interface SystemServiceProvider {
     val powerManager: PowerManager?
@@ -13,6 +14,7 @@ internal interface SystemServiceProvider {
     val telephonyManager: TelephonyManager?
     val activityManager: ActivityManager?
     val sensorManager: SensorManager?
+    val accessibilityManager: AccessibilityManager?
 }
 
 internal class SystemServiceProviderImpl(private val context: Context) : SystemServiceProvider {
@@ -34,5 +36,9 @@ internal class SystemServiceProviderImpl(private val context: Context) : SystemS
 
     override val sensorManager: SensorManager? by lazy(mode = LazyThreadSafetyMode.NONE) {
         runCatching { context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager }.getOrNull()
+    }
+
+    override val accessibilityManager: AccessibilityManager? by lazy(mode = LazyThreadSafetyMode.NONE) {
+        runCatching { context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager }.getOrNull()
     }
 }


### PR DESCRIPTION
# Description

Adds an attribute `accessibility_enabled` which is computed each time an event/span is created, to allow tracking status of accessibility services on the device.

Uses the API: https://developer.android.com/reference/android/view/accessibility/AccessibilityManager#isEnabled(), which  returns true if a accessibility features like talkback or "select to speak" are turned on.

## Related issue
Closes #733 



