### PR TITLE
feat(frontend): show logged in user avatar

### DIFF
--- a/backend/api/measure/auth.go
+++ b/backend/api/measure/auth.go
@@ -753,10 +753,29 @@ func GetAuthSession(c *gin.Context) {
 		return
 	}
 
+	user := &User{
+		ID: &userId,
+	}
+
+	err := user.getUserDetails(c.Request.Context())
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("Unable to get user details: %v", err),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"user": gin.H{
-			"id":          userId,
-			"own_team_id": ownTeamId,
+			"id":              userId,
+			"own_team_id":     ownTeamId,
+			"name":            user.Name,
+			"email":           user.Email,
+			"confirmed_at":    user.ConfirmedAt,
+			"last_sign_in_at": user.LastSignInAt,
+			"created_at":      user.CreatedAt,
+			"updated_at":      user.UpdatedAt,
 		},
 	})
 }

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -519,7 +519,13 @@ The required headers must be present in each request.
   {
     "user": {
         "id": "835283a5-cddc-472b-84ad-5ea3319efeed",
-        "own_team_id": "e47ac49d-0697-4e85-8607-1a34536c04e3"
+        "own_team_id": "e47ac49d-0697-4e85-8607-1a34536c04e3",
+        "name": "Dummy User",
+        "email": "dummy@gmail.com",
+        "confirmed_at": "2024-06-19T22:14:49.77Z",
+        "last_sign_in_at": "2024-06-19T22:14:49.77Z",
+        "created_at": "2024-06-19T22:14:49.77Z",
+        "updated_at": "2024-06-19T22:14:49.77Z",
     }
   }
   ```

--- a/frontend/dashboard/__tests__/components/__snapshots__/team_switcher_test.tsx.snap
+++ b/frontend/dashboard/__tests__/components/__snapshots__/team_switcher_test.tsx.snap
@@ -6,10 +6,10 @@ exports[`TeamSwitcher renders correctly in collapsed state 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -32,10 +32,10 @@ exports[`TeamSwitcher renders correctly in collapsed state 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div
@@ -115,15 +115,15 @@ exports[`TeamSwitcher renders correctly in error state 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           disabled=""
           type="button"
         >
           <p
-            class="pl-8 truncate w-max"
+            class="w-full truncate"
           >
             Error
           </p>
@@ -133,15 +133,15 @@ exports[`TeamSwitcher renders correctly in error state 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         disabled=""
         type="button"
       >
         <p
-          class="pl-8 truncate w-max"
+          class="w-full truncate"
         >
           Error
         </p>
@@ -208,15 +208,15 @@ exports[`TeamSwitcher renders correctly in loading state 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           disabled=""
           type="button"
         >
           <p
-            class="pl-8 truncate w-max"
+            class="w-full truncate"
           >
             Updating...
           </p>
@@ -226,15 +226,15 @@ exports[`TeamSwitcher renders correctly in loading state 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         disabled=""
         type="button"
       >
         <p
-          class="pl-8 truncate w-max"
+          class="w-full truncate"
         >
           Updating...
         </p>
@@ -301,10 +301,10 @@ exports[`TeamSwitcher renders correctly in opened state 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -327,10 +327,10 @@ exports[`TeamSwitcher renders correctly in opened state 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div
@@ -410,10 +410,10 @@ exports[`TeamSwitcher renders correctly in opened state 2`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -432,7 +432,7 @@ exports[`TeamSwitcher renders correctly in opened state 2`] = `
           </div>
         </button>
         <div
-          class="origin-top-right absolute left-0 mt-2 w-48 rounded-md shadow-lg ring-1 ring-black ring-opacity-5"
+          class="z-50 origin-top-left absolute left-0 mt-2 w-48 shadow-lg border border-black"
         >
           <div
             aria-labelledby="options-menu"
@@ -464,10 +464,10 @@ exports[`TeamSwitcher renders correctly in opened state 2`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div
@@ -486,7 +486,7 @@ exports[`TeamSwitcher renders correctly in opened state 2`] = `
         </div>
       </button>
       <div
-        class="origin-top-right absolute left-0 mt-2 w-48 rounded-md shadow-lg ring-1 ring-black ring-opacity-5"
+        class="z-50 origin-top-left absolute left-0 mt-2 w-48 shadow-lg border border-black"
       >
         <div
           aria-labelledby="options-menu"
@@ -575,10 +575,10 @@ exports[`TeamSwitcher renders correctly on new team selection 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -601,10 +601,10 @@ exports[`TeamSwitcher renders correctly on new team selection 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div
@@ -684,10 +684,10 @@ exports[`TeamSwitcher renders correctly on new team selection 2`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -710,10 +710,10 @@ exports[`TeamSwitcher renders correctly on new team selection 2`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div
@@ -793,10 +793,10 @@ exports[`TeamSwitcher renders correctly on passing in initial item index 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="z-50 relative w-40 self-center inline-block text-left"
+        class="relative w-48 self-center inline-block text-left"
       >
         <button
-          class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+          class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
           type="button"
         >
           <div
@@ -819,10 +819,10 @@ exports[`TeamSwitcher renders correctly on passing in initial item index 1`] = `
   </body>,
   "container": <div>
     <div
-      class="z-50 relative w-40 self-center inline-block text-left"
+      class="relative w-48 self-center inline-block text-left"
     >
       <button
-        class="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
+        class="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300"
         type="button"
       >
         <div

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import TeamSwitcher, { TeamsSwitcherStatus } from "../components/team_switcher"
 import { Team, TeamsApiStatus, fetchTeamsFromServer } from "../api/api_calls"
 import { measureAuth } from "../auth/measure_auth"
+import UserAvatar from "../components/user_avatar"
 
 export default function DashboardLayout({
   children,
@@ -70,6 +71,7 @@ export default function DashboardLayout({
   const searchParams = useSearchParams()
   const currentQuery = searchParams.toString()
 
+
   const getTeams = async () => {
     setTeamsApiStatus(TeamsApiStatus.Loading)
 
@@ -116,9 +118,11 @@ export default function DashboardLayout({
         <aside className="md:border-black md:border-r md:sticky md:top-0 md:h-screen">
           <nav className="flex flex-col p-2 md:h-full w-screen md:w-60">
             <div className="py-4" />
+            <UserAvatar onLogoutClick={() => logoutUser()} />
+            <div className="py-4" />
             <TeamSwitcher items={teams} initialItemIndex={teams?.findIndex((e) => e.id === selectedTeam!.id)} teamsSwitcherStatus={teamsApiStatusToTeamsSwitcherStatus[teamsApiStatus]} onChangeSelectedItem={(item) => onTeamChanged(item)} />
             {teamsApiStatus === TeamsApiStatus.Error && <p className="text-lg text-center font-display pt-4">Please refresh page to try again.</p>}
-            {teamsApiStatus === TeamsApiStatus.Success && <div className="py-4" />}
+            {teamsApiStatus === TeamsApiStatus.Success && <div className="py-8" />}
             {teamsApiStatus === TeamsApiStatus.Success &&
               <ul>
                 {menuItems.map(({ hrefSuffix, title }) => (
@@ -137,7 +141,6 @@ export default function DashboardLayout({
               <div className='px-1' />
               <p className='mt-1'>Support</p>
             </a>
-            <button className="mx-4 mb-2 outline-hidden flex justify-center hover:bg-yellow-200 active:bg-yellow-300 focus-visible:bg-yellow-200 border border-black rounded-md font-display transition-colors duration-100 py-2 px-4" onClick={() => logoutUser()}>Logout</button>
           </nav>
         </aside>
         {teamsApiStatus === TeamsApiStatus.Success && <main className="md:overflow-auto">{children}</main>}

--- a/frontend/dashboard/app/auth/measure_auth.ts
+++ b/frontend/dashboard/app/auth/measure_auth.ts
@@ -4,6 +4,12 @@ export type MeasureAuthSession = {
     user: {
         id: string,
         own_team_id: string
+        name: string,
+        email: string,
+        confirmed_at: string,
+        last_sign_in_at: string,
+        created_at: string,
+        updated_at: string,
     }
 }
 
@@ -136,7 +142,13 @@ export class MeasureAuth {
             const session: MeasureAuthSession = {
                 user: {
                     id: data.user.id,
-                    own_team_id: data.user.own_team_id
+                    own_team_id: data.user.own_team_id,
+                    name: data.user.name,
+                    email: data.user.email,
+                    confirmed_at: data.user.confirmed_at,
+                    last_sign_in_at: data.user.last_sign_in_at,
+                    created_at: data.user.created_at,
+                    updated_at: data.user.updated_at,
                 },
             }
 

--- a/frontend/dashboard/app/components/team_switcher.tsx
+++ b/frontend/dashboard/app/components/team_switcher.tsx
@@ -62,14 +62,14 @@ const TeamSwitcher: React.FC<TeamSwitcherProps> = ({ items, initialItemIndex = 0
   }
 
   return (
-    <div className="z-50 relative w-40 self-center inline-block text-left" ref={teamSwitcherRef} >
+    <div className="relative w-48 self-center inline-block text-left" ref={teamSwitcherRef} >
       <button
         type="button"
         onClick={toggleTeamSwitcher}
         disabled={teamsSwitcherStatus === TeamsSwitcherStatus.Loading || teamsSwitcherStatus === TeamsSwitcherStatus.Error}
-        className="aspect-square w-full text-xl font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300">
-        {teamsSwitcherStatus == TeamsSwitcherStatus.Loading && <p className="pl-8 truncate w-max">Updating...</p>}
-        {teamsSwitcherStatus == TeamsSwitcherStatus.Error && <p className="pl-8 truncate w-max">Error</p>}
+        className="py-2 w-full font-display border border-black rounded-md outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300">
+        {teamsSwitcherStatus == TeamsSwitcherStatus.Loading && <p className="w-full truncate">Updating...</p>}
+        {teamsSwitcherStatus == TeamsSwitcherStatus.Error && <p className="w-full truncate">Error</p>}
         {teamsSwitcherStatus == TeamsSwitcherStatus.Success &&
           <div className="flex flex-row justify-center">
             <p className="pl-8 truncate w-max">{selectedItem ? selectedItem.name : items![initialItemIndex].name}</p>
@@ -78,7 +78,7 @@ const TeamSwitcher: React.FC<TeamSwitcherProps> = ({ items, initialItemIndex = 0
       </button>
 
       {isOpen && (
-        <div className="origin-top-right absolute left-0 mt-2 w-48 rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
+        <div className="z-50 origin-top-left absolute left-0 mt-2 w-48 shadow-lg border border-black">
           <div
             role="menu"
             aria-orientation="vertical"

--- a/frontend/dashboard/app/components/user_avatar.tsx
+++ b/frontend/dashboard/app/components/user_avatar.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import React, { useEffect, useRef, useState } from 'react'
+import { measureAuth, MeasureAuthSession } from '../auth/measure_auth'
+
+interface UserAvatarProps {
+  onLogoutClick?: () => void
+}
+measureAuth.getSession
+const UserAvatar: React.FC<UserAvatarProps> = ({ onLogoutClick }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [session, setSession] = useState<MeasureAuthSession | null>(null)
+  const [sessionError, setSessionError] = useState<Error | null>(null)
+  const teamSwitcherRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        teamSwitcherRef.current &&
+        !teamSwitcherRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (
+        teamSwitcherRef.current &&
+        !teamSwitcherRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('focusin', handleFocusIn)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('focusin', handleFocusIn)
+    }
+  }, [])
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      const { session, error } = await measureAuth.getSession()
+      setSession(session)
+      setSessionError(error)
+    }
+
+    fetchSession()
+  }, [])
+
+  const toggleUserAvatar = () => {
+    setIsOpen(!isOpen)
+  }
+
+  const handleLogoutClick = () => {
+    setIsOpen(false)
+    if (onLogoutClick) {
+      onLogoutClick()
+    }
+  }
+
+  return (
+    <div className="relative w-24 self-center inline-block text-left" ref={teamSwitcherRef} >
+      <button
+        type="button"
+        onClick={toggleUserAvatar}
+        disabled={session === null || sessionError !== null}
+        className="aspect-square w-full font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300">
+        {session === null && sessionError === null && <p className="w-full truncate text-xs">Updating...</p>}
+        {session === null && sessionError !== null && <p className="w-full truncate text-xs">Error</p>}
+        {session !== null && sessionError === null && <p className="w-full text-xs p-2 truncate" title={session!.user.name}>{session!.user.name}</p>}
+      </button>
+
+      {isOpen && (
+        <div className="z-50 origin-top-left absolute -left-12 mt-2 w-48 shadow-lg border border-black">
+          <div
+            role="menu"
+            aria-orientation="vertical"
+            aria-labelledby="options-menu"
+          >
+            <button
+              onClick={handleLogoutClick}
+              className="w-full px-2 py-2 text-white bg-neutral-950 font-display text-left hover:text-black hover:bg-yellow-200 active:bg-yellow-300 outline-hidden focus:bg-yellow-200"
+              role="menuitem"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default UserAvatar


### PR DESCRIPTION
# Description

This commit:
- shows logged in user avatar
- shows a dropdown menu on avatar click with logout option
- makes team selector a rounded rect to accommodate avatar
- removed logout from side nav

<img width="979" alt="Screenshot 2025-05-01 at 8 08 01 PM" src="https://github.com/user-attachments/assets/2b9e9dc8-ff43-4eee-b39d-b4604d7fbbc5" />

## Related issue
Closes #2089 



