### PR TITLE
ci: add workflow to publish android snapshots to maven

### DIFF
--- a/.github/workflows/android-snapshots.yml
+++ b/.github/workflows/android-snapshots.yml
@@ -1,0 +1,61 @@
+name: Publish Android SDK Snapshots
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'android/**'
+
+env:
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: 'temurin'
+
+jobs:
+  publish-snapshots:
+    name: Publish Android SDK Snapshots
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          fetch-depth: 1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: 'gradle'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Check if version is snapshot
+        id: check-snapshot
+        run: |
+          version=$(grep "MEASURE_VERSION_NAME=" gradle.properties | cut -d'=' -f2)
+          if [[ "$version" == *"-SNAPSHOT" ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_OUTPUT
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Version $version is not a snapshot, skipping publish"
+          fi
+
+      - name: Publish snapshot to Central Portal
+        if: steps.check-snapshot.outputs.is_snapshot == 'true'
+        run: ./gradlew clean :measure:publishToMavenCentral --no-daemon --no-parallel --no-configuration-cache --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
+          # Signing is optional for snapshots, but we'll include it for consistency
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_ARTIFACT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_ARTIFACT_SIGNING_PASSWORD }}


### PR DESCRIPTION
# Description

Adds a workflow to publish SNAPSHOT versions of Android SDK to maven central snapshot repository.

## Related issue
References #2530 


