### PR TITLE
fix(backend): broken builds api for older android sdks

### DIFF
--- a/backend/api/measure/mapping.go
+++ b/backend/api/measure/mapping.go
@@ -93,8 +93,19 @@ func (bm BuildMapping) validate(app *App) (code int, err error) {
 	}
 
 	if pltfrm == "" {
-		err = errors.New("failed to determine app's platform")
-		return
+		// Since, older Android SDKs (<=android-gradle-plugn@0.7.0) were
+		// not sending `platform` parameter, we set the platform to Android
+		// when the payload lacks the `platform` parameter and the mapping
+		// type is `proguard`.
+		//
+		// This is critical for maintaining backwards
+		// compatibility.
+		if bm.MappingType == symbol.TypeProguard.String() {
+			pltfrm = platform.Android
+		} else {
+			err = errors.New("failed to determine app's platform")
+			return
+		}
 	}
 
 	platformMappingErr := fmt.Errorf("%q mapping type is not valid for %q platform", bm.MappingType, pltfrm)


### PR DESCRIPTION
## Summary

This PR fixes a bug where older Android SDKs using android-gradle-plugin@0.7.0 or older would fail uploading build info and build mapping because of a validation check where the server tries to determine the app's platform before proceeding with the processing and uploading of builds.

For the fix, the server tries to determine the app's platform, if it can't, it tries to set platform from the request payload, if it can't it assumes and sets the platform to Android if the `mapping_type` in the request payload is set to `proguard`.

```mermaid
flowchart
  Start([Start]) --> DecisionA{App's platform is set?}
  DecisionA --> |No| DecisionB{Request has \`platform\`?}
  DecisionB --> |No| DecisionC{Is \`mapping_type\`=\`proguard\`?}
  DecisionC --> |No| Fail
  DecisionA --> |Yes| Proceed
  DecisionC --> |Yes| Proceed
  DecisionB --> |Yes| Proceed
```

## Tasks

- [x] Fix an issue where <=android-gradle-plugin@0.7.0 would fail uploading builds because of a backward incompatible change in v0.6.0

## See also

- fixes #1983