### PR TITLE
chore(android): use snapshot version for android sdk

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.12.0
+MEASURE_VERSION_NAME=0.12.0-SNAPSHOT
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ junit-platform-launcher = "1.10.2"
 kotlin = "1.9.21"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests
-measure-android = "0.12.0"
+measure-android = "0.12.0-SNAPSHOT"
 androidx-activity-compose = "1.7.2"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"


### PR DESCRIPTION
# Description

Changes version to `SNAPSHOT` for local development.