### PR TITLE
chore(ios): update apis to support objc initialisation

### DIFF
--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -302,13 +302,24 @@ func application(_ application: UIApplication,
 
 ```objc
 
-#import <MeasureSDK/MeasureSDK.h>
+#import <Measure/measure-sh-umbrella.h>
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
-  ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
-  [Measure initializeWith:clientInfo config:config];
-  return YES;
+    ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
+    BaseMeasureConfig *config = [[BaseMeasureConfig alloc] initWithEnableLogging:YES
+                                                           samplingRateForErrorFreeSessions:1.0
+                                                           traceSamplingRate:1.0
+                                                           trackHttpHeaders:YES
+                                                           trackHttpBody:YES
+                                                           httpHeadersBlocklist:@[]
+                                                           httpUrlBlocklist:@[]
+                                                           httpUrlAllowlist:@[]
+                                                           autoStart:true
+                                                           trackViewControllerLoadTime:true
+                                                           screenshotMaskLevel:ScreenshotMaskLevelObjcAllText
+                                                           requestHeadersProvider:nil];
+    [Measure initializeWith:clientInfo config:config];
+    return YES;
   }
 
 ```

--- a/ios/DemoApp/AppDelegate.swift
+++ b/ios/DemoApp/AppDelegate.swift
@@ -15,10 +15,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         let clientInfo = ClientInfo(apiKey: "msrsh_38514d61493cf70ce99a11abcb461e9e6d823e2068c7124a0902b745598f7ffb_65ea2c1c",
                                     apiUrl: "http://localhost:8080")
-        final class CustomHeaderProvider: MsrRequestHeadersProvider {
-            private var requestHeaders: [String: String] = ["key1": "value1", "key2": "value2"]
+        final class CustomHeaderProvider: NSObject, MsrRequestHeadersProvider {
+            private var requestHeaders: NSDictionary = ["key1": "value1", "key2": "value2"]
 
-            func getRequestHeaders() -> [String: String] {
+            func getRequestHeaders() -> NSDictionary {
                 return requestHeaders
             }
         }

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -38,6 +38,7 @@ extension Measure.AttributeValue : Swift.Codable {
   required public init(from decoder: any Swift.Decoder) throws
   final public func encode(to encoder: any Swift.Encoder) throws
   public init(enableLogging: Swift.Bool? = nil, samplingRateForErrorFreeSessions: Swift.Float? = nil, traceSamplingRate: Swift.Float? = nil, trackHttpHeaders: Swift.Bool? = nil, trackHttpBody: Swift.Bool? = nil, httpHeadersBlocklist: [Swift.String]? = nil, httpUrlBlocklist: [Swift.String]? = nil, httpUrlAllowlist: [Swift.String]? = nil, autoStart: Swift.Bool? = nil, trackViewControllerLoadTime: Swift.Bool? = nil, screenshotMaskLevel: Measure.ScreenshotMaskLevel? = nil, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)? = nil)
+  @objc convenience public init(enableLogging: Swift.Bool, samplingRateForErrorFreeSessions: Swift.Float, traceSamplingRate: Swift.Float, trackHttpHeaders: Swift.Bool, trackHttpBody: Swift.Bool, httpHeadersBlocklist: [Swift.String], httpUrlBlocklist: [Swift.String], httpUrlAllowlist: [Swift.String], autoStart: Swift.Bool, trackViewControllerLoadTime: Swift.Bool, screenshotMaskLevel: Measure.ScreenshotMaskLevelObjc, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)?)
   @objc deinit
 }
 public protocol Span {
@@ -150,6 +151,17 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
     get
   }
 }
+@objc public enum ScreenshotMaskLevelObjc : Swift.Int {
+  case allTextAndMedia
+  case allText
+  case allTextExceptClickable
+  case sensitiveFieldsOnly
+  public init?(rawValue: Swift.Int)
+  public typealias RawValue = Swift.Int
+  public var rawValue: Swift.Int {
+    get
+  }
+}
 @objc public class BugReportConfig : ObjectiveC.NSObject {
   final public let colors: Measure.MsrColors
   final public let text: Measure.MsrText
@@ -202,8 +214,8 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   public func update(darkBackground: UIKit.UIColor? = nil, lightBackground: UIKit.UIColor? = nil, darkButtonBackground: UIKit.UIColor? = nil, lightButtonBackground: UIKit.UIColor? = nil, darkText: UIKit.UIColor? = nil, lightText: UIKit.UIColor? = nil, darkPlaceholder: UIKit.UIColor? = nil, lightPlaceholder: UIKit.UIColor? = nil, darkFloatingButtonBackground: UIKit.UIColor? = nil, lightFloatingButtonBackground: UIKit.UIColor? = nil, darkFloatingButtonIcon: UIKit.UIColor? = nil, lightFloatingButtonIcon: UIKit.UIColor? = nil, darkfloatingExitButtonText: UIKit.UIColor? = nil, lightfloatingExitButtonText: UIKit.UIColor? = nil, badgeColor: UIKit.UIColor? = nil, badgeTextColor: UIKit.UIColor? = nil, isDarkMode: Swift.Bool? = nil) -> Measure.MsrColors
   @objc deinit
 }
