### PR TITLE
fix(android): resolve instrumentation failure with BOM dependencies

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/DependencyUtils.kt
@@ -1,9 +1,11 @@
 package sh.measure
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.MapProperty
 import sh.measure.asm.ModuleInfo
 
@@ -34,11 +36,25 @@ fun ResolvedComponentResult.versionsMap(project: Project): MapProperty<ModuleInf
     dependencies.forEach { dependency: DependencyResult ->
         when (val requested = dependency.requested) {
             is ModuleComponentSelector -> {
-                val version = try {
+                // Try requested version first (direct dependencies)
+                var version = try {
                     SemVer.parse(requested.version)
                 } catch (e: IllegalArgumentException) {
                     SemVer()
                 }
+
+                // If requested version is empty/invalid, try resolved version (BOM case)
+                if (version == SemVer() && dependency is ResolvedDependencyResult) {
+                    val selected = dependency.selected
+                    if (selected.id is ModuleComponentIdentifier) {
+                        version = try {
+                            SemVer.parse((selected.id as ModuleComponentIdentifier).version)
+                        } catch (e: IllegalArgumentException) {
+                            SemVer()
+                        }
+                    }
+                }
+
                 versionsMap.put(
                     ModuleInfo(requested.group, requested.module),
                     version,

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/NavigationTransformer.kt
@@ -36,6 +36,9 @@ abstract class NavigationVisitorFactory :
     }
 
     override fun createClassVisitor(nextClassVisitor: ClassVisitor): ClassVisitor {
+        val versions = parameters.get().versions.get().get()
+        val navigationVersion = versions[ModuleInfo("androidx.navigation", "navigation-compose")]
+        println("[Measure] Navigation transformer creating visitor (navigation-compose version: $navigationVersion)")
         return NavigationClassVisitor(nextClassVisitor)
     }
 

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/OkHttpTransformer.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/OkHttpTransformer.kt
@@ -36,6 +36,9 @@ abstract class OkHttpVisitorFactory :
     }
 
     override fun createClassVisitor(nextClassVisitor: ClassVisitor): ClassVisitor {
+        val versions = parameters.get().versions.get().get()
+        val okHttpVersion = versions[ModuleInfo("com.squareup.okhttp3", "okhttp")]
+        println("[Measure] OkHttp transformer creating visitor (okhttp3 version: $okHttpVersion)")
         return OkHttpClassVisitor(nextClassVisitor)
     }
 

--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/VersionAwareVisitor.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/asm/VersionAwareVisitor.kt
@@ -28,6 +28,7 @@ interface VersionAwareVisitor<T : TransformerParameters> : AsmClassVisitorFactor
         return if (isVersionCompatible(versions, minVersion, maxVersion)) {
             createClassVisitor(nextClassVisitor)
         } else {
+            println("[Measure] ASM instrumentation skipped for ${classContext.currentClassData.className} - version compatibility check failed")
             nextClassVisitor
         }
     }


### PR DESCRIPTION
# Description

Fixes ASM transformation not being applied to dependencies managed by Bill of Materials (BOM). Previously, version parsing for BOM-managed dependencies always resulted in null, causing version compatibility checks to fail and preventing instrumentation.

The issue occurred because the version resolution logic only checked the requested version from direct dependencies. For BOM-managed dependencies declared without explicit versions, the requested version is empty and the actual version is determined during dependency resolution. Updated the parsing to fall back to the resolved component version when the requested version is unavailable.

Also adds some logs to make it easier to debug such issues in future.

## Related issue
Fixes #2512 