### PR TITLE
chore(backend): move crash + anr groups to clickhouse

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -1500,7 +1500,7 @@ func (e Exception) GetFileName() string {
 
 // GetLineNumber provides the line number of
 // the exception.
-func (e Exception) GetLineNumber() int {
+func (e Exception) GetLineNumber() int32 {
 	// some exception may have zero frames
 	if e.HasNoFrames() {
 		return 0
@@ -1508,11 +1508,11 @@ func (e Exception) GetLineNumber() int {
 
 	switch e.GetFramework() {
 	case FrameworkJVM:
-		return e.Exceptions[len(e.Exceptions)-1].Frames[0].LineNum
+		return int32(e.Exceptions[len(e.Exceptions)-1].Frames[0].LineNum)
 	case FrameworkDart:
-		return e.Exceptions[len(e.Exceptions)-1].Frames[0].LineNum
+		return int32(e.Exceptions[len(e.Exceptions)-1].Frames[0].LineNum)
 	case FrameworkApple:
-		return e.GetRelevantFrame().LineNum
+		return int32(e.GetRelevantFrame().LineNum)
 	}
 
 	return 0
@@ -1801,11 +1801,11 @@ func (a ANR) GetFileName() string {
 
 // GetLineNumber provides the line number of
 // the ANR.
-func (a ANR) GetLineNumber() int {
+func (a ANR) GetLineNumber() int32 {
 	if a.HasNoFrames() {
-		return 0
+		return int32(0)
 	}
-	return a.Exceptions[len(a.Exceptions)-1].Frames[0].LineNum
+	return int32(a.Exceptions[len(a.Exceptions)-1].Frames[0].LineNum)
 }
 
 // GetMethodName provides the method name of

--- a/backend/api/group/group_test.go
+++ b/backend/api/group/group_test.go
@@ -5,16 +5,11 @@ import (
 	"backend/api/paginate"
 	"reflect"
 	"testing"
-
-	"github.com/google/uuid"
 )
 
 var groups = []ExceptionGroup{
 	{
-		ID: func() uuid.UUID {
-			id, _ := uuid.Parse("018da688-071c-7207-a1fe-ef529bde9963")
-			return id
-		}(),
+		ID:         "5d41402abc4b2a76b9719d911017c592",
 		Type:       "type0",
 		Message:    "Message0",
 		MethodName: "MethodName0",
@@ -22,10 +17,7 @@ var groups = []ExceptionGroup{
 		LineNumber: 0,
 	},
 	{
-		ID: func() uuid.UUID {
-			id, _ := uuid.Parse("018da688-13e1-76db-8ad7-632401256db3")
-			return id
-		}(),
+		ID:         "6e809cbda0732ac4845916a59016f954",
 		Type:       "type1",
 		Message:    "Message1",
 		MethodName: "MethodName1",
@@ -33,10 +25,7 @@ var groups = []ExceptionGroup{
 		LineNumber: 1,
 	},
 	{
-		ID: func() uuid.UUID {
-			id, _ := uuid.Parse("018da688-50e5-7479-9225-8b6756adbe39")
-			return id
-		}(),
+		ID:         "7ce8be0fa3932e840f6a19c2b83e11ae",
 		Type:       "type2",
 		Message:    "Message2",
 		MethodName: "MethodName2",
@@ -46,7 +35,7 @@ var groups = []ExceptionGroup{
 }
 
 func TestPaginateGroups(t *testing.T) {
-	subgroup, next, previous := paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{})
+	subgroup, next, previous := paginate.Paginate(groups, &filter.AppFilter{})
 
 	{
 		expected := len(groups)
@@ -57,15 +46,15 @@ func TestPaginateGroups(t *testing.T) {
 	}
 
 	{
-		expected := groups[0].ID.String()
-		got := subgroup[0].ID.String()
+		expected := groups[0].ID
+		got := subgroup[0].ID
 		if !reflect.DeepEqual(expected, got) {
 			t.Errorf("Expected %v but got %v", expected, got)
 		}
 	}
 	{
-		expected := groups[len(groups)-1].ID.String()
-		got := subgroup[len(groups)-1].ID.String()
+		expected := groups[len(groups)-1].ID
+		got := subgroup[len(groups)-1].ID
 		if !reflect.DeepEqual(expected, got) {
 			t.Errorf("Expected %v but got %v", expected, got)
 		}
@@ -90,7 +79,7 @@ func TestPaginateGroups(t *testing.T) {
 }
 
 func TestForwardLimitOne(t *testing.T) {
-	subgroup, next, previous := paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{
+	subgroup, next, previous := paginate.Paginate(groups, &filter.AppFilter{
 		Limit: 1,
 	})
 
@@ -103,8 +92,8 @@ func TestForwardLimitOne(t *testing.T) {
 	}
 
 	{
-		expected := "018da688-071c-7207-a1fe-ef529bde9963"
-		got := subgroup[0].ID.String()
+		expected := "5d41402abc4b2a76b9719d911017c592"
+		got := subgroup[0].ID
 		if !reflect.DeepEqual(expected, got) {
 			t.Errorf("Expected %v but got %v", expected, got)
 		}
@@ -128,7 +117,7 @@ func TestForwardLimitOne(t *testing.T) {
 }
 
 func TestBackwardLimitOne(t *testing.T) {
-	subgroup, next, previous := paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{
+	subgroup, next, previous := paginate.Paginate(groups, &filter.AppFilter{
 		Limit: -1,
 	})
 
@@ -158,8 +147,8 @@ func TestBackwardLimitOne(t *testing.T) {
 }
 
 func TestForwardLimitWithID(t *testing.T) {
-	subgroup, next, previous := paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{
-		KeyID: groups[0].ID.String(),
+	subgroup, next, previous := paginate.Paginate(groups, &filter.AppFilter{
+		KeyID: groups[0].ID,
 		Limit: 1,
 	})
 
@@ -172,8 +161,8 @@ func TestForwardLimitWithID(t *testing.T) {
 	}
 
 	{
-		expected := groups[1].ID.String()
-		got := subgroup[0].ID.String()
+		expected := groups[1].ID
+		got := subgroup[0].ID
 		if !reflect.DeepEqual(expected, got) {
 			t.Errorf("Expected %v but got %v", expected, got)
 		}
@@ -195,8 +184,8 @@ func TestForwardLimitWithID(t *testing.T) {
 		}
 	}
 
-	subgroup, next, previous = paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{
-		KeyID: groups[len(groups)-1].ID.String(),
+	subgroup, next, previous = paginate.Paginate(groups, &filter.AppFilter{
+		KeyID: groups[len(groups)-1].ID,
 		Limit: 1,
 	})
 
@@ -226,8 +215,8 @@ func TestForwardLimitWithID(t *testing.T) {
 }
 
 func TestBackwardLimitWithID(t *testing.T) {
-	subgroup, next, previous := paginate.Paginate[ExceptionGroup](groups, &filter.AppFilter{
-		KeyID: groups[0].ID.String(),
+	subgroup, next, previous := paginate.Paginate(groups, &filter.AppFilter{
+		KeyID: groups[0].ID,
 		Limit: -1,
 	})
 

--- a/backend/api/journey/android.go
+++ b/backend/api/journey/android.go
@@ -326,7 +326,7 @@ func (j *JourneyAndroid) GetNodeVertices() (ids []int) {
 
 // GetNodeANRCount computes total count of ANR events
 // occurring in the ANR group.
-func (j *JourneyAndroid) GetNodeANRCount(v int, anrGroupId uuid.UUID) (anrCount int) {
+func (j *JourneyAndroid) GetNodeANRCount(v int, anrGroupId string) (anrCount int) {
 	name := j.nodelutinverse[v]
 	node := j.nodelut[name]
 
@@ -349,7 +349,7 @@ func (j *JourneyAndroid) GetNodeANRCount(v int, anrGroupId uuid.UUID) (anrCount 
 
 // GetNodeExceptionCount computes total count of exception
 // events occurring in the exception group.
-func (j *JourneyAndroid) GetNodeExceptionCount(v int, exceptionGroupId uuid.UUID) (crashCount int) {
+func (j *JourneyAndroid) GetNodeExceptionCount(v int, exceptionGroupId string) (crashCount int) {
 	name := j.nodelutinverse[v]
 	node := j.nodelut[name]
 

--- a/backend/api/journey/android_test.go
+++ b/backend/api/journey/android_test.go
@@ -23,7 +23,7 @@ func readEvents(path string) (events []event.EventField, err error) {
 }
 
 var exceptionGroupOne = group.ExceptionGroup{
-	ID: uuid.MustParse("018fba31-0012-7274-8874-8b062b9f6690"),
+	ID: "5d41402abc4b2a76b9719d911017c592",
 	EventIDs: []uuid.UUID{
 		uuid.MustParse("bd10e744-da4b-4685-bd83-fe29e4ac6ed9"),
 		uuid.MustParse("bd3aa0e2-13cf-4ccf-9ddb-7b9d4a8cc48e"),
@@ -47,7 +47,7 @@ var exceptionGroupOne = group.ExceptionGroup{
 }
 
 var exceptionGroupTwo = group.ExceptionGroup{
-	ID: uuid.MustParse("018fba30-637d-7367-85b6-0b375e16f5a2"),
+	ID: "6e809cbda0732ac4845916a59016f954",
 	EventIDs: []uuid.UUID{
 		uuid.MustParse("8fe6d874-8066-463c-b895-825d24cbf418"),
 		uuid.MustParse("2e8876ab-df6b-4325-b21a-1d04fdb03c2c"),
@@ -71,7 +71,7 @@ var exceptionGroupTwo = group.ExceptionGroup{
 }
 
 var exceptionGroupThree = group.ExceptionGroup{
-	ID: uuid.MustParse("6ed37c84-fa37-4627-879e-87c0787cfe36"),
+	ID: "7ce8be0fa3932e840f6a19c2b83e11ae",
 	EventIDs: []uuid.UUID{
 		uuid.MustParse("8fe6d874-8066-463c-b895-825d24cbf418"),
 		uuid.MustParse("02840cca-9025-44ca-88b8-31f87b958319"),
@@ -91,7 +91,7 @@ var exceptionGroupThree = group.ExceptionGroup{
 }
 
 var anrGroupOne = group.ANRGroup{
-	ID: uuid.MustParse("018fba31-08cc-7d93-9c26-1c3a5226abaa"),
+	ID: "a75f2192bae11cb76cdcdada9332bab6",
 	EventIDs: []uuid.UUID{
 		uuid.MustParse("e8f656b5-65c3-46ad-a03d-0ba777cff13f"),
 	},
@@ -897,7 +897,7 @@ func TestExceptionGroupAccessors(t *testing.T) {
 	})
 
 	groupOne := group.ExceptionGroup{
-		ID:         uuid.MustParse("b863efbe-585e-4e14-856d-fe6a3f31b64e"),
+		ID:         "ebde9cc9540087b9688fdb470fa20f17",
 		Type:       "some type",
 		Message:    "some message",
 		MethodName: "some method name",
@@ -939,7 +939,7 @@ func TestANRGroupAccessors(t *testing.T) {
 	})
 
 	groupOne := group.ANRGroup{
-		ID:         uuid.MustParse("b863efbe-585e-4e14-856d-fe6a3f31b64e"),
+		ID:         "5726012822477f24fe999a1f7223c82a",
 		Type:       "some type",
 		Message:    "some message",
 		MethodName: "some method name",

--- a/backend/api/journey/ios.go
+++ b/backend/api/journey/ios.go
@@ -256,7 +256,7 @@ func (j *JourneyiOS) GetNodeVertices() (ids []int) {
 
 // GetNodeExceptionCount computes total count of exception
 // events occurring in the exception group.
-func (j *JourneyiOS) GetNodeExceptionCount(v int, exceptionGroupId uuid.UUID) (crashCount int) {
+func (j *JourneyiOS) GetNodeExceptionCount(v int, exceptionGroupId string) (crashCount int) {
 	name := j.nodelutinverse[v]
 	node := j.nodelut[name]
 

--- a/backend/api/paginate/paginate.go
+++ b/backend/api/paginate/paginate.go
@@ -2,12 +2,10 @@ package paginate
 
 import (
 	"backend/api/filter"
-
-	"github.com/google/uuid"
 )
 
 type PaginationID interface {
-	GetID() uuid.UUID
+	GetId() string
 }
 
 // PaginateGroups accepts slice of interface GroupID and computes and
@@ -26,7 +24,7 @@ func Paginate[T PaginationID](groups []T, af *filter.AppFilter) (sliced []T, nex
 
 	start := 0
 	for i := range groups {
-		if groups[i].GetID().String() == af.KeyID {
+		if groups[i].GetId() == af.KeyID {
 			if af.Limit > 0 {
 				start = i + 1
 			} else {

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -1149,45 +1149,65 @@ The required headers must be present in each request.
     },
     "results": [
       {
-        "id": "01903291-1eb4-7b81-854b-fd9d3bbccb4b",
-        "app_id": "fddf4d6d-1df1-45f8-8bc7-9730f2236cb0",
-        "name": "java.lang.IllegalStateException@RxJava2CallAdapterFactory.java:118",
-        "fingerprint": "c37a8c1cc1c037f9",
-        "count": 41,
-        "percentage_contribution": 77.35849,
-        "created_at": "2024-06-19T22:14:49.77Z",
-        "updated_at": "2024-06-19T22:15:25.636Z"
-      },
-      {
-        "id": "01903291-6652-7ecf-9a6d-53ef16b6203a",
-        "app_id": "fddf4d6d-1df1-45f8-8bc7-9730f2236cb0",
-        "name": "java.lang.IllegalStateException@RxJava2CallAdapterFactory.java:118",
-        "fingerprint": "c3ea8c1cc1d033f9",
-        "count": 6,
-        "percentage_contribution": 11.320755,
-        "created_at": "2024-06-19T22:15:08.109Z",
-        "updated_at": "2024-06-19T22:15:23.134Z"
-      },
-      {
-        "id": "01903291-7992-7c4f-b98e-6f8e93417695",
-        "app_id": "fddf4d6d-1df1-45f8-8bc7-9730f2236cb0",
-        "name": "java.lang.IllegalStateException@RxJava2CallAdapterFactory.java:118",
-        "fingerprint": "c3faac1cc1c037bb",
-        "count": 4,
-        "percentage_contribution": 7.5471697,
-        "created_at": "2024-06-19T22:15:13.038Z",
-        "updated_at": "2024-06-19T22:15:21.224Z"
-      },
-      {
-        "id": "01903291-8379-79ee-8a27-678368a0a5b8",
-        "app_id": "fddf4d6d-1df1-45f8-8bc7-9730f2236cb0",
-        "name": "java.lang.IllegalStateException@RxJava2CallAdapterFactory.java:118",
-        "fingerprint": "c37acc1cc0c037bb",
-        "count": 2,
-        "percentage_contribution": 3.7735848,
-        "created_at": "2024-06-19T22:15:15.573Z",
-        "updated_at": "2024-06-19T22:15:19.957Z"
-      }
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "0a674646a76ebe4aa378b8e1aaa49d61",
+            "type": "java.lang.IllegalAccessException",
+            "message": "This is a new exception",
+            "method_name": "onClick",
+            "file_name": "ExceptionDemoActivity",
+            "line_number": 0,
+            "count": 11,
+            "percentage_contribution": 36.67,
+            "updated_at": "2025-06-13T14:08:58.228662166Z"
+        },
+        {
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "b98e7b3ee2144b658ee613ab18a4326f",
+            "type": "java.lang.StackOverflowError",
+            "message": "stack size 8188KB",
+            "method_name": "recursiveFunction",
+            "file_name": "ExceptionDemoActivity.kt",
+            "line_number": 195,
+            "count": 5,
+            "percentage_contribution": 16.67,
+            "updated_at": "2025-06-13T14:08:58.253760541Z"
+        },
+        {
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "2ca7a0d943d923ee99af0e94d89ee0bc",
+            "type": "java.lang.OutOfMemoryError",
+            "message": "Failed to allocate a 104857616 byte allocation with 25165824 free bytes and 88MB until OOM, target footprint 133174272, growth limit 201326592",
+            "method_name": "onClick",
+            "file_name": "ExceptionDemoActivity",
+            "line_number": 0,
+            "count": 4,
+            "percentage_contribution": 13.33,
+            "updated_at": "2025-06-13T14:08:58.084689791Z"
+        },
+        {
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "f94859bc4b47fbf05b4eec2a300de0a4",
+            "type": "sh.measure.sample.CustomException",
+            "message": "This is a nested custom exception",
+            "method_name": "onClick",
+            "file_name": "ExceptionDemoActivity",
+            "line_number": 0,
+            "count": 4,
+            "percentage_contribution": 13.33,
+            "updated_at": "2025-06-13T14:08:57.940485305Z"
+        },
+        {
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "c4ee2ff2e2496be30848cf500300be56",
+            "type": "android.app.RemoteServiceException$CrashedByAdbException",
+            "message": "shell-induced crash",
+            "method_name": "throwRemoteServiceException",
+            "file_name": "ActivityThread.java",
+            "line_number": 1990,
+            "count": 3,
+            "percentage_contribution": 10,
+            "updated_at": "2025-06-13T14:08:56.040462013Z"
+        }
     ]
   }
   ```
@@ -1850,25 +1870,29 @@ The required headers must be present in each request.
     },
     "results": [
       {
-        "id": "01903291-c21a-7e2a-923d-90d3793a8fb0",
-        "app_id": "2b7ddad4-40a6-42a7-9e21-a90577e08263",
-        "name": "sh.measure.android.anr.AnrError@ExceptionDemoActivity.kt:62",
-        "fingerprint": "c37ac85cc1d013f9",
-        "count": 3,
-        "percentage_contribution": 75,
-        "created_at": "2024-06-19T22:15:31.608Z",
-        "updated_at": "2024-06-19T22:15:34.659Z"
-      },
-      {
-        "id": "01903291-cc74-793b-ba28-842ffecdb774",
-        "app_id": "2b7ddad4-40a6-42a7-9e21-a90577e08263",
-        "name": "sh.measure.android.anr.AnrError@ExceptionDemoActivity.kt:66",
-        "fingerprint": "8368c85cc1c013f9",
-        "count": 1,
-        "percentage_contribution": 25,
-        "created_at": "2024-06-19T22:15:34.258Z",
-        "updated_at": "2024-06-19T22:15:34.258Z"
-      }
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "09ef78940bd258030ebe3937bf1e32a2",
+            "type": "sh.measure.android.anr.AnrError",
+            "message": "Application Not Responding for at least 5s",
+            "method_name": "run",
+            "file_name": "CpuUsageCollector",
+            "line_number": 0,
+            "count": 1,
+            "percentage_contribution": 50,
+            "updated_at": "2025-06-13T14:08:58.003350625Z"
+        },
+        {
+            "app_id": "19e26d60-2ad8-4ef7-8aab-333e1f5377fc",
+            "id": "19f5125829c0477f56a6e610cd81b735",
+            "type": "sh.measure.android.anr.AnrError",
+            "message": "Application Not Responding for at least 5s",
+            "method_name": "sleep",
+            "file_name": "Thread.java",
+            "line_number": -2,
+            "count": 1,
+            "percentage_contribution": 50,
+            "updated_at": "2025-06-13T14:08:56.313369888Z"
+        }
     ]
   }
   ```

--- a/docs/hosting/migration-guides/README.md
+++ b/docs/hosting/migration-guides/README.md
@@ -10,3 +10,4 @@ Choose as per your target version.
 
 - [**v0.4.x**](./v0.4.x/README.md) - Migration Guide for `v0.4.x`
 - [**v0.6.x**](./v0.6.x/README.md) - Migration Guide for `v0.6.x`
+- [**v0.8.x**](./v0.8.x/README.md) - Migration Guide for `v0.8.x`

--- a/docs/hosting/migration-guides/v0.8.x/README.md
+++ b/docs/hosting/migration-guides/v0.8.x/README.md
@@ -1,0 +1,34 @@
+# Migration Guide for `v0.8.x`
+
+Use this guide only when you are on less than `v0.8.0` and upgrading to `v0.8.x`.
+
+> [!WARNING]
+>
+> Steps mentioned in this document will cause downtime.
+
+Follow these steps when upgrading to `0.8.x`. There is some downtime involved. During the downtime SDKs would receive a `503 Service Unavailable` when sending sessions. Once the upgrade is complete, ingestion should resume normally. SDKs will retry sending unsent sessions automatically.
+
+## 1. SSH into the VM where Measure is hosted
+
+## 2. Perform the upgrade
+
+Visit [Releases](https://github.com/measure-sh/measure/releases) page to capture the latest tag matching the `[MAJOR].[MINOR].[PATCH]` format.
+
+```sh
+cd ~/measure
+git reset --hard # only applies if you have local modifications
+git fetch
+git checkout <git-tag>
+cd self-host
+sudo ./install.sh
+```
+
+## 3. Run data backfills
+
+Perform this step to complete the migration. Certain features on the Measure dashboard like user defined attributes won't work otherwise.
+
+This may take some time. Make sure your SSH connection remains active until it completes.
+
+```sh
+sudo ./migrations/v0.8.x-data-backfills.sh
+```

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -502,10 +502,8 @@ const emptyExceptionGroup = {
   "method_name": "",
   "file_name": "",
   "line_number": 0,
-  "fingerprint": "",
   "count": 0,
   "percentage_contribution": 0,
-  "created_at": "",
   "updated_at": ""
 }
 

--- a/self-host/clickhouse/20250611111806_create_unhandled_exception_groups_table.sql
+++ b/self-host/clickhouse/20250611111806_create_unhandled_exception_groups_table.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+create table if not exists unhandled_exception_groups
+(
+    `app_id` UUID not null comment 'linked app id' codec(ZSTD(3)),
+    `id` FixedString(32) not null comment 'unique fingerprint of the unhandled exception which acts as the id of the group' codec(ZSTD(3)),
+    `type` String not null comment 'type of the exception' codec(ZSTD(3)),
+    `message` String not null comment 'message of the exception' codec(ZSTD(3)),
+    `method_name` String not null comment 'method name where the exception occured' codec(ZSTD(3)),
+    `file_name` String not null comment 'file name where the exception occured' codec(ZSTD(3)),
+    `line_number` Int32 not null comment 'line number where the exception occured' codec(ZSTD(3)),
+    `updated_at` DateTime64(9, 'UTC') not null comment 'utc timestamp at the time of record updation' codec(DoubleDelta, ZSTD(3))
+)
+engine = ReplacingMergeTree(updated_at)
+partition by toYYYYMM(updated_at)
+order by (app_id, id)
+settings index_granularity = 8192
+comment 'aggregated unhandled exception groups';
+
+-- migrate:down
+drop table if exists unhandled_exception_groups;

--- a/self-host/clickhouse/20250611144409_create_anr_groups_table.sql
+++ b/self-host/clickhouse/20250611144409_create_anr_groups_table.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+create table if not exists anr_groups
+(
+    `app_id` UUID not null comment 'linked app id' codec(ZSTD(3)),
+    `id` FixedString(32) not null comment 'unique fingerprint of the unhandled exception which acts as the id of the group' codec(ZSTD(3)),
+    `type` String not null comment 'type of the ANR' codec(ZSTD(3)),
+    `message` String not null comment 'message of the ANR' codec(ZSTD(3)),
+    `method_name` String not null comment 'method name where the ANR occurred' codec(ZSTD(3)),
+    `file_name` String not null comment 'file name where the ANR occurred' codec(ZSTD(3)),
+    `line_number` Int32 not null comment 'line number where the ANR occurred' codec(ZSTD(3)),
+    `updated_at` DateTime64(9, 'UTC') not null comment 'utc timestamp at the time of record updation' codec(DoubleDelta, ZSTD(3))
+)
+engine = ReplacingMergeTree(updated_at)
+partition by toYYYYMM(updated_at)
+order by (app_id, id)
+settings index_granularity = 8192
+comment 'aggregated ANR groups';
+
+-- migrate:down
+drop table if exists anr_groups;

--- a/self-host/migrations/v0.8.x-backfills.sh
+++ b/self-host/migrations/v0.8.x-backfills.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script migrates unhandled_exception_groups and anr_groups from Postgres tables to ClickHouse tables using Docker Compose.
+
+has_command() {
+  if command -v "$1" &>/dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+if has_command docker-compose; then
+  DOCKER_COMPOSE="docker-compose"
+elif docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+else
+  echo "Neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+fi
+
+echo "Starting Postgres to ClickHouse crash + anr groups migration"
+
+# Truncate ClickHouse tables for idempotency
+$DOCKER_COMPOSE exec -T clickhouse clickhouse-client --query "TRUNCATE TABLE IF EXISTS unhandled_exception_groups"
+$DOCKER_COMPOSE exec -T clickhouse clickhouse-client --query "TRUNCATE TABLE IF EXISTS anr_groups"
+
+echo "Migrating unhandled_exception_groups..."
+TMP_TSV_UEG="/tmp/unhandled_exception_groups.tsv"
+$DOCKER_COMPOSE exec -T postgres psql -U postgres -d postgres -c "\\copy (SELECT app_id, fingerprint, type, message, method_name, file_name, line_number, updated_at FROM public.unhandled_exception_groups) TO STDOUT WITH (FORMAT TEXT, DELIMITER E'\t', NULL '\\N')" > "$TMP_TSV_UEG"
+if [ -s "$TMP_TSV_UEG" ]; then
+  cat "$TMP_TSV_UEG" | sed -E 's/([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)([+Z].*)?$/\1/' | \
+  $DOCKER_COMPOSE exec -T clickhouse clickhouse-client --query "INSERT INTO unhandled_exception_groups (app_id, id, type, message, method_name, file_name, line_number, updated_at) FORMAT TSV"
+fi
+rm "$TMP_TSV_UEG"
+echo "Migrating anr_groups..."
+TMP_TSV_ANR="/tmp/anr_groups.tsv"
+$DOCKER_COMPOSE exec -T postgres psql -U postgres -d postgres -c "\\copy (SELECT app_id, fingerprint, type, message, method_name, file_name, line_number, updated_at FROM public.anr_groups) TO STDOUT WITH (FORMAT TEXT, DELIMITER E'\t', NULL '\\N')" > "$TMP_TSV_ANR"
+if [ -s "$TMP_TSV_ANR" ]; then
+  cat "$TMP_TSV_ANR" | sed -E 's/([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)([+Z].*)?$/\1/' | \
+  $DOCKER_COMPOSE exec -T clickhouse clickhouse-client --query "INSERT INTO anr_groups (app_id, id, type, message, method_name, file_name, line_number, updated_at) FORMAT TSV"
+fi
+rm "$TMP_TSV_ANR"
+echo "Migration complete."


### PR DESCRIPTION
# Description

- Creates `unhandled_exception_groups` and `anr_groups` tables in clickhouse
- Updates ingestion to add crash + anr groups in clickhouse
- Updates read queries to query from clickhouse tables
- Adds a data backfill script to move crash + anr groups from postgres to clickhouse for users upgrading

## Related issue
Closes #1260 



