### PR TITLE
feat(android): provide configurable storage limits

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -191,13 +191,14 @@ public final class sh/measure/android/config/MeasureConfig : sh/measure/android/
 	public static final field $stable I
 	public static final field Companion Lsh/measure/android/config/MeasureConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZLsh/measure/android/config/MsrRequestHeadersProvider;)V
-	public synthetic fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZLsh/measure/android/config/MsrRequestHeadersProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZILsh/measure/android/config/MsrRequestHeadersProvider;)V
+	public synthetic fun <init> (ZZLsh/measure/android/config/ScreenshotMaskLevel;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZFZFZZILsh/measure/android/config/MsrRequestHeadersProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAutoStart ()Z
 	public fun getEnableLogging ()Z
 	public fun getHttpHeadersBlocklist ()Ljava/util/List;
 	public fun getHttpUrlAllowlist ()Ljava/util/List;
 	public fun getHttpUrlBlocklist ()Ljava/util/List;
+	public fun getMaxDiskUsageInMb ()I
 	public fun getRequestHeadersProvider ()Lsh/measure/android/config/MsrRequestHeadersProvider;
 	public fun getSamplingRateForErrorFreeSessions ()F
 	public fun getScreenshotMaskLevel ()Lsh/measure/android/config/ScreenshotMaskLevel;

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -18,6 +18,7 @@ internal data class Config(
     override val trackActivityLoadTime: Boolean = DefaultConfig.TRACK_ACTIVITY_LOAD_TIME,
     override val trackFragmentLoadTime: Boolean = DefaultConfig.TRACK_FRAGMENT_LOAD_TIME,
     override val disallowedCustomHeaders: List<String> = DefaultConfig.DISALLOWED_CUSTOM_HEADERS,
+    override val maxDiskUsageInMb: Int = DefaultConfig.MAX_ESTIMATED_DISK_USAGE_IN_MB,
     override val requestHeadersProvider: MsrRequestHeadersProvider? = null,
 ) : InternalConfig, IMeasureConfig {
     override val screenshotMaskHexColor: String = "#222222"
@@ -49,7 +50,6 @@ internal data class Config(
         EventType.LIFECYCLE_FRAGMENT,
         EventType.SCREEN_VIEW,
     )
-    override val maxSignalsInDatabase: Int = 50_000
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64
     override val maxCheckpointsPerSpan: Int = 100
@@ -60,4 +60,5 @@ internal data class Config(
     override val shakeAccelerationThreshold: Float = 20f
     override val shakeMinTimeIntervalMs: Long = 1500
     override val shakeSlop: Int = 3
+    override val estimatedEventSizeInKb: Int = 10 // 10KB
 }

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -59,8 +59,6 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { screenshotCompressionQuality }
     override val eventTypeExportAllowList: List<EventType>
         get() = getMergedConfig { eventTypeExportAllowList }
-    override val maxSignalsInDatabase: Int
-        get() = getMergedConfig { maxSignalsInDatabase }
     override val trackHttpHeaders: Boolean
         get() = getMergedConfig { trackHttpHeaders }
     override val trackHttpBody: Boolean
@@ -131,6 +129,10 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { disallowedCustomHeaders }
     override val requestHeadersProvider: MsrRequestHeadersProvider?
         get() = getMergedConfig { requestHeadersProvider }
+    override val maxDiskUsageInMb: Int
+        get() = getMergedConfig { maxDiskUsageInMb }
+    override val estimatedEventSizeInKb: Int
+        get() = getMergedConfig { estimatedEventSizeInKb }
 
     override fun shouldTrackHttpBody(url: String, contentType: String?): Boolean {
         if (!trackHttpBody) {

--- a/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
@@ -15,6 +15,7 @@ internal object DefaultConfig {
     const val TRACE_SAMPLING_RATE: Float = 0.1f
     const val TRACK_ACTIVITY_LOAD_TIME: Boolean = true
     const val TRACK_FRAGMENT_LOAD_TIME: Boolean = true
+    const val MAX_ESTIMATED_DISK_USAGE_IN_MB: Int = 50 // 50MB
     val DISALLOWED_CUSTOM_HEADERS: List<String> =
         listOf("Content-Type", "msr-req-id", "Authorization", "Content-Length")
 }

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -86,13 +86,6 @@ internal interface InternalConfig {
     val eventTypeExportAllowList: List<EventType>
 
     /**
-     * The maximum number of (events + spans) allowed in the database.
-     * If the number of events exceeds this limit, the oldest session is deleted everytime
-     * cleanup is triggered until the total number of events is below this limit.
-     */
-    val maxSignalsInDatabase: Int
-
-    /**
      * Max length of a span name. Defaults to 64.
      */
     val maxSpanNameLength: Int
@@ -147,4 +140,9 @@ internal interface InternalConfig {
      * List of custom headers that should not be included.
      */
     val disallowedCustomHeaders: List<String>
+
+    /**
+     * The estimated size of one event on disk.
+     */
+    val estimatedEventSizeInKb: Int
 }

--- a/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
@@ -31,6 +31,7 @@ internal interface IMeasureConfig {
     val traceSamplingRate: Float
     val trackActivityLoadTime: Boolean
     val trackFragmentLoadTime: Boolean
+    val maxDiskUsageInMb: Int
     val requestHeadersProvider: MsrRequestHeadersProvider?
 }
 
@@ -181,6 +182,26 @@ class MeasureConfig(
     override val trackFragmentLoadTime: Boolean = DefaultConfig.TRACK_FRAGMENT_LOAD_TIME,
 
     /**
+     * Configures the maximum disk usage in megabytes that the Measure SDK is allowed to use.
+     *
+     * This is useful to control the amount of disk space used by the SDK for storing session data,
+     * crash reports, and other collected information.
+     *
+     * Defaults to `50MB`. Allowed values are between `20MB` and `1500MB`. Any value outside this
+     * range will be clamped to the nearest limit.
+     *
+     * All Measure SDKs store data to disk and upload it to the server in batches. While the app is
+     * in foreground, the data is synced periodically and usually the disk space used by the SDK is
+     * low. However, if the device is offline or the server is unreachable, the SDK will continue to
+     * store data on disk until it reaches the maximum disk usage limit.
+     *
+     * Note that the storage usage is not exact and works on estimates and typically the SDK will
+     * use much less disk space than the configured limit. When the SDK reaches the maximum disk
+     * usage limit, it will start deleting the oldest data to make space for new data.
+     */
+    override val maxDiskUsageInMb: Int = DefaultConfig.MAX_ESTIMATED_DISK_USAGE_IN_MB,
+
+    /**
      * Allows configuring custom HTTP headers for requests made by the Measure SDK to the
      * Measure API. This is useful only for self-hosted clients who may require additional
      * headers for requests in their infrastructure.
@@ -234,6 +255,7 @@ internal data class SerializableMeasureConfig(
     val traceSamplingRate: Float = DefaultConfig.TRACE_SAMPLING_RATE,
     val trackActivityLoadTime: Boolean = DefaultConfig.TRACK_ACTIVITY_LOAD_TIME,
     val trackFragmentLoadTime: Boolean = DefaultConfig.TRACK_FRAGMENT_LOAD_TIME,
+    val maxEstimatedDiskUsageInMb: Int = DefaultConfig.MAX_ESTIMATED_DISK_USAGE_IN_MB,
     val requestHeadersProvider: MsrRequestHeadersProvider? = null,
 ) {
     fun toMeasureConfig(): MeasureConfig = MeasureConfig(
@@ -251,6 +273,7 @@ internal data class SerializableMeasureConfig(
         traceSamplingRate = traceSamplingRate,
         trackActivityLoadTime = trackActivityLoadTime,
         trackFragmentLoadTime = trackFragmentLoadTime,
+        maxDiskUsageInMb = maxEstimatedDiskUsageInMb,
         requestHeadersProvider = requestHeadersProvider,
     )
 
@@ -271,6 +294,7 @@ internal data class SerializableMeasureConfig(
                 traceSamplingRate = config.traceSamplingRate,
                 trackActivityLoadTime = config.trackActivityLoadTime,
                 trackFragmentLoadTime = config.trackFragmentLoadTime,
+                maxEstimatedDiskUsageInMb = config.maxDiskUsageInMb,
                 requestHeadersProvider = config.requestHeadersProvider,
             )
     }

--- a/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
@@ -1,5 +1,6 @@
 package sh.measure.android.storage
 
+import android.annotation.SuppressLint
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import sh.measure.android.events.AttachmentType
@@ -74,6 +75,7 @@ internal data class EventEntity(
 /**
  * Maps an attachment to [AttachmentTable] in the database.
  */
+@SuppressLint("UnsafeOptInUsageError")
 @Serializable
 internal data class AttachmentEntity(
     /**

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -16,7 +16,6 @@ internal class FakeConfigProvider : ConfigProvider {
     override var screenshotMaskHexColor: String = "#222222"
     override var screenshotCompressionQuality: Int = 25
     override val eventTypeExportAllowList: List<EventType> = emptyList()
-    override val maxSignalsInDatabase: Int = 50_000
     override var trackHttpHeaders: Boolean = true
     override var trackHttpBody: Boolean = true
     override var httpHeadersBlocklist: List<String> = emptyList()
@@ -52,6 +51,8 @@ internal class FakeConfigProvider : ConfigProvider {
     override val trackFragmentLoadTime: Boolean = true
     override val disallowedCustomHeaders: List<String> = listOf("Content-Type", "msr-req-id", "Authorization", "Content-Length")
     override val requestHeadersProvider: MsrRequestHeadersProvider? = null
+    override val estimatedEventSizeInKb: Int = 15
+    override val maxDiskUsageInMb: Int = 50
 
     var shouldTrackHttpBody = true
 

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
@@ -4,6 +4,7 @@ import sh.measure.android.SessionManager
 import sh.measure.android.events.Event
 
 internal class FakeSessionManager : SessionManager {
+    var session = "fake-session-id"
     var crashedSession = ""
     var crashedSessions = mutableListOf<String>()
     var onEventTracked = false
@@ -14,7 +15,7 @@ internal class FakeSessionManager : SessionManager {
     }
 
     override fun getSessionId(): String {
-        return "fake-session-id"
+        return session
     }
 
     override fun markCrashedSession(sessionId: String) {

--- a/android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
@@ -1,6 +1,9 @@
 package sh.measure.android.storage
 
 import androidx.concurrent.futures.ResolvableFuture
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -13,6 +16,8 @@ import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.ImmediateExecutorService
 import sh.measure.android.fakes.NoopLogger
+import java.io.File
+import kotlin.io.path.createTempDirectory
 
 class DataCleanupServiceTest {
     private val logger = NoopLogger()
@@ -29,6 +34,13 @@ class DataCleanupServiceTest {
         sessionManager,
         configProvider,
     )
+
+    private var tempTestDir: File? = null
+
+    @After
+    fun tearDown() {
+        tempTestDir?.deleteRecursively()
+    }
 
     @Test
     fun `does not attempt deletion if no stale data is present and events in database are less than threshold`() {
@@ -62,7 +74,10 @@ class DataCleanupServiceTest {
 
     @Test
     fun `given number of events in db exceed the max limit, deletes oldest session and events from database and file storage`() {
-        `when`(database.getEventsCount()).thenReturn(configProvider.maxSignalsInDatabase + 1)
+        // Set up events+spans to exceed disk usage limit (50MB with 15KB per signal)
+        // (3500 * 15) / 1024 ≈ 51.3MB > 50MB limit
+        `when`(database.getEventsCount()).thenReturn(3500)
+        `when`(database.getSpansCount()).thenReturn(0)
         `when`(database.getOldestSession()).thenReturn("session1")
         `when`(database.getEventsForSessions(listOf("session1"))).thenReturn(listOf("event1"))
         `when`(database.getAttachmentsForEvents(listOf("event1"))).thenReturn(listOf("attachment1"))
@@ -72,9 +87,41 @@ class DataCleanupServiceTest {
         // not marked for reporting.
         `when`(database.getSessionIds(any(), any(), eq(1))).thenReturn(emptyList())
 
+        // Mock getBugReportDir to handle deleteBugReports call
+        val bugReportsDir = mock<File>()
+        `when`(fileStorage.getBugReportDir()).thenReturn(bugReportsDir)
+        `when`(bugReportsDir.exists()).thenReturn(false)
+
         dataCleanupService.clearStaleData()
 
         verify(fileStorage, times(1)).deleteEventsIfExist(listOf("event1"), listOf("attachment1"))
         verify(database, times(1)).deleteSessions(listOf("session1"))
+    }
+
+    @Test
+    fun `cleans up old bug report directories while preserving current session`() {
+        tempTestDir = createTempDirectory("bug-reports-test").toFile()
+        val currentSessionDir = File(tempTestDir!!, "current-session").apply { mkdirs() }
+        val oldSessionDir1 = File(tempTestDir!!, "old-session-1").apply { mkdirs() }
+        val oldSessionDir2 = File(tempTestDir!!, "old-session-2").apply { mkdirs() }
+
+        // Add some files to verify they get cleaned up
+        File(oldSessionDir1, "report.json").writeText("{}")
+        File(oldSessionDir2, "screenshot.png").writeBytes(byteArrayOf(1, 2, 3))
+
+        sessionManager.session = "current-session"
+
+        // Setup mocks to avoid triggering other cleanup operations
+        `when`(database.getSessionIds(any(), any(), any())).thenReturn(emptyList())
+        `when`(database.getEventsCount()).thenReturn(100)
+        `when`(database.getSpansCount()).thenReturn(0)
+        `when`(fileStorage.getBugReportDir()).thenReturn(tempTestDir)
+
+        dataCleanupService.clearStaleData()
+
+        // Verify actual filesystem behavior
+        assertTrue(currentSessionDir.exists())
+        assertFalse(oldSessionDir1.exists())
+        assertFalse(oldSessionDir2.exists())
     }
 }

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -102,7 +102,7 @@ Future<void> main() async {
 * [**trackActivityLoadTime**](#trackActivityLoadTime)
 * [**trackFragmentLoadTime**](#trackFragmentLoadTime)
 * [**requestHeadersProvider**](#requestHeadersProvider)
-
+* [**maxDiskUsageInMb**](#maxDiskUsageInMb)
 ## `trackScreenshotOnCrash`
 
 Applies only to Android.
@@ -402,3 +402,19 @@ ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"api-key" apiUrl:@"
 ```
 
 </details>
+
+## `maxDiskUsageInMb`
+
+Allows setting the maximum disk usage for Measure SDK. This is useful to control the amount of disk space
+used by the SDK for storing session data, crash reports, and other collected information.
+
+All Measure SDKs store data to disk and upload it to the server in batches. While the app is in foreground, the data
+is synced periodically and usually the disk space used by the SDK is low. However, if the device is offline
+or the server is unreachable, the SDK will continue to store data on disk until it reaches the maximum disk usage limit.
+
+Defaults to `50MB`. Allowed values are between `20MB` and `1500MB`. Any value outside this range will be clamped
+to the nearest limit.
+
+Note that the storage usage is not exact and works on estimates and typically the SDK will use much less disk space than
+the configured limit. When the SDK reaches the maximum disk usage limit, it will start deleting the oldest data to make
+space for new data.


### PR DESCRIPTION
# Description

- adds a new public config (maxDiskUsageInMb)
- adds a internal config (estimatedEventSizeInKb)
- updates data cleanup logic

## Related issue
Closes #2443 


