### PR TITLE
fix(ios): update process start time logic

### DIFF
--- a/docs/features/feature-app-launch-metrics.md
+++ b/docs/features/feature-app-launch-metrics.md
@@ -91,9 +91,7 @@ A cold launch refers to an app starting up from scratch. Cold launches occur whe
 
 Once a cold launch is done, for every subsequent launch, the app still needs to be spanned but the app is still in memory and some of the system-side services are already available. So this launch is a bit faster and a bit more consistent. This type of launch is referred to as the warm launch.
 
-In iOS 15 and later, the system may, depending on device conditions, **pre-warm** your app, launching non-running application processes to reduce the amount of time the user waits before the app is usable. Pre-warming executes an app’s launch sequence up until, but not including, when main() calls UIApplicationMain. This provides the system with an opportunity to build and cache any low-level structures it requires in anticipation of a full launch.
-
-After the system pre-warms your app, its launch sequence remains in a paused state until the app launches and the sequence resumes, or the system removes the pre-warmed app from memory to reclaim resources. The system can pre-warm your app after a device reboot, and periodically as system conditions allow.
+In iOS 15 and later, the system may, depending on device conditions, **pre-warm** your app, launching non-running application processes to reduce the amount of time the user waits before the app is usable. If a app is pre-warmed, we ignore the launch event.
 
 #### Hot Launch
 

--- a/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
@@ -149,35 +149,30 @@ final class BaseSysCtl: SysCtl {
         var size = MemoryLayout<UInt64>.size
         if sysctlbyname("hw.memsize", &memorySize, &size, nil, 0) == 0 {
             self.maximumAvailableRam = memorySize / 1024
-            return self.maximumAvailableRam
         }
-        return 0
+        return self.maximumAvailableRam
     }
 
     func getProcessStartTime() -> UnsignedNumber? {
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
-        var procInfo = kinfo_proc()
-        var size = MemoryLayout.size(ofValue: procInfo)
 
-        let result = sysctl(&mib, UInt32(mib.count), &procInfo, &size, nil, 0)
-        guard result == 0 else {
-            return nil
-        }
+        var kproc = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
 
-        let startTime = procInfo.kp_proc.p_un.__p_starttime
-        return UnsignedNumber(startTime.tv_sec) + UnsignedNumber(startTime.tv_usec) / 1_000_000
+        let result = sysctl(&mib, u_int(mib.count), &kproc, &size, nil, 0)
+        guard result == 0 else { return nil }
+
+        let procStartTime = kproc.kp_proc.p_un.__p_starttime
+        let procStartTimeMillis = UInt64(procStartTime.tv_sec) * 1000 + UInt64(procStartTime.tv_usec) / 1000
+        return procStartTimeMillis
     }
 
     func getSystemBootTime() -> UnsignedNumber? {
-        var cmd = [CTL_KERN, KERN_BOOTTIME]
-        var bootTimeVal = timeval(tv_sec: 0, tv_usec: 0)
-        var size = MemoryLayout.size(ofValue: bootTimeVal)
+        var bootTime = timeval()
+        var size = MemoryLayout<timeval>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_BOOTTIME]
+        guard sysctl(&mib, 2, &bootTime, &size, nil, 0) == 0 else { return nil }
 
-        let result = sysctl(&cmd, UInt32(cmd.count), &bootTimeVal, &size, nil, 0)
-        if result != 0 {
-            return nil
-        }
-
-        return UnsignedNumber(bootTimeVal.tv_sec) + UnsignedNumber(bootTimeVal.tv_usec) / 1_000_000
+        return UnsignedNumber(bootTime.tv_sec) * 1000 + UnsignedNumber(bootTime.tv_usec) / 1000
     }
 }


### PR DESCRIPTION
# Description

This PR fixes incorrect launch time by updating the below things:

- Update sysCtl's `getProcessStartTime` to provide more accurate process start time.
- Ignore launch time collection if the app is [pre-warmed](https://developer.apple.com/documentation/uikit/about-the-app-launch-sequence#Prepare-your-app-for-prewarming)
- Use `timeProvider` instead of `Date().timeIntervalSince1970`

## Related issue
Fixes #2561 