### PR TITLE
fix(ios): make session id API public

### DIFF
--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -248,6 +248,7 @@ extension SwiftUICore.View {
 @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc final public class Measure : ObjectiveC.NSObject {
   @objc public static let shared: Measure.Measure
   @objc final public func initialize(with client: Measure.ClientInfo, config: Measure.BaseMeasureConfig? = nil)
+  @objc final public func getSessionId() -> Swift.String?
   @objc final public func start()
   @objc final public func stop()
   final public func trackEvent(name: Swift.String, attributes: [Swift.String : Measure.AttributeValue], timestamp: Swift.Int64?)

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -98,7 +98,7 @@ import UIKit
     /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
     /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
     /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
-    @objc func getSessionId() -> String? {
+    @objc public func getSessionId() -> String? {
         guard let sessionId = measureInternal?.sessionManager.sessionId else { return nil }
 
         return sessionId


### PR DESCRIPTION
# Description

The `getSessionId` function was intended to be public, but was incorrectly left internal. This PR fixes the issue.

## Related issue
References #1635



