### PR TITLE
chore(flutter): relax the sdk version constraint

### DIFF
--- a/flutter/measure_flutter/pubspec.yaml
+++ b/flutter/measure_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: ^3.6.1
+  sdk: '>=3.3.4 <4.0.0'
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
# Description

The current SDK constraint is set to `^3.6.1` which will only work for latest Dart versions. Relax it to support any version between `>=3.3.4 <4.0.0`.

## Related issue
Fixes #2059

