### PR TITLE
Ios api key url check

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/ClientInfo.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ClientInfo.swift
@@ -29,13 +29,13 @@ protocol Client {
     ///   - apiUrl: `API URL` from the Measure dashboard.
     @objc public init(apiKey: String,
                       apiUrl: String) {
-        if !apiKey.isEmpty {
+        if apiKey.isEmpty {
             debugPrint("Measure apiKey is missing, skipping initialization")
         }
         if let apiUrl = URL(string: apiUrl) {
             self.apiUrl = apiUrl
         } else {
-            self.apiUrl = URL(string: "http://localhost:8080")!
+            self.apiUrl = URL(string: fallbackApiUrl)!
             debugPrint("Measure apiUrl is invalid, skipping initialization.")
         }
 

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -79,10 +79,12 @@ import Foundation
                 measureInternal = MeasureInternal(meaureInitializer)
                 meaureInitializer.logger.log(level: .info, message: "SDK enabled in testing mode.", error: nil, data: nil)
             } else {
-                if !client.apiKey.isEmpty {
+                if !client.apiKey.isEmpty && client.apiUrl.absoluteString != fallbackApiUrl {
                     let meaureInitializer = BaseMeasureInitializer(config: config ?? BaseMeasureConfig(),
                                                                    client: client)
                     measureInternal = MeasureInternal(meaureInitializer)
+                } else {
+                    debugPrint("Skipping SDK initialization: Missing or invalid API key or API URL")
                 }
             }
         }

--- a/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
@@ -39,6 +39,7 @@ let networkInterceptorHandledKey = "NetworkInterceptorHandled"
 let screenshotName = "screenshot.png"
 let layoutSnapshotName = "layoutSnapshot.svg"
 let layoutSnapshotDirectoryName = "layoutSnapshot"
+let fallbackApiUrl = "http://fallback"
 
 struct AttributeConstants {
     static let deviceManufacturer = "Apple"


### PR DESCRIPTION
# Description

Fixes the below issues:

- When the apiKey is sent, the SDK gets initialized but logs message `Measure apiKey is missing, skipping initialization`. Removed the incorrect log messages.
- SDK gets initialized even when apiUrl is nil.

## Related issue
Fixes #1968
