### PR TITLE
chore(flutter): fix gesture events reporting

### DIFF
--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - Flutter
   - integration_test (0.0.1):
     - Flutter
-  - measure-sh (0.4.0):
+  - measure-sh (0.5.0):
     - PLCrashReporter
   - measure_flutter (0.0.1):
     - Flutter
@@ -38,7 +38,7 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  measure-sh: 1c34ec47676af9e0ea2d463c7f0d9ba2ba203aa7
+  measure-sh: bbc00908417de2a2adb1306eb732dedffe943fda
   measure_flutter: 0c0e3800e6aaa4bd153d13b4cf0b2d15e7a3e3f1
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 

--- a/ios/Sources/MeasureSDK/Swift/Gestures/GestureCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Gestures/GestureCollector.swift
@@ -74,6 +74,11 @@ final class BaseGestureCollector: GestureCollector {
         switch gesture {
         case .click(let x, let y, let touchDownTime, let touchUpTime, let target, let targetId, let targetFrame):
             let gestureTargetFinderData = gestureTargetFinder.findClickable(x: x, y: y, window: window)
+
+            if gestureTargetFinderData.target == nil && gestureTargetFinderData.targetFrame == nil && gestureTargetFinderData.targetId == nil {
+                return
+            }
+
             let width = UInt16((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0)
             let height = UInt16((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0)
 
@@ -98,6 +103,10 @@ final class BaseGestureCollector: GestureCollector {
             }
         case .longClick(let x, let y, let touchDownTime, let touchUpTime, let target, let targetId, let targetFrame):
             let gestureTargetFinderData = gestureTargetFinder.findClickable(x: x, y: y, window: window)
+            if gestureTargetFinderData.target == nil && gestureTargetFinderData.targetFrame == nil && gestureTargetFinderData.targetId == nil {
+                return
+            }
+
             let width = UInt16((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0)
             let height = UInt16((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0)
 
@@ -124,6 +133,10 @@ final class BaseGestureCollector: GestureCollector {
             let startScrollPoint = CGPoint(x: startX, y: startY)
             let endScrollPoint = CGPoint(x: endX, y: endY)
             if let gestureTargetFinderData = gestureTargetFinder.findScrollable(startScrollPoint: startScrollPoint, endScrollPoint: endScrollPoint, window: window) {
+                if gestureTargetFinderData.target == nil && gestureTargetFinderData.targetFrame == nil && gestureTargetFinderData.targetId == nil {
+                    return
+                }
+
                 let data = ScrollData(target: gestureTargetFinderData.target ?? target,
                                       targetId: gestureTargetFinderData.targetId ?? targetId,
                                       x: FloatNumber32(startX),

--- a/ios/Sources/MeasureSDK/Swift/Gestures/GestureTargetFinder.swift
+++ b/ios/Sources/MeasureSDK/Swift/Gestures/GestureTargetFinder.swift
@@ -23,7 +23,13 @@ final class BaseGestureTargetFinder: GestureTargetFinder {
             if className.contains("FlutterView") || className.contains("FlutterSemanticsScrollView") {
                 return (nil, nil, nil)
             }
+
             if let targetData = searchSubviews(view: tappedView, tapPoint: tapPoint, window: window) {
+                if let target = targetData.target {
+                    if target.contains("FlutterView") || target.contains("FlutterSemanticsScrollView") {
+                        return (nil, nil, nil)
+                    }
+                }
                 return targetData
             } else {
                 return ("\(type(of: tappedView))", tappedView.accessibilityIdentifier, tappedView.frame)


### PR DESCRIPTION
# Description

- use explicitly set widget names instead of relying on runtime type to avoid obfuscated
names
- discard ios gestures on flutter views

## Related issue
Fixes #2393 and Fixes #2392 