### PR TITLE
fix(frontend): fix error on app name change

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -579,7 +579,12 @@ const Filters: React.FC<FiltersProps> = ({
             setSelectedApp(appFromGivenId)
           }
         } else if (sessionPersistedFilters) {
-          setSelectedApp(sessionPersistedFilters.app)
+          let appFromSessionPersistedFilters = result.data.find((e: App) => e.id === sessionPersistedFilters.app.id)
+          if (appFromSessionPersistedFilters === undefined) {
+            setSelectedApp(result.data[0])
+          } else {
+            setSelectedApp(appFromSessionPersistedFilters)
+          }
         } else {
           setSelectedApp(result.data[0])
         }


### PR DESCRIPTION
# Description

When we change app name, we reload the page. Filters component finds a persisted selected app which is pointing to the old name and uses it instead of using the new app causing an error.

This commit checks uses the new app name correctly after app name change to avoid the error.

## Related issue
Fixes #2145



