### PR TITLE
feat(flutter): track screen view

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
@@ -6,6 +6,7 @@ import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.navigation.ScreenViewData
 import sh.measure.android.toEventAttachment
 import sh.measure.android.utils.ProcessInfoProvider
 import sh.measure.android.utils.toJsonElement
@@ -95,6 +96,17 @@ internal class InternalSignalCollector(
                     }
                 }
 
+                EventType.SCREEN_VIEW -> {
+                    val data = extractScreenViewData(data)
+                    signalProcessor.track(
+                        data = data,
+                        timestamp = timestamp,
+                        type = eventType,
+                        attributes = attributes,
+                        userDefinedAttributes = userDefinedAttrs,
+                    )
+                }
+
                 else -> {
                     logger.log(LogLevel.Error, "Unknown event type: $type")
                 }
@@ -102,6 +114,10 @@ internal class InternalSignalCollector(
         } catch (e: Exception) {
             logger.log(LogLevel.Error, "Failed to decode event $type", e)
         }
+    }
+
+    private fun extractScreenViewData(map: MutableMap<String, Any?>): ScreenViewData {
+        return Json.decodeFromJsonElement(ScreenViewData.serializer(), map.toJsonElement())
     }
 
     private fun extractExceptionEventData(map: Map<String, Any?>): ExceptionData {

--- a/flutter/measure_flutter/example/lib/main.dart
+++ b/flutter/measure_flutter/example/lib/main.dart
@@ -1,12 +1,8 @@
 import 'dart:async';
-import 'dart:isolate';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:measure_flutter/attribute_builder.dart';
 import 'package:measure_flutter/measure.dart';
-import 'package:measure_flutter_example/src/list_item.dart';
-import 'package:stack_trace/stack_trace.dart';
+import 'package:measure_flutter_example/src/screen_main.dart';
 
 Future<void> main() async {
   await Measure.instance.start(() => runApp(MyApp()), enableLogging: true);
@@ -28,150 +24,8 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorObservers: [MsrNavigatorObserver()],
       home: MainScreen(),
-    );
-  }
-}
-
-class MainScreen extends StatelessWidget {
-  const MainScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Measure Flutter'),
-      ),
-      body: ListView(
-        children: [
-          ListItem(title: "Track custom event", onPressed: _trackCustomEvent),
-          ListItem(title: "Throw error", onPressed: _trackError),
-          ListItem(
-              title: "Error in microtask", onPressed: _trackMicroTaskError),
-          ListItem(title: "Error in isolate", onPressed: _trackIsolateError),
-          ListItem(title: "Throw exception", onPressed: _throwException),
-          ListItem(
-            title: "Throw async exception",
-            onPressed: _throwAsyncException,
-          ),
-          ListItem(
-            title: "Throw string",
-            onPressed: _throwString,
-          ),
-          ListItem(
-            title: "Native crash",
-            onPressed: _throwNativeCrash,
-          ),
-          ListItem(
-            title: "Throw OOM",
-            onPressed: _throwOOM,
-          ),
-          ListItem(title: "No method channel", onPressed: _noMethodChannel),
-          ListItem(
-            title: "Text Overflow",
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute<TextOverflowWidget>(
-                  builder: (context) => const TextOverflowWidget(),
-                ),
-              );
-            },
-          ),
-          ListItem(
-            title: "Invalid route",
-            onPressed: () {
-              // This creates a genuine FlutterError that will be caught
-              // by FlutterError.onError in release builds
-              final navigator = Navigator.of(context);
-              navigator.pushNamed('/non_existent_route');
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _trackCustomEvent() {
-    final attrs = AttributeBuilder()
-      ..add("is_premium", true)
-      ..add("integer", 1)
-      ..add("string", "string");
-    Measure.instance.trackEvent(
-      name: "event",
-      attributes: attrs.build(),
-    );
-  }
-
-  void _throwException() {
-    throw FormatException("This is an exception");
-  }
-
-  Future<void> _throwAsyncException() async {
-    Chain.capture(() async {
-      await Future.delayed(const Duration(seconds: 2));
-      throw FormatException(
-          "This is an exception using Chain.capture from an async block");
-    });
-  }
-
-  void _trackError() {
-    throw ArgumentError("This is an error");
-  }
-
-  void _trackMicroTaskError() {
-    Future.microtask(() {
-      throw FormatException(
-          "This is an exception from inside Future.microtask");
-    });
-  }
-
-  Future<void> _trackIsolateError() async {
-    Isolate.run(() {
-      throw FormatException("This is an exception from inside Isolate.run");
-    });
-  }
-
-  void _throwString() {
-    throw "are you serious? 😕";
-  }
-
-  void _throwNativeCrash() {
-    Measure.instance.triggerNativeCrash();
-  }
-
-  void _throwOOM() {
-    List<int> list = [];
-    while (true) {
-      list.addAll(List.filled(1024 * 1024, 42));
-    }
-  }
-
-  void _noMethodChannel() async {
-    await MethodChannel('non_existent_channel')
-        .invokeMethod('non_existent_method');
-  }
-}
-
-class TextOverflowWidget extends StatelessWidget {
-  const TextOverflowWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Text Overflow Example'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
-      body: Row(
-        children: [
-          Container(width: 200),
-          Container(width: 200),
-        ],
-      ),
     );
   }
 }

