### PR TITLE
docs(android): behaviour of SDK when stopped

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -265,7 +265,8 @@ Measure.stop()
 ```
 
 > [!IMPORTANT]
-> Some SDK instrumentation remains active even when stopped. This is to maintain state and ensure seamless data collection when it is started. However, no actual data is collected or sent to the server when the SDK is stopped.
+> Some SDK instrumentation remains active even when stopped. This is to maintain state and ensure seamless data collection when it is started. 
+> Additonally, cold, warm & hot launch events are also always captured. However, no data is sent to the server until the SDK is started.
 
 # Features
 


### PR DESCRIPTION
# Description

Improve the documentation to reflect behavior of SDK when in "stopped" state.

## Related issue
Closes #2012



