### PR TITLE
chore(backend): handle empty dir cases in sessionator

### DIFF
--- a/self-host/sessionator/app/app.go
+++ b/self-host/sessionator/app/app.go
@@ -103,6 +103,13 @@ func (a App) FullName() string {
 // Validate checks if app's data and builds
 // are valid.
 func (a App) Validate() (ok bool, err error) {
+	// events and/or spans should not be empty
+	if len(a.EventAndSpanFiles) < 1 {
+		ok = false
+		err = fmt.Errorf(`app %q has zero event and span files. make sure the directory is not empty.`, a.FullName())
+		return
+	}
+
 	attribute, err := a.Attribute()
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

This PR adds a validation condition in sessionator ingest command to check if an app has events or spans before attempting to ingest. This situation might happen if any of the app version directory is empty.

## Tasks

- [x] Gracefully detect and handle the case when an app does not have events or spans before ingesting

## See also

- fixes #2328