### PR TITLE
feat(frontend): show profile pic of logged in user

### DIFF
--- a/backend/api/authsession/authsession.go
+++ b/backend/api/authsession/authsession.go
@@ -30,10 +30,11 @@ type AuthSession struct {
 }
 
 // createAccessToken creates a new access token.
-func createAccessToken(userId, ownTeamId uuid.UUID, secret []byte, expiry time.Time) (token string, err error) {
+func createAccessToken(jti, userId, ownTeamId uuid.UUID, secret []byte, expiry time.Time) (token string, err error) {
 	claims := jwt.MapClaims{
 		"iat": time.Now().Unix(),
 		"sub": userId.String(),
+		"jti": jti.String(),
 		"exp": expiry.Unix(),
 		"iss": "measure",
 		"oti": ownTeamId.String(),
@@ -81,7 +82,7 @@ func NewAuthSession(userId, ownTeamId uuid.UUID, provider string, meta json.RawM
 	atSecret := server.Server.Config.AccessTokenSecret
 	atExpiryAt := now.Add(accessTokenExpiryDuration)
 
-	accessToken, err := createAccessToken(userId, ownTeamId, atSecret, atExpiryAt)
+	accessToken, err := createAccessToken(authSession.ID, userId, ownTeamId, atSecret, atExpiryAt)
 	if err != nil {
 		return
 	}

--- a/backend/api/authsession/authstate.go
+++ b/backend/api/authsession/authstate.go
@@ -35,19 +35,21 @@ type GitHubToken struct {
 
 // GitHubUser represents the GitHub user.
 type GitHubUser struct {
-	ID       int    `json:"id"`
-	Login    string `json:"login"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
-	Company  string `json:"company"`
-	Location string `json:"location"`
+	ID        int    `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarUrl string `json:"avatar_url"`
+	Company   string `json:"company"`
+	Location  string `json:"location"`
 }
 
 // GoogleUser represents the Google user.
 type GoogleUser struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Picture string `json:"picture"`
 }
 
 // Save saves the authentication state.

--- a/backend/api/measure/user.go
+++ b/backend/api/measure/user.go
@@ -25,7 +25,7 @@ type User struct {
 
 func (u User) String() string {
 	return fmt.Sprintf(
-		"ID: %s, Name: %s, Email: %s,Email: %s, LastSignInAt: %v, CreatedAt: %v, UpdatedAt: %v",
+		"ID: %s, Name: %s, Email: %s, ConfirmedAt: %s, LastSignInAt: %v, CreatedAt: %v, UpdatedAt: %v",
 		stringOrNil(u.ID),
 		stringOrNil(u.Name),
 		stringOrNil(u.Email),

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -310,6 +310,7 @@ The required headers must be present in each request.
   {
     "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDUyMjU0ODQsImlhdCI6MTc0NTIyMzY4NCwiaXNzIjoibWVhc3VyZSIsIm90aSI6ImU0N2FjNDlkLTA2OTctNGU4NS04NjA3LTFhMzQ1MzZjMDRlMyIsInN1YiI6IjgzNTI4M2E1LWNkZGMtNDcyYi04NGFkLTVlYTMzMTllZmVlZCJ9.UA-rtIY8TPjB3gkt0xgxTTXWa84uB6nr9vMyg0gMnSI",
     "refresh_token": "yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJleHAiOjE3NDU4Mjg0ODQsImp0aSI6ImYwY2NlMjViLTkyOWQtNGI4ZS1iOTgyLWM1YmRlOWJmZmJlYyJ9.1-meGfGQ8i9IlNxKXmBlDc4lEu-O63jG2vrd7yP0-j8",
+    "session_id": "afae8473-2419-4303-a262-2aea520de295",
     "user_id": "835283a5-cddc-472b-84ad-5ea3319efeed",
     "own_team_id": "e47ac49d-0697-4e85-8607-1a34536c04e3"
   }
@@ -383,6 +384,7 @@ The required headers must be present in each request.
   {
     "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDUyMjU2NTksImlhdCI6MTc0NTIyMzg1OSwiaXNzIjoibWVhc3VyZSIsIm90aSI6ImU0N2FjNDlkLTA2OTctNGU4NS04NjA3LTFhMzQ1MzZjMDRlMyIsInN1YiI6IjgzNTI4M2E1LWNkZGMtNDcyYi04NGFkLTVlYTMzMTllZmVlZCJ9.XzbpImWw9GXFlIXHCu92QNsA1D8m_Y9ZFVDEDqG_wtM",
     "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDU4Mjg2NTksImp0aSI6Ijg0Njk3ODhkLWVjNTEtNDdkNi1hM2RkLTRhYWY2NzI4ZmYzNyJ9.MeMIsk1KEHvPa2AAbDBQWqeKJwQcxbk1lXb7Mhcz-uQ",
+    "session_id": "afae8473-2419-4303-a262-2aea520de295",
     "user_id": "835283a5-cddc-472b-84ad-5ea3319efeed",
     "own_team_id": "e47ac49d-0697-4e85-8607-1a34536c04e3"
   }

--- a/frontend/dashboard/app/auth/login/google-sign-in.tsx
+++ b/frontend/dashboard/app/auth/login/google-sign-in.tsx
@@ -41,6 +41,7 @@ export default function GoogleSignIn() {
         data-ux_mode="popup"
         data-nonce={hashedNonce}
         data-login_uri={`${origin}/auth/callback/google?nonce=${encodeURIComponent(nonce)}&state=${encodeURIComponent(state)}`}
+        data-scope="openid email profile"
         data-auto_prompt="false"
         data-itp_support="true"
         data-use_fedcm_for_prompt="true">

--- a/frontend/dashboard/app/auth/measure_auth.ts
+++ b/frontend/dashboard/app/auth/measure_auth.ts
@@ -6,6 +6,7 @@ export type MeasureAuthSession = {
         own_team_id: string
         name: string,
         email: string,
+        avatar_url: string,
         confirmed_at: string,
         last_sign_in_at: string,
         created_at: string,
@@ -113,7 +114,7 @@ export class MeasureAuth {
         }
         // Construct the OAuth URL.
         const oauthUrl = new URL("https://github.com/login/oauth/authorize")
-        oauthUrl.searchParams.append("scope", "user:email")
+        oauthUrl.searchParams.append("scope", "user:email read:user")
         oauthUrl.searchParams.append("client_id", options.clientId)
         oauthUrl.searchParams.append("state", state)
         oauthUrl.searchParams.append("redirect_uri", options.options.redirectTo.toString())
@@ -145,6 +146,7 @@ export class MeasureAuth {
                     own_team_id: data.user.own_team_id,
                     name: data.user.name,
                     email: data.user.email,
+                    avatar_url: data.user.avatar_url,
                     confirmed_at: data.user.confirmed_at,
                     last_sign_in_at: data.user.last_sign_in_at,
                     created_at: data.user.created_at,

--- a/frontend/dashboard/app/components/user_avatar.tsx
+++ b/frontend/dashboard/app/components/user_avatar.tsx
@@ -2,15 +2,17 @@
 
 import React, { useEffect, useRef, useState } from 'react'
 import { measureAuth, MeasureAuthSession } from '../auth/measure_auth'
+import Image from 'next/image'
 
 interface UserAvatarProps {
   onLogoutClick?: () => void
 }
-measureAuth.getSession
+
 const UserAvatar: React.FC<UserAvatarProps> = ({ onLogoutClick }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [session, setSession] = useState<MeasureAuthSession | null>(null)
   const [sessionError, setSessionError] = useState<Error | null>(null)
+  const [avatarLoadFailed, setAvatarLoadFailed] = useState(false)
   const teamSwitcherRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -71,7 +73,24 @@ const UserAvatar: React.FC<UserAvatarProps> = ({ onLogoutClick }) => {
         className="aspect-square w-full font-display border border-black rounded-full outline-hidden hover:enabled:bg-yellow-200 focus:enabled:bg-yellow-200 active:enabled:bg-yellow-300">
         {session === null && sessionError === null && <p className="w-full truncate text-xs">Updating...</p>}
         {session === null && sessionError !== null && <p className="w-full truncate text-xs">Error</p>}
-        {session !== null && sessionError === null && <p className="w-full text-xs p-2 truncate" title={session!.user.name}>{session!.user.name}</p>}
+        {session !== null && sessionError === null && !avatarLoadFailed && (
+          <div className="relative w-full h-full">
+            <Image
+              src={session!.user.avatar_url}
+              fill
+              loading='lazy'
+              sizes="96px"
+              alt={session!.user.name}
+              className="object-fit rounded-full"
+              onError={(_) => {
+                setAvatarLoadFailed(true)
+              }}
+            />
+          </div>
+        )}
+        {session !== null && sessionError === null && avatarLoadFailed && (
+          <p className="w-full truncate text-xs">{session!.user.name}</p>
+        )}
       </button>
 
       {isOpen && (

--- a/frontend/dashboard/next.config.js
+++ b/frontend/dashboard/next.config.js
@@ -8,6 +8,14 @@ const nextConfig = {
                 hostname: 'localhost',
                 port: '9111'
             },
+            {
+                protocol: 'https',
+                hostname: 'avatars.githubusercontent.com',
+            },
+            {
+                protocol: 'https',
+                hostname: 'lh3.googleusercontent.com',
+            },
         ],
     },
 }


### PR DESCRIPTION
# Description

<img width="243" alt="Screenshot 2025-05-04 at 2 48 44 PM" src="https://github.com/user-attachments/assets/2e2f940b-d042-4be9-8c3e-251d86428682" />


This PR:
- adds scopes to get profile pic from google & github
- stores profile pic urls in auth session user metadata
- adds session id to access token
- uses session id from access token to get current session's profile pic url
- Shows profile pic of logged in user on dashboard or shows user name as fallback
- Always uses latest pic from provider without us having to store or update it

## Related issue
Closes #2114 



