### PR TITLE
chore(flutter): use correct import for measure_flutter

### DIFF
--- a/flutter/example/lib/src/dio_interceptor.dart
+++ b/flutter/example/lib/src/dio_interceptor.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:measure_flutter/measure.dart';
+import 'package:measure_flutter/measure_flutter.dart';
 
 class TraceHeaderInterceptor extends Interceptor {
   @override


### PR DESCRIPTION
# Description

Fix warnings on main which are causing the CI to fail. This issue started after merging #2361.

## Related issue
References #2361



