### PR TITLE
refactor(ios): update public api interface

### DIFF
--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -39,7 +39,7 @@ Measure.init(
 
 #### iOS
 
-For Android, options can be set in the `BaseMeasureConfig` object which is passed to the `Measure.shared.initialize`
+For Android, options can be set in the `BaseMeasureConfig` object which is passed to the `Measure.initialize`
 method. Example:
 
 ```swift
@@ -52,7 +52,7 @@ let config = BaseMeasureConfig(enableLogging: true,
                                httpUrlAllowlist: ["api.example.com"],
                                autoStart: true,
                                trackViewControllerLoadTime: true)
-Measure.shared.initialize(with: clientInfo, config: config)
+Measure.initialize(with: clientInfo, config: config)
 ```
 
 ## Configuration Options

--- a/docs/features/feature-bug-report-ios.md
+++ b/docs/features/feature-bug-report-ios.md
@@ -15,7 +15,7 @@ Additionally, the SDK supports using shake gestures to launch the bug reporting 
 
 ## Built-in Experience
 
-Launch the default bug report interface using `Measure.shared.launchBugReport`. A screenshot can be automatically taken and added to the bug report. Users can remove or add more attachments in the UI.
+Launch the default bug report interface using `Measure.launchBugReport`. A screenshot can be automatically taken and added to the bug report. Users can remove or add more attachments in the UI.
 
 | Dark Mode                                    | Light Mode                                     |
 |----------------------------------------------|------------------------------------------------|
@@ -28,13 +28,13 @@ When the screenshot button is clicked, a floating screenshot and exit button app
 ### Example Usage
 
 ```swift
-Measure.shared.launchBugReport(takeScreenshot: true)
+Measure.launchBugReport(takeScreenshot: true)
 ```
 
 To disable taking a screenshot when launching, set `takeScreenshot: false`:
 
 ```swift
-Measure.shared.launchBugReport(takeScreenshot: false)
+Measure.launchBugReport(takeScreenshot: false)
 ```
 
 You can also pass a custom UI config and attributes:
@@ -43,7 +43,7 @@ You can also pass a custom UI config and attributes:
 let color = BugReportConfig.default.colors.update(isDarkMode: false)
 let config = BugReportConfig(colors: color)
 let attributes: [String: AttributeValue] = ["user_id": .string("12345")]
-Measure.shared.launchBugReport(takeScreenshot: true, bugReportConfig: config, attributes: attributes)
+Measure.launchBugReport(takeScreenshot: true, bugReportConfig: config, attributes: attributes)
 ```
 
 Currently, you can have a maximum of 5 attachments and a description length of 4000 characters.
@@ -62,7 +62,7 @@ let dimensions = MsrDimensions(
     topPadding: 20
 )
 let config = BugReportConfig(colors: color, dimensions: dimensions)
-Measure.shared.launchBugReport(takeScreenshot: true, bugReportConfig: config)
+Measure.launchBugReport(takeScreenshot: true, bugReportConfig: config)
 ```
 
 ## Custom Experience
@@ -72,9 +72,9 @@ You can build a custom bug reporting UI and use the SDK to track bug reports pro
 ### Example Usage
 
 ```swift
-let screenshot = Measure.shared.captureScreenshot(for: viewController)
-let layoutSnapshot = Measure.shared.captureLayoutSnapshot(from: viewController)
-Measure.shared.trackBugReport(
+let screenshot = Measure.captureScreenshot(for: viewController)
+let layoutSnapshot = Measure.captureLayoutSnapshot(from: viewController)
+Measure.trackBugReport(
     description: "Items from cart disappear after reopening the app",
     attachments: [screenshot, layoutSnapshot].compactMap { $0 },
     attributes: ["is_premium": .bool(true)]
@@ -88,14 +88,14 @@ Bug reports can include up to 5 attachments (screenshots or layout snapshots).
 ### Example Usage
 
 ```swift
-if let screenshot = Measure.shared.captureScreenshot(for: viewController) {
-    Measure.shared.trackBugReport(description: "Bug description", attachments: [screenshot], attributes: nil)
+if let screenshot = Measure.captureScreenshot(for: viewController) {
+    Measure.trackBugReport(description: "Bug description", attachments: [screenshot], attributes: nil)
 }
 ```
 
 ```swift
-if let snapshot = Measure.shared.captureLayoutSnapshot(from: viewController) {
-    Measure.shared.trackBugReport(description: "Bug description", attachments: [snapshot], attributes: nil)
+if let snapshot = Measure.captureLayoutSnapshot(from: viewController) {
+    Measure.trackBugReport(description: "Bug description", attachments: [snapshot], attributes: nil)
 }
 ```
 
@@ -110,13 +110,13 @@ let attributes: [String: AttributeValue] = [
     "is_premium_user": .bool(true),
     "user_id": .string("12345")
 ]
-Measure.shared.launchBugReport(attributes: attributes)
+Measure.launchBugReport(attributes: attributes)
 ```
 
 Or with custom bug reports:
 
 ```swift
-Measure.shared.trackBugReport(description: "Bug description", attachments: [], attributes: attributes)
+Measure.trackBugReport(description: "Bug description", attachments: [], attributes: attributes)
 ```
 
 ## Shake to Report Bug
@@ -126,24 +126,24 @@ Enable shake-to-report to allow users to launch the bug reporting flow by shakin
 ### Enable Shake to Launch
 
 ```swift
-Measure.shared.enableShakeToLaunchBugReport(takeScreenshot: true)
+Measure.enableShakeToLaunchBugReport(takeScreenshot: true)
 ```
 
 ### Disable Shake to Launch
 
 ```swift
-Measure.shared.disableShakeToLaunchBugReport()
+Measure.disableShakeToLaunchBugReport()
 ```
 
 ### Check if Shake-to-Launch is Enabled
 
 ```swift
-let enabled = Measure.shared.isShakeToLaunchBugReportEnabled()
+let enabled = Measure.isShakeToLaunchBugReportEnabled()
 ```
 
 ### Manually Handle Shake Gestures
 
 ```swift
-Measure.shared.setShakeListener(MyShakeListener())
+Measure.setShakeListener(MyShakeListener())
 // Implement MsrShakeListener protocol in MyShakeListener```
 ```

--- a/docs/features/feature-custom-events.md
+++ b/docs/features/feature-custom-events.md
@@ -36,13 +36,13 @@ Measure.trackEvent("event_name")
 Using Swift:
 
 ```swift
-Measure.shared.trackEvent(name: "event_name")
+Measure.trackEvent(name: "event_name")
 ```
 
 Using ObjC:
 
 ```objc
-[[Measure shared] trackEvent:@"event_name"];
+[Measure trackEvent:@"event_name"];
 ```
 
 ### Custom Event Attributes
@@ -68,13 +68,13 @@ Measure.trackEvent("event_name", attributes = attributes)
 Using Swift:
 
 ```swift
-Measure.shared.trackEvent(name: "event_name", attributes: ["is_premium_user": .bool(true)])
+Measure.trackEvent(name: "event_name", attributes: ["is_premium_user": .bool(true)])
 ```
 
 Using ObjC:
 
 ```objc
-[[Measure shared] trackEvent:@"event_name" attributes:@{@"is_premium_user": YES}];
+[Measure trackEvent:@"event_name" attributes:@{@"is_premium_user": YES}];
 ```
 
 ### Custom Event with Timestamp
@@ -92,11 +92,11 @@ Measure.trackEvent("event_name", timestamp = 1734443973879L)
 Using Swift:
 
 ```swift
-Measure.shared.trackEvent(name: "event_name", timestamp: 1734443973879)
+Measure.trackEvent(name: "event_name", timestamp: 1734443973879)
 ```
 
 Using ObjC:
 
 ```objc
-[[Measure shared] trackEvent:@"event_name" timestamp:1734443973879];
+[Measure trackEvent:@"event_name" timestamp:1734443973879];
 ```

--- a/docs/features/feature-identify-users.md
+++ b/docs/features/feature-identify-users.md
@@ -30,11 +30,11 @@ Measure.clearUserId()
 To set a user ID.
 
 ```swift
-Measure.shared.setUserId("user-id")
+Measure.setUserId("user-id")
 ```
 
 To clear a user ID.
 
 ```swift
-Measure.shared.clearUserId()
+Measure.clearUserId()
 ```

--- a/docs/features/feature-manually-start-stop-sdk.md
+++ b/docs/features/feature-manually-start-stop-sdk.md
@@ -32,11 +32,11 @@ Measure.stop()
 ```swift
 let config = BaseMeasureConfig(autoStart: false) // delay starting of collection
 let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
-Measure.shared.initialize(with: clientInfo, config: config)
+Measure.initialize(with: clientInfo, config: config)
 
 // Start collecting
-Measure.shared.start()
+Measure.start()
 
 // Stop collecting
-Measure.shared.stop()
+Measure.stop()
 ```

--- a/docs/features/feature-navigation-lifecycle-tracking.md
+++ b/docs/features/feature-navigation-lifecycle-tracking.md
@@ -148,13 +148,13 @@ Measure.trackScreenView("Screen Name")
 Using Swift:
 
 ```swift
-Measure.shared.trackScreenView("Home")
+Measure.trackScreenView("Home")
 ```
 
 Using ObjC:
 
 ```objc
-[[Measure shared] trackScreenView:@"Home"];
+[Measure trackScreenView:@"Home"];
 ```
 
 ## Data collected

--- a/docs/features/feature-performance-tracing.md
+++ b/docs/features/feature-performance-tracing.md
@@ -60,13 +60,13 @@ try {
     <summary>iOS</summary>
 
 ```swift
-let onboardingSpan: Span = Measure.shared.startSpan(name: "onboarding-flow")
+let onboardingSpan: Span = Measure.startSpan(name: "onboarding-flow")
 do {
-    let signupSpan = Measure.shared.startSpan("signup").setParent(parentSpan)
+    let signupSpan = Measure.startSpan("signup").setParent(parentSpan)
     userSignup()
     signupSpan.end()
 
-    let tutorialSpan = Measure.shared.startSpan("tutorial").setParent(parentSpan)
+    let tutorialSpan = Measure.startSpan("tutorial").setParent(parentSpan)
     showTutorial()
     tutorialSpan.end(status: .ok)
 } catch {
@@ -127,7 +127,7 @@ val span: Span = Measure.startSpan("span-name")
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 ```
 
 </details>
@@ -154,7 +154,7 @@ val span: Span = Measure.startSpan("span-name", timestamp = Measure.getTimestamp
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "operation-name", timestamp: Measure.shared.getCurrentTime())
+let span: Span = Measure.startSpan(name: "operation-name", timestamp: Measure.getCurrentTime())
 ```
 
 </details>
@@ -177,7 +177,7 @@ span.end(Status.Ok)
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 span.setStatus(.ok).end()
 ```
 
@@ -208,8 +208,8 @@ span.end(Status.Ok, timestamp = Measure.getTimestamp())
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
-span.setStatus(.ok).end(timestamp: Measure.shared.getCurrentTime())
+let span: Span = Measure.startSpan(name: "span-name")
+span.setStatus(.ok).end(timestamp: Measure.getCurrentTime())
 ```
 
 </details>
@@ -232,8 +232,8 @@ val childSpan: Span = Measure.startSpan("child-span").setParent(parentSpan)
   <summary>iOS</summary>
 
 ```swift
-let parentSpan: Span = Measure.shared.startSpan(name: "parent-span")
-let childSpan: Span = Measure.shared.startSpan(name: "child-span").setParent(parentSpan)
+let parentSpan: Span = Measure.startSpan(name: "parent-span")
+let childSpan: Span = Measure.startSpan(name: "child-span").setParent(parentSpan)
 ```
 
 </details>
@@ -258,7 +258,7 @@ span.setAttribute("key", "value")
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 span.setAttribute("key", "value")
 ```
 
@@ -281,7 +281,7 @@ span.setAttributes(attributes)
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 let attributes: [String: AttributeValue] = ["key": "value", "key2": 42]
 span.setAttributes(attributes)
 ```
@@ -306,7 +306,7 @@ span.removeAttribute("key")
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 span.removeAttribute("key")
 ```
 
@@ -330,7 +330,7 @@ span.setName("updated-name").end()
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name")
+let span: Span = Measure.startSpan(name: "span-name")
 span.setName("updated-name").end()
 ```
 
@@ -353,7 +353,7 @@ val span: Span = Measure.startSpan("span-name").setCheckpoint("checkpoint-name")
   <summary>iOS</summary>
 
 ```swift
-let span: Span = Measure.shared.startSpan(name: "span-name").setCheckpoint("checkpoint-name")
+let span: Span = Measure.startSpan(name: "span-name").setCheckpoint("checkpoint-name")
 ```
 
 </details>
@@ -377,7 +377,7 @@ val span: Span = spanBuilder.startSpan()
   <summary>iOS</summary>
 
 ```swift
-let spanBuilder: SpanBuilder = Measure.shared.createSpanBuilder(name: "span-name")!
+let spanBuilder: SpanBuilder = Measure.createSpanBuilder(name: "span-name")!
 let span: Span = spanBuilder.startSpan()
 ```
 
@@ -425,9 +425,9 @@ val value = Measure.getTraceParentHeaderValue(span)
     <summary>iOS</summary>
 
 ```swift
-let span = Measure.shared.startSpan(name: "http")
-let key = Measure.shared.getTraceParentHeaderKey()
-let value = Measure.shared.getTraceParentHeaderValue(span: span)
+let span = Measure.startSpan(name: "http")
+let key = Measure.getTraceParentHeaderKey()
+let value = Measure.getTraceParentHeaderValue(span: span)
 ```
 
 </details>
@@ -479,11 +479,11 @@ val okHttpClient = OkHttpClient.Builder()
 // Create a URLSession interceptor to handle tracing
 class TracingInterceptor: NSObject, URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
-        let span = Measure.shared.startSpan(name: "http")
+        let span = Measure.startSpan(name: "http")
         var tracedRequest = request
         tracedRequest.addValue(
-            Measure.shared.getTraceParentHeaderValue(span: span),
-            forHTTPHeaderField: Measure.shared.getTraceParentHeaderKey()
+            Measure.getTraceParentHeaderValue(span: span),
+            forHTTPHeaderField: Measure.getTraceParentHeaderKey()
         )
         completionHandler(tracedRequest)
         span.setStatus(.ok).end()

--- a/docs/features/feature-session-monitoring.md
+++ b/docs/features/feature-session-monitoring.md
@@ -43,11 +43,11 @@ val sessionId = Measure.getSessionId()
 Using Swift:
 
 ```swift
-let sessionId = Measure.shared.getSessionId()
+let sessionId = Measure.getSessionId()
 ```
 
 or, in Objective-C:
 
 ```objc
-NSString *sessionId = [[Measure shared] getSessionId];
+NSString *sessionId = [Measure getSessionId];
 ```

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -295,7 +295,7 @@ func application(_ application: UIApplication,
         samplingRateForErrorFreeSessions: 1
     )
     let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
-    Measure.shared.initialize(with: clientInfo, config: config)
+    Measure.initialize(with: clientInfo, config: config)
     return true
 }
 ```
@@ -307,7 +307,7 @@ func application(_ application: UIApplication,
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
   ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
-  [[Measure shared] initializeWith:clientInfo config:config];
+  [Measure initializeWith:clientInfo config:config];
   return YES;
   }
 
@@ -350,7 +350,7 @@ let config = BaseMeasureConfig(
     // useful to verify the installation
     samplingRateForErrorFreeSessions: 1
 )
-Measure.shared.initialize(with: clientInfo, config: config)
+Measure.initialize(with: clientInfo, config: config)
 ```
 
 </details>
@@ -380,7 +380,7 @@ Verify the API URL and API key are set correctly in the `ClientInfo` object when
 ```swift
 let config = BaseMeasureConfig()
 let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
-Measure.shared.initialize(with: clientInfo, config: config)
+Measure.initialize(with: clientInfo, config: config)
 ```
 
 </details>
@@ -428,7 +428,7 @@ Enable logging during SDK initialization.
 
 ```swift
 let config = BaseMeasureConfig(enableLogging: true)
-Measure.shared.initialize(with: clientInfo, config: config)
+Measure.initialize(with: clientInfo, config: config)
 ```
 
 </details>

--- a/flutter/example/ios/Runner/AppDelegate.swift
+++ b/flutter/example/ios/Runner/AppDelegate.swift
@@ -29,7 +29,7 @@ import Measure
     )
     #endif
 
-    Measure.shared.initialize(with: clientInfo, config: config)
+    Measure.initialize(with: clientInfo, config: config)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
@@ -62,7 +62,7 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
         userTriggered: Bool,
         sessionId: String?,
         threadName: String?) {
-        Measure.shared.internalTrackEvent(
+        Measure.internalTrackEvent(
             data: &data,
             type: type,
             timestamp: timestamp,
@@ -90,7 +90,7 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
         let jsonClientInfo = try JSONSerialization.data(withJSONObject: argClientInfo, options: [])
         let clientInfo = try JSONDecoder().decode(ClientInfo.self, from: jsonClientInfo)
 
-        Measure.shared.initialize(with: clientInfo, config: config)
+        Measure.initialize(with: clientInfo, config: config)
         result(nil)
     }
 }

--- a/ios/DemoApp/AppDelegate.swift
+++ b/ios/DemoApp/AppDelegate.swift
@@ -10,7 +10,6 @@ import Measure
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var measureInstance = Measure.shared
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -22,9 +21,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                        autoStart: true,
                                        trackViewControllerLoadTime: true,
                                        screenshotMaskLevel: .sensitiveFieldsOnly)
-        measureInstance.initialize(with: clientInfo, config: config)
-        measureInstance.setUserId("test_user_ios")
-        measureInstance.enableShakeToLaunchBugReport(takeScreenshot: true)
+        Measure.initialize(with: clientInfo, config: config)
+        Measure.setUserId("test_user_ios")
+        Measure.enableShakeToLaunchBugReport(takeScreenshot: true)
 
         return true
     }

