### PR TITLE
chore(flutter): add validations for custom events

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/config/config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config.dart
@@ -28,6 +28,8 @@ class Config implements InternalConfig, IMeasureConfig {
         DefaultConfig.maxDescriptionLengthInBugReport,
     this.screenshotCompressionQuality =
         DefaultConfig.screenshotCompressionQuality,
+    this.maxEventNameLength = DefaultConfig.maxEventNameLength,
+    this.customEventNameRegex = DefaultConfig.customEventNameRegex,
   });
 
   @override
@@ -72,6 +74,10 @@ class Config implements InternalConfig, IMeasureConfig {
   final int maxDescriptionLengthInBugReport;
   @override
   final int screenshotCompressionQuality;
+  @override
+  final int maxEventNameLength;
+  @override
+  final String customEventNameRegex;
 
   @override
   List<String> get defaultHttpContentTypeAllowlist =>

--- a/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
@@ -96,6 +96,12 @@ class ConfigProviderImpl implements ConfigProvider {
       _defaultConfig.screenshotCompressionQuality;
 
   @override
+  int get maxEventNameLength => _defaultConfig.maxEventNameLength;
+
+  @override
+  String get customEventNameRegex => _defaultConfig.customEventNameRegex;
+
+  @override
   bool shouldTrackHttpBody(String url, String? contentType) {
     if (!trackHttpBody) {
       return false;

--- a/flutter/packages/measure_flutter/lib/src/config/default_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/default_config.dart
@@ -20,4 +20,6 @@ class DefaultConfig {
   static const int maxAttachmentsInBugReport = 5;
   static const int maxDescriptionLengthInBugReport = 1000;
   static const int screenshotCompressionQuality = 20;
+  static const int maxEventNameLength = 64;
+  static const String customEventNameRegex = "^[a-zA-Z0-9_-]+\$";
 }

--- a/flutter/packages/measure_flutter/lib/src/config/internal_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/internal_config.dart
@@ -24,4 +24,10 @@ abstract class InternalConfig {
   /// The compression quality of the screenshot. Must be between 0 and 100, where 0 is lowest quality
   /// and smallest size while 100 is highest quality and largest size.
   int get screenshotCompressionQuality;
+
+  /// The maximum length of a custom event. Defaults to 64 chars.
+  int get maxEventNameLength;
+
+  /// The regex to validate a custom event name.
+  String get customEventNameRegex;
 }

--- a/flutter/packages/measure_flutter/lib/src/events/custom_event_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/custom_event_collector.dart
@@ -2,22 +2,27 @@ import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 import 'package:measure_flutter/src/attribute_value.dart';
+import 'package:measure_flutter/src/config/config_provider.dart';
 import 'package:measure_flutter/src/events/custom_event_data.dart';
 import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
+import '../logger/log_level.dart';
+
 final class CustomEventCollector {
   final Logger logger;
   final SignalProcessor signalProcessor;
   final TimeProvider timeProvider;
+  final ConfigProvider configProvider;
   bool _enabled = false;
 
   CustomEventCollector({
     required this.logger,
     required this.signalProcessor,
     required this.timeProvider,
+    required this.configProvider,
   });
 
   void register() {
@@ -36,6 +41,30 @@ final class CustomEventCollector {
     if (!_enabled) {
       return;
     }
+
+    if (name.isEmpty) {
+      logger.log(
+        LogLevel.error,
+        "Invalid event: name is empty",
+      );
+      return;
+    }
+
+    if (name.length > configProvider.maxEventNameLength) {
+      logger.log(
+        LogLevel.error,
+        "Invalid event($name): name exceeds maximum length of ${configProvider.maxEventNameLength} characters",
+      );
+      return;
+    }
+
+    final RegExp customEventNameRegex =
+        RegExp(configProvider.customEventNameRegex);
+    if (!customEventNameRegex.hasMatch(name)) {
+      logger.log(LogLevel.error, "Invalid event($name) format");
+      return;
+    }
+
     signalProcessor.trackEvent(
       data: CustomEventData(name: name),
       type: EventType.custom,

--- a/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
@@ -9,31 +9,9 @@ part 'msr_attachment.g.dart';
 /// 
 /// [MsrAttachment] encapsulates file data, metadata, and type information
 /// for attachments like screenshots, logs, or user-selected files.
-/// 
-/// **Usage:**
-/// ```dart
-/// // Create from bytes (e.g., screenshot)
-/// final screenshot = MsrAttachment.fromBytes(
-///   bytes: screenshotData,
-///   type: AttachmentType.screenshot,
-///   uuid: 'screenshot-123',
-/// );
-/// 
-/// // Create from file path
-/// final logFile = MsrAttachment.fromPath(
-///   path: '/path/to/log.txt',
-///   type: AttachmentType.text,
-///   size: 1024,
-///   uuid: 'log-456',
-/// );
-/// 
-/// // Include in bug report
-/// Measure.instance.trackBugReport(
-///   description: 'App crashed',
-///   attachments: [screenshot, logFile],
-///   attributes: {},
-/// );
-/// ```
+///
+/// Use [Measure.captureScreenshot] to easily capture a screenshot and convert
+/// it to an attachment.
 @JsonSerializable()
 class MsrAttachment {
   final String id;

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -123,6 +123,7 @@ final class MeasureInitializer {
       logger: logger,
       signalProcessor: signalProcessor,
       timeProvider: timeProvider,
+      configProvider: configProvider,
     );
     _fileStorage = FileStorage(methodChannel, logger);
     _exceptionCollector = ExceptionCollector(

--- a/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
@@ -24,6 +24,8 @@ class FakeConfigProvider implements ConfigProvider {
   int _maxAttachmentsInBugReport = 5;
   int _maxDescriptionLengthInBugReport = 1000;
   int _screenshotCompressionQuality = 20;
+  int _maxEventNameLength = 64;
+  String _customEventNameRegex = '^[a-zA-Z0-9_-]+\$';
 
   // Getters
   @override
@@ -94,6 +96,12 @@ class FakeConfigProvider implements ConfigProvider {
   @override
   int get screenshotCompressionQuality => _screenshotCompressionQuality;
 
+  @override
+  int get maxEventNameLength => _maxEventNameLength;
+
+  @override
+  String get customEventNameRegex => _customEventNameRegex;
+
   // Setters
   set autoInitializeNativeSDK(bool value) => _autoInitializeNativeSDK = value;
 
@@ -150,6 +158,12 @@ class FakeConfigProvider implements ConfigProvider {
 
   set screenshotCompressionQuality(int value) =>
       _screenshotCompressionQuality = value;
+
+  set customEventNameRegex(String value) =>
+      _customEventNameRegex = value;
+
+  set maxEventNameLength(int value) =>
+      _maxEventNameLength = value;
 
   // Methods
   @override


### PR DESCRIPTION
# Description

Add missing validations for custom event names.
- Max length
- Empty name
- Event name should follow expected regex


This PR also updates documentation for attachment which had an incorrect example.

## Related issue
Fixes #2434 


