### PR TITLE
chore(android): convert event type to enum

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
@@ -660,8 +660,8 @@ class EventsTest {
         }
     }
 
-    private fun String.containsEvent(eventType: String): Boolean {
-        return contains("\"type\":\"$eventType\"")
+    private fun String.containsEvent(eventType: EventType): Boolean {
+        return contains("\"type\":\"${eventType.value}\"")
     }
 
     private fun String.containsAttribute(key: String, value: String): Boolean {
@@ -697,7 +697,7 @@ class EventsTest {
         )
     }
 
-    private fun assertEventTracked(body: String, eventType: String) {
+    private fun assertEventTracked(body: String, eventType: EventType) {
         Assert.assertTrue(body.containsEvent(eventType))
     }
 
@@ -709,12 +709,12 @@ class EventsTest {
         }
     }
 
-    private fun assertEventTracked(eventType: String) {
+    private fun assertEventTracked(eventType: EventType) {
         val body = getLastRequestBody()
         Assert.assertTrue(body.containsEvent(eventType))
     }
 
-    private fun assertEventNotTracked(eventType: String) {
+    private fun assertEventNotTracked(eventType: EventType) {
         val body = getLastRequestBody()
         Assert.assertFalse(body.containsEvent(eventType))
     }

--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -2,8 +2,9 @@ package sh.measure.android
 
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.config.ScreenshotMaskLevel
+import sh.measure.android.events.EventType
 
-class FakeConfigProvider : ConfigProvider {
+internal class FakeConfigProvider : ConfigProvider {
     override fun loadNetworkConfig() {
         // no-op
     }
@@ -49,7 +50,7 @@ class FakeConfigProvider : ConfigProvider {
     override var maxUserDefinedAttributeValueLength: Int = 256
     override var screenshotMaskHexColor: String = "#222222"
     override var screenshotCompressionQuality: Int = 100
-    override var eventTypeExportAllowList: List<String> = emptyList()
+    override var eventTypeExportAllowList: List<EventType> = emptyList()
     override val autoStart: Boolean = true
     override var maxSignalsInDatabase: Int = 50000
     override val maxSpanNameLength: Int = 64

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -7,6 +7,20 @@ import android.net.Uri
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import org.jetbrains.annotations.TestOnly
+import sh.measure.android.Measure.captureLayoutSnapshot
+import sh.measure.android.Measure.captureScreenshot
+import sh.measure.android.Measure.clearUserId
+import sh.measure.android.Measure.disableShakeToLaunchBugReport
+import sh.measure.android.Measure.enableShakeToLaunchBugReport
+import sh.measure.android.Measure.getCurrentTime
+import sh.measure.android.Measure.getTraceParentHeaderKey
+import sh.measure.android.Measure.getTraceParentHeaderValue
+import sh.measure.android.Measure.imageUriToAttachment
+import sh.measure.android.Measure.launchBugReportActivity
+import sh.measure.android.Measure.setUserId
+import sh.measure.android.Measure.start
+import sh.measure.android.Measure.stop
+import sh.measure.android.Measure.trackBugReport
 import sh.measure.android.applaunch.LaunchState
 import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.attributes.AttributesBuilder
@@ -541,7 +555,7 @@ object Measure {
     internal fun simulateAppCrash(
         data: ExceptionData,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attributes: MutableMap<String, Any?>,
         attachments: MutableList<Attachment>,
     ) {

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -40,7 +40,7 @@ internal data class Config(
     override val maxUserDefinedAttributesPerEvent: Int = 100
     override val maxUserDefinedAttributeKeyLength: Int = 256 // 256 chars
     override val maxUserDefinedAttributeValueLength: Int = 256 // 256 chars
-    override val eventTypeExportAllowList: List<String> = listOf(
+    override val eventTypeExportAllowList: List<EventType> = listOf(
         EventType.COLD_LAUNCH,
         EventType.HOT_LAUNCH,
         EventType.WARM_LAUNCH,

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -1,6 +1,7 @@
 package sh.measure.android.config
 
 import androidx.annotation.VisibleForTesting
+import sh.measure.android.events.EventType
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
@@ -56,7 +57,7 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { screenshotMaskHexColor }
     override val screenshotCompressionQuality: Int
         get() = getMergedConfig { screenshotCompressionQuality }
-    override val eventTypeExportAllowList: List<String>
+    override val eventTypeExportAllowList: List<EventType>
         get() = getMergedConfig { eventTypeExportAllowList }
     override val maxSignalsInDatabase: Int
         get() = getMergedConfig { maxSignalsInDatabase }

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -83,7 +83,7 @@ internal interface InternalConfig {
      * All [EventType]'s that are always exported, regardless of other filters like session
      * sampling rate and whether the session crashed or not.
      */
-    val eventTypeExportAllowList: List<String>
+    val eventTypeExportAllowList: List<EventType>
 
     /**
      * The maximum number of (events + spans) allowed in the database.

--- a/android/measure/src/main/java/sh/measure/android/events/DefaultEventTransformer.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/DefaultEventTransformer.kt
@@ -69,6 +69,8 @@ internal class DefaultEventTransformer(
                     configProvider.shouldTrackHttpHeader(key)
                 }
             }
+
+            else -> return event
         }
         return event
     }

--- a/android/measure/src/main/java/sh/measure/android/events/Event.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/Event.kt
@@ -27,7 +27,7 @@ internal data class Event<T>(
     /**
      * The type of the event. See [EventType] for the list of event types.
      */
-    val type: String,
+    val type: EventType,
 
     /**
      * The data collected. This can be any object that is annotated with `@Serializable`.

--- a/android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -1,25 +1,34 @@
 package sh.measure.android.events
 
-internal object EventType {
-    const val STRING = "string"
-    const val EXCEPTION = "exception"
-    const val ANR = "anr"
-    const val APP_EXIT = "app_exit"
-    const val CLICK: String = "gesture_click"
-    const val LONG_CLICK: String = "gesture_long_click"
-    const val SCROLL: String = "gesture_scroll"
-    const val LIFECYCLE_ACTIVITY: String = "lifecycle_activity"
-    const val LIFECYCLE_FRAGMENT: String = "lifecycle_fragment"
-    const val LIFECYCLE_APP: String = "lifecycle_app"
-    const val COLD_LAUNCH: String = "cold_launch"
-    const val WARM_LAUNCH: String = "warm_launch"
-    const val HOT_LAUNCH: String = "hot_launch"
-    const val NETWORK_CHANGE: String = "network_change"
-    const val HTTP: String = "http"
-    const val MEMORY_USAGE: String = "memory_usage"
-    const val TRIM_MEMORY: String = "trim_memory"
-    const val CPU_USAGE: String = "cpu_usage"
-    const val SCREEN_VIEW: String = "screen_view"
-    const val CUSTOM: String = "custom"
-    const val BUG_REPORT: String = "bug_report"
+import sh.measure.android.events.EventType.entries
+
+internal enum class EventType(val value: String) {
+    STRING("string"),
+    EXCEPTION("exception"),
+    ANR("anr"),
+    APP_EXIT("app_exit"),
+    CLICK("gesture_click"),
+    LONG_CLICK("gesture_long_click"),
+    SCROLL("gesture_scroll"),
+    LIFECYCLE_ACTIVITY("lifecycle_activity"),
+    LIFECYCLE_FRAGMENT("lifecycle_fragment"),
+    LIFECYCLE_APP("lifecycle_app"),
+    COLD_LAUNCH("cold_launch"),
+    WARM_LAUNCH("warm_launch"),
+    HOT_LAUNCH("hot_launch"),
+    NETWORK_CHANGE("network_change"),
+    HTTP("http"),
+    MEMORY_USAGE("memory_usage"),
+    TRIM_MEMORY("trim_memory"),
+    CPU_USAGE("cpu_usage"),
+    SCREEN_VIEW("screen_view"),
+    CUSTOM("custom"),
+    BUG_REPORT("bug_report"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): EventType? {
+            return entries.find { it.value == value }
+        }
+    }
 }

--- a/android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -1,7 +1,5 @@
 package sh.measure.android.events
 
-import sh.measure.android.events.EventType.entries
-
 internal enum class EventType(val value: String) {
     STRING("string"),
     EXCEPTION("exception"),

--- a/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -41,7 +41,7 @@ internal interface SignalProcessor {
     fun <T> track(
         data: T,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attributes: MutableMap<String, Any?> = mutableMapOf(),
         userDefinedAttributes: Map<String, AttributeValue> = mapOf(),
         attachments: MutableList<Attachment> = mutableListOf(),
@@ -57,7 +57,7 @@ internal interface SignalProcessor {
     fun trackAppExit(
         data: AppExit,
         timestamp: Long,
-        type: String,
+        type: EventType,
         threadName: String,
         sessionId: String,
         appVersion: String?,
@@ -70,7 +70,7 @@ internal interface SignalProcessor {
     fun <T> trackUserTriggered(
         data: T,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attachments: MutableList<Attachment> = mutableListOf(),
         userDefinedAttributes: Map<String, AttributeValue> = mapOf(),
     )
@@ -83,7 +83,7 @@ internal interface SignalProcessor {
     fun trackCrash(
         data: ExceptionData,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attributes: MutableMap<String, Any?> = mutableMapOf(),
         userDefinedAttributes: Map<String, AttributeValue> = mapOf(),
         attachments: MutableList<Attachment> = mutableListOf(),
@@ -108,7 +108,7 @@ internal class SignalProcessorImpl(
     override fun <T> trackUserTriggered(
         data: T,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attachments: MutableList<Attachment>,
         userDefinedAttributes: Map<String, AttributeValue>,
     ) {
@@ -128,7 +128,7 @@ internal class SignalProcessorImpl(
     override fun <T> track(
         data: T,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attributes: MutableMap<String, Any?>,
         userDefinedAttributes: Map<String, AttributeValue>,
         attachments: MutableList<Attachment>,
@@ -178,7 +178,7 @@ internal class SignalProcessorImpl(
     override fun trackAppExit(
         data: AppExit,
         timestamp: Long,
-        type: String,
+        type: EventType,
         threadName: String,
         sessionId: String,
         appVersion: String?,
@@ -209,7 +209,7 @@ internal class SignalProcessorImpl(
     override fun trackCrash(
         data: ExceptionData,
         timestamp: Long,
-        type: String,
+        type: EventType,
         attributes: MutableMap<String, Any?>,
         userDefinedAttributes: Map<String, AttributeValue>,
         attachments: MutableList<Attachment>,
@@ -253,7 +253,7 @@ internal class SignalProcessorImpl(
 
     private fun <T> createEvent(
         timestamp: Long,
-        type: String,
+        type: EventType,
         data: T,
         attachments: MutableList<Attachment>,
         attributes: MutableMap<String, Any?>,

--- a/android/measure/src/main/java/sh/measure/android/exporter/MultipartDataFactory.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/MultipartDataFactory.kt
@@ -117,7 +117,7 @@ internal class MultipartDataFactoryImpl(
         if (serializedData.isNullOrEmpty()) {
             return null
         }
-        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"$type\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"${type.value}\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
     }
 
     private fun EventPacket.getFromFileData(): String? {
@@ -128,7 +128,7 @@ internal class MultipartDataFactoryImpl(
         if (data.isNullOrEmpty()) {
             return null
         }
-        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"$type\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"${type.value}\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
     }
 
     private fun SpanPacket.getSerializedData(): String {

--- a/android/measure/src/main/java/sh/measure/android/exporter/MultipartDataFactory.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/MultipartDataFactory.kt
@@ -117,7 +117,7 @@ internal class MultipartDataFactoryImpl(
         if (serializedData.isNullOrEmpty()) {
             return null
         }
-        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"$type\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
     }
 
     private fun EventPacket.getFromFileData(): String? {
@@ -128,7 +128,7 @@ internal class MultipartDataFactoryImpl(
         if (data.isNullOrEmpty()) {
             return null
         }
-        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+        return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"$type\":$data,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
     }
 
     private fun SpanPacket.getSerializedData(): String {

--- a/android/measure/src/main/java/sh/measure/android/exporter/NetworkPackets.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/NetworkPackets.kt
@@ -9,12 +9,13 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import sh.measure.android.events.EventType
 
 internal data class EventPacket(
     val eventId: String,
     val sessionId: String,
     val timestamp: String,
-    val type: String,
+    val type: EventType,
     val userTriggered: Boolean,
     val serializedData: String?,
     val serializedDataFilePath: String?,

--- a/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
@@ -1,5 +1,7 @@
 package sh.measure.android.storage
 
+import sh.measure.android.events.EventType
+
 internal object DbConstants {
     const val DATABASE_NAME = "measure.db"
     const val DATABASE_VERSION = DbVersion.V4
@@ -230,7 +232,7 @@ internal object Sql {
         eventCount: Int,
         ascending: Boolean,
         sessionId: String?,
-        eventTypeAllowList: List<String>,
+        eventTypeAllowList: List<EventType>,
     ): String {
         if (sessionId != null) {
             /**
@@ -275,7 +277,7 @@ internal object Sql {
                 JOIN ${SessionsTable.TABLE_NAME} s ON e.${EventTable.COL_SESSION_ID} = s.${SessionsTable.COL_SESSION_ID}
                 WHERE eb.${EventsBatchTable.COL_EVENT_ID} IS NULL
                 AND (
-                    e.${EventTable.COL_TYPE} IN (${eventTypeAllowList.joinToString(", ") { "'$it'" }})
+                    e.${EventTable.COL_TYPE} IN (${eventTypeAllowList.joinToString(", ") { "'${it.value}'" }})
                     OR (s.${SessionsTable.COL_NEEDS_REPORTING} = 1)
                 )
                 ORDER BY e.${EventTable.COL_TIMESTAMP} ${if (ascending) "ASC" else "DESC"}

--- a/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
@@ -17,7 +17,7 @@ internal data class EventEntity(
     /**
      * Type of the event. See [EventType] for possible values.
      */
-    val type: String,
+    val type: EventType,
     /**
      * Timestamp when the event was created.
      */

--- a/android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
@@ -161,8 +161,8 @@ internal fun <T> Event<T>.serializeDataToString(): String {
             json.encodeToString(BugReportData.serializer(), data as BugReportData)
         }
 
-        else -> {
-            throw IllegalArgumentException("Unknown event type: $type")
+        EventType.STRING -> {
+            json.encodeToString(String.serializer(), data as String)
         }
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -49,7 +49,7 @@ class AnrCollectorTest {
         anrCollector.onAnrDetected(timestamp)
 
         // Then
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         val timestampCaptor = argumentCaptor<Long>()
         val dataCaptor = argumentCaptor<ExceptionData>()
         val attributesCaptor = argumentCaptor<MutableMap<String, Any?>>()

--- a/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import sh.measure.android.events.EventType
 import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeIdProvider
 import sh.measure.android.fakes.NoopLogger
@@ -325,7 +326,7 @@ internal class ExporterTest {
             EventEntity(
                 id = eventId,
                 timestamp = "23456789",
-                type = "type",
+                type = EventType.STRING,
                 userTriggered = false,
                 serializedData = "data",
                 sessionId = sessionId,

--- a/android/measure/src/test/java/sh/measure/android/exporter/MultipartDataFactoryTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/MultipartDataFactoryTest.kt
@@ -27,7 +27,7 @@ class MultipartDataFactoryTest {
     @Test
     fun `createFromEventPacket with serializedData returns FormField`() {
         fun EventPacket.expectedSerializedValue(): String {
-            return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+            return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"${type.value}\":$serializedData,\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
         }
 
         // Given
@@ -48,7 +48,7 @@ class MultipartDataFactoryTest {
     @Test
     fun `createFromEventPacket with filePath returns FormField`() {
         fun EventPacket.expectedSerializedValue(): String {
-            return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"$type\",\"$type\":${getFakeFileContent()},\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
+            return "{\"id\":\"$eventId\",\"session_id\":\"$sessionId\",\"user_triggered\":$userTriggered,\"timestamp\":\"$timestamp\",\"type\":\"${type.value}\",\"${type.value}\":${getFakeFileContent()},\"attachments\":$serializedAttachments,\"attribute\":$serializedAttributes,\"user_defined_attribute\":$serializedUserDefinedAttributes}"
         }
 
         val eventEntity = TestData.getEventEntity(

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -2,6 +2,7 @@ package sh.measure.android.fakes
 
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.config.ScreenshotMaskLevel
+import sh.measure.android.events.EventType
 
 internal class FakeConfigProvider : ConfigProvider {
     override fun loadNetworkConfig() {
@@ -13,7 +14,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override var screenshotMaskLevel: ScreenshotMaskLevel = ScreenshotMaskLevel.SensitiveFieldsOnly
     override var screenshotMaskHexColor: String = "#222222"
     override var screenshotCompressionQuality: Int = 25
-    override val eventTypeExportAllowList: List<String> = emptyList()
+    override val eventTypeExportAllowList: List<EventType> = emptyList()
     override val maxSignalsInDatabase: Int = 50_000
     override var trackHttpHeaders: Boolean = false
     override var trackHttpBody: Boolean = false

--- a/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -10,6 +10,7 @@ import sh.measure.android.bugreport.BugReportData
 import sh.measure.android.events.Attachment
 import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.Event
+import sh.measure.android.events.EventType
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
 import sh.measure.android.exporter.AttachmentPacket
@@ -78,7 +79,7 @@ internal object TestData {
     fun <T> T.toEvent(
         id: String = "event-id",
         timestamp: String = "2024-03-18T12:50:12.62600000Z",
-        type: String,
+        type: EventType,
         sessionId: String = "session-id",
         attachments: MutableList<Attachment> = mutableListOf(),
         attributes: MutableMap<String, Any?> = mutableMapOf(),
@@ -352,7 +353,7 @@ internal object TestData {
 
     fun getEventEntity(
         eventId: String = "event-id",
-        type: String = "string",
+        type: EventType = EventType.STRING,
         sessionId: String = "session-id",
         userTriggered: Boolean = false,
         timestamp: String = "2024-03-18T12:50:12.62600000Z",

--- a/android/measure/src/test/java/sh/measure/android/okhttp/OkHttpEventCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/okhttp/OkHttpEventCollectorTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
+import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.fakes.NoopLogger
 import sh.measure.android.utils.AndroidTimeProvider
@@ -71,7 +72,7 @@ class OkHttpEventCollectorTest {
         val statusCode = 200
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -97,7 +98,7 @@ class OkHttpEventCollectorTest {
     fun `tracks HTTP method in lowercase for a successful request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -124,7 +125,7 @@ class OkHttpEventCollectorTest {
         val url = "http://localhost:8080/"
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -151,7 +152,7 @@ class OkHttpEventCollectorTest {
         val requestBody = "{ \"key\": \"value\" }"
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -178,7 +179,7 @@ class OkHttpEventCollectorTest {
         val requestBody = "{ \"key\": \"value\" }"
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -205,7 +206,7 @@ class OkHttpEventCollectorTest {
         val responseBody = "{ \"key\": \"value\" }"
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -232,7 +233,7 @@ class OkHttpEventCollectorTest {
         val responseBody = "{ \"key\": \"value\" }"
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -262,7 +263,7 @@ class OkHttpEventCollectorTest {
     fun `tracks request headers for a successful request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -289,7 +290,7 @@ class OkHttpEventCollectorTest {
     fun `tracks response headers for a successful request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -315,7 +316,7 @@ class OkHttpEventCollectorTest {
     fun `tracks a non null start and end time for a successful request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -342,7 +343,7 @@ class OkHttpEventCollectorTest {
     fun `tracks timestamp for a successful request`() {
         val dataCaptor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -369,7 +370,7 @@ class OkHttpEventCollectorTest {
     fun `tracks empty request headers map for a failed request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -403,7 +404,7 @@ class OkHttpEventCollectorTest {
     fun `tracks client for a successful request`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -429,7 +430,7 @@ class OkHttpEventCollectorTest {
     fun `tracks failure reason and failure description for a connection failure`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When
@@ -463,7 +464,7 @@ class OkHttpEventCollectorTest {
     fun `tracks non null call start and call end for connection failure`() {
         val captor = argumentCaptor<HttpData>()
         val timestampCaptor = argumentCaptor<Long>()
-        val typeCaptor = argumentCaptor<String>()
+        val typeCaptor = argumentCaptor<EventType>()
         okHttpEventCollector.register()
 
         // When

--- a/android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
@@ -1298,7 +1298,7 @@ class DatabaseTest {
     private fun assertEventInCursor(expectedEvent: EventEntity, cursor: Cursor) {
         assertEquals(expectedEvent.id, cursor.getString(cursor.getColumnIndex(EventTable.COL_ID)))
         assertEquals(
-            expectedEvent.type,
+            expectedEvent.type.value,
             cursor.getString(cursor.getColumnIndex(EventTable.COL_TYPE)),
         )
         assertEquals(

--- a/android/measure/src/test/java/sh/measure/android/storage/EventEntityTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/EventEntityTest.kt
@@ -2,6 +2,7 @@ package sh.measure.android.storage
 
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import sh.measure.android.events.EventType
 
 class EventEntityTest {
 
@@ -10,7 +11,7 @@ class EventEntityTest {
         assertThrows(IllegalArgumentException::class.java) {
             EventEntity(
                 id = "event-id",
-                type = "test",
+                type = EventType.STRING,
                 timestamp = "2024-03-18T12:50:12.62600000Z",
                 sessionId = "987",
                 userTriggered = false,
@@ -27,7 +28,7 @@ class EventEntityTest {
         assertThrows(IllegalArgumentException::class.java) {
             EventEntity(
                 id = "event-id",
-                type = "test",
+                type = EventType.STRING,
                 timestamp = "2024-03-18T12:50:12.62600000Z",
                 sessionId = "987",
                 userTriggered = false,

--- a/android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
@@ -98,15 +98,6 @@ class EventExtensionsKtTest {
     }
 
     @Test
-    fun `serialization fails with exception for unknown event type`() {
-        val event = TestData.getExceptionData().toEvent(type = "invalid-type")
-
-        assertThrows(IllegalArgumentException::class.java) {
-            event.serializeDataToString()
-        }
-    }
-
-    @Test
     fun `serialization fails with exception for event type mismatch`() {
         val event = TestData.getExceptionData().toEvent(type = EventType.CLICK)
 


### PR DESCRIPTION
# Description

Converts event type from strings to enum:

- This is in general better for type safety
- Event type will be made public for flutter integration exposing it as an enum makes it a better API and allows validations to be simpler.