### PR TITLE
ci(flutter): fix prepare release command

### DIFF
--- a/.github/workflows/android-prepare-release.yml
+++ b/.github/workflows/android-prepare-release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
-          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Git
         run: |
@@ -65,7 +65,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(android): prepare sdk release ${{ inputs.version }}"
           branch: android-v${{ inputs.version }}
           delete-branch: false


### PR DESCRIPTION
# Description

Use `GITHUB_TOKEN` to allow the workflow to raise a PR. This should fix the error in github action: https://github.com/measure-sh/measure/actions/runs/16222180933/job/45805225489

