### PR TITLE
fix(frontend): check window before accessing persisted filters

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -484,7 +484,10 @@ const Filters = forwardRef<
 
   const urlFilters = deserializeUrlFilters(searchParams.toString())
   const sessionPersistedFiltersKey = "sessionPersistedFilters"
-  const sessionPersistedFilters: SessionPersistedFilters | null = sessionStorage.getItem(sessionPersistedFiltersKey) === null ? null : JSON.parse(sessionStorage.getItem(sessionPersistedFiltersKey)!)
+  const sessionPersistedFilters: SessionPersistedFilters | null =
+    typeof window !== "undefined" && sessionStorage.getItem(sessionPersistedFiltersKey) !== null
+      ? JSON.parse(sessionStorage.getItem(sessionPersistedFiltersKey)!)
+      : null
 
   const [appsApiStatus, setAppsApiStatus] = useState(AppsApiStatus.Loading)
   const [rootSpanNamesApiStatus, setRootSpanNamesApiStatus] = useState(RootSpanNamesApiStatus.Loading)


### PR DESCRIPTION
# Description

Persisted filters are stored in session storage. When filters component is evaluated by the next js server, it throws an error because session storage is not available in node js. It's a browser only feature.

This commit fixes the issue by checking if window exists before attempting to fetch persisted filters.