-public protocol MsrRequestHeadersProvider {
-  func getRequestHeaders() -> [Swift.String : Swift.String]
+@objc public protocol MsrRequestHeadersProvider : ObjectiveC.NSObjectProtocol {
+  @objc func getRequestHeaders() -> Foundation.NSDictionary
 }
 @objc public enum VCLifecycleEventType : Swift.Int, Swift.Codable {
   case viewDidLoad = 0
@@ -379,6 +391,9 @@ extension Measure.SpanStatus : Swift.RawRepresentable {}
 extension Measure.ScreenshotMaskLevel : Swift.Equatable {}
 extension Measure.ScreenshotMaskLevel : Swift.Hashable {}
 extension Measure.ScreenshotMaskLevel : Swift.RawRepresentable {}
+extension Measure.ScreenshotMaskLevelObjc : Swift.Equatable {}
+extension Measure.ScreenshotMaskLevelObjc : Swift.Hashable {}
+extension Measure.ScreenshotMaskLevelObjc : Swift.RawRepresentable {}
 extension Measure.VCLifecycleEventType : Swift.Equatable {}
 extension Measure.VCLifecycleEventType : Swift.Hashable {}
 extension Measure.VCLifecycleEventType : Swift.RawRepresentable {}

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -58,7 +58,7 @@ struct Config: InternalConfig, MeasureConfig {
     let requestHeadersProvider: MsrRequestHeadersProvider?
     let disallowedCustomHeaders: [String]
 
-    internal init(enableLogging: Bool = DefaultConfig.enableLogging,
+    internal init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
                   samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
                   traceSamplingRate: Float = DefaultConfig.traceSamplingRate,
                   trackHttpHeaders: Bool = DefaultConfig.trackHttpHeaders,

--- a/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
@@ -95,7 +95,7 @@ protocol InternalConfig {
 
     /// The interval, in seconds, for providing accelerometer updates to the block handler. Defaults to 0.1 seconds.
     var accelerometerUpdateInterval: TimeInterval { get }
-    
+
     /// List of custom headers that should not be included.
     var disallowedCustomHeaders: [String] { get }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
@@ -213,4 +213,60 @@ protocol MeasureConfig {
             debugPrint("Trace sampling rate must be between 0.0 and 1.0")
         }
     }
+    
+    /// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
+    /// - Parameters:
+    ///   - enableLogging: Enable or disable internal SDK logs. Defaults to `false`.
+    ///   - samplingRateForErrorFreeSessions: Sampling rate for sessions without a crash. The sampling rate is a value between 0 and 1.
+    ///   For example, a value of `0.5` will export only 50% of the non-crashed sessions, and a value of `0` will disable sending non-crashed sessions to the server.
+    ///   - traceSamplingRate: Sampling rate for traces. The sampling rate is a value between 0 and 1.
+    ///   For example, a value of `0.1` will export only 10% of all traces, a value of `0` will disable exporting of traces.
+    ///   - trackHttpHeaders: Whether to capture http headers of a network request and response. Defaults to `false`.
+    ///   - trackHttpBody:Whether to capture http body of a network request and response. Defaults to `false`.
+    ///   - httpHeadersBlocklist:List of HTTP headers to not collect with the `http` event for both request and response. Defaults to an empty list. The following headers are always excluded:
+    ///       - Authorization
+    ///       - Cookie
+    ///       - Set-Cookie
+    ///       - Proxy-Authorization
+    ///       - WWW-Authenticate
+    ///       - X-Api-Key
+    ///   - httpUrlBlocklist: Allows disabling collection of `http` events for certain URLs.
+    ///   This is useful to setup if you do not want to collect data for certain endpoints.Note that this config is ignored if [httpUrlAllowlist] is set. You can:
+    ///       - Disables a domain, eg. example.com
+    ///       - Disable a subdomain, eg. api.example.com
+    ///       - Disable a particular path, eg. example.com/order
+    ///   - httpUrlAllowlist: Allows enabling collection of `http` events for only certain URLs. This is useful to setup if you do not want to collect data for all endpoints except for a few. You can:
+    ///       - Disables a domain, eg. example.com
+    ///       - Disable a subdomain, eg. api.example.com
+    ///       - Disable a particular path, eg. example.com/order
+    ///   - autoStart: Set this to false to delay starting the SDK, by default initializing the SDK also starts tracking.
+    ///   - trackViewControllerLoadTime: Enables or disables automatic collection of ViewController load time. Defaults to `true`.
+    ///   - screenshotMaskLevel: Allows changing the masking level of screenshots to prevent sensitive information from leaking. Defaults to [ScreenshotMaskLevel.allTextAndMedia].
+    ///   - enableShakeToLaunchBugReport: Enable or disable shake to automatically launch the bug report flow. Defaults to `false`.
+    ///   - requestHeadersProvider: Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API.
+    @objc public convenience init(enableLogging: Bool,
+                                  samplingRateForErrorFreeSessions: Float,
+                                  traceSamplingRate: Float,
+                                  trackHttpHeaders: Bool,
+                                  trackHttpBody: Bool,
+                                  httpHeadersBlocklist: [String],
+                                  httpUrlBlocklist: [String],
+                                  httpUrlAllowlist: [String],
+                                  autoStart: Bool,
+                                  trackViewControllerLoadTime: Bool,
+                                  screenshotMaskLevel: ScreenshotMaskLevelObjc,
+                                  requestHeadersProvider: MsrRequestHeadersProvider?) {
+        self.init(enableLogging: enableLogging,
+                  samplingRateForErrorFreeSessions: samplingRateForErrorFreeSessions,
+                  traceSamplingRate: traceSamplingRate,
+                  trackHttpHeaders: trackHttpHeaders,
+                  trackHttpBody: trackHttpBody,
+                  httpHeadersBlocklist: httpHeadersBlocklist,
+                  httpUrlBlocklist: httpUrlBlocklist,
+                  httpUrlAllowlist: httpUrlAllowlist,
+                  autoStart: autoStart,
+                  trackViewControllerLoadTime: trackViewControllerLoadTime,
+                  screenshotMaskLevel: screenshotMaskLevel.toSwiftValue(),
+                  requestHeadersProvider: requestHeadersProvider)
+    }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/MsrRequestHeadersProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MsrRequestHeadersProvider.swift
@@ -24,8 +24,8 @@ import Foundation
 /// Example implementation:
 ///
 /// ```swift
-/// final class CustomHeaderProvider: MsrRequestHeadersProvider {
-///     private var requestHeaders: [String: String] = [:]
+/// final class CustomHeaderProvider: NSObject, MsrRequestHeadersProvider {
+///     private var requestHeaders: NSDictionary
 ///
 ///     func addHeader(key: String, value: String) {
 ///         requestHeaders[key] = value
@@ -35,17 +35,40 @@ import Foundation
 ///         requestHeaders.removeValue(forKey: key)
 ///     }
 ///
-///     func getRequestHeaders() -> [String: String] {
+///     func getRequestHeaders() -> NSDictionary {
 ///         return requestHeaders
 ///     }
 /// }
 /// ```
-public protocol MsrRequestHeadersProvider {
+///
+/// ```objc
+/// @interface RequestHeaderProvider : NSObject <MsrRequestHeadersProvider>
+///
+/// @end
+///
+/// @implementation RequestHeaderProvider {
+/// NSMutableDictionary *_requestHeaders;
+/// }
+/// - (void)addHeaderWithKey:(NSString *)key value:(NSString *)value {
+///     _requestHeaders[key] = value;
+/// }
+///
+/// - (void)removeHeaderWithKey:(NSString *)key {
+///     [_requestHeaders removeObjectForKey:key];
+/// }
+///
+/// - (NSDictionary *)getRequestHeaders {
+///     return [_requestHeaders copy];
+/// }
+///
+/// @end
+/// ```
+@objc public protocol MsrRequestHeadersProvider: NSObjectProtocol {
     /// Returns a dictionary of custom HTTP headers to include in Measure SDK requests.
     ///
     /// This method may be called multiple times and from different threads.
     /// Implementations should return a consistent snapshot of headers at the time of the call.
     ///
     /// - Returns: A dictionary of header names to values.
-    func getRequestHeaders() -> [String: String]
+    @objc func getRequestHeaders() -> NSDictionary
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/ScreenshotMaskLevel.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ScreenshotMaskLevel.swift
@@ -22,3 +22,32 @@ public enum ScreenshotMaskLevel: String, Codable, CaseIterable {
     /// email and phone number fields.
     case sensitiveFieldsOnly
 }
+
+/// The level of masking to apply to the screenshot.
+@objc public enum ScreenshotMaskLevelObjc: Int {
+    /// The strictest level of masking which masks all text, input fields, images and videos.
+    case allTextAndMedia
+
+    /// Masks all text and input fields, including clickable elements.
+    case allText
+
+    /// Masks all text and input fields, excluding clickable elements.
+    case allTextExceptClickable
+
+    /// The most lenient level of masking which only masks sensitive input fields like passwords,
+    /// email and phone number fields.
+    case sensitiveFieldsOnly
+
+    func toSwiftValue() -> ScreenshotMaskLevel {
+        switch self {
+        case .allTextAndMedia:
+            return .allTextAndMedia
+        case .allText:
+            return .allText
+        case .allTextExceptClickable:
+            return .allTextExceptClickable
+        case .sensitiveFieldsOnly:
+            return .sensitiveFieldsOnly
+        }
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
@@ -84,7 +84,7 @@ final class BaseInternalSignalCollector: InternalSignalCollector {
 
     // Tracks an event.
     //
-    // swiftlint:disable:next function_parameter_count function_body_length
+    // swiftlint:disable:next function_parameter_count function_body_length cyclomatic_complexity
     func trackEvent(
         data: inout [String: Any?],
         type: String,

--- a/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
@@ -138,7 +138,11 @@ final class BaseHttpClient: HttpClient {
 
         let disallowed = Set(configProvider.disallowedCustomHeaders.map { $0.lowercased() })
 
-        return requestHeadersProvider.getRequestHeaders().filter { key, _ in
+        guard let headers = requestHeadersProvider.getRequestHeaders() as? [String: String] else {
+            return nil
+        }
+
+        return headers.filter { key, _ in
             !disallowed.contains(key.lowercased())
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -251,7 +251,7 @@ import UIKit
         guard let measureInternal = self.measureInternal else { return }
         return measureInternal.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
     }
-    
+
     func internalGetAttachmentDirectory() -> String? {
         guard let measureInternal = self.measureInternal else { return nil }
         return measureInternal.getDocumentDirectoryPath()
@@ -280,8 +280,19 @@ extension Measure {
     ///   ```
     ///   - Objective-C:
     ///   ```objc
-    ///   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] init];
     ///   ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"<apiKey>" apiUrl:@"<apiUrl>"];
+    ///   BaseMeasureConfig *config = [[BaseMeasureConfig alloc] initWithEnableLogging:YES
+    ///                                                          samplingRateForErrorFreeSessions:1.0
+    ///                                                          traceSamplingRate:1.0
+    ///                                                          trackHttpHeaders:YES
+    ///                                                          trackHttpBody:YES
+    ///                                                          httpHeadersBlocklist:@[]
+    ///                                                          httpUrlBlocklist:@[]
+    ///                                                          httpUrlAllowlist:@[]
+    ///                                                          autoStart:true
+    ///                                                          trackViewControllerLoadTime:true
+    ///                                                          screenshotMaskLevel:ScreenshotMaskLevelObjcAllText
+    ///                                                          requestHeadersProvider:nil];
     ///   [Measure initializeWith:clientInfo config:config];
     ///   ```
     @objc public static func initialize(with client: ClientInfo, config: BaseMeasureConfig? = nil) {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -274,7 +274,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         let transformedAttributes = transformAttributes(attributes)
         userTriggeredEventCollector.trackError(error, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
     }
-    
+
     func getDocumentDirectoryPath() -> String? {
         return systemFileManager.getDirectoryPath(directory: FileManager.SearchPathDirectory.documentDirectory)
     }

--- a/ios/Tests/MeasureSDKTests/Exporter/HttpClientTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/HttpClientTests.swift
@@ -61,8 +61,8 @@ class HttpClientTests: XCTestCase {
     }
 
     func testGetCustomHeader_notNilIfSet() {
-        class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String: String] {
+        class CustomHeader: NSObject, MsrRequestHeadersProvider {
+            func getRequestHeaders() -> NSDictionary {
                 return ["key1": "value1", "key2": "value2"]
             }
         }
@@ -75,8 +75,8 @@ class HttpClientTests: XCTestCase {
     }
 
     func testGetCustomHeader_removeValuesIfKeyContainsReservedHeaders() {
-        class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String: String] {
+        class CustomHeader: NSObject, MsrRequestHeadersProvider {
+            func getRequestHeaders() -> NSDictionary {
                 return ["key1": "value1", "key2": "value2", "Content-Type": "abc", "msr-req-id": "abc", "Authorization": "abc", "Content-Length": "abc"]
             }
         }
@@ -98,8 +98,8 @@ class HttpClientTests: XCTestCase {
     }
 
     func testGetCustomHeader_caseInsensitiveDisallowFiltering() {
-        class CustomHeader: MsrRequestHeadersProvider {
-            func getRequestHeaders() -> [String: String] {
+        class CustomHeader: NSObject, MsrRequestHeadersProvider {
+            func getRequestHeaders() -> NSDictionary {
                 return ["Authorization": "abc", "authorization": "xyz", "Key1": "value"]
             }
         }


### PR DESCRIPTION
# Description

This PR contains below changes:
- Update BaseConfigProvider to support objc initialisation.
- Update MsrRequestHeadersProvider protocol to support objc implementation.
- Updated documentation.

## Related issue
Closes #2373 