### PR TITLE
docs(backend): add banner in contributing

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,6 +9,12 @@
 
 ## Local environment setup
 
+> [!WARNING]
+>
+> Not interested in contributing? If you just want to try out measure, follow our [self hosting guide](./hosting/README.md).
+>
+> **The self hosting guide is the official and recommended way to try out measure.**
+
 ### Prerequisites
 
 - Docker >= v26.1.3
@@ -59,7 +65,7 @@ docker compose --profile init --profile migrate up
 > [!NOTE]
 >
 > #### About Compose Profiles
-> 
+>
 > Both `init` and `migrate` profiles are idempotent in nature. You can use them everytime, though for subsequent runs you may choose to skip them.
 
 Alternatively, you could build and up the containers in separate steps, like this.


### PR DESCRIPTION
## Summary

This PR adds a warning banner to contributing guide to direct users interested in just trying out measure to follow the official self host guide.

There was at least one instance of a user who used the contributing guide and found their dashboard crashing after some time.

## Tasks

- [x] Add a warning banner to direct users interested in self hosting to follow the self hosting guide.

## See also

- fixes #2100