### PR TITLE
fix(ios): fix blank svg generation

### DIFF
--- a/ios/DemoApp/Controller/ControlsViewController.swift
+++ b/ios/DemoApp/Controller/ControlsViewController.swift
@@ -47,6 +47,14 @@ class ControlsViewController: UIViewController {
         alertController.addAction(successAction)
         alertController.addAction(failureAction)
 
+        if let popover = alertController.popoverPresentationController {
+            popover.sourceView = self.view
+            popover.sourceRect = CGRect(x: self.view.bounds.midX,
+                                        y: self.view.bounds.midY,
+                                        width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
         present(alertController, animated: true, completion: nil)
     }
 
@@ -62,6 +70,14 @@ class ControlsViewController: UIViewController {
 
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         alertController.addAction(cancelAction)
+
+        if let popover = alertController.popoverPresentationController {
+            popover.sourceView = self.view
+            popover.sourceRect = CGRect(x: self.view.bounds.midX,
+                                        y: self.view.bounds.midY,
+                                        width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
 
         present(alertController, animated: true, completion: nil)
     }

--- a/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/LayoutInspector/BaseSvgGenerator.swift
@@ -13,18 +13,17 @@ struct SvgFrame {
 }
 
 protocol SvgGenerator {
-    func generate(for frames: [SvgFrame]) -> Data?
+    func generate(for frames: [SvgFrame], rootSize: CGSize) -> Data?
 }
 
 final class BaseSvgGenerator: SvgGenerator {
-    func generate(for frames: [SvgFrame]) -> Data? {
-        guard let maxWidth = frames.map({ $0.frame.maxX }).max(),
-              let maxHeight = frames.map({ $0.frame.maxY }).max() else {
+    func generate(for frames: [SvgFrame], rootSize: CGSize) -> Data? {
+        let windowWidth = rootSize.width.safeInt
+        let windowHeight = rootSize.height.safeInt
+
+        if windowWidth == Int.max || windowWidth == Int.min || windowHeight == Int.max || windowHeight == Int.min {
             return nil
         }
-
-        let windowWidth = maxWidth.safeInt
-        let windowHeight = maxHeight.safeInt
 
         var svg = """
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 \(windowWidth) \(windowHeight)">

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSvgGenerator.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSvgGenerator.swift
@@ -13,7 +13,7 @@ final class MockSvgGenerator: SvgGenerator {
     var generatedData: Data?
     var frames: [SvgFrame]?
 
-    func generate(for frames: [SvgFrame]) -> Data? {
+    func generate(for frames: [SvgFrame], rootSize: CGSize) -> Data? {
         self.frames = frames
         return generatedData
     }


### PR DESCRIPTION
# Description

When we generated layout snapshots earlier, we would collect all the frames in the current view hierarchy, check which view had the maximum X or Y coordinates and generate the SVG's viewBox height and width according to it. The idea behind this was that if any view was lurking in the background, that would be captured as well, as shown in the below screenshot.

![layoutSnapshot](https://github.com/user-attachments/assets/7afebf15-1045-4b62-931d-7afe193ba55c)

The problem with the above approach is that in some cases ios system views like pickers, maps, tableviews maintain a huge canvas in background outside the scope of the current screen. This leads to huge viewBox size especially in case of iPads and Macbooks. This is now fixed in this PR by making sure that we set the viewBox dimensions to the current size of the screen instead on the canvas dimensions. New layout snapshot for the same screen.

![layoutSnapshot](https://github.com/user-attachments/assets/c45371f6-4277-476e-8b13-5e072d57cf41)


## Related issue
Fixes #2562 