### PR TITLE
Dashboard api proxy

### DIFF
--- a/backend/api/go.mod
+++ b/backend/api/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.80.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/gin-contrib/cors v1.7.5
 	github.com/gin-gonic/gin v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/backend/api/go.sum
+++ b/backend/api/go.sum
@@ -47,12 +47,11 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
-github.com/gin-contrib/cors v1.7.5 h1:cXC9SmofOrRg0w9PigwGlHG3ztswH6bqq4vJVXnvYMk=
-github.com/gin-contrib/cors v1.7.5/go.mod h1:4q3yi7xBEDDWKapjT2o1V7mScKDDr8k+jZ0fSquGoy0=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
@@ -151,6 +150,7 @@ github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFu
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
@@ -195,6 +195,7 @@ go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a
 go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.61.0 h1:VkrF0D14uQrCmPqBkYlwWnhgcwzXvIRAjX8eXO7vy6M=
 go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.61.0/go.mod h1:p/mVr/Hs7gQnguNPXUyuiMRNtisyc9y/Oo7Kqr/6wbU=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"time"
 
 	"backend/api/inet"
 	"backend/api/measure"
 	"backend/api/server"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
@@ -60,17 +58,7 @@ func main() {
 	r.PUT("/events", measure.ValidateAPIKey(), measure.PutEvents)
 	r.PUT("/builds", measure.ValidateAPIKey(), measure.PutBuild)
 
-	cors := cors.New(cors.Config{
-		AllowOrigins:     []string{config.SiteOrigin},
-		AllowMethods:     []string{"GET", "OPTIONS", "PATCH", "DELETE", "PUT"},
-		AllowHeaders:     []string{"Authorization", "Content-Type"},
-		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
-	})
-
 	// Dashboard routes
-	// Any route below this point will use CORS
-	r.Use(cors)
 
 	// Proxy route
 	r.GET("/attachments", measure.ProxyAttachment)

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -119,7 +119,7 @@ func NewConfig() *ServerConfig {
 
 	siteOrigin := os.Getenv("SITE_ORIGIN")
 	if siteOrigin == "" {
-		log.Fatal("SITE_ORIGIN env var not set. Need for Cross Origin Resource Sharing (CORS) to work.")
+		log.Fatal("SITE_ORIGIN env var not set. Authentication and invite emails might not work.")
 	}
 
 	var txEmailAddress string = ""

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { Separator } from "@/app/components/separator"
+import { Separator } from "@/app/components/separator";
 import {
   Sidebar,
   SidebarContent,
@@ -15,13 +15,13 @@ import {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarTrigger,
-} from "@/app/components/sidebar"
-import { usePathname, useRouter } from "next/navigation"
-import React, { useEffect, useState } from 'react'
-import { Team, TeamsApiStatus, fetchTeamsFromServer } from "../api/api_calls"
-import { measureAuth } from "../auth/measure_auth"
-import TeamSwitcher, { TeamsSwitcherStatus } from '../components/team_switcher'
-import UserAvatar from '../components/user_avatar'
+} from "@/app/components/sidebar";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+import { Team, TeamsApiStatus, fetchTeamsFromServer } from "../api/api_calls";
+import { measureAuth } from "../auth/measure_auth";
+import TeamSwitcher, { TeamsSwitcherStatus } from "../components/team_switcher";
+import UserAvatar from "../components/user_avatar";
 
 const initNavData = {
   navMain: [
@@ -45,7 +45,7 @@ const initNavData = {
           url: "journeys",
           isActive: false,
           external: false,
-        }
+        },
       ],
     },
     {
@@ -112,134 +112,154 @@ const initNavData = {
       ],
     },
   ],
-}
+};
 
 export default function DashboardLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
+  const [teamsApiStatus, setTeamsApiStatus] = useState(TeamsApiStatus.Loading);
+  const [teams, setTeams] = useState<Team[] | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [navData, setNavData] = useState(initNavData);
 
-  const [teamsApiStatus, setTeamsApiStatus] = useState(TeamsApiStatus.Loading)
-  const [teams, setTeams] = useState<Team[] | null>(null)
-  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null)
-  const [navData, setNavData] = useState(initNavData)
-
-  const pathName = usePathname()
-  const router = useRouter()
+  const pathName = usePathname();
+  const router = useRouter();
 
   const getTeams = async () => {
-    setTeamsApiStatus(TeamsApiStatus.Loading)
+    setTeamsApiStatus(TeamsApiStatus.Loading);
 
-    const result = await fetchTeamsFromServer()
+    const result = await fetchTeamsFromServer();
 
     switch (result.status) {
       case TeamsApiStatus.Error:
-        setTeamsApiStatus(TeamsApiStatus.Error)
-        break
+        setTeamsApiStatus(TeamsApiStatus.Error);
+        break;
       case TeamsApiStatus.Success:
-        setTeamsApiStatus(TeamsApiStatus.Success)
-        setTeams(result.data!)
-        const teamInPath = result.data!.find((e: { id: string, name: string }) => pathName.includes(e.id))
-        setSelectedTeam(teamInPath ? teamInPath : result.data![0])
-        break
+        setTeamsApiStatus(TeamsApiStatus.Success);
+        setTeams(result.data!);
+        const teamInPath = result.data!.find(
+          (e: { id: string; name: string }) => pathName.includes(e.id),
+        );
+        setSelectedTeam(teamInPath ? teamInPath : result.data![0]);
+        break;
     }
-  }
+  };
 
   useEffect(() => {
-    measureAuth.init(router)
-  }, [])
+    measureAuth.init(router);
+  }, []);
 
   useEffect(() => {
-    getTeams()
-  }, [])
+    getTeams();
+  }, []);
 
   useEffect(() => {
-    const updatedNavData = { ...navData }
+    const updatedNavData = { ...navData };
     updatedNavData.navMain.forEach((section) => {
       section.items.forEach((item) => {
-        item.isActive = pathName.includes(item.url)
-      })
-    })
-    setNavData(updatedNavData)
-  }, [pathName])
+        item.isActive = pathName.includes(item.url);
+      });
+    });
+    setNavData(updatedNavData);
+  }, [pathName]);
 
   const logoutUser = async () => {
-    await measureAuth.signout()
-  }
+    await measureAuth.signout();
+  };
 
   const onTeamChanged = (item: Team) => {
-    const selectedTeam = teams!.find((e) => e.id === item.id)!
-    const newPath = pathName.replace(/^\/[^\/]*/, '/' + selectedTeam.id)
-    router.push(newPath)
-  }
+    const selectedTeam = teams!.find((e) => e.id === item.id)!;
+    const newPath = pathName.replace(/^\/[^\/]*/, "/" + selectedTeam.id);
+    router.push(newPath);
+  };
 
   const teamsApiStatusToTeamsSwitcherStatus = {
     [TeamsApiStatus.Loading]: TeamsSwitcherStatus.Loading,
     [TeamsApiStatus.Success]: TeamsSwitcherStatus.Success,
     [TeamsApiStatus.Error]: TeamsSwitcherStatus.Error,
-    [TeamsApiStatus.Cancelled]: TeamsSwitcherStatus.Loading
-  }
+    [TeamsApiStatus.Cancelled]: TeamsSwitcherStatus.Loading,
+  };
 
   const handleNavClick = (url: string) => {
-    const updatedNavData = { ...navData }
+    const updatedNavData = { ...navData };
     updatedNavData.navMain.forEach((section) => {
       section.items.forEach((item) => {
-        item.isActive = item.url === url
-      })
-    })
-    setNavData(updatedNavData)
-  }
+        item.isActive = item.url === url;
+      });
+    });
+    setNavData(updatedNavData);
+  };
 
   return (
     <SidebarProvider>
-      <Sidebar variant="sidebar" className='select-none'>
+      <Sidebar variant="sidebar" className="select-none">
         <SidebarHeader>
           <SidebarMenu>
             <SidebarMenuItem>
-              <TeamSwitcher items={teams} initialItemIndex={teams?.findIndex((e) => e.id === selectedTeam!.id)} teamsSwitcherStatus={teamsApiStatusToTeamsSwitcherStatus[teamsApiStatus]} onChangeSelectedItem={(item) => onTeamChanged(item)} />
+              <TeamSwitcher
+                items={teams}
+                initialItemIndex={teams?.findIndex(
+                  (e) => e.id === selectedTeam!.id,
+                )}
+                teamsSwitcherStatus={
+                  teamsApiStatusToTeamsSwitcherStatus[teamsApiStatus]
+                }
+                onChangeSelectedItem={(item) => onTeamChanged(item)}
+              />
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarHeader>
         <SidebarContent>
           <SidebarGroup>
             <SidebarMenu className="gap-2">
-              {teamsApiStatus === TeamsApiStatus.Loading &&
-                <text className='ml-2 text-xs font-body'>Loading...</text>
-              }
-              {teamsApiStatus === TeamsApiStatus.Error &&
-                <text className='ml-2 text-xs font-body'>Error fetching teams. Please refresh page to try again.</text>
-              }
-              {teamsApiStatus === TeamsApiStatus.Success && navData.navMain.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <p className="text-lg font-display">
-                    {item.title}
-                  </p>
-                  {item.items?.length ? (
-                    <SidebarMenuSub className="ml-0 border-l-0 px-1.5">
-                      {item.items.map((item) => (
-                        <SidebarMenuSubItem key={item.title}>
-                          <SidebarMenuSubButton asChild isActive={item.isActive}>
-                            <a
-                              href={item.external ? `${item.url}` : `/${selectedTeam?.id}/${item.url}`}
-                              className="font-body"
-                              onClick={(e) => {
-                                if (!item.external) {
-                                  e.preventDefault()
-                                  handleNavClick(item.url)
-                                  router.push(`/${selectedTeam?.id}/${item.url}`)
-                                }
-                              }}
+              {teamsApiStatus === TeamsApiStatus.Loading && (
+                <span className="ml-2 text-xs font-body">Loading...</span>
+              )}
+              {teamsApiStatus === TeamsApiStatus.Error && (
+                <span className="ml-2 text-xs font-body">
+                  Error fetching teams. Please refresh page to try again.
+                </span>
+              )}
+              {teamsApiStatus === TeamsApiStatus.Success &&
+                navData.navMain.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <p className="text-lg font-display">{item.title}</p>
+                    {item.items?.length ? (
+                      <SidebarMenuSub className="ml-0 border-l-0 px-1.5">
+                        {item.items.map((item) => (
+                          <SidebarMenuSubItem key={item.title}>
+                            <SidebarMenuSubButton
+                              asChild
+                              isActive={item.isActive}
                             >
-                              {item.title}
-                            </a>
-                          </SidebarMenuSubButton>
-                        </SidebarMenuSubItem>
-                      ))}
-                    </SidebarMenuSub>
-                  ) : null}
-                </SidebarMenuItem>
-              ))}
+                              <a
+                                href={
+                                  item.external
+                                    ? `${item.url}`
+                                    : `/${selectedTeam?.id}/${item.url}`
+                                }
+                                className="font-body"
+                                onClick={(e) => {
+                                  if (!item.external) {
+                                    e.preventDefault();
+                                    handleNavClick(item.url);
+                                    router.push(
+                                      `/${selectedTeam?.id}/${item.url}`,
+                                    );
+                                  }
+                                }}
+                              >
+                                {item.title}
+                              </a>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    ) : null}
+                  </SidebarMenuItem>
+                ))}
             </SidebarMenu>
           </SidebarGroup>
         </SidebarContent>
