### PR TITLE
fix(frontend): filters not updating on no data/not onboarded states

### DIFF
--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -61,7 +61,7 @@ export default function BugReportsOverview({ params }: { params: { teamId: strin
 
     const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
         // update filters only if they have changed
-        if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+        if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
             updatePageState({
                 filters: updatedFilters,
                 // Reset pagination on filters change if previous filters were not default filters

--- a/frontend/dashboard/app/[teamId]/overview/page.tsx
+++ b/frontend/dashboard/app/[teamId]/overview/page.tsx
@@ -29,7 +29,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
 
   const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
     // update filters only if they have changed
-    if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+    if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
       updatePageState({
         filters: updatedFilters
       })

--- a/frontend/dashboard/app/[teamId]/sessions/page.tsx
+++ b/frontend/dashboard/app/[teamId]/sessions/page.tsx
@@ -61,7 +61,7 @@ export default function SessionsOverview({ params }: { params: { teamId: string 
 
     const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
         // update filters only if they have changed
-        if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+        if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
             updatePageState({
                 filters: updatedFilters,
                 // Reset pagination on filters change if previous filters were not default filters

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -60,7 +60,7 @@ export default function TracesOverview({ params }: { params: { teamId: string } 
 
     const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
         // update filters only if they have changed
-        if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+        if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
             updatePageState({
                 filters: updatedFilters,
                 // Reset pagination on filters change if previous filters were not default filters

--- a/frontend/dashboard/app/components/exceptions_details.tsx
+++ b/frontend/dashboard/app/components/exceptions_details.tsx
@@ -74,7 +74,7 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
   }
 
   const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
-    if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+    if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
       updatePageState({
         filters: updatedFilters,
         keyId: pageState.filters.serialisedFilters && searchParams.get(keyIdUrlKey) ? searchParams.get(keyIdUrlKey) : pageState.keyId,

--- a/frontend/dashboard/app/components/exceptions_overview.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview.tsx
@@ -66,7 +66,7 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
 
   const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
     // update filters only if they have changed
-    if (updatedFilters.ready && pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+    if (pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
       updatePageState({
         filters: updatedFilters,
         // Reset pagination on filters change if previous filters were not default filters

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -630,6 +630,25 @@ const Filters: React.FC<FiltersProps> = ({
     }
   }
 
+  const clearFiltersOnFilterApiFail = () => {
+    console.log("Filters API failed, clearing filters")
+    setSelectedVersions(defaultFilters.versions)
+    setSelectedSessionType(defaultFilters.sessionType)
+    setSelectedOsVersions(defaultFilters.osVersions)
+    setSelectedCountries(defaultFilters.countries)
+    setSelectedNetworkProviders(defaultFilters.networkProviders)
+    setSelectedNetworkTypes(defaultFilters.networkTypes)
+    setSelectedNetworkGenerations(defaultFilters.networkGenerations)
+    setSelectedLocales(defaultFilters.locales)
+    setSelectedDeviceManufacturers(defaultFilters.deviceManufacturers)
+    setSelectedDeviceNames(defaultFilters.deviceNames)
+    setSelectedFreeText(defaultFilters.freeText)
+    setSelectedSpanStatuses(defaultFilters.spanStatuses)
+    setSelectedRootSpanName(defaultFilters.rootSpanName)
+    setSelectedBugReportStatuses(defaultFilters.bugReportStatuses)
+    setSelectedUdAttrMatchers(defaultFilters.udAttrMatchers)
+  }
+
   const getFilters = async () => {
     setFiltersApiStatus(FiltersApiStatus.Loading)
 
@@ -638,12 +657,15 @@ const Filters: React.FC<FiltersProps> = ({
     switch (result.status) {
       case FiltersApiStatus.NotOnboarded:
         setFiltersApiStatus(FiltersApiStatus.NotOnboarded)
+        clearFiltersOnFilterApiFail()
         break
       case FiltersApiStatus.NoData:
         setFiltersApiStatus(FiltersApiStatus.NoData)
+        clearFiltersOnFilterApiFail()
         break
       case FiltersApiStatus.Error:
         setFiltersApiStatus(FiltersApiStatus.Error)
+        clearFiltersOnFilterApiFail()
         break
       case FiltersApiStatus.Success:
         setFiltersApiStatus(FiltersApiStatus.Success)


### PR DESCRIPTION
# Description

When filters api call returns a no data or not onboarded state, we were not clearing previously set filters and also not updating filters in the pages (due to changes being ignored because of ready flag being false).

This PR clears filters on API failure status and applies filter changes appropriately.

## Related issue
Fixes #2056 