--- a/ios/DemoApp/Controller/ControlsViewController.swift
+++ b/ios/DemoApp/Controller/ControlsViewController.swift
@@ -16,7 +16,7 @@ class ControlsViewController: UIViewController {
 
         // Add target for UISegmentedControl when value changes
         segmentControl.addTarget(self, action: #selector(segmentControlValueChanged(_:)), for: .valueChanged)
-        Measure.shared.stop()
+        Measure.stop()
     }
 
     // Show alert when UISegmentedControl value changes

--- a/ios/DemoApp/Controller/ObjcDetailViewController.m
+++ b/ios/DemoApp/Controller/ObjcDetailViewController.m
@@ -49,13 +49,13 @@
         @"paid_user": @YES,
         @"credit_balance": @1000,
         @"latitude": @30.2661403415387};
-    [[Measure shared] start];
-    [[Measure shared] trackEvent:@"event-name" attributes:userAttributes timestamp:nil];
+    [Measure start];
+    [Measure trackEvent:@"event-name" attributes:userAttributes timestamp:nil];
     
     [self setTitle:@"Objc View Controller"];
     
     [self.view addSubview:tableView];
-    [[Measure shared] trackScreenView:@"ObjcViewController"];
+    [Measure trackScreenView:@"ObjcViewController"];
 }
 
 // MARK: - Create Table Header with Buttons

