### PR TITLE
test(android): fix flaky exception tests

### DIFF
--- a/android/measure/src/test/java/sh/measure/android/events/UserTriggeredEventCollectorImplTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/events/UserTriggeredEventCollectorImplTest.kt
@@ -48,16 +48,15 @@ class UserTriggeredEventCollectorImplTest {
     @Test
     fun `tracks handled exception event`() {
         val exception = Exception()
-        val data = TestData.getExceptionData(handled = true, exception = exception)
 
         userTriggeredEventCollector.register()
         userTriggeredEventCollector.trackHandledException(exception)
         verify(signalProcessor).trackUserTriggered(
-            data = data,
-            type = EventType.EXCEPTION,
-            timestamp = timeProvider.now(),
-            attachments = mutableListOf(),
-            userDefinedAttributes = mutableMapOf(),
+            data = any<ExceptionData>(),
+            timestamp = eq(timeProvider.now()),
+            type = eq(EventType.EXCEPTION),
+            attachments = eq(mutableListOf()),
+            userDefinedAttributes = eq(mutableMapOf()),
         )
     }
 

--- a/android/measure/src/test/java/sh/measure/android/exceptions/UnhandledExceptionCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exceptions/UnhandledExceptionCollectorTest.kt
@@ -6,6 +6,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.fakes.FakeProcessInfoProvider
@@ -53,23 +55,18 @@ internal class UnhandledExceptionCollectorTest {
         // Given
         val thread = Thread.currentThread()
         val exception = RuntimeException("Test exception")
-        val expectedException = ExceptionFactory.createMeasureException(
-            exception,
-            handled = false,
-            thread = thread,
-            foreground = processInfo.isForegroundProcess(),
-        )
 
         // When
         collector.uncaughtException(thread, exception)
 
         // Then
         verify(signalProcessor).trackCrash(
-            timestamp = timeProvider.now(),
-            type = EventType.EXCEPTION,
-            data = expectedException,
-            attributes = mutableMapOf(),
-            attachments = mutableListOf(),
+            data = any<ExceptionData>(),
+            timestamp = eq(timeProvider.now()),
+            type = eq(EventType.EXCEPTION),
+            attributes = eq(mutableMapOf()),
+            userDefinedAttributes = eq(mutableMapOf()),
+            attachments = eq(mutableListOf()),
         )
     }
 


### PR DESCRIPTION
# Description

Comparing the exception object makes tests flaky as the thread state can be different at the time when the exception object is created vs when the `ExceptionData` object is created. This PR changes the assertion to not do a deep equals check on the exceptions object.

## Related issue
Fixes #1991 
