### PR TITLE
fix(backend): metrics fetch would fail sometimes

### DIFF
--- a/backend/api/filter/appfilter_test.go
+++ b/backend/api/filter/appfilter_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"backend/api/event"
+	"reflect"
 	"testing"
 )
 
@@ -82,6 +83,172 @@ func TestParseRawUDExpression(t *testing.T) {
 
 		if expectedValue != gotValue {
 			t.Errorf("Expected %v value, got %v", expectedValue, gotValue)
+		}
+	}
+}
+
+func TestExclude(t *testing.T) {
+	// no selected versions match
+	{
+		allVersions := []string{
+			"1.0.1",
+			"1.0.1",
+			"1.0.2",
+		}
+		allCodes := []string{
+			"0",
+			"1",
+			"2",
+		}
+
+		selVersions := []string{
+			"4.5.6",
+		}
+		selCodes := []string{
+			"7",
+		}
+
+		got := exclude(allVersions, allCodes, selVersions, selCodes)
+		expected := Versions{
+			names: []string{
+				"1.0.1",
+				"1.0.1",
+				"1.0.2",
+			},
+			codes: []string{
+				"0",
+				"1",
+				"2",
+			},
+		}
+
+		if !reflect.DeepEqual(expected.Versions(), got.Versions()) {
+			t.Errorf("Expected %v, but got %v", expected.Versions(), got.Versions())
+		}
+
+		if !reflect.DeepEqual(expected.Codes(), got.Codes()) {
+			t.Errorf("Expected %v, but got %v", expected.Codes(), got.Codes())
+		}
+	}
+
+	// at least 1 selected versions match
+	{
+		allVersions := []string{
+			"1.0.1",
+			"1.0.1",
+			"1.0.2",
+		}
+		allCodes := []string{
+			"0",
+			"1",
+			"2",
+		}
+
+		selVersions := []string{
+			"1.0.1",
+		}
+		selCodes := []string{
+			"1",
+		}
+
+		got := exclude(allVersions, allCodes, selVersions, selCodes)
+		expected := Versions{
+			names: []string{
+				"1.0.1",
+				"1.0.2",
+			},
+			codes: []string{
+				"0",
+				"2",
+			},
+		}
+
+		if !reflect.DeepEqual(expected.Versions(), got.Versions()) {
+			t.Errorf("Expected %v, but got %v", expected.Versions(), got.Versions())
+		}
+
+		if !reflect.DeepEqual(expected.Codes(), got.Codes()) {
+			t.Errorf("Expected %v, but got %v", expected.Codes(), got.Codes())
+		}
+	}
+
+	// more than 1 selected versions match
+	{
+		allVersions := []string{
+			"1.0.1",
+			"1.0.1",
+			"1.0.2",
+		}
+		allCodes := []string{
+			"0",
+			"1",
+			"2",
+		}
+
+		selVersions := []string{
+			"1.0.1",
+			"1.0.2",
+		}
+		selCodes := []string{
+			"1",
+			"2",
+		}
+
+		got := exclude(allVersions, allCodes, selVersions, selCodes)
+		expected := Versions{
+			names: []string{
+				"1.0.1",
+			},
+			codes: []string{
+				"0",
+			},
+		}
+
+		if !reflect.DeepEqual(expected.Versions(), got.Versions()) {
+			t.Errorf("Expected %v, but got %v", expected.Versions(), got.Versions())
+		}
+
+		if !reflect.DeepEqual(expected.Codes(), got.Codes()) {
+			t.Errorf("Expected %v, but got %v", expected.Codes(), got.Codes())
+		}
+	}
+
+	// all selected versions match
+	{
+		allVersions := []string{
+			"1.0.1",
+			"1.0.1",
+			"1.0.2",
+		}
+		allCodes := []string{
+			"0",
+			"1",
+			"2",
+		}
+
+		selVersions := []string{
+			"1.0.1",
+			"1.0.1",
+			"1.0.2",
+		}
+		selCodes := []string{
+			"0",
+			"1",
+			"2",
+		}
+
+		got := exclude(allVersions, allCodes, selVersions, selCodes)
+		expected := Versions{
+			names: []string{},
+			codes: []string{},
+		}
+
+		if len(got.Versions()) > 0 {
+			t.Errorf("Expected %d length, but got %d length", len(expected.Versions()), len(got.Versions()))
+		}
+
+		if len(got.Codes()) > 0 {
+			t.Errorf("Expected %d length, but got %d length", len(expected.Codes()), len(got.Codes()))
 		}
 	}
 }

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -640,7 +640,7 @@ func (a App) GetSizeMetrics(ctx context.Context, af *filter.AppFilter, versions 
 
 	avgSizeStmt := sqlf.PostgreSQL.
 		From("public.build_sizes").
-		Select("round(avg(build_size), 2) as average_size").
+		Select("round(coalesce(avg(build_size), 2), 0) as average_size").
 		Where("app_id = ?", af.AppID)
 
 	if versions.HasVersions() {


### PR DESCRIPTION
## Summary

This PR addresses a couple of issues with how excluded versions were computed and how metrics database query was not coalescing on `null` inputs, resulting in a `500 Internal Server Error`.

> [!NOTE]
>
> Should test this before merging to `main`.

## Tasks

- [x] Fix an issue with the way null values were handled while fetching metrics data from postgres. `null` inputs values were not coalesced, as a result it would return null instead of zero.
- [x] Fix an issue with how excluded versions were computed. Sometimes, the excluded versions were incorrect.
- [x] Replaced the old method of computing excluded versions with a new one
- [x] Wrote tests for the new excluded function

## See also

- fixes #2188
