### PR TITLE
chore(backend): improve workflow security

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -9,7 +9,7 @@ on:
       - backend/api/**/*.sum
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
       - .github/workflows/api.yml
       - backend/api/dockerfile
@@ -17,7 +17,10 @@ on:
       - backend/api/**/*.mod
       - backend/api/**/*.sum
     tags:
-      - 'v*'
+      - "v*"
+
+permissions:
+  contents: read
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,7 +9,7 @@ on:
       - backend/cleanup/**/*.sum
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
       - .github/workflows/cleanup.yml
       - backend/cleanup/dockerfile
@@ -17,11 +17,14 @@ on:
       - backend/cleanup/**/*.mod
       - backend/cleanup/**/*.sum
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: measure-sh/cleanup
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -73,7 +76,7 @@ jobs:
         run: go get .
       - name: Test with ${{ matrix.go-version }}
         run: go test ./...
-  
+
   push:
     name: Build and push image
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -4,19 +4,22 @@ on:
   pull_request:
     paths:
       - .github/workflows/dashboard.yml
-      - 'frontend/dashboard/**'
+      - "frontend/dashboard/**"
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
       - .github/workflows/dashboard.yml
-      - 'frontend/dashboard/**'
+      - "frontend/dashboard/**"
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: measure-sh/dashboard
+
+permissions:
+  contents: read
 
 jobs:
   unit-test:
@@ -33,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "20.x"
 
       - name: Install dependencies for CI
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@
 name: Lint
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     name: Lint commit message(s)

--- a/.github/workflows/migrator.yml
+++ b/.github/workflows/migrator.yml
@@ -23,6 +23,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: measure-sh/migrator
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Summary

This PR improves the security of GitHub Workflows by default permissions to `contents: read` instead of `contents: read-write`, as recommended by GitHub's security recommendations.

## Tasks

- [x] Limit default permissions for workflow jobs to `contents: read` instead of the default of `contents: read-write`
