### PR TITLE
feat(frontend): handle nav link clicks on same page

### DIFF
--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from 'next/image'
 import React, { useState, useEffect } from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import TeamSwitcher, { TeamsSwitcherStatus } from "../components/team_switcher";
 import { TeamsApiStatus, emptyTeam, fetchTeamsFromServer } from "../api/api_calls";
@@ -67,6 +67,8 @@ export default function DashboardLayout({
 
   const pathName = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentQuery = searchParams.toString();
 
   const getTeams = async () => {
     setTeamsApiStatus(TeamsApiStatus.Loading)
@@ -121,7 +123,7 @@ export default function DashboardLayout({
               <ul>
                 {menuItems.map(({ hrefSuffix, title }) => (
                   <li key={title}>
-                    <Link href={`/${selectedTeam}/${hrefSuffix}`} className={`mx-4 mb-3 outline-hidden flex justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4 ${pathName.includes(hrefSuffix) ? 'bg-neutral-950 text-white hover:text-black focus-visible:text-black pointer-events-none' : ''}`} tabIndex={pathName.includes(hrefSuffix) ? -1 : 0}>{title}</Link>
+                    <Link href={`/${selectedTeam}/${hrefSuffix}` + (currentQuery != '' && pathName.includes(hrefSuffix) ? '?' + currentQuery : '')} className={`mx-4 mb-3 outline-hidden flex justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4 ${pathName.includes(hrefSuffix) ? 'bg-neutral-950 text-white hover:text-black focus-visible:text-black' : ''}`}>{title}</Link>
                   </li>
                 ))}
               </ul>}


### PR DESCRIPTION
# Description

Handles nav link clicks on same page. When left nav is clicked while on the same page as the nav link:
- Nav link remains clickable
- Query params should are preserved
- Page is not reloaded

## Related issue
Closes #2032 