@@ -265,5 +285,5 @@ export default function DashboardLayout({
         </main>
       </SidebarInset>
     </SidebarProvider>
-  )
+  );
 }

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1,13 +1,16 @@
-import { measureAuth } from "../auth/measure_auth"
-import { Filters } from "../components/filters"
-import { JourneyType } from "../components/journey"
-import { formatUserInputDateToServerFormat, getTimeZoneForServer } from "../utils/time_utils"
+import { measureAuth } from "../auth/measure_auth";
+import { Filters } from "../components/filters";
+import { JourneyType } from "../components/journey";
+import {
+  formatUserInputDateToServerFormat,
+  getTimeZoneForServer,
+} from "../utils/time_utils";
 
 export enum TeamsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum AppsApiStatus {
@@ -15,7 +18,7 @@ export enum AppsApiStatus {
   Success,
   Error,
   NoApps,
-  Cancelled
+  Cancelled,
 }
 
 export enum RootSpanNamesApiStatus {
@@ -23,7 +26,7 @@ export enum RootSpanNamesApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum SpanMetricsPlotApiStatus {
@@ -31,21 +34,21 @@ export enum SpanMetricsPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum SpansApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum TraceApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum FiltersApiStatus {
@@ -54,20 +57,20 @@ export enum FiltersApiStatus {
   Error,
   NotOnboarded,
   NoData,
-  Cancelled
+  Cancelled,
 }
 export enum SaveFiltersApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum FilterSource {
   Events,
   Crashes,
   Anrs,
-  Spans
+  Spans,
 }
 
 export enum SessionsVsExceptionsPlotApiStatus {
@@ -75,7 +78,7 @@ export enum SessionsVsExceptionsPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum JourneyApiStatus {
@@ -83,33 +86,33 @@ export enum JourneyApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum MetricsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum SessionsOverviewApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum ExceptionsType {
   Crash,
-  Anr
+  Anr,
 }
 
 export enum ExceptionsOverviewApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum ExceptionsOverviewPlotApiStatus {
@@ -117,7 +120,7 @@ export enum ExceptionsOverviewPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum SessionsOverviewPlotApiStatus {
@@ -125,14 +128,14 @@ export enum SessionsOverviewPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum ExceptionsDetailsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum ExceptionsDetailsPlotApiStatus {
@@ -140,14 +143,14 @@ export enum ExceptionsDetailsPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 export enum ExceptionsDistributionPlotApiStatus {
   Loading,
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum CreateTeamApiStatus {
@@ -155,7 +158,7 @@ export enum CreateTeamApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum CreateAppApiStatus {
@@ -163,7 +166,7 @@ export enum CreateAppApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum TeamNameChangeApiStatus {
@@ -171,7 +174,7 @@ export enum TeamNameChangeApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum AppNameChangeApiStatus {
@@ -179,7 +182,7 @@ export enum AppNameChangeApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum RoleChangeApiStatus {
@@ -187,14 +190,14 @@ export enum RoleChangeApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum PendingInvitesApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum ResendPendingInviteApiStatus {
@@ -202,7 +205,7 @@ export enum ResendPendingInviteApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum RemovePendingInviteApiStatus {
@@ -210,7 +213,7 @@ export enum RemovePendingInviteApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum InviteMemberApiStatus {
@@ -218,7 +221,7 @@ export enum InviteMemberApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum RemoveMemberApiStatus {
@@ -226,28 +229,28 @@ export enum RemoveMemberApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum AuthzAndMembersApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum SessionTimelineApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum FetchAlertPrefsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum UpdateAlertPrefsApiStatus {
@@ -255,14 +258,14 @@ export enum UpdateAlertPrefsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum FetchAppSettingsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum UpdateAppSettingsApiStatus {
@@ -270,7 +273,7 @@ export enum UpdateAppSettingsApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum FetchUsageApiStatus {
@@ -278,14 +281,14 @@ export enum FetchUsageApiStatus {
   Success,
   Error,
   NoApps,
-  Cancelled
+  Cancelled,
 }
 
 export enum BugReportsOverviewApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum BugReportsOverviewPlotApiStatus {
@@ -293,14 +296,14 @@ export enum BugReportsOverviewPlotApiStatus {
   Success,
   Error,
   NoData,
-  Cancelled
+  Cancelled,
 }
 
 export enum BugReportApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum UpdateBugReportStatusApiStatus {
@@ -308,700 +311,692 @@ export enum UpdateBugReportStatusApiStatus {
   Loading,
   Success,
   Error,
-  Cancelled
+  Cancelled,
 }
 
 export enum SessionType {
-  All = 'All Sessions',
-  Crashes = 'Crash Sessions',
-  ANRs = 'ANR Sessions',
-  Issues = 'Crash & ANR Sessions'
+  All = "All Sessions",
+  Crashes = "Crash Sessions",
+  ANRs = "ANR Sessions",
+  Issues = "Crash & ANR Sessions",
 }
 
 export enum SpanStatus {
   Unset = "Unset",
   Ok = "Ok",
-  Error = "Error"
+  Error = "Error",
 }
 
 export enum BugReportStatus {
   Open = "Open",
-  Closed = "Closed"
+  Closed = "Closed",
 }
 
 export type Team = {
-  id: string
-  name: string
-}
+  id: string;
+  name: string;
+};
 
 export type PendingInvite = {
-  id: string,
-  invited_by_user_id: string,
-  invited_by_email: string,
-  invited_to_team_id: string,
-  role: string,
-  email: string,
-  created_at: string,
-  updated_at: string,
-  valid_until: string
-}
+  id: string;
+  invited_by_user_id: string;
+  invited_by_email: string;
+  invited_to_team_id: string;
+  role: string;
+  email: string;
+  created_at: string;
+  updated_at: string;
+  valid_until: string;
+};
 
 export type App = {
-  id: string
-  team_id: string
-  name: string
+  id: string;
+  team_id: string;
+  name: string;
   api_key: {
-    created_at: string
-    key: string
-    last_seen: string | null
-    revoked: boolean
-  }
-  onboarded: boolean
-  created_at: string
-  updated_at: string
-  os_name: string | null
-  onboarded_at: string | null
-  unique_identifier: string | null
-}
+    created_at: string;
+    key: string;
+    last_seen: string | null;
+    revoked: boolean;
+  };
+  onboarded: boolean;
+  created_at: string;
+  updated_at: string;
+  os_name: string | null;
+  onboarded_at: string | null;
+  unique_identifier: string | null;
+};
 
 export const emptyJourney = {
-  "links": [
+  links: [
     {
-      "source": "",
-      "target": "",
-      "value": 0
-    }
+      source: "",
+      target: "",
+      value: 0,
+    },
   ],
-  "nodes": [
+  nodes: [
     {
-      "id": "au.com.shiftyjelly.pocketcasts.ui.MainActivity",
-      "issues": {
-        "anrs": [
+      id: "au.com.shiftyjelly.pocketcasts.ui.MainActivity",
+      issues: {
+        anrs: [
           {
-            "id": "",
-            "title": "",
-            "count": 0
+            id: "",
+            title: "",
+            count: 0,
           },
         ],
-        "crashes": [
+        crashes: [
           {
-            "id": "",
-            "title": "",
-            "count": 0
+            id: "",
+            title: "",
+            count: 0,
           },
-        ]
-      }
-    }
+        ],
+      },
+    },
   ],
-  "totalIssues": 0
-}
+  totalIssues: 0,
+};
 
 export const emptyMetrics = {
-  "adoption": {
-    "all_versions": 0,
-    "selected_version": 0,
-    "adoption": 0,
-    "nan": false
+  adoption: {
+    all_versions: 0,
+    selected_version: 0,
+    adoption: 0,
+    nan: false,
   },
-  "anr_free_sessions": {
-    "anr_free_sessions": 0,
-    "delta": 0,
-    "nan": false
+  anr_free_sessions: {
+    anr_free_sessions: 0,
+    delta: 0,
+    nan: false,
   },
-  "cold_launch": {
-    "delta": 0,
-    "nan": false,
-    "p95": 0
+  cold_launch: {
+    delta: 0,
+    nan: false,
+    p95: 0,
   },
-  "crash_free_sessions": {
-    "crash_free_sessions": 0,
-    "delta": 0,
-    "nan": false
+  crash_free_sessions: {
+    crash_free_sessions: 0,
+    delta: 0,
+    nan: false,
   },
-  "hot_launch": {
-    "delta": 0,
-    "nan": false,
-    "p95": 0
+  hot_launch: {
+    delta: 0,
+    nan: false,
+    p95: 0,
   },
-  "perceived_anr_free_sessions": {
-    "perceived_anr_free_sessions": 0,
-    "delta": 0,
-    "nan": false
+  perceived_anr_free_sessions: {
+    perceived_anr_free_sessions: 0,
+    delta: 0,
+    nan: false,
   },
-  "perceived_crash_free_sessions": {
-    "perceived_crash_free_sessions": 0,
-    "delta": 0,
-    "nan": false
+  perceived_crash_free_sessions: {
+    perceived_crash_free_sessions: 0,
+    delta: 0,
+    nan: false,
   },
-  "sizes": {
-    "average_app_size": 0,
-    "selected_app_size": 0,
-    "delta": 0,
-    "nan": false
+  sizes: {
+    average_app_size: 0,
+    selected_app_size: 0,
+    delta: 0,
+    nan: false,
   },
-  "warm_launch": {
-    "delta": 0,
-    "nan": false,
-    "p95": 0
-  }
-}
+  warm_launch: {
+    delta: 0,
+    nan: false,
+    p95: 0,
+  },
+};
 
 export const emptySessionsOverviewResponse = {
-  "meta": {
-    "next": false,
-    "previous": false
+  meta: {
+    next: false,
+    previous: false,
   },
-  "results": [] as {
-    "session_id": string,
-    "app_id": string,
-    "first_event_time": string,
-    "last_event_time": string,
-    "duration": string,
-    "matched_free_text": string,
-    "attribute": {
-      "app_version": "",
-      "app_build": "",
-      "user_id": "",
-      "device_name": "",
-      "device_model": "",
-      "device_manufacturer": "",
-      "os_name": "",
-      "os_version": ""
-    },
-  }[]
-}
+  results: [] as {
+    session_id: string;
+    app_id: string;
+    first_event_time: string;
+    last_event_time: string;
+    duration: string;
+    matched_free_text: string;
+    attribute: {
+      app_version: "";
+      app_build: "";
+      user_id: "";
+      device_name: "";
+      device_model: "";
+      device_manufacturer: "";
+      os_name: "";
+      os_version: "";
+    };
+  }[],
+};
 
 export const emptySpansResponse = {
-  "meta": {
-    "next": false,
-    "previous": false
+  meta: {
+    next: false,
+    previous: false,
   },
-  "results": [] as {
-    "app_id": string,
-    "span_name": string,
-    "span_id": string,
-    "trace_id": string,
-    "status": number,
-    "start_time": string,
-    "end_time": string,
-    "duration": number,
-    "app_version": string,
-    "app_build": string,
-    "os_name": string,
-    "os_version": string,
-    "device_manufacturer": string,
-    "device_model": string
-  }[]
-}
+  results: [] as {
+    app_id: string;
+    span_name: string;
+    span_id: string;
+    trace_id: string;
+    status: number;
+    start_time: string;
+    end_time: string;
+    duration: number;
+    app_version: string;
+    app_build: string;
+    os_name: string;
+    os_version: string;
+    device_manufacturer: string;
+    device_model: string;
+  }[],
+};
 
 const emptyExceptionGroup = {
-  "id": "",
-  "app_id": "",
-  "type": "",
-  "message": "",
-  "method_name": "",
-  "file_name": "",
-  "line_number": 0,
-  "count": 0,
-  "percentage_contribution": 0,
-  "updated_at": ""
-}
+  id: "",
+  app_id: "",
+  type: "",
+  message: "",
+  method_name: "",
+  file_name: "",
+  line_number: 0,
+  count: 0,
+  percentage_contribution: 0,
+  updated_at: "",
+};
 
 export const emptyExceptionsOverviewResponse = {
-  "meta": {
-    "next": false,
-    "previous": false
+  meta: {
+    next: false,
+    previous: false,
   },
-  "results": [] as typeof emptyExceptionGroup[]
-}
+  results: [] as (typeof emptyExceptionGroup)[],
+};
 
 const emptyCrashGroupDetails = {
-  "id": "",
-  "session_id": "",
-  "timestamp": "",
-  "type": "",
-  "thread_name": "",
-  "attribute": {
-    "installation_id": "",
-    "app_version": "",
-    "app_build": "",
-    "app_unique_id": "",
-    "measure_sdk_version": "",
-    "platform": "",
-    "thread_name": "",
-    "user_id": "",
-    "device_name": "",
-    "device_model": "",
-    "device_manufacturer": "",
-    "device_type": "",
-    "device_is_foldable": false,
-    "device_is_physical": false,
-    "device_density_dpi": 0,
-    "device_width_px": 0,
-    "device_height_px": 0,
-    "device_density": 0.0,
-    "device_locale": "",
-    "os_name": "",
-    "os_version": "",
-    "network_type": "",
-    "network_provider": "",
-    "network_generation": ""
+  id: "",
+  session_id: "",
+  timestamp: "",
+  type: "",
+  thread_name: "",
+  attribute: {
+    installation_id: "",
+    app_version: "",
+    app_build: "",
+    app_unique_id: "",
+    measure_sdk_version: "",
+    platform: "",
+    thread_name: "",
+    user_id: "",
+    device_name: "",
+    device_model: "",
+    device_manufacturer: "",
+    device_type: "",
+    device_is_foldable: false,
+    device_is_physical: false,
+    device_density_dpi: 0,
+    device_width_px: 0,
+    device_height_px: 0,
+    device_density: 0.0,
+    device_locale: "",
+    os_name: "",
+    os_version: "",
+    network_type: "",
+    network_provider: "",
+    network_generation: "",
   },
-  "exception": {
-    "title": "",
-    "stacktrace": ""
+  exception: {
+    title: "",
+    stacktrace: "",
   },
-  "attachments": [
+  attachments: [
     {
-      "id": "",
-      "name": "",
-      "type": "",
-      "key": "",
-      "location": ""
-    }
+      id: "",
+      name: "",
+      type: "",
+      key: "",
+      location: "",
+    },
   ],
-  "threads": [
+  threads: [
     {
-      "name": "",
-      "frames": [
-        ""
-      ]
-    }
+      name: "",
+      frames: [""],
+    },
   ],
-  "attributes": {}
-}
+  attributes: {},
+};
 
 export const emptyCrashExceptionsDetailsResponse = {
-  "meta": {
-    "next": true,
-    "previous": false
+  meta: {
+    next: true,
+    previous: false,
   },
-  "results": [] as typeof emptyCrashGroupDetails[]
-}
+  results: [] as (typeof emptyCrashGroupDetails)[],
+};
 
 const emptyAnrGroupDetails = {
-  "id": "",
-  "session_id": "",
-  "timestamp": "",
-  "type": "",
-  "thread_name": "",
-  "attribute": {
-    "installation_id": "",
-    "app_version": "",
-    "app_build": "",
-    "app_unique_id": "",
-    "measure_sdk_version": "",
-    "platform": "",
-    "thread_name": "",
-    "user_id": "",
-    "device_name": "",
-    "device_model": "",
-    "device_manufacturer": "",
-    "device_type": "",
-    "device_is_foldable": false,
-    "device_is_physical": false,
-    "device_density_dpi": 0,
-    "device_width_px": 0,
-    "device_height_px": 0,
-    "device_density": 0.0,
-    "device_locale": "",
-    "os_name": "",
-    "os_version": "",
-    "network_type": "",
-    "network_provider": "",
-    "network_generation": ""
+  id: "",
+  session_id: "",
+  timestamp: "",
+  type: "",
+  thread_name: "",
+  attribute: {
+    installation_id: "",
+    app_version: "",
+    app_build: "",
+    app_unique_id: "",
+    measure_sdk_version: "",
+    platform: "",
+    thread_name: "",
+    user_id: "",
+    device_name: "",
+    device_model: "",
+    device_manufacturer: "",
+    device_type: "",
+    device_is_foldable: false,
+    device_is_physical: false,
+    device_density_dpi: 0,
+    device_width_px: 0,
+    device_height_px: 0,
+    device_density: 0.0,
+    device_locale: "",
+    os_name: "",
+    os_version: "",
+    network_type: "",
+    network_provider: "",
+    network_generation: "",
   },
-  "anr": {
-    "title": "",
-    "stacktrace": ""
+  anr: {
+    title: "",
+    stacktrace: "",
   },
-  "attachments": [
+  attachments: [
     {
-      "id": "",
-      "name": "",
-      "type": "",
-      "key": "",
-      "location": ""
-    }
+      id: "",
+      name: "",
+      type: "",
+      key: "",
+      location: "",
+    },
   ],
-  "threads": [
+  threads: [
     {
-      "name": "",
-      "frames": [
-        ""
-      ]
-    }
+      name: "",
+      frames: [""],
+    },
   ],
-  "attributes": {}
-}
+  attributes: {},
+};
 
 export const emptyAnrExceptionsDetailsResponse = {
-  "meta": {
-    "next": true,
-    "previous": false
+  meta: {
+    next: true,
+    previous: false,
   },
-  "results": [] as typeof emptyAnrGroupDetails[]
-}
+  results: [] as (typeof emptyAnrGroupDetails)[],
+};
 
 export const defaultAuthzAndMembers = {
-  "can_invite": [
-    "viewer"
-  ],
-  "members": [
+  can_invite: ["viewer"],
+  members: [
     {
-      "id": "",
-      "name": null,
-      "email": "",
-      "role": "",
-      "last_sign_in_at": "",
-      "created_at": "",
-      "authz": {
-        "can_change_roles": [
-          ""
-        ],
-        "can_remove": true
-      }
-    }
-  ]
-}
+      id: "",
+      name: null,
+      email: "",
+      role: "",
+      last_sign_in_at: "",
+      created_at: "",
+      authz: {
+        can_change_roles: [""],
+        can_remove: true,
+      },
+    },
+  ],
+};
 
 export const emptySessionTimeline = {
-  "app_id": "2b7ddad4-40a6-42a7-9e21-a90577e08263",
-  "attribute": {
-    "installation_id": "",
-    "app_version": "",
-    "app_build": "",
-    "app_unique_id": "",
-    "measure_sdk_version": "",
-    "platform": "",
-    "thread_name": "",
-    "user_id": "",
-    "device_name": "",
-    "device_model": "",
-    "device_manufacturer": "",
-    "device_type": "",
-    "device_is_foldable": true,
-    "device_is_physical": false,
-    "device_density_dpi": 0,
-    "device_width_px": 0,
-    "device_height_px": 0,
-    "device_density": 0.0,
-    "device_locale": "",
-    "os_name": "",
-    "os_version": "",
-    "network_type": "",
-    "network_provider": "",
-    "network_generation": ""
+  app_id: "2b7ddad4-40a6-42a7-9e21-a90577e08263",
+  attribute: {
+    installation_id: "",
+    app_version: "",
+    app_build: "",
+    app_unique_id: "",
+    measure_sdk_version: "",
+    platform: "",
+    thread_name: "",
+    user_id: "",
+    device_name: "",
+    device_model: "",
+    device_manufacturer: "",
+    device_type: "",
+    device_is_foldable: true,
+    device_is_physical: false,
+    device_density_dpi: 0,
+    device_width_px: 0,
+    device_height_px: 0,
+    device_density: 0.0,
+    device_locale: "",
+    os_name: "",
+    os_version: "",
+    network_type: "",
+    network_provider: "",
+    network_generation: "",
   },
-  "cpu_usage": [
+  cpu_usage: [
     {
-      "timestamp": "",
-      "value": 0.0
-    }
+      timestamp: "",
+      value: 0.0,
+    },
   ],
-  "duration": 0,
-  "memory_usage": [
+  duration: 0,
+  memory_usage: [
     {
-      "java_max_heap": 0,
-      "java_total_heap": 0,
-      "java_free_heap": 0,
-      "total_pss": 0,
-      "rss": 0,
-      "native_total_heap": 0,
-      "native_free_heap": 0,
-      "interval": 0,
-      "timestamp": ""
-    }
+      java_max_heap: 0,
+      java_total_heap: 0,
+      java_free_heap: 0,
+      total_pss: 0,
+      rss: 0,
+      native_total_heap: 0,
+      native_free_heap: 0,
+      interval: 0,
+      timestamp: "",
+    },
   ],
-  "memory_usage_absolute": [
+  memory_usage_absolute: [
     {
-      "max_memory": 0,
-      "used_memory": 0,
-      "interval": 0,
-      "timestamp": ""
-    }
+      max_memory: 0,
+      used_memory: 0,
+      interval: 0,
+      timestamp: "",
+    },
   ],
-  "session_id": "",
-  "threads": {
-    "main": [
+  session_id: "",
+  threads: {
+    main: [
       {
-        "event_type": "lifecycle_activity",
-        "thread_name": "",
-        "type": "",
-        "class_name": "",
-        "intent": "",
-        "saved_instance_state": false,
-        "timestamp": ""
+        event_type: "lifecycle_activity",
+        thread_name: "",
+        type: "",
+        class_name: "",
+        intent: "",
+        saved_instance_state: false,
+        timestamp: "",
       },
       {
-        "event_type": "lifecycle_app",
-        "thread_name": "",
-        "type": "",
-        "timestamp": ""
+        event_type: "lifecycle_app",
+        thread_name: "",
+        type: "",
+        timestamp: "",
       },
       {
-        "event_type": "exception",
-        "type": "",
-        "message": "",
-        "method_name": "",
-        "file_name": "",
-        "line_number": 0,
-        "thread_name": "",
-        "handled": false,
-        "stacktrace": "",
-        "foreground": true,
-        "timestamp": "",
-        "attachments": [
+        event_type: "exception",
+        type: "",
+        message: "",
+        method_name: "",
+        file_name: "",
+        line_number: 0,
+        thread_name: "",
+        handled: false,
+        stacktrace: "",
+        foreground: true,
+        timestamp: "",
+        attachments: [
           {
-            "id": "",
-            "name": "",
-            "type": "",
-            "key": "",
-            "location": ""
-          }
-        ]
-      }
-    ]
+            id: "",
+            name: "",
+            type: "",
+            key: "",
+            location: "",
+          },
+        ],
+      },
+    ],
   },
-  "traces": [
+  traces: [
     {
-      "trace_id": "847be6f84f004045d9deebea9b2fafe7",
-      "trace_name": "root",
-      "thread_name": "Thread-2",
-      "start_time": "2024-12-16T03:31:04.16Z",
-      "end_time": "2024-12-16T03:31:08.167Z",
-      "duration": 4007
+      trace_id: "847be6f84f004045d9deebea9b2fafe7",
+      trace_name: "root",
+      thread_name: "Thread-2",
+      start_time: "2024-12-16T03:31:04.16Z",
+      end_time: "2024-12-16T03:31:08.167Z",
+      duration: 4007,
     },
     {
-      "trace_id": "3dd7bb2600064eea1a595021d77cb3d5",
-      "trace_name": "activity.onCreate",
-      "thread_name": "main",
-      "start_time": "2024-12-16T03:30:57.915Z",
-      "end_time": "2024-12-16T03:30:58.195Z",
-      "duration": 280
+      trace_id: "3dd7bb2600064eea1a595021d77cb3d5",
+      trace_name: "activity.onCreate",
+      thread_name: "main",
+      start_time: "2024-12-16T03:30:57.915Z",
+      end_time: "2024-12-16T03:30:58.195Z",
+      duration: 280,
     },
     {
-      "trace_id": "097d6c882be5f5ccacc0ef700b17b87a",
-      "trace_name": "SampleApp.onCreate",
-      "thread_name": "main",
-      "start_time": "2024-12-16T03:30:57.712Z",
-      "end_time": "2024-12-16T03:30:57.829Z",
-      "duration": 117
+      trace_id: "097d6c882be5f5ccacc0ef700b17b87a",
+      trace_name: "SampleApp.onCreate",
+      thread_name: "main",
+      start_time: "2024-12-16T03:30:57.712Z",
+      end_time: "2024-12-16T03:30:57.829Z",
+      duration: 117,
     },
     {
-      "trace_id": "7e5ccd666dc26dbb65f4ce92b543637e",
-      "trace_name": "activity.onCreate",
-      "thread_name": "main",
-      "start_time": "2024-12-16T03:26:48.27Z",
-      "end_time": "2024-12-16T03:26:48.351Z",
-      "duration": 81
+      trace_id: "7e5ccd666dc26dbb65f4ce92b543637e",
+      trace_name: "activity.onCreate",
+      thread_name: "main",
+      start_time: "2024-12-16T03:26:48.27Z",
+      end_time: "2024-12-16T03:26:48.351Z",
+      duration: 81,
     },
     {
-      "trace_id": "b0a9210cb6b5b98773e4ae6d98f65a8c",
-      "trace_name": "SampleApp.onCreate",
-      "thread_name": "main",
-      "start_time": "2024-12-16T03:26:48.18Z",
-      "end_time": "2024-12-16T03:26:48.232Z",
-      "duration": 52
-    }
-  ]
-}
+      trace_id: "b0a9210cb6b5b98773e4ae6d98f65a8c",
+      trace_name: "SampleApp.onCreate",
+      thread_name: "main",
+      start_time: "2024-12-16T03:26:48.18Z",
+      end_time: "2024-12-16T03:26:48.232Z",
+      duration: 52,
+    },
+  ],
+};
 
 export const emptyTrace = {
-  "app_id": "",
-  "trace_id": "",
-  "session_id": "",
-  "user_id": "",
-  "start_time": "",
-  "end_time": "",
-  "duration": 0,
-  "app_version": "",
-  "os_version": "",
-  "device_model": "",
-  "device_manufacturer": "",
-  "network_type": "",
-  "spans":
-    [
-      {
-        "span_name": "",
-        "span_id": "",
-        "parent_id": "",
-        "status": 0,
-        "start_time": "",
-        "end_time": "",
-        "duration": 0,
-        "thread_name": "",
-        "user_defined_attributes": null,
-        "checkpoints": [
-          {
-            "name": "",
-            "timestamp": ""
-          }
-        ]
-      }
-    ]
-}
+  app_id: "",
+  trace_id: "",
+  session_id: "",
+  user_id: "",
+  start_time: "",
+  end_time: "",
+  duration: 0,
+  app_version: "",
+  os_version: "",
+  device_model: "",
+  device_manufacturer: "",
+  network_type: "",
+  spans: [
+    {
+      span_name: "",
+      span_id: "",
+      parent_id: "",
+      status: 0,
+      start_time: "",
+      end_time: "",
+      duration: 0,
+      thread_name: "",
+      user_defined_attributes: null,
+      checkpoints: [
+        {
+          name: "",
+          timestamp: "",
+        },
+      ],
+    },
+  ],
+};
 
 export const emptyAlertPrefs = {
   crash_rate_spike: {
-    email: true
+    email: true,
   },
   anr_rate_spike: {
-    email: true
+    email: true,
   },
   launch_time_spike: {
-    email: true
-  }
-}
+    email: true,
+  },
+};
 
 export const emptyAppSettings = {
-  retention_period: 30
-}
+  retention_period: 30,
+};
 
 export const emptyUsage = [
   {
-    "app_id": "",
-    "app_name": "",
-    "monthly_app_usage": [
+    app_id: "",
+    app_name: "",
+    monthly_app_usage: [
       {
-        "month_year": "",
-        "event_count": 0,
-        "session_count": 0,
-        "trace_count": 0,
-        "span_count": 0,
-      }
-    ]
-  }
-]
+        month_year: "",
+        event_count: 0,
+        session_count: 0,
+        trace_count: 0,
+        span_count: 0,
+      },
+    ],
+  },
+];
 
 export const emptyBugReportsOverviewResponse = {
-  "meta": {
-    "next": false,
-    "previous": false
+  meta: {
+    next: false,
+    previous: false,
   },
-  "results": [] as {
-    "session_id": string,
-    "app_id": string,
-    "event_id": string,
-    "status": number,
-    "description": string
-    "timestamp": string
-    "attribute": {
-      "installation_id": string
-      "app_version": string,
-      "app_build": string,
-      "app_unique_id": string,
-      "measure_sdk_version": string,
-      "platform": string,
-      "thread_name": string,
-      "user_id": string,
-      "device_name": string,
-      "device_model": string,
-      "device_manufacturer": string,
-      "device_type": string,
-      "device_is_foldable": boolean,
-      "device_is_physical": boolean,
-      "device_density_dpi": number,
-      "device_width_px": number,
-      "device_height_px": number,
-      "device_density": number,
-      "device_locale": string,
-      "device_low_power_mode": boolean,
-      "device_thermal_throttling_enabled": boolean,
-      "device_cpu_arch": string,
-      "os_name": string,
-      "os_version": string,
-      "os_page_size": number,
-      "network_type": string,
-      "network_provider": string,
-      "network_generation": string
-    },
-    "user_defined_attribute": null,
-    "attachments": null,
-    "matched_free_text": string
-  }[]
-}
+  results: [] as {
+    session_id: string;
+    app_id: string;
+    event_id: string;
+    status: number;
+    description: string;
+    timestamp: string;
+    attribute: {
+      installation_id: string;
+      app_version: string;
+      app_build: string;
+      app_unique_id: string;
+      measure_sdk_version: string;
+      platform: string;
+      thread_name: string;
+      user_id: string;
+      device_name: string;
+      device_model: string;
+      device_manufacturer: string;
+      device_type: string;
+      device_is_foldable: boolean;
+      device_is_physical: boolean;
+      device_density_dpi: number;
+      device_width_px: number;
+      device_height_px: number;
+      device_density: number;
+      device_locale: string;
+      device_low_power_mode: boolean;
+      device_thermal_throttling_enabled: boolean;
+      device_cpu_arch: string;
+      os_name: string;
+      os_version: string;
+      os_page_size: number;
+      network_type: string;
+      network_provider: string;
+      network_generation: string;
+    };
+    user_defined_attribute: null;
+    attachments: null;
+    matched_free_text: string;
+  }[],
+};
 
 export const emptyBugReport = {
-  "session_id": "",
-  "app_id": "",
-  "event_id": "",
-  "status": 0,
-  "description": "",
-  "timestamp": "",
-  "attribute": {
-    "installation_id": "",
-    "app_version": "",
-    "app_build": "",
-    "app_unique_id": "",
-    "measure_sdk_version": "",
-    "platform": "",
-    "thread_name": "",
-    "user_id": "",
-    "device_name": "",
-    "device_model": "",
-    "device_manufacturer": "",
-    "device_type": "",
-    "device_is_foldable": false,
-    "device_is_physical": false,
-    "device_density_dpi": 0,
-    "device_width_px": 0,
-    "device_height_px": 0,
-    "device_density": 0,
-    "device_locale": "",
-    "device_low_power_mode": false,
-    "device_thermal_throttling_enabled": false,
-    "device_cpu_arch": "",
-    "os_name": "",
-    "os_version": "",
-    "os_page_size": 0,
-    "network_type": "",
-    "network_provider": "",
-    "network_generation": ""
+  session_id: "",
+  app_id: "",
+  event_id: "",
+  status: 0,
+  description: "",
+  timestamp: "",
+  attribute: {
+    installation_id: "",
+    app_version: "",
+    app_build: "",
+    app_unique_id: "",
+    measure_sdk_version: "",
+    platform: "",
+    thread_name: "",
+    user_id: "",
+    device_name: "",
+    device_model: "",
+    device_manufacturer: "",
+    device_type: "",
+    device_is_foldable: false,
+    device_is_physical: false,
+    device_density_dpi: 0,
+    device_width_px: 0,
+    device_height_px: 0,
+    device_density: 0,
+    device_locale: "",
+    device_low_power_mode: false,
+    device_thermal_throttling_enabled: false,
+    device_cpu_arch: "",
+    os_name: "",
+    os_version: "",
+    os_page_size: 0,
+    network_type: "",
+    network_provider: "",
+    network_generation: "",
   },
-  "user_defined_attribute": null,
-  "attachments": [
+  user_defined_attribute: null,
+  attachments: [
     {
-      "id": "",
-      "name": "",
-      "type": "",
-      "key": "",
-      "location": ""
-    }
-  ]
-}
+      id: "",
+      name: "",
+      type: "",
+      key: "",
+      location: "",
+    },
+  ],
+};
 
 export class AppVersion {
-  name: string
-  code: string
-  displayName: string
+  name: string;
+  code: string;
+  displayName: string;
 
   constructor(name: string, code: string) {
-    this.name = name
-    this.code = code
-    this.displayName = this.name + ' (' + this.code + ')'
+    this.name = name;
+    this.code = code;
+    this.displayName = this.name + " (" + this.code + ")";
   }
 }
 
 export class OsVersion {
-  name: string
-  version: string
-  displayName: string
+  name: string;
+  version: string;
+  displayName: string;
 
   constructor(name: string, version: string) {
-    this.name = name
-    this.version = version
-    this.displayName = this.name + ' ' + this.version
+    this.name = name;
+    this.version = version;
+    this.displayName = this.name + " " + this.version;
   }
 }
 
 export type UserDefAttr = {
-  key: string
-  type: string
-}
+  key: string;
+  type: string;
+};
 
 export const saveListFiltersToServer = async (filters: Filters) => {
-  if (filters.versions.length === 0 &&
+  if (
+    filters.versions.length === 0 &&
     filters.osVersions.length === 0 &&
     filters.countries.length === 0 &&
     filters.networkProviders.length === 0 &&
@@ -1012,22 +1007,21 @@ export const saveListFiltersToServer = async (filters: Filters) => {
     filters.deviceNames.length === 0 &&
     filters.udAttrMatchers.length === 0
   ) {
-    return null
+    return null;
   }
 
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-  let url = `${origin}/apps/${filters.app!.id}/shortFilters`
+  let url = `/api/apps/${filters.app!.id}/shortFilters`;
 
   const udExpression = {
-    and: filters.udAttrMatchers.map(matcher => ({
+    and: filters.udAttrMatchers.map((matcher) => ({
       cmp: {
         key: matcher.key,
         type: matcher.type,
         op: matcher.op,
-        value: String(matcher.value)
-      }
-    }))
-  }
+        value: String(matcher.value),
+      },
+    })),
+  };
 
   const bodyFilters: any = {
     versions: filters.versions.map((v) => v.name),
@@ -1041,1050 +1035,1161 @@ export const saveListFiltersToServer = async (filters: Filters) => {
     locales: filters.locales,
     device_manufacturers: filters.deviceManufacturers,
     device_names: filters.deviceNames,
-  }
+  };
 
   if (filters.udAttrMatchers.length > 0) {
-    bodyFilters.ud_expression = JSON.stringify(udExpression)
+    bodyFilters.ud_expression = JSON.stringify(udExpression);
   }
 
   const opts = {
-    method: 'POST',
+    method: "POST",
     body: JSON.stringify({
-      filters: bodyFilters
-    })
-  }
+      filters: bodyFilters,
+    }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(url, opts)
+    const res = await measureAuth.fetchMeasure(url, opts);
 
     if (!res.ok) {
-      return null
+      return null;
     }
 
-    const data = await res.json()
-    return data.filter_short_code
+    const data = await res.json();
+    return data.filter_short_code;
   } catch {
-    return null
+    return null;
   }
-}
+};
 
-async function applyGenericFiltersToUrl(url: string, filters: Filters, keyId: string | null, keyTimestamp: string | null, limit: number | null, offset: number | null) {
-  const serverFormattedStartDate = formatUserInputDateToServerFormat(filters.startDate)
-  const serverFormattedEndDate = formatUserInputDateToServerFormat(filters.endDate)
-  const timezone = getTimeZoneForServer()
+async function applyGenericFiltersToUrl(
+  url: string,
+  filters: Filters,
+  keyId: string | null,
+  keyTimestamp: string | null,
+  limit: number | null,
+  offset: number | null,
+) {
+  const serverFormattedStartDate = formatUserInputDateToServerFormat(
+    filters.startDate,
+  );
+  const serverFormattedEndDate = formatUserInputDateToServerFormat(
+    filters.endDate,
+  );
+  const timezone = getTimeZoneForServer();
 
-  const u = new URL(url)
-  const searchParams = new URLSearchParams()
+  const u = new URL(url, window.location.origin);
+  const searchParams = new URLSearchParams();
 
-  searchParams.append('from', serverFormattedStartDate)
-  searchParams.append('to', serverFormattedEndDate)
-  searchParams.append('timezone', timezone)
+  searchParams.append("from", serverFormattedStartDate);
+  searchParams.append("to", serverFormattedEndDate);
+  searchParams.append("timezone", timezone);
 
-  const filterShortCode = await saveListFiltersToServer(filters)
+  const filterShortCode = await saveListFiltersToServer(filters);
 
   if (filterShortCode !== null) {
-    searchParams.append('filter_short_code', filterShortCode)
+    searchParams.append("filter_short_code", filterShortCode);
   }
 
   // Append session type if needed
   if (filters.sessionType === SessionType.Issues) {
-    searchParams.append('crash', '1')
-    searchParams.append('anr', '1')
+    searchParams.append("crash", "1");
+    searchParams.append("anr", "1");
   } else if (filters.sessionType === SessionType.Crashes) {
-    searchParams.append('crash', '1')
+    searchParams.append("crash", "1");
   } else if (filters.sessionType === SessionType.ANRs) {
-    searchParams.append('anr', '1')
+    searchParams.append("anr", "1");
   }
 
   // Append span name if needed
   if (filters.rootSpanName !== "") {
-    searchParams.append('span_name', encodeURIComponent(filters.rootSpanName))
+    searchParams.append("span_name", encodeURIComponent(filters.rootSpanName));
   }
 
   // Append span statuses if needed
   if (filters.spanStatuses.length > 0) {
     filters.spanStatuses.forEach((v) => {
       if (v === SpanStatus.Unset) {
-        searchParams.append('span_statuses', "0")
+        searchParams.append("span_statuses", "0");
       } else if (v === SpanStatus.Ok) {
-        searchParams.append('span_statuses', "1")
+        searchParams.append("span_statuses", "1");
       } else if (v === SpanStatus.Error) {
-        searchParams.append('span_statuses', "2")
+        searchParams.append("span_statuses", "2");
       }
-    })
+    });
   }
 
   // Append bug report statuses if needed
   if (filters.bugReportStatuses.length > 0) {
     filters.bugReportStatuses.forEach((v) => {
       if (v === BugReportStatus.Open) {
-        searchParams.append('bug_report_statuses', "0")
+        searchParams.append("bug_report_statuses", "0");
       } else if (v === BugReportStatus.Closed) {
-        searchParams.append('bug_report_statuses', "1")
+        searchParams.append("bug_report_statuses", "1");
       }
-    })
+    });
   }
 
   // Append free text if present
-  if (filters.freeText !== '') {
-    searchParams.append('free_text', filters.freeText)
+  if (filters.freeText !== "") {
+    searchParams.append("free_text", filters.freeText);
   }
 
   // Append keyId if present
   if (keyId !== null) {
-    searchParams.append('key_id', keyId)
+    searchParams.append("key_id", keyId);
   }
 
   // Append keyTimestamp if present
   if (keyTimestamp !== null) {
-    searchParams.append('key_timestamp', keyTimestamp)
+    searchParams.append("key_timestamp", keyTimestamp);
   }
 
   // Append limit if present
   if (limit !== null) {
-    searchParams.append('limit', String(limit))
+    searchParams.append("limit", String(limit));
   }
 
   // Append offset if present
   if (offset !== null) {
-    searchParams.append('offset', String(offset))
+    searchParams.append("offset", String(offset));
   }
 
-  u.search = searchParams.toString()
+  u.search = searchParams.toString();
 
-  return u.toString()
+  return u.toString();
 }
 
 export const fetchTeamsFromServer = async () => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams`)
+    const res = await measureAuth.fetchMeasure(`/api/teams`);
 
     if (!res.ok) {
-      return { status: TeamsApiStatus.Error, data: null }
+      return { status: TeamsApiStatus.Error, data: null };
     }
 
-    const data: [{ id: string, name: string }] = await res.json()
+    const data: [{ id: string; name: string }] = await res.json();
 
-    return { status: TeamsApiStatus.Success, data: data }
+    return { status: TeamsApiStatus.Success, data: data };
   } catch {
-    return { status: TeamsApiStatus.Cancelled, data: null }
+    return { status: TeamsApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchAppsFromServer = async (teamId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/apps`)
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/apps`);
 
     if (!res.ok && res.status == 404) {
-      return { status: AppsApiStatus.NoApps, data: null }
+      return { status: AppsApiStatus.NoApps, data: null };
     }
 
     if (!res.ok) {
-      return { status: AppsApiStatus.Error, data: null }
+      return { status: AppsApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
-    return { status: AppsApiStatus.Success, data: data }
+    const data = await res.json();
+    return { status: AppsApiStatus.Success, data: data };
   } catch {
-    return { status: AppsApiStatus.Cancelled, data: null }
+    return { status: AppsApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchRootSpanNamesFromServer = async (selectedApp: App) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${selectedApp.id}/spans/roots/names`)
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${selectedApp.id}/spans/roots/names`,
+    );
 
     if (!res.ok) {
-      return { status: RootSpanNamesApiStatus.Error, data: null }
+      return { status: RootSpanNamesApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data.results === null) {
-      return { status: RootSpanNamesApiStatus.NoData, data: null }
+      return { status: RootSpanNamesApiStatus.NoData, data: null };
     }
 
-    return { status: RootSpanNamesApiStatus.Success, data: data }
+    return { status: RootSpanNamesApiStatus.Success, data: data };
   } catch {
-    return { status: RootSpanNamesApiStatus.Cancelled, data: null }
+    return { status: RootSpanNamesApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchSpansFromServer = async (filters: Filters, limit: number, offset: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const fetchSpansFromServer = async (
+  filters: Filters,
+  limit: number,
+  offset: number,
+) => {
+  var url = `/api/apps/${filters.app!.id}/spans?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/spans?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, limit, offset)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, limit, offset);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: SpansApiStatus.Error, data: null }
+      return { status: SpansApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: SpansApiStatus.Success, data: data }
+    return { status: SpansApiStatus.Success, data: data };
   } catch {
-    return { status: SpansApiStatus.Cancelled, data: null }
+    return { status: SpansApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchSpanMetricsPlotFromServer = async (filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+  var url = `/api/apps/${filters.app!.id}/spans/plots/metrics?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/spans/plots/metrics?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: SpanMetricsPlotApiStatus.Error, data: null }
+      return { status: SpanMetricsPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data === null) {
-      return { status: SpanMetricsPlotApiStatus.NoData, data: null }
+      return { status: SpanMetricsPlotApiStatus.NoData, data: null };
     }
 
-    return { status: SpanMetricsPlotApiStatus.Success, data: data }
+    return { status: SpanMetricsPlotApiStatus.Success, data: data };
   } catch {
-    return { status: SpanMetricsPlotApiStatus.Cancelled, data: null }
+    return { status: SpanMetricsPlotApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchTraceFromServer = async (appId: string, traceId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/traces/${traceId}`)
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appId}/traces/${traceId}`,
+    );
     if (!res.ok) {
-      return { status: TraceApiStatus.Error, data: null }
+      return { status: TraceApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: TraceApiStatus.Success, data: data }
+    return { status: TraceApiStatus.Success, data: data };
   } catch {
-    return { status: TraceApiStatus.Cancelled, data: null }
+    return { status: TraceApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchFiltersFromServer = async (selectedApp: App, filterSource: FilterSource) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  let url = `${origin}/apps/${selectedApp.id}/filters`
+export const fetchFiltersFromServer = async (
+  selectedApp: App,
+  filterSource: FilterSource,
+) => {
+  let url = `/api/apps/${selectedApp.id}/filters`;
 
   // fetch the user defined attributes
-  url += '?ud_attr_keys=1'
+  url += "?ud_attr_keys=1";
 
   // if filter is for Crashes, Anrs or Spans we append a query param indicating it
   if (filterSource === FilterSource.Crashes) {
-    url += '&crash=1'
+    url += "&crash=1";
   } else if (filterSource === FilterSource.Anrs) {
-    url += '&anr=1'
+    url += "&anr=1";
   } else if (filterSource === FilterSource.Spans) {
-    url += '&span=1'
+    url += "&span=1";
   }
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: FiltersApiStatus.Error, data: null }
+      return { status: FiltersApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data.versions === null) {
       if (!selectedApp.onboarded) {
-        return { status: FiltersApiStatus.NotOnboarded, data: null }
+        return { status: FiltersApiStatus.NotOnboarded, data: null };
       } else {
-        return { status: FiltersApiStatus.NoData, data: null }
+        return { status: FiltersApiStatus.NoData, data: null };
       }
     }
 
-    return { status: FiltersApiStatus.Success, data: data }
+    return { status: FiltersApiStatus.Success, data: data };
   } catch {
-    return { status: FiltersApiStatus.Cancelled, data: null }
+    return { status: FiltersApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchSessionsVsExceptionsPlotFromServer = async (filters: Filters) => {
+export const fetchSessionsVsExceptionsPlotFromServer = async (
+  filters: Filters,
+) => {
   // Fetch all three datasets in parallel
   const [sessionsRes, crashesRes, anrsRes] = await Promise.all([
     fetchSessionsOverviewPlotFromServer(filters),
     fetchExceptionsOverviewPlotFromServer(ExceptionsType.Crash, filters),
     fetchExceptionsOverviewPlotFromServer(ExceptionsType.Anr, filters),
-  ])
+  ]);
 
   // Handle error/no data
   if (
     sessionsRes.status !== SessionsOverviewPlotApiStatus.Success &&
     sessionsRes.status !== SessionsOverviewPlotApiStatus.NoData
   ) {
-    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null }
+    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null };
   }
   if (
     crashesRes.status !== ExceptionsOverviewPlotApiStatus.Success &&
     crashesRes.status !== ExceptionsOverviewPlotApiStatus.NoData
   ) {
-    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null }
+    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null };
   }
   if (
     anrsRes.status !== ExceptionsOverviewPlotApiStatus.Success &&
     anrsRes.status !== ExceptionsOverviewPlotApiStatus.NoData
   ) {
-    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null }
+    return { status: SessionsVsExceptionsPlotApiStatus.Error, data: null };
   }
 
   // Helper to flatten and merge all series of a type into a map of date -> count
-  function mergeSeries(seriesArr: any[], valueKey: string = 'instances') {
-    const dateMap: Record<string, number> = {}
+  function mergeSeries(seriesArr: any[], valueKey: string = "instances") {
+    const dateMap: Record<string, number> = {};
     for (const series of seriesArr || []) {
       for (const point of series.data || []) {
-        const date = point.datetime || point.x
-        const value = point[valueKey] ?? point.y ?? 0
-        dateMap[date] = (dateMap[date] || 0) + value
+        const date = point.datetime || point.x;
+        const value = point[valueKey] ?? point.y ?? 0;
+        dateMap[date] = (dateMap[date] || 0) + value;
       }
     }
-    return dateMap
+    return dateMap;
   }
 
   // Merge all series for each type
-  const sessionsMap = mergeSeries(sessionsRes.data || [])
-  const crashesMap = mergeSeries(crashesRes.data || [])
-  const anrsMap = mergeSeries(anrsRes.data || [])
+  const sessionsMap = mergeSeries(sessionsRes.data || []);
+  const crashesMap = mergeSeries(crashesRes.data || []);
+  const anrsMap = mergeSeries(anrsRes.data || []);
 
   // Get all unique dates
-  const allDates = Array.from(new Set([
-    ...Object.keys(sessionsMap),
-    ...Object.keys(crashesMap),
-    ...Object.keys(anrsMap),
-  ])).sort()
+  const allDates = Array.from(
+    new Set([
+      ...Object.keys(sessionsMap),
+      ...Object.keys(crashesMap),
+      ...Object.keys(anrsMap),
+    ]),
+  ).sort();
 
   // Build the final series arrays
   function buildSeries(id: string, map: Record<string, number>) {
     return {
       id,
       data: allDates.map((date, idx) => ({
-        id: id + '.' + idx,
+        id: id + "." + idx,
         x: date,
         y: map[date] || 0,
       })),
-    }
+    };
   }
 
   const result = [
-    buildSeries('Sessions', sessionsMap),
-    buildSeries('Crashes', crashesMap),
-    buildSeries('ANRs', anrsMap),
-  ]
+    buildSeries("Sessions", sessionsMap),
+    buildSeries("Crashes", crashesMap),
+    buildSeries("ANRs", anrsMap),
+  ];
 
   // If all are empty, return NoData
-  if (result.every(series => series.data.every(point => point.y === 0))) {
-    return { status: SessionsVsExceptionsPlotApiStatus.NoData, data: null }
+  if (result.every((series) => series.data.every((point) => point.y === 0))) {
+    return { status: SessionsVsExceptionsPlotApiStatus.NoData, data: null };
   }
 
   // Remove ANRs if all y values are 0
-  const filteredResult = result.filter(series => {
-    if (series.id === 'ANRs') {
-      return series.data.some(point => point.y !== 0)
+  const filteredResult = result.filter((series) => {
+    if (series.id === "ANRs") {
+      return series.data.some((point) => point.y !== 0);
     }
-    return true
-  })
+    return true;
+  });
 
-  return { status: SessionsVsExceptionsPlotApiStatus.Success, data: filteredResult }
-}
+  return {
+    status: SessionsVsExceptionsPlotApiStatus.Success,
+    data: filteredResult,
+  };
+};
 
-export const fetchJourneyFromServer = async (journeyType: JourneyType, exceptionsGroupdId: string | null, bidirectional: boolean, filters: Filters) => {
+export const fetchJourneyFromServer = async (
+  journeyType: JourneyType,
+  exceptionsGroupdId: string | null,
+  bidirectional: boolean,
+  filters: Filters,
+) => {
   // Must pass in exceptionsGroupdId if journey type is crash or anr details
-  if ((journeyType === JourneyType.CrashDetails || journeyType === JourneyType.AnrDetails) && exceptionsGroupdId === undefined) {
-    return { status: JourneyApiStatus.Error, data: null }
+  if (
+    (journeyType === JourneyType.CrashDetails ||
+      journeyType === JourneyType.AnrDetails) &&
+    exceptionsGroupdId === undefined
+  ) {
+    return { status: JourneyApiStatus.Error, data: null };
   }
 
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  let url = ''
+  let url = "";
   if (journeyType === JourneyType.CrashDetails) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/journey?`
+    url = `/api/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/journey?`;
   } else if (journeyType === JourneyType.AnrDetails) {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/journey?`
+    url = `api/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/journey?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/journey?`
+    url = `/api/apps/${filters.app!.id}/journey?`;
   }
 
   // Append bidirectional value
-  url = url + `bigraph=${bidirectional ? '1&' : '0&'}`
+  url = url + `bigraph=${bidirectional ? "1&" : "0&"}`;
 
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: JourneyApiStatus.Error, data: null }
+      return { status: JourneyApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: JourneyApiStatus.Success, data: data }
+    return { status: JourneyApiStatus.Success, data: data };
   } catch {
-    return { status: JourneyApiStatus.Cancelled, data: null }
+    return { status: JourneyApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchMetricsFromServer = async (filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+  let url = `/api/apps/${filters.app!.id}/metrics?`;
 
-  let url = `${origin}/apps/${filters.app!.id}/metrics?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: MetricsApiStatus.Error, data: null }
+      return { status: MetricsApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: MetricsApiStatus.Success, data: data }
+    return { status: MetricsApiStatus.Success, data: data };
   } catch {
-    return { status: MetricsApiStatus.Cancelled, data: null }
+    return { status: MetricsApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchSessionsOverviewFromServer = async (filters: Filters, keyId: string | null, keyTimestamp: string | null, limit: number, offset: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const fetchSessionsOverviewFromServer = async (
+  filters: Filters,
+  keyId: string | null,
+  keyTimestamp: string | null,
+  limit: number,
+  offset: number,
+) => {
+  var url = `/api/apps/${filters.app!.id}/sessions?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/sessions?`
-
-  url = await applyGenericFiltersToUrl(url, filters, keyId, keyTimestamp, limit, offset)
+  url = await applyGenericFiltersToUrl(
+    url,
+    filters,
+    keyId,
+    keyTimestamp,
+    limit,
+    offset,
+  );
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: SessionsOverviewApiStatus.Error, data: null }
+      return { status: SessionsOverviewApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: SessionsOverviewApiStatus.Success, data: data }
+    return { status: SessionsOverviewApiStatus.Success, data: data };
   } catch {
-    return { status: SessionsOverviewApiStatus.Cancelled, data: null }
+    return { status: SessionsOverviewApiStatus.Cancelled, data: null };
   }
-}
+};
 
 export const fetchSessionsOverviewPlotFromServer = async (filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+  var url = `/api/apps/${filters.app!.id}/sessions/plots/instances?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/sessions/plots/instances?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: SessionsOverviewPlotApiStatus.Error, data: null }
+      return { status: SessionsOverviewPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data === null) {
-      return { status: SessionsOverviewPlotApiStatus.NoData, data: null }
+      return { status: SessionsOverviewPlotApiStatus.NoData, data: null };
     }
 
-    return { status: SessionsOverviewPlotApiStatus.Success, data: data }
+    return { status: SessionsOverviewPlotApiStatus.Success, data: data };
   } catch {
-    return { status: SessionsOverviewPlotApiStatus.Cancelled, data: null }
+    return { status: SessionsOverviewPlotApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchExceptionsOverviewFromServer = async (exceptionsType: ExceptionsType, filters: Filters, keyId: string | null, limit: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  var url = ""
+export const fetchExceptionsOverviewFromServer = async (
+  exceptionsType: ExceptionsType,
+  filters: Filters,
+  keyId: string | null,
+  limit: number,
+) => {
+  var url = "";
   if (exceptionsType === ExceptionsType.Crash) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups?`
+    url = `/api/apps/${filters.app!.id}/crashGroups?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups?`
+    url = `/api/apps/${filters.app!.id}/anrGroups?`;
   }
 
-  url = await applyGenericFiltersToUrl(url, filters, keyId, null, limit, null)
+  url = await applyGenericFiltersToUrl(url, filters, keyId, null, limit, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: ExceptionsOverviewApiStatus.Error, data: null }
+      return { status: ExceptionsOverviewApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: ExceptionsOverviewApiStatus.Success, data: data }
+    return { status: ExceptionsOverviewApiStatus.Success, data: data };
   } catch {
-    return { status: ExceptionsOverviewApiStatus.Cancelled, data: null }
+    return { status: ExceptionsOverviewApiStatus.Cancelled, data: null };
   }
+};
 
-}
-
-export const fetchExceptionsDetailsFromServer = async (exceptionsType: ExceptionsType, exceptionsGroupdId: string, filters: Filters, keyId: string | null, keyTimestamp: string | null, limit: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  var url = ""
+export const fetchExceptionsDetailsFromServer = async (
+  exceptionsType: ExceptionsType,
+  exceptionsGroupdId: string,
+  filters: Filters,
+  keyId: string | null,
+  keyTimestamp: string | null,
+  limit: number,
+) => {
+  var url = "";
   if (exceptionsType === ExceptionsType.Crash) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/crashes?`
+    url = `/api/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/crashes?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/anrs?`
+    url = `/api/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/anrs?`;
   }
 
-  url = await applyGenericFiltersToUrl(url, filters, keyId, keyTimestamp, limit, null)
+  url = await applyGenericFiltersToUrl(
+    url,
+    filters,
+    keyId,
+    keyTimestamp,
+    limit,
+    null,
+  );
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: ExceptionsDetailsApiStatus.Error, data: null }
+      return { status: ExceptionsDetailsApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: ExceptionsDetailsApiStatus.Success, data: data }
+    return { status: ExceptionsDetailsApiStatus.Success, data: data };
   } catch {
-    return { status: ExceptionsDetailsApiStatus.Cancelled, data: null }
+    return { status: ExceptionsDetailsApiStatus.Cancelled, data: null };
   }
+};
 
-}
-
-export const fetchExceptionsOverviewPlotFromServer = async (exceptionsType: ExceptionsType, filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  var url = ""
+export const fetchExceptionsOverviewPlotFromServer = async (
+  exceptionsType: ExceptionsType,
+  filters: Filters,
+) => {
+  var url = "";
   if (exceptionsType === ExceptionsType.Crash) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups/plots/instances?`
+    url = `/api/apps/${filters.app!.id}/crashGroups/plots/instances?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups/plots/instances?`
+    url = `/api/apps/${filters.app!.id}/anrGroups/plots/instances?`;
   }
 
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: ExceptionsOverviewPlotApiStatus.Error, data: null }
+      return { status: ExceptionsOverviewPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data === null) {
-      return { status: ExceptionsOverviewPlotApiStatus.NoData, data: null }
+      return { status: ExceptionsOverviewPlotApiStatus.NoData, data: null };
     }
 
