### PR TITLE
fix(ios): remove hardcoded values from upload dysm script

### DIFF
--- a/ios/Scripts/upload_dsym_build_phases.sh
+++ b/ios/Scripts/upload_dsym_build_phases.sh
@@ -87,7 +87,6 @@ CURL_COMMAND="curl --request PUT \
   --form version_code=$VERSION_CODE \
   --form build_size=$BUILD_SIZE \
   --form build_type=$BUILD_TYPE \
-  --form app_unique_id=sh.measure.DemoApp" \
   --form os_name=$OS_NAME"
 
 # Attach each dSYM .tgz file


### PR DESCRIPTION
# Description

Remove hardcoded `app_unique_id` values from upload dysm script

## Related issue
Fixes #2187 