### PR TITLE
chore(ios): add more view controllers to be ignored

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
@@ -77,7 +77,18 @@ final class BaseLifecycleCollector: LifecycleCollector {
             "UIKitNavigationController",
             "NavigationStackHostingController",
             "NotifyingMulticolumnSplitViewController",
-            "StyleContextSplitViewController"
+            "StyleContextSplitViewController",
+            "UISystemAssistantViewController",
+            "UISystemKeyboardDockController",
+            "UIEditingOverlayViewController",
+            "UIInputWindowContoller",
+            "PrewarmingViewController",
+            "UIInputViewController",
+            "UICompactibilityInputViewController",
+            "UICompactibilityInputViewController",
+            "UIPredictionViewController",
+            "_UICursorAccessoryViewController",
+            "UIMultiscriptCandidateViewController"
         ]
 
         guard !excludedClassNames.contains(where: { className.contains($0) }) else { return }


### PR DESCRIPTION
# Description

Adds some new internal view controllers to be ignored from reporting. This helps us to keep journey graphs reflect what developers would expect.

## Related issue
References: #2456