-    return { status: ExceptionsOverviewPlotApiStatus.Success, data: data }
+    return { status: ExceptionsOverviewPlotApiStatus.Success, data: data };
   } catch {
-    return { status: ExceptionsOverviewPlotApiStatus.Cancelled, data: null }
+    return { status: ExceptionsOverviewPlotApiStatus.Cancelled, data: null };
   }
-}
+};
 
-
-export const fetchExceptionsDetailsPlotFromServer = async (exceptionsType: ExceptionsType, exceptionsGroupdId: string, filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  var url = ""
+export const fetchExceptionsDetailsPlotFromServer = async (
+  exceptionsType: ExceptionsType,
+  exceptionsGroupdId: string,
+  filters: Filters,
+) => {
+  var url = "";
   if (exceptionsType === ExceptionsType.Crash) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/instances?`
+    url = `/api/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/instances?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/instances?`
+    url = `/api/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/instances?`;
   }
 
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: ExceptionsDetailsPlotApiStatus.Error, data: null }
+      return { status: ExceptionsDetailsPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data === null) {
-      return { status: ExceptionsDetailsPlotApiStatus.NoData, data: null }
+      return { status: ExceptionsDetailsPlotApiStatus.NoData, data: null };
     }
 
-    return { status: ExceptionsDetailsPlotApiStatus.Success, data: data }
+    return { status: ExceptionsDetailsPlotApiStatus.Success, data: data };
   } catch {
-    return { status: ExceptionsDetailsPlotApiStatus.Cancelled, data: null }
+    return { status: ExceptionsDetailsPlotApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchExceptionsDistributionPlotFromServer = async (exceptionsType: ExceptionsType, exceptionsGroupdId: string, filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
-  var url = ""
+export const fetchExceptionsDistributionPlotFromServer = async (
+  exceptionsType: ExceptionsType,
+  exceptionsGroupdId: string,
+  filters: Filters,
+) => {
+  var url = "";
   if (exceptionsType === ExceptionsType.Crash) {
-    url = `${origin}/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/distribution?`
+    url = `/api/apps/${filters.app!.id}/crashGroups/${exceptionsGroupdId}/plots/distribution?`;
   } else {
-    url = `${origin}/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/distribution?`
+    url = `/api/apps/${filters.app!.id}/anrGroups/${exceptionsGroupdId}/plots/distribution?`;
   }
 
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: ExceptionsDistributionPlotApiStatus.Error, data: null }
+      return { status: ExceptionsDistributionPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    if (data === null || Object.values(data).every(value => typeof value === 'object' && value !== null && Object.keys(value).length === 0)) {
-      return { status: ExceptionsDistributionPlotApiStatus.NoData, data: null }
+    if (
+      data === null ||
+      Object.values(data).every(
+        (value) =>
+          typeof value === "object" &&
+          value !== null &&
+          Object.keys(value).length === 0,
+      )
+    ) {
+      return { status: ExceptionsDistributionPlotApiStatus.NoData, data: null };
     }
 
-    return { status: ExceptionsDistributionPlotApiStatus.Success, data: data }
+    return { status: ExceptionsDistributionPlotApiStatus.Success, data: data };
   } catch {
-    return { status: ExceptionsDistributionPlotApiStatus.Cancelled, data: null }
+    return {
+      status: ExceptionsDistributionPlotApiStatus.Cancelled,
+      data: null,
+    };
   }
-}
+};
 
 export const fetchAuthzAndMembersFromServer = async (teamId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/authz`)
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/authz`);
     if (!res.ok) {
-      return { status: AuthzAndMembersApiStatus.Error, data: null }
+      return { status: AuthzAndMembersApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: AuthzAndMembersApiStatus.Success, data: data }
+    return { status: AuthzAndMembersApiStatus.Success, data: data };
   } catch {
-    return { status: AuthzAndMembersApiStatus.Cancelled, data: null }
+    return { status: AuthzAndMembersApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchSessionTimelineFromServer = async (appId: string, sessionId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
+export const fetchSessionTimelineFromServer = async (
+  appId: string,
+  sessionId: string,
+) => {
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/sessions/${sessionId}`)
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appId}/sessions/${sessionId}`,
+    );
     if (!res.ok) {
-      return { status: SessionTimelineApiStatus.Error, data: null }
+      return { status: SessionTimelineApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: SessionTimelineApiStatus.Success, data: data }
+    return { status: SessionTimelineApiStatus.Success, data: data };
   } catch {
-    return { status: SessionTimelineApiStatus.Cancelled, data: null }
+    return { status: SessionTimelineApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const changeTeamNameFromServer = async (teamId: string, newTeamName: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const changeTeamNameFromServer = async (
+  teamId: string,
+  newTeamName: string,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify({ name: newTeamName })
-  }
+    method: "PATCH",
+    body: JSON.stringify({ name: newTeamName }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/rename`, opts)
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/rename`,
+      opts,
+    );
     if (!res.ok) {
-      return { status: TeamNameChangeApiStatus.Error }
+      return { status: TeamNameChangeApiStatus.Error };
     }
 
-    return { status: TeamNameChangeApiStatus.Success }
+    return { status: TeamNameChangeApiStatus.Success };
   } catch {
-    return { status: TeamNameChangeApiStatus.Cancelled }
+    return { status: TeamNameChangeApiStatus.Cancelled };
   }
-}
+};
 
 export const createTeamFromServer = async (teamName: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
   const opts = {
-    method: 'POST',
-    body: JSON.stringify({ name: teamName })
-  }
+    method: "POST",
+    body: JSON.stringify({ name: teamName }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(`/api/teams`, opts);
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: CreateTeamApiStatus.Error, error: data.error }
+      return { status: CreateTeamApiStatus.Error, error: data.error };
     }
 
-    return { status: CreateTeamApiStatus.Success, data: data }
+    return { status: CreateTeamApiStatus.Success, data: data };
   } catch {
-    return { status: CreateTeamApiStatus.Cancelled }
+    return { status: CreateTeamApiStatus.Cancelled };
   }
-}
+};
 
 export const createAppFromServer = async (teamId: string, appName: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
   const opts = {
-    method: 'POST',
-    body: JSON.stringify({ name: appName })
-  }
+    method: "POST",
+    body: JSON.stringify({ name: appName }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/apps`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/apps`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: CreateAppApiStatus.Error, error: data.error }
+      return { status: CreateAppApiStatus.Error, error: data.error };
     }
 
-    return { status: CreateAppApiStatus.Success, data: data }
+    return { status: CreateAppApiStatus.Success, data: data };
   } catch {
-    return { status: CreateAppApiStatus.Cancelled }
+    return { status: CreateAppApiStatus.Cancelled };
   }
-}
+};
 
-export const changeRoleFromServer = async (teamId: string, newRole: string, memberId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const changeRoleFromServer = async (
+  teamId: string,
+  newRole: string,
+  memberId: string,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify({ role: newRole.toLocaleLowerCase() })
-  }
+    method: "PATCH",
+    body: JSON.stringify({ role: newRole.toLocaleLowerCase() }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/members/${memberId}/role`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/members/${memberId}/role`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: RoleChangeApiStatus.Error, error: data.error }
+      return { status: RoleChangeApiStatus.Error, error: data.error };
     }
 
-    return { status: RoleChangeApiStatus.Success }
+    return { status: RoleChangeApiStatus.Success };
   } catch {
-    return { status: RoleChangeApiStatus.Cancelled }
+    return { status: RoleChangeApiStatus.Cancelled };
   }
-}
+};
 
 export const fetchPendingInvitesFromServer = async (teamId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/invites`)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/invites`);
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: PendingInvitesApiStatus.Error, error: data.error }
+      return { status: PendingInvitesApiStatus.Error, error: data.error };
     }
 
-    return { status: PendingInvitesApiStatus.Success, data: data }
+    return { status: PendingInvitesApiStatus.Success, data: data };
   } catch {
-    return { status: PendingInvitesApiStatus.Cancelled, data: null }
+    return { status: PendingInvitesApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const resendPendingInviteFromServer = async (teamId: string, inviteId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const resendPendingInviteFromServer = async (
+  teamId: string,
+  inviteId: string,
+) => {
   const opts = {
-    method: 'PATCH',
-  }
+    method: "PATCH",
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/invite/${inviteId}`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/invite/${inviteId}`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: ResendPendingInviteApiStatus.Error, error: data.error }
+      return { status: ResendPendingInviteApiStatus.Error, error: data.error };
     }
 
-    return { status: ResendPendingInviteApiStatus.Success }
+    return { status: ResendPendingInviteApiStatus.Success };
   } catch {
-    return { status: ResendPendingInviteApiStatus.Cancelled }
+    return { status: ResendPendingInviteApiStatus.Cancelled };
   }
-}
+};
 
-export const removePendingInviteFromServer = async (teamId: string, inviteId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const removePendingInviteFromServer = async (
+  teamId: string,
+  inviteId: string,
+) => {
   const opts = {
-    method: 'DELETE',
-  }
+    method: "DELETE",
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/invite/${inviteId}`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/invite/${inviteId}`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: RemovePendingInviteApiStatus.Error, error: data.error }
+      return { status: RemovePendingInviteApiStatus.Error, error: data.error };
     }
 
-    return { status: RemovePendingInviteApiStatus.Success }
+    return { status: RemovePendingInviteApiStatus.Success };
   } catch {
-    return { status: RemovePendingInviteApiStatus.Cancelled }
+    return { status: RemovePendingInviteApiStatus.Cancelled };
   }
-}
+};
 
-export const inviteMemberFromServer = async (teamId: string, email: string, role: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-  const lowerCaseRole = role.toLocaleLowerCase()
+export const inviteMemberFromServer = async (
+  teamId: string,
+  email: string,
+  role: string,
+) => {
+  const lowerCaseRole = role.toLocaleLowerCase();
   const opts = {
-    method: 'POST',
+    method: "POST",
     headers: {
       "Content-Type": `application/json`,
     },
-    body: JSON.stringify([{ email: email, role: lowerCaseRole }])
-  }
+    body: JSON.stringify([{ email: email, role: lowerCaseRole }]),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/invite`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/invite`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: InviteMemberApiStatus.Error, error: data.error }
+      return { status: InviteMemberApiStatus.Error, error: data.error };
     }
 
-    return { status: InviteMemberApiStatus.Success }
+    return { status: InviteMemberApiStatus.Success };
   } catch {
-    return { status: InviteMemberApiStatus.Cancelled }
+    return { status: InviteMemberApiStatus.Cancelled };
   }
-}
+};
 
-export const removeMemberFromServer = async (teamId: string, memberId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const removeMemberFromServer = async (
+  teamId: string,
+  memberId: string,
+) => {
   const opts = {
-    method: 'DELETE',
-  }
+    method: "DELETE",
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/members/${memberId}`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/members/${memberId}`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: RemoveMemberApiStatus.Error, error: data.error }
+      return { status: RemoveMemberApiStatus.Error, error: data.error };
     }
 
-    return { status: RemoveMemberApiStatus.Success }
+    return { status: RemoveMemberApiStatus.Success };
   } catch {
-    return { status: RemoveMemberApiStatus.Cancelled }
+    return { status: RemoveMemberApiStatus.Cancelled };
   }
-}
+};
 
 export const fetchAlertPrefsFromServer = async (appId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/alertPrefs`)
+    const res = await measureAuth.fetchMeasure(`/api/apps/${appId}/alertPrefs`);
 
     if (!res.ok) {
-      return { status: FetchAlertPrefsApiStatus.Error, data: null }
+      return { status: FetchAlertPrefsApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: FetchAlertPrefsApiStatus.Success, data: data }
+    return { status: FetchAlertPrefsApiStatus.Success, data: data };
   } catch {
-    return { status: FetchAlertPrefsApiStatus.Cancelled, data: null }
+    return { status: FetchAlertPrefsApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const updateAlertPrefsFromServer = async (appdId: string, alertPrefs: typeof emptyAlertPrefs) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const updateAlertPrefsFromServer = async (
+  appdId: string,
+  alertPrefs: typeof emptyAlertPrefs,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify(alertPrefs)
-  }
+    method: "PATCH",
+    body: JSON.stringify(alertPrefs),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appdId}/alertPrefs`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appdId}/alertPrefs`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: UpdateAlertPrefsApiStatus.Error, error: data.error }
+      return { status: UpdateAlertPrefsApiStatus.Error, error: data.error };
     }
 
-    return { status: UpdateAlertPrefsApiStatus.Success }
+    return { status: UpdateAlertPrefsApiStatus.Success };
   } catch {
-    return { status: UpdateAlertPrefsApiStatus.Cancelled }
+    return { status: UpdateAlertPrefsApiStatus.Cancelled };
   }
