### PR TITLE
fix(backend): mismatch and duplicate sessions

### DIFF
--- a/backend/api/measure/bugreport.go
+++ b/backend/api/measure/bugreport.go
@@ -138,7 +138,7 @@ func GetBugReportInstancesPlot(ctx context.Context, af *filter.AppFilter) (bugRe
 			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
-		base.Clause("AND event_id in").SubQuery("(", ")", subQuery)
+		base.SubQuery("event_id in (", ")", subQuery)
 	}
 
 	base.OrderBy("timestamp desc")
@@ -260,7 +260,7 @@ func GetBugReportsWithFilter(ctx context.Context, af *filter.AppFilter) (bugRepo
 			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
-		stmt.Clause("AND event_id in").SubQuery("(", ")", subQuery)
+		stmt.SubQuery("event_id in (", ")", subQuery)
 	}
 
 	stmt.OrderBy("timestamp desc")

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -1844,14 +1844,16 @@ func GetANRPlotInstances(ctx context.Context, af *filter.AppFilter) (issueInstan
 // GetIssuesAttributeDistribution queries distribution of attributes
 // based on datetime and filters.
 func GetIssuesAttributeDistribution(ctx context.Context, g group.IssueGroup, af *filter.AppFilter) (map[string]map[string]uint64, error) {
-	fingerprint := g.GetFingerprint()
+	var fingerprint string
 	groupType := event.TypeException
 
 	switch g.(type) {
 	case *group.ANRGroup:
 		groupType = event.TypeANR
+		fingerprint = g.(*group.ANRGroup).GetFingerprint()
 	case *group.ExceptionGroup:
 		groupType = event.TypeException
+		fingerprint = g.(*group.ExceptionGroup).GetFingerprint()
 	default:
 		err := errors.New("couldn't determine correct type of issue group")
 		return nil, err

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -658,7 +658,7 @@ func GetMetricsPlotForSpanNameWithFilter(ctx context.Context, spanName string, a
 			Clause("final").
 			Where("app_id = toUUID(?)", af.AppID)
 		af.UDExpression.Augment(subQuery)
-		stmt.Clause("AND span_id in").SubQuery("(", ")", subQuery)
+		stmt.SubQuery("span_id in (", ")", subQuery)
 	}
 
 	stmt.GroupBy("app_version, datetime")


### PR DESCRIPTION
## Summary

This PR fixes issues related to duplication on sessions overview page as well as matching of user defined attributes on sessions, spans and bug reports overview pages.

## Tasks

- [x] Fix duplication of sessions in GET `/apps/:id/sessions` API
- [x] Fix user defined attribute matching in GET `/apps/:id/sessions/plots/instances` API
- [x] Fix user defined attribute matching in GET `/apps/:id/bugReports` API
- [x] Fix user defined attribute matching in GET `/apps/:id/bugReports/plots/instances` API
- [x] Fix user defined attribute matching in GET `/apps/:id/spans` API
- [x] Fix user defined attribute matching in GET `/apps/:id/spans/plots/metrics` API

## See also

- fixes #1949
- fixes #1950