### PR TITLE
chore(backend): add data backfill for upcoming release

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -135,7 +135,7 @@ At this point, the install script will attempt to start all the Measure docker c
   <img src="https://github.com/user-attachments/assets/b33fbca4-4567-4077-9432-8be9f9c8b078" alt="Successful installation" />
 </p>
 
-At this point, all the services should be up, but they are not reachable from the internet. To make sure these services can serve traffic, let's setup: 
+At this point, all the services should be up, but they are not reachable from the internet. To make sure these services can serve traffic, let's setup:
 
 - A reverse proxy using [caddy](https://caddyserver.com/)
 - Setup DNS A recods on your domain
@@ -179,7 +179,7 @@ EOF
 ```
 
 > [!NOTE]
-> 
+>
 > In the above Caddyfile, we have used the example domains from above, but make sure you replace with your actual domain names.
 
 Next, reload caddy to make sure caddy picks up our newly generated config.
@@ -227,6 +227,7 @@ Find out the suitable version from the [list of release tags](https://github.com
 Run `git fetch` to fetch all tags.
 
 ```sh
+git reset --hard # reset local modifications, if any
 git fetch
 ```
 
@@ -263,7 +264,7 @@ You can run measure.sh locally on macOS for trying it out quickly, but keep in m
 
 ### System Requirements
 
-Make sure the following requirements present before proceeding.
+Make sure the following requirements are met before proceeding.
 
 | Name           | Version  |
 | -------------- | -------- |

--- a/docs/hosting/migration-guides/README.md
+++ b/docs/hosting/migration-guides/README.md
@@ -9,3 +9,4 @@ Some migrations may contain _optional_ steps. The specific guide would state tha
 Choose as per your target version.
 
 - [**v0.4.x**](./v0.4.x/README.md) - Migration Guide for `v0.4.x`
+- [**v0.6.x**](./v0.6.x/README.md) - Migration Guide for `v0.6.x`

--- a/docs/hosting/migration-guides/v0.6.x/README.md
+++ b/docs/hosting/migration-guides/v0.6.x/README.md
@@ -1,0 +1,34 @@
+# Migration Guide for `v0.6.x`
+
+Use this guide only when you are on less than `v0.6.0` and upgrading to `v0.6.x`.
+
+> [!WARNING]
+>
+> Steps mentioned in this document will cause downtime.
+
+Follow these steps when upgrading to `0.6.x`. There is some downtime involved. During the downtime SDKs would receive a `503 Service Unavailable` when sending sessions. Once the upgrade is complete, ingestion should resume normally. SDKs will retry sending unsent sessions automatically.
+
+## 1. SSH into the VM where Measure is hosted
+
+## 2. Perform the upgrade
+
+Visit [Releases](https://github.com/measure-sh/measure/releases) page to capture the latest tag matching the `[MAJOR].[MINOR].[PATCH]` format.
+
+```sh
+cd ~/measure
+git reset --hard # only applies if you have local modifications
+git fetch
+git checkout <git-tag>
+cd self-host
+sudo ./install.sh
+```
+
+## 3. Run data backfills
+
+Perform this step to complete the migration. Certain features on the Measure dashboard like user defined attributes won't work otherwise.
+
+This may take some time. Make sure your SSH connection remains active until it completes.
+
+```sh
+sudo ./migrations/v0.6.x-data-backfills.sh
+```

--- a/self-host/migrations/v0.6.x-data-backfills.sh
+++ b/self-host/migrations/v0.6.x-data-backfills.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+has_command() {
+  if command -v "$1" &>/dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+if has_command docker-compose; then
+  DOCKER_COMPOSE="docker-compose"
+elif docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+else
+  echo "Neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+fi
+
+echo "Starting to backfill data for Materialized View tables"
+echo
+
+# remove old resources
+$DOCKER_COMPOSE exec clickhouse clickhouse-client -q "
+drop table if exists events_null;
+drop view if exists user_def_attrs_mv_null;
+"
+
+# create a null table for 'events'
+echo "Creating null table for 'events'"
+$DOCKER_COMPOSE exec clickhouse clickhouse-client --progress -q "create table events_null as events engine = NULL;"
+
+# create a null materialized view for 'user_def_attrs' table
+echo "Creating null materialized view for 'user_def_attrs'"
+$DOCKER_COMPOSE exec clickhouse clickhouse-client --progress -q "
+create materialized view user_def_attrs_mv_null to user_def_attrs as
+select distinct app_id,
+                id                                   as event_id,
+                session_id,
+                toLastDayOfMonth(timestamp)          as end_of_month,
+                (toString(attribute.app_version),
+                 toString(attribute.app_build))      as app_version,
+                (toString(attribute.os_name),
+                 toString(attribute.os_version))     as os_version,
+                if(events.type = 'exception' and exception.handled = false,
+                   true, false)                      as exception,
+                if(events.type = 'anr', true, false) as anr,
+                arr_key                              as key,
+                tupleElement(arr_val, 1)             as type,
+                tupleElement(arr_val, 2)             as value,
+                timestamp                            as ver
+from events_null
+    array join
+     mapKeys(user_defined_attribute) as arr_key,
+     mapValues(user_defined_attribute) as arr_val
+where length(user_defined_attribute) > 0
+group by app_id, end_of_month, app_version, os_version, events.type,
+         exception.handled, key, type, value, event_id, session_id,
+         ver
+order by app_id;
+"
+
+# truncate tables just in case
+# makes this script idempotent
+$DOCKER_COMPOSE exec clickhouse clickhouse-client --progress -q "
+truncate table if exists user_def_attrs;
+"
+
+# kickstart the backfill
+echo
+echo "Backfilling 'user_def_attrs' table"
+$DOCKER_COMPOSE exec clickhouse clickhouse-client --progress -q "insert into events_null select * from events;"
+
+echo "Completed. Populated 'user_def_attrs' table."
+
+# clean up used resources
+echo "Cleaning up resources"
+$DOCKER_COMPOSE exec clickhouse clickhouse-client -q "
+drop view user_def_attrs_mv_null;
+drop view events_null;
+"


### PR DESCRIPTION
## Summary

This PR adds a data backfilling script to populate `user_def_attrs` table as a migration step. Also, added a migration guide for upgrading to `v0.6.x`.

## Tasks

- [x] Add data backfill script for upcoming release
- [x] Add migration guide for `v0.6.x`

## See also

- fixes #1976