### PR TITLE
chore(flutter): improve span end api

### DIFF
--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -38,7 +38,7 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  measure-sh: b5342feba997a74cef06ed38609de2e403cf3aa9
+  measure-sh: 1c34ec47676af9e0ea2d463c7f0d9ba2ba203aa7
   measure_flutter: 0c0e3800e6aaa4bd153d13b4cf0b2d15e7a3e3f1
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 

--- a/flutter/packages/measure_flutter/lib/src/tracing/invalid_span.dart
+++ b/flutter/packages/measure_flutter/lib/src/tracing/invalid_span.dart
@@ -67,12 +67,7 @@ class InvalidSpan implements Span {
   }
 
   @override
-  Span end() {
-    return this;
-  }
-
-  @override
-  Span endWithTimestamp(int timestamp) {
+  Span end({int? timestamp}) {
     return this;
   }
 

--- a/flutter/packages/measure_flutter/lib/src/tracing/msr_span.dart
+++ b/flutter/packages/measure_flutter/lib/src/tracing/msr_span.dart
@@ -233,14 +233,8 @@ class MsrSpan implements InternalSpan {
   }
 
   @override
-  Span end() {
-    _endSpanInternal(_timeProvider.now());
-    return this;
-  }
-
-  @override
-  Span endWithTimestamp(int timestamp) {
-    _endSpanInternal(timestamp);
+  Span end({int? timestamp}) {
+    _endSpanInternal(timestamp ?? _timeProvider.now());
     return this;
   }
 

--- a/flutter/packages/measure_flutter/lib/src/tracing/span.dart
+++ b/flutter/packages/measure_flutter/lib/src/tracing/span.dart
@@ -124,17 +124,12 @@ abstract class Span {
 
   /// Marks this span as completed, recording its end time.
   ///
-  /// Note: This method can be called only once per span. Subsequent calls will have no effect.
-  Span end();
-
-  /// Marks this span as completed using the specified end time.
-  ///
-  /// [timestamp] The end time in milliseconds since epoch, obtained via [Measure.getCurrentTime]
-  ///
-  /// Note: This method can be called only once per span. Subsequent calls will have no effect.
-  /// Use this variant when you need to trace an operation that has already completed and you
+  /// [timestamp] An optional end time in milliseconds since epoch. Use this
+  /// when you need to trace an operation that has already completed and you
   /// have captured its end time using [Measure.getCurrentTime].
-  Span endWithTimestamp(int timestamp);
+  ///
+  /// Note: This method can be called only once per span. Subsequent calls will have no effect.
+  Span end({int? timestamp});
 
   /// Checks if this span has been completed.
   ///

--- a/flutter/packages/measure_flutter/test/tracing/msr_span_test.dart
+++ b/flutter/packages/measure_flutter/test/tracing/msr_span_test.dart
@@ -324,6 +324,23 @@ void main() {
         expect(spanProcessor.endingSpanCount, 1);
         expect(spanProcessor.endedSpanCount, 1);
       });
+
+      test('uses the timestamp provided', () {
+        final span = MsrSpan.startSpan(
+          name: 'test-span',
+          logger: logger,
+          spanProcessor: spanProcessor,
+          timeProvider: timeProvider,
+          idProvider: idProvider,
+          traceSampler: traceSampler,
+          parentSpan: null,
+        ) as MsrSpan;
+
+        // End the span with explicit timestamp
+        span.end(timestamp: testClock.epochTime() + 10000);
+
+        expect(span.getDuration(), 10000);
+      });
     });
 
     group('checkpoints', () {


### PR DESCRIPTION
# Description

- Removes `span.endWithTimestamp`
- Adds optional argument to `span.end` to take a timestamp.

## Related issue
Closes #2377


