### PR TITLE
fix(flutter): gesture positions to represent device coordinates

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/method_channel/signal_processor.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/signal_processor.dart
@@ -37,9 +37,6 @@ final class DefaultSignalProcessor extends SignalProcessor {
   }) {
     var json = data.toJson();
     logger.log(LogLevel.debug, "$type: $json");
-    if (attachments != null) {
-      logger.log(LogLevel.debug, "attachments:${attachments.length}");
-    }
     return channel.trackEvent(
         data: json,
         type: type,

--- a/flutter/packages/measure_flutter/test/gestures/msr_gesture_detector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/msr_gesture_detector_test.dart
@@ -211,7 +211,7 @@ void main() {
 
         // Directly test the event handlers
         state.onPointerDown(downEvent);
-        state.onPointerUp(upEvent);
+        state.onPointerUp(upEvent, 1);
 
         await tester.pumpAndSettle();
 
@@ -551,6 +551,175 @@ void main() {
         expect(clickEvents, hasLength(1));
         expect(clickEvents.first.targetId, isNull);
       });
+    });
+
+    group('Coordinates calculation', () {
+      testWidgets('should calculate x, y, endX, endY coordinates correctly for scroll',
+              (WidgetTester tester) async {
+            final scrollEvents = <ScrollData>[];
+
+            // Set up a test environment with known device pixel ratio
+            await tester.binding.setSurfaceSize(const Size(400, 600));
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: MsrGestureDetector(
+                    onClick: (data) {},
+                    onLongClick: (data) {},
+                    onScroll: (data) => scrollEvents.add(data),
+                    child: SizedBox(
+                      height: 300,
+                      child: ListView(
+                        children: List.generate(
+                          20,
+                              (index) => ListTile(title: Text('Item $index')),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+            // Get the device pixel ratio for calculations
+            final devicePixelRatio = tester.view.devicePixelRatio;
+
+            // Define start and end positions for the scroll gesture
+            const startPosition = Offset(200, 250); // Start at center of ListView
+            const endPosition = Offset(200, 150);   // End 100 pixels up
+            const scrollDelta = Offset(0, -100);    // Upward scroll
+
+            // Perform the scroll gesture
+            await tester.dragFrom(startPosition, scrollDelta);
+            await tester.pump();
+
+            // Verify that scroll event was captured
+            expect(scrollEvents, hasLength(1));
+
+            final scrollEvent = scrollEvents.first;
+
+            // Verify target and direction
+            expect(scrollEvent.target, 'ListView');
+            expect(scrollEvent.direction, MsrScrollDirection.up);
+
+            // Verify coordinate calculations
+            // x and y should be the start position (where touch began) multiplied by device pixel ratio
+            expect(scrollEvent.x, equals((startPosition.dx * devicePixelRatio).roundToDouble()));
+            expect(scrollEvent.y, equals((startPosition.dy * devicePixelRatio).roundToDouble()));
+
+            // endX and endY should be the end position (where touch ended) multiplied by device pixel ratio
+            expect(scrollEvent.endX, equals((endPosition.dx * devicePixelRatio).roundToDouble()));
+            expect(scrollEvent.endY, equals((endPosition.dy * devicePixelRatio).roundToDouble()));
+
+            // Verify that end coordinates are different from start coordinates (confirming scroll occurred)
+            expect(scrollEvent.endY, lessThan(scrollEvent.y)); // End Y should be less than start Y for upward scroll
+            expect(scrollEvent.endX, equals(scrollEvent.x)); // X should remain the same for vertical scroll
+          });
+
+      testWidgets('should calculate coordinates correctly for horizontal scroll',
+              (WidgetTester tester) async {
+            final scrollEvents = <ScrollData>[];
+
+            await tester.binding.setSurfaceSize(const Size(400, 600));
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: MsrGestureDetector(
+                    onClick: (data) {},
+                    onLongClick: (data) {},
+                    onScroll: (data) => scrollEvents.add(data),
+                    child: SizedBox(
+                      height: 200,
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        children: List.generate(
+                          20,
+                              (index) => SizedBox(
+                            width: 100,
+                            child: ListTile(title: Text('Item $index')),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+            final devicePixelRatio = tester.view.devicePixelRatio;
+
+            // Define positions for horizontal scroll
+            const startPosition = Offset(200, 100);
+            const endPosition = Offset(100, 100);  // Move 100 pixels left
+            const scrollDelta = Offset(-100, 0);   // Leftward scroll
+
+            // Perform horizontal scroll
+            await tester.dragFrom(startPosition, scrollDelta);
+            await tester.pump();
+
+            expect(scrollEvents, hasLength(1));
+
+            final scrollEvent = scrollEvents.first;
+
+            // Verify horizontal scroll direction
+            expect(scrollEvent.direction, MsrScrollDirection.left);
+
+            // Verify coordinate calculations for horizontal scroll
+            expect(scrollEvent.x, equals((startPosition.dx * devicePixelRatio).roundToDouble()));
+            expect(scrollEvent.y, equals((startPosition.dy * devicePixelRatio).roundToDouble()));
+            expect(scrollEvent.endX, equals((endPosition.dx * devicePixelRatio).roundToDouble()));
+            expect(scrollEvent.endY, equals((endPosition.dy * devicePixelRatio).roundToDouble()));
+
+            // Verify that end coordinates reflect the horizontal movement
+            expect(scrollEvent.endX, lessThan(scrollEvent.x)); // End X should be less than start X for leftward scroll
+            expect(scrollEvent.endY, equals(scrollEvent.y)); // Y should remain the same for horizontal scroll
+          });
+
+      testWidgets('should handle device pixel ratio scaling in coordinate calculations',
+              (WidgetTester tester) async {
+            final scrollEvents = <ScrollData>[];
+
+            // Set a custom device pixel ratio for testing
+            await tester.binding.setSurfaceSize(const Size(400, 600));
+            tester.view.devicePixelRatio = 2.0;
+
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: MsrGestureDetector(
+                    onClick: (data) {},
+                    onLongClick: (data) {},
+                    onScroll: (data) => scrollEvents.add(data),
+                    child: SizedBox(
+                      height: 300,
+                      child: ListView(
+                        children: List.generate(10, (index) => ListTile(title: Text('Item $index'))),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+            const startPosition = Offset(100, 200);
+            const scrollDelta = Offset(0, -50);
+
+            await tester.dragFrom(startPosition, scrollDelta);
+            await tester.pump();
+
+            expect(scrollEvents, hasLength(1));
+
+            final scrollEvent = scrollEvents.first;
+
+            // With device pixel ratio of 2.0, coordinates should be doubled
+            expect(scrollEvent.x, equals(200.0)); // 100 * 2.0
+            expect(scrollEvent.y, equals(400.0)); // 200 * 2.0
+            expect(scrollEvent.endX, equals(200.0)); // 100 * 2.0
+            expect(scrollEvent.endY, equals(300.0)); // 150 * 2.0
+
+            // Clean up
+            tester.view.devicePixelRatio = 1;
+          });
     });
   });
 }


### PR DESCRIPTION

# Description

- Earlier local coordinates of the widget were being reported instead of the actual screen coordinates.
- Also removes a redundant log.

## Related issue
Closes #2382 