--- a/ios/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/Controller/ViewController.swift
@@ -58,12 +58,12 @@ import Measure
                                                     "paid_user": .boolean(true),
                                                     "credit_balance": .int(1000),
                                                     "latitude": .double(30.2661403415387)]
-        Measure.shared.trackEvent(name: "custom_event", attributes: attributes, timestamp: nil)
+        Measure.trackEvent(name: "custom_event", attributes: attributes, timestamp: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Measure.shared.trackScreenView("Home")
+        Measure.trackScreenView("Home")
     }
 
     // MARK: - Table Header View with Buttons
@@ -164,7 +164,7 @@ import Measure
                 topPadding: 20
             )
             let config = BugReportConfig(colors: color, dimensions: dimensions)
-            Measure.shared.launchBugReport(takeScreenshot: true, bugReportConfig: config)
+            Measure.launchBugReport(takeScreenshot: true, bugReportConfig: config)
         default:
             let controller = ControlsViewController()
             self.navigationController?.pushViewController(controller, animated: true)

--- a/ios/MeasureDemo/MeasureDemo/AppDelegate/AppDelegate.swift
+++ b/ios/MeasureDemo/MeasureDemo/AppDelegate/AppDelegate.swift
@@ -10,7 +10,7 @@ import MeasureSDK
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var measureInstance = Measure.shared
+    var measureInstance = Measure
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface
+// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -246,34 +246,35 @@ extension SwiftUICore.View {
   
 }
 @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc final public class Measure : ObjectiveC.NSObject {
-  @objc public static let shared: Measure.Measure
-  @objc final public func initialize(with client: Measure.ClientInfo, config: Measure.BaseMeasureConfig? = nil)
-  @objc final public func getSessionId() -> Swift.String?
-  @objc final public func start()
-  @objc final public func stop()
-  final public func trackEvent(name: Swift.String, attributes: [Swift.String : Measure.AttributeValue], timestamp: Swift.Int64?)
-  final public func internalTrackEvent(data: inout [Swift.String : Any?], type: Swift.String, timestamp: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], userTriggered: Swift.Bool, sessionId: Swift.String?, threadName: Swift.String?)
-  @objc final public func trackEvent(_ name: Swift.String, attributes: [Swift.String : Any], timestamp: Foundation.NSNumber?)
-  @objc final public func trackScreenView(_ screenName: Swift.String)
-  @objc final public func setUserId(_ userId: Swift.String)
-  @objc final public func clearUserId()
-  @objc final public func getCurrentTime() -> Swift.Int64
-  final public func startSpan(name: Swift.String) -> any Measure.Span
-  final public func startSpan(name: Swift.String, timestamp: Swift.Int64) -> any Measure.Span
-  final public func createSpanBuilder(name: Swift.String) -> (any Measure.SpanBuilder)?
-  final public func getTraceParentHeaderValue(span: any Measure.Span) -> Swift.String
-  final public func getTraceParentHeaderKey() -> Swift.String
-  final public func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Measure.AttributeValue]? = nil)
-  @objc final public func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Any]? = nil)
-  @objc final public func enableShakeToLaunchBugReport(takeScreenshot: Swift.Bool = true)
-  @objc final public func disableShakeToLaunchBugReport()
-  @objc final public func isShakeToLaunchBugReportEnabled() -> Swift.Bool
-  @objc final public func setShakeListener(_ listener: (any Measure.MsrShakeListener)?)
-  final public func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Measure.AttributeValue]? = nil)
-  @objc final public func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Any]? = nil)
-  @objc final public func captureScreenshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
-  @objc final public func captureLayoutSnapshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
   @objc deinit
+}
+extension Measure.Measure {
+  @objc public static func initialize(with client: Measure.ClientInfo, config: Measure.BaseMeasureConfig? = nil)
+  @objc public static func start()
+  @objc public static func stop()
+  @objc public static func getSessionId() -> Swift.String?
+  public static func internalTrackEvent(data: inout [Swift.String : Any?], type: Swift.String, timestamp: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], userTriggered: Swift.Bool, sessionId: Swift.String?, threadName: Swift.String?)
+  public static func trackEvent(name: Swift.String, attributes: [Swift.String : Measure.AttributeValue], timestamp: Swift.Int64? = nil)
+  @objc public static func trackEvent(_ name: Swift.String, attributes: [Swift.String : Any], timestamp: Foundation.NSNumber? = nil)
+  @objc public static func trackScreenView(_ screenName: Swift.String)
+  @objc public static func setUserId(_ userId: Swift.String)
+  @objc public static func clearUserId()
+  @objc public static func getCurrentTime() -> Swift.Int64
+  public static func startSpan(name: Swift.String) -> any Measure.Span
+  public static func startSpan(name: Swift.String, timestamp: Swift.Int64) -> any Measure.Span
+  public static func createSpanBuilder(name: Swift.String) -> (any Measure.SpanBuilder)?
+  public static func getTraceParentHeaderValue(span: any Measure.Span) -> Swift.String
+  public static func getTraceParentHeaderKey() -> Swift.String
+  public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Measure.AttributeValue]? = nil)
+  @objc public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Any]? = nil)
+  @objc public static func enableShakeToLaunchBugReport(takeScreenshot: Swift.Bool = true)
+  @objc public static func disableShakeToLaunchBugReport()
+  @objc public static func isShakeToLaunchBugReportEnabled() -> Swift.Bool
+  @objc public static func setShakeListener(_ listener: (any Measure.MsrShakeListener)?)
+  public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Measure.AttributeValue]? = nil)
+  @objc public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Any]? = nil)
+  @objc public static func captureScreenshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
+  @objc public static func captureLayoutSnapshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
 }
 @_inheritsConvenienceInitializers @objc(SpanOb) public class SpanOb : CoreData.NSManagedObject {
   @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)