-}
+};
 
 export const fetchAppSettingsFromServer = async (appId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/settings`)
+    const res = await measureAuth.fetchMeasure(`/api/apps/${appId}/settings`);
 
     if (!res.ok) {
-      return { status: FetchAppSettingsApiStatus.Error, data: null }
+      return { status: FetchAppSettingsApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: FetchAppSettingsApiStatus.Success, data: data }
+    return { status: FetchAppSettingsApiStatus.Success, data: data };
   } catch {
-    return { status: FetchAppSettingsApiStatus.Cancelled, data: null }
+    return { status: FetchAppSettingsApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const updateAppSettingsFromServer = async (appdId: string, appSettings: typeof emptyAppSettings) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const updateAppSettingsFromServer = async (
+  appdId: string,
+  appSettings: typeof emptyAppSettings,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify(appSettings)
-  }
+    method: "PATCH",
+    body: JSON.stringify(appSettings),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appdId}/settings`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appdId}/settings`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: UpdateAppSettingsApiStatus.Error, error: data.error }
+      return { status: UpdateAppSettingsApiStatus.Error, error: data.error };
     }
 
-    return { status: UpdateAppSettingsApiStatus.Success }
+    return { status: UpdateAppSettingsApiStatus.Success };
   } catch {
-    return { status: UpdateAppSettingsApiStatus.Cancelled }
+    return { status: UpdateAppSettingsApiStatus.Cancelled };
   }
-}
+};
 
-export const changeAppNameFromServer = async (appId: string, newAppName: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const changeAppNameFromServer = async (
+  appId: string,
+  newAppName: string,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify({ name: newAppName })
-  }
+    method: "PATCH",
+    body: JSON.stringify({ name: newAppName }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/rename`, opts)
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appId}/rename`,
+      opts,
+    );
     if (!res.ok) {
-      return { status: AppNameChangeApiStatus.Error }
+      return { status: AppNameChangeApiStatus.Error };
     }
 
-    return { status: AppNameChangeApiStatus.Success }
+    return { status: AppNameChangeApiStatus.Success };
   } catch {
-    return { status: AppNameChangeApiStatus.Cancelled }
+    return { status: AppNameChangeApiStatus.Cancelled };
   }
-}
+};
 
 export const fetchUsageFromServer = async (teamId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/teams/${teamId}/usage`)
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/usage`);
 
     if (!res.ok && res.status == 404) {
-      return { status: FetchUsageApiStatus.NoApps, data: null }
+      return { status: FetchUsageApiStatus.NoApps, data: null };
     }
 
     if (!res.ok) {
-      return { status: FetchUsageApiStatus.Error, data: null }
+      return { status: FetchUsageApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: FetchUsageApiStatus.Success, data: data }
+    return { status: FetchUsageApiStatus.Success, data: data };
   } catch {
-    return { status: FetchUsageApiStatus.Cancelled, data: null }
+    return { status: FetchUsageApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchBugReportsOverviewFromServer = async (filters: Filters, limit: number, offset: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const fetchBugReportsOverviewFromServer = async (
+  filters: Filters,
+  limit: number,
+  offset: number,
+) => {
+  var url = `/api/apps/${filters.app!.id}/bugReports?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/bugReports?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, limit, offset)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, limit, offset);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: BugReportsOverviewApiStatus.Error, data: null }
+      return { status: BugReportsOverviewApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: BugReportsOverviewApiStatus.Success, data: data }
+    return { status: BugReportsOverviewApiStatus.Success, data: data };
   } catch {
-    return { status: BugReportsOverviewApiStatus.Cancelled, data: null }
+    return { status: BugReportsOverviewApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchBugReportsOverviewPlotFromServer = async (filters: Filters) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
+export const fetchBugReportsOverviewPlotFromServer = async (
+  filters: Filters,
+) => {
+  var url = `/api/apps/${filters.app!.id}/bugReports/plots/instances?`;
 
-  var url = `${origin}/apps/${filters.app!.id}/bugReports/plots/instances?`
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null)
+  url = await applyGenericFiltersToUrl(url, filters, null, null, null, null);
 
   try {
-    const res = await measureAuth.fetchMeasure(url)
+    const res = await measureAuth.fetchMeasure(url);
 
     if (!res.ok) {
-      return { status: BugReportsOverviewPlotApiStatus.Error, data: null }
+      return { status: BugReportsOverviewPlotApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
     if (data === null) {
-      return { status: BugReportsOverviewPlotApiStatus.NoData, data: null }
+      return { status: BugReportsOverviewPlotApiStatus.NoData, data: null };
     }
 
-    return { status: BugReportsOverviewPlotApiStatus.Success, data: data }
+    return { status: BugReportsOverviewPlotApiStatus.Success, data: data };
   } catch {
-    return { status: BugReportsOverviewPlotApiStatus.Cancelled, data: null }
+    return { status: BugReportsOverviewPlotApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const fetchBugReportFromServer = async (appId: string, bugReportId: string) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
+export const fetchBugReportFromServer = async (
+  appId: string,
+  bugReportId: string,
+) => {
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/bugReports/${bugReportId}`)
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appId}/bugReports/${bugReportId}`,
+    );
     if (!res.ok) {
-      return { status: BugReportApiStatus.Error, data: null }
+      return { status: BugReportApiStatus.Error, data: null };
     }
 
-    const data = await res.json()
+    const data = await res.json();
 
-    return { status: BugReportApiStatus.Success, data: data }
+    return { status: BugReportApiStatus.Success, data: data };
   } catch {
-    return { status: BugReportApiStatus.Cancelled, data: null }
+    return { status: BugReportApiStatus.Cancelled, data: null };
   }
-}
+};
 
-export const updateBugReportStatusFromServer = async (appId: string, bugReportId: string, status: number) => {
-  const origin = process.env.NEXT_PUBLIC_API_BASE_URL
-
+export const updateBugReportStatusFromServer = async (
+  appId: string,
+  bugReportId: string,
+  status: number,
+) => {
   const opts = {
-    method: 'PATCH',
-    body: JSON.stringify({ status: Number(status) })
-  }
+    method: "PATCH",
+    body: JSON.stringify({ status: Number(status) }),
+  };
 
   try {
-    const res = await measureAuth.fetchMeasure(`${origin}/apps/${appId}/bugReports/${bugReportId}`, opts)
-    const data = await res.json()
+    const res = await measureAuth.fetchMeasure(
+      `/api/apps/${appId}/bugReports/${bugReportId}`,
+      opts,
+    );
+    const data = await res.json();
 
     if (!res.ok) {
-      return { status: UpdateBugReportStatusApiStatus.Error, error: data.error }
+      return {
+        status: UpdateBugReportStatusApiStatus.Error,
+        error: data.error,
+      };
     }
 
-    return { status: UpdateBugReportStatusApiStatus.Success }
+    return { status: UpdateBugReportStatusApiStatus.Success };
   } catch {
-    return { status: UpdateBugReportStatusApiStatus.Cancelled }
+    return { status: UpdateBugReportStatusApiStatus.Cancelled };
   }
-}
+};

--- a/frontend/dashboard/app/auth/callback/github/route.ts
+++ b/frontend/dashboard/app/auth/callback/github/route.ts
@@ -1,53 +1,53 @@
-import { NextResponse } from 'next/server'
-import { setCookiesFromJWT } from '../../cookie'
+import { NextResponse } from "next/server";
+import { setCookiesFromJWT } from "../../cookie";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
-const origin = process?.env?.NEXT_PUBLIC_SITE_URL
-const apiOrigin = process?.env?.API_BASE_URL
+const origin = process?.env?.NEXT_PUBLIC_SITE_URL;
+const apiOrigin = process?.env?.API_BASE_URL;
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const code = searchParams.get("code")
-  const state = searchParams.get("state")
-  const errRedirectUrl = `${origin}/auth/login?error=Could not sign in with GitHub`
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const errRedirectUrl = `${origin}/auth/login?error=Could not sign in with GitHub`;
   if (!code) {
-    console.log("Github login failure: no nonce")
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log("GitHub login failure: no nonce");
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
   if (!state) {
-    console.log("github login failure: no state")
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log("GitHub login failure: no state");
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
   const res = await fetch(`${apiOrigin}/auth/github`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       type: "code",
       state,
-      code
-    })
-  })
+      code,
+    }),
+  });
 
   if (!res.ok) {
-    console.log(`Github login failure: post /auth/github returned ${res.status}`)
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log(
+      `GitHub login failure: post /auth/github returned ${res.status}`,
+    );
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
-  const data = await res.json()
+  const data = await res.json();
 
   // Create a response with redirect
   let response = NextResponse.redirect(
     // Redirect to overview page with own team Id
     new URL(`${origin}/${data.own_team_id}/overview`),
-    { status: 303 }
-  )
+    { status: 303 },
+  );
 
-  response = setCookiesFromJWT(data.access_token, data.refresh_token, response)
-
-  return response
+  return setCookiesFromJWT(data.access_token, data.refresh_token, response);
 }

--- a/frontend/dashboard/app/auth/callback/google/route.ts
+++ b/frontend/dashboard/app/auth/callback/google/route.ts
@@ -1,33 +1,33 @@
-import { NextResponse } from 'next/server'
-import { setCookiesFromJWT } from '../../cookie'
+import { NextResponse } from "next/server";
+import { setCookiesFromJWT } from "../../cookie";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
-const origin = process?.env?.NEXT_PUBLIC_SITE_URL
-const apiOrigin = process?.env?.API_BASE_URL
+const origin = process?.env?.NEXT_PUBLIC_SITE_URL;
+const apiOrigin = process?.env?.API_BASE_URL;
 
 export async function POST(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const errRedirectUrl = `${origin}/auth/login?error=Could not sign in with Google`
-  const nonce = searchParams.get('nonce')
-  const state = searchParams.get('state')
+  const { searchParams } = new URL(request.url);
+  const errRedirectUrl = `${origin}/auth/login?error=Could not sign in with Google`;
+  const nonce = searchParams.get("nonce");
+  const state = searchParams.get("state");
 
-  const formdata = await request.formData()
-  const credential = formdata.get('credential')
+  const formdata = await request.formData();
+  const credential = formdata.get("credential");
 
   if (!credential) {
-    console.log("google login failure: no credential")
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log("google login failure: no credential");
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
   if (state && !nonce) {
-    console.log("google login failure: no nonce")
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log("google login failure: no nonce");
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
   if (nonce && !state) {
-    console.log("google login failure: no state")
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log("google login failure: no state");
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
   // Google API JavaScript client has an open issue where
@@ -39,37 +39,39 @@ export async function POST(request: Request) {
   // valid and proceed for now, while keeping an eye out
   // on the user agent.
   if (!nonce && !state) {
-    const headers = Object.fromEntries(request.headers)
-    console.log(`google login warning: nonce and state both are missing, request possibly originated from Safari, check UA: ${headers["user-agent"]}`)
+    const headers = Object.fromEntries(request.headers);
+    console.log(
+      `google login warning: nonce and state both are missing, request possibly originated from Safari, check UA: ${headers["user-agent"]}`,
+    );
   }
 
   const res = await fetch(`${apiOrigin}/auth/google`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       credential: String(credential),
       state,
-      nonce
-    })
-  })
+      nonce,
+    }),
+  });
 
   if (!res.ok) {
-    console.log(`google login failure: post /auth/google returned ${res.status}`)
-    return NextResponse.redirect(errRedirectUrl, { status: 302 })
+    console.log(
+      `google login failure: post /auth/google returned ${res.status}`,
+    );
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
   }
 
-  const data = await res.json()
+  const data = await res.json();
 
   // Create a response with redirect
   let response = NextResponse.redirect(
     // Redirect to overview page with own team Id
     new URL(`${origin}/${data.own_team_id}/overview`),
-    { status: 303 }
-  )
+    { status: 303 },
+  );
 
-  response = setCookiesFromJWT(data.access_token, data.refresh_token, response)
-
-  return response
+  return setCookiesFromJWT(data.access_token, data.refresh_token, response);
 }

--- a/frontend/dashboard/app/auth/cookie.ts
+++ b/frontend/dashboard/app/auth/cookie.ts
@@ -1,70 +1,38 @@
-import { NextResponse } from "next/server"
+import { NextResponse } from "next/server";
 
