### PR TITLE
fix(ios): prepare crash file if crash data is cleared

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataPersistence.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataPersistence.swift
@@ -72,6 +72,7 @@ final class BaseCrashDataPersistence: CrashDataPersistence {
                 let fileDescriptor = open(crashFilePath.path, O_WRONLY | O_TRUNC)
                 if fileDescriptor != -1 {
                     close(fileDescriptor)
+                    prepareCrashFile()
                     logger.internalLog(level: .info, message: "Crash data file cleared at \(crashFilePath.path)", error: nil, data: nil)
                 } else {
                     logger.internalLog(level: .error, message: "Failed to open crash log file for truncation at \(crashFilePath.path)", error: nil, data: nil)


### PR DESCRIPTION
# Description

To attach attributes to crashes, we currently have a open file to which we write the last generated attributes as json string when the crash occurs. When the app is opened the next time, we read this data and clear the file contents. This clearing of crash data leads to the file getting closed. Given that the file is now closed, if any crash happens in the subsequent session, the attributes will not be saved.

This PR fixes that issue by opening the file again once the crash data is cleared.

## Related issue
Fixes #2531 