### PR TITLE
fix(frontend): select first root span available if url span invalid

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -618,7 +618,7 @@ const Filters: React.FC<FiltersProps> = ({
           if (urlFilters.rootSpanName) {
             const selectedRootSpanName = parsedRootSpanNames.find((name: string) => name === urlFilters.rootSpanName)
             if (selectedRootSpanName === undefined) {
-              throw Error("Invalid root span name: " + urlFilters.rootSpanName + " provided in URL")
+              setSelectedRootSpanName(parsedRootSpanNames[0])
             } else {
               setSelectedRootSpanName(selectedRootSpanName)
             }


### PR DESCRIPTION
# Description

When user switches an app, new root spans are fetched and url is updated. Before the new root spans are fetched, the url will reflect the old root span selected. This would throw an error since the old root span in url would not be valid for the new app.

This commit default to first available root span in case of invalid url span instead of throwing an error.

## Related issue
Fixes #2117



