### PR TITLE
chore(gradle): add validation for API_KEY

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/ExtractManifestDataTask.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/ExtractManifestDataTask.kt
@@ -24,6 +24,7 @@ private const val TAG_MANIFEST = "manifest"
 private const val TAG_META_DATA = "meta-data"
 private const val ATTR_ANDROID_NAME = "android:name"
 private const val ATTR_ANDROID_VALUE = "android:value"
+private const val API_KEY_PREFIX = "msrsh"
 
 abstract class ExtractManifestDataTask : DefaultTask() {
     init {
@@ -59,6 +60,13 @@ abstract class ExtractManifestDataTask : DefaultTask() {
         if (apiKey == null) {
             logger.error(
                 "[ERROR]: $KEY_API_KEY missing in manifest, Measure SDK will not be initialized.",
+            )
+            return
+        }
+
+        if (!apiKey.startsWith(API_KEY_PREFIX)) {
+            logger.error(
+                "[ERROR]: $KEY_API_KEY is invalid, Measure SDK will not be initialized.",
             )
             return
         }

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -24,6 +24,7 @@ class MeasurePlugin : Plugin<Project> {
         const val DEFAULT_RETRIES = 3
     }
 
+    @Suppress("UnstableApiUsage")
     override fun apply(project: Project) {
         if (!project.plugins.hasPlugin("com.android.application")) {
             project.logger.warn(

--- a/android/measure-android-gradle/src/test/kotlin/sh/measure/ExtractManifestDataTaskTest.kt
+++ b/android/measure-android-gradle/src/test/kotlin/sh/measure/ExtractManifestDataTaskTest.kt
@@ -32,7 +32,7 @@ internal class ExtractManifestDataTaskTest {
         configureTask()
         task.extractManifestData()
         val validManifestOutput = """
-                {"apiKey":"api-key","apiUrl":"api-url","versionCode":"100","appUniqueId":"sh.measure.sample","versionName":"1.0.0"}
+                {"apiKey":"msrsh-api-key","apiUrl":"api-url","versionCode":"100","appUniqueId":"sh.measure.sample","versionName":"1.0.0"}
         """.trimIndent()
         Assert.assertEquals(validManifestOutput, outputFile.readText())
     }
@@ -48,6 +48,14 @@ internal class ExtractManifestDataTaskTest {
     @Test
     fun `ExtractManifestDataTask does not output the file when API URL is missing in manifest`() {
         manifestFile.writeText(manifestWithoutApiUrl)
+        configureTask()
+        task.extractManifestData()
+        Assert.assertTrue(outputFile.readText().isEmpty())
+    }
+
+    @Test
+    fun `ExtractManifestDataTask does not output the file when API KEY is invalid`() {
+        manifestFile.writeText(manifestWithInvalidApiKey)
         configureTask()
         task.extractManifestData()
         Assert.assertTrue(outputFile.readText().isEmpty())
@@ -70,7 +78,7 @@ internal class ExtractManifestDataTaskTest {
                 <application>
                     <meta-data
                         android:name="sh.measure.android.API_KEY"
-                        android:value="api-key" />
+                        android:value="msrsh-api-key" />
                         
                     <meta-data
                         android:name="sh.measure.android.API_URL"
@@ -89,6 +97,20 @@ internal class ExtractManifestDataTaskTest {
                       <meta-data
                         android:name="sh.measure.android.API_URL"
                         android:value="api-url" />
+                </application>
+            </manifest>
+    """.trimIndent()
+
+    private val manifestWithInvalidApiKey = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="sh.measure.sample"
+                android:versionCode="100"
+                android:versionName="1.0.0">
+                <application>
+                      <meta-data
+                        android:name="sh.measure.android.API_URL"
+                        android:value="invalid-api-key" />
                 </application>
             </manifest>
     """.trimIndent()


### PR DESCRIPTION
# Description

Adds a validation to ensure API_KEY starts with expected `msrsh` prefix.

## Related issue
Fixes #2023 