--- a/flutter/measure_flutter/example/lib/src/screen_main.dart
+++ b/flutter/measure_flutter/example/lib/src/screen_main.dart
@@ -1,0 +1,172 @@
+import 'dart:isolate';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:measure_flutter/attribute_builder.dart';
+import 'package:measure_flutter/measure.dart';
+import 'package:measure_flutter_example/src/screen_navigation.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+import 'list_item.dart';
+import 'screen_text_overflow.dart';
+
+class MainScreen extends StatelessWidget {
+  const MainScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Measure Flutter'),
+      ),
+      body: ListView(
+        children: [
+          ListSection(title: "Crashes"),
+          ListItem(title: "Track custom event", onPressed: _trackCustomEvent),
+          ListItem(title: "Throw error", onPressed: _trackError),
+          ListItem(
+              title: "Error in microtask", onPressed: _trackMicroTaskError),
+          ListItem(title: "Error in isolate", onPressed: _trackIsolateError),
+          ListItem(title: "Throw exception", onPressed: _throwException),
+          ListItem(
+            title: "Throw async exception",
+            onPressed: _throwAsyncException,
+          ),
+          ListItem(
+            title: "Throw string",
+            onPressed: _throwString,
+          ),
+          ListItem(
+            title: "Native crash",
+            onPressed: _throwNativeCrash,
+          ),
+          ListItem(
+            title: "Throw OOM",
+            onPressed: _throwOOM,
+          ),
+          ListItem(title: "No method channel", onPressed: _noMethodChannel),
+          ListItem(
+            title: "Text Overflow",
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<ScreenTextOverflow>(
+                  builder: (context) => const ScreenTextOverflow(),
+                  settings: RouteSettings(name: '/screen_text_overflow'),
+                ),
+              );
+            },
+          ),
+          ListItem(
+            title: "Invalid route",
+            onPressed: () {
+              // This creates a genuine FlutterError that will be caught
+              // by FlutterError.onError in release builds
+              final navigator = Navigator.of(context);
+              navigator.pushNamed('/non_existent_route');
+            },
+          ),
+          ListSection(title: "Navigation"),
+          ListItem(
+            title: "Navigate",
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<ScreenNavigation>(
+                  builder: (context) => const ScreenNavigation(),
+                  settings: RouteSettings(name: '/screen_navigation'),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _trackCustomEvent() {
+    final attrs = AttributeBuilder()
+      ..add("is_premium", true)
+      ..add("integer", 1)
+      ..add("string", "string");
+    Measure.instance.trackEvent(
+      name: "event",
+      attributes: attrs.build(),
+    );
+  }
+
+  void _throwException() {
+    throw FormatException("This is an exception");
+  }
+
+  Future<void> _throwAsyncException() async {
+    Chain.capture(() async {
+      await Future.delayed(const Duration(seconds: 2));
+      throw FormatException(
+          "This is an exception using Chain.capture from an async block");
+    });
+  }
+
+  void _trackError() {
+    throw ArgumentError("This is an error");
+  }
+
+  void _trackMicroTaskError() {
+    Future.microtask(() {
+      throw FormatException(
+          "This is an exception from inside Future.microtask");
+    });
+  }
+
+  Future<void> _trackIsolateError() async {
+    Isolate.run(() {
+      throw FormatException("This is an exception from inside Isolate.run");
+    });
+  }
+
+  void _throwString() {
+    throw "are you serious? 😕";
+  }
+
+  void _throwNativeCrash() {
+    Measure.instance.triggerNativeCrash();
+  }
+
+  void _throwOOM() {
+    List<int> list = [];
+    while (true) {
+      list.addAll(List.filled(1024 * 1024, 42));
+    }
+  }
+
+  void _noMethodChannel() async {
+    await MethodChannel('non_existent_channel')
+        .invokeMethod('non_existent_method');
+  }
+}
+
+class ListSection extends StatelessWidget {
+  final String title;
+
+  const ListSection({
+    super.key,
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        title,
+        style: TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: Colors.grey[600],
+        ),
+      ),
+      dense: true,
+      enabled: false,
+      contentPadding: EdgeInsets.symmetric(horizontal: 16),
+    );
+  }
+}

