### PR TITLE
chore(android): remove shake to launch bug report config

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -15,9 +15,6 @@ public final class sh/measure/android/Measure {
 	public static synthetic fun captureScreenshot$default (Lsh/measure/android/Measure;Landroid/app/Activity;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun clearUserId ()V
 	public final fun createSpanBuilder (Ljava/lang/String;)Lsh/measure/android/tracing/SpanBuilder;
-	public final fun disableShakeToLaunchBugReport ()V
-	public final fun enableShakeToLaunchBugReport (Z)V
-	public static synthetic fun enableShakeToLaunchBugReport$default (Lsh/measure/android/Measure;ZILjava/lang/Object;)V
 	public final fun getCurrentTime ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getTraceParentHeaderKey ()Ljava/lang/String;
@@ -30,7 +27,6 @@ public final class sh/measure/android/Measure {
 	public final fun internalTrackEvent (Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun internalTrackEvent$default (Lsh/measure/android/Measure;Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun internalTrackSpan (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJJILjava/util/Map;Ljava/util/Map;Ljava/util/Map;ZZ)V
-	public final fun isShakeToLaunchBugReportEnabled ()Z
 	public final fun launchBugReportActivity (ZLjava/util/Map;)V
 	public static synthetic fun launchBugReportActivity$default (Lsh/measure/android/Measure;ZLjava/util/Map;ILjava/lang/Object;)V
 	public final fun setShakeListener (Lsh/measure/android/bugreport/MsrShakeListener;)V
@@ -192,11 +188,10 @@ public final class sh/measure/android/config/MeasureConfig : sh/measure/android/
 	public static final field $stable I
 	public static final field Companion Lsh/measure/android/config/MeasureConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZZLsh/measure/android/config/MsrRequestHeadersProvider;)V
-	public synthetic fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZZLsh/measure/android/config/MsrRequestHeadersProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZLsh/measure/android/config/MsrRequestHeadersProvider;)V
+	public synthetic fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZLsh/measure/android/config/MsrRequestHeadersProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAutoStart ()Z
 	public fun getEnableLogging ()Z
-	public fun getEnableShakeToLaunchBugReport ()Z
 	public fun getHttpHeadersBlocklist ()Ljava/util/List;
 	public fun getHttpUrlAllowlist ()Ljava/util/List;
 	public fun getHttpUrlBlocklist ()Ljava/util/List;

--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -1,6 +1,7 @@
 package sh.measure.android
 
 import sh.measure.android.config.ConfigProvider
+import sh.measure.android.config.MsrRequestHeadersProvider
 import sh.measure.android.config.ScreenshotMaskLevel
 import sh.measure.android.events.EventType
 
@@ -63,7 +64,8 @@ internal class FakeConfigProvider : ConfigProvider {
     override val shakeAccelerationThreshold: Float = 3.5f
     override val shakeMinTimeIntervalMs: Long = 1000
     override val shakeSlop: Int = 2
-    override val enableShakeToLaunchBugReport: Boolean = true
+    override val disallowedCustomHeaders: List<String> = mutableListOf()
     override val trackActivityLoadTime: Boolean = true
     override val trackFragmentLoadTime: Boolean = true
+    override val requestHeadersProvider: MsrRequestHeadersProvider? = null
 }

--- a/android/measure/src/androidTest/java/sh/measure/android/MsrBugReportActivityRobot.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/MsrBugReportActivityRobot.kt
@@ -31,7 +31,6 @@ internal class MsrBugReportActivityRobot {
     fun initializeMeasure(config: MeasureConfig = MeasureConfig()): TestMeasureInitializer {
         val initializer = TestMeasureInitializer(
             shakeBugReportCollector = ShakeBugReportCollector(
-                autoLaunchEnabled = config.enableShakeToLaunchBugReport,
                 shakeDetector = shakeDetector,
             ),
             application = context as Application,

--- a/android/measure/src/androidTest/java/sh/measure/android/MsrBugReportActivityTest.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/MsrBugReportActivityTest.kt
@@ -150,41 +150,6 @@ class MsrBugReportActivityTest {
     }
 
     @Test
-    fun enablesShakeDeviceToLaunchBugReportActivityUsingMeasureConfig() {
-        // Given
-        robot.initializeMeasure(
-            MeasureConfig(
-                enableLogging = true,
-                enableShakeToLaunchBugReport = true,
-            ),
-        )
-        ActivityScenario.launch(TestActivity::class.java).use { activity ->
-            activity.moveToState(Lifecycle.State.RESUMED)
-            // Then
-            robot.shakeDevice()
-            robot.assertBugReportActivityLaunched()
-        }
-    }
-
-    @Test
-    fun enablesShakeDeviceToLaunchBugReportActivityAtRuntime() {
-        // Given
-        robot.initializeMeasure(
-            MeasureConfig(
-                enableLogging = true,
-                enableShakeToLaunchBugReport = false,
-            ),
-        )
-        ActivityScenario.launch(TestActivity::class.java).use { activity ->
-            activity.moveToState(Lifecycle.State.RESUMED)
-            // Then
-            Measure.enableShakeToLaunchBugReport()
-            robot.shakeDevice()
-            robot.assertBugReportActivityLaunched()
-        }
-    }
-
-    @Test
     @Ignore("Skipped as picking image from gallery is not reliable in tests")
     fun addsImageFromGallery() {
         // Unable to create an image URI which can be read by the app under test

--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -424,7 +424,6 @@ internal class TestMeasureInitializer(
         configProvider = configProvider,
     ),
     override val shakeBugReportCollector: ShakeBugReportCollector = ShakeBugReportCollector(
-        autoLaunchEnabled = configProvider.enableShakeToLaunchBugReport,
         shakeDetector = AccelerometerShakeDetector(
             sensorManager = systemServiceProvider.sensorManager,
             timeProvider = timeProvider,

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.TestOnly
 import sh.measure.android.Measure.captureLayoutSnapshot
 import sh.measure.android.Measure.captureScreenshot
 import sh.measure.android.Measure.clearUserId
-import sh.measure.android.Measure.disableShakeToLaunchBugReport
-import sh.measure.android.Measure.enableShakeToLaunchBugReport
 import sh.measure.android.Measure.getCurrentTime
 import sh.measure.android.Measure.getTraceParentHeaderKey
 import sh.measure.android.Measure.getTraceParentHeaderValue
@@ -354,57 +352,13 @@ object Measure {
     }
 
     /**
-     * Enables automatic bug reporting using shake detection.
-     * When the device is shaken, this will automatically launch the [MsrBugReportActivity].
-     *
-     * @see [disableShakeToLaunchBugReport] to disable the feature
-     */
-    fun enableShakeToLaunchBugReport(takeScreenshot: Boolean = true) {
-        if (isInitialized.get()) {
-            measure.enableShakeToLaunchBugReport(takeScreenshot)
-        }
-    }
-
-    /**
-     * Disables automatic bug reporting on shake.
-     * After calling this method, shake gestures will no longer trigger
-     * the bug report flow automatically.
-     */
-    fun disableShakeToLaunchBugReport() {
-        if (isInitialized.get()) {
-            measure.disableShakeToLaunchBugReport()
-        }
-    }
-
-    /**
-     * Checks if automatic bug reporting on shake is currently enabled.
-     *
-     * Returns true if the shake-to-report feature is active and will trigger
-     * the bug report flow when the device is shaken.
-     *
-     * @return Boolean indicating if shake detection for bug reporting is enabled
-     */
-    fun isShakeToLaunchBugReportEnabled(): Boolean {
-        if (isInitialized.get()) {
-            return measure.isShakeToLaunchBugReportEnabled()
-        }
-        return false
-    }
-
-    /**
      * Sets a custom shake listener for manual bug report handling.
-     *
-     * This method allows defining custom behavior when the device is shaken. The typical use case
-     * is to display a confirmation dialog before initiating the bug report process through
-     * [launchBugReportActivity].
      *
      * Key behaviors:
      * - Setting a non-null listener automatically begins monitoring accelerometer data
      * - Setting a null listener stops accelerometer monitoring and removes any existing listener
      * - The listener will only be triggered once every 5 seconds, regardless of how many shakes occur
      *   during that cooldown period
-     * - This method has no effect if automatic shake detection is already enabled via
-     *   [enableShakeToLaunchBugReport]
      *
      * @param listener The [MsrShakeListener] callback to invoke when a shake is detected, or null to
      *                 disable shake detection and remove the current listener

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -129,7 +129,6 @@ internal class MeasureInitializerImpl(
             samplingRateForErrorFreeSessions = inputConfig.samplingRateForErrorFreeSessions,
             autoStart = inputConfig.autoStart,
             traceSamplingRate = inputConfig.traceSamplingRate,
-            enableShakeToLaunchBugReport = inputConfig.enableShakeToLaunchBugReport,
             trackActivityLoadTime = inputConfig.trackActivityLoadTime,
             trackFragmentLoadTime = inputConfig.trackFragmentLoadTime,
             requestHeadersProvider = inputConfig.requestHeadersProvider,
@@ -451,7 +450,6 @@ internal class MeasureInitializerImpl(
         resumedActivityProvider = resumedActivityProvider,
     ),
     override val shakeBugReportCollector: ShakeBugReportCollector = ShakeBugReportCollector(
-        autoLaunchEnabled = configProvider.enableShakeToLaunchBugReport,
         shakeDetector = AccelerometerShakeDetector(
             sensorManager = systemServiceProvider.sensorManager,
             timeProvider = timeProvider,

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -234,7 +234,7 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
     fun getSessionId(): String? {
         return try {
             sessionManager.getSessionId()
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
             return null
         }
     }
@@ -302,20 +302,8 @@ internal class MeasureInternal(measureInitializer: MeasureInitializer) : AppLife
         )
     }
 
-    fun enableShakeToLaunchBugReport(takeScreenshot: Boolean) {
-        shakeBugReportCollector.enableAutoLaunch(takeScreenshot)
-    }
-
-    fun disableShakeToLaunchBugReport() {
-        shakeBugReportCollector.disableAutoLaunch()
-    }
-
     fun setShakeListener(shakeListener: MsrShakeListener?) {
         shakeBugReportCollector.setShakeListener(shakeListener)
-    }
-
-    fun isShakeToLaunchBugReportEnabled(): Boolean {
-        return shakeBugReportCollector.isShakeToLaunchBugReportEnabled()
     }
 
     fun internalTrackEvent(

--- a/android/measure/src/main/java/sh/measure/android/bugreport/MsrBugReportActivity.kt
+++ b/android/measure/src/main/java/sh/measure/android/bugreport/MsrBugReportActivity.kt
@@ -44,12 +44,10 @@ internal class MsrBugReportActivity : Activity() {
     private var uris: MutableSet<Uri> = mutableSetOf()
     private var attachments: MutableSet<ParcelableAttachment> = mutableSetOf()
     private val totalAttachments: Int get() = attachments.size + uris.size
-    private var wasShakeBugReportEnabled = false
 
     companion object {
         private const val PARCEL_SCREENSHOTS = "parcel_screenshots"
         private const val PARCEL_URIS = "parcel_uris"
-        private const val PARCEL_SHAKE_ENABLED = "parcel_shake_enabled"
 
         fun launch(
             context: Context,
@@ -77,22 +75,18 @@ internal class MsrBugReportActivity : Activity() {
 
     override fun onResume() {
         super.onResume()
-        wasShakeBugReportEnabled = Measure.isShakeToLaunchBugReportEnabled()
-        Measure.disableShakeToLaunchBugReport()
+        bugReportCollector.setBugReportFlowActive()
     }
 
     override fun onPause() {
         super.onPause()
-        if (wasShakeBugReportEnabled) {
-            Measure.enableShakeToLaunchBugReport()
-        }
+        bugReportCollector.setBugReportFlowInactive()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putParcelableArray(PARCEL_SCREENSHOTS, attachments.toTypedArray())
         outState.putParcelableArray(PARCEL_URIS, uris.toTypedArray())
-        outState.putBoolean(PARCEL_SHAKE_ENABLED, wasShakeBugReportEnabled)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -225,7 +219,6 @@ internal class MsrBugReportActivity : Activity() {
     }
 
     private fun restoreState(savedInstanceState: Bundle) {
-        wasShakeBugReportEnabled = savedInstanceState.getBoolean(PARCEL_SHAKE_ENABLED, false)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             restoreStateApi33(savedInstanceState)
         } else {

--- a/android/measure/src/main/java/sh/measure/android/bugreport/ShakeBugReportCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/bugreport/ShakeBugReportCollector.kt
@@ -1,40 +1,13 @@
 package sh.measure.android.bugreport
 
-import sh.measure.android.Measure
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 internal class ShakeBugReportCollector(
-    private val autoLaunchEnabled: Boolean,
     private val shakeDetector: ShakeDetector,
 ) : ShakeDetector.Listener {
     private val listener = AtomicReference<MsrShakeListener?>(null)
-    private val autoLaunch = AtomicBoolean(false)
-    private var takeScreenshot = false
-
-    init {
-        if (autoLaunchEnabled) {
-            enableAutoLaunch(takeScreenshot)
-        }
-    }
-
-    fun enableAutoLaunch(takeScreenshot: Boolean) {
-        autoLaunch.set(true)
-        this.takeScreenshot = takeScreenshot
-        shakeDetector.setShakeListener(this)
-        shakeDetector.start()
-    }
-
-    fun disableAutoLaunch() {
-        autoLaunch.set(false)
-        shakeDetector.setShakeListener(null)
-        shakeDetector.stop()
-    }
 
     fun setShakeListener(listener: MsrShakeListener?) {
-        if (autoLaunch.get()) {
-            return
-        }
         this.listener.set(listener)
         if (listener == null) {
             shakeDetector.setShakeListener(null)
@@ -46,14 +19,6 @@ internal class ShakeBugReportCollector(
     }
 
     override fun onShake() {
-        if (autoLaunch.get()) {
-            Measure.launchBugReportActivity(takeScreenshot = takeScreenshot)
-        } else {
-            listener.get()?.onShake()
-        }
-    }
-
-    fun isShakeToLaunchBugReportEnabled(): Boolean {
-        return autoLaunch.get()
+        listener.get()?.onShake()
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -15,7 +15,6 @@ internal data class Config(
     override val samplingRateForErrorFreeSessions: Float = DefaultConfig.SESSION_SAMPLING_RATE,
     override val autoStart: Boolean = DefaultConfig.AUTO_START,
     override val traceSamplingRate: Float = DefaultConfig.TRACE_SAMPLING_RATE,
-    override val enableShakeToLaunchBugReport: Boolean = DefaultConfig.ENABLE_SHAKE_TO_LAUNCH_BUG_REPORT,
     override val trackActivityLoadTime: Boolean = DefaultConfig.TRACK_ACTIVITY_LOAD_TIME,
     override val trackFragmentLoadTime: Boolean = DefaultConfig.TRACK_FRAGMENT_LOAD_TIME,
     override val disallowedCustomHeaders: List<String> = DefaultConfig.DISALLOWED_CUSTOM_HEADERS,
@@ -38,7 +37,7 @@ internal data class Config(
     override val sessionEndLastEventThresholdMs: Long = 20 * 60 * 1000 // 20 minutes
     override val maxSessionDurationMs: Long = 6 * 60 * 60 * 1000 // 6 hours
     override val maxEventNameLength: Int = 64 // 64 chars
-    override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+\$"
+    override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+$"
     override val maxUserDefinedAttributesPerEvent: Int = 100
     override val maxUserDefinedAttributeKeyLength: Int = 256 // 256 chars
     override val maxUserDefinedAttributeValueLength: Int = 256 // 256 chars

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -123,8 +123,6 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { shakeAccelerationThreshold }
     override val shakeSlop: Int
         get() = getMergedConfig { shakeSlop }
-    override val enableShakeToLaunchBugReport: Boolean
-        get() = getMergedConfig { enableShakeToLaunchBugReport }
     override val trackActivityLoadTime: Boolean
         get() = getMergedConfig { trackActivityLoadTime }
     override val trackFragmentLoadTime: Boolean
@@ -159,7 +157,7 @@ internal class ConfigProviderImpl(
 
         // If the allowlist is empty, then block the URLs that are in the blocklist.
         return !combinedHttpUrlBlocklist.any { value ->
-            value?.let { url.contains(it, ignoreCase = true) } ?: false
+            value?.let { url.contains(it, ignoreCase = true) } == true
         }
     }
 

--- a/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
@@ -13,7 +13,6 @@ internal object DefaultConfig {
     const val SESSION_SAMPLING_RATE: Float = 0f
     const val AUTO_START: Boolean = true
     const val TRACE_SAMPLING_RATE: Float = 0.1f
-    const val ENABLE_SHAKE_TO_LAUNCH_BUG_REPORT: Boolean = false
     const val TRACK_ACTIVITY_LOAD_TIME: Boolean = true
     const val TRACK_FRAGMENT_LOAD_TIME: Boolean = true
     val DISALLOWED_CUSTOM_HEADERS: List<String> =

--- a/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
@@ -25,7 +25,6 @@ internal interface IMeasureConfig {
     val samplingRateForErrorFreeSessions: Float
     val autoStart: Boolean
     val traceSamplingRate: Float
-    val enableShakeToLaunchBugReport: Boolean
     val trackActivityLoadTime: Boolean
     val trackFragmentLoadTime: Boolean
     val requestHeadersProvider: MsrRequestHeadersProvider?
@@ -153,17 +152,6 @@ class MeasureConfig(
      * Setting a value outside the range will throw an [IllegalArgumentException].
      */
     override val traceSamplingRate: Float = DefaultConfig.TRACE_SAMPLING_RATE,
-
-    /**
-     * Enable or disable shake to automatically launch the bug report flow. Defaults to `false`.
-     *
-     * When enabled, users can shake their device to launch the bug report activity automatically.
-     *
-     * This feature can also be enabled/disabled at runtime using:
-     * @see [Measure.disableShakeToLaunchBugReport] to disable shake to launch bug report.
-     * @see [Measure.enableShakeToLaunchBugReport] to enable shake to launch bug report.
-     */
-    override val enableShakeToLaunchBugReport: Boolean = DefaultConfig.ENABLE_SHAKE_TO_LAUNCH_BUG_REPORT,
 
     /**
      * Enable or disable automatic collection of Activity load time. Defaults to `true`.

--- a/android/measure/src/test/java/sh/measure/android/bugreport/ShakeBugReportCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/bugreport/ShakeBugReportCollectorTest.kt
@@ -2,63 +2,18 @@ package sh.measure.android.bugreport
 
 import org.junit.After
 import org.junit.Test
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class ShakeBugReportCollectorTest {
     private val shakeDetector = mock(ShakeDetector::class.java)
     private val listener = mock(MsrShakeListener::class.java)
-    private val collector = ShakeBugReportCollector(false, shakeDetector)
+    private val collector = ShakeBugReportCollector(shakeDetector)
 
     @After
     fun tearDown() {
         Mockito.reset(shakeDetector, listener)
-    }
-
-    @Test
-    fun `auto launch enabled should start shake detector`() {
-        // When
-        ShakeBugReportCollector(autoLaunchEnabled = true, shakeDetector)
-
-        // Then
-        verify(shakeDetector).start()
-    }
-
-    @Test
-    fun `enableAutoLaunch should start shake detector`() {
-        // When
-        collector.enableAutoLaunch(true)
-
-        // Then
-        verify(shakeDetector).start()
-    }
-
-    @Test
-    fun `disableAutoLaunch should stop shake detector`() {
-        // Given
-        collector.enableAutoLaunch(true)
-
-        // When
-        collector.disableAutoLaunch()
-
-        // Then
-        verify(shakeDetector).stop()
-    }
-
-    @Test
-    fun `setShakeListener should not set listener when autoLaunch is enabled`() {
-        // Given
-        collector.enableAutoLaunch(true)
-
-        // When
-        collector.setShakeListener(listener)
-
-        // Then
-        // It's called once by enableAutoLaunch
-        verify(shakeDetector, times(1)).setShakeListener(any())
     }
 
     @Test

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -48,7 +48,6 @@ internal class FakeConfigProvider : ConfigProvider {
     override val shakeAccelerationThreshold: Float = 20f
     override val shakeMinTimeIntervalMs: Long = 1500
     override val shakeSlop: Int = 3
-    override val enableShakeToLaunchBugReport: Boolean = false
     override val trackActivityLoadTime: Boolean = true
     override val trackFragmentLoadTime: Boolean = true
     override val disallowedCustomHeaders: List<String> = listOf("Content-Type", "msr-req-id", "Authorization", "Content-Length")

--- a/android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
+++ b/android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
@@ -26,7 +26,7 @@ import sh.measure.sample.screenshot.ViewScreenshotActivity
 import java.io.IOException
 import kotlin.concurrent.thread
 
-class ExceptionDemoActivity : AppCompatActivity() {
+class ExceptionDemoActivity : AppCompatActivity(), MsrShakeListener {
     private val _mutex = Any()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -91,11 +91,11 @@ class ExceptionDemoActivity : AppCompatActivity() {
         enableShakeSwitch.setOnCheckedChangeListener { _, isChecked ->
             when (isChecked) {
                 true -> {
-                    Measure.enableShakeToLaunchBugReport(true)
+                    Measure.setShakeListener(this@ExceptionDemoActivity)
                 }
 
                 false -> {
-                    Measure.disableShakeToLaunchBugReport()
+                    Measure.setShakeListener(null)
                 }
             }
         }
@@ -249,6 +249,13 @@ class ExceptionDemoActivity : AppCompatActivity() {
                 windowInsets
             }
         }
+    }
+
+    override fun onShake() {
+        Measure.launchBugReportActivity(
+            true,
+            AttributesBuilder().put("custom-key", "value").build()
+        )
     }
 }
 

--- a/docs/features/feature-bug-report-android.md
+++ b/docs/features/feature-bug-report-android.md
@@ -138,7 +138,7 @@ Add attributes when the Bug Report Activity is launched:
 
 ```kotlin
 val attributes = AttributesBuilder().put("is_premium", true).build()
-Measure.launchBugReportActivity(this, attributes = attributes)
+Measure.launchBugReportActivity(takeScreenshot = true, attributes = attributes)
 ```
 
 or, when `trackBugReport` is called:
@@ -152,32 +152,30 @@ Measure.trackBugReport(description = "...", attributes = attributes)
 
 ## Shake to Report Bug
 
-Enable this feature to use a shake gesture for launching the bug reporting flow. To enable this feature, use one of the following approaches based on your control requirements:
+A shake listener can be set up to allow users to report bugs by shaking their device. This is particularly useful for
+quickly reporting issues without navigating through the app.
 
-* Enable for the entire app: This automatically launches the bug reporting flow when users shake their devices.
+To set up a shake listener, use the `setShakeListener` method. The listener will be triggered when a shake is detected,
+use the `launchBugReportActivity` method to open the bug report interface or implement a custom UI.
 
-```kotlin
-Measure.init(context, MeasureConfig(enableShakeToLaunchBugReport = true))
-```
-
-* Enable/disable at any point in the app: Enable to automatically launch the bug reporting flow when users shake their devices.
-
-```kotlin
-// Enable shake to report
-Measure.enableShakeToLaunchBugReport()
-
-// Disable shake to report
-Measure.disableShakeToLaunchBugReport()
-```
-
-* Manually listen to the shake gesture: Use this approach to show a confirmation dialog to users before launching the bug reporting flow.
+> [!NOTE]
+> The listener can get called multiple times if the device is shaken multiple times in quick succession.
+> The `launchBugReportActivity` method handles this by ensuring that the bug report interface is only launched once.
+> However, if you implement a custom UI, you may need to handle this logic yourself.
 
 ```kotlin
 Measure.setShakeListener(object : MsrShakeListener {
     override fun onShake() {
-        Measure.launchBugReportActivity(false)
+      val attributes = AttributesBuilder().put("is_premium", true).build()
+      Measure.launchBugReportActivity(takeScreenshot = true, attributes = attributes)
     }
 })
+```
+
+To disable the shake listener, use:
+
+```kotlin
+Measure.setShakeListener(null)
 ```
 
 ## Benchmarks


### PR DESCRIPTION
# Description

⚠️  This is a breaking change. It modifies the public API for launching the bug report UI.

- Removes `enableShakeToLaunchBugReport` config.
- Removes `isShakeToLaunchBugReportEnabled`, `enableShakeToLaunchBugReport` and `disableShakeToLaunchBugReport` methods.
- Clients can use the existing APIs: `setShakeListener` along with `launchBugReport` to effectively do the same.

## Related issue
References #2357