-export function setCookiesFromJWT(accessToken: string, refreshToken: string, response: NextResponse<any>): NextResponse<any> {
-    // Decode the access token to extract the expiry
-    const accessTokenPayload = JSON.parse(
-        Buffer.from(accessToken.split('.')[1], 'base64').toString()
-    )
-    const accessExp = new Date(accessTokenPayload.exp * 1000)
+export function setCookiesFromJWT(
+  accessToken: string,
+  refreshToken: string,
+  response: NextResponse<any>,
+): NextResponse<any> {
+  // Decode the access token to extract the expiry
+  const accessTokenPayload = JSON.parse(
+    Buffer.from(accessToken.split(".")[1], "base64").toString(),
+  );
+  const accessExp = new Date(accessTokenPayload.exp * 1000);
 
-    // Decode the refresh token to extract the expiry
-    const refreshTokenPayload = JSON.parse(
-        Buffer.from(refreshToken.split('.')[1], 'base64').toString()
-    )
-    const refreshExp = new Date(refreshTokenPayload.exp * 1000)
+  // Decode the refresh token to extract the expiry
+  const refreshTokenPayload = JSON.parse(
+    Buffer.from(refreshToken.split(".")[1], "base64").toString(),
+  );
+  const refreshExp = new Date(refreshTokenPayload.exp * 1000);
+  const isDev = process.env.NODE_ENV !== "production";
 
-    // extract the domain from the NEXT_PUBLIC_SITE_URL
-    // and set it as the domain for the cookies
-    const domain = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
+  response.cookies.set("access_token", accessToken, {
+    path: "/",
+    maxAge: Math.floor((accessExp.getTime() - Date.now()) / 1000),
+    httpOnly: true,
+    secure: !isDev,
+    sameSite: isDev ? "lax" : "strict",
+  });
 
-    const isDev = process.env.NODE_ENV === 'development'
+  response.cookies.set("refresh_token", refreshToken, {
+    path: "/",
+    maxAge: Math.floor((refreshExp.getTime() - Date.now()) / 1000),
+    httpOnly: true,
+    secure: !isDev,
+    sameSite: isDev ? "lax" : "strict",
+  });
 
-    response.cookies.set('access_token', accessToken, {
-        path: '/',
-        domain: domain,
-        maxAge: Math.floor((accessExp.getTime() - Date.now()) / 1000),
-        httpOnly: true,
-        secure: !isDev,
-        sameSite: isDev ? 'lax' : 'strict',
-    })
-
-    response.cookies.set('refresh_token', refreshToken, {
-        path: '/',
-        domain: domain,
-        maxAge: Math.floor((refreshExp.getTime() - Date.now()) / 1000),
-        httpOnly: true,
-        secure: !isDev,
-        sameSite: isDev ? 'lax' : 'strict',
-    })
-
-    return response
-}
-
-export function clearCookies(response: NextResponse<any>): NextResponse<any> {
-    // extract the domain from the NEXT_PUBLIC_SITE_URL
-    // and set it as the domain for the cookies
-    const domain = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
-
-    const isDev = process.env.NODE_ENV === 'development'
-
-    response.cookies.set('access_token', '', {
-        path: '/',
-        domain: domain,
-        maxAge: -1,
-        httpOnly: true,
-        secure: !isDev,
-        sameSite: isDev ? 'lax' : 'strict',
-    })
-
-    response.cookies.set('refresh_token', '', {
-        path: '/',
-        domain: domain,
-        maxAge: -1,
-        httpOnly: true,
-        secure: !isDev,
-        sameSite: isDev ? 'lax' : 'strict',
-    })
-
-    return response
-
+  return response;
 }

--- a/frontend/dashboard/app/auth/login/github-sign-in.tsx
+++ b/frontend/dashboard/app/auth/login/github-sign-in.tsx
@@ -1,40 +1,57 @@
-"use client"
+"use client";
 
-import { measureAuth } from "@/app/auth/measure_auth"
-import { Button } from "@/app/components/button"
+import { measureAuth } from "@/app/auth/measure_auth";
+import { Button } from "@/app/components/button";
 
 async function doGitHubLogin() {
-  const { origin } = new URL(window.location.href)
+  const { origin } = new URL(window.location.href);
   const { url, error } = await measureAuth.oAuthSignin({
-    provider: 'github',
     clientId: process?.env?.NEXT_PUBLIC_OAUTH_GITHUB_KEY,
     options: {
       redirectTo: `${origin}/auth/callback/github`,
-      next: ''
-    }
-  })
+      next: "",
+    },
+  });
 
   if (error) {
-    console.error(`failed to login using GitHub`, error)
-    return
+    console.error(`failed to login using GitHub`, error);
+    return;
   }
 
   if (url) {
-    window.location.assign(url)
+    window.location.assign(url);
   }
 }
 
 function GitHubLogo() {
-  return (<svg width="20" height="18" viewBox="0 0 98 96" style={{ display: "inline", marginBottom: "4px", marginRight: "4px" }} xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f" /></svg>)
+  return (
+    <svg
+      width="20"
+      height="18"
+      viewBox="0 0 98 96"
+      style={{ display: "inline", marginBottom: "4px", marginRight: "4px" }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+        fill="#24292f"
+      />
+    </svg>
+  );
 }
 
 export default function GitHubSignIn() {
-  return <Button
-    variant="outline"
-    size={"lg"}
-    className="justify-center w-full font-display border border-black select-none"
-    onClick={() => doGitHubLogin()}>
-    <GitHubLogo />
-    <span> Sign in with GitHub</span>
-  </Button>
+  return (
+    <Button
+      variant="outline"
+      size={"lg"}
+      className="justify-center w-full font-display border border-black select-none"
+      onClick={() => doGitHubLogin()}
+    >
+      <GitHubLogo />
+      <span> Sign in with GitHub</span>
+    </Button>
+  );
 }

--- a/frontend/dashboard/app/auth/logout/route.ts
+++ b/frontend/dashboard/app/auth/logout/route.ts
@@ -1,37 +1,37 @@
-import { NextResponse } from 'next/server'
-import { clearCookies } from '../cookie'
+import { NextResponse } from "next/server";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
-const origin = process?.env?.NEXT_PUBLIC_SITE_URL
-const apiOrigin = process?.env?.API_BASE_URL
+const origin = process?.env?.NEXT_PUBLIC_SITE_URL;
+const apiOrigin = process?.env?.API_BASE_URL;
 
 export async function DELETE(request: Request) {
-    const cookies = request.headers.get('cookie')
-    const headers = new Headers(request.headers)
-    headers.set('cookie', cookies || '')
-    const res = await fetch(`${apiOrigin}/auth/signout`, {
-        method: 'DELETE',
-        headers: headers
-    })
+  const cookies = request.headers.get("cookie");
+  const headers = new Headers(request.headers);
+  headers.set("cookie", cookies || "");
+  const res = await fetch(`${apiOrigin}/auth/signout`, {
+    method: "DELETE",
+    headers: headers,
+  });
 
-    if (!res.ok) {
-        console.log(`Logout failure: post /auth/signout returned ${res.status}`)
-    }
+  if (!res.ok) {
+    console.log(`Logout failure: post /auth/signout returned ${res.status}`);
+  }
 
-    const data = await res.json()
-    if (data.error) {
-        console.log(`Logout failure: post /auth/signout returned ${data.error}`)
-    }
+  const data = await res.json();
+  if (data.error) {
+    console.log(`Logout failure: post /auth/signout returned ${data.error}`);
+  }
 
-    // Create a response with redirect
-    let response = NextResponse.redirect(
-        // Redirect to login page
-        new URL(`${origin}/auth/login`),
-        { status: 303 }
-    )
+  // Create a response with redirect
+  let response = NextResponse.redirect(
+    // Redirect to login page
+    new URL(`${origin}/auth/login`),
+    { status: 303 },
+  );
 
-    response = clearCookies(response)
+  response.cookies.delete("access_token");
+  response.cookies.delete("refresh_token");
 
-    return response
+  return response;
 }

--- a/frontend/dashboard/app/auth/measure_auth.ts
+++ b/frontend/dashboard/app/auth/measure_auth.ts
@@ -1,32 +1,31 @@
-import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime"
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 export type MeasureAuthSession = {
-    user: {
-        id: string,
-        own_team_id: string
-        name: string,
-        email: string,
-        avatar_url: string,
-        confirmed_at: string,
-        last_sign_in_at: string,
-        created_at: string,
-        updated_at: string,
-    }
-}
+  user: {
+    id: string;
+    own_team_id: string;
+    name: string;
+    email: string;
+    avatar_url: string;
+    confirmed_at: string;
+    last_sign_in_at: string;
+    created_at: string;
+    updated_at: string;
+  };
+};
 
 export type OAuthState = {
-    random: string
-    path: string
-}
+  random: string;
+  path: string;
+};
 
 export type OAuthOptions = {
-    provider: 'github' | 'google'
-    clientId: string | undefined
-    options: {
-        redirectTo: URL | string
-        next: URL | string
-    }
-}
+  clientId: string | undefined;
+  options: {
+    redirectTo: URL | string;
+    next: URL | string;
+  };
+};
 
 /**
  * MeasureAuth encapsulates login, logout and session management.
@@ -35,268 +34,273 @@ export type OAuthOptions = {
  * request cancellation.
  */
 export class MeasureAuth {
-    private apiOrigin: string
-    private inFlightRequests = new Map<string, AbortController>()
-    private router: AppRouterInstance | null = null
+  private inFlightRequests = new Map<string, AbortController>();
+  private router: AppRouterInstance | null = null;
 
-    constructor(apiOrigin: string) {
-        if (!apiOrigin) {
-            throw new Error("`apiOrigin` is required")
-        }
-        this.apiOrigin = apiOrigin
+  /**
+   * Initializes the auth module
+   */
+  public init(router: AppRouterInstance): void {
+    this.router = router;
+  }
+
+  private base64UrlEncode(input: string) {
+    let base64 = btoa(input);
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  public encodeOAuthState(path: string = ""): string {
+    const state: OAuthState = {
+      random: this.getRandomValues(32),
+      path,
+    };
+    const json = JSON.stringify(state);
+    return this.base64UrlEncode(json);
+  }
+
+  private getRandomValues(len: number): string {
+    const arr = crypto.getRandomValues(new Uint8Array(len));
+    return Array.from(arr, (byte) => byte.toString(16).padStart(2, "0")).join(
+      "",
+    );
+  }
+
+  private redirectToLogin(): void {
+    if (!this.router) {
+      throw new Error("Router is not initialized. Call `init` method first.");
+    }
+    this.router.replace("/auth/login");
+  }
+
+  /**
+   * Initiates an OAuth sign-in flow.
+   * It creates an OAuth state, contacts the backend to initialize the flow,
+   * and then constructs the external OAuth URL.
+   */
+  public async oAuthSignin(
+    options: OAuthOptions,
+  ): Promise<{ url?: URL; error?: Error }> {
+    if (!options.clientId) {
+      throw new Error("`clientId` is required");
+    }
+    const state = this.encodeOAuthState(options.options.next.toString());
+    // Determine the endpoint based on the provider.
+    const body = JSON.stringify({ type: "init", state });
+    const res = await fetch("/api/auth/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const json = await res.json();
+
+    let error: Error | undefined;
+    if (res.status === 400) {
+      error = new Error(`Bad request: ${json?.error}`);
+    } else if (res.status === 401) {
+      error = new Error(`Unauthorized: ${json?.error}`);
+    }
+    if (error) {
+      return { error };
+    }
+    // Construct the OAuth URL.
+    const oauthUrl = new URL("https://github.com/login/oauth/authorize");
+    oauthUrl.searchParams.append("scope", "user:email read:user");
+    oauthUrl.searchParams.append("client_id", options.clientId);
+    oauthUrl.searchParams.append("state", state);
+    oauthUrl.searchParams.append(
+      "redirect_uri",
+      options.options.redirectTo.toString(),
+    );
+    return { url: oauthUrl };
+  }
+
+  /**
+   * Retrieves the current session from the server and returns it.
+   * If no session is found, it returns null and redirects user to login page.
+   */
+  public async getSession(): Promise<
+    | { session: null; error: Error }
+    | { session: MeasureAuthSession; error: null }
+  > {
+    try {
+      const res = await this.fetchMeasure(`/api/auth/session`);
+
+      if (!res.ok) {
+        throw new Error("Failed to retrieve session data");
+      }
+
+      const data = await res.json();
+
+      if (!data.user) {
+        return { session: null, error: new Error("No user in session") };
+      }
+
+      // Construct a session object from the response
+      const session: MeasureAuthSession = {
+        user: {
+          id: data.user.id,
+          own_team_id: data.user.own_team_id,
+          name: data.user.name,
+          email: data.user.email,
+          avatar_url: data.user.avatar_url,
+          confirmed_at: data.user.confirmed_at,
+          last_sign_in_at: data.user.last_sign_in_at,
+          created_at: data.user.created_at,
+          updated_at: data.user.updated_at,
+        },
+      };
+
+      return { session, error: null };
+    } catch (error) {
+      return {
+        session: null,
+        error:
+          error instanceof Error
+            ? error
+            : new Error("Unknown error getting session"),
+      };
+    }
+  }
+
+  /**
+   * Refresh the access token using the refresh token
+   * @private
+   */
+  private async refreshToken(): Promise<Response> {
+    const refreshEndpoint = `/auth/refresh`;
+
+    // Create a separate controller for the refresh request
+    const controller = new AbortController();
+
+    const config: RequestInit = {
+      method: "POST",
+      credentials: "include",
+      signal: controller.signal,
+    };
+
+    try {
+      return await fetch(refreshEndpoint, config);
+    } catch (error) {
+      console.error("Failed to refresh token:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Signs out the current user by calling the backend sign-out API
+   */
+  public async signout(): Promise<void> {
+    await fetch(`/auth/logout`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+
+    // Redirect to login page after successful logout
+    this.redirectToLogin();
+  }
+
+  /**
+   * Proxies fetch requests to automatically refresh tokens if needed
+   * and cancels duplicate in-flight requests with some exceptions.
+   */
+  public async fetchMeasure(
+    resource: string | Request | URL,
+    config: RequestInit = {},
+    redirectToLogin: Boolean = true,
+  ): Promise<Response> {
+    const getEndpoint = (res: string | Request | URL): string => {
+      let urlStr: string;
+      if (res instanceof Request) {
+        urlStr = res.url;
+      } else if (res instanceof URL) {
+        urlStr = res.toString();
+      } else {
+        urlStr = res;
+      }
+      try {
+        const url = new URL(urlStr);
+        return `${url.origin}${url.pathname}`;
+      } catch {
+        return urlStr.split("?")[0];
+      }
+    };
+
+    const endpoint = getEndpoint(resource);
+
+    // Skip token refresh if we're already refreshing
+    const isRefreshRequest = endpoint === `/auth/refresh`;
+
+    // Abort existing requests for the same endpoint unless it's a GET or if it's shortFilters request
+    const existingController = this.inFlightRequests.get(endpoint);
+    const isGetRequest =
+      (config.method ? config.method.toLowerCase() : "get") === "get";
+    if (
+      existingController &&
+      !isGetRequest &&
+      !endpoint.includes("shortFilters")
+    ) {
+      existingController.abort();
+      this.inFlightRequests.delete(endpoint);
     }
 
-    /**
-     * Initializes the auth module
-     */
-    public init(router: AppRouterInstance): void {
-        this.router = router
-    }
+    const controller = new AbortController();
+    this.inFlightRequests.set(endpoint, controller);
 
-    private base64UrlEncode(input: string) {
-        let base64 = btoa(input)
-        return base64
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '')
-    }
+    const newConfig: RequestInit = {
+      ...config,
+      credentials: "include",
+      signal: controller.signal,
+      headers: {
+        ...(config.headers || {}),
+      },
+    };
 
-    public encodeOAuthState(path: string = ""): string {
-        const state: OAuthState = {
-            random: this.getRandomValues(32),
-            path,
-        }
-        const json = JSON.stringify(state)
-        return this.base64UrlEncode(json)
-    }
+    try {
+      // Make the request
+      let response = await fetch(resource, newConfig);
 
-    private getRandomValues(len: number): string {
-        const arr = crypto.getRandomValues(new Uint8Array(len))
-        return Array.from(arr, byte => byte.toString(16).padStart(2, '0')).join('')
-    }
+      // If we get a 401 Unauthorized and it's not already a refresh request
+      if (response.status === 401 && !isRefreshRequest) {
+        // Try to refresh the token
+        const refreshResponse = await this.refreshToken();
 
-    private redirectToLogin(): void {
-        if (!this.router) {
-            throw new Error("Router is not initialized. Call `init` method first.")
-        }
-        this.router.replace("/auth/login")
-    }
+        // If refresh was successful, retry the original request
+        if (refreshResponse.ok) {
+          this.inFlightRequests.delete(endpoint);
+          const retryController = new AbortController();
+          this.inFlightRequests.set(endpoint, retryController);
 
-    /**
-     * Initiates an OAuth sign-in flow.
-     * It creates an OAuth state, contacts the backend to initialize the flow,
-     * and then constructs the external OAuth URL.
-     */
-    public async oAuthSignin(options: OAuthOptions): Promise<{ url?: URL; error?: Error }> {
-        if (!options.clientId) {
-            throw new Error("`clientId` is required")
-        }
-        const state = this.encodeOAuthState(options.options.next.toString())
-        // Determine the endpoint based on the provider.
-        const path = options.provider === 'github' ? '/auth/github' : '/auth/google'
-        const url = new URL(path, this.apiOrigin)
-        const body = JSON.stringify({ type: "init", state })
-        const res = await fetch(url.toString(), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body,
-        })
-        const json = await res.json()
-
-        let error: Error | undefined
-        if (res.status === 400) {
-            error = new Error(`Bad request: ${json?.error}`)
-        } else if (res.status === 401) {
-            error = new Error(`Unauthorized: ${json?.error}`)
-        }
-        if (error) {
-            return { error }
-        }
-        // Construct the OAuth URL.
-        const oauthUrl = new URL("https://github.com/login/oauth/authorize")
-        oauthUrl.searchParams.append("scope", "user:email read:user")
-        oauthUrl.searchParams.append("client_id", options.clientId)
-        oauthUrl.searchParams.append("state", state)
-        oauthUrl.searchParams.append("redirect_uri", options.options.redirectTo.toString())
-        return { url: oauthUrl }
-    }
-
-    /**
-     * Retrieves the current session from the server and returns it.
-     * If no session is found, it returns null and redirects user to login page.
-     */
-    public async getSession(): Promise<{ session: null; error: Error } | { session: MeasureAuthSession; error: null }> {
-        try {
-            const res = await this.fetchMeasure(`${this.apiOrigin}/auth/session`)
-
-            if (!res.ok) {
-                throw new Error("Failed to retrieve session data")
-            }
-
-            const data = await res.json()
-
-            if (!data.user) {
-                return { session: null, error: new Error("No user in session") }
-            }
-
-            // Construct a session object from the response
-            const session: MeasureAuthSession = {
-                user: {
-                    id: data.user.id,
-                    own_team_id: data.user.own_team_id,
-                    name: data.user.name,
-                    email: data.user.email,
-                    avatar_url: data.user.avatar_url,
-                    confirmed_at: data.user.confirmed_at,
-                    last_sign_in_at: data.user.last_sign_in_at,
-                    created_at: data.user.created_at,
-                    updated_at: data.user.updated_at,
-                },
-            }
-
-            return { session, error: null }
-        } catch (error) {
-            return {
-                session: null,
-                error: error instanceof Error ? error : new Error("Unknown error getting session")
-            }
-        }
-    }
-
-    /**
-    * Refresh the access token using the refresh token
-    * @private
-    */
-    private async refreshToken(): Promise<Response> {
-        const refreshEndpoint = `/auth/refresh`
-
-        // Create a separate controller for the refresh request
-        const controller = new AbortController()
-
-        const config: RequestInit = {
-            method: 'POST',
-            credentials: 'include',
-            signal: controller.signal
-        }
-
-        try {
-            return await fetch(refreshEndpoint, config)
-        } catch (error) {
-            console.error('Failed to refresh token:', error)
-            throw error
-        }
-    }
-
-    /**
-     * Signs out the current user by calling the backend sign-out API
-     */
-    public async signout(): Promise<void> {
-        await fetch(`/auth/logout`, {
-            method: "DELETE",
-            credentials: 'include'
-        })
-
-        // Redirect to login page after successful logout
-        this.redirectToLogin()
-    }
-
-    /**
-    * Proxies fetch requests to automatically refresh tokens if needed
-    * and cancels duplicate in-flight requests with some exceptions.
-    */
-    public async fetchMeasure(resource: string | Request | URL, config: RequestInit = {}, redirectToLogin: Boolean = true): Promise<Response> {
-        const getEndpoint = (res: string | Request | URL): string => {
-            let urlStr: string
-            if (res instanceof Request) {
-                urlStr = res.url
-            } else if (res instanceof URL) {
-                urlStr = res.toString()
-            } else {
-                urlStr = res
-            }
-            try {
-                const url = new URL(urlStr)
-                return `${url.origin}${url.pathname}`
-            } catch {
-                return urlStr.split('?')[0]
-            }
-        }
-
-        const endpoint = getEndpoint(resource)
-
-        // Skip token refresh if we're already refreshing
-        const isRefreshRequest = endpoint === `/auth/refresh`
-
-        // Abort existing requests for the same endpoint unless it's a GET or if it's shortFilters request
-        const existingController = this.inFlightRequests.get(endpoint)
-        const isGetRequest = (config.method ? config.method.toLowerCase() : 'get') === 'get'
-        if (existingController && !isGetRequest && !endpoint.includes('shortFilters')) {
-            existingController.abort()
-            this.inFlightRequests.delete(endpoint)
-        }
-
-        const controller = new AbortController()
-        this.inFlightRequests.set(endpoint, controller)
-
-        const newConfig: RequestInit = {
+          const retryConfig: RequestInit = {
             ...config,
-            credentials: 'include',
-            signal: controller.signal,
+            credentials: "include",
+            signal: retryController.signal,
             headers: {
-                ...(config.headers || {})
+              ...(config.headers || {}),
             },
+          };
+
+          response = await fetch(resource, retryConfig);
+
+          if (response.status === 401 && redirectToLogin) {
+            // If response is still 401 after refresh and retry has been attempted, redirect to login
+            this.redirectToLogin();
+          }
+        } else if (refreshResponse.status === 401 && redirectToLogin) {
+          // If refresh token is also expired, redirect to login
+          this.redirectToLogin();
         }
+      }
 
-        try {
-            // Make the request
-            let response = await fetch(resource, newConfig)
-
-            // If we get a 401 Unauthorized and it's not already a refresh request
-            if (response.status === 401 && !isRefreshRequest) {
-                // Try to refresh the token
-                const refreshResponse = await this.refreshToken()
-
-                // If refresh was successful, retry the original request
-                if (refreshResponse.ok) {
-                    this.inFlightRequests.delete(endpoint)
-                    const retryController = new AbortController()
-                    this.inFlightRequests.set(endpoint, retryController)
-
-                    const retryConfig: RequestInit = {
-                        ...config,
-                        credentials: 'include',
-                        signal: retryController.signal,
-                        headers: {
-                            ...(config.headers || {})
-                        },
-                    }
-
-                    response = await fetch(resource, retryConfig)
-
-                    if (response.status === 401 && redirectToLogin) {
-                        // If response is still 401 after refresh and retry has been attempted, redirect to login
-                        this.redirectToLogin()
-                    }
-                } else if (refreshResponse.status === 401 && redirectToLogin) {
-                    // If refresh token is also expired, redirect to login
-                    this.redirectToLogin()
-                }
-            }
-
-            return response
-        } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                console.log(`Request to ${endpoint} was cancelled`)
-            }
-            throw error
-        } finally {
-            this.inFlightRequests.delete(endpoint)
-        }
+      return response;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        console.log(`Request to ${endpoint} was cancelled`);
+      }
+      throw error;
+    } finally {
+      this.inFlightRequests.delete(endpoint);
     }
-
-
+  }
 }
 
-export const measureAuth = new MeasureAuth(process.env.NEXT_PUBLIC_API_BASE_URL!)
-
-
+export const measureAuth = new MeasureAuth();

--- a/frontend/dashboard/app/auth/refresh/route.ts
+++ b/frontend/dashboard/app/auth/refresh/route.ts
@@ -1,40 +1,42 @@
-import { NextResponse } from 'next/server'
-import { setCookiesFromJWT } from '../cookie'
+import { NextResponse } from "next/server";
+import { setCookiesFromJWT } from "../cookie";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
-const origin = process?.env?.NEXT_PUBLIC_SITE_URL
-const apiOrigin = process?.env?.API_BASE_URL
-const errRedirectUrl = `${origin}/auth/login`
+const origin = process?.env?.NEXT_PUBLIC_SITE_URL;
+const apiOrigin = process?.env?.API_BASE_URL;
+const errRedirectUrl = `${origin}/auth/login`;
 
 export async function POST(request: Request) {
-    const cookies = request.headers.get('cookie')
-    const headers = new Headers(request.headers)
-    headers.set('cookie', cookies || '')
-    const res = await fetch(`${apiOrigin}/auth/refresh`, {
-        method: 'POST',
-        headers: headers
-    })
+  const cookies = request.headers.get("cookie");
+  const headers = new Headers(request.headers);
+  headers.set("cookie", cookies || "");
+  const res = await fetch(`${apiOrigin}/auth/refresh`, {
+    method: "POST",
+    headers: headers,
+  });
 
-    if (!res.ok) {
-        console.log(`Refresh token failure: post /auth/refresh returned ${res.status}`)
-        return NextResponse.redirect(errRedirectUrl, { status: 302 })
-    }
+  if (!res.ok) {
+    console.log(
+      `Refresh token failure: post /auth/refresh returned ${res.status}`,
+    );
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
+  }
 
-    const data = await res.json()
-    if (data.error) {
-        console.log(`Logout failure: post /auth/refresh returned ${data.error}`)
-        return NextResponse.redirect(errRedirectUrl, { status: 302 })
-    }
+  const data = await res.json();
+  if (data.error) {
+    console.log(`Logout failure: post /auth/refresh returned ${data.error}`);
+    return NextResponse.redirect(errRedirectUrl, { status: 302 });
+  }
 
-    let response = NextResponse.json(
-        {
-            "ok": true,
-        },
-        { status: 200 }
-    )
+  let response = NextResponse.json(
+    {
+      ok: true,
+    },
+    {
+      status: 200,
+    },
+  );
 
-    response = setCookiesFromJWT(data.access_token, data.refresh_token, response)
-
-    return response
+  return setCookiesFromJWT(data.access_token, data.refresh_token, response);
 }

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -1,126 +1,150 @@
-"use client"
+"use client";
 
-import { DateTime } from "luxon"
-import Link from "next/link"
-import { usePathname, useSearchParams } from "next/navigation"
-import React, { forwardRef, useEffect, useImperativeHandle, useState } from "react"
-import { App, AppsApiStatus, AppVersion, BugReportStatus, fetchAppsFromServer, fetchFiltersFromServer, fetchRootSpanNamesFromServer, FiltersApiStatus, FilterSource, OsVersion, RootSpanNamesApiStatus, SessionType, SpanStatus, UserDefAttr } from "../api/api_calls"
-import { formatDateToHumanReadableDateTime, formatIsoDateForDateTimeInputField, isValidTimestamp } from "../utils/time_utils"
-import DebounceTextInput from "./debounce_text_input"
-import DropdownSelect, { DropdownSelectType } from "./dropdown_select"
-import FilterPill from "./filter_pill"
-import LoadingSpinner from "./loading_spinner"
-import UserDefAttrSelector, { UdAttrMatcher } from "./user_def_attr_selector"
+import { DateTime } from "luxon";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+import {
+  App,
+  AppsApiStatus,
+  AppVersion,
+  BugReportStatus,
+  fetchAppsFromServer,
+  fetchFiltersFromServer,
+  fetchRootSpanNamesFromServer,
+  FiltersApiStatus,
+  FilterSource,
+  OsVersion,
+  RootSpanNamesApiStatus,
+  SessionType,
+  SpanStatus,
+  UserDefAttr,
+} from "../api/api_calls";
+import {
+  formatDateToHumanReadableDateTime,
+  formatIsoDateForDateTimeInputField,
+  isValidTimestamp,
+} from "../utils/time_utils";
+import DebounceTextInput from "./debounce_text_input";
+import DropdownSelect, { DropdownSelectType } from "./dropdown_select";
+import FilterPill from "./filter_pill";
+import LoadingSpinner from "./loading_spinner";
+import UserDefAttrSelector, { UdAttrMatcher } from "./user_def_attr_selector";
 
 export enum AppVersionsInitialSelectionType {
   Latest,
-  All
+  All,
 }
 
 interface FiltersProps {
-  ref?: React.RefObject<HTMLDivElement>
-  teamId: string,
-  appId?: string,
-  filterSource: FilterSource,
-  appVersionsInitialSelectionType: AppVersionsInitialSelectionType,
-  showNoData: boolean
-  showNotOnboarded: boolean
-  showAppSelector: boolean
-  showDates: boolean
-  showAppVersions: boolean
-  showOsVersions: boolean
-  showSessionType: boolean
-  showCountries: boolean
-  showNetworkProviders: boolean
-  showNetworkTypes: boolean
-  showNetworkGenerations: boolean
-  showLocales: boolean
-  showDeviceManufacturers: boolean
-  showDeviceNames: boolean
-  showBugReportStatus: boolean
-  showUdAttrs: boolean
-  showFreeText: boolean
-  freeTextPlaceholder?: string
-  onFiltersChanged: (filters: Filters) => void
+  ref?: React.RefObject<HTMLDivElement>;
+  teamId: string;
+  appId?: string;
+  filterSource: FilterSource;
+  appVersionsInitialSelectionType: AppVersionsInitialSelectionType;
+  showNoData: boolean;
+  showNotOnboarded: boolean;
+  showAppSelector: boolean;
+  showDates: boolean;
+  showAppVersions: boolean;
+  showOsVersions: boolean;
+  showSessionType: boolean;
+  showCountries: boolean;
+  showNetworkProviders: boolean;
+  showNetworkTypes: boolean;
+  showNetworkGenerations: boolean;
+  showLocales: boolean;
+  showDeviceManufacturers: boolean;
+  showDeviceNames: boolean;
+  showBugReportStatus: boolean;
+  showUdAttrs: boolean;
+  showFreeText: boolean;
+  freeTextPlaceholder?: string;
+  onFiltersChanged: (filters: Filters) => void;
 }
 
-const defaultFreeTextPlaceholder = "Search anything..."
+const defaultFreeTextPlaceholder = "Search anything...";
 
 enum DateRange {
-  Last15Mins = 'Last 15 Minutes',
-  Last30Mins = 'Last 30 Minutes',
-  LastHour = 'Last hour',
-  Last3Hours = 'Last 3 Hours',
-  Last6Hours = 'Last 6 Hours',
-  Last12Hours = 'Last 12 Hours',
-  Last24Hours = 'Last 24 Hours',
-  LastWeek = 'Last Week',
-  Last15Days = 'Last 15 Days',
-  LastMonth = 'Last Month',
-  Last3Months = 'Last 3 Months',
-  Last6Months = 'Last 6 Months',
-  LastYear = 'Last Year',
-  Custom = 'Custom Range'
+  Last15Mins = "Last 15 Minutes",
+  Last30Mins = "Last 30 Minutes",
+  LastHour = "Last hour",
+  Last3Hours = "Last 3 Hours",
+  Last6Hours = "Last 6 Hours",
+  Last12Hours = "Last 12 Hours",
+  Last24Hours = "Last 24 Hours",
+  LastWeek = "Last Week",
+  Last15Days = "Last 15 Days",
+  LastMonth = "Last Month",
+  Last3Months = "Last 3 Months",
+  Last6Months = "Last 6 Months",
+  LastYear = "Last Year",
+  Custom = "Custom Range",
 }
 
 export type Filters = {
-  ready: boolean
-  app: App | null
-  rootSpanName: string
-  startDate: string
-  endDate: string
-  versions: AppVersion[]
-  sessionType: SessionType
-  spanStatuses: SpanStatus[]
-  bugReportStatuses: BugReportStatus[],
-  osVersions: OsVersion[]
-  countries: string[]
-  networkProviders: string[]
-  networkTypes: string[]
-  networkGenerations: string[]
-  locales: string[]
-  deviceManufacturers: string[]
-  deviceNames: string[]
-  udAttrMatchers: UdAttrMatcher[]
-  freeText: string
-  serialisedFilters: string | null
-}
+  ready: boolean;
+  app: App | null;
+  rootSpanName: string;
+  startDate: string;
+  endDate: string;
+  versions: AppVersion[];
+  sessionType: SessionType;
+  spanStatuses: SpanStatus[];
+  bugReportStatuses: BugReportStatus[];
+  osVersions: OsVersion[];
+  countries: string[];
+  networkProviders: string[];
+  networkTypes: string[];
+  networkGenerations: string[];
+  locales: string[];
+  deviceManufacturers: string[];
+  deviceNames: string[];
+  udAttrMatchers: UdAttrMatcher[];
+  freeText: string;
+  serialisedFilters: string | null;
+};
 
 type SessionPersistedFilters = {
-  app: App
-  dateRange: string,
-  startDate: string,
-  endDate: string
-}
+  app: App;
+  dateRange: string;
+  startDate: string;
+  endDate: string;
+};
 
 type URLFilters = {
-  appId?: string
-  rootSpanName?: string
-  startDate?: string
-  endDate?: string
-  dateRange?: DateRange
-  versions?: number[]
-  sessionType?: SessionType
-  spanStatuses?: SpanStatus[]
-  bugReportStatuses?: BugReportStatus[]
-  osVersions?: number[]
-  countries?: number[]
-  networkProviders?: number[]
-  networkTypes?: number[]
-  networkGenerations?: number[]
-  locales?: number[]
-  deviceManufacturers?: number[]
-  deviceNames?: number[]
-  udAttrMatchers?: UdAttrMatcher[]
-  freeText?: string
-}
+  appId?: string;
+  rootSpanName?: string;
+  startDate?: string;
+  endDate?: string;
+  dateRange?: DateRange;
+  versions?: number[];
+  sessionType?: SessionType;
+  spanStatuses?: SpanStatus[];
+  bugReportStatuses?: BugReportStatus[];
+  osVersions?: number[];
+  countries?: number[];
+  networkProviders?: number[];
+  networkTypes?: number[];
+  networkGenerations?: number[];
+  locales?: number[];
+  deviceManufacturers?: number[];
+  deviceNames?: number[];
+  udAttrMatchers?: UdAttrMatcher[];
+  freeText?: string;
+};
 
 export const defaultFilters: Filters = {
   ready: false,
   app: null,
-  rootSpanName: '',
-  startDate: '',
-  endDate: '',
+  rootSpanName: "",
+  startDate: "",
+  endDate: "",
   versions: [],
   sessionType: SessionType.All,
   spanStatuses: [],
@@ -134,982 +158,1539 @@ export const defaultFilters: Filters = {
   deviceManufacturers: [],
   deviceNames: [],
   udAttrMatchers: [],
-  freeText: '',
-  serialisedFilters: null
-}
+  freeText: "",
+  serialisedFilters: null,
+};
 
-const Filters = forwardRef<
-  { refresh: () => void },
-  FiltersProps
->(({
-  teamId,
-  appId,
-  filterSource,
-  appVersionsInitialSelectionType,
-  showNoData,
-  showNotOnboarded,
-  showAppSelector,
-  showDates,
-  showAppVersions,
-  showOsVersions,
-  showSessionType,
-  showCountries,
-  showNetworkTypes,
-  showNetworkProviders,
-  showNetworkGenerations,
-  showLocales,
-  showDeviceManufacturers,
-  showDeviceNames,
-  showBugReportStatus,
-  showUdAttrs,
-  showFreeText,
-  freeTextPlaceholder,
-  onFiltersChanged
-}, ref) => {
+const Filters = forwardRef<{ refresh: () => void }, FiltersProps>(
+  (
+    {
+      teamId,
+      appId,
+      filterSource,
+      appVersionsInitialSelectionType,
+      showNoData,
+      showNotOnboarded,
+      showAppSelector,
+      showDates,
+      showAppVersions,
+      showOsVersions,
+      showSessionType,
+      showCountries,
+      showNetworkTypes,
+      showNetworkProviders,
+      showNetworkGenerations,
+      showLocales,
+      showDeviceManufacturers,
+      showDeviceNames,
+      showBugReportStatus,
+      showUdAttrs,
+      showFreeText,
+      freeTextPlaceholder,
+      onFiltersChanged,
+    },
+    ref,
+  ) => {
+    const urlFiltersKeyMap = {
+      appId: "a",
+      rootSpanName: "r",
+      dateRange: "d",
+      startDate: "sd",
+      endDate: "ed",
+      versions: "v",
+      sessionType: "st",
+      spanStatuses: "ss",
+      bugReportStatuses: "bs",
+      osVersions: "os",
+      countries: "c",
+      networkProviders: "np",
+      networkTypes: "nt",
+      networkGenerations: "ng",
+      locales: "l",
+      deviceManufacturers: "dm",
+      deviceNames: "dn",
+      udAttrMatchers: "ud",
+      freeText: "ft",
+    };
 
-  const urlFiltersKeyMap = {
-    appId: 'a',
-    rootSpanName: 'r',
-    dateRange: 'd',
-    startDate: 'sd',
-    endDate: 'ed',
-    versions: 'v',
-    sessionType: 'st',
-    spanStatuses: 'ss',
-    bugReportStatuses: 'bs',
-    osVersions: 'os',
-    countries: 'c',
-    networkProviders: 'np',
-    networkTypes: 'nt',
-    networkGenerations: 'ng',
-    locales: 'l',
-    deviceManufacturers: 'dm',
-    deviceNames: 'dn',
-    udAttrMatchers: 'ud',
-    freeText: 'ft'
-  }
+    function compressArrayToRanges(arr: number[]): string {
+      if (arr.length === 0) return "";
+      const sorted = [...new Set(arr)].sort((a, b) => a - b);
+      let ranges: string[] = [];
+      let start = sorted[0];
+      let current = start;
 
-  function compressArrayToRanges(arr: number[]): string {
-    if (arr.length === 0) return ''
-    const sorted = [...new Set(arr)].sort((a, b) => a - b)
-    let ranges: string[] = []
-    let start = sorted[0]
-    let current = start
-
-    for (let i = 1; i < sorted.length; i++) {
-      if (sorted[i] === current + 1) {
-        current = sorted[i]
-      } else {
-        ranges.push(start === current ? `${start}` : `${start}-${current}`)
-        start = sorted[i]
-        current = start
-      }
-    }
-    ranges.push(start === current ? `${start}` : `${start}-${current}`)
-    return ranges.join(',')
-  }
-
-  function expandRangesToArray(str: string): number[] {
-    if (!str) return []
-    const parts = str.split(',')
-    const result: number[] = []
-    for (const part of parts) {
-      if (part.includes('-')) {
-        const [start, end] = part.split('-').map(Number)
-        for (let i = start; i <= end; i++) {
-          result.push(i)
+      for (let i = 1; i < sorted.length; i++) {
+        if (sorted[i] === current + 1) {
+          current = sorted[i];
+        } else {
+          ranges.push(start === current ? `${start}` : `${start}-${current}`);
+          start = sorted[i];
+          current = start;
         }
-      } else {
-        const num = Number(part)
-        if (!isNaN(num)) result.push(num)
       }
+      ranges.push(start === current ? `${start}` : `${start}-${current}`);
+      return ranges.join(",");
     }
-    return result
-  }
 
-  function serializeUrlFilters(urlFilters: URLFilters): string {
-    const params = new URLSearchParams()
-
-    Object.entries(urlFilters).forEach(([key, value]) => {
-      const minifiedKey = urlFiltersKeyMap[key as keyof typeof urlFiltersKeyMap]
-      if (!minifiedKey || value === undefined || value === null) return
-
-      let serializedValue: string
-
-      // only add keys whose show flags are true
-      switch (key) {
-        case 'versions':
-          if (!showAppVersions) return
-          break
-        case 'osVersions':
-          if (!showOsVersions) return
-          break
-        case 'sessionType':
-          if (!showSessionType) return
-          break
-        case 'countries':
-          if (!showCountries) return
-          break
-        case 'networkProviders':
-          if (!showNetworkProviders) return
-          break
-        case 'networkTypes':
-          if (!showNetworkTypes) return
-          break
-        case 'networkGenerations':
-          if (!showNetworkGenerations) return
-          break
-        case 'locales':
-          if (!showLocales) return
-          break
-        case 'deviceManufacturers':
-          if (!showDeviceManufacturers) return
-          break
-        case 'deviceNames':
-          if (!showDeviceNames) return
-          break
-        case 'bugReportStatuses':
-          if (!showBugReportStatus) return
-          break
-        case 'udAttrMatchers':
-          if (!showUdAttrs) return
-          break
-        case 'freeText':
-          if (!showFreeText) return
-          break
-        case 'startDate':
-        case 'endDate':
-        case 'dateRange':
-          if (!showDates) return
-          break
-        case 'appId':
-          if (!showAppSelector) return
-          break
-        case 'rootSpanName':
-        case 'spanStatuses':
-          if (filterSource !== FilterSource.Spans) return
-          break
-        default:
-          break
+    function expandRangesToArray(str: string): number[] {
+      if (!str) return [];
+      const parts = str.split(",");
+      const result: number[] = [];
+      for (const part of parts) {
+        if (part.includes("-")) {
+          const [start, end] = part.split("-").map(Number);
+          for (let i = start; i <= end; i++) {
+            result.push(i);
+          }
+        } else {
+          const num = Number(part);
+          if (!isNaN(num)) result.push(num);
+        }
       }
+      return result;
+    }
 
-      switch (key) {
-        case 'versions':
-        case 'osVersions':
-        case 'countries':
-        case 'networkProviders':
-        case 'networkTypes':
-        case 'networkGenerations':
-        case 'locales':
-        case 'deviceManufacturers':
-        case 'deviceNames':
-          if ((value as number[]).length === 0) return
-          serializedValue = compressArrayToRanges(value as number[])
-          break
+    function serializeUrlFilters(urlFilters: URLFilters): string {
+      const params = new URLSearchParams();
 
-        case 'udAttrMatchers':
-          const validMatchers = (value as UdAttrMatcher[])
-            .filter(m => m?.key && m?.type && m?.op && m.value !== undefined)
-          if (validMatchers.length === 0) return
-          serializedValue = validMatchers
-            .map(m => `${encodeURIComponent(m.key)}~${encodeURIComponent(m.type)}~${encodeURIComponent(m.op)}~${encodeURIComponent(m.value)}`)
-            .join('|')
-          break
+      Object.entries(urlFilters).forEach(([key, value]) => {
+        const minifiedKey =
+          urlFiltersKeyMap[key as keyof typeof urlFiltersKeyMap];
+        if (!minifiedKey || value === undefined || value === null) return;
 
-        case 'spanStatuses':
-        case 'bugReportStatuses':
-          if ((value as string[]).length === 0) return
-          serializedValue = (value as string[]).join(',')
-          break
+        let serializedValue: string;
 
-        case 'sessionType':
-          if (value === SessionType.All) return
-          serializedValue = value.toString()
-          break
+        // only add keys whose show flags are true
+        switch (key) {
+          case "versions":
+            if (!showAppVersions) return;
+            break;
+          case "osVersions":
+            if (!showOsVersions) return;
+            break;
+          case "sessionType":
+            if (!showSessionType) return;
+            break;
+          case "countries":
+            if (!showCountries) return;
+            break;
+          case "networkProviders":
+            if (!showNetworkProviders) return;
+            break;
+          case "networkTypes":
+            if (!showNetworkTypes) return;
+            break;
+          case "networkGenerations":
+            if (!showNetworkGenerations) return;
+            break;
+          case "locales":
+            if (!showLocales) return;
+            break;
+          case "deviceManufacturers":
+            if (!showDeviceManufacturers) return;
+            break;
+          case "deviceNames":
+            if (!showDeviceNames) return;
+            break;
+          case "bugReportStatuses":
+            if (!showBugReportStatus) return;
+            break;
+          case "udAttrMatchers":
+            if (!showUdAttrs) return;
+            break;
+          case "freeText":
+            if (!showFreeText) return;
+            break;
+          case "startDate":
+          case "endDate":
+          case "dateRange":
+            if (!showDates) return;
+            break;
+          case "appId":
+            if (!showAppSelector) return;
+            break;
+          case "rootSpanName":
+          case "spanStatuses":
+            if (filterSource !== FilterSource.Spans) return;
+            break;
+          default:
+            break;
+        }
 
-        case 'dateRange':
-          if (value === DateRange.Last6Hours) return // Or your default date range
-          serializedValue = value.toString()
-          break
+        switch (key) {
+          case "versions":
+          case "osVersions":
+          case "countries":
+          case "networkProviders":
+          case "networkTypes":
+          case "networkGenerations":
+          case "locales":
+          case "deviceManufacturers":
+          case "deviceNames":
+            if ((value as number[]).length === 0) return;
+            serializedValue = compressArrayToRanges(value as number[]);
+            break;
 
-        default:
-          if (value === '') return
-          serializedValue = value.toString()
-      }
-
-      if (serializedValue) params.set(minifiedKey, serializedValue)
-    })
-
-    return params.toString()
-  }
-
-  function deserializeUrlFilters(queryString: string): URLFilters {
-    const params = new URLSearchParams(queryString)
-    const result: URLFilters = {}
-
-    for (const [minifiedKey, value] of params.entries()) {
-      const originalKey = Object.entries(urlFiltersKeyMap)
-        .find(([_, v]) => v === minifiedKey)?.[0] as keyof URLFilters
-      if (!originalKey) continue
-
-      try {
-        switch (originalKey) {
-          case 'versions':
-          case 'osVersions':
-          case 'countries':
-          case 'networkProviders':
-          case 'networkTypes':
-          case 'networkGenerations':
-          case 'locales':
-          case 'deviceManufacturers':
-          case 'deviceNames':
-            result[originalKey] = expandRangesToArray(value)
-            break
-
-          case 'udAttrMatchers':
-            result[originalKey] = value.split('|')
-              .filter(part => part)
-              .map(part => {
-                const [key, type, op, val] = part.split('~').map(decodeURIComponent)
-                return { key, type, op, value: val } as UdAttrMatcher
-              })
-              .filter(m => m.key && m.type && m.op && m.value)
-            break
-
-          case 'spanStatuses':
-            result[originalKey] = value.split(',')
-              .filter((s): s is SpanStatus =>
-                Object.values(SpanStatus).includes(s as SpanStatus)
+          case "udAttrMatchers":
+            const validMatchers = (value as UdAttrMatcher[]).filter(
+              (m) => m?.key && m?.type && m?.op && m.value !== undefined,
+            );
+            if (validMatchers.length === 0) return;
+            serializedValue = validMatchers
+              .map(
+                (m) =>
+                  `${encodeURIComponent(m.key)}~${encodeURIComponent(m.type)}~${encodeURIComponent(m.op)}~${encodeURIComponent(m.value)}`,
               )
-            break
+              .join("|");
+            break;
 
-          case 'bugReportStatuses':
-            result[originalKey] = value.split(',')
-              .filter((s): s is BugReportStatus =>
-                Object.values(BugReportStatus).includes(s as BugReportStatus)
-              )
-            break
+          case "spanStatuses":
+          case "bugReportStatuses":
+            if ((value as string[]).length === 0) return;
+            serializedValue = (value as string[]).join(",");
+            break;
 
-          case 'sessionType':
-            result[originalKey] = getSessionTypeFromString(value)
-            break
+          case "sessionType":
+            if (value === SessionType.All) return;
+            serializedValue = value.toString();
+            break;
 
-          case 'dateRange':
-            result[originalKey] = Object.values(DateRange).includes(value as DateRange)
-              ? (value as DateRange)
-              : undefined
-            break
+          case "dateRange":
+            if (value === DateRange.Last6Hours) return; // Or your default date range
+            serializedValue = value.toString();
+            break;
 
           default:
-            if (isStringKey(originalKey)) {
+            if (value === "") return;
+            serializedValue = value.toString();
+        }
+
+        if (serializedValue) params.set(minifiedKey, serializedValue);
+      });
+
+      return params.toString();
+    }
+
+    function deserializeUrlFilters(queryString: string): URLFilters {
+      const params = new URLSearchParams(queryString);
+      const result: URLFilters = {};
+
+      for (const [minifiedKey, value] of params.entries()) {
+        const originalKey = Object.entries(urlFiltersKeyMap).find(
+          ([_, v]) => v === minifiedKey,
+        )?.[0] as keyof URLFilters;
+        if (!originalKey) continue;
+
+        try {
+          switch (originalKey) {
+            case "versions":
+            case "osVersions":
+            case "countries":
+            case "networkProviders":
+            case "networkTypes":
+            case "networkGenerations":
+            case "locales":
+            case "deviceManufacturers":
+            case "deviceNames":
+              result[originalKey] = expandRangesToArray(value);
+              break;
+
+            case "udAttrMatchers":
               result[originalKey] = value
-            }
-            break
-        }
-      } catch (error) {
-        console.warn(`Failed to parse ${originalKey}`, error)
-      }
-    }
-
-    return result
-  }
-
-  // Type guard for string-based URLFilter keys
-  function isStringKey(key: string): key is
-    'appId' |
-    'rootSpanName' |
-    'startDate' |
-    'endDate' |
-    'freeText' {
-    return [
-      'appId',
-      'rootSpanName',
-      'startDate',
-      'endDate',
-      'freeText'
-    ].includes(key)
-  }
-
-  function getSessionTypeFromString(value: string): SessionType {
-    const enumValues = Object.values(SessionType) as string[]
-    const enumKeys = Object.keys(SessionType) as Array<keyof typeof SessionType>
-
-    const index = enumValues.indexOf(value)
-    if (index !== -1) {
-      return SessionType[enumKeys[index]]
-    }
-
-    throw ("Invalid string cannot be mapped to SessionType: " + value)
-  }
-
-  function mapDateRangeToDate(dateRange: string) {
-    let today = DateTime.now()
-
-    switch (dateRange) {
-      case DateRange.Last15Mins:
-        return today.minus({ minutes: 15 })
-      case DateRange.Last30Mins:
-        return today.minus({ minutes: 30 })
-      case DateRange.LastHour:
-        return today.minus({ hours: 1 })
-      case DateRange.Last3Hours:
-        return today.minus({ hours: 3 })
-      case DateRange.Last6Hours:
-        return today.minus({ hours: 6 })
-      case DateRange.Last12Hours:
-        return today.minus({ hours: 12 })
-      case DateRange.Last24Hours:
-        return today.minus({ hours: 24 })
-      case DateRange.LastWeek:
-        return today.minus({ days: 7 })
-      case DateRange.Last15Days:
-        return today.minus({ days: 15 })
-      case DateRange.LastMonth:
-        return today.minus({ months: 1 })
-      case DateRange.Last3Months:
-        return today.minus({ months: 3 })
-      case DateRange.Last6Months:
-        return today.minus({ months: 6 })
-      case DateRange.LastYear:
-        return today.minus({ years: 1 })
-      case DateRange.Custom:
-        throw Error("Custom date range cannot be mapped to date")
-    }
-  }
-
-  const customDateInputStyle = "font-display border border-black rounded-md p-1.5 text-sm transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-
-  const searchParams = useSearchParams()
-  const pathName = usePathname()
-
-  const urlFilters = deserializeUrlFilters(searchParams.toString())
-  const sessionPersistedFiltersKey = "sessionPersistedFilters"
-  const sessionPersistedFilters: SessionPersistedFilters | null =
-    typeof window !== "undefined" && sessionStorage.getItem(sessionPersistedFiltersKey) !== null
-      ? JSON.parse(sessionStorage.getItem(sessionPersistedFiltersKey)!)
-      : null
-
-  const [appsApiStatus, setAppsApiStatus] = useState(AppsApiStatus.Loading)
-  const [rootSpanNamesApiStatus, setRootSpanNamesApiStatus] = useState(RootSpanNamesApiStatus.Loading)
-  const [filtersApiStatus, setFiltersApiStatus] = useState(FiltersApiStatus.Loading)
-
-  const [apps, setApps] = useState<App[]>([])
-  const [selectedApp, setSelectedApp] = useState<App | null>(null)
-
-  const [rootSpanNames, setRootSpanNames] = useState([] as string[])
-  const [selectedRootSpanName, setSelectedRootSpanName] = useState('')
-
-  const [selectedSpanStatuses, setSelectedSpanStatuses] = useState(filterSource === FilterSource.Spans ? [SpanStatus.Unset, SpanStatus.Ok, SpanStatus.Error] : [])
-
-  const [selectedBugReportStatuses, setSelectedBugReportStatuses] = useState([BugReportStatus.Open])
-
-  const [versions, setVersions] = useState([] as AppVersion[])
-  const [selectedVersions, setSelectedVersions] = useState([] as AppVersion[])
-
-  const [selectedSessionType, setSelectedSessionType] = useState(SessionType.All)
-
-  const [osVersions, setOsVersions] = useState([] as OsVersion[])
-  const [selectedOsVersions, setSelectedOsVersions] = useState([] as OsVersion[])
-
-  const [countries, setCountries] = useState([] as string[])
-  const [selectedCountries, setSelectedCountries] = useState([] as string[])
-
-  const [networkProviders, setNetworkProviders] = useState([] as string[])
-  const [selectedNetworkProviders, setSelectedNetworkProviders] = useState([] as string[])
-
-  const [networkTypes, setNetworkTypes] = useState([] as string[])
-  const [selectedNetworkTypes, setSelectedNetworkTypes] = useState([] as string[])
-
-  const [networkGenerations, setNetworkGenerations] = useState([] as string[])
-  const [selectedNetworkGenerations, setSelectedNetworkGenerations] = useState([] as string[])
-
-  const [locales, setLocales] = useState([] as string[])
-  const [selectedLocales, setSelectedLocales] = useState([] as string[])
-
-  const [deviceManufacturers, setDeviceManufacturers] = useState([] as string[])
-  const [selectedDeviceManufacturers, setSelectedDeviceManufacturers] = useState([] as string[])
-
-  const [deviceNames, setDeviceNames] = useState([] as string[])
-  const [selectedDeviceNames, setSelectedDeviceNames] = useState([] as string[])
-
-  const [userDefAttrs, setUserDefAttrs] = useState([] as UserDefAttr[])
-  const [userDefAttrOps, setUserDefAttrOps] = useState<Map<string, string[]>>(new Map())
-  const [selectedUdAttrMatchers, setSelectedUdAttrMatchers] = useState<UdAttrMatcher[]>([])
-
-  const [selectedFreeText, setSelectedFreeText] = useState('')
-
-  const initDateRange = urlFilters.dateRange ? urlFilters.dateRange : sessionPersistedFilters ? sessionPersistedFilters.dateRange : DateRange.Last6Hours
-  const [selectedDateRange, setSelectedDateRange] = useState(initDateRange)
-  const [selectedStartDate, setSelectedStartDate] = useState(urlFilters.startDate
-    ? urlFilters.startDate
-    : sessionPersistedFilters
-      ? sessionPersistedFilters.dateRange === DateRange.Custom
-        ? sessionPersistedFilters.startDate
-        : mapDateRangeToDate(initDateRange)!.toISO()
-      : DateTime.now().minus({ hours: 6 }).toISO())
-  const [selectedEndDate, setSelectedEndDate] = useState(urlFilters.endDate
-    ? urlFilters.endDate
-    : sessionPersistedFilters
-      ? sessionPersistedFilters.dateRange === DateRange.Custom
-        ? sessionPersistedFilters.endDate
-        : DateTime.now().toISO()
-      : DateTime.now().toISO())
-
-  const getApps = async (appIdToSelect?: string) => {
-
-    setAppsApiStatus(AppsApiStatus.Loading)
-
-    const result = await fetchAppsFromServer(teamId)
-
-    switch (result.status) {
-      case AppsApiStatus.NoApps:
-        setAppsApiStatus(AppsApiStatus.NoApps)
-        break
-      case AppsApiStatus.Error:
-        setAppsApiStatus(AppsApiStatus.Error)
-        break
-      case AppsApiStatus.Success:
-        setAppsApiStatus(AppsApiStatus.Success)
-        setApps(result.data)
-        console.log(1)
-        // Prefer app from function call, then url filters, then provided appId from props, then global persisted filters and finally first one in list
-        if (appIdToSelect !== undefined) {
-          let appFromGivenId = result.data.find((e: App) => e.id === appIdToSelect)
-          if (appFromGivenId === undefined) {
-            throw Error("Invalid app Id: " + appIdToSelect + " provided to getApps function")
-          } else {
-            setSelectedApp(appFromGivenId)
-          }
-        }
-        else if (urlFilters.appId) {
-          let appFromUrlFilters = result.data.find((e: App) => e.id === urlFilters.appId)
-          if (appFromUrlFilters === undefined) {
-            throw Error("Invalid app Id: " + urlFilters.appId + " provided in URL")
-          } else {
-            setSelectedApp(appFromUrlFilters)
-          }
-          break
-        } else if (appId !== undefined) {
-          let appFromGivenId = result.data.find((e: App) => e.id === appId)
-          if (appFromGivenId === undefined) {
-            throw Error("Invalid app Id: " + appId + " provided to filters component")
-          } else {
-            setSelectedApp(appFromGivenId)
-          }
-        } else if (sessionPersistedFilters) {
-          let appFromSessionPersistedFilters = result.data.find((e: App) => e.id === sessionPersistedFilters.app.id)
-          if (appFromSessionPersistedFilters === undefined) {
-            setSelectedApp(result.data[0])
-          } else {
-            setSelectedApp(appFromSessionPersistedFilters)
-          }
-        } else {
-          setSelectedApp(result.data[0])
-        }
-        break
-    }
-  }
-
-  useEffect(() => {
-    getApps()
-  }, [])
-
-  function refresh(appIdToSelect?: string) {
-    getApps(appIdToSelect)
-  }
-
-  useImperativeHandle(ref, () => ({
-    refresh
-  }))
-
-  const getRootSpanNames = async () => {
-    setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Loading)
-
-    const result = await fetchRootSpanNamesFromServer(selectedApp!)
-
-    switch (result.status) {
-      case RootSpanNamesApiStatus.NoData:
-        setRootSpanNamesApiStatus(RootSpanNamesApiStatus.NoData)
-        break
-      case RootSpanNamesApiStatus.Error:
-        setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Error)
-        break
-      case RootSpanNamesApiStatus.Success:
-        setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Success)
-
-        if (JSON.stringify(rootSpanNames) !== JSON.stringify(result.data.results)) {
-          setRootSpanNames(result.data.results)
-          setSelectedRootSpanName(result.data.results[0])
-        }
-
-        if (result.data.results !== null) {
-          const parsedRootSpanNames = result.data.results
-          setRootSpanNames(parsedRootSpanNames)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.rootSpanName) {
-            const selectedRootSpanName = parsedRootSpanNames.find((name: string) => name === urlFilters.rootSpanName)
-            if (selectedRootSpanName === undefined) {
-              setSelectedRootSpanName(parsedRootSpanNames[0])
-            } else {
-              setSelectedRootSpanName(selectedRootSpanName)
-            }
-          } else {
-            setSelectedRootSpanName(parsedRootSpanNames[0])
-          }
-        }
-        break
-    }
-  }
-
-  const clearFiltersOnFilterApiFail = () => {
-    console.log("Filters API failed, clearing filters")
-    setSelectedVersions(defaultFilters.versions)
-    setSelectedSessionType(defaultFilters.sessionType)
-    setSelectedOsVersions(defaultFilters.osVersions)
-    setSelectedCountries(defaultFilters.countries)
-    setSelectedNetworkProviders(defaultFilters.networkProviders)
-    setSelectedNetworkTypes(defaultFilters.networkTypes)
-    setSelectedNetworkGenerations(defaultFilters.networkGenerations)
-    setSelectedLocales(defaultFilters.locales)
-    setSelectedDeviceManufacturers(defaultFilters.deviceManufacturers)
-    setSelectedDeviceNames(defaultFilters.deviceNames)
-    setSelectedFreeText(defaultFilters.freeText)
-    setSelectedSpanStatuses(defaultFilters.spanStatuses)
-    setSelectedRootSpanName(defaultFilters.rootSpanName)
-    setSelectedBugReportStatuses(defaultFilters.bugReportStatuses)
-    setSelectedUdAttrMatchers(defaultFilters.udAttrMatchers)
-  }
-
-  const getFilters = async () => {
-    setFiltersApiStatus(FiltersApiStatus.Loading)
-
-    const result = await fetchFiltersFromServer(selectedApp!, filterSource)
-
-    switch (result.status) {
-      case FiltersApiStatus.NotOnboarded:
-        setFiltersApiStatus(FiltersApiStatus.NotOnboarded)
-        clearFiltersOnFilterApiFail()
-        break
-      case FiltersApiStatus.NoData:
-        setFiltersApiStatus(FiltersApiStatus.NoData)
-        clearFiltersOnFilterApiFail()
-        break
-      case FiltersApiStatus.Error:
-        setFiltersApiStatus(FiltersApiStatus.Error)
-        clearFiltersOnFilterApiFail()
-        break
-      case FiltersApiStatus.Success:
-        setFiltersApiStatus(FiltersApiStatus.Success)
-
-        if (result.data.versions !== null) {
-          const parsedVersions = result.data.versions.map((v: { name: string; code: string }) => new AppVersion(v.name, v.code))
-
-          setVersions(parsedVersions)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.versions) {
-            const selectedVersions = urlFilters.versions
-              .filter((index) => index >= 0 && index < parsedVersions.length)
-              .map((index) => parsedVersions[index])
-            setSelectedVersions(selectedVersions)
-          }
-          else if (appVersionsInitialSelectionType === AppVersionsInitialSelectionType.All) {
-            setSelectedVersions(parsedVersions)
-          } else {
-            setSelectedVersions(parsedVersions.slice(0, 1))
-          }
-        }
-
-        if (result.data.os_versions !== null) {
-          const parsedOsVersions = result.data.os_versions.map((v: { name: string; version: string }) => new OsVersion(v.name, v.version))
-
-          setOsVersions(parsedOsVersions)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.osVersions) {
-            const selectedOsVersions = urlFilters.osVersions
-              .filter((index) => index >= 0 && index < parsedOsVersions.length)
-              .map((index) => parsedOsVersions[index])
-            setSelectedOsVersions(selectedOsVersions)
-          } else {
-            setSelectedOsVersions(parsedOsVersions)
-          }
-        }
-
-        if (result.data.countries !== null) {
-          const parsedCountries = result.data.countries
-          setCountries(parsedCountries)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.countries) {
-            const selectedCountries = urlFilters.countries
-              .filter((index) => index >= 0 && index < parsedCountries.length)
-              .map((index) => parsedCountries[index])
-            setSelectedCountries(selectedCountries)
-          } else {
-            setSelectedCountries(parsedCountries)
-          }
-        }
-
-        if (result.data.network_providers !== null) {
-          const parsedNetworkProviders = result.data.network_providers
-          setNetworkProviders(parsedNetworkProviders)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.networkProviders) {
-            const selectedNetworkProviders = urlFilters.networkProviders
-              .filter((index) => index >= 0 && index < parsedNetworkProviders.length)
-              .map((index) => parsedNetworkProviders[index])
-            setSelectedNetworkProviders(selectedNetworkProviders)
-          } else {
-            setSelectedNetworkProviders(parsedNetworkProviders)
-          }
-        }
-
-        if (result.data.network_types !== null) {
-          const parsedNetworkTypes = result.data.network_types
-          setNetworkTypes(parsedNetworkTypes)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.networkTypes) {
-            const selectedNetworkTypes = urlFilters.networkTypes
-              .filter((index) => index >= 0 && index < parsedNetworkTypes.length)
-              .map((index) => parsedNetworkTypes[index])
-            setSelectedNetworkTypes(selectedNetworkTypes)
-          } else {
-            setSelectedNetworkTypes(parsedNetworkTypes)
-          }
-        }
-
-        if (result.data.network_generations !== null) {
-          const parsedNetworkGenerations = result.data.network_generations
-          setNetworkGenerations(parsedNetworkGenerations)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.networkGenerations) {
-            const selectedNetworkGenerations = urlFilters.networkGenerations
-              .filter((index) => index >= 0 && index < parsedNetworkGenerations.length)
-              .map((index) => parsedNetworkGenerations[index])
-            setSelectedNetworkGenerations(selectedNetworkGenerations)
-          }
-          else {
-            setSelectedNetworkGenerations(parsedNetworkGenerations)
-          }
-        }
-
-        if (result.data.locales !== null) {
-          const parsedLocales = result.data.locales
-          setLocales(parsedLocales)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.locales) {
-            const selectedLocales = urlFilters.locales
-              .filter((index) => index >= 0 && index < parsedLocales.length)
-              .map((index) => parsedLocales[index])
-            setSelectedLocales(selectedLocales)
-          } else {
-            setSelectedLocales(parsedLocales)
-          }
-        }
-
-        if (result.data.device_manufacturers !== null) {
-          const parsedDeviceManufacturers = result.data.device_manufacturers
-          setDeviceManufacturers(parsedDeviceManufacturers)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.deviceManufacturers) {
-            const selectedDeviceManufacturers = urlFilters.deviceManufacturers
-              .filter((index) => index >= 0 && index < parsedDeviceManufacturers.length)
-              .map((index) => parsedDeviceManufacturers[index])
-            setSelectedDeviceManufacturers(selectedDeviceManufacturers)
-          } else {
-            setSelectedDeviceManufacturers(parsedDeviceManufacturers)
-          }
-        }
-
-        if (result.data.device_names !== null) {
-          const parsedDeviceNames = result.data.device_names
-          setDeviceNames(parsedDeviceNames)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.deviceNames) {
-            const selectedDeviceNames = urlFilters.deviceNames
-              .filter((index) => index >= 0 && index < parsedDeviceNames.length)
-              .map((index) => parsedDeviceNames[index])
-            setSelectedDeviceNames(selectedDeviceNames)
-          } else {
-            setSelectedDeviceNames(parsedDeviceNames)
-          }
-        }
-
-        if (result.data.ud_attrs !== null && result.data.ud_attrs.key_types !== null && result.data.ud_attrs.operator_types !== null) {
-          const parsedUserDefAttrs = result.data.ud_attrs.key_types
-          const parsedUserDefAttrOps = new Map<string, string[]>(Object.entries(result.data.ud_attrs.operator_types))
-
-          setUserDefAttrs(parsedUserDefAttrs)
-          setUserDefAttrOps(parsedUserDefAttrOps)
-
-          if (urlFilters.appId === selectedApp!.id && urlFilters.udAttrMatchers) {
-            const selectedUdAttrMatchers = urlFilters.udAttrMatchers
-              .filter((m: UdAttrMatcher) => {
-                // Find the attribute definition for this matcher
-                const attr = parsedUserDefAttrs.find((attr: UserDefAttr) => attr.key === m.key)
-                if (!attr) return false
-                // Use the type from the attribute definition and check if the op is valid for this type
-                const ops = parsedUserDefAttrOps.get(attr.type)
-                const opExists = ops ? ops.includes(m.op) : false
-                // Accept if key exists, op exists for the type, and value is not undefined
-                return opExists && m.value !== undefined
-              })
-            setSelectedUdAttrMatchers(selectedUdAttrMatchers)
-          } else {
-            setSelectedUdAttrMatchers([])
-          }
-        } else {
-          setUserDefAttrs([])
-          setUserDefAttrOps(new Map<string, string[]>())
-          setSelectedUdAttrMatchers([])
-        }
-
-
-        if (urlFilters.appId === selectedApp!.id && urlFilters.spanStatuses) {
-          const selectedSpanStatuses = urlFilters.spanStatuses
-            .filter((s: string) => Object.values(SpanStatus).includes(s as SpanStatus))
-            .map((s: string) => s as SpanStatus)
-          setSelectedSpanStatuses(selectedSpanStatuses)
-        } else {
-          setSelectedSpanStatuses(filterSource === FilterSource.Spans ? [SpanStatus.Unset, SpanStatus.Ok, SpanStatus.Error] : [])
-        }
-
-        if (urlFilters.appId === selectedApp!.id && urlFilters.bugReportStatuses) {
-          const selectedBugReportStatuses = urlFilters.bugReportStatuses
-            .filter((s: string) => Object.values(BugReportStatus).includes(s as BugReportStatus))
-            .map((s: string) => s as BugReportStatus)
-          setSelectedBugReportStatuses(selectedBugReportStatuses)
-        } else {
-          setSelectedBugReportStatuses([BugReportStatus.Open])
-        }
-
-        if (urlFilters.appId === selectedApp!.id && urlFilters.sessionType) {
-          setSelectedSessionType(urlFilters.sessionType)
-        } else {
-          setSelectedSessionType(SessionType.All)
-        }
-
-        if (urlFilters.appId === selectedApp!.id && urlFilters.freeText) {
-          setSelectedFreeText(urlFilters.freeText)
-        } else {
-          setSelectedFreeText('')
-        }
-
-        break
-    }
-  }
-
-  useEffect(() => {
-    if (!selectedApp) {
-      return
-    }
-
-    getFilters()
-
-    if (filterSource === FilterSource.Spans) {
-      getRootSpanNames()
-    }
-
-  }, [selectedApp])
-
-  useEffect(() => {
-    if (!selectedApp) {
-      return
-    }
-
-    let ready = false
-    if (showNoData && showNotOnboarded) {
-      ready = AppsApiStatus.Success && ((filterSource === FilterSource.Spans && rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) || filterSource !== FilterSource.Spans) && filtersApiStatus === FiltersApiStatus.Success
-    } else if (showNoData) {
-      ready = AppsApiStatus.Success && ((filterSource === FilterSource.Spans && rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) || filterSource !== FilterSource.Spans) && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NotOnboarded)
-    } else if (showNotOnboarded) {
-      ready = AppsApiStatus.Success && ((filterSource === FilterSource.Spans && rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) || filterSource !== FilterSource.Spans) && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NoData)
-    } else {
-      ready = AppsApiStatus.Success && ((filterSource === FilterSource.Spans && rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) || filterSource !== FilterSource.Spans) && (filtersApiStatus === FiltersApiStatus.Success || filtersApiStatus === FiltersApiStatus.NoData || filtersApiStatus === FiltersApiStatus.NotOnboarded)
-    }
-
-    const updatedUrlFilters: URLFilters = {
-      appId: selectedApp!.id,
-      rootSpanName: selectedRootSpanName,
-      startDate: selectedStartDate,
-      endDate: selectedEndDate,
-      dateRange: Object.values(DateRange).includes(selectedDateRange as DateRange) ? (selectedDateRange as DateRange) : undefined,
-      versions: selectedVersions.map(v => versions.findIndex(ver => ver.name === v.name && ver.code === v.code)),
-      sessionType: selectedSessionType,
-      spanStatuses: selectedSpanStatuses,
-      bugReportStatuses: selectedBugReportStatuses,
-      osVersions: selectedOsVersions.map(os => osVersions.findIndex(o =>
-        o.name === os.name && o.version === os.version)),
-      countries: selectedCountries.map(c => countries.indexOf(c)),
-      networkProviders: selectedNetworkProviders.map(np => networkProviders.indexOf(np)),
-      networkTypes: selectedNetworkTypes.map(nt => networkTypes.indexOf(nt)),
-      networkGenerations: selectedNetworkGenerations.map(ng => networkGenerations.indexOf(ng)),
-      locales: selectedLocales.map(l => locales.indexOf(l)),
-      deviceManufacturers: selectedDeviceManufacturers.map(dm => deviceManufacturers.indexOf(dm)),
-      deviceNames: selectedDeviceNames.map(dn => deviceNames.indexOf(dn)),
-      udAttrMatchers: selectedUdAttrMatchers,
-      freeText: selectedFreeText
-    }
-
-    const updatedSelectedFilters: Filters = {
-      ready: ready,
-      app: selectedApp,
-      rootSpanName: selectedRootSpanName,
-      startDate: selectedStartDate,
-      endDate: selectedEndDate,
-      versions: selectedVersions,
-      sessionType: selectedSessionType,
-      spanStatuses: selectedSpanStatuses,
-      bugReportStatuses: selectedBugReportStatuses,
-      osVersions: selectedOsVersions,
-      countries: selectedCountries,
-      networkProviders: selectedNetworkProviders,
-      networkTypes: selectedNetworkTypes,
-      networkGenerations: selectedNetworkGenerations,
-      locales: selectedLocales,
-      deviceManufacturers: selectedDeviceManufacturers,
-      deviceNames: selectedDeviceNames,
-      udAttrMatchers: selectedUdAttrMatchers,
-      freeText: selectedFreeText,
-      serialisedFilters: serializeUrlFilters(updatedUrlFilters)
-    }
-
-    // update global persisted filters
-    const updatedSessionPersistedFilters: SessionPersistedFilters = {
-      app: selectedApp!,
-      dateRange: selectedDateRange,
-      startDate: selectedStartDate,
-      endDate: selectedEndDate
-    }
-    sessionStorage.setItem(sessionPersistedFiltersKey, JSON.stringify(updatedSessionPersistedFilters))
-
-    // fire callback
-    onFiltersChanged(updatedSelectedFilters)
-  }, [filtersApiStatus, selectedStartDate, selectedEndDate, selectedVersions, selectedSessionType, selectedOsVersions, selectedCountries, selectedNetworkProviders, selectedNetworkTypes, selectedNetworkGenerations, selectedLocales, selectedDeviceManufacturers, selectedDeviceNames, selectedUdAttrMatchers, selectedFreeText, selectedRootSpanName, selectedSpanStatuses, selectedBugReportStatuses])
-
-  return (
-    <div>
-      {appsApiStatus === AppsApiStatus.Loading && <LoadingSpinner />}
-
-      {/* Error states for apps fetch */}
-      {appsApiStatus === AppsApiStatus.Error && <p className="font-body text-sm">Error fetching apps, please check if Team ID is valid or refresh page to try again</p>}
-      {appsApiStatus === AppsApiStatus.NoApps && <p className='font-body text-sm'>Looks like you don&apos;t have any apps yet. Get started by {pathName.includes("apps") ? "creating your first app!" : <Link className="underline decoration-2 underline-offset-2 decoration-yellow-200 hover:decoration-yellow-500" href={`apps`}>creating your first app!</Link>}</p>}
-
-      {/* Error states for app success but filters fetch loading or failure */}
-      {appsApiStatus === AppsApiStatus.Success && filtersApiStatus !== FiltersApiStatus.Success &&
-        <div className="flex flex-col">
-          {showAppSelector &&
-            <div className="flex flex-wrap gap-8 items-center">
-              <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={selectedApp!.name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
-              {filtersApiStatus === FiltersApiStatus.Loading && <LoadingSpinner />}
-            </div>}
-          <div className="py-4" />
-          {filtersApiStatus === FiltersApiStatus.Error && <p className="font-body text-sm">Error fetching filters, please refresh page or select a different app to try again</p>}
-          {showNoData && filtersApiStatus === FiltersApiStatus.NoData && <p className="font-body text-sm">No {filterSource === FilterSource.Crashes ? 'crashes' : filterSource === FilterSource.Anrs ? 'ANRs' : 'data'} received for this app yet</p>}
-          {showNotOnboarded && filtersApiStatus === FiltersApiStatus.NotOnboarded && <p className="font-body text-sm">Follow our <Link target='_blank' className="underline decoration-2 underline-offset-2 decoration-yellow-200 hover:decoration-yellow-500" href='https://github.com/measure-sh/measure?tab=readme-ov-file#docs'>docs</Link> to finish setting up your app.</p>}
-        </div>
-      }
-
-      {/* Error states for app success and filter success but traces loading or failure */}
-      {appsApiStatus === AppsApiStatus.Success && filtersApiStatus === FiltersApiStatus.Success && filterSource === FilterSource.Spans && rootSpanNamesApiStatus !== RootSpanNamesApiStatus.Success &&
-        <div className="flex flex-col">
-          {showAppSelector &&
-            <div className="flex flex-wrap gap-8 items-center">
-              <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={selectedApp!.name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />
-              {rootSpanNamesApiStatus === RootSpanNamesApiStatus.Loading && <LoadingSpinner />}
-            </div>}
-          <div className="py-4" />
-          {rootSpanNamesApiStatus === RootSpanNamesApiStatus.Error && <p className="font-body text-sm">Error fetching traces list, please refresh page or select a different app to try again</p>}
-          {rootSpanNamesApiStatus === RootSpanNamesApiStatus.NoData && <p className="font-body text-sm">No traces received for this app yet</p>}
-        </div>
-      }
-
-      {/* Success states for app, trace and filters fetch */}
-      {appsApiStatus === AppsApiStatus.Success && ((filterSource === FilterSource.Spans && rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) || filterSource !== FilterSource.Spans) && filtersApiStatus === FiltersApiStatus.Success &&
-        <div>
-          <div className="flex flex-wrap gap-8 items-center">
-            {showAppSelector && <DropdownSelect title="App Name" type={DropdownSelectType.SingleString} items={apps.map((e) => e.name)} initialSelected={selectedApp!.name} onChangeSelected={(item) => setSelectedApp(apps.find((e) => e.name === item)!)} />}
-
-            {filterSource === FilterSource.Spans && <DropdownSelect title="Trace Name" type={DropdownSelectType.SingleString} items={rootSpanNames} initialSelected={selectedRootSpanName} onChangeSelected={(item) => setSelectedRootSpanName(item as string)} />}
-
-            <div className="flex flex-row items-center">
-              {showDates && <DropdownSelect title="Date Range" type={DropdownSelectType.SingleString} items={Object.values(DateRange)} initialSelected={selectedDateRange} onChangeSelected={(item) => {
-                const range = item as string
-
-                // do nothing if same range is selected
-                if (range === selectedDateRange) {
-                  return
-                }
-
-                if (range === DateRange.Custom) {
-                  setSelectedDateRange(range)
-                  return
-                }
-
-                let today = DateTime.now()
-                let newDate = mapDateRangeToDate(range)
-
-                setSelectedStartDate(newDate!.toISO())
-                setSelectedEndDate(today.toISO())
-                setSelectedDateRange(range)
+                .split("|")
+                .filter((part) => part)
+                .map((part) => {
+                  const [key, type, op, val] = part
+                    .split("~")
+                    .map(decodeURIComponent);
+                  return { key, type, op, value: val } as UdAttrMatcher;
+                })
+                .filter((m) => m.key && m.type && m.op && m.value);
+              break;
+
+            case "spanStatuses":
+              result[originalKey] = value
+                .split(",")
+                .filter((s): s is SpanStatus =>
+                  Object.values(SpanStatus).includes(s as SpanStatus),
+                );
+              break;
+
+            case "bugReportStatuses":
+              result[originalKey] = value
+                .split(",")
+                .filter((s): s is BugReportStatus =>
+                  Object.values(BugReportStatus).includes(s as BugReportStatus),
+                );
+              break;
+
+            case "sessionType":
+              result[originalKey] = getSessionTypeFromString(value);
+              break;
+
+            case "dateRange":
+              result[originalKey] = Object.values(DateRange).includes(
+                value as DateRange,
+              )
+                ? (value as DateRange)
+                : undefined;
+              break;
+
+            default:
+              if (isStringKey(originalKey)) {
+                result[originalKey] = value;
               }
-              } />}
-              {showDates && selectedDateRange === DateRange.Custom && <p className="font-display px-2">:</p>}
-              {showDates && selectedDateRange === DateRange.Custom && <input type="datetime-local" defaultValue={formatIsoDateForDateTimeInputField(selectedStartDate)} max={formatIsoDateForDateTimeInputField(selectedEndDate)} className={customDateInputStyle} onChange={(e) => {
-                if (isValidTimestamp(e.target.value)) {
-                  setSelectedStartDate(DateTime.fromISO(e.target.value).toISO()!)
-                }
-              }} />}
-              {showDates && selectedDateRange === DateRange.Custom && <p className="font-display px-2">to</p>}
-              {showDates && selectedDateRange === DateRange.Custom && <input type="datetime-local" defaultValue={formatIsoDateForDateTimeInputField(selectedEndDate)} min={formatIsoDateForDateTimeInputField(selectedStartDate)} max={formatIsoDateForDateTimeInputField(DateTime.now().toISO())} className={customDateInputStyle} onChange={(e) => {
-                if (isValidTimestamp(e.target.value)) {
-                  // If "To" date is greater than now, ignore the change and reset to current end date.
-                  // We need to do this since setting "max" isn't enough in some browsers
-                  if (DateTime.fromISO(e.target.value) <= DateTime.now()) {
-                    setSelectedEndDate(DateTime.fromISO(e.target.value).toISO()!)
-                  } else {
-                    e.target.value = formatIsoDateForDateTimeInputField(selectedEndDate)
-                  }
-                }
-              }} />}
-            </div>
-            {showAppVersions && <DropdownSelect title="App versions" type={DropdownSelectType.MultiAppVersion} items={versions} initialSelected={selectedVersions} onChangeSelected={(items) => setSelectedVersions(items as AppVersion[])} />}
-            {showSessionType && <DropdownSelect title="Session Types" type={DropdownSelectType.SingleString} items={Object.values(SessionType)} initialSelected={selectedSessionType} onChangeSelected={(item) => setSelectedSessionType(getSessionTypeFromString(item as string))} />}
-            {filterSource === FilterSource.Spans && <DropdownSelect type={DropdownSelectType.MultiString} title="Span Status" items={Object.values(SpanStatus)} initialSelected={selectedSpanStatuses} onChangeSelected={(items) => setSelectedSpanStatuses(items as SpanStatus[])} />}
-            {showBugReportStatus && <DropdownSelect type={DropdownSelectType.MultiString} title="Bug Report Status" items={Object.values(BugReportStatus)} initialSelected={selectedBugReportStatuses} onChangeSelected={(items) => setSelectedBugReportStatuses(items as BugReportStatus[])} />}
-            {showOsVersions && osVersions.length > 0 && <DropdownSelect type={DropdownSelectType.MultiOsVersion} title="OS Versions" items={osVersions} initialSelected={selectedOsVersions} onChangeSelected={(items) => setSelectedOsVersions(items as OsVersion[])} />}
-            {showCountries && countries.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Country" items={countries} initialSelected={selectedCountries} onChangeSelected={(items) => setSelectedCountries(items as string[])} />}
-            {showNetworkProviders && networkProviders.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Network Provider" items={networkProviders} initialSelected={selectedNetworkProviders} onChangeSelected={(items) => setSelectedNetworkProviders(items as string[])} />}
-            {showNetworkTypes && networkTypes.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Network type" items={networkTypes} initialSelected={selectedNetworkTypes} onChangeSelected={(items) => setSelectedNetworkTypes(items as string[])} />}
-            {showNetworkGenerations && networkGenerations.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Network generation" items={networkGenerations} initialSelected={selectedNetworkGenerations} onChangeSelected={(items) => setSelectedNetworkGenerations(items as string[])} />}
-            {showLocales && locales.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Locale" items={locales} initialSelected={selectedLocales} onChangeSelected={(items) => setSelectedLocales(items as string[])} />}
-            {showDeviceManufacturers && deviceManufacturers.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Device Manufacturer" items={deviceManufacturers} initialSelected={selectedDeviceManufacturers} onChangeSelected={(items) => setSelectedDeviceManufacturers(items as string[])} />}
-            {showDeviceNames && deviceNames.length > 0 && <DropdownSelect type={DropdownSelectType.MultiString} title="Device Name" items={deviceNames} initialSelected={selectedDeviceNames} onChangeSelected={(items) => setSelectedDeviceNames(items as string[])} />}
-            {showUdAttrs && userDefAttrs.length > 0 && <UserDefAttrSelector attrs={userDefAttrs} ops={userDefAttrOps} initialSelected={selectedUdAttrMatchers} onChangeSelected={(udAttrMatchers) => setSelectedUdAttrMatchers(udAttrMatchers)} />}
-            {showFreeText && <DebounceTextInput id="free-text" placeholder={freeTextPlaceholder ? freeTextPlaceholder : defaultFreeTextPlaceholder} initialValue={selectedFreeText} onChange={(input) => setSelectedFreeText(input)} />}
-          </div>
-          <div className="py-4" />
-          <div className="flex flex-wrap gap-2 items-center">
-            {filterSource === FilterSource.Spans && <FilterPill title={selectedRootSpanName} />}
-            {showDates && <FilterPill title={`${formatDateToHumanReadableDateTime(selectedStartDate)} to ${formatDateToHumanReadableDateTime(selectedEndDate)}`} />}
-            {showAppVersions && selectedVersions.length > 0 && <FilterPill title={Array.from(selectedVersions).map((v) => v.displayName).join(', ')} />}
-            {showSessionType && <FilterPill title={selectedSessionType} />}
-            {filterSource === FilterSource.Spans && selectedSpanStatuses.length > 0 && <FilterPill title={Array.from(selectedSpanStatuses).join(', ')} />}
-            {showBugReportStatus && selectedBugReportStatuses.length > 0 && <FilterPill title={Array.from(selectedBugReportStatuses).join(', ')} />}
-            {showOsVersions && selectedOsVersions.length > 0 && <FilterPill title={Array.from(selectedOsVersions).map((v) => v.displayName).join(', ')} />}
-            {showCountries && selectedCountries.length > 0 && <FilterPill title={Array.from(selectedCountries).join(', ')} />}
-            {showNetworkProviders && selectedNetworkProviders.length > 0 && <FilterPill title={Array.from(selectedNetworkProviders).join(', ')} />}
-            {showNetworkTypes && selectedNetworkTypes.length > 0 && <FilterPill title={Array.from(selectedNetworkTypes).join(', ')} />}
-            {showNetworkGenerations && selectedNetworkGenerations.length > 0 && <FilterPill title={Array.from(selectedNetworkGenerations).join(', ')} />}
-            {showLocales && selectedLocales.length > 0 && <FilterPill title={Array.from(selectedLocales).join(', ')} />}
-            {showDeviceManufacturers && selectedDeviceManufacturers.length > 0 && <FilterPill title={Array.from(selectedDeviceManufacturers).join(', ')} />}
-            {showDeviceNames && selectedDeviceNames.length > 0 && <FilterPill title={Array.from(selectedDeviceNames).join(', ')} />}
-            {showUdAttrs && selectedUdAttrMatchers.length > 0 && <FilterPill title={selectedUdAttrMatchers.map(matcher => `${matcher.key} (${matcher.type}) ${matcher.op} ${matcher.value}`).join(', ')} />}
-            {showFreeText && selectedFreeText !== '' && <FilterPill title={"Search Text: " + selectedFreeText} />}
-          </div>
-        </div>
+              break;
+          }
+        } catch (error) {
+          console.warn(`Failed to parse ${originalKey}`, error);
+        }
       }
-    </div>
-  )
-})
 
-Filters.displayName = "Filters"
-export default Filters
+      return result;
+    }
+
+    // Type guard for string-based URLFilter keys
+    function isStringKey(
+      key: string,
+    ): key is "appId" | "rootSpanName" | "startDate" | "endDate" | "freeText" {
+      return [
+        "appId",
+        "rootSpanName",
+        "startDate",
+        "endDate",
+        "freeText",
+      ].includes(key);
+    }
+
+    function getSessionTypeFromString(value: string): SessionType {
+      const enumValues = Object.values(SessionType) as string[];
+      const enumKeys = Object.keys(SessionType) as Array<
+        keyof typeof SessionType
+      >;
+
+      const index = enumValues.indexOf(value);
+      if (index !== -1) {
+        return SessionType[enumKeys[index]];
+      }
+
+      throw "Invalid string cannot be mapped to SessionType: " + value;
+    }
+
+    function mapDateRangeToDate(dateRange: string) {
+      let today = DateTime.now();
+
+      switch (dateRange) {
+        case DateRange.Last15Mins:
+          return today.minus({ minutes: 15 });
+        case DateRange.Last30Mins:
+          return today.minus({ minutes: 30 });
+        case DateRange.LastHour:
+          return today.minus({ hours: 1 });
+        case DateRange.Last3Hours:
+          return today.minus({ hours: 3 });
+        case DateRange.Last6Hours:
+          return today.minus({ hours: 6 });
+        case DateRange.Last12Hours:
+          return today.minus({ hours: 12 });
+        case DateRange.Last24Hours:
+          return today.minus({ hours: 24 });
+        case DateRange.LastWeek:
+          return today.minus({ days: 7 });
+        case DateRange.Last15Days:
+          return today.minus({ days: 15 });
+        case DateRange.LastMonth:
+          return today.minus({ months: 1 });
+        case DateRange.Last3Months:
+          return today.minus({ months: 3 });
+        case DateRange.Last6Months:
+          return today.minus({ months: 6 });
+        case DateRange.LastYear:
+          return today.minus({ years: 1 });
+        case DateRange.Custom:
+          throw Error("Custom date range cannot be mapped to date");
+      }
+    }
+
+    const customDateInputStyle =
+      "font-display border border-black rounded-md p-1.5 text-sm transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]";
+
+    const searchParams = useSearchParams();
+    const pathName = usePathname();
+
+    const urlFilters = deserializeUrlFilters(searchParams.toString());
+    const sessionPersistedFiltersKey = "sessionPersistedFilters";
+    const sessionPersistedFilters: SessionPersistedFilters | null =
+      typeof window !== "undefined" &&
+      sessionStorage.getItem(sessionPersistedFiltersKey) !== null
+        ? JSON.parse(sessionStorage.getItem(sessionPersistedFiltersKey)!)
+        : null;
+
+    const [appsApiStatus, setAppsApiStatus] = useState(AppsApiStatus.Loading);
+    const [rootSpanNamesApiStatus, setRootSpanNamesApiStatus] = useState(
+      RootSpanNamesApiStatus.Loading,
+    );
+    const [filtersApiStatus, setFiltersApiStatus] = useState(
+      FiltersApiStatus.Loading,
+    );
+
+    const [apps, setApps] = useState<App[]>([]);
+    const [selectedApp, setSelectedApp] = useState<App | null>(null);
+
+    const [rootSpanNames, setRootSpanNames] = useState([] as string[]);
+    const [selectedRootSpanName, setSelectedRootSpanName] = useState("");
+
+    const [selectedSpanStatuses, setSelectedSpanStatuses] = useState(
+      filterSource === FilterSource.Spans
+        ? [SpanStatus.Unset, SpanStatus.Ok, SpanStatus.Error]
+        : [],
+    );
+
+    const [selectedBugReportStatuses, setSelectedBugReportStatuses] = useState([
+      BugReportStatus.Open,
+    ]);
+
+    const [versions, setVersions] = useState([] as AppVersion[]);
+    const [selectedVersions, setSelectedVersions] = useState(
+      [] as AppVersion[],
+    );
+
+    const [selectedSessionType, setSelectedSessionType] = useState(
+      SessionType.All,
+    );
+
+    const [osVersions, setOsVersions] = useState([] as OsVersion[]);
+    const [selectedOsVersions, setSelectedOsVersions] = useState(
+      [] as OsVersion[],
+    );
+
+    const [countries, setCountries] = useState([] as string[]);
+    const [selectedCountries, setSelectedCountries] = useState([] as string[]);
+
+    const [networkProviders, setNetworkProviders] = useState([] as string[]);
+    const [selectedNetworkProviders, setSelectedNetworkProviders] = useState(
+      [] as string[],
+    );
+
+    const [networkTypes, setNetworkTypes] = useState([] as string[]);
+    const [selectedNetworkTypes, setSelectedNetworkTypes] = useState(
+      [] as string[],
+    );
+
+    const [networkGenerations, setNetworkGenerations] = useState(
+      [] as string[],
+    );
+    const [selectedNetworkGenerations, setSelectedNetworkGenerations] =
+      useState([] as string[]);
+
+    const [locales, setLocales] = useState([] as string[]);
+    const [selectedLocales, setSelectedLocales] = useState([] as string[]);
+
+    const [deviceManufacturers, setDeviceManufacturers] = useState(
+      [] as string[],
+    );
+    const [selectedDeviceManufacturers, setSelectedDeviceManufacturers] =
+      useState([] as string[]);
+
+    const [deviceNames, setDeviceNames] = useState([] as string[]);
+    const [selectedDeviceNames, setSelectedDeviceNames] = useState(
+      [] as string[],
+    );
+
+    const [userDefAttrs, setUserDefAttrs] = useState([] as UserDefAttr[]);
+    const [userDefAttrOps, setUserDefAttrOps] = useState<Map<string, string[]>>(
+      new Map(),
+    );
+    const [selectedUdAttrMatchers, setSelectedUdAttrMatchers] = useState<
+      UdAttrMatcher[]
+    >([]);
+
+    const [selectedFreeText, setSelectedFreeText] = useState("");
+
+    const initDateRange = urlFilters.dateRange
+      ? urlFilters.dateRange
+      : sessionPersistedFilters
+        ? sessionPersistedFilters.dateRange
+        : DateRange.Last6Hours;
+    const [selectedDateRange, setSelectedDateRange] = useState(initDateRange);
+    const [selectedStartDate, setSelectedStartDate] = useState(
+      urlFilters.startDate
+        ? urlFilters.startDate
+        : sessionPersistedFilters
+          ? sessionPersistedFilters.dateRange === DateRange.Custom
+            ? sessionPersistedFilters.startDate
+            : mapDateRangeToDate(initDateRange)!.toISO()
+          : DateTime.now().minus({ hours: 6 }).toISO(),
+    );
+    const [selectedEndDate, setSelectedEndDate] = useState(
+      urlFilters.endDate
+        ? urlFilters.endDate
+        : sessionPersistedFilters
+          ? sessionPersistedFilters.dateRange === DateRange.Custom
+            ? sessionPersistedFilters.endDate
+            : DateTime.now().toISO()
+          : DateTime.now().toISO(),
+    );
+
+    const getApps = async (appIdToSelect?: string) => {
+      setAppsApiStatus(AppsApiStatus.Loading);
+
+      const result = await fetchAppsFromServer(teamId);
+
+      switch (result.status) {
+        case AppsApiStatus.NoApps:
+          setAppsApiStatus(AppsApiStatus.NoApps);
+          break;
+        case AppsApiStatus.Error:
+          setAppsApiStatus(AppsApiStatus.Error);
+          break;
+        case AppsApiStatus.Success:
+          setAppsApiStatus(AppsApiStatus.Success);
+          setApps(result.data);
+          // Prefer app from function call, then url filters, then provided appId from props, then global persisted filters and finally first one in list
+          if (appIdToSelect !== undefined) {
+            let appFromGivenId = result.data.find(
+              (e: App) => e.id === appIdToSelect,
+            );
+            if (appFromGivenId === undefined) {
+              throw Error(
+                "Invalid app Id: " +
+                  appIdToSelect +
+                  " provided to getApps function",
+              );
+            } else {
+              setSelectedApp(appFromGivenId);
+            }
+          } else if (urlFilters.appId) {
+            let appFromUrlFilters = result.data.find(
+              (e: App) => e.id === urlFilters.appId,
+            );
+            if (appFromUrlFilters === undefined) {
+              throw Error(
+                "Invalid app Id: " + urlFilters.appId + " provided in URL",
+              );
+            } else {
+              setSelectedApp(appFromUrlFilters);
+            }
+            break;
+          } else if (appId !== undefined) {
+            let appFromGivenId = result.data.find((e: App) => e.id === appId);
+            if (appFromGivenId === undefined) {
+              throw Error(
+                "Invalid app Id: " + appId + " provided to filters component",
+              );
+            } else {
+              setSelectedApp(appFromGivenId);
+            }
+          } else if (sessionPersistedFilters) {
+            let appFromSessionPersistedFilters = result.data.find(
+              (e: App) => e.id === sessionPersistedFilters.app.id,
+            );
+            if (appFromSessionPersistedFilters === undefined) {
+              setSelectedApp(result.data[0]);
+            } else {
+              setSelectedApp(appFromSessionPersistedFilters);
+            }
+          } else {
+            setSelectedApp(result.data[0]);
+          }
+          break;
+      }
+    };
+
+    useEffect(() => {
+      getApps();
+    }, []);
+
+    function refresh(appIdToSelect?: string) {
+      getApps(appIdToSelect);
+    }
+
+    useImperativeHandle(ref, () => ({
+      refresh,
+    }));
+
+    const getRootSpanNames = async () => {
+      setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Loading);
+
+      const result = await fetchRootSpanNamesFromServer(selectedApp!);
+
+      switch (result.status) {
+        case RootSpanNamesApiStatus.NoData:
+          setRootSpanNamesApiStatus(RootSpanNamesApiStatus.NoData);
+          break;
+        case RootSpanNamesApiStatus.Error:
+          setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Error);
+          break;
+        case RootSpanNamesApiStatus.Success:
+          setRootSpanNamesApiStatus(RootSpanNamesApiStatus.Success);
+
+          if (
+            JSON.stringify(rootSpanNames) !==
+            JSON.stringify(result.data.results)
+          ) {
+            setRootSpanNames(result.data.results);
+            setSelectedRootSpanName(result.data.results[0]);
+          }
+
+          if (result.data.results !== null) {
+            const parsedRootSpanNames = result.data.results;
+            setRootSpanNames(parsedRootSpanNames);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.rootSpanName
+            ) {
+              const selectedRootSpanName = parsedRootSpanNames.find(
+                (name: string) => name === urlFilters.rootSpanName,
+              );
+              if (selectedRootSpanName === undefined) {
+                setSelectedRootSpanName(parsedRootSpanNames[0]);
+              } else {
+                setSelectedRootSpanName(selectedRootSpanName);
+              }
+            } else {
+              setSelectedRootSpanName(parsedRootSpanNames[0]);
+            }
+          }
+          break;
+      }
+    };
+
+    const clearFiltersOnFilterApiFail = () => {
+      console.log("Filters API failed, clearing filters");
+      setSelectedVersions(defaultFilters.versions);
+      setSelectedSessionType(defaultFilters.sessionType);
+      setSelectedOsVersions(defaultFilters.osVersions);
+      setSelectedCountries(defaultFilters.countries);
+      setSelectedNetworkProviders(defaultFilters.networkProviders);
+      setSelectedNetworkTypes(defaultFilters.networkTypes);
+      setSelectedNetworkGenerations(defaultFilters.networkGenerations);
+      setSelectedLocales(defaultFilters.locales);
+      setSelectedDeviceManufacturers(defaultFilters.deviceManufacturers);
+      setSelectedDeviceNames(defaultFilters.deviceNames);
+      setSelectedFreeText(defaultFilters.freeText);
+      setSelectedSpanStatuses(defaultFilters.spanStatuses);
+      setSelectedRootSpanName(defaultFilters.rootSpanName);
+      setSelectedBugReportStatuses(defaultFilters.bugReportStatuses);
+      setSelectedUdAttrMatchers(defaultFilters.udAttrMatchers);
+    };
+
+    const getFilters = async () => {
+      setFiltersApiStatus(FiltersApiStatus.Loading);
+
+      const result = await fetchFiltersFromServer(selectedApp!, filterSource);
+
+      switch (result.status) {
+        case FiltersApiStatus.NotOnboarded:
+          setFiltersApiStatus(FiltersApiStatus.NotOnboarded);
+          clearFiltersOnFilterApiFail();
+          break;
+        case FiltersApiStatus.NoData:
+          setFiltersApiStatus(FiltersApiStatus.NoData);
+          clearFiltersOnFilterApiFail();
+          break;
+        case FiltersApiStatus.Error:
+          setFiltersApiStatus(FiltersApiStatus.Error);
+          clearFiltersOnFilterApiFail();
+          break;
+        case FiltersApiStatus.Success:
+          setFiltersApiStatus(FiltersApiStatus.Success);
+
+          if (result.data.versions !== null) {
+            const parsedVersions = result.data.versions.map(
+              (v: { name: string; code: string }) =>
+                new AppVersion(v.name, v.code),
+            );
+
+            setVersions(parsedVersions);
+
+            if (urlFilters.appId === selectedApp!.id && urlFilters.versions) {
+              const selectedVersions = urlFilters.versions
+                .filter((index) => index >= 0 && index < parsedVersions.length)
+                .map((index) => parsedVersions[index]);
+              setSelectedVersions(selectedVersions);
+            } else if (
+              appVersionsInitialSelectionType ===
+              AppVersionsInitialSelectionType.All
+            ) {
+              setSelectedVersions(parsedVersions);
+            } else {
+              setSelectedVersions(parsedVersions.slice(0, 1));
+            }
+          }
+
+          if (result.data.os_versions !== null) {
+            const parsedOsVersions = result.data.os_versions.map(
+              (v: { name: string; version: string }) =>
+                new OsVersion(v.name, v.version),
+            );
+
+            setOsVersions(parsedOsVersions);
+
+            if (urlFilters.appId === selectedApp!.id && urlFilters.osVersions) {
+              const selectedOsVersions = urlFilters.osVersions
+                .filter(
+                  (index) => index >= 0 && index < parsedOsVersions.length,
+                )
+                .map((index) => parsedOsVersions[index]);
+              setSelectedOsVersions(selectedOsVersions);
+            } else {
+              setSelectedOsVersions(parsedOsVersions);
+            }
+          }
+
+          if (result.data.countries !== null) {
+            const parsedCountries = result.data.countries;
+            setCountries(parsedCountries);
+
+            if (urlFilters.appId === selectedApp!.id && urlFilters.countries) {
+              const selectedCountries = urlFilters.countries
+                .filter((index) => index >= 0 && index < parsedCountries.length)
+                .map((index) => parsedCountries[index]);
+              setSelectedCountries(selectedCountries);
+            } else {
+              setSelectedCountries(parsedCountries);
+            }
+          }
+
+          if (result.data.network_providers !== null) {
+            const parsedNetworkProviders = result.data.network_providers;
+            setNetworkProviders(parsedNetworkProviders);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.networkProviders
+            ) {
+              const selectedNetworkProviders = urlFilters.networkProviders
+                .filter(
+                  (index) =>
+                    index >= 0 && index < parsedNetworkProviders.length,
+                )
+                .map((index) => parsedNetworkProviders[index]);
+              setSelectedNetworkProviders(selectedNetworkProviders);
+            } else {
+              setSelectedNetworkProviders(parsedNetworkProviders);
+            }
+          }
+
+          if (result.data.network_types !== null) {
+            const parsedNetworkTypes = result.data.network_types;
+            setNetworkTypes(parsedNetworkTypes);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.networkTypes
+            ) {
+              const selectedNetworkTypes = urlFilters.networkTypes
+                .filter(
+                  (index) => index >= 0 && index < parsedNetworkTypes.length,
+                )
+                .map((index) => parsedNetworkTypes[index]);
+              setSelectedNetworkTypes(selectedNetworkTypes);
+            } else {
+              setSelectedNetworkTypes(parsedNetworkTypes);
+            }
+          }
+
+          if (result.data.network_generations !== null) {
+            const parsedNetworkGenerations = result.data.network_generations;
+            setNetworkGenerations(parsedNetworkGenerations);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.networkGenerations
+            ) {
+              const selectedNetworkGenerations = urlFilters.networkGenerations
+                .filter(
+                  (index) =>
+                    index >= 0 && index < parsedNetworkGenerations.length,
+                )
+                .map((index) => parsedNetworkGenerations[index]);
+              setSelectedNetworkGenerations(selectedNetworkGenerations);
+            } else {
+              setSelectedNetworkGenerations(parsedNetworkGenerations);
+            }
+          }
+
+          if (result.data.locales !== null) {
+            const parsedLocales = result.data.locales;
+            setLocales(parsedLocales);
+
+            if (urlFilters.appId === selectedApp!.id && urlFilters.locales) {
+              const selectedLocales = urlFilters.locales
+                .filter((index) => index >= 0 && index < parsedLocales.length)
+                .map((index) => parsedLocales[index]);
+              setSelectedLocales(selectedLocales);
+            } else {
+              setSelectedLocales(parsedLocales);
+            }
+          }
+
+          if (result.data.device_manufacturers !== null) {
+            const parsedDeviceManufacturers = result.data.device_manufacturers;
+            setDeviceManufacturers(parsedDeviceManufacturers);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.deviceManufacturers
+            ) {
+              const selectedDeviceManufacturers = urlFilters.deviceManufacturers
+                .filter(
+                  (index) =>
+                    index >= 0 && index < parsedDeviceManufacturers.length,
+                )
+                .map((index) => parsedDeviceManufacturers[index]);
+              setSelectedDeviceManufacturers(selectedDeviceManufacturers);
+            } else {
+              setSelectedDeviceManufacturers(parsedDeviceManufacturers);
+            }
+          }
+
+          if (result.data.device_names !== null) {
+            const parsedDeviceNames = result.data.device_names;
+            setDeviceNames(parsedDeviceNames);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.deviceNames
+            ) {
+              const selectedDeviceNames = urlFilters.deviceNames
+                .filter(
+                  (index) => index >= 0 && index < parsedDeviceNames.length,
+                )
+                .map((index) => parsedDeviceNames[index]);
+              setSelectedDeviceNames(selectedDeviceNames);
+            } else {
+              setSelectedDeviceNames(parsedDeviceNames);
+            }
+          }
+
+          if (
+            result.data.ud_attrs !== null &&
+            result.data.ud_attrs.key_types !== null &&
+            result.data.ud_attrs.operator_types !== null
+          ) {
+            const parsedUserDefAttrs = result.data.ud_attrs.key_types;
+            const parsedUserDefAttrOps = new Map<string, string[]>(
+              Object.entries(result.data.ud_attrs.operator_types),
+            );
+
+            setUserDefAttrs(parsedUserDefAttrs);
+            setUserDefAttrOps(parsedUserDefAttrOps);
+
+            if (
+              urlFilters.appId === selectedApp!.id &&
+              urlFilters.udAttrMatchers
+            ) {
+              const selectedUdAttrMatchers = urlFilters.udAttrMatchers.filter(
+                (m: UdAttrMatcher) => {
+                  // Find the attribute definition for this matcher
+                  const attr = parsedUserDefAttrs.find(
+                    (attr: UserDefAttr) => attr.key === m.key,
+                  );
+                  if (!attr) return false;
+                  // Use the type from the attribute definition and check if the op is valid for this type
+                  const ops = parsedUserDefAttrOps.get(attr.type);
+                  const opExists = ops ? ops.includes(m.op) : false;
+                  // Accept if key exists, op exists for the type, and value is not undefined
+                  return opExists && m.value !== undefined;
+                },
+              );
+              setSelectedUdAttrMatchers(selectedUdAttrMatchers);
+            } else {
+              setSelectedUdAttrMatchers([]);
+            }
+          } else {
+            setUserDefAttrs([]);
+            setUserDefAttrOps(new Map<string, string[]>());
+            setSelectedUdAttrMatchers([]);
+          }
+
+          if (urlFilters.appId === selectedApp!.id && urlFilters.spanStatuses) {
+            const selectedSpanStatuses = urlFilters.spanStatuses
+              .filter((s: string) =>
+                Object.values(SpanStatus).includes(s as SpanStatus),
+              )
+              .map((s: string) => s as SpanStatus);
+            setSelectedSpanStatuses(selectedSpanStatuses);
+          } else {
+            setSelectedSpanStatuses(
+              filterSource === FilterSource.Spans
+                ? [SpanStatus.Unset, SpanStatus.Ok, SpanStatus.Error]
+                : [],
+            );
+          }
+
+          if (
+            urlFilters.appId === selectedApp!.id &&
+            urlFilters.bugReportStatuses
+          ) {
+            const selectedBugReportStatuses = urlFilters.bugReportStatuses
+              .filter((s: string) =>
+                Object.values(BugReportStatus).includes(s as BugReportStatus),
+              )
+              .map((s: string) => s as BugReportStatus);
+            setSelectedBugReportStatuses(selectedBugReportStatuses);
+          } else {
+            setSelectedBugReportStatuses([BugReportStatus.Open]);
+          }
+
+          if (urlFilters.appId === selectedApp!.id && urlFilters.sessionType) {
+            setSelectedSessionType(urlFilters.sessionType);
+          } else {
+            setSelectedSessionType(SessionType.All);
+          }
+
+          if (urlFilters.appId === selectedApp!.id && urlFilters.freeText) {
+            setSelectedFreeText(urlFilters.freeText);
+          } else {
+            setSelectedFreeText("");
+          }
+
+          break;
+      }
+    };
+
+    useEffect(() => {
+      if (!selectedApp) {
+        return;
+      }
+
+      getFilters();
+
+      if (filterSource === FilterSource.Spans) {
+        getRootSpanNames();
+      }
+    }, [selectedApp]);
+
+    useEffect(() => {
+      if (!selectedApp) {
+        return;
+      }
+
+      let ready = false;
+      if (showNoData && showNotOnboarded) {
+        ready =
+          AppsApiStatus.Success &&
+          ((filterSource === FilterSource.Spans &&
+            rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            filterSource !== FilterSource.Spans) &&
+          filtersApiStatus === FiltersApiStatus.Success;
+      } else if (showNoData) {
+        ready =
+          AppsApiStatus.Success &&
+          ((filterSource === FilterSource.Spans &&
+            rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            filterSource !== FilterSource.Spans) &&
+          (filtersApiStatus === FiltersApiStatus.Success ||
+            filtersApiStatus === FiltersApiStatus.NotOnboarded);
+      } else if (showNotOnboarded) {
+        ready =
+          AppsApiStatus.Success &&
+          ((filterSource === FilterSource.Spans &&
+            rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            filterSource !== FilterSource.Spans) &&
+          (filtersApiStatus === FiltersApiStatus.Success ||
+            filtersApiStatus === FiltersApiStatus.NoData);
+      } else {
+        ready =
+          AppsApiStatus.Success &&
+          ((filterSource === FilterSource.Spans &&
+            rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            filterSource !== FilterSource.Spans) &&
+          (filtersApiStatus === FiltersApiStatus.Success ||
+            filtersApiStatus === FiltersApiStatus.NoData ||
+            filtersApiStatus === FiltersApiStatus.NotOnboarded);
+      }
+
+      const updatedUrlFilters: URLFilters = {
+        appId: selectedApp!.id,
+        rootSpanName: selectedRootSpanName,
+        startDate: selectedStartDate,
+        endDate: selectedEndDate,
+        dateRange: Object.values(DateRange).includes(
+          selectedDateRange as DateRange,
+        )
+          ? (selectedDateRange as DateRange)
+          : undefined,
+        versions: selectedVersions.map((v) =>
+          versions.findIndex(
+            (ver) => ver.name === v.name && ver.code === v.code,
+          ),
+        ),
+        sessionType: selectedSessionType,
+        spanStatuses: selectedSpanStatuses,
+        bugReportStatuses: selectedBugReportStatuses,
+        osVersions: selectedOsVersions.map((os) =>
+          osVersions.findIndex(
+            (o) => o.name === os.name && o.version === os.version,
+          ),
+        ),
+        countries: selectedCountries.map((c) => countries.indexOf(c)),
+        networkProviders: selectedNetworkProviders.map((np) =>
+          networkProviders.indexOf(np),
+        ),
+        networkTypes: selectedNetworkTypes.map((nt) =>
+          networkTypes.indexOf(nt),
+        ),
+        networkGenerations: selectedNetworkGenerations.map((ng) =>
+          networkGenerations.indexOf(ng),
+        ),
+        locales: selectedLocales.map((l) => locales.indexOf(l)),
+        deviceManufacturers: selectedDeviceManufacturers.map((dm) =>
+          deviceManufacturers.indexOf(dm),
+        ),
+        deviceNames: selectedDeviceNames.map((dn) => deviceNames.indexOf(dn)),
+        udAttrMatchers: selectedUdAttrMatchers,
+        freeText: selectedFreeText,
+      };
+
+      const updatedSelectedFilters: Filters = {
+        ready: ready,
+        app: selectedApp,
+        rootSpanName: selectedRootSpanName,
+        startDate: selectedStartDate,
+        endDate: selectedEndDate,
+        versions: selectedVersions,
+        sessionType: selectedSessionType,
+        spanStatuses: selectedSpanStatuses,
+        bugReportStatuses: selectedBugReportStatuses,
+        osVersions: selectedOsVersions,
+        countries: selectedCountries,
+        networkProviders: selectedNetworkProviders,
+        networkTypes: selectedNetworkTypes,
+        networkGenerations: selectedNetworkGenerations,
+        locales: selectedLocales,
+        deviceManufacturers: selectedDeviceManufacturers,
+        deviceNames: selectedDeviceNames,
+        udAttrMatchers: selectedUdAttrMatchers,
+        freeText: selectedFreeText,
+        serialisedFilters: serializeUrlFilters(updatedUrlFilters),
+      };
+
+      // update global persisted filters
+      const updatedSessionPersistedFilters: SessionPersistedFilters = {
+        app: selectedApp!,
+        dateRange: selectedDateRange,
+        startDate: selectedStartDate,
+        endDate: selectedEndDate,
+      };
+      sessionStorage.setItem(
+        sessionPersistedFiltersKey,
+        JSON.stringify(updatedSessionPersistedFilters),
+      );
+
+      // fire callback
+      onFiltersChanged(updatedSelectedFilters);
+    }, [
+      filtersApiStatus,
+      selectedStartDate,
+      selectedEndDate,
+      selectedVersions,
+      selectedSessionType,
+      selectedOsVersions,
+      selectedCountries,
+      selectedNetworkProviders,
+      selectedNetworkTypes,
+      selectedNetworkGenerations,
+      selectedLocales,
+      selectedDeviceManufacturers,
+      selectedDeviceNames,
+      selectedUdAttrMatchers,
+      selectedFreeText,
+      selectedRootSpanName,
+      selectedSpanStatuses,
+      selectedBugReportStatuses,
+    ]);
+
+    return (
+      <div>
+        {appsApiStatus === AppsApiStatus.Loading && <LoadingSpinner />}
+
+        {/* Error states for apps fetch */}
+        {appsApiStatus === AppsApiStatus.Error && (
+          <p className="font-body text-sm">
+            Error fetching apps, please check if Team ID is valid or refresh
+            page to try again
+          </p>
+        )}
+        {appsApiStatus === AppsApiStatus.NoApps && (
+          <p className="font-body text-sm">
+            Looks like you don&apos;t have any apps yet. Get started by{" "}
+            {pathName.includes("apps") ? (
+              "creating your first app!"
+            ) : (
+              <Link
+                className="underline decoration-2 underline-offset-2 decoration-yellow-200 hover:decoration-yellow-500"
+                href={`apps`}
+              >
+                creating your first app!
+              </Link>
+            )}
+          </p>
+        )}
+
+        {/* Error states for app success but filters fetch loading or failure */}
+        {appsApiStatus === AppsApiStatus.Success &&
+          filtersApiStatus !== FiltersApiStatus.Success && (
+            <div className="flex flex-col">
+              {showAppSelector && (
+                <div className="flex flex-wrap gap-8 items-center">
+                  <DropdownSelect
+                    title="App Name"
+                    type={DropdownSelectType.SingleString}
+                    items={apps.map((e) => e.name)}
+                    initialSelected={selectedApp!.name}
+                    onChangeSelected={(item) =>
+                      setSelectedApp(apps.find((e) => e.name === item)!)
+                    }
+                  />
+                  {filtersApiStatus === FiltersApiStatus.Loading && (
+                    <LoadingSpinner />
+                  )}
+                </div>
+              )}
+              <div className="py-4" />
+              {filtersApiStatus === FiltersApiStatus.Error && (
+                <p className="font-body text-sm">
+                  Error fetching filters, please refresh page or select a
+                  different app to try again
+                </p>
+              )}
+              {showNoData && filtersApiStatus === FiltersApiStatus.NoData && (
+                <p className="font-body text-sm">
+                  No{" "}
+                  {filterSource === FilterSource.Crashes
+                    ? "crashes"
+                    : filterSource === FilterSource.Anrs
+                      ? "ANRs"
+                      : "data"}{" "}
+                  received for this app yet
+                </p>
+              )}
+              {showNotOnboarded &&
+                filtersApiStatus === FiltersApiStatus.NotOnboarded && (
+                  <p className="font-body text-sm">
+                    Follow our{" "}
+                    <Link
+                      target="_blank"
+                      className="underline decoration-2 underline-offset-2 decoration-yellow-200 hover:decoration-yellow-500"
+                      href="https://github.com/measure-sh/measure?tab=readme-ov-file#docs"
+                    >
+                      docs
+                    </Link>{" "}
+                    to finish setting up your app.
+                  </p>
+                )}
+            </div>
+          )}
+
+        {/* Error states for app success and filter success but traces loading or failure */}
+        {appsApiStatus === AppsApiStatus.Success &&
+          filtersApiStatus === FiltersApiStatus.Success &&
+          filterSource === FilterSource.Spans &&
+          rootSpanNamesApiStatus !== RootSpanNamesApiStatus.Success && (
+            <div className="flex flex-col">
+              {showAppSelector && (
+                <div className="flex flex-wrap gap-8 items-center">
+                  <DropdownSelect
+                    title="App Name"
+                    type={DropdownSelectType.SingleString}
+                    items={apps.map((e) => e.name)}
+                    initialSelected={selectedApp!.name}
+                    onChangeSelected={(item) =>
+                      setSelectedApp(apps.find((e) => e.name === item)!)
+                    }
+                  />
+                  {rootSpanNamesApiStatus ===
+                    RootSpanNamesApiStatus.Loading && <LoadingSpinner />}
+                </div>
+              )}
+              <div className="py-4" />
+              {rootSpanNamesApiStatus === RootSpanNamesApiStatus.Error && (
+                <p className="font-body text-sm">
+                  Error fetching traces list, please refresh page or select a
+                  different app to try again
+                </p>
+              )}
+              {rootSpanNamesApiStatus === RootSpanNamesApiStatus.NoData && (
+                <p className="font-body text-sm">
+                  No traces received for this app yet
+                </p>
+              )}
+            </div>
+          )}
+
+        {/* Success states for app, trace and filters fetch */}
+        {appsApiStatus === AppsApiStatus.Success &&
+          ((filterSource === FilterSource.Spans &&
+            rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            filterSource !== FilterSource.Spans) &&
+          filtersApiStatus === FiltersApiStatus.Success && (
+            <div>
+              <div className="flex flex-wrap gap-8 items-center">
+                {showAppSelector && (
+                  <DropdownSelect
+                    title="App Name"
+                    type={DropdownSelectType.SingleString}
+                    items={apps.map((e) => e.name)}
+                    initialSelected={selectedApp!.name}
+                    onChangeSelected={(item) =>
+                      setSelectedApp(apps.find((e) => e.name === item)!)
+                    }
+                  />
+                )}
+
+                {filterSource === FilterSource.Spans && (
+                  <DropdownSelect
+                    title="Trace Name"
+                    type={DropdownSelectType.SingleString}
+                    items={rootSpanNames}
+                    initialSelected={selectedRootSpanName}
+                    onChangeSelected={(item) =>
+                      setSelectedRootSpanName(item as string)
+                    }
+                  />
+                )}
+
+                <div className="flex flex-row items-center">
+                  {showDates && (
+                    <DropdownSelect
+                      title="Date Range"
+                      type={DropdownSelectType.SingleString}
+                      items={Object.values(DateRange)}
+                      initialSelected={selectedDateRange}
+                      onChangeSelected={(item) => {
+                        const range = item as string;
+
+                        // do nothing if same range is selected
+                        if (range === selectedDateRange) {
+                          return;
+                        }
+
+                        if (range === DateRange.Custom) {
+                          setSelectedDateRange(range);
+                          return;
+                        }
+
+                        let today = DateTime.now();
+                        let newDate = mapDateRangeToDate(range);
+
+                        setSelectedStartDate(newDate!.toISO());
+                        setSelectedEndDate(today.toISO());
+                        setSelectedDateRange(range);
+                      }}
+                    />
+                  )}
+                  {showDates && selectedDateRange === DateRange.Custom && (
+                    <p className="font-display px-2">:</p>
+                  )}
+                  {showDates && selectedDateRange === DateRange.Custom && (
+                    <input
+                      type="datetime-local"
+                      defaultValue={formatIsoDateForDateTimeInputField(
+                        selectedStartDate,
+                      )}
+                      max={formatIsoDateForDateTimeInputField(selectedEndDate)}
+                      className={customDateInputStyle}
+                      onChange={(e) => {
+                        if (isValidTimestamp(e.target.value)) {
+                          setSelectedStartDate(
+                            DateTime.fromISO(e.target.value).toISO()!,
+                          );
+                        }
+                      }}
+                    />
+                  )}
+                  {showDates && selectedDateRange === DateRange.Custom && (
+                    <p className="font-display px-2">to</p>
+                  )}
+                  {showDates && selectedDateRange === DateRange.Custom && (
+                    <input
+                      type="datetime-local"
+                      defaultValue={formatIsoDateForDateTimeInputField(
+                        selectedEndDate,
+                      )}
+                      min={formatIsoDateForDateTimeInputField(
+                        selectedStartDate,
+                      )}
+                      max={formatIsoDateForDateTimeInputField(
+                        DateTime.now().toISO(),
+                      )}
+                      className={customDateInputStyle}
+                      onChange={(e) => {
+                        if (isValidTimestamp(e.target.value)) {
+                          // If "To" date is greater than now, ignore the change and reset to current end date.
+                          // We need to do this since setting "max" isn't enough in some browsers
+                          if (
+                            DateTime.fromISO(e.target.value) <= DateTime.now()
+                          ) {
+                            setSelectedEndDate(
+                              DateTime.fromISO(e.target.value).toISO()!,
+                            );
+                          } else {
+                            e.target.value =
+                              formatIsoDateForDateTimeInputField(
+                                selectedEndDate,
+                              );
+                          }
+                        }
+                      }}
+                    />
+                  )}
+                </div>
+                {showAppVersions && (
+                  <DropdownSelect
+                    title="App versions"
+                    type={DropdownSelectType.MultiAppVersion}
+                    items={versions}
+                    initialSelected={selectedVersions}
+                    onChangeSelected={(items) =>
+                      setSelectedVersions(items as AppVersion[])
+                    }
+                  />
+                )}
+                {showSessionType && (
+                  <DropdownSelect
+                    title="Session Types"
+                    type={DropdownSelectType.SingleString}
+                    items={Object.values(SessionType)}
+                    initialSelected={selectedSessionType}
+                    onChangeSelected={(item) =>
+                      setSelectedSessionType(
+                        getSessionTypeFromString(item as string),
+                      )
+                    }
+                  />
+                )}
+                {filterSource === FilterSource.Spans && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Span Status"
+                    items={Object.values(SpanStatus)}
+                    initialSelected={selectedSpanStatuses}
+                    onChangeSelected={(items) =>
+                      setSelectedSpanStatuses(items as SpanStatus[])
+                    }
+                  />
+                )}
+                {showBugReportStatus && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Bug Report Status"
+                    items={Object.values(BugReportStatus)}
+                    initialSelected={selectedBugReportStatuses}
+                    onChangeSelected={(items) =>
+                      setSelectedBugReportStatuses(items as BugReportStatus[])
+                    }
+                  />
+                )}
+                {showOsVersions && osVersions.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiOsVersion}
+                    title="OS Versions"
+                    items={osVersions}
+                    initialSelected={selectedOsVersions}
+                    onChangeSelected={(items) =>
+                      setSelectedOsVersions(items as OsVersion[])
+                    }
+                  />
+                )}
+                {showCountries && countries.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Country"
+                    items={countries}
+                    initialSelected={selectedCountries}
+                    onChangeSelected={(items) =>
+                      setSelectedCountries(items as string[])
+                    }
+                  />
+                )}
+                {showNetworkProviders && networkProviders.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Network Provider"
+                    items={networkProviders}
+                    initialSelected={selectedNetworkProviders}
+                    onChangeSelected={(items) =>
+                      setSelectedNetworkProviders(items as string[])
+                    }
+                  />
+                )}
+                {showNetworkTypes && networkTypes.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Network type"
+                    items={networkTypes}
+                    initialSelected={selectedNetworkTypes}
+                    onChangeSelected={(items) =>
+                      setSelectedNetworkTypes(items as string[])
+                    }
+                  />
+                )}
+                {showNetworkGenerations && networkGenerations.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Network generation"
+                    items={networkGenerations}
+                    initialSelected={selectedNetworkGenerations}
+                    onChangeSelected={(items) =>
+                      setSelectedNetworkGenerations(items as string[])
+                    }
+                  />
+                )}
+                {showLocales && locales.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Locale"
+                    items={locales}
+                    initialSelected={selectedLocales}
+                    onChangeSelected={(items) =>
+                      setSelectedLocales(items as string[])
+                    }
+                  />
+                )}
+                {showDeviceManufacturers && deviceManufacturers.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Device Manufacturer"
+                    items={deviceManufacturers}
+                    initialSelected={selectedDeviceManufacturers}
+                    onChangeSelected={(items) =>
+                      setSelectedDeviceManufacturers(items as string[])
+                    }
+                  />
+                )}
+                {showDeviceNames && deviceNames.length > 0 && (
+                  <DropdownSelect
+                    type={DropdownSelectType.MultiString}
+                    title="Device Name"
+                    items={deviceNames}
+                    initialSelected={selectedDeviceNames}
+                    onChangeSelected={(items) =>
+                      setSelectedDeviceNames(items as string[])
+                    }
+                  />
+                )}
+                {showUdAttrs && userDefAttrs.length > 0 && (
+                  <UserDefAttrSelector
+                    attrs={userDefAttrs}
+                    ops={userDefAttrOps}
+                    initialSelected={selectedUdAttrMatchers}
+                    onChangeSelected={(udAttrMatchers) =>
+                      setSelectedUdAttrMatchers(udAttrMatchers)
+                    }
+                  />
+                )}
+                {showFreeText && (
+                  <DebounceTextInput
+                    id="free-text"
+                    placeholder={
+                      freeTextPlaceholder
+                        ? freeTextPlaceholder
+                        : defaultFreeTextPlaceholder
+                    }
+                    initialValue={selectedFreeText}
+                    onChange={(input) => setSelectedFreeText(input)}
+                  />
+                )}
+              </div>
+              <div className="py-4" />
+              <div className="flex flex-wrap gap-2 items-center">
+                {filterSource === FilterSource.Spans && (
+                  <FilterPill title={selectedRootSpanName} />
+                )}
+                {showDates && (
+                  <FilterPill
+                    title={`${formatDateToHumanReadableDateTime(selectedStartDate)} to ${formatDateToHumanReadableDateTime(selectedEndDate)}`}
+                  />
+                )}
+                {showAppVersions && selectedVersions.length > 0 && (
+                  <FilterPill
+                    title={Array.from(selectedVersions)
+                      .map((v) => v.displayName)
+                      .join(", ")}
+                  />
+                )}
+                {showSessionType && <FilterPill title={selectedSessionType} />}
+                {filterSource === FilterSource.Spans &&
+                  selectedSpanStatuses.length > 0 && (
+                    <FilterPill
+                      title={Array.from(selectedSpanStatuses).join(", ")}
+                    />
+                  )}
+                {showBugReportStatus &&
+                  selectedBugReportStatuses.length > 0 && (
+                    <FilterPill
+                      title={Array.from(selectedBugReportStatuses).join(", ")}
+                    />
+                  )}
+                {showOsVersions && selectedOsVersions.length > 0 && (
+                  <FilterPill
+                    title={Array.from(selectedOsVersions)
+                      .map((v) => v.displayName)
+                      .join(", ")}
+                  />
+                )}
+                {showCountries && selectedCountries.length > 0 && (
+                  <FilterPill
+                    title={Array.from(selectedCountries).join(", ")}
+                  />
+                )}
+                {showNetworkProviders &&
+                  selectedNetworkProviders.length > 0 && (
+                    <FilterPill
+                      title={Array.from(selectedNetworkProviders).join(", ")}
+                    />
+                  )}
+                {showNetworkTypes && selectedNetworkTypes.length > 0 && (
+                  <FilterPill
+                    title={Array.from(selectedNetworkTypes).join(", ")}
+                  />
+                )}
+                {showNetworkGenerations &&
+                  selectedNetworkGenerations.length > 0 && (
+                    <FilterPill
+                      title={Array.from(selectedNetworkGenerations).join(", ")}
+                    />
+                  )}
+                {showLocales && selectedLocales.length > 0 && (
+                  <FilterPill title={Array.from(selectedLocales).join(", ")} />
+                )}
+                {showDeviceManufacturers &&
+                  selectedDeviceManufacturers.length > 0 && (
+                    <FilterPill
+                      title={Array.from(selectedDeviceManufacturers).join(", ")}
+                    />
+                  )}
+                {showDeviceNames && selectedDeviceNames.length > 0 && (
+                  <FilterPill
+                    title={Array.from(selectedDeviceNames).join(", ")}
+                  />
+                )}
+                {showUdAttrs && selectedUdAttrMatchers.length > 0 && (
+                  <FilterPill
+                    title={selectedUdAttrMatchers
+                      .map(
+                        (matcher) =>
+                          `${matcher.key} (${matcher.type}) ${matcher.op} ${matcher.value}`,
+                      )
+                      .join(", ")}
+                  />
+                )}
+                {showFreeText && selectedFreeText !== "" && (
+                  <FilterPill title={"Search Text: " + selectedFreeText} />
+                )}
+              </div>
+            </div>
+          )}
+      </div>
+    );
+  },
+);
+
+Filters.displayName = "Filters";
+export default Filters;

