### PR TITLE
fix(ios): add safe uiapplication swizzling

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Utils/Extensions/UIApplication+Extension.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Extensions/UIApplication+Extension.swift
@@ -23,11 +23,7 @@ extension UIApplication {
     @objc func swizzled_sendEvent(_ event: UIEvent) {
         gestureCollector?.processEvent(event)
 
-        if let imp = SwizzlingUtility.originalIMP(for: UIApplication.self, selector: #selector(sendEvent(_:))) {
-            typealias SendEventFunc = @convention(c) (UIApplication, Selector, UIEvent) -> Void
-            let original = unsafeBitCast(imp, to: SendEventFunc.self)
-            original(self, #selector(sendEvent(_:)), event)
-        }
+        swizzled_sendEvent(event)
     }
 
     func setGestureCollector(_ collector: GestureCollector) {
@@ -39,7 +35,7 @@ extension UIApplication {
             for: UIApplication.self,
             originalSelector: #selector(sendEvent(_:)),
             swizzledSelector: #selector(swizzled_sendEvent(_:)),
-            strategy: .replace
+            strategy: .exchange
         )
     }
 }


### PR DESCRIPTION
# Description

We are swizzling UIApplication.sendEvent(_:) using .replace swizzling strategy. This replaces the implementation of sendEvent(_:) with our swizzled_sendEvent(_:), and records the old implementation. Inside our swizzled_sendEvent(_:), we manually call the old implementation. The crash suggests that the old implementation could not be found.

To fix this, we'll use `method_exchangeImplementations` instead of `class_replaceMethod` for swizzling and call the old implementation in the new implementation itself, there by removing the need for maintaining a copy of the old implementation.

## Related issue
Fixes #2584