### PR TITLE
Revert "fix(android): use correct timestamp for launch metric calculation (#2473)

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
+++ b/android/measure/src/main/java/sh/measure/android/applaunch/LaunchTracker.kt
@@ -183,7 +183,7 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                 if (callbacks != null) {
                     callbacks?.onColdLaunch(
                         coldLaunchData = coldLaunchData,
-                        coldLaunchTime = SystemClock.elapsedRealtime(),
+                        coldLaunchTime = System.currentTimeMillis(),
                     )
                 } else {
                     this@LaunchTracker.coldLaunchData = coldLaunchData
@@ -216,7 +216,10 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                     is_lukewarm = false,
                 )
                 if (callbacks != null) {
-                    callbacks?.onWarmLaunch(warmLaunchData, SystemClock.elapsedRealtime())
+                    callbacks?.onWarmLaunch(
+                        warmLaunchData = warmLaunchData,
+                        warmLaunchTime = System.currentTimeMillis(),
+                    )
                 } else {
                     this@LaunchTracker.warmLaunchData = warmLaunchData
                 }
@@ -235,7 +238,10 @@ internal class LaunchTracker : ActivityLifecycleAdapter {
                     is_lukewarm = true,
                 )
                 if (callbacks != null) {
-                    callbacks?.onWarmLaunch(warmLaunchData, SystemClock.elapsedRealtime())
+                    callbacks?.onWarmLaunch(
+                        warmLaunchData = warmLaunchData,
+                        warmLaunchTime = System.currentTimeMillis(),
+                    )
                 } else {
                     this@LaunchTracker.warmLaunchData = warmLaunchData
                 }


### PR DESCRIPTION
# Description

This reverts commit d619e6ed5ff4074677cc4b38bb75400497aaeee8 added in PR: #2473.

This change is not needed as the event timestamp is irrelevant to launch time calculation. Using the wall clock time is the correct behaviour.

## Related issue
References #2473 



