### PR TITLE
ci(flutter): update android sdk version

### DIFF
--- a/flutter/measure_flutter/android/build.gradle
+++ b/flutter/measure_flutter/android/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 
     dependencies {
-        api("sh.measure:measure-android:0.10.0-SNAPSHOT")
+        api("sh.measure:measure-android:0.11.0-SNAPSHOT")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
     }
 


### PR DESCRIPTION
# Description

Flutter checks are failing due to older SDK version specified in Flutter Android Plugin. All Flutter workflows are currently failing: https://github.com/measure-sh/measure/pull/2042

This PR fixes the issue. 



