### PR TITLE
chore(backend): upgrade to latest clickhouse lts version

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -285,7 +285,7 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.10-alpine
+    image: clickhouse/clickhouse-server:25.3-alpine
     environment:
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
## Summary

This PR upgrades ClickHouse to latest LTS (25.3) which brings us closer to the version we'll use for SaaS.

> [!IMPORTANT]
>
> ## To Maintainers
>
> After pulling `main`, please edit your `self-host/.env` file and set a password for the `CLICKHOUSE_PASSWORD` variable. Otherwise, all ClickHouse queries will fail.

## Tasks

- upgrade clickhouse to 25.3 lts

## See also
- fixes #1981