### PR TITLE
fix(android): use correct timestamp for launch metric calculation

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -183,7 +183,7 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                 if (callbacks != null) {
                     callbacks?.onColdLaunch(
                         coldLaunchData = coldLaunchData,
-                        coldLaunchTime = System.currentTimeMillis(),
+                        coldLaunchTime = SystemClock.elapsedRealtime(),
                     )
                 } else {
                     this@LaunchTracker.coldLaunchData = coldLaunchData
@@ -216,7 +216,7 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                     is_lukewarm = false,
                 )
                 if (callbacks != null) {
-                    callbacks?.onWarmLaunch(warmLaunchData, System.currentTimeMillis())
+                    callbacks?.onWarmLaunch(warmLaunchData, SystemClock.elapsedRealtime())
                 } else {
                     this@LaunchTracker.warmLaunchData = warmLaunchData
                 }
@@ -235,7 +235,7 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                     is_lukewarm = true,
                 )
                 if (callbacks != null) {
-                    callbacks?.onWarmLaunch(warmLaunchData, System.currentTimeMillis())
+                    callbacks?.onWarmLaunch(warmLaunchData, SystemClock.elapsedRealtime())
                 } else {
                     this@LaunchTracker.warmLaunchData = warmLaunchData
                 }


### PR DESCRIPTION
# Description

Use `System.currentTimeMillis()` instead of `SystemClock.elapsedRealtime()`. This causes the different clock times to be compared for launch metrics calculation.

This issue started occurring since: https://github.com/measure-sh/measure/pull/2386 (released in `android-v0.11.0`).
This fix is planned for release in `android-v0.11.1`.

## How to prevent this in future
- We almost never want to use `System.currentTimeMillis()`, adding a detekt rule would help: #2474 

## Related issue
Fixes #2472 