### PR TITLE
fix(backend): filter duplicate ud attribute keys

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -1053,7 +1053,7 @@ func (af *AppFilter) getUDAttrKeys(ctx context.Context) (keytypes []event.UDKeyT
 	stmt := sqlf.From(table_name).
 		Select("distinct key").
 		Select("toString(type) type").
-		Clause("prewhere app_id = toUUID(?)", af.AppID).
+		Clause("final prewhere app_id = toUUID(?)", af.AppID).
 		OrderBy("key")
 
 	defer stmt.Close()

--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -1043,28 +1043,35 @@ func (af *AppFilter) getDeviceNames(ctx context.Context) (deviceNames []string, 
 // getUDAttrKeys finds distinct user defined attribute
 // key and its types.
 func (af *AppFilter) getUDAttrKeys(ctx context.Context) (keytypes []event.UDKeyType, err error) {
-	var table_name string
+	var table string
 	if af.Span {
-		table_name = "span_user_def_attrs"
+		table = "span_user_def_attrs"
 	} else {
-		table_name = "user_def_attrs"
+		table = "user_def_attrs"
 	}
 
-	stmt := sqlf.From(table_name).
+	substmt := sqlf.From(table).
 		Select("distinct key").
-		Select("toString(type) type").
+		Select("argMax(type, ver) last_inserted_type").
 		Clause("final prewhere app_id = toUUID(?)", af.AppID).
-		OrderBy("key")
-
-	defer stmt.Close()
+		GroupBy("key")
 
 	if af.Crash {
-		stmt.Where("exception = true")
+		substmt.Where("exception = true")
 	}
 
 	if af.ANR {
-		stmt.Where("anr = true")
+		substmt.Where("anr = true")
 	}
+
+	stmt := sqlf.With("last_type", substmt).
+		Select("distinct t.key, t.type").
+		From(table+" t").
+		Join("last_type lt", "t.key = lt.key").
+		Where("t.type = lt.last_inserted_type").
+		OrderBy("key")
+
+	defer stmt.Close()
 
 	rows, err := server.Server.ChPool.Query(ctx, stmt.String(), stmt.Args()...)
 	if err != nil {

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -268,6 +268,7 @@ func (a App) GetExceptionGroupsWithFilter(ctx context.Context, af *filter.AppFil
 		if af.HasUDExpression() && !af.UDExpression.Empty() {
 			subQuery := sqlf.From("user_def_attrs").
 				Select("event_id id").
+				Clause("final").
 				Where("app_id = toUUID(?)", af.AppID).
 				Where("exception = true")
 			af.UDExpression.Augment(subQuery)
@@ -525,6 +526,7 @@ func (a App) GetANRGroupsWithFilter(ctx context.Context, af *filter.AppFilter) (
 		if af.HasUDExpression() && !af.UDExpression.Empty() {
 			subQuery := sqlf.From("user_def_attrs").
 				Select("event_id id").
+				Clause("final").
 				Where("app_id = toUUID(?)", af.AppID)
 			af.UDExpression.Augment(subQuery)
 			eventDataStmt.Clause("AND id in").SubQuery("(", ")", subQuery)

--- a/backend/api/measure/bugreport.go
+++ b/backend/api/measure/bugreport.go
@@ -135,6 +135,7 @@ func GetBugReportInstancesPlot(ctx context.Context, af *filter.AppFilter) (bugRe
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("distinct event_id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
 		base.Clause("AND event_id in").SubQuery("(", ")", subQuery)
@@ -256,6 +257,7 @@ func GetBugReportsWithFilter(ctx context.Context, af *filter.AppFilter) (bugRepo
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("distinct event_id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
 		stmt.Clause("AND event_id in").SubQuery("(", ")", subQuery)
@@ -486,30 +488,30 @@ func UpdateBugReportStatusById(ctx context.Context, bugReportId string, status u
 	}
 
 	query := fmt.Sprintf(`
-    INSERT INTO bug_reports 
-    SELECT 
-        event_id, 
-        app_id, 
-        session_id, 
-        timestamp, 
-        '%d' AS status, 
-        description, 
-        app_version, 
-        os_version, 
-        country_code, 
-        network_provider, 
-        network_type, 
-        network_generation, 
-        device_locale, 
-        device_manufacturer, 
-        device_name, 
-        device_model, 
-        user_id, 
-        device_low_power_mode, 
-        device_thermal_throttling_enabled, 
-        user_defined_attribute, 
+    INSERT INTO bug_reports
+    SELECT
+        event_id,
+        app_id,
+        session_id,
+        timestamp,
+        '%d' AS status,
+        description,
+        app_version,
+        os_version,
+        country_code,
+        network_provider,
+        network_type,
+        network_generation,
+        device_locale,
+        device_manufacturer,
+        device_name,
+        device_model,
+        user_id,
+        device_low_power_mode,
+        device_thermal_throttling_enabled,
+        user_defined_attribute,
         attachments
-    FROM bug_reports 
+    FROM bug_reports
     WHERE event_id = toUUID('%s')
     `, status, bugReportId)
 

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -1366,6 +1366,7 @@ func GetExceptionsWithFilter(ctx context.Context, group *group.ExceptionGroup, a
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where("exception = true")
 		af.UDExpression.Augment(subQuery)
@@ -1535,6 +1536,7 @@ func GetExceptionPlotInstances(ctx context.Context, af *filter.AppFilter) (issue
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where("exception = true")
 		af.UDExpression.Augment(subQuery)
@@ -1635,6 +1637,7 @@ func GetANRsWithFilter(ctx context.Context, group *group.ANRGroup, af *filter.Ap
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where("anr = true")
 		af.UDExpression.Augment(subQuery)
@@ -1804,6 +1807,7 @@ func GetANRPlotInstances(ctx context.Context, af *filter.AppFilter) (issueInstan
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where("anr = true")
 		af.UDExpression.Augment(subQuery)
@@ -1908,6 +1912,7 @@ func GetIssuesAttributeDistribution(ctx context.Context, g group.IssueGroup, af 
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where(fmt.Sprintf("%s = true", groupType))
 		af.UDExpression.Augment(subQuery)
@@ -1997,6 +2002,7 @@ func GetIssuesPlot(ctx context.Context, g group.IssueGroup, af *filter.AppFilter
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("event_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID).
 			Where(fmt.Sprintf("%s = true", groupType))
 		af.UDExpression.Augment(subQuery)

--- a/backend/api/measure/session.go
+++ b/backend/api/measure/session.go
@@ -365,6 +365,7 @@ func GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (sessions 
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("user_def_attrs").
 			Select("distinct session_id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
 		stmt.SubQuery("session_id in (", ")", subQuery)

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -534,6 +534,7 @@ func GetSpansForSpanNameWithFilter(ctx context.Context, spanName string, af *fil
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("span_user_def_attrs").
 			Select("span_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
 		stmt.Clause("AND span_id in").SubQuery("(", ")", subQuery)
@@ -654,6 +655,7 @@ func GetMetricsPlotForSpanNameWithFilter(ctx context.Context, spanName string, a
 	if af.HasUDExpression() && !af.UDExpression.Empty() {
 		subQuery := sqlf.From("span_user_def_attrs").
 			Select("span_id id").
+			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
 		stmt.Clause("AND span_id in").SubQuery("(", ")", subQuery)

--- a/self-host/clickhouse/20250325045646_replace_user_def_attrs_table.sql
+++ b/self-host/clickhouse/20250325045646_replace_user_def_attrs_table.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+create or replace table user_def_attrs
+(
+    `app_id`       UUID not null comment 'associated app id' codec(LZ4),
+    `event_id`     UUID not null comment 'id of the event' codec(LZ4),
+    `session_id`   UUID not null comment 'id of the session' codec(LZ4),
+    `end_of_month` DateTime not null comment 'last day of the month' codec(DoubleDelta, ZSTD(3)),
+    `app_version`  Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite app version' codec(ZSTD(3)),
+    `os_version`   Tuple(LowCardinality(String), LowCardinality(String)) comment 'composite os version' codec (ZSTD(3)),
+    `exception`    Bool comment 'true if source is exception event' codec (ZSTD(3)),
+    `anr`          Bool comment 'true if source is anr event' codec (ZSTD(3)),
+    `key`          LowCardinality(String) comment 'key of the user defined attribute' codec (ZSTD(3)),
+    `type`         Enum('string' = 1, 'int64', 'float64', 'bool') comment 'type of the user defined attribute' codec (ZSTD(3)),
+    `value`        String comment 'value of the user defined attribute' codec (ZSTD(3)),
+    `ver`          DateTime64(9) not null comment 'high precision timestamp version for ReplacingMergeTree',
+    index end_of_month_minmax_idx end_of_month type minmax granularity 2,
+    index exception_bloom_idx exception type bloom_filter granularity 2,
+    index anr_bloom_idx anr type bloom_filter granularity 2,
+    index key_bloom_idx key type bloom_filter(0.05) granularity 1,
+    index key_set_idx key type set(1000) granularity 2,
+    index session_bloom_idx session_id type bloom_filter granularity 2
+)
+engine = ReplacingMergeTree(ver)
+partition by toYYYYMM(end_of_month)
+order by (app_id, end_of_month, app_version, os_version, exception, anr,
+            key, type, value, event_id, session_id)
+settings index_granularity = 8192
+comment 'derived user defined attributes';
+
+
+-- migrate:down
+create or replace table user_def_attrs
+(
+    `app_id`       UUID not null comment 'associated app id' codec(LZ4),
+    `event_id`     UUID not null comment 'id of the event' codec(LZ4),
+    `session_id`   UUID not null comment 'id of the session' codec(LZ4),
+    `end_of_month` DateTime not null comment 'last day of the month' codec(DoubleDelta, ZSTD(3)),
+    `app_version`  Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite app version' codec(ZSTD(3)),
+    `os_version`   Tuple(LowCardinality(String), LowCardinality(String)) comment 'composite os version' codec (ZSTD(3)),
+    `exception`    Bool comment 'true if source is exception event' codec (ZSTD(3)),
+    `anr`          Bool comment 'true if source is anr event' codec (ZSTD(3)),
+    `key`          LowCardinality(String) comment 'key of the user defined attribute' codec (ZSTD(3)),
+    `type`         Enum('string' = 1, 'int64', 'float64', 'bool') comment 'type of the user defined attribute' codec (ZSTD(3)),
+    `value`        String comment 'value of the user defined attribute' codec (ZSTD(3)),
+    index end_of_month_minmax_idx end_of_month type minmax granularity 2,
+    index exception_bloom_idx exception type bloom_filter granularity 2,
+    index anr_bloom_idx anr type bloom_filter granularity 2,
+    index key_bloom_idx key type bloom_filter(0.05) granularity 1,
+    index key_set_idx key type set(1000) granularity 2,
+    index session_bloom_idx session_id type bloom_filter granularity 2
+)
+engine = ReplacingMergeTree
+partition by toYYYYMM(end_of_month)
+order by (app_id, end_of_month, app_version, os_version, exception, anr,
+            key, type, value, event_id, session_id)
+settings index_granularity = 8192
+comment 'derived user defined attributes';

--- a/self-host/clickhouse/20250325052401_alter_user_def_attrs_mv.sql
+++ b/self-host/clickhouse/20250325052401_alter_user_def_attrs_mv.sql
@@ -1,0 +1,51 @@
+-- migrate:up
+alter table user_def_attrs_mv modify query
+select distinct app_id,
+                id                                   as event_id,
+                session_id,
+                toLastDayOfMonth(timestamp)          as end_of_month,
+                (toString(attribute.app_version),
+                 toString(attribute.app_build))      as app_version,
+                (toString(attribute.os_name),
+                 toString(attribute.os_version))     as os_version,
+                if(events.type = 'exception' and exception.handled = false,
+                   true, false)                      as exception,
+                if(events.type = 'anr', true, false) as anr,
+                arr_key                              as key,
+                tupleElement(arr_val, 1)             as type,
+                tupleElement(arr_val, 2)             as value,
+                timestamp                            as ver
+from events
+    array join
+     mapKeys(user_defined_attribute) as arr_key,
+     mapValues(user_defined_attribute) as arr_val
+where length(user_defined_attribute) > 0
+group by app_id, end_of_month, app_version, os_version, events.type,
+         exception.handled, key, type, value, event_id, session_id,
+         ver
+order by app_id;
+
+-- migrate:down
+alter table user_def_attrs_mv modify query
+select distinct app_id,
+                id                                   as event_id,
+                session_id,
+                toLastDayOfMonth(timestamp)          as end_of_month,
+                (toString(attribute.app_version),
+                 toString(attribute.app_build))      as app_version,
+                (toString(attribute.os_name),
+                 toString(attribute.os_version))     as os_version,
+                if(events.type = 'exception' and exception.handled = false,
+                   true, false)                      as exception,
+                if(events.type = 'anr', true, false) as anr,
+                arr_key                              as key,
+                tupleElement(arr_val, 1)             as type,
+                tupleElement(arr_val, 2)             as value
+from events
+    array join
+     mapKeys(user_defined_attribute) as arr_key,
+     mapValues(user_defined_attribute) as arr_val
+where length(user_defined_attribute) > 0
+group by app_id, end_of_month, app_version, os_version, events.type,
+         exception.handled, key, type, value, event_id, session_id
+order by app_id;

--- a/self-host/clickhouse/20250325094723_replace_span_user_def_attrs_table.sql
+++ b/self-host/clickhouse/20250325094723_replace_span_user_def_attrs_table.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+create or replace table span_user_def_attrs
+(
+    `app_id`       UUID not null comment 'associated app id' codec(LZ4),
+    `span_id`      FixedString(16) not null comment 'id of the span' codec(ZSTD(3)),
+    `session_id`   UUID not null comment 'id of the session' codec(LZ4),
+    `end_of_month` DateTime not null comment 'last day of the month' codec(DoubleDelta, ZSTD(3)),
+    `app_version`  Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite app version' codec(ZSTD(3)),
+    `os_version`   Tuple(LowCardinality(String), LowCardinality(String)) comment 'composite os version' codec (ZSTD(3)),
+    `key`          LowCardinality(String) comment 'key of the user defined attribute' codec (ZSTD(3)),
+    `type`         Enum('string' = 1, 'int64', 'float64', 'bool') comment 'type of the user defined attribute' codec (ZSTD(3)),
+    `value`        String comment 'value of the user defined attribute' codec (ZSTD(3)),
+    `ver`          DateTime64(9) not null comment 'high precision timestamp version for ReplacingMergeTree',
+    index end_of_month_minmax_idx end_of_month type minmax granularity 2,
+    index key_bloom_idx key type bloom_filter(0.05) granularity 1,
+    index key_set_idx key type set(1000) granularity 2,
+    index session_bloom_idx session_id type bloom_filter granularity 2
+)
+engine = ReplacingMergeTree(ver)
+partition by toYYYYMM(end_of_month)
+order by (app_id, end_of_month, app_version, os_version, key, type, value, span_id, session_id)
+settings index_granularity = 8192
+comment 'derived span user defined attributes';
+
+
+-- migrate:down
+create or replace table span_user_def_attrs
+(
+    `app_id`       UUID not null comment 'associated app id' codec(LZ4),
+    `span_id`      FixedString(16) not null comment 'id of the span' codec(ZSTD(3)),
+    `session_id`   UUID not null comment 'id of the session' codec(LZ4),
+    `end_of_month` DateTime not null comment 'last day of the month' codec(DoubleDelta, ZSTD(3)),
+    `app_version`  Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite app version' codec(ZSTD(3)),
+    `os_version`   Tuple(LowCardinality(String), LowCardinality(String)) comment 'composite os version' codec (ZSTD(3)),
+    `key`          LowCardinality(String) comment 'key of the user defined attribute' codec (ZSTD(3)),
+    `type`         Enum('string' = 1, 'int64', 'float64', 'bool') comment 'type of the user defined attribute' codec (ZSTD(3)),
+    `value`        String comment 'value of the user defined attribute' codec (ZSTD(3)),
+    index end_of_month_minmax_idx end_of_month type minmax granularity 2,
+    index key_bloom_idx key type bloom_filter(0.05) granularity 1,
+    index key_set_idx key type set(1000) granularity 2,
+    index session_bloom_idx session_id type bloom_filter granularity 2
+)
+engine = ReplacingMergeTree
+partition by toYYYYMM(end_of_month)
+order by (app_id, end_of_month, app_version, os_version, key, type, value, span_id, session_id)
+settings index_granularity = 8192
+comment 'derived span user defined attributes';

--- a/self-host/clickhouse/20250325100452_alter_span_user_def_attrs_mv.sql
+++ b/self-host/clickhouse/20250325100452_alter_span_user_def_attrs_mv.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+alter table span_user_def_attrs_mv modify query
+select distinct app_id,
+                span_id,
+                session_id,
+                toLastDayOfMonth(start_time)         as end_of_month,
+                attribute.app_version                as app_version,
+                attribute.os_version                 as os_version,
+                arr_key                              as key,
+                tupleElement(arr_val, 1)             as type,
+                tupleElement(arr_val, 2)             as value,
+                start_time                            as ver
+from spans
+    array join
+     mapKeys(user_defined_attribute) as arr_key,
+     mapValues(user_defined_attribute) as arr_val
+where length(user_defined_attribute) > 0
+group by app_id, end_of_month, app_version, os_version,
+        key, type, value, span_id, session_id, ver
+order by app_id;
+
+-- migrate:down
+alter table span_user_def_attrs_mv modify query
+select distinct app_id,
+                span_id,
+                session_id,
+                toLastDayOfMonth(start_time)         as end_of_month,
+                attribute.app_version                as app_version,
+                attribute.os_version                 as os_version,
+                arr_key                              as key,
+                tupleElement(arr_val, 1)             as type,
+                tupleElement(arr_val, 2)             as value
+from spans
+    array join
+     mapKeys(user_defined_attribute) as arr_key,
+     mapValues(user_defined_attribute) as arr_val
+where length(user_defined_attribute) > 0
+group by app_id, end_of_month, app_version, os_version,
+        key, type, value, span_id, session_id
+order by app_id;


### PR DESCRIPTION
> [!NOTE]
>
> ## To Maintainers
>
> Please run ClickHouse migrations. [Follow this guide](https://github.com/measure-sh/measure/blob/main/self-host/clickhouse/README.md#running-clickhouse-migrations)

## Summary

This PR modifies `user_def_attrs`, `span_user_def_attrs` table and `user_def_attrs_mv`, `span_user_def_attrs_mv` materialized view to add a `ver` table parameter for ReplacingMergeTree engine. Additionally, each call site(s) of user defined attributes gain the `final` clause.

## Tasks

- [x] Add migration to replace `user_def_attrs` table
- [x] Add migration to alter `user_def_attrs_mv` view
- [x] Add migration to replace `span_user_def_attrs` table
- [x] Add migration to replace `span_user_def_attrs_mv` view
- [x] Add `final` clause to each call site of user defined attributes
- [x] Filter out old duplicate key/type combination(s)

## See also

- fixes #1939
