### PR TITLE
fix(gradle): close okhttp response object after use

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -120,8 +120,10 @@ abstract class BuildUploadTask : DefaultTask() {
         val request: Request = getRequest(url, manifestData, requestBody)
         try {
             val response = client.newCall(request).execute()
-            if (!response.isSuccessful) {
-                logError(response)
+            response.use {
+                if (!response.isSuccessful) {
+                    logError(response)
+                }
             }
         } catch (e: IOException) {
             logger.error("[ERROR]: Failed to upload mapping file to Measure, ${e.message}")


### PR DESCRIPTION
# Description

Properly close the response body after use to avoid leak.

## Related issue
Fixes #2469 