### PR TITLE
fix(backend): insert metrics asynchronously

### DIFF
--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -2457,7 +2457,7 @@ func PutEvents(c *gin.Context) {
 	defer insertMetricsIngestionSelectStmt.Close()
 	insertMetricsIngestionFullStmt := "INSERT INTO ingestion_metrics " + selectSQL
 
-	if err := server.Server.ChPool.Exec(ctx, insertMetricsIngestionFullStmt, args...); err != nil {
+	if err := server.Server.ChPool.AsyncInsert(ctx, insertMetricsIngestionFullStmt, false, args...); err != nil {
 		msg := `failed to insert metrics into clickhouse`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Summary

This PR updates the ingestion metrics insert to write data asynchronously into the table.

## Tasks

- [x] Change ingestion metrics insert to use async insert

## See also

- fixes #2610