### PR TITLE
fix(gradle): prevent authorization header from getting filtered

### DIFF
--- a/android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/android/measure-android-gradle/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -23,7 +23,7 @@ import java.io.IOException
 import java.net.URI
 import java.net.URL
 
-private const val HEADER_AUTHORIZATION = "Authorization"
+internal const val HEADER_AUTHORIZATION = "Authorization"
 private const val VERSION_CODE = "version_code"
 private const val APP_UNIQUE_ID = "app_unique_id"
 private const val VERSION_NAME = "version_name"
@@ -135,8 +135,8 @@ abstract class BuildUploadTask : DefaultTask() {
         url: URL, manifestData: ManifestData, requestBody: RequestBody
     ): Request {
         val requestBuilder = Request.Builder()
-        requestBuilder.url(url).header(HEADER_AUTHORIZATION, "Bearer ${manifestData.apiKey}")
         requestBuilder.headers(sanitizedCustomHeaders())
+        requestBuilder.url(url).header(HEADER_AUTHORIZATION, "Bearer ${manifestData.apiKey}")
         requestBuilder.put(requestBody)
         return requestBuilder.build()
     }

--- a/android/measure-android-gradle/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
+++ b/android/measure-android-gradle/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
@@ -10,6 +10,7 @@ import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -73,7 +74,7 @@ class BuildUploadTaskTest {
     }
 
     @Test
-    fun `BuildUploadTaskTest sends request to upload mapping file`() {
+    fun `sends request to upload mapping file`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
         task.upload()
         val recordedRequest = mockWebServer.takeRequest()
@@ -104,7 +105,7 @@ class BuildUploadTaskTest {
     }
     
     @Test
-    fun `BuildUploadTaskTest sends request with Flutter symbols when available`() {
+    fun `sends request with Flutter symbols when available`() {
         // Create a Flutter symbols file in the Flutter symbols directory
         val flutterSymbolsDir = temporaryFolder.root.resolve("flutter_symbols")
         val symbolsFile = File(flutterSymbolsDir, "app.android-arm64.symbols")
@@ -127,6 +128,34 @@ class BuildUploadTaskTest {
         assertTrue(requestBody.contains("flutter symbols data"))
     }
 
+    @Test
+    fun `sends request with API_KEY in the header`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val requestHeaders = recordedRequest.headers
+        assertTrue(requestHeaders.names().contains(HEADER_AUTHORIZATION))
+        assertTrue(requestHeaders.values(HEADER_AUTHORIZATION).contains("Bearer msrsh_123"))
+    }
+
+    @Test
+    fun `sends request with custom headers`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val requestHeaders = recordedRequest.headers
+        assertTrue(requestHeaders.names().containsAll(allowedCustomHeaders))
+    }
+
+    @Test
+    fun `disallowed custom headers are filtered`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val requestHeaders = recordedRequest.headers
+        assertFalse(requestHeaders.names().contains("msr-req-id"))
+    }
+
     private val appSize = """
         123765
         aab
@@ -134,7 +163,7 @@ class BuildUploadTaskTest {
 
     private fun manifestData(url: String): String {
         return """
-            {"apiKey":"api-key","apiUrl":"$url","versionCode":"7575527","appUniqueId":"sh.measure.sample","versionName":"1.23.12"}
+            {"apiKey":"msrsh_123","apiUrl":"$url","versionCode":"7575527","appUniqueId":"sh.measure.sample","versionName":"1.23.12"}
         """.trimIndent()
     }
 }


### PR DESCRIPTION
# Description

Fixes invalid api-key error for `/builds` API. The _Authorization_ header was getting filtered after this PR: #2343 was merged.

## Related issue
Fixes #2548 