--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
@@ -219,7 +219,7 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
         present(imagePicker, animated: true)
     }
 
-    private func setupConstraints() {
+    private func setupConstraints() { // swiftlint:disable:this function_body_length
         let safeArea = view.safeAreaLayoutGuide
 
         NSLayoutConstraint.activate([

--- a/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
@@ -100,10 +100,10 @@ protocol MeasureConfig {
     ///
     /// When enabled, users can shake their device to launch the bug report activity automatically.
     let enableShakeToLaunchBugReport: Bool
-    
+
     public required init(from decoder: Decoder) throws {
          let container = try decoder.container(keyedBy: CodingKeys.self)
-         
+
          enableLogging = try container.decodeIfPresent(Bool.self, forKey: .enableLogging) ?? DefaultConfig.enableLogging
          samplingRateForErrorFreeSessions = try container.decodeIfPresent(Float.self, forKey: .samplingRateForErrorFreeSessions) ?? DefaultConfig.sessionSamplingRate
          traceSamplingRate = try container.decodeIfPresent(Float.self, forKey: .traceSamplingRate) ?? DefaultConfig.traceSamplingRate
@@ -116,10 +116,10 @@ protocol MeasureConfig {
          trackViewControllerLoadTime = try container.decodeIfPresent(Bool.self, forKey: .trackViewControllerLoadTime) ?? DefaultConfig.trackViewControllerLoadTime
          screenshotMaskLevel = try container.decodeIfPresent(ScreenshotMaskLevel.self, forKey: .screenshotMaskLevel) ?? DefaultConfig.screenshotMaskLevel
          enableShakeToLaunchBugReport = try container.decodeIfPresent(Bool.self, forKey: .enableShakeToLaunchBugReport) ?? DefaultConfig.enableShakeToLaunchBugReport
-         
+
          super.init()
      }
-    
+
     /// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
     /// - Parameters:
     ///   - enableLogging: Enable or disable internal SDK logs. Defaults to `false`.

--- a/ios/Sources/MeasureSDK/Swift/Exception/BinaryImage.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/BinaryImage.swift
@@ -13,7 +13,7 @@ struct BinaryImage: Codable {
 
     /// End address - upper memory boundary of the binary
     let endAddress: String?
-    
+
     /// Base address - The base address for Dart exceptions.
     let baseAddress: String?
 

--- a/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
@@ -22,7 +22,7 @@ struct Exception: Codable {
 
     /// An optional array of all the `BinaryImage` needed for symbolication.
     let binaryImages: [BinaryImage]?
-    
+
     /// Specifies the framework where the exception originated from.
     let framework: String?
 

--- a/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
@@ -69,12 +69,12 @@ final class BaseSvgGenerator: SvgGenerator {
     }
 
     private func svgRect(frame: CGRect, isTarget: Bool) -> String {
-        let x = frame.origin.x.safeInt
-        let y = frame.origin.y.safeInt
+        let originX = frame.origin.x.safeInt
+        let originY = frame.origin.y.safeInt
         let width = frame.width.safeInt
         let height = frame.height.safeInt
         let targetClass = isTarget ? " class=\"target-rect\"" : ""
 
-        return "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(width)\" height=\"\(height)\"\(targetClass)/>"
+        return "<rect x=\"\(originX)\" y=\"\(originY)\" width=\"\(width)\" height=\"\(height)\"\(targetClass)/>"
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/LayoutInspector/LayoutSnapshotGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/LayoutInspector/LayoutSnapshotGenerator.swift
@@ -80,7 +80,7 @@ final class BaseLayoutSnapshotGenerator: LayoutSnapshotGenerator {
                 completion(nil)
                 return
             }
-            
+
             let attachment = attachmentProcessor.getAttachmentObject(
                 for: layoutSnapshot,
                 name: layoutSnapshotName,

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -17,22 +17,7 @@ import UIKit
 /// that exceptions and other events are captured promptly.
 ///
 @objc public final class Measure: NSObject {
-    /// The shared instance of `Measure`.
-    ///
-    /// Use this property to access the singleton instance of the `Measure` class. The shared instance is lazily
-    /// instantiated the first time it is accessed, ensuring that the SDK is initialized only once.
-    ///
-    /// - Example:
-    ///   - Swift:
-    ///   ```swift
-    ///   let clientInfo = ClientInfo(apiKey: "apiKey", apiUrl: "apiUrl")
-    ///   Measure.shared.initialize(with: clientInfo)
-    ///   ```
-    ///   - Objective-C:
-    ///   ```objc
-    ///   [[Measure shared] initializeWith:clientInfo config:config];
-    ///   ```
-    @objc public static let shared: Measure = {
+    @objc static let shared: Measure = {
         let instance = Measure()
         return instance
     }()
@@ -40,37 +25,13 @@ import UIKit
     private var measureLifecycleLock = NSLock()
     private var measureInternal: MeasureInternal?
     var meaureInitializerInternal: MeasureInitializer?
-//    private var floatingButtonController: FloatingButtonController?
 
     // Private initializer to ensure the singleton pattern
     private override init() {
         super.init()
     }
 
-    /// Initializes the Measure SDK. The SDK must be initialized before using any of the other methods.
-    ///
-    /// It is recommended to initialize the SDK as early as possible in the application startup so that exceptions and other events can be captured as early as possible.
-    ///
-    /// An optional `MeasureConfig` can be passed to configure the SDK. If not provided, the SDK will use the default configuration.
-    ///
-    /// Initializing the SDK multiple times will have no effect.
-    /// - Parameter config: The configuration for the Measure SDK.
-    /// - Parameter client: `ClientInfo` object consisting the api-key and api-url
-    ///
-    /// - Example:
-    ///   - Swift:
-    ///   ```swift
-    ///   let config = BaseMeasureConfig()
-    ///   let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
-    ///   Measure.shared.initialize(with: clientInfo, config: config)
-    ///   ```
-    ///   - Objective-C:
-    ///   ```objc
-    ///   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
-    ///   ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
-    ///   [[Measure shared] initializeWith:clientInfo config:config];
-    ///   ```
-    @objc public func initialize(with client: ClientInfo, config: BaseMeasureConfig? = nil) {
+    @objc func initialize(with client: ClientInfo, config: BaseMeasureConfig? = nil) {
         measureInitializerLock.lock()
         defer { measureInitializerLock.unlock() }
 
@@ -93,15 +54,207 @@ import UIKit
         }
     }
 
-    /// Returns the session ID for the current session, or nil if the SDK has not been initialized.
-    ///
-    /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
-    /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
-    /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
-    @objc public func getSessionId() -> String? {
+    @objc func getSessionId() -> String? {
         guard let sessionId = measureInternal?.sessionManager.sessionId else { return nil }
 
         return sessionId
+    }
+
+    @objc func start() {
+        SignPost.trace(subcategory: "MeasureLifecycle", label: "measureStart") {
+            measureLifecycleLock.lock()
+            defer { measureLifecycleLock.unlock() }
+
+            guard let measureInternal = self.measureInternal else { return }
+            measureInternal.start()
+        }
+    }
+
+    @objc func stop() {
+        SignPost.trace(subcategory: "MeasureLifecycle", label: "measureStop") {
+            measureLifecycleLock.lock()
+            defer { measureLifecycleLock.unlock() }
+
+            guard let measureInternal = self.measureInternal else { return }
+            measureInternal.stop()
+        }
+    }
+
+    func trackEvent(name: String, attributes: [String: AttributeValue], timestamp: Int64?) {
+        guard let measureInternal = measureInternal else { return }
+
+        measureInternal.trackEvent(name: name, attributes: attributes, timestamp: timestamp)
+    }
+
+    func internalTrackEvent(data: inout [String: Any?], // swiftlint:disable:this function_parameter_count
+                            type: String,
+                            timestamp: Int64,
+                            attributes: [String: Any?],
+                            userDefinedAttrs: [String: AttributeValue],
+                            userTriggered: Bool,
+                            sessionId: String?,
+                            threadName: String?) {
+        guard let internalEventCollector = measureInternal?.internalSignalCollector else { return }
+        internalEventCollector.trackEvent(data: &data,
+                                          type: type,
+                                          timestamp: timestamp,
+                                          attributes: attributes,
+                                          userDefinedAttrs: userDefinedAttrs,
+                                          userTriggered: userTriggered,
+                                          sessionId: sessionId,
+                                          threadName: threadName)
+    }
+
+    @objc func trackEvent(_ name: String, attributes: [String: Any], timestamp: NSNumber?) {
+        guard let measureInternal = measureInternal else { return }
+
+        measureInternal.trackEvent(name, attributes: attributes, timestamp: timestamp)
+    }
+
+    @objc func trackScreenView(_ screenName: String) {
+        guard let userTriggeredEventCollector = measureInternal?.userTriggeredEventCollector else { return }
+
+        userTriggeredEventCollector.trackScreenView(screenName)
+    }
+
+    @objc func setUserId(_ userId: String) {
+        guard let measureInternal = measureInternal else { return }
+        measureInternal.setUserId(userId)
+    }
+
+    @objc func clearUserId() {
+        guard let measureInternal = measureInternal else { return }
+        measureInternal.clearUserId()
+    }
+
+    @objc func getCurrentTime() -> Int64 {
+        guard let measureInternal = self.measureInternal else { return 0 }
+        return measureInternal.timeProvider.now()
+    }
+
+    func startSpan(name: String) -> Span {
+        guard let measureInternal = self.measureInternal else { return InvalidSpan() }
+        return measureInternal.startSpan(name: name)
+    }
+
+    func startSpan(name: String, timestamp: Int64) -> Span {
+        guard let measureInternal = self.measureInternal else { return InvalidSpan() }
+        return measureInternal.startSpan(name: name, timestamp: timestamp)
+    }
+
+    func createSpanBuilder(name: String) -> SpanBuilder? {
+        guard let measureInternal = self.measureInternal else { return nil }
+        return measureInternal.createSpan(name: name)
+    }
+
+    func getTraceParentHeaderValue(span: Span) -> String {
+        guard let measureInternal = self.measureInternal else { return "" }
+        return measureInternal.getTraceParentHeaderValue(for: span)
+    }
+
+    func getTraceParentHeaderKey() -> String {
+        guard let measureInternal = self.measureInternal else { return "" }
+        return measureInternal.getTraceParentHeaderKey()
+    }
+
+    func launchBugReport(takeScreenshot: Bool = true,
+                         bugReportConfig: BugReportConfig = .default,
+                         attributes: [String: AttributeValue]? = nil) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
+    }
+
+    @objc func launchBugReport(takeScreenshot: Bool = true,
+                               bugReportConfig: BugReportConfig = .default,
+                               attributes: [String: Any]? = nil) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
+    }
+
+    @objc func enableShakeToLaunchBugReport(takeScreenshot: Bool = true) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.enableShakeToLaunchBugReport(takeScreenshot: takeScreenshot)
+    }
+
+    @objc func disableShakeToLaunchBugReport() {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.disableShakeToLaunchBugReport()
+    }
+
+    @objc func isShakeToLaunchBugReportEnabled() -> Bool {
+        guard let measureInternal = self.measureInternal else { return false }
+        return measureInternal.isShakeToLaunchBugReportEnabled()
+    }
+
+    @objc func setShakeListener(_ listener: MsrShakeListener?) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.setShakeListener(listener)
+    }
+
+    func trackBugReport(description: String,
+                        attachments: [MsrAttachment] = [],
+                        attributes: [String: AttributeValue]? = nil) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.trackBugReport(description: description, attachments: attachments, attributes: attributes)
+    }
+
+    @objc func trackBugReport(description: String,
+                              attachments: [MsrAttachment] = [],
+                              attributes: [String: Any]? = nil) {
+        guard let measureInternal = self.measureInternal else { return }
+        measureInternal.trackBugReport(description: description, attachments: attachments, attributes: attributes)
+    }
+
+    @objc func captureScreenshot(for viewController: UIViewController, completion: @escaping (MsrAttachment?) -> Void) {
+        guard let measureInternal = self.measureInternal else {
+            completion(nil)
+            return
+        }
+        measureInternal.captureScreenshot(for: viewController) { msrAttachment in
+            completion(msrAttachment)
+        }
+    }
+
+    @objc func captureLayoutSnapshot(for viewController: UIViewController, completion: @escaping (MsrAttachment?) -> Void) {
+        guard let measureInternal = self.measureInternal else {
+            completion(nil)
+            return
+        }
+
+        measureInternal.captureLayoutSnapshot(for: viewController) { msrAttachment in
+            completion(msrAttachment)
+        }
+    }
+}
+
+// MARK: - Static Convenience API
+
+extension Measure {
+    /// Initializes the Measure SDK. The SDK must be initialized before using any of the other methods.
+    ///
+    /// It is recommended to initialize the SDK as early as possible in the application startup so that exceptions and other events can be captured as early as possible.
+    ///
+    /// An optional `MeasureConfig` can be passed to configure the SDK. If not provided, the SDK will use the default configuration.
+    ///
+    /// Initializing the SDK multiple times will have no effect.
+    /// - Parameter config: The configuration for the Measure SDK.
+    /// - Parameter client: `ClientInfo` object consisting the api-key and api-url
+    ///
+    /// - Example:
+    ///   - Swift:
+    ///   ```swift
+    ///   let config = BaseMeasureConfig()
+    ///   let clientInfo = ClientInfo(apiKey: "<apiKey>", apiUrl: "<apiUrl>")
+    ///   Measure.initialize(with: clientInfo, config: config)
+    ///   ```
+    ///   - Objective-C:
+    ///   ```objc
+    ///   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
+    ///   ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
+    ///   [Measure initializeWith:clientInfo config:config];
+    ///   ```
+    @objc public static func initialize(with client: ClientInfo, config: BaseMeasureConfig? = nil) {
+        Measure.shared.initialize(with: client, config: config)
     }
 
     /// Starts tracking.
@@ -112,20 +265,14 @@ import UIKit
     /// - Example:
     ///   - Swift:
     ///   ```swift
-    ///   Measure.shared.start()
+    ///   Measure.start()
     ///   ```
     ///   - Objective-C:
     ///   ```objc
-    ///   [[Measure shared] start];
+    ///   [Measure start];
     ///   ```
-    @objc public func start() {
-        SignPost.trace(subcategory: "MeasureLifecycle", label: "measureStart") {
-            measureLifecycleLock.lock()
-            defer { measureLifecycleLock.unlock() }
-            
-            guard let measureInternal = self.measureInternal else { return }
-            measureInternal.start()
-        }
+    @objc public static func start() {
+        Measure.shared.start()
     }
 
     /// Stops tracking.
@@ -136,37 +283,23 @@ import UIKit
     /// - Example:
     ///   - Swift:
     ///   ```swift
-    ///   Measure.shared.stop()
+    ///   Measure.stop()
     ///   ```
     ///   - Objective-C:
     ///   ```objc
-    ///   [[Measure shared] stop];
+    ///   [Measure stop];
     ///   ```
-    @objc public func stop() {
-        SignPost.trace(subcategory: "MeasureLifecycle", label: "measureStop") {
-            measureLifecycleLock.lock()
-            defer { measureLifecycleLock.unlock() }
-            
-            guard let measureInternal = self.measureInternal else { return }
-            measureInternal.stop()
-        }
+    @objc public static func stop() {
+        Measure.shared.stop()
     }
 
-    /// Tracks an event with optional timestamp.
-    /// Event names should be clear and consistent to aid in dashboard searches
+    /// Returns the session ID for the current session, or nil if the SDK has not been initialized.
     ///
-    ///   ```swift
-    ///   Measure.shared.trackEvent(name: "event-name", attributes:["user_name": .string("Alice")], timestamp: nil)
-    ///   ```
-    /// - Parameters:
-    ///   - name: Name of the event (max 64 characters)
-    ///   - attributes: Key-value pairs providing additional context
-    ///   - timestamp: Optional timestamp for the event, defaults to current time
-    ///
-    public func trackEvent(name: String, attributes: [String: AttributeValue], timestamp: Int64?) {
-        guard let measureInternal = measureInternal else { return }
-
-        measureInternal.trackEvent(name: name, attributes: attributes, timestamp: timestamp)
+    /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
+    /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
+    /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
+    @objc public static func getSessionId() -> String? {
+        Measure.shared.getSessionId()
     }
 
     /// An internal method to track events from cross-platform frameworks
@@ -194,16 +327,15 @@ import UIKit
     ///     be associated with the current session ID.
     ///   - threadName: Optional thread name associated with the event. By default the event
     ///     will be associated with the thread on which this function is processed.
-    public func internalTrackEvent(data: inout [String: Any?], // swiftlint:disable:this function_parameter_count
-                                   type: String,
-                                   timestamp: Int64,
-                                   attributes: [String: Any?],
-                                   userDefinedAttrs: [String: AttributeValue],
-                                   userTriggered: Bool,
-                                   sessionId: String?,
-                                   threadName: String?) {
-        guard let internalEventCollector = measureInternal?.internalSignalCollector else { return }
-        internalEventCollector.trackEvent(data: &data,
+    public static func internalTrackEvent(data: inout [String: Any?], // swiftlint:disable:this function_parameter_count
+                                          type: String,
+                                          timestamp: Int64,
+                                          attributes: [String: Any?],
+                                          userDefinedAttrs: [String: AttributeValue],
+                                          userTriggered: Bool,
+                                          sessionId: String?,
+                                          threadName: String?) {
+        Measure.shared.internalTrackEvent(data: &data,
                                           type: type,
                                           timestamp: timestamp,
                                           attributes: attributes,
@@ -216,20 +348,33 @@ import UIKit
     /// Tracks an event with optional timestamp.
     /// Event names should be clear and consistent to aid in dashboard searches
     ///
-    /// Note:
-    /// This method is primarily intended for Objective-C use.
-    ///
-    ///   ```objc
-    ///   [[Measure shared] trackEvent:@"event-name" attributes:@{@"user_name": @"Alice"} timestamp:nil];
+    ///   ```swift
+    ///   Measure.trackEvent(name: "event-name", attributes:["user_name": .string("Alice")], timestamp: nil)
     ///   ```
     /// - Parameters:
     ///   - name: Name of the event (max 64 characters)
     ///   - attributes: Key-value pairs providing additional context
     ///   - timestamp: Optional timestamp for the event, defaults to current time
-    @objc public func trackEvent(_ name: String, attributes: [String: Any], timestamp: NSNumber?) {
-        guard let measureInternal = measureInternal else { return }
+    ///
+    public static func trackEvent(name: String, attributes: [String: AttributeValue], timestamp: Int64? = nil) {
+        Measure.shared.trackEvent(name: name, attributes: attributes, timestamp: timestamp)
+    }
 
-        measureInternal.trackEvent(name, attributes: attributes, timestamp: timestamp)
+    /// Tracks an event with optional timestamp.
+    /// Event names should be clear and consistent to aid in dashboard searches
+    ///
+    /// Note:
+    /// This method is primarily intended for Objective-C use.
+    ///
+    ///   ```objc
+    ///   [Measure trackEvent:@"event-name" attributes:@{@"user_name": @"Alice"} timestamp:nil];
+    ///   ```
+    /// - Parameters:
+    ///   - name: Name of the event (max 64 characters)
+    ///   - attributes: Key-value pairs providing additional context
+    ///   - timestamp: Optional timestamp for the event, defaults to current time
+    @objc public static func trackEvent(_ name: String, attributes: [String: Any], timestamp: NSNumber? = nil) {
+        Measure.shared.trackEvent(name, attributes: attributes, timestamp: timestamp)
     }
 
     /// Call when a screen is viewed by the user.
@@ -240,16 +385,14 @@ import UIKit
     ///
     /// Example usage:
     /// ```swift
-    /// Measure.shared.trackScreenView("Home")
+    /// Measure.trackScreenView("Home")
     /// ```
     ///
     /// ```objc
-    /// [[Measure shared] trackScreenView:@"ObjcViewController"]
+    /// [Measure trackScreenView:@"ObjcViewController"]
     /// ```
-    @objc public func trackScreenView(_ screenName: String) {
-        guard let userTriggeredEventCollector = measureInternal?.userTriggeredEventCollector else { return }
-
-        userTriggeredEventCollector.trackScreenView(screenName)
+    @objc public static func trackScreenView(_ screenName: String) {
+        Measure.shared.trackScreenView(screenName)
     }
 
     /// Sets the user ID for the current user.
@@ -262,47 +405,43 @@ import UIKit
     ///
     /// Example usage:
     /// ```swift
-    /// Measure.shared.setUserId("user_id")
+    /// Measure.setUserId("user_id")
     /// ```
     ///
     /// ```objc
-    /// [[Measure shared] setUserId:@"user_id"]
+    /// [Measure setUserId:@"user_id"]
     /// ```
     ///
     /// - Parameter userId: userId string.
-    @objc public func setUserId(_ userId: String) {
-        guard let measureInternal = measureInternal else { return }
-        measureInternal.setUserId(userId)
+    @objc public static func setUserId(_ userId: String) {
+        Measure.shared.setUserId(userId)
     }
 
     /// Clears the user ID, if previously set by `setUserId`.
     ///
     /// Example usage:
     /// ```swift
-    /// Measure.shared.clearUserId()
+    /// Measure.clearUserId()
     /// ```
     ///
     /// ```objc
-    /// [[Measure shared] clearUserId]
+    /// [Measure clearUserId]
     /// ```
-    @objc public func clearUserId() {
-        guard let measureInternal = measureInternal else { return }
-        measureInternal.clearUserId()
+    @objc public static func clearUserId() {
+        Measure.shared.clearUserId()
     }
 
     /// Returns the current time in milliseconds since epoch.
     /// - Returns: The current time in milliseconds since epoch.
-    @objc public func getCurrentTime() -> Int64 {
-        guard let measureInternal = self.measureInternal else { return 0 }
-        return measureInternal.timeProvider.now()
+    @objc public static func getCurrentTime() -> Int64 {
+        Measure.shared.getCurrentTime()
     }
 
     /// Starts a new performance tracing span with the specified name.
     /// - Parameter name: The name to identify this span. Follow the naming convention guide for consistent naming practices.
     /// - Returns: A new span instance if the SDK is initialized, or an invalid no-op span if not initialized
-    public func startSpan(name: String) -> Span {
-        guard let measureInternal = self.measureInternal else { return InvalidSpan() }
-        return measureInternal.startSpan(name: name)
+    public static func startSpan(name: String) -> Span {
+        Measure.shared.startSpan(name: name)
     }
 
     /// Starts a new performance tracing span with the specified name and start timestamp.
@@ -313,9 +452,8 @@ import UIKit
     ///
     /// Note: Use this method when you need to trace an operation that has already started and you have
     /// captured its start time using `getCurrentTime()`.
-    public func startSpan(name: String, timestamp: Int64) -> Span {
-        guard let measureInternal = self.measureInternal else { return InvalidSpan() }
-        return measureInternal.startSpan(name: name, timestamp: timestamp)
+    public static func startSpan(name: String, timestamp: Int64) -> Span {
+        Measure.shared.startSpan(name: name, timestamp: timestamp)
     }
 
     /// Creates a configurable span builder for deferred span creation.
@@ -323,9 +461,8 @@ import UIKit
     /// - Returns: A builder instance to configure the span if the SDK is initialized, or nil if the SDK is not initialized
     ///
     /// Note: Use this method when you need to create a span without immediately starting it.
-    public func createSpanBuilder(name: String) -> SpanBuilder? {
-        guard let measureInternal = self.measureInternal else { return nil }
-        return measureInternal.createSpan(name: name)
+    public static func createSpanBuilder(name: String) -> SpanBuilder? {
+        Measure.shared.createSpanBuilder(name: name)
     }
 
     /// Returns the W3C traceparent header value for the given span.
@@ -336,17 +473,15 @@ import UIKit
     ///
     /// Note: Use this value in the `traceparent` HTTP header when making API calls to enable
     /// distributed tracing between your mobile app and backend services.
-    public func getTraceParentHeaderValue(span: Span) -> String {
-        guard let measureInternal = self.measureInternal else { return "" }
-        return measureInternal.getTraceParentHeaderValue(for: span)
+    public static func getTraceParentHeaderValue(span: Span) -> String {
+        Measure.shared.getTraceParentHeaderValue(span: span)
     }
 
     /// Returns the W3C traceparent header key/name.
     /// - Returns: The standardized header key 'traceparent' that should be used when adding
     /// distributed tracing context to HTTP requests
-    public func getTraceParentHeaderKey() -> String {
-        guard let measureInternal = self.measureInternal else { return "" }
-        return measureInternal.getTraceParentHeaderKey()
+    public static func getTraceParentHeaderKey() -> String {
+        Measure.shared.getTraceParentHeaderKey()
     }
 
     /// Takes a screenshot and launches the bug report flow.
@@ -354,11 +489,12 @@ import UIKit
     ///   - takeScreenshot: Set to `false` to disable the screenshot. Defaults to `true`.
     ///   - bugReportConfig: A configuration object used to customize the appearance and behavior of the bug report UI.
     ///   - attributes: Optional key-value pairs for additional metadata about the bug report.
-    public func launchBugReport(takeScreenshot: Bool = true,
-                                bugReportConfig: BugReportConfig = .default,
-                                attributes: [String: AttributeValue]? = nil) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
+    public static func launchBugReport(takeScreenshot: Bool = true,
+                                       bugReportConfig: BugReportConfig = .default,
+                                       attributes: [String: AttributeValue]? = nil) {
+        Measure.shared.launchBugReport(takeScreenshot: takeScreenshot,
+                                       bugReportConfig: bugReportConfig,
+                                       attributes: attributes)
     }
 
     /// Takes a screenshot and launches the bug report flow.
@@ -370,11 +506,12 @@ import UIKit
     ///   - takeScreenshot: Set to `false` to disable the screenshot. Defaults to `true`.
     ///   - bugReportConfig: A configuration object used to customize the appearance and behavior of the bug report UI.
     ///   - attributes: Optional key-value pairs for additional metadata about the bug report.
-    @objc public func launchBugReport(takeScreenshot: Bool = true,
-                                      bugReportConfig: BugReportConfig = .default,
-                                      attributes: [String: Any]? = nil) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
+    @objc public static func launchBugReport(takeScreenshot: Bool = true,
+                                             bugReportConfig: BugReportConfig = .default,
+                                             attributes: [String: Any]? = nil) {
+        Measure.shared.launchBugReport(takeScreenshot: takeScreenshot,
+                                       bugReportConfig: bugReportConfig,
+                                       attributes: attributes)
     }
 
     /// Enables automatic bug reporting using shake detection.
@@ -382,26 +519,23 @@ import UIKit
     ///
     /// - Parameter takeScreenshot: Set to `true` to include a screenshot with the report (default is `true`).
     /// - SeeAlso: `disableShakeToLaunchBugReport()`
-    @objc public func enableShakeToLaunchBugReport(takeScreenshot: Bool = true) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.enableShakeToLaunchBugReport(takeScreenshot: takeScreenshot)
+    @objc public static func enableShakeToLaunchBugReport(takeScreenshot: Bool = true) {
+        Measure.shared.enableShakeToLaunchBugReport(takeScreenshot: takeScreenshot)
     }
 
     /// Disables automatic bug reporting triggered by shaking the device.
     /// After calling this method, shake gestures will no longer open the bug report screen.
     ///
     /// - SeeAlso: `enableShakeToLaunchBugReport(takeScreenshot:)`
-    @objc public func disableShakeToLaunchBugReport() {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.disableShakeToLaunchBugReport()
+    @objc public static func disableShakeToLaunchBugReport() {
+        Measure.shared.disableShakeToLaunchBugReport()
     }
 
     /// Checks whether the shake-to-launch bug report feature is currently enabled.
     ///
     /// - Returns: `true` if shake detection is active and will launch the bug report UI, otherwise `false`.
-    @objc public func isShakeToLaunchBugReportEnabled() -> Bool {
-        guard let measureInternal = self.measureInternal else { return false }
-        return measureInternal.isShakeToLaunchBugReportEnabled()
+    @objc public static func isShakeToLaunchBugReportEnabled() -> Bool {
+        Measure.shared.isShakeToLaunchBugReportEnabled()
     }
 
     /// Sets a custom shake listener for manually handling shake gestures.
@@ -415,9 +549,8 @@ import UIKit
     /// - Has no effect if automatic shake reporting is already enabled.
     ///
     /// - Parameter listener: A custom `MsrShakeListener` to receive shake callbacks, or `nil` to disable.
-    @objc public func setShakeListener(_ listener: MsrShakeListener?) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.setShakeListener(listener)
+    @objc public static func setShakeListener(_ listener: MsrShakeListener?) {
+        Measure.shared.setShakeListener(listener)
     }
 
     /// Tracks a custom bug report.
@@ -429,11 +562,12 @@ import UIKit
     ///   - description: Description of the bug. Max characters: 4000.
     ///   - attachments: Optional list of attachments. Max: 5.
     ///   - attributes: Optional key-value pairs for additional metadata about the bug report.
-    public func trackBugReport(description: String,
-                               attachments: [MsrAttachment] = [],
-                               attributes: [String: AttributeValue]? = nil) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.trackBugReport(description: description, attachments: attachments, attributes: attributes)
+    public static func trackBugReport(description: String,
+                                      attachments: [MsrAttachment] = [],
+                                      attributes: [String: AttributeValue]? = nil) {
+        Measure.shared.trackBugReport(description: description,
+                                      attachments: attachments,
+                                      attributes: attributes)
     }
 
     /// Tracks a custom bug report
@@ -448,11 +582,12 @@ import UIKit
     ///   - description: Description of the bug. Max characters: 4000.
     ///   - attachments: Optional list of attachments. Max: 5.
     ///   - attributes: Optional key-value pairs for additional metadata about the bug report.
-    @objc public func trackBugReport(description: String,
-                                     attachments: [MsrAttachment] = [],
-                                     attributes: [String: Any]? = nil) {
-        guard let measureInternal = self.measureInternal else { return }
-        measureInternal.trackBugReport(description: description, attachments: attachments, attributes: attributes)
+    @objc public static func trackBugReport(description: String,
+                                            attachments: [MsrAttachment] = [],
+                                            attributes: [String: Any]? = nil) {
+        Measure.shared.trackBugReport(description: description,
+                                      attachments: attachments,
+                                      attributes: attributes)
     }
 
     /// Captures a screenshot of the specified view controller's window.
@@ -465,14 +600,9 @@ import UIKit
     /// - Parameters:
     ///   - viewController: The view controller whose view hierarchy will be captured.
     ///   - completion: A closure that returns an optional `MsrAttachment` containing the redacted screenshot data. Returns `nil` if the capture fails.
-    @objc public func captureScreenshot(for viewController: UIViewController, completion: @escaping (MsrAttachment?) -> Void) {
-        guard let measureInternal = self.measureInternal else {
-            completion(nil)
-            return
-        }
-        measureInternal.captureScreenshot(for: viewController) { msrAttachment in
-            completion(msrAttachment)
-        }
+    @objc public static func captureScreenshot(for viewController: UIViewController,
+                                               completion: @escaping (MsrAttachment?) -> Void) {
+        Measure.shared.captureScreenshot(for: viewController, completion: completion)
     }
 
     /// Asynchronously captures a layout snapshot of the given view controller's view hierarchy.
@@ -487,14 +617,8 @@ import UIKit
     /// - Parameters:
     ///   - viewController: The `UIViewController` whose layout should be captured.
     ///   - completion: A closure called with an optional `MsrAttachment` containing the layout snapshot data.
-    @objc public func captureLayoutSnapshot(for viewController: UIViewController, completion: @escaping (MsrAttachment?) -> Void) {
-        guard let measureInternal = self.measureInternal else {
-            completion(nil)
-            return
-        }
-
-        measureInternal.captureLayoutSnapshot(for: viewController) { msrAttachment in
-            completion(msrAttachment)
-        }
+    @objc public static func captureLayoutSnapshot(for viewController: UIViewController,
+                                                   completion: @escaping (MsrAttachment?) -> Void) {
+        Measure.shared.captureLayoutSnapshot(for: viewController, completion: completion)
     }
-}
+} // swiftlint:disable:this file_length

--- a/ios/Sources/MeasureSDK/Swift/Tracing/Span.swift
+++ b/ios/Sources/MeasureSDK/Swift/Tracing/Span.swift
@@ -16,7 +16,7 @@ import Foundation
 ///
 /// Example:
 /// ```
-/// let span = Measure.shared.startSpan("load_data")
+/// let span = Measure.startSpan("load_data")
 /// do {
 ///     // perform work
 ///     span.setCheckpoint("checkpoint")

--- a/ios/SwiftUIDemo/SwiftUIDemoApp.swift
+++ b/ios/SwiftUIDemo/SwiftUIDemoApp.swift
@@ -15,7 +15,7 @@ struct SwiftUIDemoApp: App {
                                     apiUrl: "http://localhost:8080")
         let config = BaseMeasureConfig(enableLogging: true,
                                        samplingRateForErrorFreeSessions: 1.0)
-        Measure.shared.initialize(with: clientInfo, config: config)
+        Measure.initialize(with: clientInfo, config: config)
     }
 
     var body: some Scene {

--- a/ios/TestApp/AppDelegate.swift
+++ b/ios/TestApp/AppDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    let measureInstance = Measure.shared
     var mockMeasureInitializer: MockMeasureInitializer?
     let labelMessage: UILabel = {
         let lbl = UILabel()
@@ -41,8 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let config = BaseMeasureConfig(enableLogging: true,
                                        samplingRateForErrorFreeSessions: 1.0)
         mockMeasureInitializer = MockMeasureInitializer()
-        measureInstance.meaureInitializerInternal = mockMeasureInitializer
-        measureInstance.initialize(with: clientInfo, config: config)
+        Measure.shared.meaureInitializerInternal = mockMeasureInitializer
+        Measure.initialize(with: clientInfo, config: config)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.addLogLabels()
         }

--- a/ios/Tests/MeasureSDKTests/Config/ClientInfoTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/ClientInfoTests.swift
@@ -9,7 +9,6 @@ import XCTest
 @testable import Measure
 
 final class ClientInfoTests: XCTestCase {
-    
     private let validApiKey = "test-api-key"
     private let validApiUrl = "https://localhost:8080"
     private let invalidApiUrl = "%%%"
@@ -22,9 +21,9 @@ final class ClientInfoTests: XCTestCase {
         }
         """
         let data = json.data(using: .utf8)!
-        
+
         let clientInfo = try JSONDecoder().decode(ClientInfo.self, from: data)
-        
+
         XCTAssertEqual(clientInfo.apiKey, validApiKey)
         XCTAssertEqual(clientInfo.apiUrl.absoluteString, validApiUrl)
     }
@@ -36,7 +35,7 @@ final class ClientInfoTests: XCTestCase {
         }
         """
         let data = json.data(using: .utf8)!
-        
+
         XCTAssertThrowsError(try JSONDecoder().decode(ClientInfo.self, from: data)) { error in
             XCTAssertTrue(error is DecodingError)
         }
@@ -49,7 +48,7 @@ final class ClientInfoTests: XCTestCase {
         }
         """
         let data = json.data(using: .utf8)!
-        
+
         XCTAssertThrowsError(try JSONDecoder().decode(ClientInfo.self, from: data)) { error in
             XCTAssertTrue(error is DecodingError)
         }

--- a/ios/Tests/MeasureSDKTests/CoreData/SessionStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/SessionStoreTests.swift
@@ -78,7 +78,7 @@ final class SessionStoreTests: XCTestCase {
             self.sessionStore.deleteSession("2")
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self.sessionStore.getAllSessions() { sessions in
+                self.sessionStore.getAllSessions { sessions in
                     XCTAssertNil(sessions, "Expected all sessions to be deleted.")
                     expectation.fulfill()
                 }
@@ -118,7 +118,7 @@ final class SessionStoreTests: XCTestCase {
         sessionStore.insertSession(session2)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            self.sessionStore.getOldestSession() { oldestSessionId in
+            self.sessionStore.getOldestSession { oldestSessionId in
                 XCTAssertEqual(oldestSessionId, "1", "Expected session with ID '1' to be the oldest.")
                 expectation.fulfill()
             }

--- a/ios/Tests/MeasureSDKTests/Event/InternalSignalCollectorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Event/InternalSignalCollectorTests.swift
@@ -44,7 +44,7 @@ final class BaseInternalSignalCollectorTests: XCTestCase {
 
         XCTAssertNotNil(signalProcessor.data)
     }
-    
+
     func testTrackEvent_tracksScreenViewEvent() {
         eventCollector.enable()
         var eventData: [String: Any?] = ["name": "home"]
@@ -160,11 +160,11 @@ final class BaseInternalSignalCollectorTests: XCTestCase {
         }
         XCTAssertEqual(data, expectedException)
     }
-    
-    func testTrackEvent_WithUnobfuscatedFlutterException_tracksExceptionEvent() {
+
+    func testTrackEvent_WithUnobfuscatedFlutterException_tracksExceptionEvent() { // swiftlint:disable:this function_body_length
         eventCollector.enable()
         let type = EventType.exception.rawValue
-        
+
         guard var eventData = fileManagerHelper.getExceptionDict(fileName: "flutter_unobfuscated", fileExtension: "json") else {
             XCTFail("Failed to read JSON file from test bundle.")
             return

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMotionManager.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMotionManager.swift
@@ -25,7 +25,7 @@ final class MockMotionManager: MotionManager {
         stopCalled = true
     }
 
-    func simulateAcceleration(x: Double, y: Double, z: Double) {
+    func simulateAcceleration(x: Double, y: Double, z: Double) { // swiftlint:disable:this identifier_name
         guard let handler = capturedHandler else { return }
         let data = TestableAccelerometerData(x: x, y: y, z: z)
         handler(data, nil)
@@ -46,7 +46,7 @@ final class MockShakeListener: ShakeDetectorListener {
 final class TestableAccelerometerData: CMAccelerometerData {
     private let testAcceleration: CMAcceleration
 
-    init(x: Double, y: Double, z: Double) {
+    init(x: Double, y: Double, z: Double) { // swiftlint:disable:this identifier_name
         self.testAcceleration = CMAcceleration(x: x, y: y, z: z)
         super.init()
     }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockScreenshotGenerator.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockScreenshotGenerator.swift
@@ -14,7 +14,7 @@ final class MockScreenshotGenerator: ScreenshotGenerator {
     func generate(window: UIWindow, name: String, storageType: AttachmentStorageType, completion: @escaping (Attachment?) -> Void) {
         completion(attachment)
     }
-    
+
     func generate(viewController: UIViewController, completion: @escaping (Attachment?) -> Void) {
         completion(attachment)
     }


### PR DESCRIPTION
# Description

Currently the iOS public api use a shared singleton pattern, i.e. `Measure.shared.initialize`. This PR updates this public interface to drop shared, like `Measure.initialize` making the public apis more consistent with other platforms.

## Related issue
Closes #2318 