### PR TITLE
feat(android): track session start event

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/SessionStartData.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionStartData.kt
@@ -1,0 +1,8 @@
+package sh.measure.android
+
+import android.annotation.SuppressLint
+import kotlinx.serialization.Serializable
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+internal object SessionStartData

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -50,6 +50,7 @@ internal data class Config(
         EventType.LIFECYCLE_ACTIVITY,
         EventType.LIFECYCLE_FRAGMENT,
         EventType.SCREEN_VIEW,
+        EventType.SESSION_START,
     )
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64

--- a/android/measure/src/main/java/sh/measure/android/events/CustomEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/CustomEventCollector.kt
@@ -40,7 +40,6 @@ internal class CustomEventCollector(
             userTriggered = true,
             userDefinedAttributes = attributes,
         )
-        logger.log(LogLevel.Debug, "Custom event($name) received")
     }
 
     private fun validateName(name: String): Boolean {

--- a/android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -22,6 +22,7 @@ internal enum class EventType(val value: String) {
     SCREEN_VIEW("screen_view"),
     CUSTOM("custom"),
     BUG_REPORT("bug_report"),
+    SESSION_START("session_start"),
     ;
 
     companion object {

--- a/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -241,6 +241,12 @@ internal class SignalProcessorImpl(
                 { "msr-store-span" },
                 {
                     signalStore.store(spanData)
+                    if (logger.enabled) {
+                        logger.log(
+                            LogLevel.Debug,
+                            "Span processed: ${spanData.name}, ${spanData.duration}ms",
+                        )
+                    }
                 },
             )
         }
@@ -248,7 +254,7 @@ internal class SignalProcessorImpl(
 
     private fun <T> onEventTracked(event: Event<T>) {
         if (logger.enabled) {
-            logger.log(LogLevel.Debug, "${event.type}, ${event.data}")
+            logger.log(LogLevel.Debug, "Event processed: ${event.type}, ${event.data}")
         }
         sessionManager.onEventTracked(event)
     }
@@ -323,7 +329,10 @@ internal class SignalProcessorImpl(
         }
     }
 
-    private fun validateUserDefinedAttributes(event: String, attributes: Map<String, AttributeValue>): Boolean {
+    private fun validateUserDefinedAttributes(
+        event: String,
+        attributes: Map<String, AttributeValue>,
+    ): Boolean {
         if (attributes.size > configProvider.maxUserDefinedAttributesPerEvent) {
             logger.log(
                 LogLevel.Error,

--- a/android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.modules.SerializersModule
+import sh.measure.android.SessionStartData
 import sh.measure.android.appexit.AppExit
 import sh.measure.android.applaunch.ColdLaunchData
 import sh.measure.android.applaunch.HotLaunchData
@@ -163,6 +164,10 @@ internal fun <T> Event<T>.serializeDataToString(): String {
 
         EventType.STRING -> {
             json.encodeToString(String.serializer(), data as String)
+        }
+
+        EventType.SESSION_START -> {
+            json.encodeToString(SessionStartData.serializer(), data as SessionStartData)
         }
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -289,4 +289,27 @@ class SessionManagerTest {
         sessionManager.markCrashedSessions(sessionIds)
         verify(database).markCrashedSessions(sessionIds)
     }
+
+    @Test
+    fun `returns correct result on initialization`() {
+        val initialTime = timeProvider.elapsedRealtime
+        val r1 = sessionManager.init()
+
+        // verify result
+        assertEquals(SessionInitResult.NewSessionCreated(sessionManager.getSessionId()), r1)
+
+        // setup recent session mock
+        val session = RecentSession(
+            id = "previous-session-id",
+            lastEventTime = initialTime,
+            createdAt = initialTime - Duration.ofMinutes(3).toMillis(),
+            crashed = false,
+            versionCode = packageInfoProvider.getVersionCode(),
+        )
+        `when`(prefsStorage.getRecentSession()).thenReturn(session)
+
+        // verify result
+        val r2 = sessionManager.init()
+        assertEquals(SessionInitResult.SessionResumed(sessionManager.getSessionId()), r2)
+    }
 }

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
@@ -1,5 +1,6 @@
 package sh.measure.android.fakes
 
+import sh.measure.android.SessionInitResult
 import sh.measure.android.SessionManager
 import sh.measure.android.events.Event
 
@@ -10,8 +11,8 @@ internal class FakeSessionManager : SessionManager {
     var onEventTracked = false
     var markedSessionWithBugReport = false
 
-    override fun init() {
-        // no-op
+    override fun init(): SessionInitResult {
+        return SessionInitResult.NewSessionCreated(session)
     }
 
     override fun getSessionId(): String {


### PR DESCRIPTION
# Description

- Tracks a `session_start` event when a new session is created.
- Always send `session_start` event regardless of sampling conditions.
- Also updates event and span processing logs for easier debugging.

## Related issue
Closes #2572 


