### PR TITLE
feat(ios): add session start event

### DIFF
--- a/ios/DemoApp/Podfile.lock
+++ b/ios/DemoApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - measure-sh (0.5.1):
-    - PLCrashReporter
-  - PLCrashReporter (1.12.0)
+  - measure-sh (0.6.0):
+    - PLCrashReporter (= 1.11.2)
+  - PLCrashReporter (1.11.2)
 
 DEPENDENCIES:
   - measure-sh (from `../../`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  measure-sh: 00fcdea443b73eb5bfa25e73fc5b3973582109b4
-  PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
+  measure-sh: 12885ddb1cd8c67cb318611a6f9d387e25afba8a
+  PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
 
 PODFILE CHECKSUM: eca229ccc523688877a34e50f11f504a0fe75bed
 

--- a/ios/DemoAppSwiftUI/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/ios/DemoAppSwiftUI/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -11,7 +11,7 @@ import Measure
 @main
 struct DemoAppSwiftUIApp: App {
     init() {
-        let clientInfo = ClientInfo(apiKey: "msrsh_48153449fa6045685d605a6dcb684cbf42d5b1cdf780cd79bd58a4423ce8b23d_e6b33343",
+        let clientInfo = ClientInfo(apiKey: "msrsh_297eb17091394bdcb6e57718f3e7ae2b4448322b2583312bd492891844dc21d1_e9467a30",
                                     apiUrl: "http://localhost:8080")
         let config = BaseMeasureConfig(enableLogging: true,
                                        samplingRateForErrorFreeSessions: 1.0)

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		CF86818F2DB6541F00C62DA5 /* SpanId.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF86818D2DB6541F00C62DA5 /* SpanId.swift */; };
 		CF8681902DB6541F00C62DA5 /* TraceId.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF86818E2DB6541F00C62DA5 /* TraceId.swift */; };
 		CF9D74C52E6169F3007D6D30 /* LifecycleManagerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */; };
+		CF9D75792E66C0FA007D6D30 /* SessionStartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */; };
 		CFB838212DAFEF780023592B /* SpanProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB838202DAFEF780023592B /* SpanProcessorTests.swift */; };
 		CFB8382C2DB1597B0023592B /* SpanOb+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */; };
 		CFB8382D2DB1597B0023592B /* SpanOb+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */; };
@@ -578,6 +579,7 @@
 		CF86818D2DB6541F00C62DA5 /* SpanId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanId.swift; sourceTree = "<group>"; };
 		CF86818E2DB6541F00C62DA5 /* TraceId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceId.swift; sourceTree = "<group>"; };
 		CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleManagerInternal.swift; sourceTree = "<group>"; };
+		CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStartData.swift; sourceTree = "<group>"; };
 		CFB838202DAFEF780023592B /* SpanProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanProcessorTests.swift; sourceTree = "<group>"; };
 		CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -956,6 +958,7 @@
 				69E4B4D22DA7581A00361E25 /* MeasureInitializer.swift */,
 				526D18192D5A1913009A2E90 /* MeasureInternal.swift */,
 				526D181A2D5A1913009A2E90 /* RecentSession.swift */,
+				CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */,
 				526D181B2D5A1913009A2E90 /* SessionManager.swift */,
 				526D179A2D5A1913009A2E90 /* AppLaunch */,
 				526D17A42D5A1913009A2E90 /* Attribute */,
@@ -1607,6 +1610,7 @@
 				526D188C2D5A1913009A2E90 /* UserDefaultStorage.swift in Sources */,
 				CFD88D152DA799CA0095115E /* SpanCollector.swift in Sources */,
 				526D182C2D5A1913009A2E90 /* DeviceAttributeProcessor.swift in Sources */,
+				CF9D75792E66C0FA007D6D30 /* SessionStartData.swift in Sources */,
 				526D18872D5A1913009A2E90 /* Randomizer.swift in Sources */,
 				526D18312D5A1913009A2E90 /* ClientInfo.swift in Sources */,
 				526D18672D5A1913009A2E90 /* LayoutSnapshotGenerator.swift in Sources */,

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -113,7 +113,8 @@ struct Config: InternalConfig, MeasureConfig {
                                          .warmLaunch,
                                          .lifecycleSwiftUI,
                                          .lifecycleViewController,
-                                         .screenView]
+                                         .screenView,
+                                         .sessionStart]
         self.screenshotMaskHexColor = "#222222"
         self.screenshotCompressionQuality = 25
         self.layoutSnapshotDebounceInterval = 750 // 750 ms

