### PR TITLE
fix(ios): add proper implementation for LifecycleManagerInternal

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		CF83E3212E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF83E3202E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift */; };
 		CF86818F2DB6541F00C62DA5 /* SpanId.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF86818D2DB6541F00C62DA5 /* SpanId.swift */; };
 		CF8681902DB6541F00C62DA5 /* TraceId.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF86818E2DB6541F00C62DA5 /* TraceId.swift */; };
+		CF9D74C52E6169F3007D6D30 /* LifecycleManagerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */; };
 		CFB838212DAFEF780023592B /* SpanProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB838202DAFEF780023592B /* SpanProcessorTests.swift */; };
 		CFB8382C2DB1597B0023592B /* SpanOb+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */; };
 		CFB8382D2DB1597B0023592B /* SpanOb+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */; };
@@ -576,6 +577,7 @@
 		CF83E3202E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrRequestHeadersProvider.swift; sourceTree = "<group>"; };
 		CF86818D2DB6541F00C62DA5 /* SpanId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanId.swift; sourceTree = "<group>"; };
 		CF86818E2DB6541F00C62DA5 /* TraceId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceId.swift; sourceTree = "<group>"; };
+		CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleManagerInternal.swift; sourceTree = "<group>"; };
 		CFB838202DAFEF780023592B /* SpanProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanProcessorTests.swift; sourceTree = "<group>"; };
 		CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -848,6 +850,7 @@
 			children = (
 				526D17E72D5A1913009A2E90 /* LifecycleCollector.swift */,
 				526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */,
+				CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */,
 				526D17E92D5A1913009A2E90 /* LifecycleManager.swift */,
 				526D17EA2D5A1913009A2E90 /* MsrViewController.swift */,
 				526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */,
@@ -1614,6 +1617,7 @@
 				526D18352D5A1913009A2E90 /* InternalConfig.swift in Sources */,
 				526D18442D5A1913009A2E90 /* SystemCrashReporter.swift in Sources */,
 				CF86818F2DB6541F00C62DA5 /* SpanId.swift in Sources */,
+				CF9D74C52E6169F3007D6D30 /* LifecycleManagerInternal.swift in Sources */,
 				CF8681902DB6541F00C62DA5 /* TraceId.swift in Sources */,
 				CF1BB49E2DCDF99A00588506 /* ShakeBugReportCollector.swift in Sources */,
 				526D18402D5A1913009A2E90 /* CrashDataPersistence.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -136,6 +136,12 @@ extension Measure.BatchOb {
   public func update(title: UIKit.UIFont? = nil, button: UIKit.UIFont? = nil, placeholder: UIKit.UIFont? = nil) -> Measure.MsrFonts
   @objc deinit
 }
+@_inheritsConvenienceInitializers @objc(LifecycleManagerInternal) public class LifecycleManagerInternal : ObjectiveC.NSObject {
+  @objc public static let shared: Measure.LifecycleManagerInternal
+  @objc public func sendLifecycleEvent(_ event: Measure.VCLifecycleEventType, for viewController: UIKit.UIViewController)
+  @objc override dynamic public init()
+  @objc deinit
+}
 public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterable {
   case allTextAndMedia
   case allText

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleManager.swift
@@ -8,7 +8,6 @@
 import Foundation
 import UIKit
 
-@objc(LifecycleManagerInternal)
 final class LifecycleManager: NSObject {
     @objc static let shared = LifecycleManager()
     private var lifecycleCollector: LifecycleCollector?

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleManagerInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleManagerInternal.swift
@@ -1,0 +1,19 @@
+//
+//  LifecycleManagerInternal.swift
+//  Measure
+//
+//  Created by Adwin Ross on 28/08/25.
+//
+
+import Foundation
+import UIKit
+
+@objc(LifecycleManagerInternal)
+public class LifecycleManagerInternal: NSObject {
+    @objc public static let shared = LifecycleManagerInternal()
+
+    @objc public func sendLifecycleEvent(_ event: VCLifecycleEventType,
+                                         for viewController: UIViewController) {
+        LifecycleManager.shared.sendLifecycleEvent(event, for: viewController)
+    }
+}


### PR DESCRIPTION
# Description

Add proper implementation for objc class LifecycleManagerInternal in swift.

## Related issue
Fixes #2602 