### PR TITLE
fix(android): discard span with empty name

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/tracing/SpanProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/tracing/SpanProcessor.kt
@@ -56,6 +56,15 @@ internal class MsrSpanProcessor(
             return false
         }
 
+        // discard span if it is empty
+        if (name.isBlank()) {
+            logger.log(
+                LogLevel.Error,
+                "Span name is does not contain any characters, span will be dropped",
+            )
+            return false
+        }
+
         // discard span if it exceeds max span name length
         if (name.length > configProvider.maxSpanNameLength) {
             logger.log(

--- a/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanProcessorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/tracing/MsrSpanProcessorTest.kt
@@ -73,6 +73,26 @@ class MsrSpanProcessorTest {
     }
 
     @Test
+    fun `discards span if name is empty`() {
+        val spanProcessor = MsrSpanProcessor(logger, signalProcessor, emptyList(), configProvider)
+        TestData.getSpan(
+            logger = logger,
+            timeProvider = timeProvider,
+            spanProcessor = spanProcessor,
+            name = "",
+        ).end()
+
+        TestData.getSpan(
+            logger = logger,
+            timeProvider = timeProvider,
+            spanProcessor = spanProcessor,
+            name = "    ",
+        ).end()
+
+        verify(signalProcessor, never()).trackSpan(any())
+    }
+
+    @Test
     fun `discards span if it exceeds max length`() {
         val spanProcessor = MsrSpanProcessor(logger, signalProcessor, emptyList(), configProvider)
         TestData.getSpan(


### PR DESCRIPTION
# Description

Discards invalid spans created with empty name and logs an error.

## Related issue
Fixes #2526 