### PR TITLE
docs: document attribute key restrictions

### DIFF
--- a/docs/features/feature-custom-events.md
+++ b/docs/features/feature-custom-events.md
@@ -57,6 +57,7 @@ A custom event can also contain attributes, which are key-value pairs.
 
 > [!NOTE]
 > - Attribute keys must be strings with a maximum length of `256` characters.
+> - Attribute keys must only contain alphabets, numbers, hyphens and underscores.
 > - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
 > - String attribute values can have a maximum length of `256` characters.
 

--- a/docs/features/feature-performance-tracing.md
+++ b/docs/features/feature-performance-tracing.md
@@ -318,6 +318,12 @@ final childSpan = Measure.instance.startSpan("child-span").setParent(parentSpan)
 
 Attributes are key-value pairs that can be attached to a span. Attributes are used to add additional context to a span.
 
+> [!NOTE]
+> - Attribute keys must be strings with a maximum length of `256` characters.
+> - Attribute keys must only contain alphabets, numbers, hyphens and underscores.
+> - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+> - String attribute values can have a maximum length of `256` characters.
+
 To add attributes to a span, use `setAttribute`.
 
 <details>


### PR DESCRIPTION
## Summary

This PR updates user facing documentation to create awareness about character restrictions when choosing user defined attribute keys.

## Tasks

- [x] Update note with character validation restrictions when setting user defined attribute keys in Custom Events feature
- [x] Add note with character validation restrictions when setting user defined attribute keys in Performance Tracing feature

## See also

- fixes #2478