### PR TITLE
docs(backend): update sessionator example config

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -235,6 +235,13 @@ When contributing to databases, please strictly follow the following guidelines.
     docker compose watch
     ```
 
+6. Additionally, copy `postgres_dsn` and `clickhouse_dsn` variables in sessionator config.toml from [`config.toml.example`](../self-host/session-data/config.toml.example)
+
+    ```toml
+    postgres_dsn = "postgresql://..."
+    clickhouse_dsn = "clickhouse://..."
+    ```
+
 ## Release process
 
 To trigger a release, create a signed git tag using [git-cliff](https://git-cliff.org/) and push the tag. Here's a one liner.

--- a/self-host/session-data/config.toml.example
+++ b/self-host/session-data/config.toml.example
@@ -30,7 +30,7 @@
 # object storage (like S3).
 
 postgres_dsn = "postgresql://postgres:postgres@127.0.0.1:5432/measure?search_path=measure"
-clickhouse_dsn = "clickhouse://default:@127.0.0.1:9000/measure"
+clickhouse_dsn = "clickhouse://app_admin:dummY_pa55w0rd@127.0.0.1:9000/measure"
 
 aws_endpoint_url = "http://127.0.0.1:9119"
 


### PR DESCRIPTION
## Summary

This PR updates the contributing guide and sessionator example config with latest correct state.

## Tasks

- [x] Update `config.toml.example` file and contributing docs
- [x] Update `docs/CONTRIBUTING.md` accordingly

## See also

- fixes #2614