### PR TITLE
fix(frontend): update span display to accomodate large values

### DIFF
--- a/frontend/dashboard/app/components/trace_viz.tsx
+++ b/frontend/dashboard/app/components/trace_viz.tsx
@@ -327,32 +327,24 @@ const TraceViz: React.FC<TraceVizProps> = ({ inputTrace }) => {
         {/* spans column */}
         <div className='flex flex-col w-[800px] overflow-x-auto select-none'>
 
-          {/* timing indicator */}
+          {/* timing indicator - values */}
+          <div className='w-full flex flex-row justify-between px-[8px] pt-[8px]'>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(0)}</p>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(trace.duration * 0.2)}</p>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(trace.duration * 0.4)}</p>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(trace.duration * 0.6)}</p>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(trace.duration * 0.8)}</p>
+            <p className='text-[10px] max-w-1/6 truncate'>{formatMillisToHumanReadable(trace.duration)}</p>
+          </div>
+
+          {/* timing indicator - markers */}
           <div className='w-full flex flex-row justify-between p-[8px]'>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>0ms</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>{(trace.duration * 0.2 / 1000).toPrecision(2)}s</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>{(trace.duration * 0.4 / 1000).toPrecision(2)}s</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>{(trace.duration * 0.6 / 1000).toPrecision(2)}s</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>{(trace.duration * 0.8 / 1000).toPrecision(2)}s</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
-            <div className='flex flex-col items-start'>
-              <p className='text-[10px]'>{(trace.duration / 1000).toPrecision(2)}s</p>
-              <div className='w-[0.5px] h-2 bg-neutral-950' />
-            </div>
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
+            <div className='w-[0.5px] h-2 bg-neutral-950' />
           </div>
 
           {trace.spans.filter((span) => span.visibility !== SpanVisibility.Hidden).map((span, spanIndex) => (
@@ -364,7 +356,7 @@ const TraceViz: React.FC<TraceVizProps> = ({ inputTrace }) => {
                   style={{
                     marginLeft: `${span.leftOffset}px`,
                   }}>
-                  {span.duration}ms
+                  {formatMillisToHumanReadable(span.duration)}
                 </p>
 
                 {/* span */}


### PR DESCRIPTION
# Description

Larger span values get displayed as exponents and become hard to read. This commit:
- Splits time value and time marker divs so markers are not shifted by time values being larger or smaller
- Shows time and span values in human readable format instead of just milliseconds and seconds

<img width="808" height="326" alt="Screenshot 2025-08-12 at 3 25 06 PM" src="https://github.com/user-attachments/assets/cee47258-65ea-4a50-b093-09c207750cf2" />

<img width="1099" height="324" alt="Screenshot 2025-08-12 at 3 29 51 PM" src="https://github.com/user-attachments/assets/ccf0f1ce-83f1-4680-bad0-ff07bdfb758a" />

## Related issue
Fixes #2511



