### PR TITLE
chore(backend): add versioning column for bug reports table

### DIFF
--- a/backend/api/measure/bugreport.go
+++ b/backend/api/measure/bugreport.go
@@ -22,6 +22,7 @@ type BugReport struct {
 	Status               uint8              `json:"status" binding:"required"`
 	Description          string             `json:"description" binding:"required"`
 	Timestamp            *time.Time         `json:"timestamp" binding:"required"`
+	UpdatedAt            *time.Time         `json:"updated_at" binding:"required"`
 	Attribute            *event.Attribute   `json:"attribute" binding:"required"`
 	UserDefinedAttribute event.UDAttribute  `json:"user_defined_attribute" binding:"required"`
 	Attachments          []event.Attachment `json:"attachments" binding:"required"`
@@ -184,6 +185,7 @@ func GetBugReportsWithFilter(ctx context.Context, af *filter.AppFilter) (bugRepo
 		Select("event_id").
 		Select("session_id").
 		Select("timestamp").
+		Select("updated_at").
 		Select("status").
 		Select("description").
 		Select("tupleElement(app_version, 1)").
@@ -306,6 +308,7 @@ func GetBugReportsWithFilter(ctx context.Context, af *filter.AppFilter) (bugRepo
 			&bugReport.EventID,
 			&bugReport.SessionID,
 			&bugReport.Timestamp,
+			&bugReport.UpdatedAt,
 			&bugReport.Status,
 			&bugReport.Description,
 			&bugReport.Attribute.AppVersion,
@@ -394,6 +397,7 @@ func GetBugReportById(ctx context.Context, bugReportId string) (bugReport BugRep
 		Select("app_id").
 		Select("session_id").
 		Select("timestamp").
+		Select("updated_at").
 		Select("status").
 		Select("description").
 		Select("tupleElement(app_version, 1)").
@@ -432,6 +436,7 @@ func GetBugReportById(ctx context.Context, bugReportId string) (bugReport BugRep
 		&bugReport.AppID,
 		&bugReport.SessionID,
 		&bugReport.Timestamp,
+		&bugReport.UpdatedAt,
 		&bugReport.Status,
 		&bugReport.Description,
 		&bugReport.Attribute.AppVersion,
@@ -494,6 +499,7 @@ func UpdateBugReportStatusById(ctx context.Context, bugReportId string, status u
         app_id,
         session_id,
         timestamp,
+		now64(9, 'UTC') AS updated_at,
         '%d' AS status,
         description,
         app_version,
@@ -511,7 +517,7 @@ func UpdateBugReportStatusById(ctx context.Context, bugReportId string, status u
         device_thermal_throttling_enabled,
         user_defined_attribute,
         attachments
-    FROM bug_reports
+    FROM bug_reports FINAL
     WHERE event_id = toUUID('%s')
     `, status, bugReportId)
 

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -4456,6 +4456,7 @@ The required headers must be present in each request.
         "status": 0,
         "description": "Unresponsive button. Kept tapping but nothing happens",
         "timestamp": "2024-12-16T03:31:07.127Z",
+        "updated_at": "2024-12-16T03:31:07.127Z",
         "attribute": {
           "installation_id": "00000000-0000-0000-0000-000000000000",
           "app_version": "0.9.0-SNAPSHOT.debug",
@@ -4497,6 +4498,7 @@ The required headers must be present in each request.
         "status": 0,
         "description": "This app sucks!",
         "timestamp": "2024-11-18T14:14:41.622Z",
+        "updated_at": "2024-11-18T14:14:41.622Z",
         "attribute": {
           "installation_id": "00000000-0000-0000-0000-000000000000",
           "app_version": "0.9.0-SNAPSHOT.debug",
@@ -4538,6 +4540,7 @@ The required headers must be present in each request.
         "status": 0,
         "description": "Screen too slow to load. I'm switching to another app!!!",
         "timestamp": "2024-11-14T04:55:19.37Z",
+        "updated_at": "2024-11-14T04:55:19.37Z",
         "attribute": {
           "installation_id": "00000000-0000-0000-0000-000000000000",
           "app_version": "0.9.0-SNAPSHOT.debug",
@@ -4579,6 +4582,7 @@ The required headers must be present in each request.
         "status": 1,
         "description": "Can't click button. Screen frozen.",
         "timestamp": "2024-07-25T07:26:16.44Z",
+        "updated_at": "2024-07-25T07:26:16.44Z",
         "attribute": {
           "installation_id": "00000000-0000-0000-0000-000000000000",
           "app_version": "1.0",
@@ -4620,6 +4624,7 @@ The required headers must be present in each request.
         "status": 0,
         "description": "Clicking button leads to crash.",
         "timestamp": "2024-06-13T13:37:23.33Z",
+        "updated_at": "2024-06-13T13:37:23.33Z",
         "attribute": {
           "installation_id": "00000000-0000-0000-0000-000000000000",
           "app_version": "1.0",
@@ -4846,6 +4851,7 @@ The required headers must be present in each request.
     "status": 0,
     "description": "This app sucks!",
     "timestamp": "2024-11-18T14:14:41.622Z",
+    "updated_at": "2024-11-18T14:14:41.622Z",
     "attribute": {
       "installation_id": "00000000-0000-0000-0000-000000000000",
       "app_version": "0.9.0-SNAPSHOT.debug",

--- a/self-host/clickhouse/20250618105257_create_new_bug_reports_table.sql
+++ b/self-host/clickhouse/20250618105257_create_new_bug_reports_table.sql
@@ -1,0 +1,36 @@
+-- migrate:up
+
+create table bug_reports_new
+(
+    `event_id`                            UUID NOT NULL COMMENT 'bug report event id' CODEC(ZSTD(3)),
+    `app_id`                              UUID NOT NULL COMMENT 'unique id of the app' CODEC(ZSTD(3)),
+    `session_id`                          UUID NOT NULL COMMENT 'session id' CODEC(ZSTD(3)),
+    `timestamp`                           DateTime64(9, 'UTC') NOT NULL COMMENT 'timestamp of the bug report' CODEC(DoubleDelta, ZSTD(3)),
+    `updated_at`                          DateTime64(9, 'UTC') NOT NULL COMMENT 'timestamp when record was last updated' CODEC(DoubleDelta, ZSTD(3)),
+    `status`                              UInt8 NOT NULL COMMENT 'status of the bug report 0 (Closed) or 1 (Open)' CODEC(ZSTD(3)),
+    `description`                         String COMMENT 'description of the bug report' CODEC(ZSTD(3)),
+    `app_version`                         Tuple(LowCardinality(String), LowCardinality(String)) NOT NULL COMMENT 'composite app version' CODEC(ZSTD(3)),
+    `os_version`                          Tuple(LowCardinality(String), LowCardinality(String)) NOT NULL COMMENT 'composite os version' CODEC(ZSTD(3)),
+    `country_code`                        LowCardinality(String) COMMENT 'country code' CODEC(ZSTD(3)),
+    `network_provider`                    LowCardinality(String) COMMENT 'name of the network service provider' CODEC(ZSTD(3)),
+    `network_type`                        LowCardinality(String) COMMENT 'wifi, cellular, vpn and so on' CODEC(ZSTD(3)),
+    `network_generation`                  LowCardinality(String) COMMENT '2g, 3g, 4g and so on' CODEC(ZSTD(3)),
+    `device_locale`                       LowCardinality(String) COMMENT 'rfc 5646 locale string' CODEC(ZSTD(3)),
+    `device_manufacturer`                 LowCardinality(String) COMMENT 'manufacturer of the device' CODEC(ZSTD(3)),
+    `device_name`                         LowCardinality(String) COMMENT 'name of the device' CODEC(ZSTD(3)),
+    `device_model`                        LowCardinality(String) COMMENT 'model of the device' CODEC(ZSTD(3)),
+    `user_id`                             LowCardinality(String) COMMENT 'attributed user id' CODEC(ZSTD(3)),
+    `device_low_power_mode`               Boolean COMMENT 'true if low power mode is enabled',
+    `device_thermal_throttling_enabled`   Boolean COMMENT 'true if thermal throttling is enabled',
+    `user_defined_attribute`              Map(LowCardinality(String), Tuple(Enum('string' = 1, 'int64', 'float64', 'bool'), String)) COMMENT 'user defined attributes' CODEC(ZSTD(3)),
+    `attachments`                         String COMMENT 'attachment metadata'
+)
+ENGINE = ReplacingMergeTree(updated_at)
+partition by toYYYYMM(timestamp)
+order by (app_id, os_version, app_version, session_id, timestamp, event_id)
+SETTINGS index_granularity = 8192
+COMMENT 'aggregated app bug reports with versioning';
+
+-- migrate:down
+
+drop table if exists bug_reports_new;

--- a/self-host/clickhouse/20250618114246_copy_bug_reports_data_to_new_table.sql
+++ b/self-host/clickhouse/20250618114246_copy_bug_reports_data_to_new_table.sql
@@ -1,0 +1,31 @@
+-- migrate:up
+
+insert into bug_reports_new 
+select 
+    event_id,
+    app_id,
+    session_id,
+    timestamp,
+    timestamp as updated_at,
+    status,
+    description,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    device_model,
+    user_id,
+    device_low_power_mode,
+    device_thermal_throttling_enabled,
+    user_defined_attribute,
+    attachments
+from bug_reports;
+
+-- migrate:down
+
+truncate table bug_reports_new;

--- a/self-host/clickhouse/20250618114324_rename_bug_reports_to_bug_reports_old.sql
+++ b/self-host/clickhouse/20250618114324_rename_bug_reports_to_bug_reports_old.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+rename table bug_reports to bug_reports_old;
+
+-- migrate:down
+
+rename table bug_reports_old to bug_reports;

--- a/self-host/clickhouse/20250618114425_rename_bug_reports_new_to_bug_reports.sql
+++ b/self-host/clickhouse/20250618114425_rename_bug_reports_new_to_bug_reports.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+rename table bug_reports_new to bug_reports;
+
+-- migrate:down
+
+rename table bug_reports to bug_reports_new;

--- a/self-host/clickhouse/20250618114435_drop_bug_reports_mv.sql
+++ b/self-host/clickhouse/20250618114435_drop_bug_reports_mv.sql
@@ -1,0 +1,33 @@
+-- migrate:up
+
+drop view if exists bug_reports_mv;
+
+-- migrate:down
+create materialized view bug_reports_mv to bug_reports as
+select distinct id                                                             as event_id,
+                app_id,
+                session_id,
+                any(timestamp)                                                 as timestamp,
+                0                                                              as status,
+                any(bug_report.description)                                    as description,
+                any((toString(attribute.app_version),
+                     toString(attribute.app_build)))                           as app_version,
+                any((toString(attribute.os_name),
+                     toString(attribute.os_version)))                          as os_version,
+                any(toString(inet.country_code))                               as country_code,
+                any(toString(attribute.network_provider))                      as network_provider,
+                any(toString(attribute.network_type))                          as network_type,
+                any(toString(attribute.network_generation))                    as network_generation,
+                any(toString(attribute.device_locale))                         as device_locale,
+                any(toString(attribute.device_manufacturer))                   as device_manufacturer,
+                any(toString(attribute.device_name))                           as device_name,
+                any(toString(attribute.device_model))                          as device_model,
+                any(toString(attribute.user_id))                               as user_id,
+                any(attribute.device_low_power_mode)                           as device_low_power_mode,
+                any(attribute.device_thermal_throttling_enabled)               as device_thermal_throttling_enabled,
+                any(user_defined_attribute)                                    as user_defined_attribute,
+                any(attachments)                                               as attachments
+from events
+where type = 'bug_report'
+group by app_id, session_id, event_id
+order by app_id, os_version, app_version, session_id, timestamp, event_id;

--- a/self-host/clickhouse/20250618114512_create_bug_reports_mv.sql
+++ b/self-host/clickhouse/20250618114512_create_bug_reports_mv.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+
+create materialized view bug_reports_mv to bug_reports as
+select
+    event_id,
+    app_id,
+    session_id,
+    temp_timestamp AS timestamp,
+    temp_timestamp AS updated_at,
+    status,
+    description,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    device_model,
+    user_id,
+    device_low_power_mode,
+    device_thermal_throttling_enabled,
+    user_defined_attribute,
+    attachments
+from (
+    select
+        id AS event_id,
+        app_id,
+        session_id,
+        any(timestamp) AS temp_timestamp,
+        0 AS status,
+        any(bug_report.description) AS description,
+        any((toString(attribute.app_version), toString(attribute.app_build))) AS app_version,
+        any((toString(attribute.os_name), toString(attribute.os_version))) AS os_version,
+        any(toString(inet.country_code)) AS country_code,
+        any(toString(attribute.network_provider)) AS network_provider,
+        any(toString(attribute.network_type)) AS network_type,
+        any(toString(attribute.network_generation)) AS network_generation,
+        any(toString(attribute.device_locale)) AS device_locale,
+        any(toString(attribute.device_manufacturer)) AS device_manufacturer,
+        any(toString(attribute.device_name)) AS device_name,
+        any(toString(attribute.device_model)) AS device_model,
+        any(toString(attribute.user_id)) AS user_id,
+        any(attribute.device_low_power_mode) AS device_low_power_mode,
+        any(attribute.device_thermal_throttling_enabled) AS device_thermal_throttling_enabled,
+        any(user_defined_attribute) AS user_defined_attribute,
+        any(attachments) AS attachments
+    from events
+    where type = 'bug_report'
+    group by app_id, session_id, event_id
+);
+
+-- migrate:down
+
+drop view if exists bug_reports_mv;

--- a/self-host/clickhouse/20250618114533_drop_old_bug_reports_table.sql
+++ b/self-host/clickhouse/20250618114533_drop_old_bug_reports_table.sql
@@ -1,0 +1,35 @@
+-- migrate:up
+
+drop table if exists bug_reports_old;
+
+-- migrate:down
+
+create table if not exists bug_reports_old
+(
+    `event_id`                            UUID not null comment 'bug report event id' codec(ZSTD(3)),
+    `app_id`                              UUID not null comment 'unique id of the app' codec(ZSTD(3)),
+    `session_id`                          UUID not null comment 'session id' codec(ZSTD(3)),
+    `timestamp`                           DateTime64(9, 'UTC') not null comment 'timestamp of the bug report' codec(DoubleDelta, ZSTD(3)),
+    `status`                              UInt8 not null comment 'status of the bug report 0 (Closed) or 1 (Open)' codec(ZSTD(3)),
+    `description`                         String comment 'description of the bug report' codec(ZSTD(3)),
+    `app_version`                         Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite app version' codec(ZSTD(3)),
+    `os_version`                          Tuple(LowCardinality(String), LowCardinality(String)) not null comment 'composite os version' codec(ZSTD(3)),
+    `country_code`                        LowCardinality(String) comment 'country code' codec(ZSTD(3)),
+    `network_provider`                    LowCardinality(String) comment 'name of the network service provider' codec(ZSTD(3)),
+    `network_type`                        LowCardinality(String) comment 'wifi, cellular, vpn and so on' codec(ZSTD(3)),
+    `network_generation`                  LowCardinality(String) comment '2g, 3g, 4g and so on' codec(ZSTD(3)),
+    `device_locale`                       LowCardinality(String) comment 'rfc 5646 locale string' codec(ZSTD(3)),
+    `device_manufacturer`                 LowCardinality(String) comment 'manufacturer of the device' codec(ZSTD(3)),
+    `device_name`                         LowCardinality(String) comment 'name of the device' codec(ZSTD(3)),
+    `device_model`                        LowCardinality(String) comment 'model of the device' codec(ZSTD(3)),
+    `user_id`                             LowCardinality(String) comment 'attributed user id' codec(ZSTD(3)),
+    `device_low_power_mode`               Boolean comment 'true if low power mode is enabled',
+    `device_thermal_throttling_enabled`   Boolean comment 'true if thermal throttling is enabled',
+    `user_defined_attribute`              Map(LowCardinality(String), Tuple(Enum('string' = 1, 'int64', 'float64', 'bool'), String)) comment 'user defined attributes' codec(ZSTD(3)),
+    `attachments`                         String comment 'attachment metadata'
+)
+engine = ReplacingMergeTree
+partition by toYYYYMM(timestamp)
+order by (app_id, os_version, app_version, session_id, timestamp, event_id)
+settings index_granularity = 8192
+comment 'aggregated app bug reports';


### PR DESCRIPTION
# Description

Bug reports table in clickhouse did not have a versioning column.

This means that clikchouse will by default prioritise insert order.

When we query a bug report with an id and a FINAL clause it will return what it thinks is the correct one which works fine when we are not running distributed clickhouse but will break if we are sharding/partitioning since insert order will depend on which shard/partition we are talking to making it non-deterministic.

We fix this by explicitly adding an `updated_at` column and using that for versioning.

The steps are:
1. Create a new bug reports table (since we can't add versioning column by altering a table)
2. Copy existing bug reports to it
3. Rename current bug reports table to `bug_reports_old`
4. Rename new table to `bug_reports`
5. Drop materialized view pointing to old table
6. Create materialized view pointing to new table
7. Drop `bug_reports_old`

## Related issue
Closes #2312



