### PR TITLE
fix(frontend): add missing css semicolons

### DIFF
--- a/frontend/dashboard/app/components/session_timeline.tsx
+++ b/frontend/dashboard/app/components/session_timeline.tsx
@@ -243,6 +243,7 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({ teamId, appId, sessio
     const percentage = elapsedTime.toMillis() / duration.toMillis()
     const scrollPercentage = Math.max(0, Math.min(percentage, 1))
 
+    console.log("scrollPercentage", scrollPercentage)
     setSeekBarValue(scrollPercentage * 100)
     setSelectedEventIndex(eventIndex)
   }

--- a/frontend/dashboard/app/components/session_timeline_seekbar.tsx
+++ b/frontend/dashboard/app/components/session_timeline_seekbar.tsx
@@ -19,7 +19,6 @@ const SessionTimelineSeekBar: React.FC<SessionTimelineSeekBarProps> = ({ value, 
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const newValue = parseInt(e.target.value, 10)
-    console.log(value)
     onChange(newValue)
   }
 
@@ -48,59 +47,59 @@ const SessionTimelineSeekBar: React.FC<SessionTimelineSeekBarProps> = ({ value, 
       <style jsx>{`
         /* Webkit (Chrome, Safari, Edge) */
         input[type='range']::-webkit-slider-thumb {
-          -webkit-appearance: none
-          cursor: pointer
-          width: var(--thumb-width)
-          height: var(--thumb-height)
-          background-color: transparent
-          border: calc(var(--thumb-width)/2) dashed var(--thumb-color) 
-          border-radius: 0
-          transform-origin: bottom center
-          margin-top: calc(-1 * var(--thumb-height) - var(--thumb-margin)) /* Only extends upward */
+          -webkit-appearance: none;
+          cursor: pointer;
+          width: var(--thumb-width);
+          height: var(--thumb-height);
+          background-color: transparent;
+          border: calc(var(--thumb-width)/2) dashed var(--thumb-color);
+          border-radius: 0;
+          transform-origin: bottom center;
+          margin-top: calc(-1 * var(--thumb-height) - var(--thumb-margin)); /* Only extends upward */
         }
 
         /* Firefox */
         input[type='range']::-moz-range-thumb {
-          width: var(--thumb-width)
-          height: var(--thumb-height)
-          background-color: transparent
-          border: calc(var(--thumb-width)/2) dashed var(--thumb-color) 
-          border-radius: 0
-          border: none
-          transform-origin: bottom center
-          margin-top: calc(-1 * var(--thumb-height) - var(--thumb-margin)) /* Only extends upward */
+          width: var(--thumb-width);
+          height: var(--thumb-height);
+          background-color: transparent;
+          border: calc(var(--thumb-width)/2) dashed var(--thumb-color);
+          border-radius: 0;
+          border: none;
+          transform-origin: bottom center;
+          margin-top: calc(-1 * var(--thumb-height) - var(--thumb-margin)); /* Only extends upward */
         }
 
         /* Track styling */
         input[type='range']::-webkit-slider-runnable-track {
-          width: 100%
-          height: 8px
+          width: 100%;
+          height: 8px;
           background: linear-gradient(to right, 
-            var(--progress-color) 0%, 
-            var(--progress-color) var(--progress-percent),
-            var(--track-color) var(--progress-percent),
-            var(--track-color) 100%)
-          border: 1px solid var(--track-border-color)
-          border-radius: 8px
-          cursor: pointer
+        var(--progress-color) 0%, 
+        var(--progress-color) var(--progress-percent),
+        var(--track-color) var(--progress-percent),
+        var(--track-color) 100%);
+          border: 1px solid var(--track-border-color);
+          border-radius: 8px;
+          cursor: pointer;
         }
 
         input[type='range']::-moz-range-track {
-          width: 100%
-          height: 8px
+          width: 100%;
+          height: 8px;
           background: linear-gradient(to right, 
-            var(--progress-color) 0%, 
-            var(--progress-color) var(--progress-percent),
-            var(--track-color) var(--progress-percent),
-            var(--track-color) 100%)
-          border: 1px solid var(--track-border-color)
-          border-radius: 8px
-          cursor: pointer
+        var(--progress-color) 0%, 
+        var(--progress-color) var(--progress-percent),
+        var(--track-color) var(--progress-percent),
+        var(--track-color) 100%);
+          border: 1px solid var(--track-border-color);
+          border-radius: 8px;
+          cursor: pointer;
         }
 
         /* Ensure the thumb is always visible */
         input[type='range'] {
-          z-index: 1
+          z-index: 1;
         }
       `}</style>
     </div>


### PR DESCRIPTION
# Description

During a previous formatting change, semicolons were inadvertently removed from css making it invalid and hiding the session timeline seekbar.

This PR adds the missing semicolons.

## Related issue
Fixes #2128 



