### PR TITLE
chore(frontend): replace journey with sessions graph in overview

### DIFF
--- a/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
@@ -1,0 +1,157 @@
+import UserJourneys from '@/app/[teamId]/journeys/page'
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+const replaceMock = jest.fn()
+
+// Mock next/navigation hooks
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({
+        replace: replaceMock,
+    }),
+    useSearchParams: () => new URLSearchParams(),
+}))
+
+// Mock API calls and constants
+jest.mock('@/app/api/api_calls', () => ({
+    __esModule: true,
+    FilterSource: { Events: 'events' },
+}))
+
+// Mock Filters component
+jest.mock('@/app/components/filters', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="filters-mock">
+            <button
+                data-testid="update-filters"
+                onClick={() => props.onFiltersChanged({ ready: true, serialisedFilters: 'updated' })}
+            >
+                Update Filters
+            </button>
+        </div>
+    ),
+    AppVersionsInitialSelectionType: { Latest: 'latest' },
+    defaultFilters: { ready: false, serialisedFilters: '' },
+}))
+
+// Mock DebounceTextInput
+jest.mock('@/app/components/debounce_text_input', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <input
+            data-testid="debounce-text-input-mock"
+            value={props.initialValue}
+            onChange={e => props.onChange(e.target.value)}
+        />
+    ),
+}))
+
+// Mock TabSelect
+jest.mock('@/app/components/tab_select', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="tab-select-mock">
+            {props.items.map((item: string) => (
+                <button
+                    key={item}
+                    data-testid={`tab-${item}`}
+                    onClick={() => props.onChangeSelected(item)}
+                >
+                    {item}
+                </button>
+            ))}
+        </div>
+    ),
+}))
+
+// Mock Journey component
+jest.mock('@/app/components/journey', () => ({
+    __esModule: true,
+    JourneyType: { Paths: 'Paths', Exceptions: 'Exceptions' },
+    default: (props: any) => (
+        <div data-testid={`journey-mock-${props.journeyType}`}>{`Journey Rendered: ${props.journeyType}`}</div>
+    ),
+}))
+
+describe('UserJourneys Page', () => {
+    beforeEach(() => {
+        replaceMock.mockClear()
+    })
+
+    it('renders the User Journeys heading and Filters component', () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        expect(screen.getByText('User Journeys')).toBeInTheDocument()
+        expect(screen.getByTestId('filters-mock')).toBeInTheDocument()
+    })
+
+    it('does not render Journey, TabSelect or DebounceTextInput when filters are not ready', () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        expect(screen.queryByTestId('tab-select-mock')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('debounce-text-input-mock')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('journey-mock-Paths')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('journey-mock-Exceptions')).not.toBeInTheDocument()
+    })
+
+    it('renders TabSelect, DebounceTextInput, and Journey (Paths) when filters become ready and updates URL', async () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        const updateButton = screen.getByTestId('update-filters')
+
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+
+        expect(await screen.findByTestId('tab-select-mock')).toBeInTheDocument()
+        expect(await screen.findByTestId('debounce-text-input-mock')).toBeInTheDocument()
+        expect(await screen.findByTestId('journey-mock-Paths')).toBeInTheDocument()
+        expect(replaceMock).toHaveBeenCalledWith('?updated', { scroll: false })
+    })
+
+    it('renders Journey (Exceptions) when Exceptions tab is selected', async () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        const updateButton = screen.getByTestId('update-filters')
+
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+
+        const exceptionsTab = await screen.findByTestId('tab-Exceptions')
+        await act(async () => {
+            fireEvent.click(exceptionsTab)
+        })
+
+        expect(await screen.findByTestId('journey-mock-Exceptions')).toBeInTheDocument()
+    })
+
+    it('updates searchText when DebounceTextInput changes', async () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        const updateButton = screen.getByTestId('update-filters')
+
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+
+        const input = await screen.findByTestId('debounce-text-input-mock')
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'search term' } })
+        })
+        // No assertion needed, just ensure no crash and input is present
+        expect(input).toBeInTheDocument()
+    })
+
+    it('does not update filters if they remain unchanged', async () => {
+        render(<UserJourneys params={{ teamId: '123' }} />)
+        const updateButton = screen.getByTestId('update-filters')
+
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+        expect(replaceMock).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+        expect(replaceMock).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/dashboard/__tests__/pages/overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/overview_test.tsx
@@ -36,13 +36,12 @@ jest.mock('@/app/components/filters', () => ({
     defaultFilters: { ready: false, serialisedFilters: '' }, // Mock defaultFilters
 }))
 
-// Mock Journey component
-jest.mock('@/app/components/journey', () => ({
+// Mock SessionsVsExceptionsOverviewPlot component
+jest.mock('@/app/components/sessions_vs_exceptions_overview_plot', () => ({
     __esModule: true, // Ensures the mock behaves like an ES module
     default: () => (
-        <div data-testid="journey-mock">Journey Component Rendered</div>
+        <div data-testid="sessions-vs-exceptions-overview-plot-mock">SessionsVsExceptionsOverviewPlot Component Rendered</div>
     ),
-    JourneyType: { Overview: 'overview' }, // Mock the JourneyType enum
 }))
 
 // Mock MetricsOverview component
@@ -75,7 +74,7 @@ describe('Overview Component', () => {
             fireEvent.click(updateButton)
         })
 
-        expect(await screen.findByTestId('journey-mock')).toBeInTheDocument()
+        expect(await screen.findByTestId('sessions-vs-exceptions-overview-plot-mock')).toBeInTheDocument()
         expect(await screen.findByTestId('metrics-overview-mock')).toBeInTheDocument()
         expect(replaceMock).toHaveBeenCalledWith('?updated', { scroll: false })
     })

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -39,6 +39,12 @@ const initNavData = {
           url: "sessions",
           isActive: false,
           external: false,
+        },
+        {
+          title: "Journeys",
+          url: "journeys",
+          isActive: false,
+          external: false,
         }
       ],
     },

--- a/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
+++ b/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
@@ -75,7 +75,7 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
           enableArea={true}
           areaOpacity={0.1}
           colors={{ scheme: 'nivo' }}
-          margin={{ top: 40, right: 20, bottom: 140, left: 100 }}
+          margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
           xFormat="time:%Y-%m-%d"
           xScale={{
             format: '%Y-%m-%d',
@@ -121,6 +121,8 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
           }}
           pointLabelYOffset={-12}
           useMesh={true}
+          enableGridX={false}
+          enableGridY={false}
           enableSlices="x"
           sliceTooltip={({ slice }) => {
             return (

--- a/frontend/dashboard/app/components/debounce_text_input.tsx
+++ b/frontend/dashboard/app/components/debounce_text_input.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import React, { useCallback, useEffect, useState } from 'react'
+import { cn } from '../utils/shadcn_utils'
 
 interface DebounceTextInputProps {
+  className?: string
   id: string
   placeholder: string
   initialValue: string
@@ -10,6 +12,7 @@ interface DebounceTextInputProps {
 }
 
 const DebounceTextInput: React.FC<DebounceTextInputProps> = ({
+  className,
   id,
   placeholder,
   initialValue,
@@ -42,7 +45,7 @@ const DebounceTextInput: React.FC<DebounceTextInputProps> = ({
       id={id}
       type="text"
       placeholder={placeholder}
-      className="w-full font-body border border-black rounded-md p-2 text-sm transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] placeholder:text-neutral-400"
+      className={cn("w-full font-body border border-black rounded-md p-2 text-sm transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] placeholder:text-neutral-400", className)}
       value={inputValue}
       onChange={handleInputChange}
     />

--- a/frontend/dashboard/app/components/exceptions_details_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_details_plot.tsx
@@ -119,6 +119,8 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ exception
           }}
           pointLabelYOffset={-12}
           useMesh={true}
+          enableGridX={false}
+          enableGridY={false}
           enableSlices="x"
           sliceTooltip={({ slice }) => {
             return (

--- a/frontend/dashboard/app/components/exceptions_distribution_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_distribution_plot.tsx
@@ -102,6 +102,8 @@ const ExceptionsDistributionPlot: React.FC<ExceptionsDistributionPlotProps> = ({
             legendOffset: -50,
             legendPosition: 'middle'
           }}
+          enableGridX={false}
+          enableGridY={false}
           tooltip={({
             id,
             value,

--- a/frontend/dashboard/app/components/exceptions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview_plot.tsx
@@ -88,7 +88,7 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
           enableArea={true}
           areaOpacity={0.1}
           colors={{ scheme: 'nivo' }}
-          margin={{ top: 40, right: 20, bottom: 140, left: 100 }}
+          margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
           xFormat="time:%Y-%m-%d"
           xScale={{
             format: '%Y-%m-%d',
@@ -134,6 +134,8 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
           }}
           pointLabelYOffset={-12}
           useMesh={true}
+          enableGridX={false}
+          enableGridY={false}
           enableSlices="x"
           sliceTooltip={({ slice }) => {
             return (

--- a/frontend/dashboard/app/components/session_timeline.tsx
+++ b/frontend/dashboard/app/components/session_timeline.tsx
@@ -437,6 +437,8 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({ teamId, appId, sessio
                     ]
                   ]
                 }}
+                enableGridX={false}
+                enableGridY={false}
                 tooltip={({ point }) => {
                   if (!memoryDataLookup) return null
 
@@ -511,6 +513,8 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({ teamId, appId, sessio
                     ]
                   ]
                 }}
+                enableGridX={false}
+                enableGridY={false}
                 tooltip={({ point }) => {
                   if (!memoryAbsDataLookup) return null
 
@@ -586,6 +590,8 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({ teamId, appId, sessio
                     ]
                   ]
                 }}
+                enableGridX={false}
+                enableGridY={false}
                 tooltip={({ point }) => {
                   return (
                     <div className='bg-neutral-800 text-white flex flex-col p-2 text-xs rounded-md'>

--- a/frontend/dashboard/app/components/sessions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/sessions_overview_plot.tsx
@@ -75,7 +75,7 @@ const SessionsOverviewPlot: React.FC<SessionsOverviewPlotProps> = ({ filters }) 
           enableArea={true}
           areaOpacity={0.1}
           colors={{ scheme: 'nivo' }}
-          margin={{ top: 40, right: 20, bottom: 140, left: 100 }}
+          margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
           xFormat="time:%Y-%m-%d"
           xScale={{
             format: '%Y-%m-%d',
@@ -121,6 +121,8 @@ const SessionsOverviewPlot: React.FC<SessionsOverviewPlotProps> = ({ filters }) 
           }}
           pointLabelYOffset={-12}
           useMesh={true}
+          enableGridX={false}
+          enableGridY={false}
           enableSlices="x"
           sliceTooltip={({ slice }) => {
             return (

--- a/frontend/dashboard/app/components/sessions_vs_exceptions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/sessions_vs_exceptions_overview_plot.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { ResponsiveLine } from '@nivo/line'
+import React, { useEffect, useState } from 'react'
+import { SessionsVsExceptionsPlotApiStatus, fetchSessionsVsExceptionsPlotFromServer } from '../api/api_calls'
+import { formatDateToHumanReadableDate } from '../utils/time_utils'
+import { Filters } from './filters'
+import LoadingSpinner from './loading_spinner'
+
+interface SessionsVsExceptionsPlotProps {
+  filters: Filters
+}
+
+type SessionsVsExceptionsPlot = {
+  id: string
+  data: {
+    id: string
+    x: string
+    y: number
+  }[]
+}[]
+
+const SessionsVsExceptionsPlot: React.FC<SessionsVsExceptionsPlotProps> = ({ filters }) => {
+  const [sessionsVsExceptionsPlotApiStatus, setSessionsVsExceptionsPlotApiStatus] = useState(SessionsVsExceptionsPlotApiStatus.Loading)
+  const [plot, setPlot] = useState<SessionsVsExceptionsPlot>()
+
+  const colorMap = {
+    Sessions: 'oklch(90.1% 0.058 230.902)',
+    Crashes: 'oklch(80.8% 0.114 19.571)',
+    ANRs: 'oklch(89.2% 0.058 10.001)'
+  } as const;
+  const labelMap = {
+    Sessions: 'Sessions',
+    Crashes: 'Crashes',
+    ANRs: 'ANRs'
+  } as const;
+
+  const getSessionsVsExceptionsPlot = async () => {
+    // Don't try to fetch plot if filters aren't ready
+    if (!filters.ready) {
+      return
+    }
+
+    setSessionsVsExceptionsPlotApiStatus(SessionsVsExceptionsPlotApiStatus.Loading)
+
+    const result = await fetchSessionsVsExceptionsPlotFromServer(filters)
+
+    switch (result.status) {
+      case SessionsVsExceptionsPlotApiStatus.Error:
+        setSessionsVsExceptionsPlotApiStatus(SessionsVsExceptionsPlotApiStatus.Error)
+        break
+      case SessionsVsExceptionsPlotApiStatus.NoData:
+        setSessionsVsExceptionsPlotApiStatus(SessionsVsExceptionsPlotApiStatus.NoData)
+        setPlot(undefined)
+        break
+      case SessionsVsExceptionsPlotApiStatus.Success:
+        setSessionsVsExceptionsPlotApiStatus(SessionsVsExceptionsPlotApiStatus.Success)
+        setPlot(result.data ?? undefined)
+        break
+    }
+  }
+
+  useEffect(() => {
+    getSessionsVsExceptionsPlot()
+  }, [filters])
+
+  return (
+    <div className="flex font-body items-center justify-center w-full h-[24rem]">
+      {sessionsVsExceptionsPlotApiStatus === SessionsVsExceptionsPlotApiStatus.Loading && <LoadingSpinner />}
+      {sessionsVsExceptionsPlotApiStatus === SessionsVsExceptionsPlotApiStatus.Error && <p className="text-lg font-display text-center p-4">Error fetching plot, please change filters or refresh page to try again</p>}
+      {sessionsVsExceptionsPlotApiStatus === SessionsVsExceptionsPlotApiStatus.NoData && <p className="text-lg font-display text-center p-4">No Data</p>}
+      {sessionsVsExceptionsPlotApiStatus === SessionsVsExceptionsPlotApiStatus.Success &&
+        <ResponsiveLine
+          data={plot!}
+          curve="monotoneX"
+          enableArea={true}
+          areaOpacity={0.1}
+          colors={({ id }) => colorMap[id as keyof typeof colorMap] || '#888'}
+          margin={{ top: 40, right: 40, bottom: 80, left: 40 }}
+          xFormat="time:%Y-%m-%d"
+          xScale={{
+            format: '%Y-%m-%d',
+            precision: 'day',
+            type: 'time',
+            useUTC: false
+          }}
+          yScale={{
+            type: 'linear',
+            min: 0,
+            max: 'auto'
+          }}
+          yFormat="d"
+          axisTop={null}
+          axisRight={null}
+          axisBottom={{
+            tickPadding: 20,
+            format: '%b %d, %Y',
+            legendPosition: 'middle'
+          }}
+          axisLeft={{
+            tickSize: 1,
+            tickPadding: 5,
+            format: value => Number.isInteger(value) ? value : '',
+          }}
+          pointSize={6}
+          pointBorderWidth={1.5}
+          pointColor={"rgba(255, 255, 255, 255)"}
+          pointBorderColor={({ serieId }: { serieId: string }) => colorMap[serieId as keyof typeof colorMap] || '#888'}
+          pointLabelYOffset={-12}
+          useMesh={true}
+          enableGridX={false}
+          enableGridY={false}
+          enableSlices="x"
+          sliceTooltip={({ slice }) => {
+            const order = ['Sessions', 'Crashes', 'ANRs'] as const;
+            const pointsById: Record<string, typeof slice.points[number]> = Object.fromEntries(slice.points.map(p => [p.serieId, p]));
+            return (
+              <div className="bg-neutral-800 text-white flex flex-col p-2 text-xs rounded-md">
+                <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                {order.map((key) => {
+                  const point = pointsById[key];
+                  if (!point) return null;
+                  return (
+                    <div className="flex flex-row items-center p-2" key={point.id}>
+                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: colorMap[key] }} />
+                      <div className="px-2" />
+                      <p>{labelMap[key]} - </p>
+                      <div className="px-2" />
+                      <p>{point.data.yFormatted} {labelMap[key]}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          }}
+        />}
+    </div>
+  )
+
+}
+
+export default SessionsVsExceptionsPlot

--- a/frontend/dashboard/app/components/span_metrics_plot.tsx
+++ b/frontend/dashboard/app/components/span_metrics_plot.tsx
@@ -123,7 +123,7 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
             enableArea={true}
             areaOpacity={0.1}
             colors={{ scheme: 'nivo' }}
-            margin={{ top: 20, right: 20, bottom: 140, left: 100 }}
+            margin={{ top: 20, right: 40, bottom: 140, left: 100 }}
             xFormat="time:%Y-%m-%d"
             xScale={{
               format: '%Y-%m-%d',
@@ -168,6 +168,8 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
             }}
             pointLabelYOffset={-12}
             useMesh={true}
+            enableGridX={false}
+            enableGridY={false}
             enableSlices="x"
             sliceTooltip={({ slice }) => {
               return (


### PR DESCRIPTION
# Description

- replaces journey with session vs exceptions graph in overview
- adds a journeys page with journeys
- adds paths and exceptions variants for journeys
- adds journey node search. This allows users to filter nodes. Only nodes matching search text or connecting to matched nodes are displayed.
- removes grids from all graphs

## Related issue
Closes #2202



