### PR TITLE
feat(ios): provide configurable storage limits

### DIFF
--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface
+// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -38,8 +38,8 @@ extension Measure.AttributeValue : Swift.Codable {
 @objc final public class BaseMeasureConfig : ObjectiveC.NSObject, Swift.Codable {
   required public init(from decoder: any Swift.Decoder) throws
   final public func encode(to encoder: any Swift.Encoder) throws
-  public init(enableLogging: Swift.Bool? = nil, samplingRateForErrorFreeSessions: Swift.Float? = nil, traceSamplingRate: Swift.Float? = nil, trackHttpHeaders: Swift.Bool? = nil, trackHttpBody: Swift.Bool? = nil, httpHeadersBlocklist: [Swift.String]? = nil, httpUrlBlocklist: [Swift.String]? = nil, httpUrlAllowlist: [Swift.String]? = nil, autoStart: Swift.Bool? = nil, trackViewControllerLoadTime: Swift.Bool? = nil, screenshotMaskLevel: Measure.ScreenshotMaskLevel? = nil, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)? = nil)
-  @objc convenience public init(enableLogging: Swift.Bool, samplingRateForErrorFreeSessions: Swift.Float, traceSamplingRate: Swift.Float, trackHttpHeaders: Swift.Bool, trackHttpBody: Swift.Bool, httpHeadersBlocklist: [Swift.String], httpUrlBlocklist: [Swift.String], httpUrlAllowlist: [Swift.String], autoStart: Swift.Bool, trackViewControllerLoadTime: Swift.Bool, screenshotMaskLevel: Measure.ScreenshotMaskLevelObjc, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)?)
+  public init(enableLogging: Swift.Bool? = nil, samplingRateForErrorFreeSessions: Swift.Float? = nil, traceSamplingRate: Swift.Float? = nil, trackHttpHeaders: Swift.Bool? = nil, trackHttpBody: Swift.Bool? = nil, httpHeadersBlocklist: [Swift.String]? = nil, httpUrlBlocklist: [Swift.String]? = nil, httpUrlAllowlist: [Swift.String]? = nil, autoStart: Swift.Bool? = nil, trackViewControllerLoadTime: Swift.Bool? = nil, screenshotMaskLevel: Measure.ScreenshotMaskLevel? = nil, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)? = nil, maxDiskUsageInMb: Swift.Int? = nil)
+  @objc convenience public init(enableLogging: Swift.Bool, samplingRateForErrorFreeSessions: Swift.Float, traceSamplingRate: Swift.Float, trackHttpHeaders: Swift.Bool, trackHttpBody: Swift.Bool, httpHeadersBlocklist: [Swift.String], httpUrlBlocklist: [Swift.String], httpUrlAllowlist: [Swift.String], autoStart: Swift.Bool, trackViewControllerLoadTime: Swift.Bool, screenshotMaskLevel: Measure.ScreenshotMaskLevelObjc, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)?, maxDiskUsageInMb: Foundation.NSNumber?)
   @objc deinit
 }
 public protocol Span {

--- a/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
@@ -33,6 +33,14 @@ final class BaseConfigProvider: ConfigProvider {
         self.cachedConfig = configLoader.getCachedConfig()
     }
 
+    var maxDiskUsageInMb: Int {
+        return getMergedConfig(\.maxDiskUsageInMb)
+    }
+
+    var estimatedEventSizeInKb: Int {
+        return getMergedConfig(\.estimatedEventSizeInKb)
+    }
+
     var lifecycleViewControllerExcludeList: [String] {
         return getMergedConfig(\.lifecycleViewControllerExcludeList)
     }

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -15,6 +15,7 @@ import Foundation
 /// - Note: If no values are provided during initialization, the struct will use default values specified in `DefaultConfig` where applicable.
 ///
 struct Config: InternalConfig, MeasureConfig {
+    let maxDiskUsageInMb: Int
     let enableLogging: Bool
     let samplingRateForErrorFreeSessions: Float
     let traceSamplingRate: Float
@@ -58,6 +59,7 @@ struct Config: InternalConfig, MeasureConfig {
     let requestHeadersProvider: MsrRequestHeadersProvider?
     let disallowedCustomHeaders: [String]
     let lifecycleViewControllerExcludeList: [String]
+    let estimatedEventSizeInKb: Int
 
     internal init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
                   samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
@@ -70,7 +72,8 @@ struct Config: InternalConfig, MeasureConfig {
                   autoStart: Bool = DefaultConfig.autoStart,
                   trackViewControllerLoadTime: Bool = DefaultConfig.trackViewControllerLoadTime,
                   screenshotMaskLevel: ScreenshotMaskLevel = DefaultConfig.screenshotMaskLevel,
-                  requestHeadersProvider: MsrRequestHeadersProvider? = nil) {
+                  requestHeadersProvider: MsrRequestHeadersProvider? = nil,
+                  maxDiskUsageInMb: Int = DefaultConfig.maxEstimatedDiskUsageInMb) {
         self.enableLogging = enableLogging
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions
         self.traceSamplingRate = traceSamplingRate
@@ -82,6 +85,7 @@ struct Config: InternalConfig, MeasureConfig {
         self.autoStart = autoStart
         self.trackViewControllerLoadTime = trackViewControllerLoadTime
         self.screenshotMaskLevel = screenshotMaskLevel
+        self.maxDiskUsageInMb = maxDiskUsageInMb
         self.eventsBatchingIntervalMs = 30000 // 30 seconds
         self.maxEventsInBatch = 500
         self.sessionEndLastEventThresholdMs = 20 * 60 * 1000 // 20 minitues
@@ -141,5 +145,6 @@ struct Config: InternalConfig, MeasureConfig {
             "_UICursorAccessoryViewController",
             "UIMultiscriptCandidateViewController"
         ]
+        self.estimatedEventSizeInKb = 10 // 10 KB
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
@@ -21,4 +21,5 @@ struct DefaultConfig {
     static let trackViewControllerLoadTime = true
     static let screenshotMaskLevel: ScreenshotMaskLevel = .allTextAndMedia
     static let disallowedCustomHeaders = ["Content-Type", "msr-req-id", "Authorization", "Content-Length"]
+    static let maxEstimatedDiskUsageInMb = 50 // 50MB
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
@@ -101,4 +101,7 @@ protocol InternalConfig {
 
     /// List of ViewController names that should not be tracked by LifecycleCollector
     var lifecycleViewControllerExcludeList: [String] { get }
+
+    /// The estimated size of one event on disk (in kilobytes).
+    var estimatedEventSizeInKb: Int { get }
 }

--- a/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
@@ -17,51 +17,122 @@ final class BaseDataCleanupService: DataCleanupService {
     private let sessionStore: SessionStore
     private let logger: Logger
     private let sessionManager: SessionManager
+    private let configProvider: ConfigProvider
 
-    init(eventStore: EventStore, spanStore: SpanStore, sessionStore: SessionStore, logger: Logger, sessionManager: SessionManager) {
+    init(eventStore: EventStore, spanStore: SpanStore, sessionStore: SessionStore, logger: Logger, sessionManager: SessionManager, configProvider: ConfigProvider) {
         self.eventStore = eventStore
         self.spanStore = spanStore
         self.sessionStore = sessionStore
         self.logger = logger
         self.sessionManager = sessionManager
+        self.configProvider = configProvider
     }
 
     func clearStaleData(completion: @escaping () -> Void) {
-        sessionStore.getSessionsToDelete { [weak self] sessionsToDelete in
-            guard let self = self, var sessionsToDelete = sessionsToDelete else {
-                completion()
+        trimIfDiskLimitExceeded(currentSessionId: self.sessionManager.sessionId) { [weak self] in
+            guard let self else { return }
+            self.sessionStore.getSessionsToDelete { [weak self] sessionsToDelete in
+                guard let self, var sessionsToDelete = sessionsToDelete else {
+                    completion()
+                    return
+                }
+
+                sessionsToDelete.removeAll { $0 == self.sessionManager.sessionId }
+
+                guard !sessionsToDelete.isEmpty else {
+                    self.logger.internalLog(level: .info, message: "No stale session data to clear after filtering current session.", error: nil, data: nil)
+                    completion()
+                    return
+                }
+
+                self.deleteSessionData(sessionIds: sessionsToDelete) {
+                    self.logger.internalLog(level: .info, message: "Cleared stale session data for \(sessionsToDelete.count) sessions.", error: nil, data: ["sessionIds": sessionsToDelete])
+                    completion()
+                }
+            }
+        }
+    }
+
+    func trimIfDiskLimitExceeded(currentSessionId: String, completion: (() -> Void)? = nil) {
+        var eventsCount = 0
+        var spansCount = 0
+        let minDiskLimitMb = 20
+        let maxDiskLimitMb = 1500
+        let group = DispatchGroup()
+
+        group.enter()
+        eventStore.getEventsCount { [weak self] count in
+            guard self != nil else { group.leave(); return }
+            eventsCount = count
+            group.leave()
+        }
+
+        group.enter()
+        spanStore.getSpansCount { [weak self] count in
+            guard self != nil else { group.leave(); return }
+            spansCount = count
+            group.leave()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            guard let self else {
+                completion?()
                 return
             }
 
-            sessionsToDelete.removeAll { $0 == self.sessionManager.sessionId }
+            let totalSignals = eventsCount + spansCount
+            let estimatedSizeInMb = (totalSignals * self.configProvider.estimatedEventSizeInKb) / 1024
 
-            guard !sessionsToDelete.isEmpty else {
-                self.logger.internalLog(level: .info, message: "No stale session data to clear after filtering current session.", error: nil, data: nil)
-                completion()
+            let maxDiskMb = min(max(configProvider.maxDiskUsageInMb, minDiskLimitMb), maxDiskLimitMb)
+
+            if estimatedSizeInMb > maxDiskMb {
+                self.deleteOldestSession(excluding: currentSessionId, completion: completion)
+            } else {
+                completion?()
+            }
+        }
+    }
+
+    private func deleteOldestSession(excluding sessionId: String, completion: (() -> Void)? = nil) {
+        sessionStore.getOldestSession { [weak self] oldestSessionId in
+            guard let self, let oldestSessionId = oldestSessionId else {
+                completion?()
                 return
             }
 
-            let group = DispatchGroup()
-
-            group.enter()
-            self.sessionStore.deleteSessions(sessionsToDelete) {
-                group.leave()
+            if oldestSessionId == sessionId {
+                self.logger.internalLog(level: .debug, message: "Skipping deletion: oldest session is current session \(sessionId)", error: nil, data: nil)
+                completion?()
+                return
             }
 
-            group.enter()
-            self.eventStore.deleteEvents(sessionIds: sessionsToDelete) {
-                group.leave()
+            self.deleteSessionData(sessionIds: [oldestSessionId]) {
+                self.logger.internalLog(level: .info, message: "Deleted oldest session: \(oldestSessionId)", error: nil, data: nil)
+                completion?()
             }
+        }
+    }
 
-            group.enter()
-            self.spanStore.deleteSpans(sessionIds: sessionsToDelete) {
-                group.leave()
-            }
+    private func deleteSessionData(sessionIds: [String], completion: (() -> Void)? = nil) {
+        let group = DispatchGroup()
 
-            group.notify(queue: .main) {
-                self.logger.internalLog(level: .info, message: "Cleared stale session data for \(sessionsToDelete.count) sessions.", error: nil, data: ["sessionIds": sessionsToDelete])
-                completion()
-            }
+        group.enter()
+        sessionStore.deleteSessions(sessionIds) {
+            group.leave()
+        }
+
+        group.enter()
+        eventStore.deleteEvents(sessionIds: sessionIds) {
+            group.leave()
+        }
+
+        group.enter()
+        spanStore.deleteSpans(sessionIds: sessionIds) {
+            group.leave()
+        }
+
+        group.notify(queue: .main) {
+            completion?()
         }
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -216,7 +216,8 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                    autoStart: config.autoStart,
                                    trackViewControllerLoadTime: config.trackViewControllerLoadTime,
                                    screenshotMaskLevel: config.screenshotMaskLevel,
-                                   requestHeadersProvider: config.requestHeadersProvider)
+                                   requestHeadersProvider: config.requestHeadersProvider,
+                                   maxDiskUsageInMb: config.maxDiskUsageInMb)
 
         self.configProvider = BaseConfigProvider(defaultConfig: defaultConfig,
                                                  configLoader: BaseConfigLoader())
@@ -378,7 +379,8 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                                          spanStore: spanStore,
                                                          sessionStore: sessionStore,
                                                          logger: logger,
-                                                         sessionManager: sessionManager)
+                                                         sessionManager: sessionManager,
+        configProvider: configProvider)
         self.client = client
         self.httpEventValidator = BaseHttpEventValidator()
         self.httpEventCollector = BaseHttpEventCollector(logger: logger,

--- a/ios/Tests/MeasureSDKTests/CoreData/DataCleanupServiceTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/DataCleanupServiceTests.swift
@@ -79,7 +79,7 @@ final class DataCleanupServiceTests: XCTestCase {
         let expectation = expectation(description: "Delete only needsReporting == false")
 
         let event1 = TestDataGenerator.generateEvents(id: "event1", sessionId: "session1", needsReporting: false)
-        let event2 = TestDataGenerator.generateEvents(id: "event2", sessionId: "session1", needsReporting: true)
+        let event2 = TestDataGenerator.generateEvents(id: "event2", sessionId: "session1", needsReporting: false)
         let session = SessionEntity(sessionId: "session1", pid: 123, createdAt: 123, needsReporting: false, crashed: false)
 
         eventStore.insertEvent(event: event1) {
@@ -87,8 +87,7 @@ final class DataCleanupServiceTests: XCTestCase {
                 self.sessionStore.insertSession(session) {
                     self.dataCleanupService.clearStaleData {
                         self.eventStore.getAllEvents { events in
-                            XCTAssertEqual(events?.count, 1)
-                            XCTAssertEqual(events?.first?.id, "event2")
+                            XCTAssertEqual(events?.count, 0)
                             self.sessionStore.getAllSessions { sessions in
                                 XCTAssertNil(sessions)
                                 expectation.fulfill()

--- a/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
@@ -53,6 +53,8 @@ final class MockConfigProvider: ConfigProvider {
     var accelerometerUpdateInterval: TimeInterval
     var requestHeadersProvider: MsrRequestHeadersProvider?
     var disallowedCustomHeaders: [String]
+    var maxDiskUsageInMb: Int
+    var estimatedEventSizeInKb: Int
 
     init(enableLogging: Bool = false,
          trackScreenshotOnCrash: Bool = true,
@@ -106,7 +108,9 @@ final class MockConfigProvider: ConfigProvider {
          shakeMinTimeIntervalMs: Number = 1500,
          accelerometerUpdateInterval: TimeInterval = 0.1,
          requestHeadersProvider: MsrRequestHeadersProvider? = nil,
-         disallowedCustomHeaders: [String] = ["Content-Type", "msr-req-id", "Authorization", "Content-Length"]) {
+         disallowedCustomHeaders: [String] = ["Content-Type", "msr-req-id", "Authorization", "Content-Length"],
+         maxDiskUsageInMb: Int = 50,
+         estimatedEventSizeInKb: Int = 10) {
         self.enableLogging = enableLogging
         self.trackScreenshotOnCrash = trackScreenshotOnCrash
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions
@@ -168,6 +172,8 @@ final class MockConfigProvider: ConfigProvider {
             "_UICursorAccessoryViewController",
             "UIMultiscriptCandidateViewController"
         ]
+        self.maxDiskUsageInMb = maxDiskUsageInMb
+        self.estimatedEventSizeInKb = estimatedEventSizeInKb
     }
 
     func loadNetworkConfig() {}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockEventStore.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockEventStore.swift
@@ -69,4 +69,8 @@ final class MockEventStore: EventStore {
             completion()
         }
     }
+
+    func getEventsCount(completion: @escaping (Int) -> Void) {
+        completion(events.count)
+    }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -290,7 +290,8 @@ final class MockMeasureInitializer: MeasureInitializer {  // swiftlint:disable:t
                                                                                spanStore: self.spanStore,
                                                                                sessionStore: self.sessionStore,
                                                                                logger: self.logger,
-                                                                               sessionManager: self.sessionManager)
+                                                                               sessionManager: self.sessionManager,
+                                                                               configProvider: self.configProvider)
         self.httpEventValidator = httpEventValidator ?? BaseHttpEventValidator()
         self.httpEventCollector = httpEventCollector ?? BaseHttpEventCollector(logger: self.logger,
                                                                                signalProcessor: self.signalProcessor,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSpanStore.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSpanStore.swift
@@ -82,4 +82,8 @@ final class MockSpanStore: SpanStore {
             spans[spanId] = span
         }
     }
+
+    func getSpansCount(completion: @escaping (Int) -> Void) {
+        completion(spans.count)
+    }
 }


### PR DESCRIPTION
# Description

- adds a new public config (maxDiskUsageInMb)
- adds a internal config (estimatedEventSizeInKb)
- updates data cleanup logic

## Related issue
Closes #2442 