### PR TITLE
chore(ios): update heartbeat tests

### DIFF
--- a/ios/Tests/MeasureSDKTests/Exporter/HeartbeatTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/HeartbeatTests.swift
@@ -11,10 +11,13 @@ import XCTest
 final class MockHeartbeatListener: HeartbeatListener {
     var pulseCalled = false
     var pulseCalledCount = 0
+    private let lock = NSLock()
 
     func pulse() {
+        lock.lock()
         pulseCalled = true
         pulseCalledCount += 1
+        lock.unlock()
     }
 }
 
@@ -36,17 +39,17 @@ final class BaseHeartbeatTests: XCTestCase {
         super.tearDown()
     }
 
-//    func testListenerReceivesPulseAfterStart() {
-//        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
-//
-//        let expectation = XCTestExpectation(description: "Listener should receive pulse")
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-//            XCTAssertTrue(self.mockListener.pulseCalled, "Listener should have received pulse")
-//            expectation.fulfill()
-//        }
-//
-//        wait(for: [expectation], timeout: 1.0)
-//    }
+    func testListenerReceivesPulseAfterStart() {
+        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
+
+        let expectation = XCTestExpectation(description: "Listener should receive pulse")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertTrue(self.mockListener.pulseCalled, "Listener should have received pulse")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
 
     func testStopPreventsFurtherPulses() {
         heartbeat.start(intervalMs: 100, initialDelayMs: 0)
@@ -64,16 +67,16 @@ final class BaseHeartbeatTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-//    func testStartDoesNotTriggerMultipleTimers() {
-//        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
-//        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
-//
-//        let expectation = XCTestExpectation(description: "Listener should receive only one pulse")
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-//            XCTAssertTrue(self.mockListener.pulseCalled, "Listener should have received pulse")
-//            expectation.fulfill()
-//        }
-//
-//        wait(for: [expectation], timeout: 1.0)
-//    }
+    func testStartDoesNotTriggerMultipleTimers() {
+        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
+        heartbeat.start(intervalMs: 100, initialDelayMs: 0)
+
+        let expectation = XCTestExpectation(description: "Listener should receive only one pulse")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertTrue(self.mockListener.pulseCalled, "Listener should have received pulse")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
 }


### PR DESCRIPTION
# Description

The iOS tests are flaky because of the random failure of HeartBeatTests. 

Because the tests run in a multithreaded environment, the `pulse` function needs to be thread-safe. This is what was causing the inconsistancy.

## Related issue
Closes #1942 
