### PR TITLE
chore(android): centralize user defined attributes validation

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/events/CustomEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/CustomEventCollector.kt
@@ -1,7 +1,6 @@
 package sh.measure.android.events
 
 import sh.measure.android.attributes.AttributeValue
-import sh.measure.android.attributes.StringAttr
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
@@ -32,9 +31,7 @@ internal class CustomEventCollector(
         if (!validateName(name)) {
             return
         }
-        if (!validateAttributes(name, attributes)) {
-            return
-        }
+
         val data = CustomEventData(name)
         signalProcessor.track(
             timestamp = timestamp ?: timeProvider.now(),
@@ -68,44 +65,5 @@ internal class CustomEventCollector(
         }
 
         return true
-    }
-
-    private fun validateAttributes(name: String, attributes: Map<String, AttributeValue>): Boolean {
-        if (attributes.size > configProvider.maxUserDefinedAttributesPerEvent) {
-            logger.log(
-                LogLevel.Error,
-                "Invalid event($name): exceeds maximum of ${configProvider.maxUserDefinedAttributesPerEvent} attributes",
-            )
-            return false
-        }
-
-        return attributes.all { (key, value) ->
-            val isKeyValid = isKeyValid(key)
-            val isValueValid = isValueValid(value)
-            if (!isKeyValid) {
-                logger.log(
-                    LogLevel.Error,
-                    "Invalid event($name): invalid attribute key: $key",
-                )
-            }
-            if (!isValueValid) {
-                logger.log(
-                    LogLevel.Error,
-                    "Invalid event($name): invalid attribute value: $value",
-                )
-            }
-            isKeyValid && isValueValid
-        }
-    }
-
-    private fun isKeyValid(key: String): Boolean {
-        return key.length <= configProvider.maxUserDefinedAttributeKeyLength
-    }
-
-    private fun isValueValid(value: AttributeValue): Boolean {
-        return when (value) {
-            is StringAttr -> value.value.length <= configProvider.maxUserDefinedAttributeValueLength
-            else -> true
-        }
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -5,6 +5,7 @@ import sh.measure.android.appexit.AppExit
 import sh.measure.android.attributes.Attribute
 import sh.measure.android.attributes.AttributeProcessor
 import sh.measure.android.attributes.AttributeValue
+import sh.measure.android.attributes.StringAttr
 import sh.measure.android.attributes.appendAttributes
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.exceptions.ExceptionData
@@ -152,7 +153,7 @@ internal class SignalProcessorImpl(
                             userTriggered = userTriggered,
                             userDefinedAttributes = userDefinedAttributes,
                             sessionId = sessionId,
-                        )
+                        ) ?: return@trace
                         applyAttributes(attributes, event, resolvedThreadName)
                         InternalTrace.trace(label = { "msr-store-event" }, block = {
                             signalStore.store(event)
@@ -194,7 +195,7 @@ internal class SignalProcessorImpl(
                     userTriggered = false,
                     userDefinedAttributes = mutableMapOf(),
                     sessionId = sessionId,
-                )
+                ) ?: return@trace
                 applyAttributes(attributes, event, threadName)
                 event.updateVersionAttribute(appVersion, appBuild)
                 InternalTrace.trace(label = { "msr-store-event" }, block = {
@@ -223,7 +224,7 @@ internal class SignalProcessorImpl(
             attributes = attributes,
             userTriggered = false,
             userDefinedAttributes = userDefinedAttributes,
-        )
+        ) ?: return
         if (configProvider.trackScreenshotOnCrash && takeScreenshot) {
             addScreenshotAsAttachment(event)
         }
@@ -261,7 +262,10 @@ internal class SignalProcessorImpl(
         userDefinedAttributes: Map<String, AttributeValue> = mutableMapOf(),
         userTriggered: Boolean,
         sessionId: String? = null,
-    ): Event<T> {
+    ): Event<T>? {
+        if (!validateUserDefinedAttributes(type.value, userDefinedAttributes)) {
+            return null
+        }
         val id = idProvider.uuid()
         val resolvedSessionId = sessionId ?: sessionManager.getSessionId()
         return Event(
@@ -316,6 +320,45 @@ internal class SignalProcessorImpl(
         }
         if (appBuild != null) {
             attributes[Attribute.APP_BUILD_KEY] = appBuild
+        }
+    }
+
+    private fun validateUserDefinedAttributes(event: String, attributes: Map<String, AttributeValue>): Boolean {
+        if (attributes.size > configProvider.maxUserDefinedAttributesPerEvent) {
+            logger.log(
+                LogLevel.Error,
+                "Invalid event($event): exceeds maximum of ${configProvider.maxUserDefinedAttributesPerEvent} attributes",
+            )
+            return false
+        }
+
+        return attributes.all { (key, value) ->
+            val isKeyValid = isKeyValid(key)
+            val isValueValid = isValueValid(value)
+            if (!isKeyValid) {
+                logger.log(
+                    LogLevel.Error,
+                    "Invalid event($event): invalid attribute key: $key",
+                )
+            }
+            if (!isValueValid) {
+                logger.log(
+                    LogLevel.Error,
+                    "Invalid event($event): invalid attribute value: $value",
+                )
+            }
+            isKeyValid && isValueValid
+        }
+    }
+
+    private fun isKeyValid(key: String): Boolean {
+        return key.length <= configProvider.maxUserDefinedAttributeKeyLength
+    }
+
+    private fun isValueValid(value: AttributeValue): Boolean {
+        return when (value) {
+            is StringAttr -> value.value.length <= configProvider.maxUserDefinedAttributeValueLength
+            else -> true
         }
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/events/CustomEventCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/events/CustomEventCollectorTest.kt
@@ -95,32 +95,6 @@ class CustomEventCollectorTest {
     }
 
     @Test
-    fun `trackEvent should drop event when attributes exceed maximum count`() {
-        val attributes = (0..configProvider.maxUserDefinedAttributesPerEvent).associate {
-            "key$it" to StringAttr("value")
-        }
-        collector.trackEvent("validEvent", attributes, null)
-        verifyNoInteractions(signalProcessor)
-    }
-
-    @Test
-    fun `trackEvent should drop event when attribute key exceeds maximum length`() {
-        val longKey = "k".repeat(configProvider.maxUserDefinedAttributeKeyLength + 1)
-        val attributes = mapOf(longKey to StringAttr("value"))
-        collector.trackEvent("event", attributes, null)
-        verifyNoInteractions(signalProcessor)
-    }
-
-    @Test
-    fun `trackEvent should drop event when string attribute value exceeds maximum length`() {
-        val invalidAttributeValue =
-            "v".repeat(configProvider.maxUserDefinedAttributeValueLength + 1)
-        val attributes = mapOf("key" to StringAttr(invalidAttributeValue))
-        collector.trackEvent("event", attributes, null)
-        verifyNoInteractions(signalProcessor)
-    }
-
-    @Test
     fun `trackEvent should process event with non-string attribute values without length validation`() {
         val attributes = mapOf(
             "key1" to IntAttr(123),


### PR DESCRIPTION
# Description

We have multiple track methods in the public API
which can have user defined attributes, however,
the validation is not added in all cases.

This PR centralizes the validation by adding it to SignalProcessor.

## Related issue
Closes #2519 


