### PR TITLE
fix(ios): attach crash report to the correct session

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
@@ -81,7 +81,7 @@ final class CrashReportingManager: CrashReportManager {
         }
 
         let crashDataAttributes = crashDataPersistence.readCrashData()
-        if let attributes = crashDataAttributes.attribute, let sessionId = crashDataPersistence.sessionId {
+        if let attributes = crashDataAttributes.attribute, let sessionId = crashDataAttributes.sessionId {
             exception.foreground = crashDataPersistence.isForeground
             self.signalProcessor.track(data: exception,
                                        timestamp: Number(date.timeIntervalSince1970 * 1000),

--- a/ios/Sources/MeasureSDK/Swift/SessionManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/SessionManager.swift
@@ -75,7 +75,7 @@ final class BaseSessionManager: SessionManager {
 
     private func createNewSession() {
         currentSessionId = idProvider.uuid()
-        logger.log(level: .info, message: "New session created", error: nil, data: nil)
+        logger.log(level: .info, message: "New session created: \(currentSessionId ?? "nil")", error: nil, data: nil)
         shouldReportSession = shouldMarkSessionForExport()
         let session = SessionEntity(sessionId: sessionId,
                                     pid: ProcessInfo.processInfo.processIdentifier,


### PR DESCRIPTION
# Description

When a crash happens, it gets attached to the current session instead of previous session

## Related issue
Fixes #2195 
