### PR TITLE
fix(ios): update cpu frequency generation logic

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
@@ -31,52 +31,113 @@ final class BaseSysCtl: SysCtl {
         return cpuCores
     }
 
-    func getCpuFrequency() -> UInt64 {
+    func getCpuFrequency() -> UInt64 { // swiftlint:disable:this function_body_length
         guard clockSpeed == 0 else {
             return clockSpeed
         }
-        let cpuFrequencies: [String: UInt64] = [
-            // --- A-Series Chips (iPhones & iPads) ---
-            "A17 Pro": 3780000000,   // 3.78 GHz
-            "A16 Bionic": 3460000000,   // 3.46 GHz
-            "A15 Bionic": 3230000000,   // 3.23 GHz
-            "A14 Bionic": 3100000000,   // 3.10 GHz
-            "A13 Bionic": 2650000000,   // 2.65 GHz
-            "A12Z Bionic": 2490000000,  // 2.49 GHz (iPad Pro)
-            "A12X Bionic": 2490000000,  // 2.49 GHz (iPad Pro)
-            "A12 Bionic": 2490000000,   // 2.49 GHz
-            "A11 Bionic": 2390000000,   // 2.39 GHz
-            "A10X Fusion": 2380000000,  // 2.38 GHz (iPad Pro)
-            "A10 Fusion": 2340000000,   // 2.34 GHz
-            "A9X": 2260000000,  // 2.26 GHz (iPad Pro)
-            "A9": 1850000000,   // 1.85 GHz
 
-            // --- Apple Silicon (Mac & iPad Pro) ---
-            "M4 Max": 4500000000,  // 4.50 GHz
-            "M4 Pro": 4500000000,  // 4.50 GHz
-            "M4": 4400000000,  // 4.40 GHz
-            "M3 Max": 4250000000,  // 4.25 GHz
-            "M3 Pro": 4100000000,  // 4.10 GHz
-            "M3": 4000000000,  // 4.00 GHz
-            "M2 Ultra": 3490000000,  // 3.49 GHz
-            "M2 Max": 3490000000,  // 3.49 GHz
-            "M2 Pro": 3490000000,  // 3.49 GHz
-            "M2": 3490000000,  // 3.49 GHz
-            "M1 Ultra": 3200000000,  // 3.20 GHz
-            "M1 Max": 3200000000,  // 3.20 GHz
-            "M1 Pro": 3200000000,  // 3.20 GHz
-            "M1": 3200000000   // 3.20 GHz
+        // Get device model identifier
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let deviceModel = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+
+        let cpuFrequencies: [String: UInt64] = [
+            // iPhone
+            "iPhone5,1": 1300000000, // iPhone 5
+            "iPhone5,2": 1300000000, // iPhone 5
+            "iPhone5,3": 1000000000, // iPhone 5C
+            "iPhone5,4": 1000000000, // iPhone 5C
+            "iPhone6,1": 1300000000, // iPhone 5S
+            "iPhone6,2": 1300000000, // iPhone 5S
+            "iPhone7,1": 1400000000, // iPhone 6 Plus
+            "iPhone7,2": 1400000000, // iPhone 6
+            "iPhone8,1": 1850000000, // iPhone 6s
+            "iPhone8,2": 1850000000, // iPhone 6s Plus
+            "iPhone8,4": 1850000000, // iPhone SE (1st Gen)
+            "iPhone9,1": 2340000000, // iPhone 7
+            "iPhone9,2": 2340000000, // iPhone 7 Plus
+            "iPhone9,3": 2340000000, // iPhone 7
+            "iPhone9,4": 2340000000, // iPhone 7 Plus
+            "iPhone10,1": 2390000000, // iPhone 8
+            "iPhone10,2": 2390000000, // iPhone 8 Plus
+            "iPhone10,3": 2390000000, // iPhone X
+            "iPhone10,4": 2390000000, // iPhone 8
+            "iPhone10,5": 2390000000, // iPhone 8 Plus
+            "iPhone10,6": 2390000000, // iPhone X
+            "iPhone11,2": 2490000000, // iPhone XS
+            "iPhone11,4": 2490000000, // iPhone XS Max
+            "iPhone11,6": 2490000000, // iPhone XS Max
+            "iPhone11,8": 2490000000, // iPhone XR
+            "iPhone12,1": 2650000000, // iPhone 11
+            "iPhone12,3": 2650000000, // iPhone 11 Pro
+            "iPhone12,5": 2650000000, // iPhone 11 Pro Max
+            "iPhone12,8": 2650000000, // iPhone SE 2nd Gen
+            "iPhone13,1": 2990000000, // iPhone 12 Mini
+            "iPhone13,2": 2990000000, // iPhone 12
+            "iPhone13,3": 2990000000, // iPhone 12 Pro
+            "iPhone13,4": 2990000000, // iPhone 12 Pro Max
+            "iPhone14,2": 3230000000, // iPhone 13 Pro
+            "iPhone14,3": 3230000000, // iPhone 13 Pro Max
+            "iPhone14,4": 3230000000, // iPhone 13 Mini
+            "iPhone14,5": 3230000000, // iPhone 13
+            "iPhone14,6": 3230000000, // iPhone SE 3rd Gen
+            "iPhone14,7": 3460000000, // iPhone 14
+            "iPhone14,8": 3460000000, // iPhone 14 Plus
+            "iPhone15,2": 3780000000, // iPhone 14 Pro
+            "iPhone15,3": 3780000000, // iPhone 14 Pro Max
+            "iPhone15,4": 3460000000, // iPhone 15
+            "iPhone15,5": 3460000000, // iPhone 15 Plus
+            "iPhone16,1": 4000000000, // iPhone 15 Pro
+            "iPhone16,2": 4000000000, // iPhone 15 Pro Max
+            "iPhone17,1": 4000000000, // iPhone 16 Pro
+            "iPhone17,2": 4000000000, // iPhone 16 Pro Max
+            "iPhone17,3": 3800000000, // iPhone 16
+            "iPhone17,4": 3800000000, // iPhone 16 Plus
+            "iPhone17,5": 3800000000, // iPhone 16e
+
+            // iPads
+            "iPad6,11": 1850000000, // iPad (2017)
+            "iPad6,12": 1850000000, // iPad (2017)
+            "iPad7,5": 2100000000,  // iPad 6th Gen
+            "iPad7,6": 2100000000,  // iPad 6th Gen
+            "iPad7,11": 2200000000, // iPad 7th Gen
+            "iPad7,12": 2200000000, // iPad 7th Gen
+            "iPad11,6": 2500000000, // iPad 8th Gen
+            "iPad11,7": 2500000000, // iPad 8th Gen
+            "iPad12,1": 2500000000, // iPad 9th Gen
+            "iPad12,2": 2500000000, // iPad 9th Gen
+            "iPad13,18": 2500000000, // iPad 10th Gen
+            "iPad13,19": 2500000000, // iPad 10th Gen
+            "iPad13,1": 3200000000,  // iPad Air 4
+            "iPad13,2": 3200000000,  // iPad Air 4
+            "iPad13,16": 3490000000, // iPad Air 5
+            "iPad13,17": 3490000000, // iPad Air 5
+            "iPad14,8": 3490000000,  // iPad Air 6
+            "iPad14,9": 3490000000,  // iPad Air 6
+            "iPad14,10": 3490000000, // iPad Air 6
+            "iPad14,11": 3490000000, // iPad Air 6
+            "iPad15,3": 3780000000,  // iPad Air 7
+            "iPad15,4": 3780000000,  // iPad Air 7
+            "iPad15,5": 3780000000,  // iPad Air 7
+            "iPad15,6": 3780000000,  // iPad Air 7
+            "iPad15,7": 3460000000,  // iPad 11th Gen
+            "iPad15,8": 3460000000,  // iPad 11th Gen
+            "iPad16,1": 3200000000,  // iPad mini 7
+            "iPad16,2": 3200000000,  // iPad mini 7
+            "iPad14,1": 3000000000,  // iPad mini 6
+            "iPad14,2": 3000000000,  // iPad mini 6
+
+            // Simulators
+            "arm64": 2400000000,     // Apple Silicon Simulator
+            "x86_64": 2400000000,    // Intel Mac Simulator
+            "i386": 2400000000       // Older 32-bit simulators
         ]
 
-        var size = 0
-        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
-        var cpuName = [CChar](repeating: 0, count: size)
-        sysctlbyname("machdep.cpu.brand_string", &cpuName, &size, nil, 0)
-
-        var modelName = String(cString: cpuName)
-        modelName = modelName.replacingOccurrences(of: "Apple ", with: "")
-        clockSpeed = cpuFrequencies[modelName] ?? 0
-
+        clockSpeed = cpuFrequencies[deviceModel] ?? 0
         return clockSpeed
     }
 


### PR DESCRIPTION
# Description

Updated the logic to generate cpu frequency.

Earlier, we relied on getting the CPU frequency from chip name, now we rely on getting the CPU frequency from device model.

## Related issue
Fixes #2084 
