### PR TITLE
fix(backend): add podman support

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -23,6 +23,7 @@ measure.sh is designed from the ground up for easy self-hosting. Follow along to
   - [3. Start the containers](#3-start-the-containers)
   - [4. Access your Measure dashboard](#4-access-your-measure-dashboard)
 - [Frequently Asked Questions](#frequently-asked-questions)
+  - [Q. Can I use podman instead of docker?](#q-can-i-use-podman-instead-of-docker)
   - [Q. Why does ClickHouse consume high amount of CPU or memory?](#q-why-does-clickhouse-consume-high-amount-of-cpu-or-memory)
 
 ## Objectives
@@ -108,6 +109,7 @@ sudo ./install.sh
 > - [podman](https://podman.io/)
 > - [podman-docker](https://packages.debian.org/bookworm/podman-docker)
 > - [podman-compose](https://github.com/containers/podman-compose)
+> - [docker-compose](https://github.com/docker/compose)
 >
 > You can continue to use regular docker commands like, `docker ps -a` or `docker compose ps -a`. It should work seamlessly.
 
@@ -267,7 +269,7 @@ It'll take a few minutes for the upgrade to complete.
 
 ## Run on macOS locally
 
-You can run measure.sh locally on macOS for trying it out quickly, but keep in mind that not all features may not work as expected on macOS.
+You can run measure.sh locally on macOS for trying it out quickly, but keep in mind that not all features may work as expected on macOS.
 
 > [!WARNING]
 >
@@ -280,32 +282,23 @@ Make sure the following requirements are met before proceeding.
 | Name           | Version  |
 | -------------- | -------- |
 | Docker         | v26.1+   |
+| Podman         | v5.0.3+  |
 | Docker Compose | v2.27.3+ |
 | node           | v20+     |
 
 ### 1. Clone the measure repo
 
-Clone the repository with git and change to the `measure` directory.
-
-```sh
-git clone https://github.com/measure-sh/measure.git && cd measure
-```
-
-Checkout to git a tag. Replace `GIT-TAG` with an existing git tag. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
+Choose a git a tag to use. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
 
 > [!IMPORTANT]
 >
 > Always choose a tag matching the format `v[MAJOR].[MINOR].[PATCH]`, for example: `v1.2.3`.
 > These tags are tailored for self host deployments.
 
-```sh
-git checkout GIT-TAG
-```
-
-Next, change to the `self-host` directory. All commands will be run from the `self-host` directory after this point.
+Clone the repository with git and change to the `measure` directory. Replace `GIT-TAG` with your chosen git tag.
 
 ```sh
-cd self-host
+git clone https://github.com/measure-sh/measure.git -b GIT-TAG && cd measure/self-host
 ```
 
 ### 2. Run `config.sh` script to configure
@@ -315,6 +308,14 @@ Run the `config.sh` script to auto configure most settings.
 ```sh
 ./config.sh
 ```
+
+> [!NOTE]
+>
+> For production usage, use the *--production* flag.
+>
+> ```sh
+> ./config.sh --production
+> ```
 
 To continue, you'll need to obtain a Google & GitHub OAuth Application's credentials. This is required to setup authentication in Measure dashboard. Follow the below links to obtain Google & GitHub OAuth credentials.
 
@@ -343,6 +344,16 @@ Visit [Dashboard](http://localhost:3000/auth/login) to access your dashboard and
 ## Frequently Asked Questions
 
 Typical questions asked by other self host-ers.
+
+### Q. Can I use podman instead of docker?
+
+Yes, you can. Use the `--podman` flag when running the installation script.
+
+```sh
+sudo ./install.sh --podman
+```
+
+You can administer the instance using docker and docker compose commands as if you were using docker.
 
 ### Q. Why does ClickHouse consume high amount of CPU or memory?
 

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -100,6 +100,21 @@ Run the install script with `sudo`.
 sudo ./install.sh
 ```
 
+> [!NOTE]
+>
+> To use **podman** instead of **docker**, use the *--podman* flag.
+>
+> ```sh
+> sudo ./install.sh --podman
+> ```
+>
+> This would install the following packages.
+> - [podman](https://podman.io/)
+> - [podman-docker](https://packages.debian.org/bookworm/podman-docker)
+> - [podman-compose](https://github.com/containers/podman-compose)
+>
+> You can continue to use regular docker commands like, `docker ps -a` or `docker compose ps -a`. It should work seamlessly.
+
 The measure.sh install script will check your system's requirements and start the installation. It can take a few minutes to complete.
 
 ### 4. Configure and start your self hosted measure instance

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -69,30 +69,26 @@ Let's start by moving to your home directory.
 cd ~
 ```
 
-Clone the repository with git and change to the `measure` directory.
-
-```sh
-git clone https://github.com/measure-sh/measure.git && cd measure
-```
-
-Checkout to git a tag. Replace `GIT-TAG` with an existing git tag. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
+Choose a git tag. You can find out the latest stable release tag from the [releases](https://github.com/measure-sh/measure/releases) page.
 
 > [!IMPORTANT]
 >
 > Always choose a tag matching the format `v[MAJOR].[MINOR].[PATCH]`, for example: `v1.2.3`.
 > These tags are tailored for self host deployments.
 
+Clone the repository with git and change to the `measure` directory. Replace `GIT-TAG` with your chosen git tag.
+
 ```sh
-git checkout GIT-TAG
+git clone https://github.com/measure-sh/measure.git -b GIT-TAG && cd measure
 ```
 
-Next, change into the `self-host` directory. All commands will be run mostly from this directory.
+### 3. Run the `install.sh` script
+
+Next, change into the `self-host` directory. All successive commands will be run from this directory.
 
 ```sh
 cd self-host
 ```
-
-### 3. Run the `install.sh` script
 
 Run the install script with `sudo`.
 

--- a/self-host/compose.prod.yml
+++ b/self-host/compose.prod.yml
@@ -20,6 +20,9 @@ services:
     develop: !reset null
     restart: unless-stopped
 
+  migrator:
+    develop: !reset null
+
   symbolicator:
     volumes:
       # no need to !reset or !override as compose merges entries
@@ -28,9 +31,6 @@ services:
       # see: https://docs.docker.com/reference/compose-file/merge/#unique-resources
       - ./symbolicator/config.prod.yml:/etc/symbolicator/config.yml:ro
     restart: unless-stopped
-
-  migrator:
-    develop: !reset null
 
   clickhouse:
     ports:

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -29,6 +29,7 @@ name: measure
 services:
   dashboard:
     build:
+      dockerfile: dockerfile
       context: ../frontend/dashboard
     ports:
       - "3000:3000"
@@ -49,6 +50,7 @@ services:
 
   api:
     build:
+      dockerfile: dockerfile
       context: ../backend/api
     ports:
       - "8080:8080"
@@ -110,6 +112,7 @@ services:
 
   cleanup:
     build:
+      dockerfile: dockerfile
       context: ../backend/cleanup
     ports:
       - "8081:8081"
@@ -153,6 +156,38 @@ services:
       mc:
         condition: service_completed_successfully
         required: false
+
+  migrator:
+    profiles:
+      - migrate
+    build:
+      dockerfile: dockerfile
+      context: ../backend/migrator
+    environment:
+      - POSTGRES_DSN=${POSTGRES_DSN}
+      - CLICKHOUSE_DSN=${CLICKHOUSE_DSN}
+      - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL}
+      - SYMBOLS_S3_BUCKET=${SYMBOLS_S3_BUCKET}
+      - SYMBOLS_S3_BUCKET_REGION=${SYMBOLS_S3_BUCKET_REGION}
+      - SYMBOLS_ACCESS_KEY=${SYMBOLS_ACCESS_KEY}
+      - SYMBOLS_SECRET_ACCESS_KEY=${SYMBOLS_SECRET_ACCESS_KEY}
+    develop:
+      watch:
+        - path: ../backend/migrator
+          action: rebuild
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_completed_successfully
+        required: false
+    volumes:
+      - migrator-volume:/data
+    command: ["migrate"]
 
   symbolicator:
     image: ghcr.io/measure-sh/symbolicator
@@ -234,37 +269,6 @@ services:
         restart: true
     volumes:
       - ./clickhouse:/opt/clickhouse
-    command: ["migrate"]
-
-  migrator:
-    profiles:
-      - migrate
-    build:
-      context: ../backend/migrator
-    environment:
-      - POSTGRES_DSN=${POSTGRES_DSN}
-      - CLICKHOUSE_DSN=${CLICKHOUSE_DSN}
-      - AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL}
-      - SYMBOLS_S3_BUCKET=${SYMBOLS_S3_BUCKET}
-      - SYMBOLS_S3_BUCKET_REGION=${SYMBOLS_S3_BUCKET_REGION}
-      - SYMBOLS_ACCESS_KEY=${SYMBOLS_ACCESS_KEY}
-      - SYMBOLS_SECRET_ACCESS_KEY=${SYMBOLS_SECRET_ACCESS_KEY}
-    develop:
-      watch:
-        - path: ../backend/migrator
-          action: rebuild
-    depends_on:
-      postgres:
-        condition: service_healthy
-      clickhouse:
-        condition: service_healthy
-      minio:
-        condition: service_healthy
-      mc:
-        condition: service_completed_successfully
-        required: false
-    volumes:
-      - migrator-volume:/data
     command: ["migrate"]
 
   postgres:

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -292,10 +292,9 @@ Pin: release n=trixie
 Pin-Priority: 100
 EOF
     $PKGMAN update
-    $PKGMAN install -y -t trixie podman
-    $PKGMAN install -y podman-docker jq git
+    $PKGMAN install -y -t trixie podman podman-docker jq git
   else
-    error "We don't support installing podman on non Debain based distributions."
+    error "We don't support installing podman on non Debian based distributions."
   fi
 
   if is_ubuntu; then
@@ -303,7 +302,7 @@ EOF
     $PKGMAN update
     $PKGMAN -y install podman podman-docker jq git
   else
-    error "We don't support installing podman on non Debain based distributions."
+    error "We don't support installing podman on non Ubuntu based distributions."
   fi
 
   local arch_name=""

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -278,6 +278,10 @@ install_docker() {
 # considering the appropriate environment.
 # ------------------------------------------------------------------------------
 install_podman() {
+  if ! is_debian || ! is_ubuntu; then
+    error "We don't support installing podman on non Debian based distributions."
+  fi
+
   if is_debian; then
     echo "deb http://deb.debian.org/debian/ trixie main" | tee /etc/apt/sources.list.d/trixie.list >/dev/null
     tee /etc/apt/preferences.d/99pinning >/dev/null <<EOF
@@ -293,16 +297,12 @@ Pin-Priority: 100
 EOF
     $PKGMAN update
     $PKGMAN install -y -t trixie podman podman-docker jq git
-  else
-    error "We don't support installing podman on non Debian based distributions."
   fi
 
   if is_ubuntu; then
     debug "Installing podman for ubuntu"
     $PKGMAN update
     $PKGMAN -y install podman podman-docker jq git
-  else
-    error "We don't support installing podman on non Ubuntu based distributions."
   fi
 
   local arch_name=""

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -292,7 +292,8 @@ Pin: release n=trixie
 Pin-Priority: 100
 EOF
     $PKGMAN update
-    $PKGMAN install -y trixie podman podman-docker jq git
+    $PKGMAN install -y -t trixie podman
+    $PKGMAN install -y podman-docker jq git
   else
     error "We don't support installing podman on non Debain based distributions."
   fi

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -356,6 +356,9 @@ start_docker() {
   if [[ $USE_PODMAN == true ]]; then
     service="podman.socket"
     # suppress podman message
+    if [[ ! -d /etc/containers ]]; then
+      mkdir -p /etc/containers
+    fi
     touch /etc/containers/nodocker
   fi
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -423,6 +423,17 @@ update_symbolicator_origin() {
 # stop_docker_compose stops services using docker compose.
 # ------------------------------------------------------------------------------
 stop_docker_compose() {
+  if is_debian && [[ "$USE_PODMAN" == "true" ]]; then
+    $DOCKER_COMPOSE_CMD \
+      --profile init \
+      --profile migrate \
+      --file compose.yml \
+      --file compose.prod.yml \
+      down
+
+    return 0
+  fi
+
   $DOCKER_COMPOSE_CMD \
     --progress plain \
     --profile init \
@@ -437,6 +448,22 @@ stop_docker_compose() {
 # ------------------------------------------------------------------------------
 start_docker_compose() {
   info "Starting measure.sh docker containers"
+
+  if is_debian && [[ "$USE_PODMAN" == "true" ]]; then
+    $DOCKER_COMPOSE_CMD \
+      --profile init \
+      --profile migrate \
+      --file compose.yml \
+      --file compose.prod.yml \
+      up \
+      --build \
+      --pull always \
+      --detach \
+      --remove-orphans \
+      --wait
+
+    return 0
+  fi
 
   $DOCKER_COMPOSE_CMD \
     --progress plain \

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -278,7 +278,7 @@ install_docker() {
 # considering the appropriate environment.
 # ------------------------------------------------------------------------------
 install_podman() {
-  if ! is_debian || ! is_ubuntu; then
+  if ! is_debian && ! is_ubuntu; then
     error "We don't support installing podman on non Debian based distributions."
   fi
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -382,7 +382,7 @@ start_docker() {
     touch /etc/containers/nodocker
   fi
 
-  if is_ubuntu; then
+  if is_ubuntu || is_debian; then
     if [ -d /run/systemd/system ]; then
       systemctl start "$service"
     elif [ -f /etc/init.d/docker ]; then

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -35,10 +35,6 @@ MINIMUM_DOCKER_COMPOSE_VERSION="2.27.3"
 # ------------------------------------------------------------------------------
 DEBUG=${DEBUG:-0}
 UNINSTALL_DOCKER=${UNINSTALL_DOCKER:-0}
-
-# ------------------------------------------------------------------------------
-# Flags and variables.
-# ------------------------------------------------------------------------------
 USE_PODMAN=false
 CONTAINER_RUNTIME=docker
 DOCKER_COMPOSE_BIN=0
@@ -255,6 +251,11 @@ install_docker() {
   fi
 
   if is_debian; then
+    if [[ $USE_PODMAN == true ]]; then
+      install_podman
+      return 0
+    fi
+
     debug "Installing docker for debian"
     debug "$DISTRO_CODENAME"
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -277,6 +277,14 @@ install_docker() {
 # considering the appropriate environment.
 # ------------------------------------------------------------------------------
 install_podman() {
+  if is_debian || is_ubuntu; then
+    debug "Installing podman for ubuntu"
+    $PKGMAN update
+    $PKGMAN -y install podman podman-docker jq git
+  else
+    error "We don't support installing podman on non Debain based distributions."
+  fi
+
   local arch_name=""
   arch_name=$(uname -m)
   local target_arch=""
@@ -329,14 +337,6 @@ install_podman() {
 
   local podman_compose_version="v1.3.0"
   local podman_compose_location="/usr/local/bin/podman-compose"
-
-  if is_debian || is_ubuntu; then
-    debug "Installing podman for ubuntu"
-    $PKGMAN update
-    $PKGMAN -y install podman podman-docker jq git
-  else
-    error "We don't support installing podman on non Debain based distributions."
-  fi
 
   info "Downloading latest release of docker compose from $compose_download_url"
   curl -sSL "$compose_download_url" -o "$compose_location"


### PR DESCRIPTION
## Summary

This PR adds support for `--podman` flag in `self-host/install.sh` script to setup and use podman as an alternative to docker.

## Tasks

- [x] Add support for `--podman` flag in install.sh script
- [x] :books: Update self host guide to add information about podman
- [x] Tested with Podman Desktop with compose
- [x] Tested installation with Ubuntu (Oracular)
- [x] Tested installation with Debian (Bookworm)

## See also

- fixes #2051
