### PR TITLE
docs: remove defunct command from contribution guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,14 +26,13 @@ After cloning the repostiory, run the following commands for the best contributi
 > [!NOTE]
 >
 > You would need [node](https://nodejs.org/) to run the above commands. We recommend you always stick to the `lts` version of node.
-> If you need to setup node, we recommend you use [fnm (Fast Node Manager)](https://github.com/Schniz/fnm) to manage node version(s). Follow [fnm's installation instructions](https://github.com/Schniz/fnm?tab=readme-ov-file#installation).
+> If you need to setup node, we recommend you use [fnm (Fast Node Manager)](https://github.com/Schniz/fnm) to manage node versions. Follow [fnm's installation instructions](https://github.com/Schniz/fnm?tab=readme-ov-file#installation).
 
 In the repo root, run
 
 ```sh
 npm install
 npm prepare
-npm --prefix frontend/dashboard install
 ```
 
 The above commands would install the required dependencies and setup git hooks as intended. This is a one-time setup, unless you do a fresh clone again.
@@ -52,7 +51,7 @@ Next, run `./config.sh`
 ./config.sh
 ```
 
-This will start the configuration wizard and prepre all the environment variable files - `.env` tuned for local development.
+This will start the configuration wizard and prepre all the environment variable files tuned for local development.
 
 ### Start services
 
@@ -97,7 +96,9 @@ docker compose --profile init --profile migrate down
 In case of any issues related to incoherent state, reset your environment by running. Keep in mind that this will remove all Measure volumes and all the data contained in those volumes.
 
 ```sh
-docker compose down --volumes
+# would stop all containers and
+# remove images, orphan containers, volumes & networks
+docker compose down --rmi --remove-orphans --volumes
 ```
 
 And rerun.
@@ -123,6 +124,7 @@ All commits landing in any branch are first linted in your local environment and
   - **android** for commits related to Android SDK
   - **frontend** for commits related to dashboard web app
   - **backend** for commits related to backend infrastructure
+  - **[and more](https://github.com/measure-sh/measure/blob/d8b2c6048d854ac3c69535f0c4d955e4758a54c9/.commitlintrc.js#L13)**
 - Try not to exceed **72** characters for commit header message
 - Try not to exceed **100** characters for each line in body. Break each line with newlines to remain under 100 characters.
 - Make sure commit message headers are in lowercase


### PR DESCRIPTION
## Summary

This PR updates the contribution guide to remove a defunct `npm install` command step to avoid certain race conditions leading to a crash of the dashboard service during local development. Additionally, improve the **Troubleshooting** section and document all valid commit scopes.

## Tasks

- [x] Remove the unneeded `npm install` command
- [x] Improve the **Troubleshooting** section
- [x] Add a link to all valid Conventional Commits scopes

## See also

- fixes #2136
