### PR TITLE
chore(backend): delete stale auth sessions in cleanup

### DIFF
--- a/backend/api/authsession/authsession.go
+++ b/backend/api/authsession/authsession.go
@@ -139,22 +139,6 @@ func GetAuthSession(ctx context.Context, id uuid.UUID) (authSession AuthSession,
 	return
 }
 
-// RemoveExpiredSessions removes expired auth sessions.
-func RemoveExpiredSessions(ctx context.Context) (err error) {
-	stmt := sqlf.PostgreSQL.
-		DeleteFrom("public.auth_sessions").
-		Where("rt_expiry_at < ?", time.Now())
-
-	defer stmt.Close()
-
-	_, err = server.Server.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
 // Save saves the authentication session to database.
 func (au *AuthSession) Save(ctx context.Context, tx *pgx.Tx) (err error) {
 	stmt := sqlf.PostgreSQL.

--- a/backend/api/measure/auth.go
+++ b/backend/api/measure/auth.go
@@ -429,10 +429,6 @@ func SigninGitHub(c *gin.Context) {
 			"own_team_id":   team.ID,
 		})
 
-		// deliberately ignore any error, because
-		// expired sessions may get cleared eventually
-		authsession.RemoveExpiredSessions(ctx)
-
 		return
 	default:
 		fmt.Println(msg)
@@ -641,10 +637,6 @@ func SigninGoogle(c *gin.Context) {
 		"user_id":       userId,
 		"own_team_id":   team.ID,
 	})
-
-	// deliberately ignore any error, because
-	// expired sessions may get cleared eventually
-	authsession.RemoveExpiredSessions(ctx)
 }
 
 // RefreshToken refreshes a previous session from


### PR DESCRIPTION
# Description

Stale auth sessions were being removed on every sign in. This could slow down sign in api if there are a large number of stale auth sessions.

This commit moves the cleanup operation to cleanup service.

## Related issue
Closes #2077



