### PR TITLE
chore(ios): remove swift-lint check on ci

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,12 +20,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Run SwiftLint
-        uses: cirruslabs/swiftlint-action@fdc2695c66b8807e7b1571d08097a99cf1fde41b
-        with:
-          version: latest
-          directory: ios
-
       - name: Clean Derived Data
         run: |
           rm -rf ~/Library/Developer/Xcode/DerivedData


### PR DESCRIPTION
# Description

Remove swift lint check from ci. This will be added later as a pre-commit hook.

## Related issue
References #2011 



