### PR TITLE
fix(ios): convert float to int safely

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
@@ -23,8 +23,8 @@ final class BaseSvgGenerator: SvgGenerator {
             return nil
         }
 
-        let windowWidth = Int(maxWidth)
-        let windowHeight = Int(maxHeight)
+        let windowWidth = maxWidth.safeInt
+        let windowHeight = maxHeight.safeInt
 
         var svg = """
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 \(windowWidth) \(windowHeight)">


### PR DESCRIPTION
# Description

SDK crashes randomly when trying to generate layout snapshot. This happens when float value when converted to int exceeds the Int limit. This PR fixes the same.

## Related issue
Fixes #2380 