### PR TITLE
docs(backend): fix incorrect command in contributing guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,7 +98,7 @@ In case of any issues related to incoherent state, reset your environment by run
 ```sh
 # would stop all containers and
 # remove images, orphan containers, volumes & networks
-docker compose down --rmi --remove-orphans --volumes
+docker compose down --rmi all --remove-orphans --volumes
 ```
 
 And rerun.


### PR DESCRIPTION
## Summary

This PR fixes the command to remove all compose services under the **Troubleshooting** section in the contributing guide.

## Tasks

- [x] Add the missing 'all' option for the --rmi flag under troubleshooting section for the command to remove all services & all its related resources

## See also

- fixes #2413