--- a/flutter/measure_flutter/example/lib/src/screen_navigation.dart
+++ b/flutter/measure_flutter/example/lib/src/screen_navigation.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ScreenNavigation extends StatelessWidget {
+  const ScreenNavigation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Navigation'),
+      ),
+      body: Center(
+        child: Text("Navigation"),
+      ),
+    );
+  }
+}

--- a/flutter/measure_flutter/example/lib/src/screen_text_overflow.dart
+++ b/flutter/measure_flutter/example/lib/src/screen_text_overflow.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class ScreenTextOverflow extends StatelessWidget {
+  const ScreenTextOverflow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Text Overflow Example'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: Row(
+        children: [
+          Container(width: 200),
+          Container(width: 200),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/measure_flutter/lib/measure.dart
+++ b/flutter/measure_flutter/lib/measure.dart
@@ -10,6 +10,8 @@ import 'package:measure_flutter/src/measure_initializer.dart';
 import 'package:measure_flutter/src/measure_interface.dart';
 import 'package:measure_flutter/src/measure_internal.dart';
 
+export 'src/navigation/navigator_observer.dart';
+
 class Measure implements MeasureApi {
   Measure._();
 
@@ -74,6 +76,13 @@ class Measure implements MeasureApi {
   void triggerNativeCrash() {
     if (_isInitialized) {
       _measure.triggerNativeCrash();
+    }
+  }
+
+  @override
+  void trackScreenViewEvent({required String name, bool userTriggered = true}) {
+    if (_isInitialized) {
+      _measure.trackScreenViewEvent(name: name, userTriggered: userTriggered);
     }
   }
 

--- a/flutter/measure_flutter/lib/src/events/event_type.dart
+++ b/flutter/measure_flutter/lib/src/events/event_type.dart
@@ -1,4 +1,5 @@
 final class EventType {
   static final String custom = "custom";
   static final String exception = "exception";
+  static final String screenView = "screen_view";
 }

--- a/flutter/measure_flutter/lib/src/logger/flutter_logger.dart
+++ b/flutter/measure_flutter/lib/src/logger/flutter_logger.dart
@@ -13,7 +13,12 @@ final class FlutterLogger implements Logger {
   void log(LogLevel level, String message,
       [dynamic error, StackTrace? stackTrace]) {
     if (!enabled) return;
-    developer.log(message,
-        level: level.level, error: error, stackTrace: stackTrace);
+    developer.log(
+      message,
+      level: level.level,
+      error: error,
+      stackTrace: stackTrace,
+      name: "Measure",
+    );
   }
 }

--- a/flutter/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/measure_flutter/lib/src/measure_initializer.dart
@@ -6,6 +6,7 @@ import 'package:measure_flutter/src/logger/flutter_logger.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
+import 'package:measure_flutter/src/navigation/navigation_collector.dart';
 
 final class MeasureInitializer {
   final MeasureConfig config;
@@ -13,6 +14,7 @@ final class MeasureInitializer {
   late final MsrMethodChannel _methodChannel;
   late final CustomEventCollector _customEventCollector;
   late final ExceptionCollector _exceptionCollector;
+  late final NavigationCollector _navigationCollector;
   late final SignalProcessor _signalProcessor;
 
   Logger get logger => _logger;
@@ -22,6 +24,8 @@ final class MeasureInitializer {
   CustomEventCollector get customEventCollector => _customEventCollector;
 
   ExceptionCollector get exceptionCollector => _exceptionCollector;
+
+  NavigationCollector get navigationCollector => _navigationCollector;
 
   SignalProcessor get signalProcessor => _signalProcessor;
 
@@ -42,6 +46,8 @@ final class MeasureInitializer {
       logger: logger,
       signalProcessor: signalProcessor,
     );
+    _navigationCollector =
+        NavigationCollector(signalProcessor: signalProcessor);
   }
 
   @visibleForTesting
@@ -63,5 +69,7 @@ final class MeasureInitializer {
       logger: _logger,
       signalProcessor: signalProcessor,
     );
+    _navigationCollector =
+        NavigationCollector(signalProcessor: signalProcessor);
   }
 }

--- a/flutter/measure_flutter/lib/src/measure_interface.dart
+++ b/flutter/measure_flutter/lib/src/measure_interface.dart
@@ -14,4 +14,9 @@ abstract class MeasureApi {
   void trackHandledError(Object error, StackTrace stack);
 
   void triggerNativeCrash();
+
+  void trackScreenViewEvent({
+    required String name,
+    bool userTriggered = true,
+  });
 }

--- a/flutter/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/measure_flutter/lib/src/measure_internal.dart
@@ -5,12 +5,14 @@ import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/measure_initializer.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
+import 'package:measure_flutter/src/navigation/navigation_collector.dart';
 
 final class MeasureInternal {
   final MeasureInitializer initializer;
   final Logger logger;
   final CustomEventCollector _customEventCollector;
   final ExceptionCollector _exceptionCollector;
+  final NavigationCollector _navigationCollector;
   final MsrMethodChannel _methodChannel;
 
   MeasureInternal({
@@ -18,7 +20,8 @@ final class MeasureInternal {
   })  : logger = initializer.logger,
         _customEventCollector = initializer.customEventCollector,
         _methodChannel = initializer.methodChannel,
-        _exceptionCollector = initializer.exceptionCollector;
+        _exceptionCollector = initializer.exceptionCollector,
+        _navigationCollector = initializer.navigationCollector;
 
   Future<void> init() async {
     registerCollectors();
@@ -43,5 +46,13 @@ final class MeasureInternal {
 
   void triggerNativeCrash() {
     _methodChannel.triggerNativeCrash();
+  }
+
+  void trackScreenViewEvent({
+    required String name,
+    bool userTriggered = true,
+  }) {
+    _navigationCollector.trackScreenViewEvent(
+        name: name, userTriggered: userTriggered);
   }
 }

--- a/flutter/measure_flutter/lib/src/method_channel/signal_processor.dart
+++ b/flutter/measure_flutter/lib/src/method_channel/signal_processor.dart
@@ -1,4 +1,5 @@
 import 'package:measure_flutter/attribute_value.dart';
+import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:measure_flutter/src/serialization/json_serializable.dart';
@@ -30,6 +31,7 @@ final class DefaultSignalProcessor extends SignalProcessor {
     String? threadName,
   }) {
     var json = data.toJson();
+    logger.log(LogLevel.debug, "$type: $json");
     return channel.trackEvent(json, type, timestamp.millisecondsSinceEpoch,
         userDefinedAttrs, userTriggered, threadName);
   }

--- a/flutter/measure_flutter/lib/src/navigation/navigation_collector.dart
+++ b/flutter/measure_flutter/lib/src/navigation/navigation_collector.dart
@@ -1,0 +1,25 @@
+import 'package:measure_flutter/src/events/event_type.dart';
+import 'package:measure_flutter/src/method_channel/signal_processor.dart';
+import 'package:measure_flutter/src/navigation/screen_view_data.dart';
+
+class NavigationCollector {
+  final SignalProcessor signalProcessor;
+
+  const NavigationCollector({
+    required this.signalProcessor,
+  });
+
+  Future<void> trackScreenViewEvent({
+    required String name,
+    required bool userTriggered,
+  }) {
+    final data = ScreenViewData(name: name);
+    return signalProcessor.trackEvent(
+      data: data,
+      type: EventType.screenView,
+      timestamp: DateTime.now(),
+      userDefinedAttrs: {},
+      userTriggered: userTriggered,
+    );
+  }
+}

--- a/flutter/measure_flutter/lib/src/navigation/navigator_observer.dart
+++ b/flutter/measure_flutter/lib/src/navigation/navigator_observer.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:measure_flutter/src/measure_interface.dart';
+
+import '../../measure.dart';
+
+class MsrNavigatorObserver extends NavigatorObserver {
+  final MeasureApi _measure;
+
+  MsrNavigatorObserver() : _measure = Measure.instance;
+
+  @visibleForTesting
+  MsrNavigatorObserver.withMeasure(this._measure);
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    _trackScreenView(route.settings.name);
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    _trackScreenView(previousRoute?.settings.name);
+  }
+
+  @override
+  void didReplace({Route? newRoute, Route? oldRoute}) {
+    _trackScreenView(newRoute?.settings.name);
+  }
+
+  void _trackScreenView(String? name) {
+    if (name != null && name.isNotEmpty) {
+      _measure.trackScreenViewEvent(name: name, userTriggered: false);
+    }
+  }
+}

--- a/flutter/measure_flutter/lib/src/navigation/screen_view_data.dart
+++ b/flutter/measure_flutter/lib/src/navigation/screen_view_data.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../serialization/json_serializable.dart';
+
+part 'screen_view_data.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class ScreenViewData implements JsonSerialized {
+  final String name;
+
+  const ScreenViewData({
+    required this.name,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => _$ScreenViewDataToJson(this);
+
+  factory ScreenViewData.fromJson(Map<String, dynamic> json) =>
+      _$ScreenViewDataFromJson(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ScreenViewData &&
+          runtimeType == other.runtimeType &&
+          name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+}

--- a/flutter/measure_flutter/lib/src/navigation/screen_view_data.g.dart
+++ b/flutter/measure_flutter/lib/src/navigation/screen_view_data.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'screen_view_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ScreenViewData _$ScreenViewDataFromJson(Map<String, dynamic> json) =>
+    ScreenViewData(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$ScreenViewDataToJson(ScreenViewData instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };

--- a/flutter/measure_flutter/test/navigation/navigator_observer_test.dart
+++ b/flutter/measure_flutter/test/navigation/navigator_observer_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/measure.dart';
+
+import '../utils/fake_measure.dart';
+
+void main() {
+  group('MsrNavigatorObserver', () {
+    late FakeMeasure fakeMeasure;
+    late MsrNavigatorObserver observer;
+
+    setUp(() {
+      fakeMeasure = FakeMeasure();
+      observer = MsrNavigatorObserver.withMeasure(fakeMeasure);
+    });
+
+    tearDown(() {
+      fakeMeasure.clear();
+    });
+
+    group('didPush', () {
+      test('should track screen view with route name', () {
+        // Arrange
+        const routeName = '/home';
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: routeName),
+          builder: (context) => Container(),
+        );
+        final previousRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: '/previous'),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPush(route, previousRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 1);
+        expect(fakeMeasure.trackedScreenViews.last.name, routeName);
+        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
+      });
+
+      test('should not track screen view when route name is null', () {
+        // Arrange
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: null),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPush(route, null);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+    });
+
+    group('didPop', () {
+      test('should track screen view with previous route name', () {
+        // Arrange
+        const previousRouteName = '/previous';
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: '/current'),
+          builder: (context) => Container(),
+        );
+        final previousRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: previousRouteName),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPop(route, previousRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 1);
+        expect(fakeMeasure.trackedScreenViews.last.name, previousRouteName);
+        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
+      });
+
+      test('should not track screen view when previous route is null', () {
+        // Arrange
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: '/current'),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPop(route, null);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+
+      test('should not track screen view when previous route is empty', () {
+        // Arrange
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: ''),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPop(route, null);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+
+      test('should not track screen view when previous route name is null', () {
+        // Arrange
+        final route = MaterialPageRoute(
+          settings: const RouteSettings(name: '/current'),
+          builder: (context) => Container(),
+        );
+        final previousRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: null),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didPop(route, previousRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+    });
+
+    group('didReplace', () {
+      test('should track screen view with new route name', () {
+        // Arrange
+        const newRouteName = '/new';
+        final newRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: newRouteName),
+          builder: (context) => Container(),
+        );
+        final oldRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: '/old'),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 1);
+        expect(fakeMeasure.trackedScreenViews.last.name, newRouteName);
+        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
+      });
+
+      test('should not track screen view when new route is null', () {
+        // Arrange
+        final oldRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: '/old'),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didReplace(newRoute: null, oldRoute: oldRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+
+      test('should not track screen view when new route name is null', () {
+        // Arrange
+        final newRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: null),
+          builder: (context) => Container(),
+        );
+        final oldRoute = MaterialPageRoute(
+          settings: const RouteSettings(name: '/old'),
+          builder: (context) => Container(),
+        );
+
+        // Act
+        observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+
+        // Assert
+        expect(fakeMeasure.trackedScreenViews.length, 0);
+      });
+    });
+  });
+}

--- a/flutter/measure_flutter/test/navigation/screen_view_collector_test.dart
+++ b/flutter/measure_flutter/test/navigation/screen_view_collector_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/navigation/navigation_collector.dart';
+
+import '../utils/fake_signal_processor.dart';
+
+void main() {
+  group('NavigationCollector', () {
+    late FakeSignalProcessor fakeSignalProcessor;
+    late NavigationCollector navigationCollector;
+
+    setUp(() {
+      fakeSignalProcessor = FakeSignalProcessor();
+      navigationCollector = NavigationCollector(
+        signalProcessor: fakeSignalProcessor,
+      );
+    });
+
+    group('trackScreenViewEvent', () {
+      test('should track screen view event', () async {
+        // Arrange
+        const screenName = 'HomeScreen';
+        const userTriggered = true;
+
+        // Act
+        await navigationCollector.trackScreenViewEvent(
+          name: screenName,
+          userTriggered: userTriggered,
+        );
+
+        // Assert
+        expect(fakeSignalProcessor.trackedScreenViewEvents.length, equals(1));
+
+        final trackedEvent = fakeSignalProcessor.trackedScreenViewEvents.first;
+        expect(trackedEvent.name, equals(screenName));
+      });
+    });
+  });
+}

--- a/flutter/measure_flutter/test/utils/fake_measure.dart
+++ b/flutter/measure_flutter/test/utils/fake_measure.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:measure_flutter/attribute_value.dart';
+import 'package:measure_flutter/src/measure_interface.dart';
+
+class FakeMeasure implements MeasureApi {
+  final List<ScreenViewCall> trackedScreenViews = [];
+
+  @override
+  Future<void> start(FutureOr<void> Function() action,
+      {bool enableLogging = false}) async {
+    await action();
+  }
+
+  @override
+  void trackEvent(
+      {required String name,
+      Map<String, AttributeValue> attributes = const {},
+      DateTime? timestamp}) {}
+
+  @override
+  Future<void> trackHandledError(Object error, StackTrace stack) async {}
+
+  @override
+  void triggerNativeCrash() {}
+
+  @override
+  void trackScreenViewEvent({required String name, bool userTriggered = true}) {
+    trackedScreenViews.add(ScreenViewCall(name, userTriggered));
+  }
+
+  void clear() {
+    trackedScreenViews.clear();
+  }
+}
+
+class ScreenViewCall {
+  final String name;
+  final bool userTriggered;
+
+  ScreenViewCall(this.name, this.userTriggered);
+}

--- a/flutter/measure_flutter/test/utils/fake_signal_processor.dart
+++ b/flutter/measure_flutter/test/utils/fake_signal_processor.dart
@@ -2,11 +2,13 @@ import 'package:measure_flutter/attribute_value.dart';
 import 'package:measure_flutter/src/events/custom_event_data.dart';
 import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
+import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 import 'package:measure_flutter/src/serialization/json_serializable.dart';
 
 class FakeSignalProcessor implements SignalProcessor {
   final trackedExceptions = <ExceptionData>[];
   final trackedCustomEvents = <CustomEventData>[];
+  final trackedScreenViewEvents = <ScreenViewData>[];
 
   @override
   Future<void> trackEvent<T extends JsonSerialized>({
@@ -22,6 +24,9 @@ class FakeSignalProcessor implements SignalProcessor {
     }
     if (data is CustomEventData) {
       trackedCustomEvents.add(data);
+    }
+    if (data is ScreenViewData) {
+      trackedScreenViewEvents.add(data);
     }
     return Future<void>.value();
   }

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
+// swift-compiler-version: Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface
 import AVKit
 import CoreData
 import CoreMotion

--- a/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol InternalSignalCollector {
     func enable()
     func disable()
+    // swiftlint:disable:next function_parameter_count
     func trackEvent(
         data: inout [String: Any?], type: String, timestamp: Int64, attributes: [String: Any?],
         userDefinedAttrs: [String: AttributeValue], userTriggered: Bool, sessionId: String?, threadName: String?)
@@ -22,7 +23,6 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
     private var isEnabled = AtomicBool(false)
     var isForeground: Bool
 
-    
     init(logger: Logger, signalProcessor: SignalProcessor) {
         self.logger = logger
         self.signalProcessor = signalProcessor
@@ -43,6 +43,7 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
         }
     }
 
+    // swiftlint:disable:next function_parameter_count function_body_length
     func trackEvent(
         data: inout [String: Any?], type: String, timestamp: Int64, attributes: [String: Any?],
         userDefinedAttrs: [String: AttributeValue], userTriggered: Bool, sessionId: String?,
@@ -51,15 +52,24 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
         guard isEnabled.get() else {
             return
         }
-            
+
         let evaluatedAttributes = Attributes()
-        let serializedUserDefinedAttributes = EventSerializer.serializeUserDefinedAttribute(userDefinedAttrs)
-        
+        let serializedUserDefinedAttributes = EventSerializer.serializeUserDefinedAttribute(
+            userDefinedAttrs)
+
         do {
             switch type {
             case EventType.custom.rawValue:
                 let customEventData = try extractCustomEventData(data: data)
-                signalProcessor.track(data: customEventData, timestamp: timestamp, type: EventType.custom, attributes: evaluatedAttributes, sessionId: sessionId, attachments: nil, userDefinedAttributes: serializedUserDefinedAttributes, threadName: threadName)
+                signalProcessor.track(
+                    data: customEventData,
+                    timestamp: timestamp,
+                    type: EventType.custom,
+                    attributes: evaluatedAttributes,
+                    sessionId: sessionId,
+                    attachments: nil,
+                    userDefinedAttributes: serializedUserDefinedAttributes,
+                    threadName: threadName)
             case EventType.exception.rawValue:
                 // adding foreground property to the exception data here
                 // as we don't want to add duplicate logic in Flutter/RN
@@ -67,16 +77,46 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
                 if data.keys.contains("foreground") {
                     data["foreground"] = isForeground
                 } else {
-                    logger.log(level: .debug, message: "invalid exception event, missing foreground property", error: nil, data: nil)
+                    logger.log(
+                        level: .debug,
+                        message: "invalid exception event, missing foreground property",
+                        error: nil,
+                        data: nil)
                 }
                 let exceptionData = try extractExceptionData(data: data)
-                signalProcessor.track(data: exceptionData, timestamp: timestamp, type: EventType.exception, attributes: evaluatedAttributes, sessionId: sessionId, attachments: nil, userDefinedAttributes: serializedUserDefinedAttributes, threadName: threadName)
-                
+                signalProcessor.track(
+                    data: exceptionData,
+                    timestamp: timestamp,
+                    type: EventType.exception,
+                    attributes: evaluatedAttributes,
+                    sessionId: sessionId,
+                    attachments: nil,
+                    userDefinedAttributes: serializedUserDefinedAttributes,
+                    threadName: threadName)
+            case EventType.screenView.rawValue:
+                let screenViewData = try extractScreenViewData(data: data)
+                signalProcessor.track(
+                    data: screenViewData,
+                    timestamp: timestamp,
+                    type: EventType.screenView,
+                    attributes: evaluatedAttributes,
+                    sessionId: sessionId,
+                    attachments: nil,
+                    userDefinedAttributes: serializedUserDefinedAttributes,
+                    threadName: threadName)
             default:
-                logger.log(level: .debug, message: "Unimplemented event type: $type", error: nil, data: nil)
+                logger.log(
+                    level: .debug,
+                    message: "Unimplemented event type: $type",
+                    error: nil,
+                    data: nil)
             }
         } catch {
-            logger.log(level: .error, message: "Error processing event: \(error)", error: error, data: nil)
+            logger.log(
+                level: .error,
+                message: "Error processing event: \(error)",
+                error: error,
+                data: nil)
             return
         }
     }
@@ -85,9 +125,16 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(CustomEventData.self, from: jsonData)
     }
-    
+
     func extractExceptionData(data: [String: Any?]) throws -> Exception {
-        let jsonData = try JSONSerialization.data(withJSONObject: data, options: [.prettyPrinted])
+        let jsonData = try JSONSerialization.data(
+            withJSONObject: data,
+            options: [.prettyPrinted])
         return try JSONDecoder().decode(Exception.self, from: jsonData)
+    }
+
+    func extractScreenViewData(data: [String: Any?]) throws -> ScreenViewData {
+        let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
+        return try JSONDecoder().decode(ScreenViewData.self, from: jsonData)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Event/InternalSignalCollectorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Event/InternalSignalCollectorTests.swift
@@ -26,9 +26,9 @@ final class BaseInternalSignalCollectorTests: XCTestCase {
         )
     }
 
-    func testTrackEvent_withoutPlatformAttribute_logsWarning() {
+    func testTrackEvent_tracksCustomEvent() {
         eventCollector.enable()
-        var eventData: [String: Any?] = ["key": "value"]
+        var eventData: [String: Any?] = ["name": "custom-event"]
         let type = EventType.custom.rawValue
 
         eventCollector.trackEvent(
@@ -42,13 +42,13 @@ final class BaseInternalSignalCollectorTests: XCTestCase {
             threadName: nil
         )
 
-        XCTAssertNil(signalProcessor.data)
+        XCTAssertNotNil(signalProcessor.data)
     }
-
-    func testTrackEvent_tracksCustomEvent() {
+    
+    func testTrackEvent_tracksScreenViewEvent() {
         eventCollector.enable()
-        var eventData: [String: Any?] = ["name": "custom-event"]
-        let type = EventType.custom.rawValue
+        var eventData: [String: Any?] = ["name": "home"]
+        let type = EventType.screenView.rawValue
 
         eventCollector.trackEvent(
             data: &eventData,


### PR DESCRIPTION
# Description

* Expose API to track screen view manually
* Expose `MsrNavgatorObserver` to automatically track screen view events.
* Handle `screen_view` event in Android & iOS `InternalSignalProcessor`.
* Break down `main.dart` in sample app to make it easy to read.
* Add a name (`Measure`) to the logger for easily parsing logs from our SDK.

## Related issue
Closes #2212 


