### PR TITLE
chore(ios): add http event configurations to measure config

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -3,6 +3,7 @@
 * [Minimum requirements](#minimum-requirements)
 * [Quick reference](#quick-reference)
 * [Getting started](#getting-started)
+* [Configuration options](#configuration-options)
 * [Features](#features)
   * [Automatic collection](#automatic-collection)
   * [Crash Reporting](#crash-reporting)
@@ -105,6 +106,10 @@ Reopen the app and check the Measure dashboard—you should see the crash report
 > When triggering a crash, **make sure the Xcode debugger is not attached**, as crashes may not be properly reported when running the app in debug mode.
 
 🎉 Congratulations! You have successfully integrated Measure into your app!
+
+# Configuration options
+
+See all the [configuration options](configuration-options.md) available.
 
 # Features
 

--- a/docs/ios/configuration-options.md
+++ b/docs/ios/configuration-options.md
@@ -1,0 +1,85 @@
+# Configuration Options
+
+Measure provides a number of configuration options to customize the data collected and the behavior of the SDK. These
+options can be set in the `MeasureConfig` object which is passed to the `Measure.shared.initialize` method. Example:
+
+```swift
+let config = BaseMeasureConfig(enableLogging: true,
+                               samplingRateForErrorFreeSessions: 1.0,
+                               trackHttpHeaders: true,
+                               trackHttpBody: true,
+                               httpHeadersBlocklist: ["Authorization"],
+                               httpUrlBlocklist: ["http://localhost:8080"],
+                               httpUrlAllowlist: ["example.com"])
+Measure.shared.initialize(with: clientInfo, config: config)
+```
+
+# Contents
+
+* [**samplingRateForErrorFreeSessions**](#samplingRateForErrorFreeSessions)
+* [**enableLogging**](#enableLogging)
+* [**trackHttpHeaders**](#trackHttpHeaders)
+* [**httpHeadersBlocklist**](#httpHeadersBlocklist)
+* [**trackHttpBody**](#trackHttpBody)
+* [**httpUrlBlocklist**](#httpUrlBlocklist)
+* [**httpUrlAllowlist**](#httpUrlAllowlist)
+
+
+## `samplingRateForErrorFreeSessions`
+
+Controls sampling rate for non-crashed sessions. Defaults to 0. 
+
+A value between 0.0 and 1.0 can be set:
+* 0.0 (default): Only collect crashed sessions
+* 0.1: Collect 10% of non-crashed sessions
+* 1.0: Collect all sessions
+
+Note that all crashed sessions are collected regardless of this setting.
+
+## `enableLogging`
+
+Allows enabling/disabling internal logging of Measure SDK. This is useful to debug issues with the SDK
+itself. By default, logging is disabled.
+
+
+## `trackHttpHeaders`
+
+Allows enabling/disabling capturing of HTTP request and response headers. Disabled by default.
+
+## `httpHeadersBlocklist`
+
+Allows specifying HTTP headers which should not be captured.
+See [HTTP headers blocklist](features/feature_network_monitoring.md#httpHeadersBlocklist)
+
+By default, the following headers are always disallowed to prevent sensitive information from
+leaking:
+
+* Authorization
+* Cookie
+* Set-Cookie
+* Proxy-Authorization
+* WWW-Authenticate
+* X-Api-Key
+
+## `trackHttpBody`
+
+Allows enabling/disabling capturing of HTTP request and response body. Disabled by default.
+
+## `httpUrlBlocklist`
+
+Allows disabling collection of `http` events for certain URLs. This is useful to setup if you do not
+want to collect data for certain endpoints or third party domains. By default, no URLs are blocked.
+
+Note that this list is used only if `httpUrlAllowlist` is empty.
+
+The check is made using [String.contains] to see if the URL contains any of the strings in
+the list.
+
+## `httpUrlAllowlist`
+
+Allows enabling collection of `http` events only for certain URLs. This is useful to setup if you want
+to collect data only for certain endpoints or third party domains. If this list is empty, `httpUrlBlocklist` is
+considered. By default, this list is empty.
+
+The check is made using [String.contains] to see if the URL contains any of the strings in
+the list.

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -237,6 +237,8 @@
 		CF4FE3952D913BAC0073D8AE /* Measure.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 524CC5BA2C6A4B11001AB506 /* Measure.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CF7CAE4A2D940E4700E15CDB /* AppVersionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE492D940E4700E15CDB /* AppVersionInfo.swift */; };
 		CF7CAE4C2D940F2700E15CDB /* MockAppVersionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE4B2D940F2700E15CDB /* MockAppVersionInfo.swift */; };
+		CF7CAE552D952FA600E15CDB /* HttpEventValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */; };
+		CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -578,6 +580,8 @@
 		52F3775A2CB41F0B006147E8 /* ObjcDetailViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcDetailViewController.m; sourceTree = "<group>"; };
 		CF7CAE492D940E4700E15CDB /* AppVersionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionInfo.swift; sourceTree = "<group>"; };
 		CF7CAE4B2D940F2700E15CDB /* MockAppVersionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppVersionInfo.swift; sourceTree = "<group>"; };
+		CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpEventValidator.swift; sourceTree = "<group>"; };
+		CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpEventValidatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -814,6 +818,7 @@
 			children = (
 				526D17DC2D5A1913009A2E90 /* HttpData.swift */,
 				526D17DD2D5A1913009A2E90 /* HttpEventCollector.swift */,
+				CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */,
 				526D17DE2D5A1913009A2E90 /* HttpInterceptorCallbacks.swift */,
 				526D17DF2D5A1913009A2E90 /* MSRNetworkInterceptor.swift */,
 				526D17E02D5A1913009A2E90 /* NetworkInterceptorProtocol.swift */,
@@ -1152,12 +1157,13 @@
 				52B7F0FB2D757F81001498BC /* Exporter */,
 				52B7F0FD2D757F81001498BC /* Gestures */,
 				52B7F1042D757F81001498BC /* Helper */,
+				CF7CAE562D95342F00E15CDB /* Http */,
 				52B7F1062D757F81001498BC /* LayoutInspector */,
 				52B7F1222D757F81001498BC /* Mocks */,
 				52B7F1272D757F81001498BC /* Performance */,
 				52B7F1292D757F81001498BC /* ScreenshotGenerator */,
-				52B7F12C2D757F81001498BC /* Utils */,
 				52B7F12D2D757F81001498BC /* SessionManagerTests.swift */,
+				52B7F12C2D757F81001498BC /* Utils */,
 			);
 			path = MeasureSDKTests;
 			sourceTree = "<group>";
@@ -1249,6 +1255,14 @@
 				52F377512CB41EDE006147E8 /* ViewController.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		CF7CAE562D95342F00E15CDB /* Http */ = {
+			isa = PBXGroup;
+			children = (
+				CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */,
+			);
+			path = Http;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1554,6 +1568,7 @@
 				526D188B2D5A1913009A2E90 /* TimeProvider.swift in Sources */,
 				526D18732D5A1913009A2E90 /* CpuUsageData.swift in Sources */,
 				526D18662D5A1913009A2E90 /* BaseSvgGenerator.swift in Sources */,
+				CF7CAE552D952FA600E15CDB /* HttpEventValidator.swift in Sources */,
 				526D18912D5A1913009A2E90 /* MeasureInitializer.swift in Sources */,
 				526D18582D5A1913009A2E90 /* HttpModels.swift in Sources */,
 				526D18702D5A1913009A2E90 /* NetworkChangeDetector.swift in Sources */,
@@ -1742,6 +1757,7 @@
 				52B7F13A2D757F81001498BC /* DataCleanupServiceTests.swift in Sources */,
 				52B7F15B2D757F81001498BC /* MockCrashDataPersistence.swift in Sources */,
 				52B7F14D2D757F81001498BC /* Attributes+Extension.swift in Sources */,
+				CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */,
 				52B7F1342D757F81001498BC /* AttributeProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -28,7 +28,7 @@ public enum AttributeValue {
   case double(Swift.Double)
 }
 @objc final public class BaseMeasureConfig : ObjectiveC.NSObject {
-  public init(enableLogging: Swift.Bool? = nil, samplingRateForErrorFreeSessions: Swift.Float? = nil)
+  public init(enableLogging: Swift.Bool? = nil, samplingRateForErrorFreeSessions: Swift.Float? = nil, trackHttpHeaders: Swift.Bool? = nil, trackHttpBody: Swift.Bool? = nil, httpHeadersBlocklist: [Swift.String]? = nil, httpUrlBlocklist: [Swift.String]? = nil, httpUrlAllowlist: [Swift.String]? = nil)
   @objc deinit
 }
 @objc final public class ClientInfo : ObjectiveC.NSObject {

--- a/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
@@ -33,6 +33,26 @@ final class BaseConfigProvider: ConfigProvider {
         self.cachedConfig = configLoader.getCachedConfig()
     }
 
+    var trackHttpHeaders: Bool {
+        return getMergedConfig(\.trackHttpHeaders)
+    }
+
+    var trackHttpBody: Bool {
+        return getMergedConfig(\.trackHttpBody)
+    }
+
+    var httpHeadersBlocklist: [String] {
+        return getMergedConfig(\.httpHeadersBlocklist)
+    }
+
+    var httpUrlBlocklist: [String] {
+        return getMergedConfig(\.httpUrlBlocklist)
+    }
+
+    var httpUrlAllowlist: [String] {
+        return getMergedConfig(\.httpUrlAllowlist)
+    }
+    
     var layoutSnapshotDebounceInterval: Number {
         return getMergedConfig(\.layoutSnapshotDebounceInterval)
     }

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -38,11 +38,26 @@ struct Config: InternalConfig, MeasureConfig {
     let screenshotMaskHexColor: String
     let screenshotCompressionQuality: Int
     let layoutSnapshotDebounceInterval: Number
+    let trackHttpHeaders: Bool
+    let trackHttpBody: Bool
+    let httpHeadersBlocklist: [String]
+    let httpUrlBlocklist: [String]
+    let httpUrlAllowlist: [String]
 
     internal init(enableLogging: Bool = DefaultConfig.enableLogging,
-                  samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate) {
+                  samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
+                  trackHttpHeaders: Bool = DefaultConfig.trackHttpHeaders,
+                  trackHttpBody: Bool = DefaultConfig.trackHttpBody,
+                  httpHeadersBlocklist: [String] = DefaultConfig.httpHeadersBlocklist,
+                  httpUrlBlocklist: [String] = DefaultConfig.httpUrlBlocklist,
+                  httpUrlAllowlist: [String] = DefaultConfig.httpUrlAllowlist) {
         self.enableLogging = enableLogging
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions
+        self.trackHttpHeaders = trackHttpHeaders
+        self.trackHttpBody = trackHttpBody
+        self.httpHeadersBlocklist = httpHeadersBlocklist
+        self.httpUrlBlocklist = httpUrlBlocklist
+        self.httpUrlAllowlist = httpUrlAllowlist
         self.eventsBatchingIntervalMs = 30000 // 30 seconds
         self.maxEventsInBatch = 500
         self.sessionEndLastEventThresholdMs = 20 * 60 * 1000 // 20 minitues

--- a/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
@@ -11,4 +11,9 @@ import Foundation
 struct DefaultConfig {
     static let enableLogging = false
     static let sessionSamplingRate: Float = 0.0
+    static let trackHttpHeaders = false
+    static let trackHttpBody = false
+    static let httpHeadersBlocklist: [String] = []
+    static let httpUrlBlocklist: [String] = []
+    static let httpUrlAllowlist: [String] = []
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
@@ -11,27 +11,94 @@ import Foundation
 protocol MeasureConfig {
     var enableLogging: Bool { get }
     var samplingRateForErrorFreeSessions: Float { get }
+    var trackHttpHeaders: Bool { get }
+    var trackHttpBody: Bool { get }
+    var httpHeadersBlocklist: [String] { get }
+    var httpUrlBlocklist: [String] { get }
+    var httpUrlAllowlist: [String] { get }
 }
 
 /// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
-///
-/// Properties:
-/// - `enableLogging`: Whether to enable internal SDK logging. Defaults to `false`.
-/// - `sessionSamplingRate`: The sampling rate for non-crashed sessions. Must be between 0.0 and 1.0. Defaults to 1.0.
-///
 @objc public final class BaseMeasureConfig: NSObject, MeasureConfig {
+    /// Whether to enable internal SDK logging. Defaults to `false`.
     let enableLogging: Bool
+
+    /// The sampling rate for non-crashed sessions. Must be between 0.0 and 1.0. Defaults to 1.0.
     let samplingRateForErrorFreeSessions: Float
+
+    /// Whether to capture http headers of a network request and response. Defaults to `false`.
+    let trackHttpHeaders: Bool
+
+    /// Whether to capture http body of a network request and response. Defaults to `false`.
+    let trackHttpBody: Bool
+
+    /// List of HTTP headers to not collect with the `http` event for both request and response.
+    /// Defaults to an empty list. The following headers are always excluded:
+    /// - * Authorization
+    /// - * Cookie
+    /// - * Set-Cookie
+    /// - * Proxy-Authorization
+    /// - * WWW-Authenticate
+    /// - * X-Api-Key
+    ///
+    let httpHeadersBlocklist: [String]
+    
+    /// Allows disabling collection of `http` events for certain URLs. This is useful to setup if you do not want to collect data for certain endpoints.
+    ///
+    /// Note that this config is ignored if [httpUrlAllowlist] is set.
+    ///
+    /// You can:
+    /// - Disables a domain, eg. example.com
+    /// - Disable a subdomain, eg. api.example.com
+    /// - Disable a particular path, eg. example.com/order
+    ///
+    let httpUrlBlocklist: [String]
+    
+    /// Allows enabling collection of `http` events for only certain URLs. This is useful to setup if you do not want to collect data for all endpoints except for a few.
+    ///
+    /// You can:
+    /// - Disables a domain, eg. example.com
+    /// - Disable a subdomain, eg. api.example.com
+    /// - Disable a particular path, eg. example.com/order
+    ///
+    let httpUrlAllowlist: [String]
 
     /// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
     /// - Parameters:
     ///   - enableLogging: Enable or disable internal SDK logs. Defaults to `false`.
     ///   - samplingRateForErrorFreeSessions: Sampling rate for sessions without a crash. The sampling rate is a value between 0 and 1.
     ///   For example, a value of `0.5` will export only 50% of the non-crashed sessions, and a value of `0` will disable sending non-crashed sessions to the server.
+    ///   - trackHttpHeaders: Whether to capture http headers of a network request and response. Defaults to `false`.
+    ///   - trackHttpBody:Whether to capture http body of a network request and response. Defaults to `false`.
+    ///   - httpHeadersBlocklist:List of HTTP headers to not collect with the `http` event for both request and response. Defaults to an empty list. The following headers are always excluded:
+    ///       - Authorization
+    ///       - Cookie
+    ///       - Set-Cookie
+    ///       - Proxy-Authorization
+    ///       - WWW-Authenticate
+    ///       - X-Api-Key
+    ///   - httpUrlBlocklist: Allows disabling collection of `http` events for certain URLs. This is useful to setup if you do not want to collect data for certain endpoints.Note that this config is ignored if [httpUrlAllowlist] is set. You can:
+    ///       - Disables a domain, eg. example.com
+    ///       - Disable a subdomain, eg. api.example.com
+    ///       - Disable a particular path, eg. example.com/order
+    ///   - httpUrlAllowlist: Allows enabling collection of `http` events for only certain URLs. This is useful to setup if you do not want to collect data for all endpoints except for a few. You can:
+    ///       - Disables a domain, eg. example.com
+    ///       - Disable a subdomain, eg. api.example.com
+    ///       - Disable a particular path, eg. example.com/order
     public init(enableLogging: Bool? = nil,
-                samplingRateForErrorFreeSessions: Float? = nil) {
+                samplingRateForErrorFreeSessions: Float? = nil,
+                trackHttpHeaders: Bool? = nil,
+                trackHttpBody: Bool? = nil,
+                httpHeadersBlocklist: [String]? = nil,
+                httpUrlBlocklist: [String]? = nil,
+                httpUrlAllowlist: [String]? = nil) {
         self.enableLogging = enableLogging ?? DefaultConfig.enableLogging
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions ?? DefaultConfig.sessionSamplingRate
+        self.trackHttpHeaders = trackHttpHeaders ?? DefaultConfig.trackHttpHeaders
+        self.trackHttpBody = trackHttpBody ?? DefaultConfig.trackHttpBody
+        self.httpHeadersBlocklist = httpHeadersBlocklist ?? DefaultConfig.httpHeadersBlocklist
+        self.httpUrlBlocklist = httpUrlBlocklist ?? DefaultConfig.httpUrlBlocklist
+        self.httpUrlAllowlist = httpUrlAllowlist ?? DefaultConfig.httpUrlAllowlist
 
         if !(0.0...1.0).contains(self.samplingRateForErrorFreeSessions) {
             debugPrint("Session sampling rate must be between 0.0 and 1.0")

--- a/ios/Sources/MeasureSDK/Swift/Http/HttpEventValidator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/HttpEventValidator.swift
@@ -1,0 +1,32 @@
+//
+//  HttpEventValidator.swift
+//  Measure
+//
+//  Created by Adwin Ross on 27/03/25.
+//
+
+import Foundation
+
+protocol HttpEventValidator {
+    func shouldTrackHttpEvent(_ httpContentTypeAllowlist: [String]?, contentType: String, requestUrl: String, allowedDomains: [String]?, ignoredDomains: [String]?) -> Bool
+}
+
+final class BaseHttpEventValidator: HttpEventValidator {
+    func shouldTrackHttpEvent(_ httpContentTypeAllowlist: [String]?, contentType: String, requestUrl: String, allowedDomains: [String]?, ignoredDomains: [String]?) -> Bool {
+        // Skip if content type is not in httpContentTypeAllowlist
+        if let httpContentTypeAllowlist = httpContentTypeAllowlist, !httpContentTypeAllowlist.contains(where: { contentType.contains($0) }) {
+            return false
+        }
+
+        // Skip if allowedDomains is non-empty and the URL doesn't match any domain in allowedDomains
+        if let allowedDomains = allowedDomains.flatMap({ $0 }), !allowedDomains.isEmpty && !allowedDomains.contains(where: { requestUrl.contains($0) }) {
+            return false
+        }
+        // Skip if the URL is in ignored domains, only if allowedDomains is empty
+        else if let ignoreDomains = ignoredDomains.flatMap({ $0 }), ignoreDomains.contains(where: { requestUrl.contains($0) }) {
+            return false
+        }
+
+        return true
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Http/MSRNetworkInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/MSRNetworkInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// A network interceptor that enables monitoring network requests.
 public struct MSRNetworkInterceptor {
     static var isEnabled = false
     private static let lock = NSLock()

--- a/ios/TestApp/MockMeasureInitializer.swift
+++ b/ios/TestApp/MockMeasureInitializer.swift
@@ -56,6 +56,7 @@ final class MockMeasureInitializer: MeasureInitializer {
     let userPermissionManager: UserPermissionManager
     let svgGenerator: SvgGenerator
     let appVersionInfo: AppVersionInfo
+    let httpEventValidator: HttpEventValidator
 
     init(config: MeasureConfig, // swiftlint:disable:this function_body_length
          client: Client) {
@@ -196,12 +197,14 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                          logger: logger,
                                                          sessionManager: sessionManager)
         self.client = client
+        self.httpEventValidator = BaseHttpEventValidator()
         self.httpEventCollector = BaseHttpEventCollector(logger: logger,
                                                          eventProcessor: eventProcessor,
                                                          timeProvider: timeProvider,
                                                          urlSessionTaskSwizzler: URLSessionTaskSwizzler(),
                                                          httpInterceptorCallbacks: HttpInterceptorCallbacks(),
                                                          client: client,
-                                                         configProvider: configProvider)
+                                                         configProvider: configProvider,
+                                                         httpEventValidator: httpEventValidator)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Http/HttpEventValidatorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Http/HttpEventValidatorTests.swift
@@ -1,0 +1,54 @@
+//
+//  HttpEventValidatorTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 27/03/25.
+//
+
+import XCTest
+@testable import Measure
+
+class HttpEventValidatorTests: XCTestCase {
+    private var validator: HttpEventValidator!
+
+    override func setUp() {
+        super.setUp()
+        validator = BaseHttpEventValidator()
+    }
+
+    func test_shouldTrackHttpEvent_whenContentTypeIsInAllowlist() {
+        let result = validator.shouldTrackHttpEvent(["application/json"], contentType: "application/json", requestUrl: "https://example.com", allowedDomains: nil, ignoredDomains: nil)
+        
+        XCTAssertTrue(result, "Request should be tracked when content type is in allowlist")
+    }
+    
+    func test_shouldNotTrackHttpEvent_whenContentTypeNotInAllowlist() {
+        let result = validator.shouldTrackHttpEvent(["application/json"], contentType: "text/html", requestUrl: "https://example.com", allowedDomains: nil, ignoredDomains: nil)
+        
+        XCTAssertFalse(result, "Request should not be tracked when content type is not in allowlist")
+    }
+    
+    func test_shouldTrackHttpEvent_whenURLMatchesAllowedDomains() {
+        let result = validator.shouldTrackHttpEvent(nil, contentType: "application/json", requestUrl: "https://example.com", allowedDomains: ["example.com"], ignoredDomains: nil)
+        
+        XCTAssertTrue(result, "Request should be tracked when URL matches allowed domains")
+    }
+    
+    func test_shouldNotTrackHttpEvent_whenURLDoesNotMatchAllowedDomains() {
+        let result = validator.shouldTrackHttpEvent(nil, contentType: "application/json", requestUrl: "https://other.com", allowedDomains: ["example.com"], ignoredDomains: nil)
+        
+        XCTAssertFalse(result, "Request should not be tracked when URL does not match allowed domains")
+    }
+    
+    func test_shouldNotTrackHttpEvent_whenURLIsInIgnoredDomains_andAllowedDomainsIsEmpty() {
+        let result = validator.shouldTrackHttpEvent(nil, contentType: "application/json", requestUrl: "https://ignored.com", allowedDomains: [], ignoredDomains: ["ignored.com"])
+        
+        XCTAssertFalse(result, "Request should not be tracked when URL is in ignored domains and allowed domains is empty")
+    }
+    
+    func test_shouldTrackHttpEvent_whenAllowedDomainsIsNonEmptyAndIgnoredDomainsExists() {
+        let result = validator.shouldTrackHttpEvent(nil, contentType: "application/json", requestUrl: "https://example.com", allowedDomains: ["example.com"], ignoredDomains: ["ignored.com"])
+        
+        XCTAssertTrue(result, "Request should be tracked when allowed domains is non-empty even if ignored domains exist")
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
@@ -33,6 +33,11 @@ final class MockConfigProvider: ConfigProvider {
     var screenshotMaskHexColor: String
     var screenshotCompressionQuality: Int
     var layoutSnapshotDebounceInterval: Number
+    var trackHttpHeaders: Bool
+    var trackHttpBody: Bool
+    var httpHeadersBlocklist: [String]
+    var httpUrlBlocklist: [String]
+    var httpUrlAllowlist: [String]
 
     init(enableLogging: Bool = false,
          trackScreenshotOnCrash: Bool = true,
@@ -67,7 +72,12 @@ final class MockConfigProvider: ConfigProvider {
                                                   .screenView],
          screenshotMaskHexColor: String = "#222222",
          screenshotCompressionQuality: Int = 25,
-         layoutSnapshotDebounceInterval: Number = 750) {
+         layoutSnapshotDebounceInterval: Number = 750,
+         trackHttpHeaders: Bool = false,
+         trackHttpBody: Bool = false,
+         httpHeadersBlocklist: [String] = [],
+         httpUrlBlocklist: [String] = [],
+         httpUrlAllowlist: [String] = []) {
         self.enableLogging = enableLogging
         self.trackScreenshotOnCrash = trackScreenshotOnCrash
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions
@@ -92,6 +102,11 @@ final class MockConfigProvider: ConfigProvider {
         self.screenshotMaskHexColor = screenshotMaskHexColor
         self.screenshotCompressionQuality = screenshotCompressionQuality
         self.layoutSnapshotDebounceInterval = layoutSnapshotDebounceInterval
+        self.trackHttpHeaders = trackHttpHeaders
+        self.trackHttpBody = trackHttpBody
+        self.httpHeadersBlocklist = httpHeadersBlocklist
+        self.httpUrlBlocklist = httpUrlBlocklist
+        self.httpUrlAllowlist = httpUrlAllowlist
     }
 
     func loadNetworkConfig() {}


### PR DESCRIPTION
# Description

Added the below properties to measure config
- trackHttpHeaders
- trackHttpBody
- httpHeadersBlocklist
- httpUrlBlocklist
- httpUrlAllowlist

This PR also contains:

- Tests
- Moved common logic from `NetworkInterceptorProtocol` and `URLSessionTaskInterceptor` to `HttpEventValidator` which check if a Http event needs to be tracked based on `httpHeadersBlocklist`, `httpUrlBlocklist` and `httpUrlAllowlist`

## Related issue
Closes #1979 
