### PR TITLE
chore(ios): update shake detector api

### DIFF
--- a/docs/features/feature-bug-report-ios.md
+++ b/docs/features/feature-bug-report-ios.md
@@ -124,8 +124,8 @@ Measure.trackBugReport(description: "Bug description", attachments: [], attribut
 A shake listener can be set up to allow users to report bugs by shaking their device. This is particularly useful for
 quickly reporting issues without navigating through the app.
 
-To set up a shake listener, use the `setShakeListener` method. The listener will be triggered when a shake is detected,
-use the `launchBugReport` method to open the bug report interface or implement a custom UI.
+To set up a shake listener, use the `onShake` method and pass a closure. This closure will be called whenever a shake gesture is detected.
+You can either launch the default bug report interface using `launchBugReport`, or implement your own custom UI.
 
 > [!NOTE]
 > The listener can get called multiple times if the device is shaken multiple times in quick succession.
@@ -133,12 +133,13 @@ use the `launchBugReport` method to open the bug report interface or implement a
 > However, if you implement a custom UI, you may need to handle this logic yourself.
 
 ```swift
-Measure.setShakeListener(MyShakeListener())
-// Implement MsrShakeListener protocol in MyShakeListener```
+Measure.onShake {
+    Measure.launchBugReport(takeScreenshot: true, bugReportConfig: BugReportConfig.default, attributes: nil)
+}
 ```
 
 To disable the shake listener, use:
 
 ```swift
-Measure.setShakeListener(null)
+Measure.onShake(nil)
 ```

--- a/ios/DemoApp/AppDelegate.swift
+++ b/ios/DemoApp/AppDelegate.swift
@@ -23,6 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                        screenshotMaskLevel: .sensitiveFieldsOnly)
         Measure.initialize(with: clientInfo, config: config)
         Measure.setUserId("test_user_ios")
+        Measure.onShake {
+            Measure.launchBugReport(takeScreenshot: true, bugReportConfig: BugReportConfig.default, attributes: nil)
+        }
 
         return true
     }

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface
+// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
+// swift-module-flags: -target arm64-apple-ios12 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -222,9 +222,6 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
     get
   }
 }
-@objc public protocol MsrShakeListener {
-  @objc func onShake()
-}
 @objc public class MsrDimensions : ObjectiveC.NSObject {
   final public let topPadding: CoreFoundation.CGFloat
   public init(topPadding: CoreFoundation.CGFloat)
@@ -268,7 +265,7 @@ extension Measure.Measure {
   public static func getTraceParentHeaderKey() -> Swift.String
   public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Measure.AttributeValue]? = nil)
   @objc public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Any]? = nil)
-  @objc public static func setShakeListener(_ listener: (any Measure.MsrShakeListener)?)
+  @objc public static func onShake(_ handler: (() -> Swift.Void)?)
   public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Measure.AttributeValue]? = nil)
   @objc public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Any]? = nil)
   @objc public static func captureScreenshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)

--- a/ios/Sources/MeasureSDK/Swift/BugReport/ShakeBugReportCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/ShakeBugReportCollector.swift
@@ -10,20 +10,15 @@ import UIKit
 
 final class ShakeBugReportCollector: ShakeDetectorListener {
     private let shakeDetector: ShakeDetector
-    private let bugReportManager: BugReportManager
-    private var listener: MsrShakeListener?
-    private var takeScreenshot: Bool = false
-    private let screenshotGenerator: ScreenshotGenerator
+    private var shakeHandler: (() -> Void)?
 
-    init(bugReportManager: BugReportManager, shakeDetector: ShakeDetector, screenshotGenerator: ScreenshotGenerator) {
+    init(shakeDetector: ShakeDetector) {
         self.shakeDetector = shakeDetector
-        self.bugReportManager = bugReportManager
-        self.screenshotGenerator = screenshotGenerator
     }
 
-    func setShakeListener(_ listener: MsrShakeListener?) {
-        self.listener = listener
-        if listener == nil {
+    func setShakeHandler(_ handler: (() -> Void)?) {
+        self.shakeHandler = handler
+        if handler == nil {
             shakeDetector.setShakeListener(nil)
             shakeDetector.stop()
         } else {
@@ -33,8 +28,6 @@ final class ShakeBugReportCollector: ShakeDetectorListener {
     }
 
     func onShake() {
-        if let listener = listener {
-            listener.onShake()
-        }
+        shakeHandler?()
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/BugReport/ShakeDetector.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/ShakeDetector.swift
@@ -28,8 +28,3 @@ protocol ShakeDetector {
 protocol ShakeDetectorListener: AnyObject {
     func onShake()
 }
-
-/// Listener called when a shake motion is detected.
-@objc public protocol MsrShakeListener: AnyObject {
-    func onShake()
-}

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -56,7 +56,7 @@ struct Config: InternalConfig, MeasureConfig {
     let accelerometerUpdateInterval: TimeInterval
     let screenshotMaskLevel: ScreenshotMaskLevel
 
-    internal init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
+    internal init(enableLogging: Bool = DefaultConfig.enableLogging,
                   samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
                   traceSamplingRate: Float = DefaultConfig.traceSamplingRate,
                   trackHttpHeaders: Bool = DefaultConfig.trackHttpHeaders,

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -41,7 +41,7 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
     }
 
-    private func convertToCodableValue(_ dictionary: [String: Any]) -> [String: CodableValue] {
+    private func convertToCodableValue(_ dictionary: [String: Any]) -> [String: CodableValue] {  // swiftlint:disable:this cyclomatic_complexity
         var result: [String: CodableValue] = [:]
 
         for (key, value) in dictionary {

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -200,9 +200,9 @@ import UIKit
         measureInternal.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
     }
 
-    @objc func setShakeListener(_ listener: MsrShakeListener?) {
+    @objc func onShake(_ handler: (() -> Void)?) {
         guard let measureInternal = self.measureInternal else { return }
-        measureInternal.setShakeListener(listener)
+        measureInternal.onShake(handler)
     }
 
     func trackBugReport(description: String,
@@ -587,19 +587,16 @@ extension Measure {
                                        attributes: attributes)
     }
 
-    /// Sets a custom shake listener for manually handling shake gestures.
-    /// This is useful for showing a confirmation UI or triggering a custom bug reporting flow instead of
-    /// launching the built-in experience.
+    /// Sets a custom shake listener using a closure for handling shake gestures.
     ///
-    /// Key behavior:
-    /// - Setting a non-`nil` listener enables shake detection.
-    /// - Setting `nil` disables shake detection.
-    /// - The listener is throttled and will only fire once every 5 seconds.
-    /// - Has no effect if automatic shake reporting is already enabled.
+    /// - Note:
+    ///   - Setting a non-`nil` handler enables shake detection.
+    ///   - Setting `nil` disables shake detection.
+    ///   - Has no effect if automatic shake reporting is already enabled.
     ///
-    /// - Parameter listener: A custom `MsrShakeListener` to receive shake callbacks, or `nil` to disable.
-    @objc public static func setShakeListener(_ listener: MsrShakeListener?) {
-        Measure.shared.setShakeListener(listener)
+    /// - Parameter handler: Closure to call when shake is detected.
+    @objc public static func onShake(_ handler: (() -> Void)?) {
+        Measure.shared.onShake(handler)
     }
 
     /// Tracks a custom bug report.

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -406,8 +406,6 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                                          sessionManager: sessionManager,
                                                          idProvider: idProvider)
         self.shakeDetector = AccelerometerShakeDetector(configProvider: configProvider)
-        self.shakeBugReportCollector = ShakeBugReportCollector(bugReportManager: bugReportManager,
-                                                               shakeDetector: shakeDetector,
-                                                               screenshotGenerator: screenshotGenerator)
+        self.shakeBugReportCollector = ShakeBugReportCollector(shakeDetector: shakeDetector)
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -230,8 +230,8 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         bugReportCollector.startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: attributes)
     }
 
-    func setShakeListener(_ shakeListener: MsrShakeListener?) {
-        shakeBugReportCollector.setShakeListener(shakeListener)
+    func onShake(_ handler: (() -> Void)?) {
+        shakeBugReportCollector.setShakeHandler(handler)
     }
 
     func trackBugReport(description: String,

--- a/ios/Tests/MeasureSDKTests/BugReport/ShakeBugReportCollectorTests.swift
+++ b/ios/Tests/MeasureSDKTests/BugReport/ShakeBugReportCollectorTests.swift
@@ -9,33 +9,27 @@ import XCTest
 @testable import Measure
 
 final class ShakeBugReportCollectorTests: XCTestCase {
-    func test_onShake_delegatesToListener() {
+    func test_onShake_invokesHandler() {
         let bugManager = MockBugReportManager()
         let shakeDetector = MockShakeDetector()
-        let listener = MockMsrShakeListener()
-        let collector = ShakeBugReportCollector(
-            bugReportManager: bugManager,
-            shakeDetector: shakeDetector,
-            screenshotGenerator: MockScreenshotGenerator()
-        )
+        let collector = ShakeBugReportCollector(shakeDetector: shakeDetector)
 
-        collector.setShakeListener(listener)
+        var didCall = false
+        collector.setShakeHandler {
+            didCall = true
+        }
+
         shakeDetector.simulateShake()
 
-        XCTAssertTrue(listener.didShakeCalled)
+        XCTAssertTrue(didCall)
         XCTAssertFalse(bugManager.didOpenBugReporter)
     }
 
-    func test_setShakeListener_nilListener_stopsDetector() {
-        let bugManager = MockBugReportManager()
+    func test_setShakeHandler_nil_stopsDetector() {
         let shakeDetector = MockShakeDetector()
-        let collector = ShakeBugReportCollector(
-            bugReportManager: bugManager,
-            shakeDetector: shakeDetector,
-            screenshotGenerator: MockScreenshotGenerator()
-        )
+        let collector = ShakeBugReportCollector(shakeDetector: shakeDetector)
 
-        collector.setShakeListener(nil)
+        collector.setShakeHandler(nil)
 
         XCTAssertTrue(shakeDetector.didStop)
         XCTAssertNil(shakeDetector.getShakeListener())

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -8,7 +8,7 @@
 import Foundation
 @testable import Measure
 
-final class MockMeasureInitializer: MeasureInitializer {
+final class MockMeasureInitializer: MeasureInitializer {  // swiftlint:disable:this type_body_length
     let configProvider: ConfigProvider
     let client: Client
     let logger: Logger
@@ -318,8 +318,6 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                          sessionManager: self.sessionManager,
                                                          idProvider: self.idProvider)
         self.shakeDetector = AccelerometerShakeDetector(configProvider: self.configProvider)
-        self.shakeBugReportCollector = ShakeBugReportCollector(bugReportManager: self.bugReportManager,
-                                                               shakeDetector: self.shakeDetector,
-                                                               screenshotGenerator: self.screenshotGenerator)
+        self.shakeBugReportCollector = ShakeBugReportCollector(shakeDetector: self.shakeDetector)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockShakeDetector.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockShakeDetector.swift
@@ -38,11 +38,3 @@ final class MockShakeDetector: ShakeDetector {
         currentListener?.onShake()
     }
 }
-
-final class MockMsrShakeListener: MsrShakeListener {
-    var didShakeCalled = false
-
-    func onShake() {
-        didShakeCalled = true
-    }
-}


### PR DESCRIPTION
# Description

⚠️  This is a breaking change. It modifies the public API for implementing shake listener.

- Remove `MsrShakeListener` protocol.
- Add a `onShake` api with a completion handler which gets called when a shake gesture is detected.

## Related issue
References #2357 