--- a/frontend/dashboard/next.config.js
+++ b/frontend/dashboard/next.config.js
@@ -1,22 +1,31 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    output: 'standalone',
-    images: {
-        remotePatterns: [
-            {
-                protocol: 'http',
-                hostname: 'localhost',
-                port: '9111'
-            },
-            {
-                protocol: 'https',
-                hostname: 'avatars.githubusercontent.com',
-            },
-            {
-                protocol: 'https',
-                hostname: 'lh3.googleusercontent.com',
-            },
-        ],
-    },
-}
-module.exports = nextConfig
+  output: "standalone",
+  images: {
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "9111",
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+    ],
+  },
+  rewrites: async () => {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.API_BASE_URL}/:path*`,
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary

This PR refactors authentication mechanism to use a reverse proxy for all API HTTP requests originating from the Dashboard. It also eliminates CORS from API backend. For SDK APIs, only bearer token is read from `Authorization` header. For Dashboard APIs, only cookies (`access_token`, `refresh_token`) are read from cookies.

The mechanism of setting cookies hasn't changed. All nextjs routes continue to set cookies to avoid any major disruptions. No environment variables for API or Dashboard has changed, again to ensure no major disruptions and easier upgrades.

## Tasks

- [x] asdfasdf

## See also

- fixes #2401 