### PR TITLE
fix(ios): disable shake listener when app moves to background

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/BugReport/ShakeBugReportCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/ShakeBugReportCollector.swift
@@ -30,4 +30,12 @@ final class ShakeBugReportCollector: ShakeDetectorListener {
     func onShake() {
         shakeHandler?()
     }
+
+    func pause() {
+        shakeDetector.stop()
+    }
+
+    func resume() {
+        _ = shakeDetector.start()
+    }
 }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -287,6 +287,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.lifecycleCollector.applicationDidEnterBackground()
         self.cpuUsageCollector.pause()
         self.memoryUsageCollector.pause()
+        self.shakeBugReportCollector.pause()
         self.dataCleanupService.clearStaleData {}
     }
 
@@ -298,6 +299,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.lifecycleCollector.applicationWillEnterForeground()
         self.cpuUsageCollector.resume()
         self.memoryUsageCollector.resume()
+        self.shakeBugReportCollector.resume()
     }
 
     private func applicationWillTerminate() {


### PR DESCRIPTION
# Description

Disable shake listener when app moves to background

## Related issue
Fixes #2555
