### PR TITLE
chore(gradle): fix tests and run them on ci

### DIFF
--- a/.github/workflows/android-checks.yml
+++ b/.github/workflows/android-checks.yml
@@ -19,8 +19,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  checks:
-    name: Run checks
+  android-checks:
+    name: Android SDK checks
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -40,10 +40,30 @@ jobs:
       - name: Run all checks
         run: ./gradlew check
 
+  gradle-plugin-checks:
+    name: Gradle Plugin checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: 'gradle'
+      - name: Publish to maven local
+        run: ./gradlew :measure:publishToMavenLocal
+      - name: Run Gradle plugin checks
+        run: ./gradlew :measure-android-gradle:test --no-daemon --no-parallel --no-configuration-cache --stacktrace
+
   # ensures benchmark app is not broken
   assemble-benchmarks:
     runs-on: ubuntu-latest
-    needs: [ checks ]
     defaults:
       run:
         working-directory: android
@@ -63,7 +83,6 @@ jobs:
   # ensures sample app is not broken
   assemble-sample:
     runs-on: ubuntu-latest
-    needs: [ checks ]
     defaults:
       run:
         working-directory: android

--- a/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
+++ b/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
@@ -62,7 +62,8 @@ class MeasurePluginTest {
         agpVersion: SemVer,
         gradleVersion: GradleVersion,
     ) {
-        val project = MeasurePluginFixture(agpVersion, minifyEnabled = true, enabled = false).gradleProject
+        val project =
+            MeasurePluginFixture(agpVersion, minifyEnabled = true, enabled = false).gradleProject
         val assembleResult = build(gradleVersion, project.rootDir, ":app:assembleRelease")
         assertThat(assembleResult).doesNotHaveTask(":app:extractReleaseManifestData")
         assertThat(assembleResult).doesNotHaveTask(":app:calculateApkSizeRelease")
@@ -95,7 +96,11 @@ class MeasurePluginTest {
     ) {
         server.enqueue(MockResponse().setResponseCode(200))
         server.start(8080)
-        val project = MeasurePluginFixture(agpVersion, setMeasureApiKey = true, measureApiUrl = "http://localhost:8080").gradleProject
+        val project = MeasurePluginFixture(
+            agpVersion,
+            setMeasureApiKey = true,
+            measureApiUrl = "http://localhost:8080"
+        ).gradleProject
         build(gradleVersion, project.rootDir, ":app:assembleRelease")
         assertEquals(1, server.requestCount)
     }
@@ -108,7 +113,8 @@ class MeasurePluginTest {
     ) {
         val project = MeasurePluginFixture(agpVersion, setMeasureApiKey = false).gradleProject
         val result = build(gradleVersion, project.rootDir, ":app:assembleRelease")
-        assertThat(result).output().contains("[ERROR]: sh.measure.android.API_KEY missing in manifest, Measure SDK will not be initialized.")
+        assertThat(result).output()
+            .contains("[ERROR]: sh.measure.android.API_KEY missing in manifest, Measure SDK will not be initialized.")
     }
 
     @ParameterizedTest
@@ -119,7 +125,8 @@ class MeasurePluginTest {
     ) {
         val project = MeasurePluginFixture(agpVersion, setMeasureApiUrl = false).gradleProject
         val result = build(gradleVersion, project.rootDir, ":app:assembleRelease")
-        assertThat(result).output().contains("[ERROR]: sh.measure.android.API_URL missing in manifest, Measure SDK will not be initialized.")
+        assertThat(result).output()
+            .contains("[ERROR]: sh.measure.android.API_URL missing in manifest, Measure SDK will not be initialized.")
     }
 
     @ParameterizedTest
@@ -151,11 +158,8 @@ class MeasurePluginTest {
             return Stream.of(
                 Arguments.of(SemVer(7, 4, 1), GradleVersion.version("7.5")),
                 Arguments.of(SemVer(8, 0, 2), GradleVersion.version("8.0")),
-                Arguments.of(SemVer(8, 2, 1), GradleVersion.version("8.2")),
                 Arguments.of(SemVer(8, 3, 2), GradleVersion.version("8.5")),
-                Arguments.of(SemVer(8, 4, 1), GradleVersion.version("8.6")),
                 Arguments.of(SemVer(8, 5, 2), GradleVersion.version("8.7")),
-                Arguments.of(SemVer(8, 6, 1), GradleVersion.version("8.7")),
                 Arguments.of(SemVer(8, 7, 3), GradleVersion.version("8.9")),
                 Arguments.of(SemVer(8, 8, 0), GradleVersion.version("8.10.2")),
                 Arguments.of(SemVer(8, 9, 0), GradleVersion.version("8.11.1")),

--- a/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/fixtures/MeasurePluginFixture.kt
+++ b/android/measure-android-gradle/src/functionalTest/kotlin/sh/measure/fixtures/MeasurePluginFixture.kt
@@ -118,7 +118,7 @@ class MeasurePluginFixture(
             """
             <meta-data 
                 android:name="sh.measure.android.API_KEY" 
-                android:value="1234567890"/>
+                android:value="msrsh_1234567890"/>
             """.trimIndent()
         } else {
             ""

--- a/android/measure-android-gradle/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
+++ b/android/measure-android-gradle/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
@@ -122,7 +122,7 @@ class BuildUploadTaskTest {
         
         // Verify Flutter symbols are included
         assertTrue(requestBody.contains("name=\"mapping_type\""))
-        assertTrue(requestBody.contains("flutter_symbols"))
+        assertTrue(requestBody.contains("elf_debug"))
         assertTrue(requestBody.contains("app.android-arm64.symbols"))
         assertTrue(requestBody.contains("flutter symbols data"))
     }


### PR DESCRIPTION
# Description

- Fix functional tests and reduce the number of gradle versions on which they are run
- Run plugin unit tests on CI 

## Related issue
Closes #2448 



