### PR TITLE
chore(android): hide config serialization from public api

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -210,21 +210,8 @@ public final class sh/measure/android/config/MeasureConfig : sh/measure/android/
 	public fun getTrackScreenshotOnCrash ()Z
 }
 
-public final class sh/measure/android/config/MeasureConfig$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field $stable I
-	public static final field INSTANCE Lsh/measure/android/config/MeasureConfig$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lsh/measure/android/config/MeasureConfig;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lsh/measure/android/config/MeasureConfig;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
 public final class sh/measure/android/config/MeasureConfig$Companion {
 	public final fun fromJson (Ljava/util/Map;)Lsh/measure/android/config/MeasureConfig;
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public abstract interface class sh/measure/android/config/MsrRequestHeadersProvider {


### PR DESCRIPTION
# Description

To allow Flutter to configure the native SDK during initialization we made `MeasureConfig` implement `@Serializable`. This leaks the serialization details in the public API which is not ideal. To hide the serialization details from public API, a new internal wrapper has been introduced over `MeasureConfig` which instead handles serialization.

This makes adding new configs a bit harder, but this can be solved later using a annotation processor to generate code.

## Related issue
Closes #2384 


