### PR TITLE
chore(backend): check for alerts at start of every hour

### DIFF
--- a/backend/alerts/main.go
+++ b/backend/alerts/main.go
@@ -79,7 +79,7 @@ func main() {
 
 func initCron(ctx context.Context) *cron.Cron {
 	cron := cron.New()
-	cron.AddFunc("@hourly", func() { alerts.CreateCrashAndAnrAlerts(ctx) })
+	cron.AddFunc("0 0 * * * *", func() { alerts.CreateCrashAndAnrAlerts(ctx) })
 	cron.AddFunc("@daily", func() { alerts.CreateDailySummary(ctx) })
 	cron.AddFunc("@every 5m", func() { email.SendPendingAlertEmails(ctx) })
 	cron.Start()


### PR DESCRIPTION
# Description

Check for alerts at start of every hour instead of hourly since service start. This will lead to more consistent alert creation behaviour.

## Related issue
Closes #2616 



