### PR TITLE
docs: add a faqs page in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ Welcome to Measure's documentation. You'll find all the relevant information for
 4. [**API Documentation**](./api/README.md) - APIs that various Measure SDKs use
 5. [**Versioning Guide**](./versioning/README.md) - Understand how versions are tagged
 6. [**Contribution Guide**](./CONTRIBUTING.md) - Contribute to Measure
+7. [**FAQs**](./faqs.md) - Explore frequently asked quetsions

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,0 +1,18 @@
+# Frequently Asked Questions
+
+A few product questions that you may have.
+
+## Q. Why am I seeing "No data" for app launch metrics?
+
+To successfully compute cold/warm/hot metrics, there are 2 requirements.
+
+1. There must be at least 2 versions of the app
+2. The launch metrics duration must be above a certain threshold. The default thresholds for cold/warm/hot are as follows.
+
+    | **Type** | **Threshold** |
+    | -------- | ------------- |
+    | Cold     | > 30s         |
+    | Warm     | > 10s         |
+    | Hot      | > 0s          |
+
+If any of the above requirements are not met, you may see "No data" reported for either cold/warm/hot launch metrics. Applicable to both Android and iOS.


### PR DESCRIPTION
## Summary

This PR adds a FAQs page in docs to address frequently asked questions.

## See also

- fixes #2140
