### PR TITLE
chore(frontend): use circle checkbox for multi select dropdown for clearer selected state differentiation

### DIFF
--- a/frontend/dashboard/app/components/dropdown_select.tsx
+++ b/frontend/dashboard/app/components/dropdown_select.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Check, ChevronsUpDown } from "lucide-react"
+import { Check, ChevronsUpDown, Circle, CircleCheck } from "lucide-react"
 import React, { useEffect, useState } from 'react'
 import { AppVersion, OsVersion } from '../api/api_calls'
 
@@ -309,7 +309,7 @@ const DropdownSelect: React.FC<DropdownSelectProps> = ({ title, type, items, ini
               >
                 {isMultiSelect() && (
                   <span className="mr-2 flex items-center justify-center w-4 h-4">
-                    {isItemSelected(item) ? <Check className="h-4 w-4" /> : null}
+                    {isItemSelected(item) ? <CircleCheck className="h-4 w-4" /> : <Circle className="h-4 w-4 opacity-50" />}
                   </span>
                 )}
                 <span className="flex-1 truncate font-display text-sm">{renderItemContent(item)}</span>

--- a/frontend/dashboard/app/components/user_def_attr_selector.tsx
+++ b/frontend/dashboard/app/components/user_def_attr_selector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Check, ChevronsUpDown } from "lucide-react"
+import { ChevronsUpDown, Circle, CircleCheck } from "lucide-react"
 import React, { useEffect, useState } from 'react'
 import { UserDefAttr } from '../api/api_calls'
 import { cn } from '../utils/shadcn_utils'
@@ -200,10 +200,8 @@ const UserDefAttrSelector: React.FC<UserDefAttrSelectorProps> = ({ attrs, ops, i
               >
                 <div className="w-full flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-0">
                   <div className="flex items-center justify-center w-full sm:w-[5%]">
-                    <Check className={cn(
-                      "h-4 w-4",
-                      isAttrSelected(attr) ? "opacity-100" : "opacity-0"
-                    )} />
+                    {!isAttrSelected(attr) && <Circle className={cn("h-4 w-4 opacity-50")} />}
+                    {isAttrSelected(attr) && <CircleCheck className={cn("h-4 w-4")} />}
                   </div>
 
                   <div className="flex items-center w-full sm:w-[15%]">


### PR DESCRIPTION
# Description

Uses circle checkbox for multi select dropdown for clearer selected state differentiation


https://github.com/user-attachments/assets/74c7dbba-af23-4925-acde-8fbb505e32a6



## Related issue
Closes #2327



