### PR TITLE
ci(android): fix prepare release command

### DIFF
--- a/.github/workflows/android-prepare-release.yml
+++ b/.github/workflows/android-prepare-release.yml
@@ -66,11 +66,15 @@ jobs:
           KOTLIN_REPLACEMENT='implementation("sh.measure:measure-android:${{ inputs.version }}")'
           sed -i "s/$KOTLIN_PATTERN/$KOTLIN_REPLACEMENT/" sdk-integration-guide.md
 
+      - name: Commit changes
+        run: |
+          git add ../docs/sdk-integration-guide.md gradle.properties
+          git commit -m "chore(android): prepare sdk release ${{ inputs.version }}"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
-          commit-message: "chore(android): prepare sdk release ${{ inputs.version }}"
           branch: android-v${{ inputs.version }}
           delete-branch: false
           title: "chore(android): prepare sdk release ${{ inputs.version }}"


### PR DESCRIPTION
# Description

- Added a commit step: Before calling create-pull-request, added a step to explicitly commit the changes. This ensures the branch has the changes committed before the action tries to work with it.
- Removed commit-message from create-pull-request: Since we're now committing manually, we don't need the action to create a commit for us.



