### PR TITLE
fix(android): take persistable permission for uris

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
@@ -45,7 +45,7 @@ internal class UnhandledExceptionCollector(
                 ),
                 timestamp = timeProvider.now(),
                 type = EventType.EXCEPTION,
-                takeScreenshot = false,
+                takeScreenshot = true,
             )
         } catch (e: Throwable) {
             // Prevent an infinite loop of exceptions if the above code fails.

--- a/android/measure/src/test/java/sh/measure/android/exceptions/UnhandledExceptionCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exceptions/UnhandledExceptionCollectorTest.kt
@@ -68,7 +68,7 @@ internal class UnhandledExceptionCollectorTest {
             userDefinedAttributes = eq(mutableMapOf()),
             attachments = eq(mutableListOf()),
             threadName = eq(null),
-            takeScreenshot = eq(false),
+            takeScreenshot = eq(true),
         )
     }
 


### PR DESCRIPTION
# Description

Without peristable permission, images being selected using multi-select API were not being tracked.

- Ensure media picker URIs have persistable permission to allow reading the image for storage.
- Fix validation to use both initial screenshot and selected uris.

## Related issue
References #2502 