--- a/ios/Sources/MeasureSDK/Swift/CoreData/Entities/EventEntity.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/Entities/EventEntity.swift
@@ -37,6 +37,7 @@ struct EventEntity { // swiftlint:disable:this type_body_length
     let customEvent: Data?
     var needsReporting: Bool
     let bugReport: Data?
+    let sessionStartData: Data?
 
     init<T: Codable>(_ event: Event<T>, needsReporting: Bool) { // swiftlint:disable:this cyclomatic_complexity function_body_length
         self.id = event.id
@@ -258,6 +259,17 @@ struct EventEntity { // swiftlint:disable:this type_body_length
         } else {
             self.bugReport = nil
         }
+
+        if event.type == .sessionStart {
+            do {
+                let data = try JSONEncoder().encode(SessionStartData())
+                self.sessionStartData = data
+            } catch {
+                self.sessionStartData = nil
+            }
+        } else {
+            self.sessionStartData = nil
+        }
     }
 
     init(id: String,
@@ -288,6 +300,7 @@ struct EventEntity { // swiftlint:disable:this type_body_length
          customEvent: Data?,
          screenView: Data?,
          bugReport: Data?,
+         sessionStartData: Data?,
          needsReporting: Bool) {
         self.id = id
         self.sessionId = sessionId
@@ -318,6 +331,7 @@ struct EventEntity { // swiftlint:disable:this type_body_length
         self.screenView = screenView
         self.needsReporting = needsReporting
         self.bugReport = bugReport
+        self.sessionStartData = sessionStartData
     }
 
     func getEvent<T: Codable>() -> Event<T> { // swiftlint:disable:this cyclomatic_complexity function_body_length
@@ -456,6 +470,14 @@ struct EventEntity { // swiftlint:disable:this type_body_length
             if let bugReportData = self.bugReport {
                 do {
                     decodedData = try JSONDecoder().decode(T.self, from: bugReportData)
+                } catch {
+                    decodedData = nil
+                }
+            }
+        case .sessionStart:
+            if let sessionStartData = self.sessionStartData {
+                do {
+                    decodedData = try JSONDecoder().decode(T.self, from: sessionStartData)
                 } catch {
                     decodedData = nil
                 }

--- a/ios/Sources/MeasureSDK/Swift/CoreData/EventStore.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/EventStore.swift
@@ -307,6 +307,7 @@ extension EventOb {
             customEvent: customEvent,
             screenView: screenView,
             bugReport: bugReport,
+            sessionStartData: nil,
             needsReporting: needsReporting
         )
     }

--- a/ios/Sources/MeasureSDK/Swift/Events/EventType.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/EventType.swift
@@ -25,4 +25,5 @@ enum EventType: String, Codable {
     case custom
     case screenView = "screen_view"
     case bugReport = "bug_report"
+    case sessionStart = "session_start"
 }

--- a/ios/Sources/MeasureSDK/Swift/Exporter/EventSerializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/EventSerializer.swift
@@ -51,6 +51,8 @@ struct EventSerializer {
             eventType = ScreenViewData.self
         case .bugReport:
             eventType = BugReportData.self
+        case .sessionStart:
+            eventType = SessionStartData.self
         }
 
         // Call the generic helper function

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -164,7 +164,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.lifecycleObserver.applicationWillTerminate = applicationWillTerminate
         self.logger.log(level: .info, message: "Initializing Measure SDK", error: nil, data: nil)
         self.sessionManager.setPreviousSessionCrashed(crashReportManager.hasPendingCrashReport)
-        self.sessionManager.start()
+        self.sessionManager.start { sessionId in
+            self.trackSessionStart(sessionId: sessionId)
+        }
         self.crashDataPersistence.prepareCrashFile()
         self.crashDataPersistence.sessionId = sessionManager.sessionId
         self.crashReportManager.trackException()
@@ -411,5 +413,16 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         }
 
         return transformedAttributes
+    }
+
+    private func trackSessionStart(sessionId: String?) {
+        signalProcessor.track(data: SessionStartData(),
+                              timestamp: timeProvider.now(),
+                              type: .sessionStart,
+                              attributes: nil,
+                              sessionId: sessionId,
+                              attachments: nil,
+                              userDefinedAttributes: nil,
+                              threadName: nil)
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/SessionManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/SessionManager.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol SessionManager {
     var sessionId: String { get }
     var shouldReportSession: Bool { get }
-    func start()
+    func start(onNewSession: (String?) -> Void)
     func applicationDidEnterBackground()
     func applicationWillEnterForeground()
     func applicationWillTerminate()
@@ -159,21 +159,25 @@ final class BaseSessionManager: SessionManager {
         }
     }
 
-    func start() {
+    func start(onNewSession: (String?) -> Void) {
         if isAppVersionUpdated() || isAppBuildNumberUpdated() {
             logger.log(level: .info, message: "Ending previous session as app version or build number has been updated.", error: nil, data: nil)
             createNewSession()
+            onNewSession(currentSessionId)
         } else if isFrameworkVersionUpdated() {
             logger.log(level: .info, message: "Ending previous session as SDK version has been updated.", error: nil, data: nil)
             createNewSession()
+            onNewSession(currentSessionId)
         } else if isSessonDurationThreadholdReached() {
             logger.log(level: .info, message: "Ending previous session as maxSessionDurationMs threshold is reached.", error: nil, data: nil)
             createNewSession()
+            onNewSession(currentSessionId)
         } else if let recentSessionId = getRecentSessionId() {
             logger.log(level: .info, message: "Continuing previous session \(recentSessionId)", error: nil, data: nil)
             currentSessionId = recentSessionId
         } else {
             createNewSession()
+            onNewSession(currentSessionId)
         }
     }
 

--- a/ios/Sources/MeasureSDK/Swift/SessionStartData.swift
+++ b/ios/Sources/MeasureSDK/Swift/SessionStartData.swift
@@ -1,0 +1,10 @@
+//
+//  SessionStartData.swift
+//  Measure
+//
+//  Created by Adwin Ross on 02/09/25.
+//
+
+import Foundation
+
+struct SessionStartData: Codable {}

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |spec|
   }
   spec.resources    = ["ios/Sources/MeasureSDK/Swift/XCDataModel/MeasureModel.xcdatamodeld"]
   spec.frameworks   = "Foundation", "UIKit", "CoreData"
-  spec.dependency "PLCrashReporter"
+  spec.dependency "PLCrashReporter", "1.11.2"
 end


### PR DESCRIPTION
# Description

This PR adds below changes.

* Add a new event type called `session_start`, which is the first event triggered at the start of each session.
* Store and export to server.
* Always send `session_start` event regardless of sampling conditions.

## Related issue
Closes #2573 