### PR TITLE
chore(ios): add lifecycleViewControllerExcludeList to internal config

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
@@ -33,6 +33,10 @@ final class BaseConfigProvider: ConfigProvider {
         self.cachedConfig = configLoader.getCachedConfig()
     }
 
+    var lifecycleViewControllerExcludeList: [String] {
+        return getMergedConfig(\.lifecycleViewControllerExcludeList)
+    }
+
     var disallowedCustomHeaders: [String] {
         return getMergedConfig(\.disallowedCustomHeaders)
     }

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -57,6 +57,7 @@ struct Config: InternalConfig, MeasureConfig {
     let screenshotMaskLevel: ScreenshotMaskLevel
     let requestHeadersProvider: MsrRequestHeadersProvider?
     let disallowedCustomHeaders: [String]
+    let lifecycleViewControllerExcludeList: [String]
 
     internal init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
                   samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
@@ -122,5 +123,23 @@ struct Config: InternalConfig, MeasureConfig {
         self.accelerometerUpdateInterval = 0.1
         self.requestHeadersProvider = requestHeadersProvider
         self.disallowedCustomHeaders = DefaultConfig.disallowedCustomHeaders
+        self.lifecycleViewControllerExcludeList = [
+            "UIHostingController",
+            "UIKitNavigationController",
+            "NavigationStackHostingController",
+            "NotifyingMulticolumnSplitViewController",
+            "StyleContextSplitViewController",
+            "UISystemAssistantViewController",
+            "UISystemKeyboardDockController",
+            "UIEditingOverlayViewController",
+            "UIInputWindowContoller",
+            "PrewarmingViewController",
+            "UIInputViewController",
+            "UICompactibilityInputViewController",
+            "UICompactibilityInputViewController",
+            "UIPredictionViewController",
+            "_UICursorAccessoryViewController",
+            "UIMultiscriptCandidateViewController"
+        ]
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
@@ -98,4 +98,7 @@ protocol InternalConfig {
 
     /// List of custom headers that should not be included.
     var disallowedCustomHeaders: [String] { get }
+
+    /// List of ViewController names that should not be tracked by LifecycleCollector
+    var lifecycleViewControllerExcludeList: [String] { get }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
@@ -213,7 +213,7 @@ protocol MeasureConfig {
             debugPrint("Trace sampling rate must be between 0.0 and 1.0")
         }
     }
-    
+
     /// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
     /// - Parameters:
     ///   - enableLogging: Enable or disable internal SDK logs. Defaults to `false`.

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
@@ -71,27 +71,7 @@ final class BaseLifecycleCollector: LifecycleCollector {
 
         let className = String(describing: type(of: viewController))
 
-        // Filter out internal UIKit controllers we don't want to trace
-        let excludedClassNames = [
-            "UIHostingController",
-            "UIKitNavigationController",
-            "NavigationStackHostingController",
-            "NotifyingMulticolumnSplitViewController",
-            "StyleContextSplitViewController",
-            "UISystemAssistantViewController",
-            "UISystemKeyboardDockController",
-            "UIEditingOverlayViewController",
-            "UIInputWindowContoller",
-            "PrewarmingViewController",
-            "UIInputViewController",
-            "UICompactibilityInputViewController",
-            "UICompactibilityInputViewController",
-            "UIPredictionViewController",
-            "_UICursorAccessoryViewController",
-            "UIMultiscriptCandidateViewController"
-        ]
-
-        guard !excludedClassNames.contains(where: { className.contains($0) }) else { return }
+        guard !configProvider.lifecycleViewControllerExcludeList.contains(where: { className.contains($0) }) else { return }
 
         trackEvent(VCLifecycleData(type: vcLifecycleType.stringValue, className: className), type: .lifecycleViewController)
 


### PR DESCRIPTION
# Description

Add lifecycleViewControllerExcludeList to internal config, which will contain a list of ViewController names that should not be tracked by LifecycleCollector.

## Related issue
Closes #2467 