### PR TITLE
feat(flutter): manually start or stop the SDK

### DIFF
--- a/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
+++ b/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
@@ -26,11 +26,11 @@ class SampleApp : Application() {
                 trackActivityIntentData = true,
                 httpUrlBlocklist = listOf("http://localhost:8080"),
                 samplingRateForErrorFreeSessions = 1f,
-                autoStart = true,
+                autoStart = false,
                 traceSamplingRate = 1.0f,
             ),
             clientInfo = ClientInfo(
-                apiUrl = "your-api-url",
+                apiUrl = "http://localhost:8080",
                 apiKey = "msrsh-your-api-key"
             )
         )

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:measure_flutter/measure.dart';
 import 'package:measure_flutter_example/src/screen_main.dart';
@@ -13,12 +12,14 @@ Future<void> main() async {
       trackHttpHeaders: true,
       trackHttpBody: true,
       httpUrlBlocklist: ['http://localhost'],
+      autoStart: false,
     ),
     clientInfo: ClientInfo(
-      apiKey: _getApiKey(kReleaseMode),
+      apiKey: "msrsh-123",
       apiUrl: "https://localhost:8080",
     ),
   );
+  // await Measure.instance.start();
 }
 
 class MyApp extends StatelessWidget {
@@ -30,13 +31,5 @@ class MyApp extends StatelessWidget {
       navigatorObservers: [MsrNavigatorObserver()],
       home: MainScreen(),
     );
-  }
-}
-
-String _getApiKey(bool releaseMode) {
-  if (releaseMode) {
-    return "your-api-key";
-  } else {
-    return "your-api-key";
   }
 }

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -12,14 +12,13 @@ Future<void> main() async {
       trackHttpHeaders: true,
       trackHttpBody: true,
       httpUrlBlocklist: ['http://localhost'],
-      autoStart: false,
+      autoStart: true,
     ),
     clientInfo: ClientInfo(
       apiKey: "msrsh-123",
       apiUrl: "https://localhost:8080",
     ),
   );
