### PR TITLE
fix(frontend): add tick rotation to fix overview sessions vs exceptions graph date overlap

### DIFF
--- a/frontend/dashboard/app/components/sessions_vs_exceptions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/sessions_vs_exceptions_overview_plot.tsx
@@ -95,7 +95,8 @@ const SessionsVsExceptionsPlot: React.FC<SessionsVsExceptionsPlotProps> = ({ fil
           axisBottom={{
             tickPadding: 20,
             format: '%b %d, %Y',
-            legendPosition: 'middle'
+            legendPosition: 'middle',
+            tickRotation: 45
           }}
           axisLeft={{
             tickSize: 1,


### PR DESCRIPTION
# Description

Adds tick rotation to fix overview sessions vs exceptions graph date overlap

<img width="1070" height="413" alt="Screenshot 2025-07-25 at 4 03 06 PM" src="https://github.com/user-attachments/assets/3af9a717-1013-4a60-9299-1d58ba222eb4" />


## Related issue
Fixes #2457 



