### PR TITLE
chore(backend): update daily summary email schedule & header

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -726,7 +726,7 @@ func formatDailySummaryEmailBody(appName, dashboardURL string, date time.Time, m
             <!-- Date Header -->
             <div style="text-align: center; margin-bottom: 32px;">
                 <h2 style="margin: 0; font-size: 18px; color: #2d3748; font-family: 'Josefin Sans', sans-serif; font-weight: 600;">
-                    %s
+                    %s (Last 24 hours)
                 </h2>
             </div>
 

--- a/backend/alerts/main.go
+++ b/backend/alerts/main.go
@@ -80,7 +80,7 @@ func main() {
 func initCron(ctx context.Context) *cron.Cron {
 	cron := cron.New()
 	cron.AddFunc("0 0 * * * *", func() { alerts.CreateCrashAndAnrAlerts(ctx) })
-	cron.AddFunc("@daily", func() { alerts.CreateDailySummary(ctx) })
+	cron.AddFunc("0 0 6 * * *", func() { alerts.CreateDailySummary(ctx) })
 	cron.AddFunc("@every 5m", func() { email.SendPendingAlertEmails(ctx) })
 	cron.Start()
 	return cron


### PR DESCRIPTION
# Description

- Updates daily summary email sending time to 6 AM UTC
- Updates date header in email to clarify that this summary is for Last 24 hours

## Related issue
Closes #2620



