### PR TITLE
fix(ios): generate non nil network attributes for first event

### DIFF
--- a/ios/DemoApp/SceneDelegate.swift
+++ b/ios/DemoApp/SceneDelegate.swift
@@ -13,13 +13,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-
-        // Create and show the floating button
-//        floatingButtonController = FloatingButtonViewController()
-//        floatingButtonController?.view.frame = windowScene.coordinateSpace.bounds
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-//            self.window?.addSubview(self.floatingButtonController!.view)
-//        })
     }
 
     @objc func floatingButtonWasTapped() {

--- a/ios/Sources/MeasureSDK/Swift/Attribute/AppAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/AppAttributeProcessor.swift
@@ -14,7 +14,7 @@ final class AppAttributeProcessor: BaseComputeOnceAttributeProcessor {
     private lazy var appUniqueId: String = AttributeConstants.unknown
     private lazy var measureSdkVersion: String = AttributeConstants.unknown
 
-    override func updateAttribute(_ attribute: inout Attributes) {
+    override func updateAttribute(_ attribute: Attributes) {
         attribute.appVersion = appVersion
         attribute.appBuild = appBuild
         attribute.appUniqueId = appUniqueId

--- a/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
@@ -28,7 +28,7 @@ enum DeviceType: String, Codable {
     case phone
 }
 
-struct Attributes: Codable {
+class Attributes: Codable {
     var threadName: String?
     var deviceName: String?
     var deviceModel: String?

--- a/ios/Sources/MeasureSDK/Swift/Attribute/AttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/AttributeProcessor.swift
@@ -9,5 +9,5 @@ import Foundation
 
 /// An interface marking a class as an attribute processor. It is responsible for generating, caching and appending attributes to an event. 
 protocol AttributeProcessor {
-    func appendAttributes(_ attribute: inout Attributes)
+    func appendAttributes(_ attribute: Attributes)
 }

--- a/ios/Sources/MeasureSDK/Swift/Attribute/ComputeOnceAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/ComputeOnceAttributeProcessor.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol ComputeOnceAttributeProcessor {
     func computeAttributes()
-    func updateAttribute(_ attribute: inout Attributes)
+    func updateAttribute(_ attribute: Attributes)
 }
 
 /// Generates the attributes once and then caches them. Subsequent calls to [appendAttributes] will return the cached attributes.
@@ -20,15 +20,15 @@ protocol ComputeOnceAttributeProcessor {
 class BaseComputeOnceAttributeProcessor: AttributeProcessor, ComputeOnceAttributeProcessor {
     private var isComputed = false
 
-    func appendAttributes(_ attribute: inout Attributes) {
+    func appendAttributes(_ attribute: Attributes) {
         if !isComputed {
             computeAttributes()
             isComputed = true
         }
-        updateAttribute(&attribute)
+        updateAttribute(attribute)
     }
 
-    func updateAttribute(_ attribute: inout Attributes) {
+    func updateAttribute(_ attribute: Attributes) {
         fatalError("Subclasses must override updateAttribute()")
     }
 

--- a/ios/Sources/MeasureSDK/Swift/Attribute/DeviceAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/DeviceAttributeProcessor.swift
@@ -27,7 +27,7 @@ final class DeviceAttributeProcessor: BaseComputeOnceAttributeProcessor {
     private var osVersion: String?
     private var deviceCpuArch: String?
 
-    override func updateAttribute(_ attribute: inout Attributes) {
+    override func updateAttribute(_ attribute: Attributes) {
         attribute.deviceName = deviceName
         attribute.deviceModel = deviceModel
         attribute.deviceManufacturer = deviceManufacturer

--- a/ios/Sources/MeasureSDK/Swift/Attribute/InstallationIdAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/InstallationIdAttributeProcessor.swift
@@ -18,7 +18,7 @@ final class InstallationIdAttributeProcessor: BaseComputeOnceAttributeProcessor 
         self.idProvider = idProvider
     }
 
-    override func updateAttribute(_ attribute: inout Attributes) {
+    override func updateAttribute(_ attribute: Attributes) {
         attribute.installationId = installationId
     }
 

--- a/ios/Sources/MeasureSDK/Swift/Attribute/NetworkStateAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/NetworkStateAttributeProcessor.swift
@@ -21,7 +21,18 @@ final class NetworkStateAttributeProcessor: AttributeProcessor {
     }
 
     func appendAttributes(_ attributes: inout Attributes) {
-        if let cache = cachedAttributes {
+        if cachedAttributes == nil {
+            let newCache = (
+                type: getNetworkType(),
+                gen: getNetworkGeneration(),
+                provider: getNetworkProvider()
+            )
+            cachedAttributes = newCache
+            lastUpdateTime = Date()
+            attributes.networkType = newCache.type
+            attributes.networkGeneration = newCache.gen
+            attributes.networkProvider = newCache.provider
+        } else if let cache = cachedAttributes {
             attributes.networkType = cache.type
             attributes.networkGeneration = cache.gen
             attributes.networkProvider = cache.provider

--- a/ios/Sources/MeasureSDK/Swift/Attribute/NetworkStateAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/NetworkStateAttributeProcessor.swift
@@ -20,7 +20,7 @@ final class NetworkStateAttributeProcessor: AttributeProcessor {
         self.measureDispatchQueue = measureDispatchQueue
     }
 
-    func appendAttributes(_ attributes: inout Attributes) {
+    func appendAttributes(_ attributes: Attributes) {
         if cachedAttributes == nil {
             let newCache = (
                 type: getNetworkType(),

--- a/ios/Sources/MeasureSDK/Swift/Attribute/UserAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/UserAttributeProcessor.swift
@@ -20,7 +20,7 @@ final class UserAttributeProcessor: AttributeProcessor {
         self.measureDispatchQueue = measureDispatchQueue
     }
 
-    func appendAttributes(_ attributes: inout Attributes) {
+    func appendAttributes(_ attributes: Attributes) {
         loadedFromDisk.setTrueIfFalse {
             userId = userDefaultStorage.getUserId()
         }

--- a/ios/Sources/MeasureSDK/Swift/Events/Event.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/Event.swift
@@ -158,7 +158,7 @@ final class Event<T: Codable>: Codable {
     /// - Parameter attributeProcessors: A list of processors that modify the event's attributes.
     func appendAttributes(_ attributeProcessors: [AttributeProcessor]) {
         attributeProcessors.forEach { processor in
-            processor.appendAttributes(&self.attributes!)
+            processor.appendAttributes(self.attributes!)
         }
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
@@ -259,9 +259,9 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
         let sessionId = sessionManager.sessionId
 
         // apply attributes
-        var parsedAttributes = Attributes(dict: attributes)
+        let parsedAttributes = Attributes(dict: attributes)
         for attributeProcessor in attributeProcessors {
-            attributeProcessor.appendAttributes(&parsedAttributes)
+            attributeProcessor.appendAttributes(parsedAttributes)
         }
 
         // deserialize checkpoints
@@ -311,22 +311,22 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(HttpData.self, from: jsonData)
     }
-    
+
     func extractBugReportData(data: [String: Any?]) throws -> BugReportData {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(BugReportData.self, from: jsonData)
     }
-    
+
     func extractClickData(data: [String: Any?]) throws -> ClickData {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(ClickData.self, from: jsonData)
     }
-    
+
     func extractLongClickData(data: [String: Any?]) throws -> LongClickData {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(LongClickData.self, from: jsonData)
     }
-    
+
     func extractScrollData(data: [String: Any?]) throws -> ScrollData {
         let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
         return try JSONDecoder().decode(ScrollData.self, from: jsonData)

--- a/ios/Sources/MeasureSDK/Swift/Events/SignalProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/SignalProcessor.swift
@@ -146,7 +146,7 @@ final class BaseSignalProcessor: SignalProcessor {
         userDefinedAttributes: String?,
         threadName: String?
     ) {
-        let resolvedThreadName = threadName ?? Thread.current.name ?? "unknown"
+        let resolvedThreadName = threadName ?? OperationQueue.current?.underlyingQueue?.label ?? "unknown"
 
         measureDispatchQueue.submit { [weak self] in
             guard let self else { return }
@@ -162,7 +162,7 @@ final class BaseSignalProcessor: SignalProcessor {
                 userDefinedAttributes: userDefinedAttributes
             )
 
-            self.appendAttributes(event: event, threadName: resolvedThreadName)
+            self.appendAttributes(event: event, threadName: resolvedThreadName.isEmpty ? "unknown" : resolvedThreadName )
 
             let needsReporting = self.sessionManager.shouldReportSession ||
             self.configProvider.eventTypeExportAllowList.contains(event.type)
@@ -178,7 +178,6 @@ final class BaseSignalProcessor: SignalProcessor {
 
     private func appendAttributes<T: Codable>(event: Event<T>, threadName: String?) {
         SignPost.trace(subcategory: "Event", label: "appendAttributes") {
-            let threadName = threadName ?? OperationQueue.current?.underlyingQueue?.label ?? "unknown"
             event.attributes?.threadName = threadName
             event.attributes?.deviceLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
             event.appendAttributes(self.attributeProcessors)

--- a/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
@@ -42,16 +42,16 @@ final class BaseNetworkClient: NetworkClient {
                 }
             }
         }
-        
+
         for spanEntity in spans {
             let span = spanEntity.toSpanDataCodable()
-            
+
             let encoder = JSONEncoder()
             if let data = try? encoder.encode(span) {
                 multipartData.append(.formField(name: formFieldSpan, value: data))
             }
         }
-        
+
         return httpClient.sendMultipartRequest(url: baseUrl.appendingPathComponent(eventsEndpoint),
                                                method: .put,
                                                headers: [authorization: "\(bearer) \(apiKey)",

--- a/ios/Sources/MeasureSDK/Swift/Tracing/SpanProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Tracing/SpanProcessor.swift
@@ -39,11 +39,11 @@ final class BaseSpanProcessor: SpanProcessor {
         SignPost.trace(subcategory: "Span", label: "spanProcessorOnStart") {
             logger.log(level: .debug, message: "Span started: \(span.name)", error: nil, data: nil)
             let threadName = OperationQueue.current?.underlyingQueue?.label ?? "unknown"
-            var attributes = Attributes()
+            let attributes = Attributes()
             attributes.threadName = threadName
             attributes.deviceLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
             attributeProcessors.forEach { processor in
-                processor.appendAttributes(&attributes)
+                processor.appendAttributes(attributes)
             }
             span.setInternalAttribute(attributes)
         }

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -100,7 +100,7 @@ final class BaseSystemFileManager: SystemFileManager {
             return nil
         }
     }
-    
+
     func getDirectoryPath(directory: FileManager.SearchPathDirectory) -> String? {
         guard let directoryURL = fileManager.urls(for: directory, in: .userDomainMask).first else {
             logger.internalLog(level: .error, message: "Unable to access directory \(directory)", error: nil, data: nil)

--- a/ios/Tests/MeasureSDKTests/Attribute/AttributeProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/AttributeProcessorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class AttributeProcessorTests: XCTestCase {
     func testAppendsAttributes() {
-        var attributes = Attributes(deviceName: "iPhone 14")
+        let attributes = Attributes(deviceName: "iPhone 14")
 
         let attributeProcessor1 = MockAttributeProcessor { attributes in
             attributes.threadName = "com.thread.main"
@@ -20,7 +20,7 @@ final class AttributeProcessorTests: XCTestCase {
         }
 
         let processors: [AttributeProcessor] = [attributeProcessor1, attributeProcessor2]
-        processors.forEach { $0.appendAttributes(&attributes) }
+        processors.forEach { $0.appendAttributes(attributes) }
 
         XCTAssertEqual(attributes.threadName, "com.thread.main")
         XCTAssertEqual(attributes.measureSdkVersion, "0.0.1")
@@ -28,7 +28,7 @@ final class AttributeProcessorTests: XCTestCase {
     }
 
     func testUpdatesValueIfTwoProcessorsSetSameKey() {
-        var attributes = Attributes(deviceName: "iPhone 14")
+        let attributes = Attributes(deviceName: "iPhone 14")
 
         let attributeProcessor1 = MockAttributeProcessor { attributes in
             attributes.threadName = "com.thread.main"
@@ -38,17 +38,17 @@ final class AttributeProcessorTests: XCTestCase {
         }
 
         let processors: [AttributeProcessor] = [attributeProcessor1, attributeProcessor2]
-        processors.forEach { $0.appendAttributes(&attributes) }
+        processors.forEach { $0.appendAttributes(attributes) }
 
         XCTAssertEqual(attributes.threadName, "com.thread.background")
         XCTAssertEqual(attributes.deviceName, "iPhone 14")
     }
 
     func testNoopWhenEmptyListOfProcessorsIsPassed() {
-        var attributes = Attributes()
+        let attributes = Attributes()
 
         let processors: [AttributeProcessor] = []
-        processors.forEach { $0.appendAttributes(&attributes) }
+        processors.forEach { $0.appendAttributes(attributes) }
 
         XCTAssertEqual(attributes.threadName, nil)
         XCTAssertEqual(attributes.deviceName, nil)

--- a/ios/Tests/MeasureSDKTests/Attribute/ComputeOnceAttributeProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/ComputeOnceAttributeProcessorTests.swift
@@ -16,15 +16,15 @@ final class ComputeOnceAttributeProcessorTests: XCTestCase {
             override func computeAttributes() {
                 computeAttributesCalledCount += 1
             }
-            override func updateAttribute(_ attribute: inout Attributes) {}
+            override func updateAttribute(_ attribute: Attributes) {}
         }
 
         let processor = TestComputeOnceAttributeProcessor()
         var attributes = Attributes()
 
-        processor.appendAttributes(&attributes)
-        processor.appendAttributes(&attributes)
-        processor.appendAttributes(&attributes)
+        processor.appendAttributes(attributes)
+        processor.appendAttributes(attributes)
+        processor.appendAttributes(attributes)
 
         XCTAssertEqual(processor.computeAttributesCalledCount, 1)
     }

--- a/ios/Tests/MeasureSDKTests/Attribute/InstallationIdAttributeProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/InstallationIdAttributeProcessorTests.swift
@@ -36,7 +36,7 @@ final class InstallationIdAttributeProcessorTests: XCTestCase {
     }
 
     func testGivenInstallationIdIsNotSetThenCreatesStoresAndReturnsInstallationIdInUserDefaults() {
-        installationIdAttributeProcessor.appendAttributes(&attributes)
+        installationIdAttributeProcessor.appendAttributes(attributes)
 
         XCTAssertEqual(attributes.installationId, installationId)
     }
@@ -44,7 +44,7 @@ final class InstallationIdAttributeProcessorTests: XCTestCase {
     func testGivenInstallationIdIsAlreadySetThenReturnsTheStoredInstallationId() {
         userDefaultStorage.installationId = installationId
 
-        installationIdAttributeProcessor.appendAttributes(&attributes)
+        installationIdAttributeProcessor.appendAttributes(attributes)
 
         XCTAssertEqual(attributes.installationId, installationId)
     }

--- a/ios/Tests/MeasureSDKTests/Attribute/UserAttributeProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/UserAttributeProcessorTests.swift
@@ -46,7 +46,7 @@ final class UserAttributeProcessorTests: XCTestCase {
     func testAppendsUserIdToAttributesFromMemory() {
         userAttributeProcessor.setUserId("user-id")
 
-        userAttributeProcessor.appendAttributes(&attributes)
+        userAttributeProcessor.appendAttributes(attributes)
 
         XCTAssertEqual("user-id", attributes.userId)
     }
@@ -54,7 +54,7 @@ final class UserAttributeProcessorTests: XCTestCase {
     func testAppendsUserIdToAttributesFromUserDefaults() {
         userDefaultStorage.setUserId("user-id")
 
-        userAttributeProcessor.appendAttributes(&attributes)
+        userAttributeProcessor.appendAttributes(attributes)
 
         XCTAssertEqual("user-id", attributes.userId)
     }

--- a/ios/Tests/MeasureSDKTests/Exporter/HttpClientTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/HttpClientTests.swift
@@ -62,7 +62,7 @@ class HttpClientTests: XCTestCase {
 
     func testGetCustomHeader_notNilIfSet() {
         class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String : String] {
+            func getRequestHeaders() -> [String: String] {
                 return ["key1": "value1", "key2": "value2"]
             }
         }
@@ -76,7 +76,7 @@ class HttpClientTests: XCTestCase {
 
     func testGetCustomHeader_removeValuesIfKeyContainsReservedHeaders() {
         class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String : String] {
+            func getRequestHeaders() -> [String: String] {
                 return ["key1": "value1", "key2": "value2", "Content-Type": "abc", "msr-req-id": "abc", "Authorization": "abc", "Content-Length": "abc"]
             }
         }
@@ -99,7 +99,7 @@ class HttpClientTests: XCTestCase {
 
     func testGetCustomHeader_caseInsensitiveDisallowFiltering() {
         class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String : String] {
+            func getRequestHeaders() -> [String: String] {
                 return ["Authorization": "abc", "authorization": "xyz", "Key1": "value"]
             }
         }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockAttributeProcessor.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockAttributeProcessor.swift
@@ -8,7 +8,7 @@
 import Foundation
 @testable import Measure
 
-typealias AttributeAppendBlock = (inout Attributes) -> Void
+typealias AttributeAppendBlock = (Attributes) -> Void
 
 final class MockAttributeProcessor: AttributeProcessor {
     private let appendBlock: AttributeAppendBlock
@@ -18,8 +18,8 @@ final class MockAttributeProcessor: AttributeProcessor {
         self.appendBlock = appendBlock
     }
 
-    func appendAttributes(_ attributes: inout Attributes) {
+    func appendAttributes(_ attributes: Attributes) {
         appendCalled = true
-        appendBlock(&attributes)
+        appendBlock(attributes)
     }
 }

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
   spec.version      = "0.4.0"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
-  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }
   spec.author       = "measure.sh"
   spec.platform     = :ios, "12.0"
   spec.swift_version = "5.10"


### PR DESCRIPTION
# Description

This PR contains the below changes
- Fix network attributes being set to nil when first event is tracked.
- Fix empty thread name.
- Update `Attribute` to be a class instead of a struct. The reason for doing is that classes are passed by reference and structs are passed by value. Given that the event object passes a single attribute object across multiple attribute processors to be updated, it makes more sense for it to be a class rather than a struct.

## Related issue
Fixes #2366 