-  // await Measure.instance.start();
 }
 
 class MyApp extends StatelessWidget {

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:measure_flutter/measure.dart';
 import 'package:measure_flutter_example/src/screen_main.dart';
 
 Future<void> main() async {
-  await Measure.instance.start(
+  await Measure.instance.init(
     () => runApp(MyApp()),
     config: const MeasureConfig(
       enableLogging: true,

--- a/flutter/example/lib/src/screen_main.dart
+++ b/flutter/example/lib/src/screen_main.dart
@@ -12,8 +12,15 @@ import 'package:stack_trace/stack_trace.dart';
 import 'list_item.dart';
 import 'screen_text_overflow.dart';
 
-class MainScreen extends StatelessWidget {
+class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
+
+  @override
+  State<MainScreen> createState() => _MainScreenState();
+}
+
+class _MainScreenState extends State<MainScreen> {
+  bool _isTrackingEnabled = false;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +30,43 @@ class MainScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Container(
+              decoration: BoxDecoration(
+                color: Colors.purple,
+                borderRadius: BorderRadius.circular(48),
+              ),
+              child: ListTile(
+                title: const Text(
+                  'Enable tracking',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                trailing: Switch(
+                  value: _isTrackingEnabled,
+                  onChanged: (bool value) {
+                    setState(() {
+                      _isTrackingEnabled = value;
+                    });
+                    _onTrackingToggle(_isTrackingEnabled);
+                  },
+                  activeColor: Colors.white,
+                  activeTrackColor: Colors.white30,
+                  inactiveThumbColor: Colors.white70,
+                  inactiveTrackColor: Colors.white12,
+                ),
+                onTap: () {
+                  setState(() {
+                    _isTrackingEnabled = !_isTrackingEnabled;
+                  });
+                  _onTrackingToggle(_isTrackingEnabled);
+                },
+              ),
+            ),
+          ),
           ListSection(title: "Crashes"),
           ListItem(title: "Track custom event", onPressed: _trackCustomEvent),
           ListItem(title: "Throw error", onPressed: _trackError),
@@ -88,6 +132,14 @@ class MainScreen extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  void _onTrackingToggle(bool isEnabled) {
+    if (isEnabled) {
+      Measure.instance.start();
+    } else {
+      Measure.instance.stop();
+    }
   }
 
   void _trackCustomEvent() {

--- a/flutter/example/lib/src/screen_main.dart
+++ b/flutter/example/lib/src/screen_main.dart
@@ -20,7 +20,7 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
-  bool _isTrackingEnabled = false;
+  bool _isTrackingEnabled = true;
 
   @override
   Widget build(BuildContext context) {

--- a/flutter/packages/measure_dio/test/fake_measure.dart
+++ b/flutter/packages/measure_dio/test/fake_measure.dart
@@ -12,7 +12,7 @@ class FakeMeasure implements MeasureApi {
   var _shouldTrackHttpHeader = false;
 
   @override
-  Future<void> start(
+  Future<void> init(
     FutureOr<void> Function() action, {
     required ClientInfo clientInfo,
     MeasureConfig config = const MeasureConfig(),

--- a/flutter/packages/measure_dio/test/fake_measure.dart
+++ b/flutter/packages/measure_dio/test/fake_measure.dart
@@ -94,4 +94,14 @@ class FakeMeasure implements MeasureApi {
   bool shouldTrackHttpUrl(String url) {
     return _shouldTrackHttpUrl;
   }
+
+  @override
+  Future<void> start() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> stop() {
+    throw UnimplementedError();
+  }
 }

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
@@ -5,6 +5,8 @@ object MethodConstants {
     const val FUNCTION_TRACK_EVENT = "trackEvent"
     const val FUNCTION_TRIGGER_NATIVE_CRASH = "triggerNativeCrash"
     const val FUNCTION_INITIALIZE_NATIVE_SDK = "initializeNativeSDK"
+    const val FUNCTION_START = "start"
+    const val FUNCTION_STOP = "stop"
 
     // arguments
     const val ARG_EVENT_DATA = "event_data"

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
@@ -28,6 +28,8 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
                 MethodConstants.FUNCTION_TRACK_EVENT -> handleTrackEvent(call, result)
                 MethodConstants.FUNCTION_TRIGGER_NATIVE_CRASH -> triggerNativeCrash()
                 MethodConstants.FUNCTION_INITIALIZE_NATIVE_SDK -> initializeNativeSdk(call, result)
+                MethodConstants.FUNCTION_START -> start(call, result)
+                MethodConstants.FUNCTION_STOP -> stop(call, result)
                 else -> result.notImplemented()
             }
         } catch (e: MethodArgumentException) {
@@ -110,6 +112,15 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
         result.success(null)
     }
 
+    private fun start(call: MethodCall, result: MethodChannel.Result) {
+        Measure.start()
+        result.success(null)
+    }
+
+    private fun stop(call: MethodCall, result: MethodChannel.Result) {
+        Measure.stop()
+        result.success(null)
+    }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)

--- a/flutter/packages/measure_flutter/ios/Classes/Constants.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/Constants.swift
@@ -12,6 +12,8 @@ enum MethodConstants {
     static let functionTrackEvent = "trackEvent"
     static let functionTriggerNativeCrash = "triggerNativeCrash"
     static let functionInitializeNativeSdk = "initializeNativeSDK"
+    static let functionStart = "start"
+    static let functionStop = "stop"
 
     // arguments
     static let argEventData = "event_data"

--- a/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
@@ -18,6 +18,10 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
                 triggerNativeCrash()
             case MethodConstants.functionInitializeNativeSdk:
                 try initializeNativeSdk(call, result: result)
+            case MethodConstants.functionStart:
+                try start(call, result: result)
+            case MethodConstants.functionStop:
+                try stop(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -91,6 +95,17 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
         let clientInfo = try JSONDecoder().decode(ClientInfo.self, from: jsonClientInfo)
 
         Measure.shared.initialize(with: clientInfo, config: config)
+        result(nil)
+    }
+    
+    private func start(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        Measure.shared.start()
+        result(nil)
+    }
+
+    
+    private func stop(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        Measure.shared.stop()
         result(nil)
     }
 }

--- a/flutter/packages/measure_flutter/lib/measure.dart
+++ b/flutter/packages/measure_flutter/lib/measure.dart
@@ -35,7 +35,7 @@ class Measure implements MeasureApi {
   bool get isInitialized => _isInitialized;
 
   @override
-  Future<void> start(
+  Future<void> init(
     FutureOr<void> Function() action, {
     required ClientInfo clientInfo,
     MeasureConfig config = const MeasureConfig(),

--- a/flutter/packages/measure_flutter/lib/measure.dart
+++ b/flutter/packages/measure_flutter/lib/measure.dart
@@ -54,6 +54,20 @@ class Measure implements MeasureApi {
     return action();
   }
 
+  @override
+  Future<void> start() async {
+    if (isInitialized) {
+      return _measure.start();
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    if (isInitialized) {
+      return _measure.stop();
+    }
+  }
+
   /// Initialize both native SDK and internal Measure components
   Future<void> _initializeMeasureSDK(
     MeasureConfig config,
@@ -73,6 +87,7 @@ class Measure implements MeasureApi {
     if (config.autoInitializeNativeSDK) {
       var jsonConfig = config.toJson();
       var jsonClientInfo = clientInfo.toJson();
+      _logInputConfig(config.enableLogging, jsonConfig, jsonClientInfo);
       return methodChannel.initializeNativeSDK(jsonConfig, jsonClientInfo);
     }
     return Future.value();
@@ -256,6 +271,22 @@ class Measure implements MeasureApi {
         error: error,
         stackTrace: stackTrace,
         level: 900,
+      );
+    }
+  }
+
+  void _logInputConfig(bool enableLogging, Map<String, dynamic> jsonConfig,
+      Map<String, String> jsonClientInfo) {
+    if (enableLogging) {
+      developer.log(
+        'Initializing measure-flutter with config: $jsonConfig',
+        name: 'Measure',
+        level: 100,
+      );
+      developer.log(
+        'Initializing measure-flutter with client info: $jsonClientInfo',
+        name: 'Measure',
+        level: 100,
       );
     }
   }

--- a/flutter/packages/measure_flutter/lib/src/config/config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config.dart
@@ -6,6 +6,7 @@ class Config implements InternalConfig, IMeasureConfig {
   const Config({
     this.enableLogging = DefaultConfig.enableLogging,
     this.autoInitializeNativeSDK = DefaultConfig.autoInitializeNativeSDK,
+    this.autoStart = DefaultConfig.autoStart,
     this.trackHttpHeaders = DefaultConfig.trackHttpHeaders,
     this.trackHttpBody = DefaultConfig.trackHttpBody,
     this.httpHeadersBlocklist = DefaultConfig.httpHeadersBlocklist,
@@ -24,6 +25,8 @@ class Config implements InternalConfig, IMeasureConfig {
   final bool enableLogging;
   @override
   final bool autoInitializeNativeSDK;
+  @override
+  final bool autoStart;
   @override
   final bool trackHttpHeaders;
   @override

--- a/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
@@ -27,6 +27,9 @@ class ConfigProviderImpl implements ConfigProvider {
   bool get autoInitializeNativeSDK => _defaultConfig.autoInitializeNativeSDK;
 
   @override
+  bool get autoStart => _defaultConfig.autoStart;
+
+  @override
   bool get trackHttpHeaders => _defaultConfig.trackHttpHeaders;
 
   @override

--- a/flutter/packages/measure_flutter/lib/src/config/default_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/default_config.dart
@@ -1,6 +1,7 @@
 class DefaultConfig {
   static const bool enableLogging = false;
   static const bool autoInitializeNativeSDK = true;
+  static const bool autoStart = true;
   static const bool trackHttpHeaders = false;
   static const bool trackHttpBody = false;
   static const List<String> httpHeadersBlocklist = [];

--- a/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:measure_flutter/measure.dart';
 
 import 'default_config.dart';
 
@@ -8,6 +9,8 @@ abstract class IMeasureConfig {
   bool get enableLogging;
 
   bool get autoInitializeNativeSDK;
+
+  bool get autoStart;
 
   bool get trackHttpHeaders;
 
@@ -43,6 +46,16 @@ class MeasureConfig implements IMeasureConfig {
   /// The native SDK must be initialized manually if set to `false`.
   @override
   final bool autoInitializeNativeSDK;
+
+  /// Control when the SDK starts collecting events. Defaults to `true`.
+  ///
+  /// By default, initializing the SDK also starts collecting events. Set this
+  /// to false to manually control when to collect events.
+  ///
+  /// Call [Measure.start] to manually start collecting events.
+  /// Call [Measure.stop] to stop collecting events.
+  @override
+  final bool autoStart;
 
   /// Whether to capture http headers of a network request and response. Defaults to `false`.
   @override
@@ -176,6 +189,7 @@ class MeasureConfig implements IMeasureConfig {
   const MeasureConfig({
     this.enableLogging = DefaultConfig.enableLogging,
     this.autoInitializeNativeSDK = DefaultConfig.autoInitializeNativeSDK,
+    this.autoStart = DefaultConfig.autoStart,
     this.trackHttpHeaders = DefaultConfig.trackHttpHeaders,
     this.trackHttpBody = DefaultConfig.trackHttpBody,
     this.httpHeadersBlocklist = DefaultConfig.httpHeadersBlocklist,

--- a/flutter/packages/measure_flutter/lib/src/config/measure_config.g.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/measure_config.g.dart
@@ -12,6 +12,7 @@ MeasureConfig _$MeasureConfigFromJson(Map<String, dynamic> json) =>
           json['enableLogging'] as bool? ?? DefaultConfig.enableLogging,
       autoInitializeNativeSDK: json['autoInitializeNativeSDK'] as bool? ??
           DefaultConfig.autoInitializeNativeSDK,
+      autoStart: json['autoStart'] as bool? ?? DefaultConfig.autoStart,
       trackHttpHeaders:
           json['trackHttpHeaders'] as bool? ?? DefaultConfig.trackHttpHeaders,
       trackHttpBody:
@@ -48,6 +49,7 @@ Map<String, dynamic> _$MeasureConfigToJson(MeasureConfig instance) =>
     <String, dynamic>{
       'enableLogging': instance.enableLogging,
       'autoInitializeNativeSDK': instance.autoInitializeNativeSDK,
+      'autoStart': instance.autoStart,
       'trackHttpHeaders': instance.trackHttpHeaders,
       'trackHttpBody': instance.trackHttpBody,
       'httpHeadersBlocklist': instance.httpHeadersBlocklist,

--- a/flutter/packages/measure_flutter/lib/src/events/custom_event_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/custom_event_collector.dart
@@ -1,5 +1,6 @@
 import 'dart:isolate';
 
+import 'package:flutter/cupertino.dart';
 import 'package:measure_flutter/attribute_value.dart';
 import 'package:measure_flutter/src/events/custom_event_data.dart';
 import 'package:measure_flutter/src/events/event_type.dart';
@@ -9,7 +10,7 @@ import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 final class CustomEventCollector {
   final Logger logger;
   final SignalProcessor signalProcessor;
-  bool enabled = false;
+  bool _enabled = false;
 
   CustomEventCollector({
     required this.logger,
@@ -17,11 +18,11 @@ final class CustomEventCollector {
   });
 
   void register() {
-    enabled = true;
+    _enabled = true;
   }
 
   void unregister() {
-    enabled = false;
+    _enabled = false;
   }
 
   void trackCustomEvent(
@@ -29,7 +30,7 @@ final class CustomEventCollector {
     DateTime? timestamp,
     Map<String, AttributeValue> attributes,
   ) {
-    if (!enabled) {
+    if (!_enabled) {
       return;
     }
     signalProcessor.trackEvent(
@@ -40,5 +41,10 @@ final class CustomEventCollector {
       userTriggered: true,
       threadName: Isolate.current.debugName,
     );
+  }
+
+  @visibleForTesting
+  bool isEnabled() {
+    return _enabled;
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
@@ -12,7 +12,7 @@ import '../events/event_type.dart';
 final class ExceptionCollector {
   final Logger logger;
   final SignalProcessor signalProcessor;
-  bool enabled = false;
+  bool _enabled = false;
 
   ExceptionCollector({
     required this.logger,
@@ -20,23 +20,23 @@ final class ExceptionCollector {
   });
 
   void register() {
-    enabled = true;
+    _enabled = true;
   }
 
   void unregister() {
-    enabled = false;
+    _enabled = false;
   }
 
   Future<void> trackError(
     FlutterErrorDetails details, {
     required bool handled,
-  }) {
-    if (!enabled) return Future.value();
+  }) async {
+    if (!_enabled) return;
     final ExceptionData? exceptionData =
         ExceptionFactory.from(details, handled);
     if (exceptionData == null) {
       logger.log(LogLevel.error, "Failed to parse exception");
-      return Future.value();
+      return;
     }
     return signalProcessor.trackEvent(
       data: exceptionData,
@@ -46,5 +46,10 @@ final class ExceptionCollector {
       userTriggered: false,
       threadName: Isolate.current.debugName,
     );
+  }
+
+  @visibleForTesting
+  bool isEnabled() {
+    return _enabled;
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
@@ -4,8 +4,17 @@ import 'http_data.dart';
 
 class HttpCollector {
   final SignalProcessor signalProcessor;
+  bool _enabled = false;
 
   HttpCollector({required this.signalProcessor});
+
+  void register() {
+    _enabled = true;
+  }
+
+  void unregister() {
+    _enabled = false;
+  }
 
   void trackHttpEvent({
     required String url,
@@ -21,6 +30,9 @@ class HttpCollector {
     String? responseBody,
     String? client,
   }) {
+    if (!_enabled) {
+      return;
+    }
     final data = HttpData(
       url: url,
       method: method,

--- a/flutter/packages/measure_flutter/lib/src/measure_api.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_api.dart
@@ -9,7 +9,7 @@ abstract class MeasureApi {
     required DateTime? timestamp,
   });
 
-  Future<void> start(
+  Future<void> init(
     FutureOr<void> Function() action, {
     required ClientInfo clientInfo,
     MeasureConfig config = const MeasureConfig(),

--- a/flutter/packages/measure_flutter/lib/src/measure_api.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_api.dart
@@ -15,6 +15,10 @@ abstract class MeasureApi {
     MeasureConfig config = const MeasureConfig(),
   });
 
+  Future<void> start();
+
+  Future<void> stop();
+
   void trackHandledError(Object error, StackTrace stack);
 
   void triggerNativeCrash();

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -52,6 +52,15 @@ final class MeasureInitializer {
         httpHeadersBlocklist: inputConfig.httpHeadersBlocklist,
         httpUrlBlocklist: inputConfig.httpUrlBlocklist,
         httpUrlAllowlist: inputConfig.httpUrlAllowlist,
+        autoStart: inputConfig.autoStart,
+        autoInitializeNativeSDK: inputConfig.autoInitializeNativeSDK,
+        samplingRateForErrorFreeSessions:
+            inputConfig.samplingRateForErrorFreeSessions,
+        traceSamplingRate: inputConfig.traceSamplingRate,
+        trackActivityIntentData: inputConfig.trackActivityIntentData,
+        trackActivityLoadTime: inputConfig.trackActivityLoadTime,
+        trackFragmentLoadTime: inputConfig.trackFragmentLoadTime,
+        trackViewControllerLoadTime: inputConfig.trackViewControllerLoadTime,
       ),
     );
     _methodChannel = MsrMethodChannel();

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -31,12 +31,23 @@ final class MeasureInternal {
         _navigationCollector = initializer.navigationCollector;
 
   Future<void> init() async {
-    registerCollectors();
+    if (configProvider.autoStart) {
+      registerCollectors();
+    }
   }
 
   void registerCollectors() {
     _exceptionCollector.register();
     _customEventCollector.register();
+    _httpCollector.register();
+    _navigationCollector.register();
+  }
+
+  void unregisterCollectors() {
+    _exceptionCollector.unregister();
+    _customEventCollector.unregister();
+    _httpCollector.unregister();
+    _navigationCollector.unregister();
   }
 
   void trackCustomEvent(String name, DateTime? timestamp,
@@ -91,5 +102,15 @@ final class MeasureInternal {
       responseBody: responseBody,
       client: client,
     );
+  }
+
+  Future<void> start() async {
+    registerCollectors();
+    return methodChannel.start();
+  }
+
+  Future<void> stop() async {
+    unregisterCollectors();
+    return methodChannel.stop();
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
@@ -3,6 +3,8 @@ class MethodConstants {
   static const String functionTrackEvent = 'trackEvent';
   static const String functionTriggerNativeCrash = 'triggerNativeCrash';
   static const String functionInitializeNativeSDK = 'initializeNativeSDK';
+  static const String functionStart = 'start';
+  static const String functionStop = 'stop';
 
   // Argument keys
   static const String argEventData = 'event_data';

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
@@ -47,4 +47,14 @@ class MsrMethodChannel extends MeasureFlutterPlatform {
       MethodConstants.argClientInfo: clientInfo,
     });
   }
+
+  @override
+  Future<void> start() async {
+    return _methodChannel.invokeMethod(MethodConstants.functionStart);
+  }
+
+  @override
+  Future<void> stop() async {
+    return _methodChannel.invokeMethod(MethodConstants.functionStop);
+  }
 }

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
@@ -36,4 +36,12 @@ abstract class MeasureFlutterPlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('initializeNativeSDK() has not been implemented.');
   }
+
+  Future<void> start() {
+    throw UnimplementedError('start() has not been implemented.');
+  }
+
+  Future<void> stop() {
+    throw UnimplementedError('stop() has not been implemented.');
+  }
 }

--- a/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
@@ -4,15 +4,27 @@ import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 
 class NavigationCollector {
   final SignalProcessor signalProcessor;
+  bool _enabled = false;
 
-  const NavigationCollector({
+  void register() {
+    _enabled = true;
+  }
+
+  void unregister() {
+    _enabled = false;
+  }
+
+  NavigationCollector({
     required this.signalProcessor,
   });
 
   Future<void> trackScreenViewEvent({
     required String name,
     required bool userTriggered,
-  }) {
+  }) async {
+    if (!_enabled) {
+      return;
+    }
     final data = ScreenViewData(name: name);
     return signalProcessor.trackEvent(
       data: data,

--- a/flutter/packages/measure_flutter/test/events/custom_event_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/events/custom_event_collector_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     test('should be disabled by default', () {
       // When
-      final isEnabled = collector.enabled;
+      final isEnabled = collector.isEnabled();
 
       // Then
       expect(isEnabled, false);
@@ -34,7 +34,7 @@ void main() {
       collector.register();
 
       // Then
-      expect(collector.enabled, true);
+      expect(collector.isEnabled(), true);
     });
 
     test('should disable tracking when unregistered', () {
@@ -45,7 +45,7 @@ void main() {
       collector.unregister();
 
       // Then
-      expect(collector.enabled, false);
+      expect(collector.isEnabled(), false);
     });
 
     test('should not track events when disabled', () {
@@ -61,7 +61,7 @@ void main() {
       expect(signalProcessor.trackedCustomEvents.length, 0);
     });
 
-    test('should track events when enabled', () {
+    test('should track events when isEnabled()', () {
       // Given
       collector.register();
       final name = 'test_event';

--- a/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
@@ -23,20 +23,20 @@ void main() {
     });
 
     test('initial state should be disabled', () {
-      expect(collector.enabled, false);
+      expect(collector.isEnabled(), false);
     });
 
     test('registers the collector', () {
       collector.register();
-      expect(collector.enabled, true);
+      expect(collector.isEnabled(), true);
     });
 
     test('unregisters the collector', () {
       collector.register();
-      expect(collector.enabled, true);
+      expect(collector.isEnabled(), true);
 
       collector.unregister();
-      expect(collector.enabled, false);
+      expect(collector.isEnabled(), false);
     });
 
     test('tracks exception with un-obfuscated stacktrace', () {

--- a/flutter/packages/measure_flutter/test/measure_test.dart
+++ b/flutter/packages/measure_flutter/test/measure_test.dart
@@ -10,7 +10,7 @@ void main() {
 
       var isStarted = false;
 
-      await measure.start(
+      await measure.init(
         () {
           isStarted = true;
         },
@@ -30,7 +30,7 @@ void main() {
 
       var isStarted = false;
 
-      await measure.start(
+      await measure.init(
         () {
           isStarted = true;
         },
@@ -50,7 +50,7 @@ void main() {
 
       var isStarted = false;
 
-      await measure.start(
+      await measure.init(
         () {
           isStarted = true;
         },
@@ -70,7 +70,7 @@ void main() {
 
       var isStarted = false;
 
-      await measure.start(
+      await measure.init(
         () {
           isStarted = true;
         },

--- a/flutter/packages/measure_flutter/test/measure_test.dart
+++ b/flutter/packages/measure_flutter/test/measure_test.dart
@@ -85,4 +85,6 @@ void main() {
       expect(isStarted, true);
     });
   });
+
+
 }

--- a/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
@@ -13,6 +13,7 @@ void main() {
       navigationCollector = NavigationCollector(
         signalProcessor: fakeSignalProcessor,
       );
+      navigationCollector.register();
     });
 
     group('trackScreenViewEvent', () {

--- a/flutter/packages/measure_flutter/test/utils/fake_measure.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_measure.dart
@@ -7,7 +7,7 @@ class FakeMeasure implements MeasureApi {
   final List<ScreenViewCall> trackedScreenViews = [];
 
   @override
-  Future<void> start(
+  Future<void> init(
     FutureOr<void> Function() action, {
     required ClientInfo clientInfo,
     MeasureConfig config = const MeasureConfig(),

--- a/flutter/packages/measure_flutter/test/utils/fake_measure.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_measure.dart
@@ -68,6 +68,16 @@ class FakeMeasure implements MeasureApi {
   bool shouldTrackHttpUrl(String url) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> start() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> stop() {
+    throw UnimplementedError();
+  }
 }
 
 class ScreenViewCall {

--- a/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
@@ -36,4 +36,14 @@ class TestMethodChannel implements MsrMethodChannel {
   ) {
     return Future.value();
   }
+
+  @override
+  Future<void> start() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> stop() {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
# Description

* Expose `start` and `stop` APIs.
* Rename the main method to initialize SDK to `init` to be consistent with other SDKs.

## Related issue
Closes #2310 


