### PR TITLE
fix(frontend): show google login after nonce calculation

### DIFF
--- a/frontend/dashboard/app/auth/login/google-sign-in.tsx
+++ b/frontend/dashboard/app/auth/login/google-sign-in.tsx
@@ -34,6 +34,12 @@ export default function GoogleSignIn() {
     setState(state)
   }, [])
 
+  const ready = nonce && hashedNonce
+
+  if (!ready) {
+    return null
+  }
+
   return (
     <>
       <Script src="https://accounts.google.com/gsi/client" />


### PR DESCRIPTION
# Description

Google login was being shown before non was calculated. If user quickly tries to login, nonce would not be sent leading to login error. This commit renders the login UI after nonce calculation to fix this issue.

## Related issue
Fixes #2282




