### PR TITLE
fix(ios): remove deprecated UIWebView usage

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
@@ -135,7 +135,6 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
                 UITextField.self,
                 UIImageView.self,
                 WKWebView.self,
-                UIWebView.self,
                 AVPlayerViewController().view.classForCoder
             ].compactMap { $0 as? UIView.Type }
 


### PR DESCRIPTION
# Description

Remove deprecated UIWebView API usage to fix inability to publish iOS app to apple.

## Related issue
Fixes #2536

