### PR TITLE
feat(backend): implement session targeting

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -59,6 +59,7 @@ func main() {
 	// SDK routes
 	r.PUT("/events", measure.ValidateAPIKey(), measure.PutEvents)
 	r.PUT("/builds", measure.ValidateAPIKey(), measure.PutBuilds)
+	r.GET("/config", measure.ValidateAPIKey(), measure.GetConfig)
 
 	// Proxy routes
 	r.GET("/proxy/attachments", measure.ProxyAttachment)
@@ -114,6 +115,11 @@ func main() {
 		apps.GET(":id/bugReports/:bugReportId", measure.GetBugReport)
 		apps.PATCH(":id/bugReports/:bugReportId", measure.UpdateBugReportStatus)
 		apps.GET(":id/alerts", measure.GetAlertsOverview)
+		apps.GET(":id/sessionTargetingRules", measure.GetSessionTargetingRules)
+		apps.GET(":id/sessionTargetingRules/:ruleId", measure.GetSessionTargetingRule)
+		apps.POST(":id/sessionTargetingRules", measure.CreateSessionTargetingRule)
+		apps.PATCH(":id/sessionTargetingRules/:ruleId", measure.UpdateSessionTargetingRule)
+		apps.GET(":id/sessionTargetingRules/config", measure.GetSessionTargetingDashboardConfig)
 	}
 
 	teams := r.Group("/teams", measure.ValidateAccessToken())

--- a/backend/api/measure/sdkconfig.go
+++ b/backend/api/measure/sdkconfig.go
@@ -1,0 +1,108 @@
+package measure
+
+import (
+	"backend/api/server"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/leporo/sqlf"
+)
+
+const (
+	cacheControlHeader = "Cache-Control"
+	cacheControlValue  = "max-age=600" // 10 minutes
+)
+
+// Session targeting rule
+type sessionTargetingRule struct {
+	ID           uuid.UUID `json:"id"`
+	Name         string    `json:"name"`
+	Status       int       `json:"status"`
+	SamplingRate float64   `json:"sampling_rate"`
+	Rule         string    `json:"rule"`
+}
+
+// SDK config contains session targeting
+// rules and will have more configurations
+// in future.
+type SDKConfig struct {
+	SessionTargetingConfig []sessionTargetingRule `json:"session_targeting"`
+}
+
+// GetConfig returns the SDK config
+// for session targeting
+func GetConfig(c *gin.Context) {
+	appId, err := uuid.Parse(c.GetString("appId"))
+	if err != nil {
+		msg := `error parsing app's uuid`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	// session targeting config
+	stmt := sqlf.PostgreSQL.From("session_targeting_rules").
+		Select("id").
+		Select("name").
+		Select("status").
+		Select("sampling_rate").
+		Select("rule").
+		Where("app_id = ?", appId).
+		Where("status = 1").
+		OrderBy("updated_at DESC")
+
+	defer stmt.Close()
+
+	rows, err := server.Server.PgPool.Query(c.Request.Context(), stmt.String(), stmt.Args()...)
+	if err != nil {
+		msg := "failed to fetch session targeting config"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+	defer rows.Close()
+
+	sessionTargetingConfigs := make([]sessionTargetingRule, 0)
+
+	for rows.Next() {
+		var stConfig sessionTargetingRule
+		if err := rows.Scan(
+			&stConfig.ID,
+			&stConfig.Name,
+			&stConfig.Status,
+			&stConfig.SamplingRate,
+			&stConfig.Rule,
+		); err != nil {
+			msg := "failed to scan session targeting config"
+			fmt.Println(msg, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":   msg,
+				"details": err.Error(),
+			})
+			return
+		}
+		sessionTargetingConfigs = append(sessionTargetingConfigs, stConfig)
+	}
+
+	if err := rows.Err(); err != nil {
+		msg := "error iterating session targeting config"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	sdkConfig := SDKConfig{
+		SessionTargetingConfig: sessionTargetingConfigs,
+	}
+
+	c.Header(cacheControlHeader, cacheControlValue)
+	c.JSON(http.StatusOK, sdkConfig)
+}

--- a/backend/api/measure/session_targeting.go
+++ b/backend/api/measure/session_targeting.go
@@ -1,0 +1,617 @@
+package measure
+
+import (
+	"backend/api/filter"
+	"backend/api/opsys"
+	"backend/api/server"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/leporo/sqlf"
+)
+
+// Represents a session targting rule.
+type SessionTargetingRule struct {
+	Id             uuid.UUID `json:"id"`
+	TeamId         uuid.UUID `json:"team_id"`
+	AppId          uuid.UUID `json:"app_id"`
+	Name           string    `json:"name"`
+	Status         int       `json:"status"`
+	SamplingRate   float64   `json:"sampling_rate"`
+	Rule           string    `json:"rule"`
+	CreatedAt      time.Time `json:"created_at"`
+	CreatedBy      uuid.UUID `json:"-"`
+	CreatedByEmail string    `json:"created_by"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	UpdatedBy      uuid.UUID `json:"-"`
+	UpdatedByEmail string    `json:"updated_by"`
+}
+
+// Payload for creating a new
+// session targeting rule.
+type CreateSTRulePayload struct {
+	Name         string  `json:"name" binding:"required"`
+	Status       int     `json:"status" binding:"min=0,max=1"`
+	SamplingRate float64 `json:"sampling_rate" binding:"required"`
+	Rule         string  `json:"rule" binding:"required"`
+}
+
+// Payload to update an existing
+// session targeting rule.
+type UpdateSTRulePayload struct {
+	Name         *string  `json:"name,omitempty"`
+	Status       *int     `json:"status,omitempty" binding:"omitempty"`
+	SamplingRate *float64 `json:"sampling_rate,omitempty" binding:"omitempty"`
+	Rule         *string  `json:"rule,omitempty"`
+}
+
+// EventConfig part of the session
+// targeting dashboard config.
+type EventConfig struct {
+	Type       string       `json:"type"`
+	Attrs      []AttrConfig `json:"attrs"`
+	HasUdAttrs bool         `json:"has_ud_attrs"`
+}
+
+// AttrConfig part of the session
+// targeting dashboard config.
+type AttrConfig struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	Hint string `json:"hint"`
+}
+
+// OperatorTypes part of the session
+// targeting dashboard config.
+type OperatorTypes struct {
+	Bool    []string `json:"bool"`
+	Float64 []string `json:"float64"`
+	Int64   []string `json:"int64"`
+	String  []string `json:"string"`
+}
+
+// Session targeting config used
+// by the dashboard.
+type STDashboardConfig struct {
+	Events        []EventConfig `json:"events"`
+	SessionAttrs  []AttrConfig  `json:"session_attrs"`
+	EventUdAttrs  []AttrConfig  `json:"event_ud_attrs"`
+	OperatorTypes OperatorTypes `json:"operator_types"`
+}
+
+func CreateDefaultSTRules(ctx context.Context, teamId string, appId string, userId string) (err error) {
+	now := time.Now()
+
+	defaultRules := []CreateSTRulePayload{
+		{
+			Name:         "Sessions with crashes",
+			Rule:         "(event_type == \"exception\" && exception.handled == false)",
+			SamplingRate: 100.0,
+			Status:       1,
+		},
+		{
+			Name:         "Sessions with ANRs",
+			Rule:         "(event_type == \"anr\")",
+			SamplingRate: 100.0,
+			Status:       1,
+		},
+		{
+			Name:         "Sessions with bug reports",
+			Rule:         "(event_type == \"bug_report\")",
+			SamplingRate: 100.0,
+			Status:       1,
+		},
+	}
+
+	stmt := sqlf.PostgreSQL.InsertInto("session_targeting_rules")
+
+	for _, payload := range defaultRules {
+		ruleId := uuid.New()
+		stmt.NewRow().
+			Set("id", ruleId).
+			Set("team_id", teamId).
+			Set("app_id", appId).
+			Set("name", payload.Name).
+			Set("status", payload.Status).
+			Set("sampling_rate", payload.SamplingRate).
+			Set("rule", payload.Rule).
+			Set("created_at", now).
+			Set("created_by", userId).
+			Set("updated_at", now).
+			Set("updated_by", userId)
+	}
+
+	defer stmt.Close()
+
+	_, err = server.Server.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetSTRules provides session targeting rules
+// that matches various filter criteria
+// in a paginated fashion.
+func GetSTRules(ctx context.Context, af *filter.AppFilter) (rules []SessionTargetingRule, next, previous bool, err error) {
+	stmt := sqlf.PostgreSQL.From("session_targeting_rules").
+		Select("id").
+		Select("team_id").
+		Select("app_id").
+		Select("name").
+		Select("status").
+		Select("sampling_rate").
+		Select("rule").
+		Select("created_at").
+		Select("created_by").
+		Select("updated_at").
+		Select("updated_by").
+		Where("app_id = ?", af.AppID)
+
+	if af.Limit > 0 {
+		stmt.Limit(uint64(af.Limit) + 1)
+	}
+
+	if af.Offset >= 0 {
+		stmt.Offset(uint64(af.Offset))
+	}
+
+	stmt.OrderBy("updated_at DESC")
+
+	defer stmt.Close()
+
+	rows, err := server.Server.PgPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, false, false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rule SessionTargetingRule
+		if err := rows.Scan(
+			&rule.Id,
+			&rule.TeamId,
+			&rule.AppId,
+			&rule.Name,
+			&rule.Status,
+			&rule.SamplingRate,
+			&rule.Rule,
+			&rule.CreatedAt,
+			&rule.CreatedBy,
+			&rule.UpdatedAt,
+			&rule.UpdatedBy,
+		); err != nil {
+			return nil, false, false, err
+		}
+		rules = append(rules, rule)
+	}
+
+	resultLen := len(rules)
+
+	if len(rules) == 0 {
+		return nil, false, false, nil
+	}
+
+	// Set pagination next & previous flags
+	if resultLen > af.Limit {
+		rules = rules[:resultLen-1]
+		next = true
+	}
+	if af.Offset > 0 {
+		previous = true
+	}
+
+	// Populate user emails for all rules
+	if err := populateUserEmails(ctx, rules); err != nil {
+		return nil, false, false, err
+	}
+
+	return rules, next, previous, nil
+}
+
+// GetSTRuleById fetches a session targeting
+// rule by its ruleId.
+func GetSTRuleById(ctx context.Context, ruleId string) (rule SessionTargetingRule, err error) {
+	stmt := sqlf.PostgreSQL.From("session_targeting_rules").
+		Select("id").
+		Select("team_id").
+		Select("app_id").
+		Select("name").
+		Select("status").
+		Select("sampling_rate").
+		Select("rule").
+		Select("created_at").
+		Select("created_by").
+		Select("updated_at").
+		Select("updated_by").
+		Where("id = ?", ruleId)
+
+	defer stmt.Close()
+
+	row := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...)
+
+	if err := row.Scan(
+		&rule.Id,
+		&rule.TeamId,
+		&rule.AppId,
+		&rule.Name,
+		&rule.Status,
+		&rule.SamplingRate,
+		&rule.Rule,
+		&rule.CreatedAt,
+		&rule.CreatedBy,
+		&rule.UpdatedAt,
+		&rule.UpdatedBy,
+	); err != nil {
+		return rule, err
+	}
+
+	// Populate user emails
+	emailLUT, err := GetEmails(ctx, []uuid.UUID{rule.CreatedBy, rule.UpdatedBy})
+	if err != nil {
+		return rule, err
+	}
+	rule.CreatedByEmail = emailLUT[rule.CreatedBy]
+	rule.UpdatedByEmail = emailLUT[rule.UpdatedBy]
+
+	return rule, nil
+}
+
+// CreateSTRule validates and creates
+// a new session targeting rule for
+// an app.
+func CreateSTRule(ctx context.Context, teamId string, appId string, userId string, payload CreateSTRulePayload) (rule SessionTargetingRule, err error) {
+	if payload.Name == "" {
+		return rule, errors.New("name is empty")
+	}
+
+	if payload.Status != 0 && payload.Status != 1 {
+		return rule, errors.New("status must be 0 or 1")
+	}
+
+	if payload.SamplingRate < 0 || payload.SamplingRate > 100 {
+		return rule, errors.New("sampling_rate must be between 0 and 100")
+	}
+
+	if payload.Rule == "" {
+		return rule, errors.New("rule is empty")
+	}
+
+	now := time.Now()
+	ruleId := uuid.New()
+
+	stmt := sqlf.PostgreSQL.
+		InsertInto("session_targeting_rules").
+		Set("id", ruleId).
+		Set("team_id", teamId).
+		Set("app_id", appId).
+		Set("name", payload.Name).
+		Set("status", payload.Status).
+		Set("sampling_rate", payload.SamplingRate).
+		Set("rule", payload.Rule).
+		Set("created_at", now).
+		Set("created_by", userId).
+		Set("updated_at", now).
+		Set("updated_by", userId).
+		Returning("id").
+		Returning("team_id").
+		Returning("app_id").
+		Returning("name").
+		Returning("status").
+		Returning("sampling_rate").
+		Returning("rule").
+		Returning("created_at").
+		Returning("created_by").
+		Returning("updated_at").
+		Returning("updated_by")
+
+	defer stmt.Close()
+
+	row := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...)
+
+	if err := row.Scan(
+		&rule.Id,
+		&rule.TeamId,
+		&rule.AppId,
+		&rule.Name,
+		&rule.Status,
+		&rule.SamplingRate,
+		&rule.Rule,
+		&rule.CreatedAt,
+		&rule.CreatedBy,
+		&rule.UpdatedAt,
+		&rule.UpdatedBy,
+	); err != nil {
+		return rule, err
+	}
+
+	return rule, nil
+}
+
+// UpdateSTRule updates an existing
+// session targeting rule.
+func UpdateSTRule(ctx context.Context, teamId string, appId string, userId string, ruleId string, payload UpdateSTRulePayload) error {
+	now := time.Now()
+
+	stmt := sqlf.PostgreSQL.
+		Update("session_targeting_rules").
+		Set("updated_at", now).
+		Set("updated_by", userId).
+		Where("id = ?", ruleId).
+		Where("team_id = ?", teamId).
+		Where("app_id = ?", appId)
+
+	// Only update fields that are provided
+	if payload.Name != nil && *payload.Name != "" {
+		stmt = stmt.Set("name", *payload.Name)
+	}
+
+	if payload.Status != nil && (*payload.Status == 0 || *payload.Status == 1) {
+		stmt = stmt.Set("status", *payload.Status)
+	}
+
+	if payload.SamplingRate != nil && (*payload.SamplingRate >= 0 && *payload.SamplingRate <= 100) {
+		stmt = stmt.Set("sampling_rate", *payload.SamplingRate)
+	}
+
+	if payload.Rule != nil && *payload.Rule != "" {
+		stmt = stmt.Set("rule", *payload.Rule)
+	}
+
+	defer stmt.Close()
+
+	result, err := server.Server.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return fmt.Errorf("failed to update rule: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("rule not found: id=%s, team_id=%s, app_id=%s", ruleId, teamId, appId)
+	}
+
+	return nil
+}
+
+// GetSTDashboardConfig creates and returns
+// the config required to render session
+// targeting rule creation page.
+func GetSTDashboardConfig(ctx context.Context, appId uuid.UUID, osName string) (STDashboardConfig, error) {
+	eventUdAttrs, err := getUDAttrKeys(ctx, appId)
+	if err != nil {
+		return STDashboardConfig{}, err
+	}
+
+	return STDashboardConfig{
+		Events:        newEventsConfig(osName),
+		SessionAttrs:  newSessionConfig(osName),
+		EventUdAttrs:  eventUdAttrs,
+		OperatorTypes: newOperatorTypes(),
+	}, nil
+}
+
+func getUDAttrKeys(ctx context.Context, appId uuid.UUID) (attributes []AttrConfig, err error) {
+	var table string = "user_def_attrs"
+	substmt := sqlf.From(table).
+		Select("distinct key").
+		Select("argMax(type, ver) last_inserted_type").
+		Clause("final prewhere app_id = toUUID(?)", appId).
+		GroupBy("key")
+
+	stmt := sqlf.With("last_type", substmt).
+		Select("distinct t.key, t.type").
+		From(table+" t").
+		Join("last_type lt", "t.key = lt.key").
+		Where("t.type = lt.last_inserted_type").
+		OrderBy("key")
+
+	defer stmt.Close()
+
+	rows, err := server.Server.ChPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return
+	}
+
+	for rows.Next() {
+		var attribute AttrConfig
+		if err = rows.Scan(&attribute.Key, &attribute.Type); err != nil {
+			return
+		}
+
+		attributes = append(attributes, attribute)
+	}
+
+	err = rows.Err()
+
+	return
+}
+
+// newEventsConfig creates OS-specific
+// events configuration
+func newEventsConfig(osName string) []EventConfig {
+	// Common events for both iOS and Android
+	events := []EventConfig{
+		{
+			Type:       "exception",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "handled", Type: "bool"},
+			},
+		},
+		{
+			Type:       "bug_report",
+			HasUdAttrs: true,
+			Attrs:      []AttrConfig{},
+		},
+		{
+			Type:       "custom",
+			HasUdAttrs: true,
+			Attrs: []AttrConfig{
+				{Key: "name", Type: "string", Hint: "Enter custom event name"},
+			},
+		},
+		{
+			Type:       "screen_view",
+			HasUdAttrs: true,
+			Attrs: []AttrConfig{
+				{Key: "name", Type: "string", Hint: "Enter screen name"},
+			},
+		},
+		{
+			Type:       "http",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "url", Type: "string", Hint: "Enter a HTTP URL"},
+				{Key: "status_code", Type: "int64", Hint: "Enter HTTP status code"},
+			},
+		},
+	}
+
+	// Define platform-specific events
+	androidEvents := []EventConfig{
+		{
+			Type:       "anr",
+			HasUdAttrs: false,
+			Attrs:      []AttrConfig{},
+		},
+		{
+			Type:       "lifecycle_activity",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "class_name", Type: "string", Hint: "Enter Activity class name"},
+			},
+		},
+		{
+			Type:       "lifecycle_fragment",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "class_name", Type: "string", Hint: "Enter Fragment class name"},
+			},
+		},
+	}
+
+	iosEvents := []EventConfig{
+		{
+			Type:       "lifecycle_view_controller",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "class_name", Type: "string", Hint: "Enter View Controller class name"},
+			},
+		},
+		{
+			Type:       "lifecycle_swift_ui",
+			HasUdAttrs: false,
+			Attrs: []AttrConfig{
+				{Key: "class_name", Type: "string", Hint: "Enter Swift View class name"},
+			},
+		},
+	}
+
+	switch opsys.ToFamily(osName) {
+	case opsys.Android:
+		events = append(events, androidEvents...)
+	case opsys.AppleFamily:
+		events = append(events, iosEvents...)
+	default:
+		// Unknown OS - include both Android and iOS events
+		events = append(events, androidEvents...)
+		events = append(events, iosEvents...)
+	}
+
+	// sort values by event type
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Type < events[j].Type
+	})
+
+	return events
+}
+
+// newEventsConfig creates OS-specific
+// session attributes configuration.
+func newSessionConfig(osName string) []AttrConfig {
+	switch opsys.ToFamily(osName) {
+	case opsys.Android:
+		return []AttrConfig{
+			{Key: "app_build", Type: "string", Hint: "Enter your app's build number"},
+			{Key: "app_version", Type: "string", Hint: "Enter your app's version"},
+			{Key: "device_is_foldable", Type: "bool"},
+			{Key: "device_is_physical", Type: "bool"},
+			{Key: "device_locale", Type: "string", Hint: "Enter a locale like en_US, fr_FR"},
+			{Key: "device_low_power_mode", Type: "bool"},
+			{Key: "device_manufacturer", Type: "string", Hint: "E.g. Apple, Samsung, Google"},
+			{Key: "device_model", Type: "string", Hint: "E.g. Redmi Go, Pixel 4a "},
+			{Key: "device_name", Type: "string", Hint: "E.g. sunfish, tiare"},
+			{Key: "device_thermal_throttling_enabled", Type: "bool"},
+			{Key: "device_type", Type: "string", Hint: "E.g. phone or tablet"},
+			{Key: "installation_id", Type: "string", Hint: "Enter an installation ID"},
+			{Key: "user_id", Type: "string", Hint: "Enter a user ID"},
+			{Key: "os_version", Type: "string", Hint: "Enter API level like 21, 36"},
+		}
+	case opsys.AppleFamily:
+		return []AttrConfig{
+			{Key: "app_build", Type: "string", Hint: "Enter your app's build ID"},
+			{Key: "app_version", Type: "string", Hint: "Enter your app's version"},
+			{Key: "device_is_foldable", Type: "bool"},
+			{Key: "device_is_physical", Type: "bool"},
+			{Key: "device_locale", Type: "string", Hint: "Enter a locale like en_US, fr_FR"},
+			{Key: "device_low_power_mode", Type: "bool"},
+			{Key: "device_model", Type: "string", Hint: "E.g. iPhone 17"},
+			{Key: "device_thermal_throttling_enabled", Type: "bool"},
+			{Key: "device_type", Type: "string", Hint: "E.g. phone or tablet"},
+			{Key: "installation_id", Type: "string", Hint: "Enter an installation Id"},
+			{Key: "os_version", Type: "string", Hint: "E.g. 18.3.1, 18.4.1"},
+			{Key: "user_id", Type: "string", Hint: "Enter a user ID"},
+		}
+	default:
+		return []AttrConfig{}
+	}
+}
+
+func newOperatorTypes() OperatorTypes {
+	return OperatorTypes{
+		Bool:    []string{"eq", "neq"},
+		Float64: []string{"eq", "neq", "gt", "lt", "gte", "lte"},
+		Int64:   []string{"eq", "neq", "gt", "lt", "gte", "lte"},
+		String:  []string{"eq", "neq", "contains", "startsWith"},
+	}
+}
+
+// populateUserEmails fetches and
+// populates email addresses for
+// one or more rules
+func populateUserEmails(ctx context.Context, rules []SessionTargetingRule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	// Extract unique user IDs from all rules
+	idLUT := make(map[uuid.UUID]bool)
+	for _, rule := range rules {
+		idLUT[rule.CreatedBy] = true
+		idLUT[rule.UpdatedBy] = true
+	}
+
+	if len(idLUT) > 0 {
+		ids := make([]uuid.UUID, 0, len(idLUT))
+		for id := range idLUT {
+			ids = append(ids, id)
+		}
+
+		emailLUT, err := GetEmails(ctx, ids)
+		if err != nil {
+			return fmt.Errorf("failed to fetch user emails: %w", err)
+		}
+
+		// Populate emails for all rules
+		for i := range rules {
+			rules[i].CreatedByEmail = emailLUT[rules[i].CreatedBy]
+			rules[i].UpdatedByEmail = emailLUT[rules[i].UpdatedBy]
+		}
+	}
+
+	return nil
+}

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -194,6 +194,32 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-32)
     - [Response Body](#response-body-35)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-35)
+  - [GET `/apps/:id/sessionTargetingRules`](#get-appsidsessiontargetingrules)
+    - [Usage Notes](#usage-notes-35)
+    - [Authorization \& Content Type](#authorization--content-type-33)
+    - [Response Body](#response-body-35)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-35)
+  - [GET `/apps/:id/sessionTargetingRules/:ruleId`](#get-appsidsessiontargetingrulesruleid)
+    - [Usage Notes](#usage-notes-36)
+    - [Authorization \& Content Type](#authorization--content-type-34)
+    - [Response Body](#response-body-36)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-36) 
+  - [POST `/apps/:id/sessionTargetingRules`](#post-appsidsessiontargetingrules)
+    - [Usage Notes](#usage-notes-37)
+    - [Authorization \& Content Type](#authorization--content-type-35)
+    - [Response Body](#response-body-37)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-37)
+  - [PATCH `/apps/:id/sessionTargetingRules/:ruleId`](#patch-appsidsessiontargetingrulesruleid)
+    - [Usage Notes](#usage-notes-38)
+    - [Authorization \& Content Type](#authorization--content-type-36)
+    - [Response Body](#response-body-38)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-38)
+  - [GET `/apps/:id/sessionTargetingRules/config`](#get-appsidsessiontargetingrulesconfig)
+    - [Usage Notes](#usage-notes-39)
+    - [Authorization \& Content Type](#authorization--content-type-37)
+    - [Response Body](#response-body-39)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-39)
+
 - [Teams](#teams)
   - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-33)
@@ -756,6 +782,11 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/bugReports/:bugReportId`**](#get-appsidbugreportsbugreportid) - Fetch a bug report.
 - [**PATCH `/apps/:id/bugReports/:bugReportId`**](#patch-appsidbugreportsbugreportid) - Update a bug report's status.
 - [**GET `/apps/:id/alerts`**](#get-appsidalerts) - Fetch an app's alerts with optional filters.
+- [**GET `/apps/:id/sessionTargetingRules`**](#get-appsidsessiontargetingrules) - Fetch an app's session targeting rules.
+- [**GET `/apps/:id/sessionTargetingRules/:ruleId`**](#get-appsidsessiontargetingruleruleid) - Fetch a session targeting rule by rule ID.
+- [**POST `/apps/:id/sessionTargetingRules/`**](#post-appsidsessiontargetingrules) - Creates a new session targeting rule.
+- [**PATCH `/apps/:id/sessionTargetingRules/:ruleId`**](#patch-appsidsessiontargetingrulesruleid) - Updates an existin targeting rule.
+- [**GET `/apps/:id/sessionTargetingRules/config`**](#get-appsidsessiontargetingrulesconfig) - Fetch an app's session targeting rules dashboard config.
 
 ### GET `/apps/:id/journey`
 
@@ -5219,6 +5250,452 @@ The required headers must be present in each request.
   ```
 
 #### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### GET `/apps/:id/sessionTargetingRules`
+
+#### Usage Notes
+
+
+Fetch an app's session targeting rules.
+
+- App's UUID must be passed in the URI
+- Accepts no query parameters
+- Pass `limit` and `offset` values to paginate results
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+    ```json
+    {
+      "meta": {
+          "next": false,
+          "previous": false
+      },
+      "results": [
+          {
+              "id": "c5ebde36-575f-4dcb-8eb0-495802a0154d",
+              "team_id": "e1977fdc-893e-4694-bbcd-8e7e10ee3b34",
+              "app_id": "3082f92d-f2ce-4477-a371-789911ab78ad",
+              "name": "Rule 2",
+              "status": 1,
+              "sampling_rate": 1.122123,
+              "rule": "(event_type == \"custom\" event.user_defined_attrs.boolean == false)",
+              "created_at": "2025-09-23T03:19:22.879673Z",
+              "created_by": "soodabhay23@gmail.com",
+              "updated_at": "2025-09-23T09:14:37.766358Z",
+              "updated_by": "soodabhay23@gmail.com"
+          },
+          {
+              "id": "1ead1ab4-03ba-434f-8928-1f3b908e0e2e",
+              "team_id": "e1977fdc-893e-4694-bbcd-8e7e10ee3b34",
+              "app_id": "3082f92d-f2ce-4477-a371-789911ab78ad",
+              "name": "Rule 1",
+              "status": 0,
+              "sampling_rate": 100,
+              "rule": "(event_type == \"anr\")",
+              "created_at": "2025-09-23T06:18:51.618236Z",
+              "created_by": "soodabhay23@gmail.com",
+              "updated_at": "2025-09-23T09:14:31.615099Z",
+              "updated_by": "soodabhay23@gmail.com"
+          }
+      ]
+  }
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### GET `/apps/:id/sessionTargetingRules/:ruleId`
+
+#### Usage Notes
+
+Fetch an app's session targeting rules.
+
+- App's UUID must be passed in the URI
+- Accepts no query parameters 
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+    ```json
+    {
+    "id": "c5ebde36-575f-4dcb-8eb0-495802a0154d",
+    "team_id": "e1977fdc-893e-4694-bbcd-8e7e10ee3b34",
+    "app_id": "3082f92d-f2ce-4477-a371-789911ab78ad",
+    "name": "Rule 2",
+    "status": 1,
+    "sampling_rate": 1.122123,
+    "rule": "(event_type == \"custom\" \u0026\u0026 event.user_defined_attrs.boolean == false)",
+    "created_at": "2025-09-23T03:19:22.879673Z",
+    "created_by": "foo@email.com",
+    "updated_at": "2025-09-23T09:14:37.766358Z",
+    "updated_by": "bar@email.com"
+    }
+    ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### POST `/apps/:id/sessionTargetingRules`
+
+#### Usage Notes
+
+Creates a new session targeting rule.
+
+- App's UUID must be passed in the URI
+- Accepts no query parameters
+- The request body must contain `name`, `status`, `sampling_rate` and `rule`
+  - `name` - the name of the rule
+  - `status` - represents whether the rule is active or not. Must be either 0 or 1
+  - `sampling_rate` - percentage sampling rate. Must be a value between 0 and 100.
+  - `rule` - must be a valid CEL expression.
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+    ```json
+    {
+      "name": "Rule 2",
+      "status": 1,
+      "sampling_rate": 1.122123,
+      "rule": "(event_type == \"custom\" \u0026\u0026 event.user_defined_attrs.boolean == false)",
+    }
+    ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### PATCH `/apps/:id/sessionTargetingRules/:ruleId`
+
+#### Usage Notes
+
+Creates a new session targeting rule.
+
+- App's UUID must be passed in the URI
+- Rule ID must be passed in the URI
+- The request body may contain: `name`, `status`, `sampling_rate` and `rule`
+  - `name` - the name of the rule 
+  - `status` - represents whether the rule is active or not. Must be either 0 or 1
+  - `sampling_rate` - percentage sampling rate. Must be a value between 0 and 100.
+  - `rule` - must be a valid CEL expression.
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+    ```json
+    {
+      "name": "Rule Name",
+      "status": 1,
+      "sampling_rate": 1.122123,
+      "rule": "(event_type == \"custom\" \u0026\u0026 event.user_defined_attrs.boolean == false)",
+    }
+    ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### GET `/apps/:id/sessionTargetingRules/config`
+
+#### Usage Notes
+
+Fetch an apps session targeting rule config.
+
+- App's UUID must be passed in the URI
+- Accepts no query parameters
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+    ```json
+    {
+    "result": {
+        "events": [
+            {
+                "type": "anr",
+                "attrs": [],
+                "has_ud_attrs": false
+            },
+            {
+                "type": "bug_report",
+                "attrs": [],
+                "has_ud_attrs": true
+            },
+            {
+                "type": "custom",
+                "attrs": [
+                    {
+                        "key": "name",
+                        "type": "string",
+                        "hint": "Enter custom event name"
+                    }
+                ],
+                "has_ud_attrs": true
+            }
+        ],
+        "session_attrs": [
+            {
+                "key": "app_build",
+                "type": "string",
+                "hint": "Enter your app's build number"
+            },
+            {
+                "key": "app_version",
+                "type": "string",
+                "hint": "Enter your app's version"
+            }
+        ],
+        "event_ud_attrs": [
+            {
+                "key": "long",
+                "type": "int64",
+            },
+            {
+                "key": "string",
+                "type": "string",
+            }
+        ],
+        "operator_types": {
+            "bool": [ "eq", "neq" ],
+            "float64": [ "eq", "neq", "gt", "lt", "gte", "lte" ],
+            "int64": [ "eq", "neq", "gt", "lt", "gte", "lte" ],
+            "string": [ "eq", "neq", "contains", "startsWith" ]
+        }
+      }
+    }
+    ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes & Troubleshooting
 
 List of HTTP status codes for success and failures.
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -18,6 +18,10 @@ Find all the endpoints, resources and detailed documentation for Measure SDK RES
     - [Request Body](#request-body-1)
       - [Mappings](#mappings)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-1)
+  - [GET `/config`](#get-config)
+    - [Authorization \& Content Type](#authorization--content-type-1)
+    - [Response Body](#response-body-2)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-2)
 - [References](#references)
   - [Attributes](#attributes)
   - [User Defined Attributes](#user-defined-attributes)
@@ -415,6 +419,61 @@ List of HTTP status codes for success and failures.
 | `400 Bad Request`           | Request body is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
 | `401 Unauthorized`          | Either the Measure API key is not present or has expired.                                                               |
 | `413 Content Too Large`     | Build/mapping file size exceeded maximum allowed limit.                                                                 |
+| `429 Too Many Requests`     | Rate limit has exceeded. Retry request respecting `Retry-After` response header.                                        |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                              |
+| `503 Service Unavailable`   | Measure server is temporarily unavailable. Retry request respecting `Retry-After` response header.                      |
+
+</details>
+
+### GET `/config`
+
+Provides a dynamic config to the SDK. 
+
+#### Usage Notes
+
+- Clients must respect the `Cache-control: max-age` header.   
+
+#### Authorization \& Content Type
+
+1. Set the Measure API key in `Authorization: Bearer <api-key>` format
+
+2. Set the content type as `Content-Type: application/json`.
+
+#### Response Body
+
+  ```json
+  {
+    "session_targeting": [
+      {
+        "id": "74d3e6af-91a3-4518-b0a6-8b4f97f73181",
+        "name": "Test",
+        "status": 1,
+        "sampling_rate": 100,
+        "rule": "(attribute.app_build == \"123\")"
+      },
+      {
+        "id": "c5ebde36-575f-4dcb-8eb0-495802a0154d",
+        "name": "Rule 2",
+        "status": 1,
+        "sampling_rate": 1.122123,
+        "rule": "(event_type == \"custom\" && event.user_defined_attrs.boolean == false)"
+      }
+    ]
+  }
+  ```
+
+#### Status Codes \& Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+<summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Build info uploaded                                                                                                     |
+| `400 Bad Request`           | Request body is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the Measure API key is not present or has expired.                                                               |
 | `429 Too Many Requests`     | Rate limit has exceeded. Retry request respecting `Retry-After` response header.                                        |
 | `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                              |
 | `503 Service Unavailable`   | Measure server is temporarily unavailable. Retry request respecting `Retry-After` response header.                      |

--- a/frontend/dashboard/__tests__/cel/cel_conversion_test.ts
+++ b/frontend/dashboard/__tests__/cel/cel_conversion_test.ts
@@ -1,0 +1,162 @@
+import { conditionsToCel } from "@/app/utils/cel/cel_generator";
+import { celToConditions } from "@/app/utils/cel/cel_parser";
+
+describe('CEL to conditions and back to CEL', () => {
+
+    test('processes a single event condition', () => {
+        const cel = '(event_type == "anr")';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple event conditions with AND operator', () => {
+        const cel = '((event_type == "anr") && (event_type == "exception"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple event conditions with OR operator', () => {
+        const cel = '((event_type == "anr") || (event_type == "exception"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes event with attribute', () => {
+        const cel = '(event_type == "exception" && exception.handled == false)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes event with attribute and ud-attribute', () => {
+        const cel = '(event_type == "custom" && custom.name == "login" && event.user_defined_attrs.is_premium_user == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes event with ud-attribute', () => {
+        const cel = '(event_type == "custom" && event.user_defined_attrs.is_premium_user == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes session attribute only', () => {
+        const cel = '(attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: undefined, session: conditions.session, });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple session attributes with AND operator', () => {
+        const cel = '((attribute.is_device_foldable == true) && (attribute.app_version == "1.0.0"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: undefined, session: conditions.session, });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple session attributes with OR operator', () => {
+        const cel = '((attribute.is_device_foldable == true) || (attribute.app_version == "1.0.0"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: undefined, session: conditions.session, });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes combined event and session conditions', () => {
+        const cel = '(event_type == "anr") && (attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: conditions.session });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with contains operator', () => {
+        const cel = '(event_type == "custom" && custom.name.contains("log"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with startsWith operator', () => {
+        const cel = '(event_type == "custom" && custom.name.startsWith("log"))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with gte operator', () => {
+        const cel = '(event_type == "custom" && custom.retry_cound >= 1)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with lte operator', () => {
+        const cel = '(event_type == "custom" && custom.retry_cound <= 1)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with lt operator', () => {
+        const cel = '(event_type == "custom" && custom.retry_cound < 1)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes condition with gt operator', () => {
+        const cel = '(event_type == "custom" && custom.retry_cound > 1)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: undefined, session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes a span condition', () => {
+        const cel = '(span_name == "Activity TTID")';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: conditions.trace , session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple span conditions with AND operator', () => {
+        const cel = '((span_name == "Activity TTID") && (span_name.startsWith("HTTP GET /config")))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: conditions.trace , session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes multiple span conditions with OR operator', () => {
+        const cel = '((span_name == "Activity TTID") || (span_name.startsWith("HTTP GET /config")))';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: conditions.trace , session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes a span condition with user defined attributes', () => {
+        const cel = '(span_name == "Activity TTID" && trace.user_defined_attrs.api_level >= 21)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.trace).toBeDefined();
+
+        const outputCel = conditionsToCel({ event: undefined, trace: conditions.trace , session: undefined });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes a span condition with session conditions', () => {
+        const cel = '(span_name == "Activity TTID") && (attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: undefined, trace: conditions.trace, session: conditions.session });
+        expect(outputCel).toBe(cel);
+    });
+
+    test('processes complex combined conditions', () => {
+        const cel = '((event_type == "anr") && (event_type == "exception")) && (span_name == "Activity TTID" && trace.user_defined_attrs.api_level >= 21) && (attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+        const outputCel = conditionsToCel({ event: conditions.event, trace: conditions.trace, session: conditions.session });
+        expect(outputCel).toBe(cel);
+    });
+});

--- a/frontend/dashboard/__tests__/cel/cel_generator_test.ts
+++ b/frontend/dashboard/__tests__/cel/cel_generator_test.ts
@@ -1,0 +1,550 @@
+import { conditionsToCel } from "@/app/utils/cel/cel_generator";
+import { ParsedConditions } from "@/app/utils/cel/cel_parser";
+
+describe('CEL Generator', () => {
+    describe('CEL from event conditions', () => {
+        test('generates CEL for single event type condition', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'anr',
+                        attrs: [],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                }
+            };
+
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "anr")');
+        });
+
+        test('generates CEL for event with standard attribute', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'exception',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'handled',
+                            type: 'boolean',
+                            value: false,
+                            operator: 'eq'
+                        }],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "exception" && exception.handled == false)');
+        });
+
+        test('generates CEL for event with user-defined attribute', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'custom',
+                        attrs: [],
+                        ud_attrs: [
+                            {
+                                id: 'ud_attr1',
+                                key: 'user_tier',
+                                type: 'string',
+                                value: 'premium',
+                                operator: 'eq'
+                            }
+                        ],
+                    }],
+                    operators: []
+                }
+            };
+
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "custom" && event.user_defined_attrs.user_tier == "premium")');
+        });
+
+        test('generates CEL for event with both standard and user-defined attributes', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'exception',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'handled',
+                            type: 'boolean',
+                            value: false,
+                            operator: 'eq'
+                        }],
+                        ud_attrs: [{
+                            id: 'ud_attr1',
+                            key: 'user_tier',
+                            type: 'string',
+                            value: 'premium',
+                            operator: 'eq'
+                        }],
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "exception" && exception.handled == false && event.user_defined_attrs.user_tier == "premium")');
+        });
+
+        test('generates CEL for multiple event conditions with AND operator', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'exception',
+                        attrs: [],
+                        ud_attrs: [],
+                    }, {
+                        id: 'cond2',
+                        type: 'anr',
+                        attrs: [],
+                        ud_attrs: [],
+                    }],
+                    operators: ['AND']
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('((event_type == "exception") && (event_type == "anr"))');
+        });
+
+        test('generates CEL for multiple event conditions with AND operator', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'exception',
+                        attrs: [],
+                        ud_attrs: [],
+                    }, {
+                        id: 'cond2',
+                        type: 'anr',
+                        attrs: [],
+                        ud_attrs: [],
+                    }],
+                    operators: ['OR']
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('((event_type == "exception") || (event_type == "anr"))');
+        });
+
+        test('generates CEL with string contains operator', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'custom',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'name',
+                            type: 'string',
+                            value: 'abc',
+                            operator: 'contains'
+                        }],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "custom" && custom.name.contains("abc"))');
+        });
+
+        test('generates CEL with string startsWith operator', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'custom',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'name',
+                            type: 'string',
+                            value: 'prefix_',
+                            operator: 'startsWith'
+                        }],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "custom" && custom.name.startsWith("prefix_"))');
+        });
+
+        test('generates CEL with numeric comparison operators', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'custom',
+                        attrs: [
+                            { id: 'attr1', key: 'count', type: 'number', value: 5, operator: 'gt' },
+                            { id: 'attr2', key: 'limit', type: 'number', value: 10, operator: 'lte' }
+                        ],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "custom" && custom.count > 5 && custom.limit <= 10)');
+        });
+    });
+
+    describe('CEL from session conditions', () => {
+        test('generates CEL for single session attribute', () => {
+            const conditions: ParsedConditions = {
+                session: {
+                    conditions: [{
+                        id: 'cond1',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'is_device_foldable',
+                            type: 'boolean',
+                            value: true,
+                            operator: 'eq'
+                        }]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(attribute.is_device_foldable == true)');
+        });
+
+        test('generates CEL for multiple session attributes with AND operator', () => {
+            const conditions: ParsedConditions = {
+                session: {
+                    conditions: [
+                        {
+                            id: 'cond1',
+                            attrs: [{
+                                id: 'attr1',
+                                key: 'is_device_foldable',
+                                type: 'boolean',
+                                value: true,
+                                operator: 'eq'
+                            }]
+                        },
+                        {
+                            id: 'cond2',
+                            attrs: [{
+                                id: 'attr2',
+                                key: 'app_version',
+                                type: 'string',
+                                value: '1.0.0',
+                                operator: 'eq'
+                            }]
+                        }
+                    ],
+                    operators: ['AND']
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('((attribute.is_device_foldable == true) && (attribute.app_version == "1.0.0"))');
+        });
+
+        test('generates CEL for session attribute with string operators', () => {
+            const conditions: ParsedConditions = {
+                session: {
+                    conditions: [{
+                        id: 'cond1',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'device_model',
+                            type: 'string',
+                            value: 'Samsung',
+                            operator: 'startsWith'
+                        }]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(attribute.device_model.startsWith("Samsung"))');
+        });
+    });
+
+    describe('Trace Conditions', () => {
+        test('generates CEL for single span name condition', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'Activity TTID',
+                        operator: 'eq',
+                        ud_attrs: []
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name == "Activity TTID")');
+        });
+
+        test('generates CEL for span name with string contains operator', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'HTTP',
+                        operator: 'contains',
+                        ud_attrs: []
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name.contains("HTTP"))');
+        });
+
+        test('generates CEL for span name with string startsWith operator', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'HTTP GET',
+                        operator: 'startsWith',
+                        ud_attrs: []
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name.startsWith("HTTP GET"))');
+        });
+
+        test('generates CEL for span with user-defined attributes', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'Activity TTID',
+                        operator: 'eq',
+                        ud_attrs: [{
+                            id: 'ud_attr1',
+                            key: 'api_level',
+                            type: 'number',
+                            value: 21,
+                            operator: 'gte'
+                        }]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name == "Activity TTID" && trace.user_defined_attrs.api_level >= 21)');
+        });
+
+        test('generates CEL for span with multiple user-defined attributes', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'HTTP Request',
+                        operator: 'eq',
+                        ud_attrs: [
+                            {
+                                id: 'ud_attr1',
+                                key: 'status_code',
+                                type: 'number',
+                                value: 200,
+                                operator: 'eq'
+                            },
+                            {
+                                id: 'ud_attr2',
+                                key: 'method',
+                                type: 'string',
+                                value: 'GET',
+                                operator: 'eq'
+                            }
+                        ]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name == "HTTP Request" && trace.user_defined_attrs.status_code == 200 && trace.user_defined_attrs.method == "GET")');
+        });
+
+        test('generates CEL for multiple trace conditions with AND operator', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [
+                        {
+                            id: 'cond1',
+                            spanName: 'Activity TTID',
+                            operator: 'eq',
+                            ud_attrs: []
+                        },
+                        {
+                            id: 'cond2',
+                            spanName: 'HTTP GET',
+                            operator: 'startsWith',
+                            ud_attrs: []
+                        }
+                    ],
+                    operators: ['AND']
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('((span_name == "Activity TTID") && (span_name.startsWith("HTTP GET")))');
+        });
+
+        test('generates CEL for multiple trace conditions with OR operator', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [
+                        {
+                            id: 'cond1',
+                            spanName: 'Activity TTID',
+                            operator: 'eq',
+                            ud_attrs: []
+                        },
+                        {
+                            id: 'cond2',
+                            spanName: 'HTTP GET /config',
+                            operator: 'startsWith',
+                            ud_attrs: []
+                        }
+                    ],
+                    operators: ['OR']
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('((span_name == "Activity TTID") || (span_name.startsWith("HTTP GET /config")))');
+        });
+
+        test('generates CEL for user-defined attributes with string operators', () => {
+            const conditions: ParsedConditions = {
+                trace: {
+                    conditions: [{
+                        id: 'cond1',
+                        spanName: 'Database Query',
+                        operator: 'eq',
+                        ud_attrs: [
+                            {
+                                id: 'ud_attr1',
+                                key: 'table_name',
+                                type: 'string',
+                                value: 'user',
+                                operator: 'contains'
+                            },
+                            {
+                                id: 'ud_attr2',
+                                key: 'query_type',
+                                type: 'string',
+                                value: 'SELECT',
+                                operator: 'startsWith'
+                            }
+                        ]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(span_name == "Database Query" && trace.user_defined_attrs.table_name.contains("user") && trace.user_defined_attrs.query_type.startsWith("SELECT"))');
+        });
+    });
+
+    describe('CEL from combined conditions', () => {
+        test('generates CEL for event and session conditions', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'anr',
+                        attrs: [],
+                        ud_attrs: []
+                    }],
+                    operators: []
+                },
+                session: {
+                    conditions: [{
+                        id: 'cond2',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'is_device_foldable',
+                            type: 'boolean',
+                            value: true,
+                            operator: 'eq'
+                        }]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "anr") && (attribute.is_device_foldable == true)');
+        });
+
+        test('generates CEL for event, trace, and session conditions', () => {
+            const conditions: ParsedConditions = {
+                event: {
+                    conditions: [{
+                        id: 'cond1',
+                        type: 'custom',
+                        attrs: [],
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                },
+                trace: {
+                    conditions: [{
+                        id: 'cond2',
+                        spanName: 'Activity TTID',
+                        operator: 'eq',
+                        ud_attrs: [],
+                    }],
+                    operators: []
+                },
+                session: {
+                    conditions: [{
+                        id: 'cond3',
+                        attrs: [{
+                            id: 'attr1',
+                            key: 'platform',
+                            type: 'string',
+                            value: 'android',
+                            operator: 'eq'
+                        }]
+                    }],
+                    operators: []
+                }
+            };
+
+            const result = conditionsToCel(conditions);
+            expect(result).toBe('(event_type == "custom") && (span_name == "Activity TTID") && (attribute.platform == "android")');
+        });
+    });
+});

--- a/frontend/dashboard/__tests__/cel/cel_parser_test.ts
+++ b/frontend/dashboard/__tests__/cel/cel_parser_test.ts
@@ -1,0 +1,335 @@
+import { celToConditions } from "@/app/utils/cel/cel_parser";
+
+describe('CEL Parser', () => {
+    test('parses single event type condition', () => {
+        const cel = '(event_type == "anr")';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(1);
+        expect(conditions.event!.conditions[0]).toMatchObject({
+            type: 'anr',
+            attrs: [],
+            ud_attrs: []
+        });
+        expect(conditions.event!.operators).toHaveLength(0);
+        expect(conditions.session).toBeUndefined();
+        expect(conditions.trace).toBeUndefined();
+    });
+
+    test('parses multiple event conditions with AND operator', () => {
+        const cel = '((event_type == "anr") && (event_type == "exception"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(2);
+        expect(conditions.event!.conditions[0].type).toBe('anr');
+        expect(conditions.event!.conditions[1].type).toBe('exception');
+        expect(conditions.event!.operators).toEqual(['AND']);
+    });
+
+    test('parses multiple event conditions with OR operator', () => {
+        const cel = '((event_type == "anr") || (event_type == "exception"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(2);
+        expect(conditions.event!.conditions[0].type).toBe('anr');
+        expect(conditions.event!.conditions[1].type).toBe('exception');
+        expect(conditions.event!.operators).toEqual(['OR']);
+    });
+
+    test('parses event with attribute', () => {
+        const cel = '(event_type == "exception" && exception.handled == false)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(1);
+
+        const condition = conditions.event!.conditions[0];
+        expect(condition.type).toBe('exception');
+        expect(condition.attrs).toHaveLength(1);
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'handled',
+            type: 'bool',
+            value: false,
+            operator: 'eq'
+        });
+    });
+
+    test('parses event with user-defined attribute', () => {
+        const cel = '(event_type == "custom" && event.user_defined_attrs.is_premium_user == true)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(1);
+
+        const condition = conditions.event!.conditions[0];
+        expect(condition.type).toBe('custom');
+        expect(condition.ud_attrs).toHaveLength(1);
+        expect(condition.ud_attrs![0]).toMatchObject({
+            key: 'is_premium_user',
+            type: 'bool',
+            value: true,
+            operator: 'eq'
+        });
+    });
+
+    test('parses event with both regular and user-defined attributes', () => {
+        const cel = '(event_type == "custom" && custom.name == "login" && event.user_defined_attrs.is_premium_user == true)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(1);
+
+        const condition = conditions.event!.conditions[0];
+        expect(condition.type).toBe('custom');
+        expect(condition.attrs).toHaveLength(1);
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'name',
+            type: 'string',
+            value: 'login',
+            operator: 'eq'
+        });
+        expect(condition.ud_attrs).toHaveLength(1);
+        expect(condition.ud_attrs![0]).toMatchObject({
+            key: 'is_premium_user',
+            type: 'bool',
+            value: true,
+            operator: 'eq'
+        });
+    });
+
+    test('parses session attribute condition', () => {
+        const cel = '(attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.session).toBeDefined();
+        expect(conditions.session!.conditions).toHaveLength(1);
+        expect(conditions.session!.conditions[0].attrs).toHaveLength(1);
+        expect(conditions.session!.conditions[0].attrs[0]).toMatchObject({
+            key: 'is_device_foldable',
+            type: 'bool',
+            value: true,
+            operator: 'eq'
+        });
+        expect(conditions.event).toBeUndefined();
+        expect(conditions.trace).toBeUndefined();
+    });
+
+    test('parses multiple session attributes with AND operator', () => {
+        const cel = '((attribute.is_device_foldable == true) && (attribute.app_version == "1.0.0"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.session).toBeDefined();
+        expect(conditions.session!.conditions).toHaveLength(2);
+        expect(conditions.session!.operators).toEqual(['AND']);
+        expect(conditions.session!.conditions[0].attrs[0].key).toBe('is_device_foldable');
+        expect(conditions.session!.conditions[1].attrs[0].key).toBe('app_version');
+    });
+
+    test('parses multiple session attributes with OR operator', () => {
+        const cel = '((attribute.is_device_foldable == true) || (attribute.app_version == "1.0.0"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.session).toBeDefined();
+        expect(conditions.session!.conditions).toHaveLength(2);
+        expect(conditions.session!.operators).toEqual(['OR']);
+    });
+
+    test('parses span name condition', () => {
+        const cel = '(span_name == "Activity TTID")';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.trace).toBeDefined();
+        expect(conditions.trace!.conditions).toHaveLength(1);
+        expect(conditions.trace!.conditions[0]).toMatchObject({
+            spanName: 'Activity TTID',
+            operator: 'eq',
+            ud_attrs: []
+        });
+        expect(conditions.event).toBeUndefined();
+        expect(conditions.session).toBeUndefined();
+    });
+
+    test('parses multiple span conditions with AND operator', () => {
+        const cel = '((span_name == "Activity TTID") && (span_name.startsWith("HTTP GET /config")))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.trace).toBeDefined();
+        expect(conditions.trace!.conditions).toHaveLength(2);
+        expect(conditions.trace!.operators).toEqual(['AND']);
+        expect(conditions.trace!.conditions[0].spanName).toBe('Activity TTID');
+        expect(conditions.trace!.conditions[1].spanName).toBe('HTTP GET /config');
+        expect(conditions.trace!.conditions[1].operator).toBe('startsWith');
+    });
+
+    test('parses span condition with user-defined attributes', () => {
+        const cel = '(span_name == "Activity TTID" && trace.user_defined_attrs.api_level >= 21)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.trace).toBeDefined();
+        expect(conditions.trace!.conditions).toHaveLength(1);
+
+        const condition = conditions.trace!.conditions[0];
+        expect(condition.spanName).toBe('Activity TTID');
+        expect(condition.ud_attrs).toHaveLength(1);
+        expect(condition.ud_attrs![0]).toMatchObject({
+            key: 'api_level',
+            type: 'number',
+            value: 21,
+            operator: 'gte'
+        });
+    });
+
+    test('parses combined event and session conditions', () => {
+        const cel = '(event_type == "anr") && (attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.session).toBeDefined();
+
+        expect(conditions.event!.conditions).toHaveLength(1);
+        expect(conditions.event!.conditions[0].type).toBe('anr');
+
+        expect(conditions.session!.conditions).toHaveLength(1);
+        expect(conditions.session!.conditions[0].attrs[0].key).toBe('is_device_foldable');
+    });
+
+    test('parses condition with contains operator', () => {
+        const cel = '(event_type == "custom" && custom.name.contains("log"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        const condition = conditions.event!.conditions[0];
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'name',
+            type: 'string',
+            value: 'log',
+            operator: 'contains'
+        });
+    });
+
+    test('parses condition with startsWith operator', () => {
+        const cel = '(event_type == "custom" && custom.name.startsWith("log"))';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        const condition = conditions.event!.conditions[0];
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'name',
+            type: 'string',
+            value: 'log',
+            operator: 'startsWith'
+        });
+    });
+
+    test('parses condition with numeric comparison operators', () => {
+        const testCases = [
+            { cel: '(event_type == "custom" && custom.retry_count >= 1)', operator: 'gte' },
+            { cel: '(event_type == "custom" && custom.retry_count <= 1)', operator: 'lte' },
+            { cel: '(event_type == "custom" && custom.retry_count < 1)', operator: 'lt' },
+            { cel: '(event_type == "custom" && custom.retry_count > 1)', operator: 'gt' },
+            { cel: '(event_type == "custom" && custom.retry_count != 1)', operator: 'neq' }
+        ];
+
+        testCases.forEach(({ cel, operator }) => {
+            const conditions = celToConditions(cel);
+            expect(conditions.event).toBeDefined();
+            const condition = conditions.event!.conditions[0];
+            expect(condition.attrs![0]).toMatchObject({
+                key: 'retry_count',
+                type: 'number',
+                value: 1,
+                operator
+            });
+        });
+    });
+
+    test('parses complex combined conditions', () => {
+        const cel = '((event_type == "anr") && (event_type == "exception")) && (span_name == "Activity TTID" && trace.user_defined_attrs.api_level >= 21) && (attribute.is_device_foldable == true)';
+        const conditions = celToConditions(cel);
+
+        // Event conditions
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions).toHaveLength(2);
+        expect(conditions.event!.operators).toEqual(['AND']);
+        expect(conditions.event!.conditions[0].type).toBe('anr');
+        expect(conditions.event!.conditions[1].type).toBe('exception');
+
+        // Trace conditions
+        expect(conditions.trace).toBeDefined();
+        expect(conditions.trace!.conditions).toHaveLength(1);
+        expect(conditions.trace!.conditions[0].spanName).toBe('Activity TTID');
+        expect(conditions.trace!.conditions[0].ud_attrs).toHaveLength(1);
+
+        // Session conditions
+        expect(conditions.session).toBeDefined();
+        expect(conditions.session!.conditions).toHaveLength(1);
+        expect(conditions.session!.conditions[0].attrs[0].key).toBe('is_device_foldable');
+    });
+
+    test('parses condition with null value', () => {
+        const cel = '(event_type == "custom" && custom.value == null)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        const condition = conditions.event!.conditions[0];
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'value',
+            type: 'null',
+            value: null,
+            operator: 'eq'
+        });
+    });
+
+    test('parses condition with string value', () => {
+        const cel = '(event_type == "custom" && custom.message == "hello world")';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        const condition = conditions.event!.conditions[0];
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'message',
+            type: 'string',
+            value: 'hello world',
+            operator: 'eq'
+        });
+    });
+
+    test('parses condition with number value', () => {
+        const cel = '(event_type == "custom" && custom.count == 42)';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        const condition = conditions.event!.conditions[0];
+        expect(condition.attrs![0]).toMatchObject({
+            key: 'count',
+            type: 'number',
+            value: 42,
+            operator: 'eq'
+        });
+    });
+
+    test('handles whitespace in expression', () => {
+        const cel = '  ( event_type  ==  "anr"  )  ';
+        const conditions = celToConditions(cel);
+
+        expect(conditions.event).toBeDefined();
+        expect(conditions.event!.conditions[0].type).toBe('anr');
+    });
+
+    test('returns empty result for invalid expression', () => {
+        const cel = 'invalid expression';
+        const conditions = celToConditions(cel);
+
+        expect(conditions).toEqual({});
+    });
+
+    test('returns empty result for malformed parentheses', () => {
+        const cel = '(event_type == "anr"';
+        const conditions = celToConditions(cel);
+
+        expect(conditions).toEqual({});
+    });
+});

--- a/frontend/dashboard/__tests__/pages/session_targeting_rule_test.tsx
+++ b/frontend/dashboard/__tests__/pages/session_targeting_rule_test.tsx
@@ -1,0 +1,565 @@
+import SessionTargetingRule from '@/app/components/session_targeting/session_targeting_rule'
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+// Global replace and push mocks for router
+const replaceMock = jest.fn()
+const pushMock = jest.fn()
+
+// Mock next/navigation hooks
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({
+        replace: replaceMock,
+        push: pushMock,
+    }),
+}))
+
+// Mock API calls and constants for session targeting
+jest.mock('@/app/api/api_calls', () => ({
+    __esModule: true,
+    sessionTargetingConfigResponse: {
+        result: {
+            events: [
+                { type: 'click', attrs: [{ key: 'button_id', type: 'string' }], ud_attrs: true }
+            ],
+            session_attrs: [{ key: 'user_id', type: 'string' }],
+            event_ud_attrs: { key_types: [{ key: 'custom_attr', type: 'string' }] },
+            operator_types: { string: ['eq', 'neq'], number: ['eq', 'gt'] }
+        }
+    },
+    emptySessionTargetingRuleResponse: {
+        results: {
+            id: 'rule-123',
+            name: 'Test Rule',
+            sampling_rate: 75,
+            status: 1,
+            rule: 'event.type == "click"'
+        }
+    },
+    SessionTargetingConfigApiStatus: {
+        Loading: 'loading',
+        Error: 'error',
+        Success: 'success'
+    },
+    SessionTargetingRuleApiStatus: {
+        Loading: 'loading',
+        Error: 'error',
+        Success: 'success'
+    },
+    CreateSessionTargetingRuleApiStatus: {
+        Loading: 'loading',
+        Error: 'error',
+        Success: 'success'
+    },
+    UpdateSessionTargetingRuleApiStatus: {
+        Loading: 'loading',
+        Error: 'error',
+        Success: 'success'
+    },
+    fetchSessionTargetingConfigFromServer: jest.fn(() =>
+        Promise.resolve({
+            status: 'success',
+            data: {
+                result: {
+                    events: [
+                        {
+                            type: 'anr', attrs: [
+                                {
+                                    key: 'handled',
+                                    type: 'bool'
+                                }
+                            ], ud_attrs: false
+                        },
+                        {
+                            type: 'exception', attrs: [
+                                {
+                                    key: 'handled',
+                                    type: 'bool'
+                                }
+                            ], ud_attrs: false
+                        }
+                    ],
+                    session_attrs: [
+                        {
+                            key: 'is_device_foldable',
+                            type: 'bool'
+                        }
+                    ],
+                    event_ud_attrs: {},
+                    operator_types: {
+                        string: ['eq', 'neq'],
+                        bool: ['eq', 'neq']
+                    }
+                }
+            }
+        })
+    ),
+    fetchSessionTargetingRuleFromServer: jest.fn(() =>
+        Promise.resolve({
+            status: 'success',
+            data: {
+                id: 'rule-123',
+                name: 'Test Rule',
+                sampling_rate: 75,
+                status: 1,
+                rule: '(event_type == "anr")'
+            }
+        })
+    ),
+    createSessionTargetingRule: jest.fn(),
+    updateSessionTargetingRule: jest.fn(),
+}))
+
+// Mock loading component
+jest.mock('@/app/components/loading_spinner', () => () => (
+    <div data-testid="loading-spinner-mock">Loading...</div>
+))
+
+// Mock attribute components
+jest.mock('@/app/components/session_targeting/rule_builder_attribute_row', () => ({
+    attr,
+    onRemoveAttr,
+    conditionId,
+    attrType
+}: any) => (
+    <div data-testid={`attribute-row-${attr.id}`}>
+        <span>Attribute: {attr.key}</span>
+        <span>{String(attr.value)}</span>
+        <button
+            data-testid={`remove-attribute-${attr.id}`}
+            onClick={() => onRemoveAttr?.(conditionId, attr.id, attrType)}
+        >
+            Remove
+        </button>
+    </div>
+))
+
+jest.mock('@/app/components/session_targeting/rule_builder_add_attribute', () => ({
+    title,
+    onAdd,
+    disabled
+}: any) => (
+    <button
+        data-testid={`add-attribute-${title.toLowerCase().replace(/\s+/g, '-')}`}
+        onClick={onAdd}
+        disabled={disabled}
+    >
+        + Add {title}
+    </button>
+))
+
+// Mock crypto.randomUUID
+Object.defineProperty(global.crypto, 'randomUUID', {
+    value: jest.fn(() => 'mock-uuid-123'),
+    writable: true
+})
+
+describe('SessionTargetingRule Component - Page State', () => {
+    beforeEach(() => {
+        replaceMock.mockClear()
+        pushMock.mockClear()
+    })
+
+    const defaultProps = {
+        params: {
+            teamId: 'team-123',
+            appId: 'app-123'
+        },
+        isEditMode: false
+    }
+
+    it('renders loading state when page is loading', () => {
+        // Mock API to never resolve to keep loading state
+        const { fetchSessionTargetingConfigFromServer } = require('@/app/api/api_calls')
+        fetchSessionTargetingConfigFromServer.mockImplementationOnce(() => new Promise(() => { }))
+
+        render(<SessionTargetingRule {...defaultProps} />)
+
+        // Verify loading spinner is visible
+        expect(screen.getByTestId('loading-spinner-mock')).toBeInTheDocument()
+        expect(screen.queryByText('Session Targeting Rule')).toBeInTheDocument()
+
+        // Verify main UI elements are not rendered during loading
+        expect(screen.queryByText('Rule name')).not.toBeInTheDocument()
+        expect(screen.queryByText('Sampling rate %')).not.toBeInTheDocument()
+        expect(screen.queryByText('Active')).not.toBeInTheDocument()
+        expect(screen.queryByText('Event Conditions')).not.toBeInTheDocument()
+        expect(screen.queryByText('Session Conditions')).not.toBeInTheDocument()
+    })
+
+    it('renders error state when API call fails', async () => {
+        const { fetchSessionTargetingConfigFromServer, } = require('@/app/api/api_calls')
+        fetchSessionTargetingConfigFromServer.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'error'
+            })
+        )
+
+        render(<SessionTargetingRule {...defaultProps} />)
+
+        // Wait for the error state to appear and verify exact error message
+        expect(await screen.findByText('Error loading rule. Please refresh the page to try again.')).toBeInTheDocument()
+
+        // Verify loading spinner is not visible
+        expect(screen.queryByTestId('loading-spinner-mock')).not.toBeInTheDocument()
+
+        // Verify main UI elements are not rendered in error state
+        expect(screen.queryByText('Session Targeting Rule')).not.toBeInTheDocument()
+        expect(screen.queryByText('Rule name')).not.toBeInTheDocument()
+        expect(screen.queryByText('Sampling rate %')).not.toBeInTheDocument()
+        expect(screen.queryByText('Active')).not.toBeInTheDocument()
+        expect(screen.queryByText('Event Conditions')).not.toBeInTheDocument()
+        expect(screen.queryByText('Session Conditions')).not.toBeInTheDocument()
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+        expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+
+    it('renders ready state in create mode when API call succeeds', async () => {
+        render(<SessionTargetingRule {...defaultProps} />)
+
+        // Wait for the ready state to appear and verify main heading
+        expect(await screen.findByText('Session Targeting Rule')).toBeInTheDocument()
+
+        // Verify loading spinner is not visible
+        expect(screen.queryByTestId('loading-spinner-mock')).not.toBeInTheDocument()
+
+        // Verify form labels are rendered
+        expect(screen.getByText('Rule name')).toBeInTheDocument()
+        expect(screen.getByText('Sampling rate %')).toBeInTheDocument()
+        expect(screen.getByText('Active')).toBeInTheDocument()
+
+        // Verify form inputs are rendered with initial values
+        const ruleNameInput = screen.getByPlaceholderText('Enter rule name')
+        expect(ruleNameInput).toBeInTheDocument()
+        expect(ruleNameInput).toHaveValue('')
+
+        const samplingRateInput = screen.getByPlaceholderText('0-100%')
+        expect(samplingRateInput).toBeInTheDocument()
+        expect(samplingRateInput).toHaveValue(100)
+
+        // Verify condition sections are rendered
+        expect(screen.getByText('Event Conditions')).toBeInTheDocument()
+        expect(screen.getByText('Session Conditions')).toBeInTheDocument()
+
+        // Verify two add condition buttons are present
+        const addConditionButtons = screen.getAllByText('+ Add condition')
+        expect(addConditionButtons.length).toBe(2)
+    })
+
+    it('renders ready state in edit mode with existing rule data', async () => {
+        // Mock the rule data from server
+        const { fetchSessionTargetingRuleFromServer, fetchSessionTargetingConfigFromServer } = require('@/app/api/api_calls')
+        fetchSessionTargetingRuleFromServer.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success',
+                data: {
+                    id: 'rule-456',
+                    name: 'Complex Test Rule',
+                    sampling_rate: 85,
+                    status: 1, // enabled
+                    rule: '((event_type == "anr") && (event_type == "exception")) && (attribute.is_device_foldable == true)'
+                }
+            })
+        )
+
+        fetchSessionTargetingConfigFromServer.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success',
+                data: {
+                    result: {
+                        events: [
+                            { type: 'anr', attrs: [], ud_attrs: false },
+                            { type: 'exception', attrs: [], ud_attrs: false }
+                        ],
+                        session_attrs: [
+                            {
+                                key: 'is_device_foldable',
+                                type: 'bool'
+
+                            }
+                        ],
+                        event_ud_attrs: {},
+                        operator_types: {
+                            string: ['eq', 'neq'],
+                        }
+                    }
+                }
+            })
+        )
+
+        const editModeProps = {
+            params: {
+                teamId: 'team-123',
+                appId: 'app-123',
+                ruleId: 'rule-456'
+            },
+            isEditMode: true
+        }
+
+        render(<SessionTargetingRule {...editModeProps} />)
+
+        // Wait for the ready state to appear and verify main heading
+        expect(await screen.findByText('Session Targeting Rule')).toBeInTheDocument()
+
+        // Verify loading spinner is not visible
+        expect(screen.queryByTestId('loading-spinner-mock')).not.toBeInTheDocument()
+
+        // Update button is disabled when no changes are made
+        const updateButton = screen.getByText('Update Rule')
+        expect(updateButton).toBeDisabled()
+
+        // Verify form is populated with existing rule data
+        const ruleNameInput = screen.getByPlaceholderText('Enter rule name')
+        expect(ruleNameInput).toBeInTheDocument()
+        expect(ruleNameInput).toHaveValue('Complex Test Rule')
+
+        const samplingRateInput = screen.getByPlaceholderText('0-100%')
+        expect(samplingRateInput).toBeInTheDocument()
+        expect(samplingRateInput).toHaveValue(85)
+
+        // Verify condition sections are rendered
+        expect(screen.getByText('Event Conditions')).toBeInTheDocument()
+        expect(screen.getByText('Session Conditions')).toBeInTheDocument()
+
+        // Check for event types: "anr" and "exception"
+        expect(screen.getByText('anr')).toBeInTheDocument()
+        expect(screen.getByText('exception')).toBeInTheDocument()
+
+        // Check for session attribute
+        expect(screen.getByText('Attribute: is_device_foldable')).toBeInTheDocument()
+
+        // Check for boolean value
+        expect(screen.getByText('true')).toBeInTheDocument()
+    })
+})
+
+describe('SessionTargetingRule Component - Add/remove Event Attributes', () => {
+    beforeEach(() => {
+        replaceMock.mockClear()
+        pushMock.mockClear()
+    })
+
+    const defaultProps = {
+        params: {
+            teamId: 'team-123',
+            appId: 'app-123'
+        },
+        isEditMode: false
+    }
+
+    it('adds and removes event attributes correctly', async () => {
+        render(<SessionTargetingRule {...defaultProps} />)
+
+        // Wait for ready state
+        await screen.findByText('Session Targeting Rule')
+
+        // Add an event condition first
+        const addEventConditionButton = screen.getAllByText('+ Add condition')[0]
+        await act(async () => {
+            fireEvent.click(addEventConditionButton)
+        })
+
+        // Verify event condition was added
+        expect(screen.getByText('anr')).toBeInTheDocument()
+
+        // Add an attribute to the event condition
+        const addAttributeButton = screen.getByTestId('add-attribute-attributes')
+        await act(async () => {
+            fireEvent.click(addAttributeButton)
+        })
+
+        // Verify attribute was added
+        expect(screen.getByTestId('attribute-row-mock-uuid-123')).toBeInTheDocument()
+        expect(screen.getByText('Attribute: handled')).toBeInTheDocument()
+
+        // Remove the attribute
+        const removeAttributeButton = screen.getByTestId('remove-attribute-mock-uuid-123')
+        await act(async () => {
+            fireEvent.click(removeAttributeButton)
+        })
+
+        // Verify attribute was removed
+        expect(screen.queryByTestId('attribute-row-mock-uuid-123')).not.toBeInTheDocument()
+        expect(screen.queryByText('Attribute: handled')).not.toBeInTheDocument()
+
+        // Event condition should still exist
+        expect(screen.getByText('anr')).toBeInTheDocument()
+    })
+})
+
+describe('SessionTargetingRule Component - Save Rule', () => {
+    beforeEach(() => {
+        replaceMock.mockClear()
+        pushMock.mockClear()
+    })
+
+    const defaultProps = {
+        params: {
+            teamId: 'team-123',
+            appId: 'app-123'
+        },
+        isEditMode: false
+    }
+
+    it('creates new rule when published', async () => {
+        const { createSessionTargetingRule } = require('@/app/api/api_calls')
+        createSessionTargetingRule.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success'
+            })
+        )
+
+        render(<SessionTargetingRule {...defaultProps} />)
+
+        // Wait for ready state
+        await screen.findByText('Session Targeting Rule')
+
+        // Enter rule name
+        const ruleNameInput = screen.getByPlaceholderText('Enter rule name')
+        await act(async () => {
+            fireEvent.change(ruleNameInput, { target: { value: 'Test Rule Name' } })
+        })
+
+        // Change sampling rate
+        const samplingRateInput = screen.getByPlaceholderText('0-100%')
+        await act(async () => {
+            fireEvent.change(samplingRateInput, { target: { value: '75' } })
+        })
+
+        // Toggle status to enabled
+        const statusToggle = screen.getByRole('switch')
+        await act(async () => {
+            fireEvent.click(statusToggle)
+        })
+
+        // Add one event condition
+        const addEventConditionButton = screen.getAllByText('+ Add condition')[0]
+        await act(async () => {
+            fireEvent.click(addEventConditionButton)
+        })
+
+        // Add one session condition
+        const addSessionConditionButton = screen.getAllByText("+ Add condition")[1]
+        await act(async () => {
+            fireEvent.click(addSessionConditionButton)
+        })
+
+        // Click publish button
+        const publishButton = screen.getByText('Publish Rule')
+        await act(async () => {
+            fireEvent.click(publishButton)
+        })
+
+        // Verify API was called with correct rule name
+        expect(createSessionTargetingRule).toHaveBeenCalledWith(
+            'app-123',
+            expect.objectContaining({
+                name: 'Test Rule Name',
+                status: 1,
+                sampling_rate: 75,
+                rule: '(event_type == "anr") && (attribute.is_device_foldable == false)'
+            })
+        )
+    })
+
+    it('udpates existing rule with updated values when published', async () => {
+        const { updateSessionTargetingRule } = require('@/app/api/api_calls')
+        updateSessionTargetingRule.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success'
+            })
+        )
+
+        // Mock the rule data from server
+        const { fetchSessionTargetingRuleFromServer, fetchSessionTargetingConfigFromServer } = require('@/app/api/api_calls')
+        fetchSessionTargetingRuleFromServer.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success',
+                data: {
+                    id: 'rule-456',
+                    name: 'Initial Test Rule',
+                    sampling_rate: 100,
+                    status: 0, // disabled
+                    rule: '((event_type == "anr") && (event_type == "exception")) && (attribute.is_device_foldable == true)'
+                }
+            })
+        )
+
+        fetchSessionTargetingConfigFromServer.mockImplementationOnce(() =>
+            Promise.resolve({
+                status: 'success',
+                data: {
+                    result: {
+                        events: [
+                            { type: 'anr', attrs: [], ud_attrs: false },
+                            { type: 'exception', attrs: [], ud_attrs: false }
+                        ],
+                        session_attrs: [
+                            {
+                                key: 'is_device_foldable',
+                                type: 'bool'
+
+                            }
+                        ],
+                        event_ud_attrs: {},
+                        operator_types: {
+                            string: ['eq', 'neq'],
+                        }
+                    }
+                }
+            })
+        )
+
+        const editModeProps = {
+            params: {
+                teamId: 'team-123',
+                appId: 'app-123',
+                ruleId: 'rule-456'
+            },
+            isEditMode: true
+        }
+
+        render(<SessionTargetingRule {...editModeProps} />)
+
+        // Wait for ready state
+        await screen.findByText('Session Targeting Rule')
+
+        // Enter rule name
+        const ruleNameInput = screen.getByPlaceholderText('Enter rule name')
+        await act(async () => {
+            fireEvent.change(ruleNameInput, { target: { value: 'Test Rule Name' } })
+        })
+
+        // Change sampling rate
+        const samplingRateInput = screen.getByPlaceholderText('0-100%')
+        await act(async () => {
+            fireEvent.change(samplingRateInput, { target: { value: '75' } })
+        })
+
+        // Toggle status to enabled
+        const statusToggle = screen.getByRole('switch')
+        await act(async () => {
+            fireEvent.click(statusToggle)
+        })
+
+        // Click update button
+        const updateButton = screen.getByText('Update Rule')
+        await act(async () => {
+            fireEvent.click(updateButton)
+        })
+
+        // Verify API was called with correct rule name
+        expect(updateSessionTargetingRule).toHaveBeenCalledWith(
+            'app-123',
+            'rule-456',
+            expect.objectContaining({
+                name: 'Test Rule Name',
+                status: 1,
+                sampling_rate: 75,
+                rule: '((event_type == "anr") && (event_type == "exception")) && (attribute.is_device_foldable == true)'
+            })
+        )
+    })
+})

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -91,6 +91,16 @@ const initNavData = {
     {
       title: "Settings",
       items: [
+        /*
+        Hidden as the SDKs are yet to 
+        implement this feature.
+        {
+          title: "Session Targeting",
+          url: "session_targeting",
+          isActive: false,
+          external: false,
+        },
+        */
         {
           title: "Apps",
           url: "apps",

--- a/frontend/dashboard/app/[teamId]/session_targeting/[appId]/[ruleId]/edit/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_targeting/[appId]/[ruleId]/edit/page.tsx
@@ -1,0 +1,10 @@
+import SessionTargetingRule from '@/app/components/session_targeting/session_targeting_rule';
+
+export default function EditSessionTargetingRule({ params }: { params: { teamId: string; appId: string; type: string; ruleId: string; ruleName: string } }) {
+    return (
+        <SessionTargetingRule 
+            params={params}
+            isEditMode={true}
+        />
+    );
+}

--- a/frontend/dashboard/app/[teamId]/session_targeting/[appId]/create/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_targeting/[appId]/create/page.tsx
@@ -1,0 +1,10 @@
+import SessionTargetingRule from '@/app/components/session_targeting/session_targeting_rule';
+
+export default function CreateSessionTargetingRule({ params }: { params: { teamId: string; appId: string; type: string } }) {
+    return (
+        <SessionTargetingRule 
+            params={params}
+            isEditMode={false}
+        />
+    );
+}

--- a/frontend/dashboard/app/[teamId]/session_targeting/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_targeting/page.tsx
@@ -1,0 +1,261 @@
+"use client"
+
+import { FilterSource, SessionTargetingRulesApiStatus, SessionTargetingRulesResponse, fetchSessionTargetingRulesFromServer } from "@/app/api/api_calls";
+import CreateSessionTargetingRule from "@/app/components/session_targeting/create_session_targeting_rule";
+import Filters, { AppVersionsInitialSelectionType, defaultFilters } from "@/app/components/filters";
+import LoadingBar from "@/app/components/loading_bar";
+import Paginator from "@/app/components/paginator";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/app/components/table';
+import { formatDateToHumanReadableDate, formatDateToHumanReadableTime } from "@/app/utils/time_utils";
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from "react";
+
+interface PageState {
+    targetingRulesApiStatus: SessionTargetingRulesApiStatus
+    filters: typeof defaultFilters
+    targetingRules: SessionTargetingRulesResponse | null
+    paginationOffset: number
+}
+
+const paginationLimit = 5
+const paginationOffsetUrlKey = "po"
+
+export default function SessionTargetingOverview({ params }: { params: { teamId: string } }) {
+    const router = useRouter()
+    const searchParams = useSearchParams()
+
+    const initialState: PageState = {
+        targetingRulesApiStatus: SessionTargetingRulesApiStatus.Loading,
+        filters: defaultFilters,
+        targetingRules: null,
+        paginationOffset: searchParams.get(paginationOffsetUrlKey) ? parseInt(searchParams.get(paginationOffsetUrlKey)!) : 0
+    }
+
+    const [pageState, setPageState] = useState<PageState>(initialState)
+
+    const updatePageState = (newState: Partial<PageState>) => {
+        setPageState(prevState => {
+            const updatedState = { ...prevState, ...newState }
+            return updatedState
+        })
+    }
+
+    const getTargetingRules = async () => {
+        updatePageState({ targetingRulesApiStatus: SessionTargetingRulesApiStatus.Loading })
+        const result = await fetchSessionTargetingRulesFromServer(pageState.filters.app!.id, paginationLimit, pageState.paginationOffset)
+
+        switch (result.status) {
+            case SessionTargetingRulesApiStatus.Error:
+                updatePageState({
+                    targetingRulesApiStatus: SessionTargetingRulesApiStatus.Error,
+                })
+                break
+            case SessionTargetingRulesApiStatus.NoData:
+                updatePageState({
+                    targetingRulesApiStatus: SessionTargetingRulesApiStatus.NoData,
+                })
+                break
+            case SessionTargetingRulesApiStatus.Success:
+                updatePageState({
+                    targetingRulesApiStatus: SessionTargetingRulesApiStatus.Success,
+                    targetingRules: result.data
+                })
+                break
+        }
+    }
+
+    const handleFiltersChanged = (updatedFilters: typeof defaultFilters) => {
+        // update filters only if they have changed
+        if (pageState.filters.ready !== updatedFilters.ready || pageState.filters.serialisedFilters !== updatedFilters.serialisedFilters) {
+            updatePageState({
+                filters: updatedFilters,
+                // Reset pagination on filters change if previous filters were not default filters
+                paginationOffset: pageState.filters.serialisedFilters && searchParams.get(paginationOffsetUrlKey) ? 0 : pageState.paginationOffset,
+                // Clear targeting rules to prevent showing stale data while new data loads
+                targetingRules: null
+            })
+        }
+    }
+
+    const handleNextPage = () => {
+        updatePageState({ paginationOffset: pageState.paginationOffset + paginationLimit })
+    }
+
+    const handlePrevPage = () => {
+        updatePageState({ paginationOffset: Math.max(0, pageState.paginationOffset - paginationLimit) })
+    }
+
+    useEffect(() => {
+        if (!pageState.filters.ready) {
+            return
+        }
+
+        // update url
+        router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(pageState.paginationOffset)}&${pageState.filters.serialisedFilters!}`, { scroll: false })
+
+        getTargetingRules()
+    }, [pageState.paginationOffset, pageState.filters])
+
+    return (
+        <div className="flex flex-col selection:bg-yellow-200/75 items-start">
+            <div className="flex flex-row items-center gap-2 justify-between w-full">
+                <p className="font-display text-4xl max-w-6xl text-center">Session Targeting</p>
+                <CreateSessionTargetingRule
+                    onSelect={() => {
+                        router.push(`/${params.teamId}/session_targeting/${pageState.filters.app!.id}/create`)
+                    }}
+                    disabled={!pageState.filters.ready || pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Loading || pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Error}
+                />
+            </div>
+
+            <div className="py-4" />
+
+            {/* Shows app selector */}
+            <Filters
+                teamId={params.teamId}
+                filterSource={FilterSource.Events}
+                appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
+                showNoData={false}
+                showNotOnboarded={false}
+                showAppSelector={true}
+                showAppVersions={false}
+                showDates={false}
+                showSessionType={false}
+                showOsVersions={false}
+                showCountries={false}
+                showNetworkTypes={false}
+                showNetworkProviders={false}
+                showNetworkGenerations={false}
+                showLocales={false}
+                showDeviceManufacturers={false}
+                showDeviceNames={false}
+                showBugReportStatus={false}
+                showUdAttrs={false}
+                showFreeText={false}
+                onFiltersChanged={handleFiltersChanged} />
+
+            {/* Error state for sampling rules fetch */}
+            {pageState.filters.ready
+                && pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Error
+                && <p className="text-lg font-display">Error fetching sampling rules, please change filters, refresh page or select a different app to try again</p>}
+
+            {/* Empty state */}
+            {pageState.filters.ready
+                && pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.NoData &&
+                <div className="flex flex-col items-center">
+                    <p className="font-body text-sm">No session targeting rules created for this app yet</p>
+                    <div className="py-2" />
+                </div>}
+
+            {/* Main sampling rules UI */}
+            {pageState.filters.ready
+                && pageState.targetingRules
+                && pageState.targetingRules.results.length > 0
+                && (pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Success || pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Loading) &&
+                <div className="flex flex-col items-center w-full">
+                    <div className='self-end'>
+                        <Paginator
+                            prevEnabled={pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Loading ? false : pageState.targetingRules!.meta.previous}
+                            nextEnabled={pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Loading ? false : pageState.targetingRules!.meta.next}
+                            displayText=''
+                            onNext={handleNextPage}
+                            onPrev={handlePrevPage}
+                        />
+                    </div>
+
+                    <div className={`py-1 w-full ${pageState.targetingRulesApiStatus === SessionTargetingRulesApiStatus.Loading ? 'visible' : 'invisible'}`}>
+                        <LoadingBar />
+                    </div>
+
+                    <div className="py-4" />
+                    <Table className="font-display">
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-[40%]">Rule name</TableHead>
+                                <TableHead className="w-[20%] text-center">Last updated</TableHead>
+                                <TableHead className="w-[20%] text-center">Updated by</TableHead>
+                                <TableHead className="w-[20%] text-center p-4">Status</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {pageState.targetingRules?.results?.map(({ id, name, status, updated_at, updated_by, sampling_rate }, idx) => {
+                                const ruleHref = `/${params.teamId}/session_targeting/${pageState.filters.app!.id}/${id}/edit`
+                                return (
+                                    <TableRow
+                                        key={`${idx}-${id}`}
+                                        className="font-body hover:bg-yellow-200 focus-visible:border-yellow-200 select-none"
+                                        tabIndex={0}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault()
+                                                router.push(ruleHref)
+                                            }
+                                        }}
+                                    >
+                                        <TableCell className="w-[40%] relative p-0">
+                                            <a
+                                                href={ruleHref}
+                                                className="absolute inset-0 z-10 cursor-pointer"
+                                                tabIndex={-1}
+                                                aria-label={`ID: ${id}`}
+                                                style={{ display: 'block' }}
+                                            />
+                                            <div className="pointer-events-none p-4">
+                                                <p className='truncate select-none flex-1'>{name}</p>
+                                                <div className='py-1' />
+                                                <div className="flex items-center gap-2">
+                                                    <p className="text-xs text-gray-500 select-none">
+                                                        Sampling rate: {sampling_rate}%
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="w-[20%] text-center relative p-0">
+                                            <a
+                                                href={ruleHref}
+                                                className="absolute inset-0 z-10 cursor-pointer"
+                                                tabIndex={-1}
+                                                aria-hidden="true"
+                                                style={{ display: 'block' }}
+                                            />
+                                            <div className="pointer-events-none p-4">
+                                                <p className='truncate select-none'>{formatDateToHumanReadableDate(updated_at)}</p>
+                                                <div className='py-1' />
+                                                <p className='truncate select-none'>{formatDateToHumanReadableTime(updated_at)}</p>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="w-[20%] text-center relative p-0">
+                                            <a
+                                                href={ruleHref}
+                                                className="absolute inset-0 z-10 cursor-pointer"
+                                                tabIndex={-1}
+                                                aria-hidden="true"
+                                                style={{ display: 'block' }}
+                                            />
+                                            <div className="pointer-events-none p-4">
+                                                <p className='truncate select-none'>{updated_by}</p>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="w-[20%] text-center relative p-0">
+                                            <a
+                                                href={ruleHref}
+                                                className="absolute inset-0 z-10 cursor-pointer"
+                                                tabIndex={-1}
+                                                aria-hidden="true"
+                                                style={{ display: 'block' }}
+                                            />
+                                            <div className="pointer-events-none p-4 items-center flex justify-center">
+                                                <p className={`w-22 px-2 py-1 rounded-full border text-sm font-body select-none text-center ${status === 1 ? 'border-green-600 text-green-600 bg-green-50' : 'border-indigo-600 text-indigo-600 bg-indigo-50'}`}>
+                                                    {status === 1 ? 'Enabled' : 'Disabled'}
+                                                </p>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                )
+                            })}
+                        </TableBody>
+                    </Table>
+                </div>}
+        </div>
+    )
+}

--- a/frontend/dashboard/app/components/dropdown_select.tsx
+++ b/frontend/dashboard/app/components/dropdown_select.tsx
@@ -30,9 +30,10 @@ interface DropdownSelectProps {
   items: string[] | AppVersion[] | OsVersion[]
   initialSelected: string | AppVersion | OsVersion | string[] | AppVersion[] | OsVersion[]
   onChangeSelected?: (item: string | AppVersion | OsVersion | string[] | AppVersion[] | OsVersion[]) => void
+  buttonClassName?: string
 }
 
-const DropdownSelect: React.FC<DropdownSelectProps> = ({ title, type, items, initialSelected, onChangeSelected }) => {
+const DropdownSelect: React.FC<DropdownSelectProps> = ({ title, type, items, initialSelected, onChangeSelected, buttonClassName }) => {
   const [open, setOpen] = useState(false)
   const [selected, setSelected] = useState(initialSelected)
   const [searchValue, setSearchValue] = useState("")
@@ -222,7 +223,7 @@ const DropdownSelect: React.FC<DropdownSelectProps> = ({ title, type, items, ini
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className="flex justify-between font-display border border-black w-fit min-w-[150px] select-none"
+          className={buttonClassName || "flex justify-between font-display border border-black w-fit min-w-[150px] select-none"}
         >
           <span className="truncate">{getDisplayText()}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/frontend/dashboard/app/components/session_targeting/create_session_targeting_rule.tsx
+++ b/frontend/dashboard/app/components/session_targeting/create_session_targeting_rule.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Button } from "@/app/components/button";
+import { Plus } from "lucide-react";
+
+interface CreateSamplingRuleProps {
+  onSelect?: () => void;
+  disabled?: boolean;
+}
+
+const CreateSessionTargetingRule: React.FC<CreateSamplingRuleProps> = ({ onSelect, disabled }) => {
+  const handleClick = () => {
+    if (onSelect && !disabled) onSelect();
+  };
+
+  return (
+    <Button
+      variant="outline"
+      className="font-display border border-black select-none"
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      <Plus /> Create Rule
+    </Button>
+  );
+};
+
+export default CreateSessionTargetingRule;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_add_attribute.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_add_attribute.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Button } from "../button";
+
+interface RuleBuilderAddAttributeProps {
+    title: string;
+    onAdd: () => void;
+    disabled?: boolean;
+}
+
+const RuleBuilderAddAttribute = ({ title, onAdd, disabled = false }: RuleBuilderAddAttributeProps) => {
+    return (
+        <div className="flex items-center gap-3">
+            <p className="text-sm">{title}</p>
+            <Button
+                variant="ghost"
+                size="lg"
+                className="text-sm hover:bg-yellow-200 p-2 h-6 select-none"
+                onClick={onAdd}
+                disabled={disabled}
+            >
+                + Add
+            </Button>
+        </div>
+    );
+};
+
+export default RuleBuilderAddAttribute;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_attribute_row.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_attribute_row.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import DropdownSelect, { DropdownSelectType } from '@/app/components/dropdown_select';
+import { Button } from '@/app/components/button';
+import { X } from 'lucide-react';
+
+type AttrType = 'attrs' | 'ud_attrs';
+
+const getTypeDisplayName = (type: string): string => {
+    const typeMap: { [key: string]: string } = {
+        'float64': 'decimal',
+        'int64': 'number',
+        'number': 'number',
+        'string': 'text'
+    };
+
+    return typeMap[type] || type;
+};
+
+const RuleBuilderAttributeRow = ({
+    attr,
+    conditionId,
+    attrType,
+    attrKeys,
+    operatorTypesMapping,
+    getOperatorsForType,
+    onUpdateAttr,
+    onRemoveAttr,
+    showDeleteButton = true
+}: {
+    attr: { id: string; key: string; type: string; value: string | boolean | number; operator?: string; hasError?: boolean; errorMessage?: string; hint?: string };
+    conditionId: string;
+    attrType: AttrType;
+    attrKeys: string[];
+    operatorTypesMapping: any;
+    getOperatorsForType: (mapping: any, type: string) => string[];
+    onUpdateAttr: (conditionId: string, attrId: string, field: 'key' | 'type' | 'value' | 'operator', value: any, attrType: AttrType) => void;
+    onRemoveAttr?: (conditionId: string, attrId: string, attrType: AttrType) => void;
+    showDeleteButton?: boolean;
+}) => {
+    const operatorTypes = getOperatorsForType(operatorTypesMapping, attr.type);
+
+    const handleValueChange = (newValue: string | boolean | number) => {
+        onUpdateAttr(conditionId, attr.id, 'value', newValue, attrType);
+    };
+
+    return (
+        <div className={`flex items-center group ${attr.hasError ? 'mb-8' : ''}`}>
+            {/* Attribute Key Dropdown */}
+            <div className="flex-[35] mr-3 min-w-0">
+                <DropdownSelect
+                    type={DropdownSelectType.SingleString}
+                    title="Attributes"
+                    items={attrKeys}
+                    initialSelected={attr.key}
+                    onChangeSelected={(selected) => {
+                        onUpdateAttr(conditionId, attr.id, 'key', selected as string, attrType);
+                    }}
+                    buttonClassName="flex justify-between font-display border border-black w-full select-none"
+                />
+            </div>
+
+            {/* Operator Dropdown */}
+            <div className="flex-[15] mr-3">
+                <DropdownSelect
+                    type={DropdownSelectType.SingleString}
+                    title="Condition"
+                    items={operatorTypes}
+                    initialSelected={attr.operator || operatorTypes[0] || 'eq'}
+                    onChangeSelected={(selected) => {
+                        onUpdateAttr(conditionId, attr.id, 'operator', selected as string, attrType);
+                    }}
+                    buttonClassName="flex justify-between font-display border border-black w-full select-none"
+                />
+            </div>
+
+            {/* Value section */}
+            <div className="flex-[35] mr-3">
+                {attr.type === 'bool' ? (
+                    <DropdownSelect
+                        type={DropdownSelectType.SingleString}
+                        title="Value"
+                        items={['true', 'false']}
+                        initialSelected={attr.value ? 'true' : 'false'}
+                        onChangeSelected={(selected) => {
+                            handleValueChange((selected as string) === 'true')
+                        }}
+                        buttonClassName="flex justify-between font-display border border-black w-full select-none"
+                    />
+                ) : (
+                    <div className="relative">
+                        <input
+                            id="change-team-name-input"
+                            type={attr.type === 'number' || attr.type === 'int64' || attr.type === 'float64' ? 'number' : 'text'}
+                            placeholder={attr.hint ? attr.hint :`Enter ${getTypeDisplayName(attr.type)} value`}
+                            value={attr.value as string | number}
+                            onChange={(e) => {
+                                const value = (attr.type === 'number' || attr.type === 'int64' || attr.type === 'float64') ?
+                                    (e.target.value === '' ? '' : Number(e.target.value)) :
+                                    e.target.value
+                                handleValueChange(value)
+                            }}
+                            className={`w-full border rounded-md outline-hidden text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] py-2 px-4 font-body placeholder:text-neutral-400 ${attr.hasError ? 'border-red-500' : 'border-black'}`}
+                        />
+                        {attr.hasError && attr.errorMessage && (
+                            <p className="absolute top-full left-0 w-full text-red-500 text-xs mt-1 ml-1">{attr.errorMessage}</p>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Remove Attribute Button */}
+            <div className="flex justify-start flex-[15]">
+                {showDeleteButton && onRemoveAttr ? (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onRemoveAttr(conditionId, attr.id, attrType)}
+                        className="h-8 w-8 p-0 hover:bg-yellow-200 focus:bg-yellow-200 focus:opacity-100 flex-shrink-0
+                       opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                    >
+                        <X className="h-4 w-4" />
+                    </Button>
+                ) : (
+                    <div className="h-8 w-8"></div>
+                )}
+            </div>
+        </div>
+    )
+};
+
+export default RuleBuilderAttributeRow;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_condition_container.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_condition_container.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Button } from "../button";
+import { Trash2 } from "lucide-react";
+
+interface RuleBuilderConditionContainerProps {
+    conditionId: string;
+    onRemoveCondition: (conditionId: string) => void;
+    children: React.ReactNode;
+}
+
+const ConditionContainer = ({
+    conditionId,
+    onRemoveCondition,
+    children
+}: RuleBuilderConditionContainerProps) => {
+    return (
+        <div className="group px-4 py-4 bg-sky-100 rounded-md">
+            <div className="flex justify-between items-start">
+                <div className="flex-1">
+                    {children}
+                </div>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onRemoveCondition(conditionId)}
+                    className="h-6 w-6 p-2 hover:bg-yellow-200 focus:bg-yellow-200 focus:opacity-100 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex-shrink-0 mt-1"
+                >
+                    <Trash2 className="h-3 w-3 data-testid={`delete-${conditionId}" />
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default ConditionContainer;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_condition_section.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_condition_section.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { Button } from "../button";
+
+interface RuleBuilderConditionSectionProps {
+    title: string;
+    conditionCount: number;
+    maxConditions: number;
+    onAddCondition: () => void;
+    children: React.ReactNode;
+}
+
+const RuleBuilderConditionSection = ({
+    title,
+    conditionCount,
+    maxConditions,
+    onAddCondition,
+    children
+}: RuleBuilderConditionSectionProps) => {
+    const handleAddCondition = () => {
+        onAddCondition();
+    };
+
+    return (
+        <div className="py-2">
+            <div className="flex items-center justify-between select-none rounded">
+                <div className="flex items-center gap-2">
+                    <h2 className="font-display text-xl">{title}</h2>
+                </div>
+                <Button
+                    variant="outline"
+                    className="font-display border border-black select-none"
+                    disabled={conditionCount >= maxConditions}
+                    loading={false}
+                    onClick={handleAddCondition}
+                >
+                    + Add condition
+                </Button>
+            </div>
+
+            <div className="py-2" />
+
+            <div className="mt-2">
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default RuleBuilderConditionSection;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_event_condition.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_event_condition.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
+import RuleBuilderAttributeRow from "./rule_builder_attribute_row";
+import RuleBuilderAddAttribute from "./rule_builder_add_attribute";
+import ConditionContainer from "./rule_builder_condition_container";
+
+interface RuleBuilderEventConditionProps {
+    condition: any;
+    eventTypes: string[];
+    availableAttrs: any[];
+    userDefinedAttrs: any[];
+    operatorTypesMapping: any;
+    canAddMoreAttrs: boolean;
+    canAddMoreUdAttrs: boolean;
+    supportsUdAttrs: boolean;
+    onUpdateEventType: (conditionId: string, eventType: string) => void;
+    onRemoveCondition: (conditionId: string) => void;
+    onAddAttribute: (conditionId: string, type: 'attrs' | 'ud_attrs') => void;
+    onUpdateAttr: (conditionId: string, attrId: string, field: 'key' | 'type' | 'value' | 'operator', value: any, attrType: 'attrs' | 'ud_attrs') => void;
+    onRemoveAttr: (conditionId: string, attrId: string, attrType: 'attrs' | 'ud_attrs') => void;
+    getOperatorsForType: (mapping: any, type: string) => string[];
+}
+
+const RuleBuilderEventCondition = ({
+    condition,
+    eventTypes,
+    availableAttrs,
+    userDefinedAttrs,
+    operatorTypesMapping,
+    canAddMoreAttrs,
+    canAddMoreUdAttrs,
+    supportsUdAttrs,
+    onUpdateEventType,
+    onRemoveCondition,
+    onAddAttribute,
+    onUpdateAttr,
+    onRemoveAttr,
+    getOperatorsForType
+}: RuleBuilderEventConditionProps) => {
+    return (
+        <ConditionContainer
+            conditionId={condition.id}
+            onRemoveCondition={onRemoveCondition}
+        >
+            <div className="space-y-6">
+                <div className="flex flex-row items-center">
+                    <p className="text-sm">Event Type</p>
+                    <div className="px-3" />
+                    <DropdownSelect
+                        type={DropdownSelectType.SingleString}
+                        title="Select Event Type"
+                        items={eventTypes}
+                        initialSelected={condition.type || ""}
+                        onChangeSelected={(selected) => {
+                            onUpdateEventType(condition.id, selected as string)
+                        }}
+                    />
+                </div>
+
+                {availableAttrs.length > 0 && (
+                    <div className="space-y-4">
+                        <RuleBuilderAddAttribute
+                            title="Attributes"
+                            onAdd={() => onAddAttribute(condition.id, 'attrs')}
+                            disabled={!canAddMoreAttrs}
+                        />
+
+                        {condition.attrs && condition.attrs.map((attr: any) => {
+                            const attrKeys = availableAttrs.map(a => a.key);
+
+                            return (
+                                <RuleBuilderAttributeRow
+                                    key={attr.id}
+                                    attr={attr}
+                                    conditionId={condition.id}
+                                    attrType="attrs"
+                                    attrKeys={attrKeys}
+                                    operatorTypesMapping={operatorTypesMapping}
+                                    getOperatorsForType={getOperatorsForType}
+                                    onUpdateAttr={onUpdateAttr}
+                                    onRemoveAttr={onRemoveAttr}
+                                />
+                            )
+                        })}
+                    </div>
+                )}
+
+                {condition.type && supportsUdAttrs && userDefinedAttrs.length > 0 && (
+                    <div className="space-y-4">
+                        <RuleBuilderAddAttribute
+                            title="User-defined Attributes"
+                            onAdd={() => onAddAttribute(condition.id, 'ud_attrs')}
+                            disabled={!canAddMoreUdAttrs}
+                        />
+
+                        {condition.ud_attrs && condition.ud_attrs.map((udAttr: any) => {
+                            const attrKeys = userDefinedAttrs.map(a => a.key);
+
+                            return (
+                                <RuleBuilderAttributeRow
+                                    key={udAttr.id}
+                                    attr={udAttr}
+                                    conditionId={condition.id}
+                                    attrType="ud_attrs"
+                                    attrKeys={attrKeys}
+                                    operatorTypesMapping={operatorTypesMapping}
+                                    getOperatorsForType={getOperatorsForType}
+                                    onUpdateAttr={onUpdateAttr}
+                                    onRemoveAttr={onRemoveAttr}
+                                />
+                            )
+                        })}
+                    </div>
+                )}
+            </div>
+        </ConditionContainer>
+    );
+};
+
+export default RuleBuilderEventCondition;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_logical_operator.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_logical_operator.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+const RuleBuilderLogicalOperator = ({
+    value,
+    onChange
+}: {
+    value: 'AND' | 'OR';
+    onChange: (operator: 'AND' | 'OR') => void;
+}) => {
+    return (
+        <div className="flex items-center justify-center relative py-12">
+            {/* Top connecting line */}
+            <div className="absolute top-0 left-1/2 transform -translate-x-1/2 w-px h-12 bg-neutral-300"></div>
+
+            {/* Circular toggle button */}
+            <button
+                type="button"
+                onClick={() => onChange(value === 'AND' ? 'OR' : 'AND')}
+                className={`relative z-10 w-12 h-12 rounded-full border transition-colors flex items-center justify-center text-sm font-sans hover:bg-yellow-200 border-neutral-300`}
+            >
+                {value}
+            </button>
+
+            {/* Bottom connecting line */}
+            <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-px h-12 bg-neutral-300"></div>
+        </div>
+    );
+};
+
+export default RuleBuilderLogicalOperator;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_session_condition.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_session_condition.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import RuleBuilderAttributeRow from "./rule_builder_attribute_row";
+import ConditionContainer from "./rule_builder_condition_container";
+
+interface RuleBuilderSessionConditionProps {
+    condition: any;
+    sessionAttrs: any[];
+    operatorTypesMapping: any;
+    onRemoveCondition: (conditionId: string) => void;
+    onUpdateAttr: (conditionId: string, attrId: string, field: 'key' | 'type' | 'value' | 'operator', value: any, attrType: 'attrs' | 'ud_attrs') => void;
+    getOperatorsForType: (mapping: any, type: string) => string[];
+}
+
+const RuleBuilderSessionCondition = ({
+    condition,
+    sessionAttrs,
+    operatorTypesMapping,
+    onRemoveCondition,
+    onUpdateAttr,
+    getOperatorsForType
+}: RuleBuilderSessionConditionProps) => {
+    return (
+        <ConditionContainer
+            conditionId={condition.id}
+            onRemoveCondition={onRemoveCondition}
+        >
+            {sessionAttrs.length > 0 && condition.attrs && (
+                <div className="space-y-4">
+                    {condition.attrs.map((attr: any) => {
+                        const attrKeys = sessionAttrs.map(a => a.key);
+
+                        return (
+                            <RuleBuilderAttributeRow
+                                key={attr.id}
+                                attr={attr}
+                                conditionId={condition.id}
+                                attrType="attrs"
+                                attrKeys={attrKeys}
+                                operatorTypesMapping={operatorTypesMapping}
+                                getOperatorsForType={getOperatorsForType}
+                                onUpdateAttr={onUpdateAttr}
+                                showDeleteButton={false}
+                            />
+                        )
+                    })}
+                </div>
+            )}
+        </ConditionContainer>
+    );
+};
+
+export default RuleBuilderSessionCondition;

--- a/frontend/dashboard/app/components/session_targeting/rule_builder_trace_condition.tsx
+++ b/frontend/dashboard/app/components/session_targeting/rule_builder_trace_condition.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
+import RuleBuilderAttributeRow from "./rule_builder_attribute_row";
+import RuleBuilderAddAttribute from "./rule_builder_add_attribute";
+import ConditionContainer from "./rule_builder_condition_container";
+
+interface RuleBuilderTraceConditionProps {
+    condition: any;
+    spanNames: string[];
+    spanUdAttrs: any[];
+    operatorTypesMapping: any;
+    canAddMoreUdAttrs: boolean;
+    onRemoveCondition: (conditionId: string) => void;
+    onAddAttribute: (conditionId: string) => void;
+    onUpdateSpanName: (conditionId: string, spanName: string) => void;
+    onUpdateAttr: (conditionId: string, attrId: string, field: 'key' | 'type' | 'value' | 'operator', value: any, attrType: 'attrs' | 'ud_attrs') => void;
+    onRemoveAttr: (conditionId: string, attrId: string, attrType: 'attrs' | 'ud_attrs') => void;
+    getOperatorsForType: (mapping: any, type: string) => string[];
+}
+
+const SamplingTraceCondition = ({
+    condition,
+    spanNames,
+    spanUdAttrs,
+    operatorTypesMapping,
+    canAddMoreUdAttrs,
+    onRemoveCondition,
+    onAddAttribute,
+    onUpdateSpanName,
+    onUpdateAttr,
+    onRemoveAttr,
+    getOperatorsForType
+}: RuleBuilderTraceConditionProps) => {
+    return (
+        <ConditionContainer
+            conditionId={condition.id}
+            onRemoveCondition={onRemoveCondition}
+        >
+            <div className="space-y-6">
+                <div className="flex flex-row items-center">
+                    <p className="text-sm">Span Name</p>
+                    <div className="px-3" />
+                    <DropdownSelect
+                        type={DropdownSelectType.SingleString}
+                        title="Select Span Name"
+                        items={spanNames}
+                        initialSelected={condition.spanName || ""}
+                        onChangeSelected={(selected) => {
+                            onUpdateSpanName(condition.id, selected as string)
+                        }}
+                    />
+                </div>
+
+                {spanUdAttrs.length > 0 && (
+                    <div className="space-y-4">
+                        <RuleBuilderAddAttribute
+                            title="User-defined Attributes"
+                            onAdd={() => onAddAttribute(condition.id)}
+                            disabled={!canAddMoreUdAttrs || !spanUdAttrs.length}
+                        />
+
+                        {condition.ud_attrs && condition.ud_attrs.map((udAttr: any) => {
+                            const attrKeys = spanUdAttrs.map(a => a.key);
+
+                            return (
+                                <RuleBuilderAttributeRow
+                                    key={udAttr.id}
+                                    attr={udAttr}
+                                    conditionId={condition.id}
+                                    attrType="ud_attrs"
+                                    attrKeys={attrKeys}
+                                    operatorTypesMapping={operatorTypesMapping}
+                                    getOperatorsForType={getOperatorsForType}
+                                    onUpdateAttr={onUpdateAttr}
+                                    onRemoveAttr={onRemoveAttr}
+                                />
+                            )
+                        })}
+                    </div>
+                )}
+            </div>
+        </ConditionContainer>
+    );
+};
+
+export default SamplingTraceCondition;

--- a/frontend/dashboard/app/components/session_targeting/save_session_targeting_rule.tsx
+++ b/frontend/dashboard/app/components/session_targeting/save_session_targeting_rule.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { Button } from "../button";
+
+interface SaveSessionTargetingProps {
+    isEditMode: boolean;
+    isDisabled: boolean;
+    isLoading: boolean;
+    onPublish: () => void;
+    onUpdate: () => void;
+}
+
+const SaveSessionTargetingRule = ({
+    isEditMode,
+    isDisabled,
+    isLoading,
+    onPublish,
+    onUpdate
+}: SaveSessionTargetingProps) => {
+
+    const handleClick = () => {
+        if (isEditMode) {
+            onUpdate();
+        } else {
+            onPublish();
+        }
+    };
+
+    return (
+        <Button
+            variant="outline"
+            className="font-display border border-black select-none"
+            disabled={isDisabled}
+            loading={isLoading}
+            onClick={handleClick}
+        >
+            {isEditMode ? 'Update Rule' : 'Publish Rule'}
+        </Button>
+    );
+};
+
+export default SaveSessionTargetingRule;

--- a/frontend/dashboard/app/components/session_targeting/session_targeting_rule.tsx
+++ b/frontend/dashboard/app/components/session_targeting/session_targeting_rule.tsx
@@ -1,0 +1,910 @@
+"use client"
+
+import { createSessionTargetingRule, CreateSessionTargetingRuleApiStatus, SessionTargetingConfigResponse, fetchSessionTargetingConfigFromServer, fetchSessionTargetingRuleFromServer, SessionTargetingConfigApiStatus, SessionTargetingRuleApiStatus, updateSessionTargetingRule, UpdateSessionTargetingRuleApiStatus, SessionTargetingRuleResponse } from '@/app/api/api_calls';
+import { conditionsToCel } from '@/app/utils/cel/cel_generator';
+import { EventCondition, EventConditions, SessionCondition, SessionConditions } from '@/app/utils/cel/conditions';
+import LoadingSpinner from '@/app/components/loading_spinner';
+import RuleBuilderConditionSection from '@/app/components/session_targeting/rule_builder_condition_section';
+import RuleBuilderEventCondition from '@/app/components/session_targeting/rule_builder_event_condition';
+import RuleBuilderLogicalOperator from '@/app/components/session_targeting/rule_builder_logical_operator';
+import RuleBuilderSessionCondition from '@/app/components/session_targeting/rule_builder_session_condition';
+import SaveSessionTargetingRule from '@/app/components/session_targeting/save_session_targeting_rule';
+import { toastNegative, toastPositive } from '@/app/utils/use_toast';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { celToConditions } from '../../utils/cel/cel_parser';
+import { Switch } from '../switch';
+
+const MAX_CONDITIONS = 10;
+const MAX_ATTRIBUTES_PER_CONDITION = 10;
+const MAX_RULE_NAME_LENGTH = 256;
+
+enum PageStatus {
+    Loading = 'loading',
+    Ready = 'ready',
+    Error = 'error'
+}
+interface PageState {
+    status: PageStatus
+    config: SessionTargetingConfigResponse | null
+    ruleResponse: SessionTargetingRuleResponse | null
+}
+
+interface RuleState {
+    name: string
+    samplingRate: string
+    status: 'enabled' | 'disabled'
+    eventConditions: EventConditions
+    sessionConditions: SessionConditions
+}
+
+interface SaveRuleState {
+    isSubmitting: boolean
+}
+
+interface SessionTargetingRuleProps {
+    params: {
+        teamId: string;
+        appId: string;
+        ruleId?: string;
+    };
+    isEditMode: boolean;
+}
+
+type AttrType = 'attrs' | 'ud_attrs';
+
+const initialPageState: PageState = {
+    status: PageStatus.Loading,
+    config: null,
+    ruleResponse: null,
+}
+
+const initialSaveRuleState: SaveRuleState = {
+    isSubmitting: false,
+}
+
+const emptyRuleState: RuleState = {
+    name: '',
+    samplingRate: '100',
+    status: 'disabled',
+    eventConditions: { conditions: [], operators: [] },
+    sessionConditions: { conditions: [], operators: [] }
+}
+
+const createEmptySessionCondition = (): SessionCondition => ({
+    id: crypto.randomUUID(),
+    attrs: []
+})
+
+const createEmptyEventCondition = (eventType: string): EventCondition => ({
+    id: crypto.randomUUID(),
+    type: eventType,
+    attrs: [],
+    ud_attrs: []
+})
+
+const getEventTypesFromResponse = (response: SessionTargetingConfigResponse) => {
+    return response.result?.events?.map(event => event.type) || [];
+};
+
+const getEventAttributes = (response: SessionTargetingConfigResponse, eventType: string) => {
+    const event = response.result?.events?.find(e => e.type === eventType);
+    return event?.attrs || [];
+};
+
+const getSessionAttributes = (response: SessionTargetingConfigResponse) => {
+    return response.result?.session_attrs || [];
+};
+
+const doesEventSupportUdAttrs = (response: SessionTargetingConfigResponse, eventType: string): boolean => {
+    const event = response.result?.events?.find(e => e.type === eventType);
+    return event?.has_ud_attrs === true;
+};
+
+const getUserDefinedAttributes = (response: SessionTargetingConfigResponse) => {
+    return response.result?.event_ud_attrs || [];
+};
+
+const getOperatorTypesMapping = (response: SessionTargetingConfigResponse) => {
+    return response.result?.operator_types || {};
+};
+
+const getOperatorsForType = (operatorMapping: Record<string, string[]>, type: string): string[] => {
+    return operatorMapping[type] || [];
+};
+
+const getDefaultOperatorForType = (type: string): string => {
+    switch (type) {
+        case 'string':
+            return 'eq'
+        case 'bool':
+        case 'boolean':
+            return 'eq'
+        case 'int64':
+        case 'float64':
+        case 'number':
+            return 'eq'
+        default:
+            return 'eq'
+    }
+}
+
+const canAddMoreAttributes = (
+    condition: EventCondition | SessionCondition,
+    availableAttrs: any[],
+    attrType: AttrType = 'attrs'
+): boolean => {
+    if (attrType === 'ud_attrs' && 'ud_attrs' in condition) {
+        const currentAttrs = condition.ud_attrs;
+        const currentCount = currentAttrs ? currentAttrs.length : 0;
+
+        if (currentCount >= MAX_ATTRIBUTES_PER_CONDITION) {
+            return false;
+        }
+    } else if (attrType === 'attrs') {
+        const currentAttrs = condition.attrs;
+        const currentCount = currentAttrs ? currentAttrs.length : 0;
+
+        if (currentCount >= MAX_ATTRIBUTES_PER_CONDITION) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return availableAttrs.length > 0;
+};
+
+const getAvailableAttributes = (
+    SessionTargetingConfig: SessionTargetingConfigResponse,
+    eventType: string | null,
+    attrType: AttrType
+) => {
+    if (attrType === 'attrs' && eventType) {
+        return getEventAttributes(SessionTargetingConfig, eventType);
+    } else if (attrType === 'ud_attrs' && eventType) {
+        if (doesEventSupportUdAttrs(SessionTargetingConfig, eventType)) {
+            return getUserDefinedAttributes(SessionTargetingConfig);
+        }
+        return [];
+    }
+    return [];
+};
+
+const isValueEmpty = (value: string | boolean | number): boolean => {
+    return String(value).trim() === '';
+};
+
+const formatSamplingRate = (value: string): string => {
+    if (value === '') return ''
+
+    const numValue = parseFloat(value)
+    if (isNaN(numValue)) return ''
+
+    // Clamp to 0-100 range
+    const clampedValue = Math.max(0, Math.min(100, numValue))
+    // Limit to 6 decimal places and remove trailing zeros
+    const formattedValue = Math.round(clampedValue * 1000000) / 1000000
+    return formattedValue.toString()
+};
+
+const parseSamplingRateForSubmission = (value: string): number => {
+    const numValue = parseFloat(value)
+    return isNaN(numValue) ? 0 : Math.max(0, Math.min(100, numValue))
+};
+
+const validateAllAttributes = (eventConditions: EventConditions, sessionConditions: SessionConditions): { eventConditions: EventConditions, sessionConditions: SessionConditions } => {
+    // Validate event conditions
+    const validatedEventConditions = {
+        ...eventConditions,
+        conditions: eventConditions.conditions.map(condition => ({
+            ...condition,
+            attrs: condition.attrs?.map(attr => ({
+                ...attr,
+                hasError: isValueEmpty(attr.value),
+                errorMessage: isValueEmpty(attr.value) ? 'Please enter a value' : undefined
+            })) || [],
+            ud_attrs: condition.ud_attrs?.map(attr => ({
+                ...attr,
+                hasError: isValueEmpty(attr.value),
+                errorMessage: isValueEmpty(attr.value) ? 'Please enter a value' : undefined
+            })) || []
+        }))
+    };
+
+    // Validate session conditions
+    const validatedSessionConditions = {
+        ...sessionConditions,
+        conditions: sessionConditions.conditions.map(condition => ({
+            ...condition,
+            attrs: condition.attrs?.map(attr => ({
+                ...attr,
+                hasError: isValueEmpty(attr.value),
+                errorMessage: isValueEmpty(attr.value) ? 'Please enter a value' : undefined
+            })) || []
+        }))
+    };
+
+    return { eventConditions: validatedEventConditions, sessionConditions: validatedSessionConditions };
+};
+
+const isValidForm = (eventConditions: EventConditions, sessionConditions: SessionConditions, ruleName: string): boolean => {
+    const hasValidEventConditions = eventConditions.conditions.some(condition =>
+        condition.type !== null ||
+        (condition.attrs && condition.attrs.length > 0) ||
+        (condition.ud_attrs && condition.ud_attrs.length > 0)
+    )
+
+    const hasValidSessionConditions = sessionConditions.conditions.some(condition =>
+        condition.attrs && condition.attrs.length > 0
+    )
+
+    const hasValidName = ruleName.trim().length > 0
+    const hasAtLeastOneCondition = hasValidEventConditions || hasValidSessionConditions
+
+    return hasValidName && hasAtLeastOneCondition
+}
+
+const compareRuleState = (left: RuleState, right: RuleState): boolean => {
+    return JSON.stringify(left) === JSON.stringify(right)
+}
+
+export default function SessionTargetingRule({ params, isEditMode }: SessionTargetingRuleProps) {
+    const router = useRouter()
+    const [pageState, setPageState] = useState<PageState>(initialPageState)
+    const [saveRuleState, setSaveRuleState] = useState<SaveRuleState>(initialSaveRuleState)
+    const [ruleState, setRuleState] = useState<RuleState>(emptyRuleState)
+    const [initialRuleState, setInitialRuleState] = useState<RuleState | null>(null)
+
+    const isFormValid = useMemo(() => {
+        return isValidForm(ruleState.eventConditions, ruleState.sessionConditions, ruleState.name)
+    }, [ruleState.eventConditions, ruleState.sessionConditions, ruleState.name])
+
+    const hasUnsavedChanges = !initialRuleState ? false : !compareRuleState(ruleState, initialRuleState)
+
+    useEffect(() => {
+        const initializePage = async () => {
+            try {
+                const config = await loadConfig()
+                if (isEditMode) {
+                    const rule = await loadRule()
+                    setupEditMode(rule)
+                } else {
+                    setupCreateMode(config)
+                }
+            } catch (error) {
+                setPageState(prev => ({ ...prev, status: PageStatus.Error }))
+            }
+        }
+
+        initializePage()
+    }, [])
+
+    const loadConfig = async () => {
+        const result = await fetchSessionTargetingConfigFromServer(params.appId)
+
+        if (result.status === SessionTargetingConfigApiStatus.Error) {
+            throw new Error('Failed to load session targeting config')
+        }
+
+        const config = result.data
+        setPageState(prev => ({ ...prev, config }))
+        return config
+    }
+
+    const loadRule = async () => {
+        if (!params.ruleId) {
+            throw new Error('Failed to load session targeting rule: missing rule ID')
+        }
+
+        const result = await fetchSessionTargetingRuleFromServer(params.appId, params.ruleId)
+
+        if (result.status === SessionTargetingRuleApiStatus.Error) {
+            throw new Error('Failed to load session targeting rule')
+        }
+
+        const rule = result.data
+        setPageState(prev => ({ ...prev, ruleResponse: rule }))
+        return rule
+    }
+
+    const setupCreateMode = (config: SessionTargetingConfigResponse) => {
+        setInitialRuleState(emptyRuleState)
+        setPageState(prev => ({
+            ...prev,
+            status: PageStatus.Ready
+        }))
+    }
+
+    const setupEditMode = (ruleResponse: SessionTargetingRuleResponse) => {
+        const ruleData = ruleResponse
+        const conditions = celToConditions(ruleData.rule)
+
+        const eventConditions = conditions?.event
+            ? conditions?.event
+            : { conditions: [], operators: [] }
+
+        const sessionConditions = conditions?.session
+            ? conditions?.session
+            : { conditions: [], operators: [] }
+
+        const newRuleState: RuleState = {
+            name: ruleData.name || '',
+            samplingRate: String(ruleData.sampling_rate || 100),
+            status: ruleData.status === 1 ? 'enabled' : 'disabled',
+            eventConditions: eventConditions,
+            sessionConditions: sessionConditions
+        }
+
+        setRuleState(newRuleState)
+        setInitialRuleState(newRuleState)
+        setPageState(prev => ({
+            ...prev,
+            status: PageStatus.Ready
+        }))
+    }
+
+
+    const handleTitleChange = (name: string) => {
+        setRuleState(prev => ({ ...prev, name }))
+        setPageState(prev => ({
+            ...prev,
+        }))
+    }
+
+    const handleSamplingRateChange = (value: string) => {
+        // Store raw input value to allow intermediate states
+        setRuleState(prev => ({ ...prev, samplingRate: value }))
+    }
+
+    const handleSamplingRateBlur = (value: string) => {
+        // Format and validate on blur
+        const formattedValue = formatSamplingRate(value)
+        setRuleState(prev => ({ ...prev, samplingRate: formattedValue }))
+    }
+
+    const handleStatusChange = (enabled: boolean) => {
+        setRuleState(prev => ({ ...prev, status: enabled ? 'enabled' : 'disabled' }))
+    }
+
+    const addEventCondition = () => {
+        if (!pageState.config || ruleState.eventConditions.conditions.length >= MAX_CONDITIONS) return
+
+        const eventTypes = getEventTypesFromResponse(pageState.config)
+        if (eventTypes.length === 0) return
+
+        const newCondition = createEmptyEventCondition(eventTypes[0])
+
+        const newOperators = ruleState.eventConditions.conditions.length > 0
+            ? [...ruleState.eventConditions.operators, 'AND' as const]
+            : []
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                conditions: [...ruleState.eventConditions.conditions, newCondition],
+                operators: newOperators
+            }
+        }))
+    }
+
+    const removeEventCondition = (conditionId: string) => {
+        const conditionIndex = ruleState.eventConditions.conditions.findIndex(c => c.id === conditionId)
+        if (conditionIndex === -1) return
+
+        const newConditions = ruleState.eventConditions.conditions.filter(c => c.id !== conditionId)
+        const newOperators = removeOperatorAtIndex(ruleState.eventConditions.operators, conditionIndex)
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                conditions: newConditions,
+                operators: newOperators
+            }
+        }))
+    }
+
+    const updateEventCondition = (conditionId: string, type: string) => {
+        const updatedConditions = ruleState.eventConditions.conditions.map((condition) =>
+            condition.id === conditionId
+                ? { ...condition, type, attrs: [], ud_attrs: [] }
+                : condition
+        )
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                ...ruleState.eventConditions,
+                conditions: updatedConditions
+            }
+        }))
+    }
+
+    const updateEventOperator = (operatorIndex: number, operator: 'AND' | 'OR') => {
+        const newOperators = [...ruleState.eventConditions.operators]
+        newOperators[operatorIndex] = operator
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                ...ruleState.eventConditions,
+                operators: newOperators
+            }
+        }))
+    }
+
+    const addAttribute = (conditionId: string, attrType: AttrType) => {
+        const condition = ruleState.eventConditions.conditions.find(c => c.id === conditionId)
+        if (!condition || !condition.type || !pageState.config) return
+
+        const availableAttrs = getAvailableAttributes(pageState.config, condition.type, attrType)
+        if (!canAddMoreAttributes(condition, availableAttrs, attrType)) return
+
+        const firstAttr = availableAttrs[0]
+        if (!firstAttr) return
+
+        const newAttr = createDefaultAttribute(firstAttr)
+
+        const updatedConditions = ruleState.eventConditions.conditions.map((cond) =>
+            cond.id === conditionId
+                ? {
+                    ...cond,
+                    [attrType]: cond[attrType] ? [...cond[attrType]!, newAttr] : [newAttr]
+                }
+                : cond
+        )
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                ...ruleState.eventConditions,
+                conditions: updatedConditions
+            }
+        }))
+    }
+
+    const removeAttribute = (conditionId: string, attrId: string, attrType: AttrType) => {
+        const condition = ruleState.eventConditions.conditions.find(c => c.id === conditionId)
+        const currentAttrs = condition?.[attrType]
+        if (!currentAttrs) return
+
+        const updatedAttrs = currentAttrs.filter((attr) => attr.id !== attrId)
+
+        const updatedConditions = ruleState.eventConditions.conditions.map((cond) =>
+            cond.id === conditionId
+                ? { ...cond, [attrType]: updatedAttrs.length > 0 ? updatedAttrs : null }
+                : cond
+        )
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                ...ruleState.eventConditions,
+                conditions: updatedConditions
+            }
+        }))
+    }
+
+    const updateAttribute = (
+        conditionId: string,
+        attrId: string,
+        field: 'key' | 'type' | 'value' | 'operator',
+        value: any,
+        attrType: AttrType
+    ) => {
+        if (!pageState.config) return
+
+        const condition = ruleState.eventConditions.conditions.find(c => c.id === conditionId)
+        const currentAttrs = condition?.[attrType]
+        if (!currentAttrs) return
+
+        const updatedAttrs = currentAttrs.map((attr) => {
+            if (attr.id === attrId) {
+                const updatedAttr = { ...attr, [field]: value }
+
+                if (field === 'key') {
+                    const availableAttrs = getAvailableAttributes(pageState.config!, condition.type, attrType)
+                    const selectedAttr = availableAttrs.find(a => a.key === value)
+                    if (selectedAttr) {
+                        updatedAttr.type = selectedAttr.type
+                        updatedAttr.value = selectedAttr.type === 'boolean' ? false : ''
+                        updatedAttr.operator = getDefaultOperatorForType(selectedAttr.type)
+                        updatedAttr.hint = selectedAttr.hint
+                        updatedAttr.hasError = false
+                        updatedAttr.errorMessage = undefined
+                    }
+                } else if (field === 'value') {
+                    // Clear validation errors when user starts typing
+                    updatedAttr.hasError = false
+                    updatedAttr.errorMessage = undefined
+                }
+
+                return updatedAttr
+            }
+            return attr
+        })
+
+        const updatedConditions = ruleState.eventConditions.conditions.map((cond) =>
+            cond.id === conditionId
+                ? { ...cond, [attrType]: updatedAttrs }
+                : cond
+        )
+
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: {
+                ...ruleState.eventConditions,
+                conditions: updatedConditions
+            }
+        }))
+    }
+
+    const addSessionCondition = () => {
+        if (!pageState.config || ruleState.sessionConditions.conditions.length >= MAX_CONDITIONS) return
+
+        const sessionAttrs = getSessionAttributes(pageState.config)
+        const newCondition = createEmptySessionCondition()
+
+        if (sessionAttrs.length > 0) {
+            const firstAttr = sessionAttrs[0]
+            newCondition.attrs = [createDefaultAttribute(firstAttr)]
+        }
+
+        const newOperators = ruleState.sessionConditions.conditions.length > 0
+            ? [...ruleState.sessionConditions.operators, 'AND' as const]
+            : []
+
+        setRuleState(prev => ({
+            ...prev,
+            sessionConditions: {
+                conditions: [...ruleState.sessionConditions.conditions, newCondition],
+                operators: newOperators
+            }
+        }))
+    }
+
+    const removeSessionCondition = (conditionId: string) => {
+        const conditionIndex = ruleState.sessionConditions.conditions.findIndex(c => c.id === conditionId)
+        if (conditionIndex === -1) return
+
+        const newConditions = ruleState.sessionConditions.conditions.filter(c => c.id !== conditionId)
+        const newOperators = removeOperatorAtIndex(ruleState.sessionConditions.operators, conditionIndex)
+
+        setRuleState(prev => ({
+            ...prev,
+            sessionConditions: {
+                conditions: newConditions,
+                operators: newOperators
+            }
+        }))
+    }
+
+    const updateSessionOperator = (operatorIndex: number, operator: 'AND' | 'OR') => {
+        const newOperators = [...ruleState.sessionConditions.operators]
+        newOperators[operatorIndex] = operator
+
+        setRuleState(prev => ({
+            ...prev,
+            sessionConditions: {
+                ...ruleState.sessionConditions,
+                operators: newOperators
+            }
+        }))
+    }
+
+    const updateSessionAttribute = (
+        conditionId: string,
+        attrId: string,
+        field: 'key' | 'type' | 'value' | 'operator',
+        value: any
+    ) => {
+        if (!pageState.config) return
+
+        const condition = ruleState.sessionConditions.conditions.find(c => c.id === conditionId)
+        const currentAttrs = condition?.attrs
+        if (!currentAttrs) return
+
+        const updatedAttrs = currentAttrs.map((attr) => {
+            if (attr.id === attrId) {
+                const updatedAttr = { ...attr, [field]: value }
+
+                if (field === 'key') {
+                    const sessionAttrs = getSessionAttributes(pageState.config!)
+                    const selectedAttr = sessionAttrs.find(a => a.key === value)
+                    if (selectedAttr) {
+                        updatedAttr.type = selectedAttr.type
+                        updatedAttr.value = selectedAttr.type === 'bool' ? false : ''
+                        updatedAttr.operator = getDefaultOperatorForType(selectedAttr.type)
+                        updatedAttr.hint = selectedAttr.hint
+                        updatedAttr.hasError = false
+                        updatedAttr.errorMessage = undefined
+                    }
+                } else if (field === 'value') {
+                    // Clear validation errors when user starts typing
+                    updatedAttr.hasError = false
+                    updatedAttr.errorMessage = undefined
+                }
+
+                return updatedAttr
+            }
+            return attr
+        })
+
+        const updatedConditions = ruleState.sessionConditions.conditions.map((cond) =>
+            cond.id === conditionId
+                ? { ...cond, attrs: updatedAttrs }
+                : cond
+        )
+
+        setRuleState(prev => ({
+            ...prev,
+            sessionConditions: {
+                ...ruleState.sessionConditions,
+                conditions: updatedConditions
+            }
+        }))
+    }
+
+    const removeOperatorAtIndex = (operators: ('AND' | 'OR')[], conditionIndex: number): ('AND' | 'OR')[] => {
+        const newOperators = [...operators]
+
+        if (conditionIndex < newOperators.length) {
+            newOperators.splice(conditionIndex, 1)
+        } else if (conditionIndex > 0 && newOperators.length > 0) {
+            newOperators.splice(conditionIndex - 1, 1)
+        }
+
+        return newOperators
+    }
+
+    const createDefaultAttribute = (attrConfig: any) => ({
+        id: crypto.randomUUID(),
+        key: attrConfig.key,
+        type: attrConfig.type,
+        value: attrConfig.type === 'bool' ? false : '',
+        operator: getDefaultOperatorForType(attrConfig.type),
+        hint: attrConfig.hint,
+    })
+
+    const handleSubmit = async () => {
+        // Validate all attributes
+        const { eventConditions: validatedEventConditions, sessionConditions: validatedSessionConditions } =
+            validateAllAttributes(ruleState.eventConditions, ruleState.sessionConditions);
+
+        // Check if there are any validation errors
+        const hasAttributeErrors =
+            validatedEventConditions.conditions.some(condition =>
+                (condition.attrs && condition.attrs.some(attr => attr.hasError)) ||
+                (condition.ud_attrs && condition.ud_attrs.some(attr => attr.hasError))
+            ) ||
+            validatedSessionConditions.conditions.some(condition =>
+                condition.attrs && condition.attrs.some(attr => attr.hasError)
+            );
+
+        // Update state with validation results
+        setRuleState(prev => ({
+            ...prev,
+            eventConditions: validatedEventConditions,
+            sessionConditions: validatedSessionConditions
+        }));
+
+        // If there are validation errors, show toast and stop submission
+        if (hasAttributeErrors) {
+            toastNegative(`Please complete the required fields and try again.`);
+            return;
+        }
+
+        const ruleCel = conditionsToCel({
+            event: ruleState.eventConditions,
+            trace: undefined,
+            session: ruleState.sessionConditions
+        })
+
+        if (!ruleCel) {
+            return
+        }
+
+        const ruleData = {
+            name: ruleState.name,
+            status: ruleState.status === 'enabled' ? 1 : 0,
+            sampling_rate: parseSamplingRateForSubmission(ruleState.samplingRate),
+            rule: ruleCel,
+        }
+
+        setSaveRuleState(prev => ({ ...prev, isSubmitting: true }));
+
+        try {
+            const result = isEditMode
+                ? await updateSessionTargetingRule(params.appId, pageState.ruleResponse!.id, ruleData)
+                : await createSessionTargetingRule(params.appId, ruleData)
+
+            if (result.status === CreateSessionTargetingRuleApiStatus.Success ||
+                result.status === UpdateSessionTargetingRuleApiStatus.Success) {
+                toastPositive(isEditMode ? 'Rule updated successfully' : 'Rule published successfully')
+                router.replace(`/${params.teamId}/session_targeting`)
+            } else {
+                toastNegative('Failed to save rule. Please try again.')
+            }
+        } catch (error) {
+            toastNegative('Failed to save rule. Please try again.')
+        } finally {
+            setSaveRuleState(prev => ({ ...prev, isSubmitting: false }));
+        }
+    }
+
+    if (pageState.status === PageStatus.Error) {
+        return (
+            <div className="flex flex-col selection:bg-yellow-200/75 items-start">
+                <p className="text-lg font-display">
+                    Error loading rule. Please refresh the page to try again.
+                </p>
+            </div>
+        )
+    }
+
+
+    const eventTypes = pageState.config ? getEventTypesFromResponse(pageState.config) : []
+    const operatorTypesMapping = pageState.config ? getOperatorTypesMapping(pageState.config) : {}
+    const sessionAttrs = pageState.config ? getSessionAttributes(pageState.config) : []
+
+    return (
+        <div className="flex flex-col selection:bg-yellow-200/75 items-start">
+            <div className="flex flex-row items-start gap-2 justify-between w-full">
+                <div className="flex flex-col">
+                    <h1 className="font-display text-4xl">Session Targeting Rule</h1>
+
+                    <div className="py-6" />
+
+                    {/* Loading state */}
+                    {pageState.status === PageStatus.Loading && (
+                        <LoadingSpinner />
+                    )}
+
+                    {/* Rule name, status and sampling rate */}
+                    {pageState.status === PageStatus.Ready && (
+                        <>
+                            <div className="grid gap-y-8 items-center max-w-2xl" style={{ gridTemplateColumns: '120px 1fr' }}>
+                                <p className="text-sm">Rule name</p>
+                                <input
+                                    type="text"
+                                    placeholder="Enter rule name"
+                                    value={ruleState.name}
+                                    maxLength={MAX_RULE_NAME_LENGTH}
+                                    onChange={(e) => handleTitleChange(e.target.value)}
+                                    className={`w-96 border rounded-md outline-hidden text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] py-2 px-4 font-body placeholder:text-neutral-400 'border-black'
+                                        }`}
+                                />
+                                <p className="text-sm">Sampling rate %</p>
+                                <div className="flex items-center">
+                                    <input
+                                        type="number"
+                                        inputMode="decimal"
+                                        placeholder="0-100%"
+                                        value={ruleState.samplingRate}
+                                        min="0"
+                                        max="100"
+                                        step="0.000001"
+                                        onChange={(e) => handleSamplingRateChange(e.target.value)}
+                                        onBlur={(e) => handleSamplingRateBlur(e.target.value)}
+                                        className="w-48 border border-black rounded-md outline-hidden text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] py-2 px-4 font-body placeholder:text-neutral-400"
+                                    />
+                                </div>
+                                <p className="text-sm">Active</p>
+                                <div className="flex items-center">
+                                    <Switch
+                                        className={"data-[state=checked]:bg-emerald-500"}
+                                        disabled={false}
+                                        checked={ruleState.status === 'enabled'}
+                                        onCheckedChange={handleStatusChange}
+                                    />
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+                <SaveSessionTargetingRule
+                    isEditMode={isEditMode}
+                    isDisabled={!isFormValid || pageState.status !== PageStatus.Ready || !hasUnsavedChanges}
+                    isLoading={saveRuleState.isSubmitting}
+                    onPublish={handleSubmit}
+                    onUpdate={handleSubmit}
+                />
+            </div>
+
+            <div className="py-8" />
+
+            {/* Main sampling conditions UI */}
+            {pageState.status == PageStatus.Ready && (
+                <div className="w-full space-y-4">
+                    <div className="w-full space-y-4">
+                        {/* Event conditions */}
+                        <RuleBuilderConditionSection
+                            title="Event Conditions"
+                            conditionCount={ruleState.eventConditions.conditions.length}
+                            maxConditions={MAX_CONDITIONS}
+                            onAddCondition={addEventCondition}
+                        >
+                            {ruleState.eventConditions.conditions.length > 0 && (
+                                <div className="pt-1">
+                                    {ruleState.eventConditions.conditions.map((condition, index) => {
+                                        const availableAttrs = condition.type && pageState.config ? getEventAttributes(pageState.config, condition.type) : []
+                                        const canAddMoreAttrs = canAddMoreAttributes(condition, availableAttrs, 'attrs')
+                                        const userDefinedAttrs = pageState.config ? getUserDefinedAttributes(pageState.config) : []
+                                        const canAddMoreUdAttrs = canAddMoreAttributes(condition, userDefinedAttrs, 'ud_attrs')
+                                        const supportsUdAttrs = pageState.config && condition.type ? doesEventSupportUdAttrs(pageState.config, condition.type) : false
+
+                                        return (
+                                            <div key={condition.id}>
+                                                <RuleBuilderEventCondition
+                                                    condition={condition}
+                                                    eventTypes={eventTypes}
+                                                    availableAttrs={availableAttrs}
+                                                    userDefinedAttrs={userDefinedAttrs}
+                                                    operatorTypesMapping={operatorTypesMapping}
+                                                    canAddMoreAttrs={canAddMoreAttrs}
+                                                    canAddMoreUdAttrs={canAddMoreUdAttrs}
+                                                    supportsUdAttrs={supportsUdAttrs}
+                                                    onUpdateEventType={updateEventCondition}
+                                                    onRemoveCondition={removeEventCondition}
+                                                    onAddAttribute={addAttribute}
+                                                    onUpdateAttr={updateAttribute}
+                                                    onRemoveAttr={removeAttribute}
+                                                    getOperatorsForType={getOperatorsForType}
+                                                />
+
+                                                {index < ruleState.eventConditions.conditions.length - 1 && (
+                                                    <div className="flex justify-center">
+                                                        <RuleBuilderLogicalOperator
+                                                            value={ruleState.eventConditions.operators[index] || 'AND'}
+                                                            onChange={(operator) => updateEventOperator(index, operator)}
+                                                        />
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            )}
+                        </RuleBuilderConditionSection>
+
+                        <div className="py-2" />
+
+                        {/* Session conditions */}
+                        <RuleBuilderConditionSection
+                            title="Session Conditions"
+                            conditionCount={ruleState.sessionConditions.conditions.length}
+                            maxConditions={MAX_CONDITIONS}
+                            onAddCondition={addSessionCondition}
+                        >
+                            {ruleState.sessionConditions.conditions.length > 0 && (
+                                <div className="pt-1">
+                                    {ruleState.sessionConditions.conditions.map((condition, index) => (
+                                        <div key={condition.id}>
+                                            <RuleBuilderSessionCondition
+                                                condition={condition}
+                                                sessionAttrs={sessionAttrs}
+                                                operatorTypesMapping={operatorTypesMapping}
+                                                onRemoveCondition={removeSessionCondition}
+                                                onUpdateAttr={updateSessionAttribute}
+                                                getOperatorsForType={getOperatorsForType}
+                                            />
+
+                                            {index < ruleState.sessionConditions.conditions.length - 1 && (
+                                                <div className="flex justify-center">
+                                                    <RuleBuilderLogicalOperator
+                                                        value={ruleState.sessionConditions.operators[index] || 'AND'}
+                                                        onChange={(operator) => updateSessionOperator(index, operator)}
+                                                    />
+                                                </div>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </RuleBuilderConditionSection>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/dashboard/app/utils/cel/cel_generator.ts
+++ b/frontend/dashboard/app/utils/cel/cel_generator.ts
@@ -1,0 +1,313 @@
+/**
+ * Converts UI state conditions into Common 
+ * Expression Language (CEL) strings.
+ * 
+ * This is the reverse of the CEL parser, used to 
+ * regenerate CEL expressions for filtering and 
+ * evaluation.
+ */
+
+import { EventCondition, SessionCondition, TraceCondition, EventConditions, SessionConditions, TraceConditions } from "./conditions"
+import { ParsedConditions } from "./cel_parser"
+
+const OPERATOR_MAPPINGS = {
+  eq: '==',
+  neq: '!=',
+  gt: '>',
+  lt: '<',
+  gte: '>=',
+  lte: '<=',
+  contains: 'contains',
+  startsWith: 'startsWith'
+} as const
+
+const LOGICAL_OPERATOR_MAPPINGS = {
+  AND: '&&',
+  OR: '||'
+} as const
+
+/**
+ * Formats a value for CEL syntax, wrapping strings in quotes.
+ */
+function formatValueForCel(value: string | boolean | number, type: string): string {
+  return type === 'string' ? `"${value}"` : String(value)
+}
+
+/**
+ * Creates a CEL expression for an event type.
+ * Example output: 'event_type == "anr"'
+ */
+function createEventTypeCondition(eventType: string): string {
+  return `event_type == "${eventType}"`
+}
+
+/**
+ * Creates a CEL expression for a standard event attribute.
+ * Example output: 'exception.handled == false'
+ */
+function createEventAttributeCondition(
+  attribute: {
+    key: string;
+    type: string;
+    value: string | boolean | number;
+    operator?: string
+  },
+  eventType: string
+): string {
+  const operator = OPERATOR_MAPPINGS[attribute.operator as keyof typeof OPERATOR_MAPPINGS] || '=='
+  const formattedValue = formatValueForCel(attribute.value, attribute.type)
+  const fullKey = `${eventType}.${attribute.key}`
+
+  if (attribute.type === 'string' && (operator === 'contains' || operator === 'startsWith')) {
+    return `${fullKey}.${operator}(${formattedValue})`
+  }
+
+  return `${fullKey} ${operator} ${formattedValue}`
+}
+
+/**
+ * Creates a CEL expression for a user-defined event attribute.
+ * Example output: 'event.user_defined_attrs.is_premium == true'
+ */
+function createUserDefinedEventAttributeCondition(attribute: {
+  key: string;
+  type: string;
+  value: string | boolean | number;
+  operator?: string
+}): string {
+  const operator = OPERATOR_MAPPINGS[attribute.operator as keyof typeof OPERATOR_MAPPINGS] || '=='
+  const formattedValue = formatValueForCel(attribute.value, attribute.type)
+  const fullKey = `event.user_defined_attrs.${attribute.key}`
+
+  if (attribute.type === 'string' && (operator === 'contains' || operator === 'startsWith')) {
+    return `${fullKey}.${operator}(${formattedValue})`
+  }
+
+  return `${fullKey} ${operator} ${formattedValue}`
+}
+
+/**
+ * Creates a CEL expression for a session attribute.
+ * Example output: 'attribute.session_duration > 300'
+ */
+function createSessionAttributeCondition(attribute: {
+  key: string;
+  type: string;
+  value: string | boolean | number;
+  operator?: string
+}): string {
+  const operator = OPERATOR_MAPPINGS[attribute.operator as keyof typeof OPERATOR_MAPPINGS] || '=='
+  const formattedValue = formatValueForCel(attribute.value, attribute.type)
+
+  if (attribute.type === 'string' && (operator === 'contains' || operator === 'startsWith')) {
+    return `attribute.${attribute.key}.${operator}(${formattedValue})`
+  }
+
+  return `attribute.${attribute.key} ${operator} ${formattedValue}`
+}
+
+/** 
+ * Creates a CEL expression for a span name.
+ * Example output: 'span_name.contains("HTTP")'
+ */
+function createSpanNameCondition(spanName: string, operator: string): string {
+  const formattedValue = formatValueForCel(spanName, 'string')
+
+  if (operator === 'contains' || operator === 'startsWith') {
+    return `span_name.${operator}(${formattedValue})`
+  }
+
+  const celOperator = OPERATOR_MAPPINGS[operator as keyof typeof OPERATOR_MAPPINGS] || '=='
+  return `span_name ${celOperator} ${formattedValue}`
+}
+
+/**
+ * Creates a CEL expression for a span's user-defined attribute.
+ * Example output: 'trace.user_defined_attrs.is_critical == true'
+ */
+function createSpanUserDefinedAttributeCondition(attribute: {
+  key: string;
+  type: string;
+  value: string | boolean | number;
+  operator?: string
+}): string {
+  const operator = OPERATOR_MAPPINGS[attribute.operator as keyof typeof OPERATOR_MAPPINGS] || '=='
+  const formattedValue = formatValueForCel(attribute.value, attribute.type)
+  const fullKey = `trace.user_defined_attrs.${attribute.key}`
+
+  if (attribute.type === 'string' && (operator === 'contains' || operator === 'startsWith')) {
+    return `${fullKey}.${operator}(${formattedValue})`
+  }
+
+  return `${fullKey} ${operator} ${formattedValue}`
+}
+
+/**
+ * Converts a single event condition object into an 
+ * array of its constituent CEL parts.
+ * Example output: ['event_type == "exception"', 'exception.handled == false']
+ */
+function buildEventConditionParts(condition: EventCondition): string[] {
+  const parts: string[] = []
+
+  if (condition.type) {
+    parts.push(createEventTypeCondition(condition.type))
+  }
+
+  condition.attrs?.forEach(attr =>
+    parts.push(createEventAttributeCondition(attr, condition.type))
+  )
+
+  condition.ud_attrs?.forEach(attr =>
+    parts.push(createUserDefinedEventAttributeCondition(attr))
+  )
+
+  return parts
+}
+
+/**
+ * Converts a single session condition object into an 
+ * array of its constituent CEL parts.
+ * Example output: ['attribute.session_duration > 300', 'attribute.user_country == "US"']
+ */
+function buildSessionConditionParts(condition: SessionCondition): string[] {
+  return condition.attrs?.map(createSessionAttributeCondition) || []
+}
+
+/**
+ * Converts a single trace condition object into an 
+ * array of its constituent CEL parts.
+ * Example output: ['span_name.contains("HTTP")', 'trace.user_defined_attrs.is_critical == true']
+ */
+function buildTraceConditionParts(condition: TraceCondition): string[] {
+  const parts: string[] = []
+
+  if (condition.spanName) {
+    parts.push(createSpanNameCondition(condition.spanName, condition.operator))
+  }
+
+  condition.ud_attrs?.forEach(attr =>
+    parts.push(createSpanUserDefinedAttributeCondition(attr))
+  )
+
+  return parts
+}
+
+/**
+ * Joins an array of CEL parts for a 
+ * single condition using the AND (`&&`) operator.
+ * Example output: 'part1 && part2 && part3'
+ */
+function combineConditionParts(parts: string[]): string {
+  if (parts.length === 0) return ''
+  return parts.join(' && ')
+}
+
+/**
+ * Combines multiple completed condition strings 
+ * using specified logical operators (`&&` or `||`).
+ * Example output: '(cond1) && (cond2) || (cond3)'
+ */
+function combineConditionsWithLogicalOperators(
+  conditions: string[],
+  operators: ('AND' | 'OR')[]
+): string {
+  if (conditions.length === 0) return ''
+  if (conditions.length === 1) return conditions[0]
+
+  let result = `(${conditions[0]})`
+
+  for (let i = 0; i < operators.length && i + 1 < conditions.length; i++) {
+    const celOperator = LOGICAL_OPERATOR_MAPPINGS[operators[i]]
+    result = `${result} ${celOperator} (${conditions[i + 1]})`
+  }
+
+  return result
+}
+
+/**
+ * High-level processor for all event conditions.
+ * It builds, combines, and links all event conditions into a single CEL string.
+ * Example output: '(event_type == "anr" && exception.handled == false) || (event_type == "crash")'
+ */
+function processEventConditions(eventConditions: EventConditions | undefined): string | null {
+  if (!eventConditions?.conditions?.length) return null
+
+  const conditionStrings = eventConditions.conditions
+    .map(buildEventConditionParts)
+    .filter(parts => parts.length > 0)
+    .map(combineConditionParts)
+
+  return conditionStrings.length > 0
+    ? combineConditionsWithLogicalOperators(conditionStrings, eventConditions.operators || [])
+    : null
+}
+
+/**
+ * High-level processor for all session conditions.
+ * It builds, combines, and links all session conditions into a single CEL string.
+ * Example output: '(attribute.session_duration > 300) && (attribute.user_country == "US")'
+ */
+function processSessionConditions(sessionConditions: SessionConditions | undefined): string | null {
+  if (!sessionConditions?.conditions?.length) return null
+
+  const conditionStrings = sessionConditions.conditions
+    .map(buildSessionConditionParts)
+    .filter(parts => parts.length > 0)
+    .map(combineConditionParts)
+
+  return conditionStrings.length > 0
+    ? combineConditionsWithLogicalOperators(conditionStrings, sessionConditions.operators || [])
+    : null
+}
+
+/**
+ * High-level processor for all trace conditions.
+ * Example output: '(span_name.contains("HTTP")) || (trace.user_defined_attrs.is_critical == true)'
+ */
+function processTraceConditions(traceConditions: TraceConditions | undefined): string | null {
+  if (!traceConditions?.conditions?.length) return null
+
+  const conditionStrings = traceConditions.conditions
+    .map(buildTraceConditionParts)
+    .filter(parts => parts.length > 0)
+    .map(combineConditionParts)
+
+  return conditionStrings.length > 0
+    ? combineConditionsWithLogicalOperators(conditionStrings, traceConditions.operators || [])
+    : null
+}
+
+/**
+ * Wraps and joins the final event, session, and trace CEL groups with AND (`&&`).
+ * Each group is individually wrapped in parentheses.
+ */
+function wrapConditionGroups(conditionGroups: string[]): string {
+  if (conditionGroups.length === 0) return ''
+
+  if (conditionGroups.length === 1) {
+    return `(${conditionGroups[0]})`
+  }
+
+  const wrappedGroups = conditionGroups.map(group => `(${group})`)
+  return wrappedGroups.join(' && ')
+}
+
+/**
+ * Converts a structured `ParsedConditions` object into a final CEL expression string.
+ * This is the main entry point for the CEL generation logic.
+ */
+export function conditionsToCel(parsedConditions: ParsedConditions): string | null {
+  const eventCelExpression = processEventConditions(parsedConditions.event)
+  const traceCelExpression = processTraceConditions(parsedConditions.trace)
+  const sessionCelExpression = processSessionConditions(parsedConditions.session)
+
+  const conditionGroups = [eventCelExpression, traceCelExpression, sessionCelExpression]
+    .filter((group): group is string => Boolean(group))
+
+  if (conditionGroups.length === 0) {
+    return null
+  }
+
+  return wrapConditionGroups(conditionGroups)
+}

--- a/frontend/dashboard/app/utils/cel/cel_parser.ts
+++ b/frontend/dashboard/app/utils/cel/cel_parser.ts
@@ -1,0 +1,616 @@
+/**
+ * CEL (Common Expression Language) Parser
+ * 
+ * This module parses tokenized CEL expressions into structured condition objects
+ * that can be used for event, session, and trace filtering. It builds an Abstract
+ * Syntax Tree (AST) and converts it into domain-specific condition formats.
+ */
+
+import { EventConditions, SessionConditions, TraceConditions, EventCondition, SessionCondition, TraceCondition } from './conditions'
+import { CelTokenizer, Token, TokenType, CelParseError } from './cel_tokenizer'
+
+/**
+ * Result of parsing a CEL expression
+ */
+export interface ParsedConditions {
+  event?: EventConditions
+  session?: SessionConditions
+  trace?: TraceConditions
+}
+
+/**
+ * Represents a field path like "event.user_defined_attrs.key"
+ */
+interface FieldPath {
+  segments: string[]
+  position: number
+}
+
+/**
+ * Represents a literal value in the expression
+ */
+interface Literal {
+  type: 'string' | 'number' | 'boolean' | 'null'
+  value: string | number | boolean | null
+  position: number
+}
+
+/**
+ * Represents a comparison operation (field operator value)
+ */
+interface Comparison {
+  field: FieldPath
+  operator: string
+  value: Literal
+  position: number
+}
+
+/**
+ * Represents a logical operation (AND/OR) between expressions
+ */
+interface LogicalExpression {
+  left: Comparison | LogicalExpression
+  operator: 'AND' | 'OR'
+  right: Comparison | LogicalExpression
+  position: number
+}
+
+/**
+ * Union type for all expression types
+ */
+type Expression = Comparison | LogicalExpression
+
+/**
+ * Parser for CEL expressions that builds structured condition objects
+ */
+class CelParser {
+  private tokens: Token[]
+  private currentPosition = 0
+  private idGenerator = 0
+
+  // Condition builders for different types
+  private eventConditions: EventCondition[] = []
+  private sessionConditions: SessionCondition[] = []
+  private traceConditions: TraceCondition[] = []
+
+  // Operator sequences for combining conditions
+  private eventOperators: ('AND' | 'OR')[] = []
+  private sessionOperators: ('AND' | 'OR')[] = []
+  private traceOperators: ('AND' | 'OR')[] = []
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens
+  }
+
+  /**
+   * Parses the tokens into structured conditions
+   * @returns Parsed conditions organized by type (event, session, trace)
+   */
+  parse(): ParsedConditions {
+    this.resetState()
+
+    try {
+      const ast = this.parseExpression()
+      this.convertAstToConditions(ast)
+      this.validateParsingComplete()
+      return this.buildResult()
+    } catch (error) {
+      return this.handleParsingError(error)
+    }
+  }
+
+  /**
+   * Resets parser state for a new parsing operation
+   */
+  private resetState(): void {
+    this.currentPosition = 0
+    this.idGenerator = 0
+    this.clearConditions()
+  }
+
+  /**
+   * Clears all condition arrays and operators
+   */
+  private clearConditions(): void {
+    this.eventConditions = []
+    this.sessionConditions = []
+    this.traceConditions = []
+    this.eventOperators = []
+    this.sessionOperators = []
+    this.traceOperators = []
+  }
+
+  /**
+   * Parses the top-level expression (handles OR operations)
+   */
+  private parseExpression(): Expression {
+    return this.parseOrExpression()
+  }
+
+  /**
+   * Parses OR expressions (lowest precedence logical operator)
+   */
+  private parseOrExpression(): Expression {
+    let left = this.parseAndExpression()
+
+    while (this.consumeIfMatches(TokenType.OR)) {
+      const operatorPos = this.previousToken().position
+      const right = this.parseAndExpression()
+      left = { left, operator: 'OR', right, position: operatorPos }
+    }
+
+    return left
+  }
+
+  /**
+   * Parses AND expressions (higher precedence than OR)
+   */
+  private parseAndExpression(): Expression {
+    let left = this.parsePrimaryExpression()
+
+    while (this.consumeIfMatches(TokenType.AND)) {
+      const operatorPos = this.previousToken().position
+      const right = this.parsePrimaryExpression()
+      left = { left, operator: 'AND', right, position: operatorPos }
+    }
+
+    return left
+  }
+
+  /**
+   * Parses primary expressions (comparisons and parenthesized expressions)
+   */
+  private parsePrimaryExpression(): Expression {
+    if (this.consumeIfMatches(TokenType.LPAREN)) {
+      const expr = this.parseExpression()
+      this.consumeExpected(TokenType.RPAREN, 'Expected closing parenthesis')
+      return expr
+    }
+
+    return this.parseComparison()
+  }
+
+  /**
+   * Parses a comparison expression (field operator value)
+   */
+  private parseComparison(): Comparison {
+    const field = this.parseFieldPath()
+    const operator = this.parseComparisonOperator()
+    const value = this.parseLiteral()
+
+    // Handle method call syntax (contains, startsWith)
+    if (operator === 'contains' || operator === 'startsWith') {
+      this.consumeExpected(TokenType.RPAREN, `Expected closing parenthesis after ${operator} method call`)
+    }
+
+    return { field, operator, value, position: field.position }
+  }
+
+  /**
+   * Parses a field path like "event.user_defined_attrs.key"
+   */
+  private parseFieldPath(): FieldPath {
+    const startPos = this.currentToken().position
+    const segments: string[] = []
+
+    this.validateIdentifierExpected()
+    segments.push(this.advance().value)
+
+    while (this.consumeIfMatches(TokenType.DOT)) {
+      // Stop if we encounter method calls
+      if (this.isCurrentToken(TokenType.CONTAINS) || this.isCurrentToken(TokenType.STARTS_WITH)) {
+        break
+      }
+
+      this.validateIdentifierExpected()
+      segments.push(this.advance().value)
+    }
+
+    return { segments, position: startPos }
+  }
+
+  /**
+   * Parses comparison operators including method calls
+   */
+  private parseComparisonOperator(): string {
+    const token = this.currentToken()
+
+    // Method call operators
+    if (this.consumeIfMatches(TokenType.CONTAINS, TokenType.STARTS_WITH)) {
+      const methodName = this.previousToken().value
+      this.consumeExpected(TokenType.LPAREN, `Expected opening parenthesis after ${methodName}`)
+      return methodName
+    }
+
+    // Standard comparison operators
+    if (this.consumeIfMatches(
+      TokenType.EQUALS, TokenType.NOT_EQUALS,
+      TokenType.GREATER_THAN, TokenType.LESS_THAN,
+      TokenType.GREATER_EQUAL, TokenType.LESS_EQUAL
+    )) {
+      return this.convertTokenTypeToOperator(this.previousToken().type)
+    }
+
+    throw new CelParseError(
+      'Expected comparison operator',
+      token.position,
+      token.value,
+      ['==', '!=', '>', '<', '>=', '<=', 'contains', 'startsWith']
+    )
+  }
+
+  /**
+   * Parses literal values (strings, numbers, booleans, null)
+   */
+  private parseLiteral(): Literal {
+    const token = this.currentToken()
+
+    if (this.consumeIfMatches(TokenType.STRING)) {
+      return { type: 'string', value: this.previousToken().value, position: token.position }
+    }
+    if (this.consumeIfMatches(TokenType.NUMBER)) {
+      return { type: 'number', value: parseFloat(this.previousToken().value), position: token.position }
+    }
+    if (this.consumeIfMatches(TokenType.BOOLEAN)) {
+      return { type: 'boolean', value: this.previousToken().value === 'true', position: token.position }
+    }
+    if (this.consumeIfMatches(TokenType.NULL)) {
+      return { type: 'null', value: null, position: token.position }
+    }
+
+    throw new CelParseError(
+      'Expected literal value',
+      token.position,
+      token.value,
+      ['string', 'number', 'boolean', 'null']
+    )
+  }
+
+  /**
+   * Converts the AST into structured conditions
+   */
+  private convertAstToConditions(expr: Expression): void {
+    this.processExpression(expr, [])
+  }
+
+  /**
+   * Recursively processes expressions and builds conditions
+   */
+  private processExpression(expr: Expression, operators: ('AND' | 'OR')[]): void {
+    if (this.isLogicalExpression(expr)) {
+      this.processExpression(expr.left, operators)
+      operators.push(expr.operator)
+      this.processExpression(expr.right, operators)
+    } else {
+      this.processComparison(expr, operators)
+    }
+  }
+
+  /**
+   * Processes a comparison and adds it to the appropriate condition list
+   */
+  private processComparison(comparison: Comparison, operators: ('AND' | 'OR')[]): void {
+    const category = this.categorizeFieldPath(comparison.field.segments)
+
+    switch (category) {
+      case 'event':
+        this.addEventCondition(comparison)
+        this.transferOperators(operators, this.eventOperators)
+        break
+      case 'session':
+        this.addSessionCondition(comparison)
+        this.transferOperators(operators, this.sessionOperators)
+        break
+      case 'trace':
+        this.addTraceCondition(comparison)
+        this.transferOperators(operators, this.traceOperators)
+        break
+    }
+  }
+
+  /**
+   * Determines the category of a field based on its path segments
+   */
+  private categorizeFieldPath(segments: string[]): 'event' | 'session' | 'trace' {
+    const firstSegment = segments[0]
+
+    if (firstSegment === 'event_type' || firstSegment === 'event') {
+      return 'event'
+    }
+    if (firstSegment === 'attribute') {
+      return 'session'
+    }
+    if (firstSegment === 'span_name' || firstSegment === 'trace') {
+      return 'trace'
+    }
+
+    // Default to event for unknown fields
+    return 'event'
+  }
+
+  /**
+   * Adds an event condition based on the comparison
+   */
+  private addEventCondition(comparison: Comparison): void {
+    const segments = comparison.field.segments
+
+    if (segments[0] === 'event_type') {
+      this.addEventTypeCondition(comparison)
+    } else if (this.isUserDefinedEventAttribute(segments)) {
+      this.addEventUserDefinedAttribute(comparison, segments)
+    } else {
+      this.addEventAttribute(comparison, segments)
+    }
+  }
+
+  /**
+   * Adds an event type condition
+   */
+  private addEventTypeCondition(comparison: Comparison): void {
+    const eventType = comparison.value.value as string
+    let condition = this.findEventConditionByType(eventType)
+
+    if (!condition) {
+      condition = this.createEventCondition(eventType)
+      this.eventConditions.push(condition)
+    }
+  }
+
+  /**
+   * Adds a user-defined event attribute
+   */
+  private addEventUserDefinedAttribute(comparison: Comparison, segments: string[]): void {
+    const key = segments.slice(2).join('.')
+    const condition = this.getLastEventCondition()
+
+    if (!condition) {
+      throw new CelParseError('User-defined attribute found without a preceding event_type', comparison.position)
+    }
+
+    condition.ud_attrs!.push(this.createAttributeFromComparison(comparison, key))
+  }
+
+  /**
+   * Adds a regular event attribute
+   */
+  private addEventAttribute(comparison: Comparison, segments: string[]): void {
+    const eventType = segments[0] === 'event' ? segments[1] : segments[0]
+    const fullPathKey = segments.join('.')
+
+    let condition = this.findEventConditionByType(eventType)
+    if (!condition) {
+      condition = this.createEventCondition(eventType)
+      this.eventConditions.push(condition)
+    }
+
+    condition.attrs!.push(this.createAttributeFromComparison(comparison, fullPathKey))
+  }
+
+  /**
+   * Adds a session condition
+   */
+  private addSessionCondition(comparison: Comparison): void {
+    const key = comparison.field.segments.join('.')
+    const condition: SessionCondition = {
+      id: this.generateId(),
+      attrs: [this.createAttributeFromComparison(comparison, key)]
+    }
+    this.sessionConditions.push(condition)
+  }
+
+  /**
+   * Adds a trace condition
+   */
+  private addTraceCondition(comparison: Comparison): void {
+    const segments = comparison.field.segments
+
+    if (segments[0] === 'span_name') {
+      this.addSpanNameCondition(comparison)
+    } else if (this.isUserDefinedTraceAttribute(segments)) {
+      this.addTraceUserDefinedAttribute(comparison, segments)
+    }
+  }
+
+  /**
+   * Adds a span name condition
+   */
+  private addSpanNameCondition(comparison: Comparison): void {
+    const condition: TraceCondition = {
+      id: this.generateId(),
+      spanName: comparison.value.value as string,
+      operator: comparison.operator,
+      ud_attrs: []
+    }
+    this.traceConditions.push(condition)
+  }
+
+  /**
+   * Adds a trace user-defined attribute
+   */
+  private addTraceUserDefinedAttribute(comparison: Comparison, segments: string[]): void {
+    const currentCondition = this.getLastTraceCondition()
+    if (!currentCondition) {
+      throw new CelParseError('Trace attribute found without a preceding span name', comparison.position)
+    }
+
+    const fullPathKey = segments.join('.')
+    currentCondition.ud_attrs!.push(this.createAttributeFromComparison(comparison, fullPathKey))
+  }
+
+  // Helper methods for token management
+  private consumeIfMatches(...types: TokenType[]): boolean {
+    if (types.some(type => this.isCurrentToken(type))) {
+      this.advance()
+      return true
+    }
+    return false
+  }
+
+  private isCurrentToken(type: TokenType): boolean {
+    return !this.isAtEnd() && this.currentToken().type === type
+  }
+
+  private advance(): Token {
+    if (!this.isAtEnd()) this.currentPosition++
+    return this.previousToken()
+  }
+
+  private isAtEnd(): boolean {
+    return this.currentToken().type === TokenType.EOF
+  }
+
+  private currentToken(): Token {
+    return this.tokens[this.currentPosition]
+  }
+
+  private previousToken(): Token {
+    return this.tokens[this.currentPosition - 1]
+  }
+
+  private consumeExpected(type: TokenType, message: string): Token {
+    if (this.isCurrentToken(type)) return this.advance()
+
+    const token = this.currentToken()
+    throw new CelParseError(message, token.position, token.value, [type])
+  }
+
+  // Helper methods for validation and utility
+  private validateIdentifierExpected(): void {
+    if (!this.isCurrentToken(TokenType.IDENTIFIER)) {
+      const token = this.currentToken()
+      throw new CelParseError(
+        'Expected field name',
+        token.position,
+        token.value,
+        ['identifier']
+      )
+    }
+  }
+
+  private validateParsingComplete(): void {
+    if (!this.isAtEnd()) {
+      const token = this.currentToken()
+      throw new CelParseError(
+        'Unexpected tokens after expression',
+        token.position,
+        token.value
+      )
+    }
+  }
+
+  private handleParsingError(error: unknown): ParsedConditions {
+    if (error instanceof CelParseError) {
+      console.error('CEL Parse Error:', error.message, 'at position', error.position, 'token:', error.token, 'expected:', error.expected)
+    } else {
+      console.error('Failed to parse CEL expression:', error)
+    }
+    return {}
+  }
+
+  private convertTokenTypeToOperator(type: TokenType): string {
+    switch (type) {
+      case TokenType.EQUALS:
+        return 'eq'
+      case TokenType.NOT_EQUALS:
+        return 'neq'
+      case TokenType.GREATER_THAN:
+        return 'gt'
+      case TokenType.LESS_THAN:
+        return 'lt'
+      case TokenType.GREATER_EQUAL:
+        return 'gte'
+      case TokenType.LESS_EQUAL:
+        return 'lte'
+      default:
+        throw new CelParseError('Invalid comparison operator', this.currentToken().position, this.currentToken().value)
+    }
+  }
+
+  // Helper methods for condition management
+  private generateId(): string {
+    return `id-${this.idGenerator++}`
+  }
+
+  private findEventConditionByType(eventType: string): EventCondition | undefined {
+    return this.eventConditions.find(c => c.type === eventType)
+  }
+
+  private createEventCondition(eventType: string): EventCondition {
+    return {
+      id: this.generateId(),
+      type: eventType,
+      attrs: [],
+      ud_attrs: []
+    }
+  }
+
+  private getLastEventCondition(): EventCondition | undefined {
+    return this.eventConditions[this.eventConditions.length - 1]
+  }
+
+  private getLastTraceCondition(): TraceCondition | undefined {
+    return this.traceConditions[this.traceConditions.length - 1]
+  }
+
+  private createAttributeFromComparison(comparison: Comparison, key: string) {
+    const parsedKey = key.split('.').pop() || key
+    return {
+      id: this.generateId(),
+      key: parsedKey,
+      type: comparison.value.type === 'boolean' ? 'bool' : comparison.value.type,
+      value: comparison.value.value as string | number | boolean,
+      operator: comparison.operator
+    }
+  }
+
+  private isUserDefinedEventAttribute(segments: string[]): boolean {
+    return segments[0] === 'event' && segments[1] === 'user_defined_attrs'
+  }
+
+  private isUserDefinedTraceAttribute(segments: string[]): boolean {
+    return (segments[0] === 'trace') && segments[1] === 'user_defined_attrs'
+  }
+
+  private isLogicalExpression(expr: Expression): expr is LogicalExpression {
+    return 'operator' in expr && (expr.operator === 'AND' || expr.operator === 'OR')
+  }
+
+  private transferOperators(source: ('AND' | 'OR')[], target: ('AND' | 'OR')[]): void {
+    if (source.length > 0) {
+      target.push(...source)
+      source.length = 0
+    }
+  }
+
+  /**
+   * Builds the final result from parsed conditions
+   */
+  private buildResult(): ParsedConditions {
+    const result: ParsedConditions = {}
+
+    if (this.eventConditions.length > 0) {
+      result.event = { conditions: this.eventConditions, operators: this.eventOperators }
+    }
+    if (this.sessionConditions.length > 0) {
+      result.session = { conditions: this.sessionConditions, operators: this.sessionOperators }
+    }
+    if (this.traceConditions.length > 0) {
+      result.trace = { conditions: this.traceConditions, operators: this.traceOperators }
+    }
+
+    return result
+  }
+}
+
+/**
+ * Parses a CEL expression string into structured conditions
+ */
+export function celToConditions(expression: string): ParsedConditions {
+  if (!expression?.trim()) {
+    return { event: undefined, trace: undefined, session: undefined };
+  }
+  const tokenizer = new CelTokenizer(expression);
+  const tokens = tokenizer.tokenize();
+  const parser = new CelParser(tokens);
+  return parser.parse();
+}

--- a/frontend/dashboard/app/utils/cel/cel_tokenizer.ts
+++ b/frontend/dashboard/app/utils/cel/cel_tokenizer.ts
@@ -1,0 +1,314 @@
+/**
+ * CEL (Common Expression Language) Tokenizer
+ * 
+ * This module provides tokenization for CEL expressions, breaking down input strings
+ * into meaningful tokens for parsing.
+ */
+
+/**
+ * Error thrown during CEL parsing with detailed context information
+ */
+export class CelParseError extends Error {
+  constructor(
+    message: string,
+    public position: number,
+    public token?: string,
+    public expected?: string[]
+  ) {
+    const contextInfo = token ? ` (found: '${token}')` : ''
+    const expectedInfo = expected ? ` (expected: ${expected.join(' or ')})` : ''
+    super(`${message} at position ${position}${contextInfo}${expectedInfo}`)
+    this.name = 'CelParseError'
+  }
+}
+
+/**
+ * Token types supported by the CEL tokenizer
+ */
+export enum TokenType {
+  // Literal values
+  IDENTIFIER = 'IDENTIFIER',
+  STRING = 'STRING',
+  NUMBER = 'NUMBER',
+  BOOLEAN = 'BOOLEAN',
+  NULL = 'NULL',
+
+  // Comparison operators
+  EQUALS = 'EQUALS',
+  NOT_EQUALS = 'NOT_EQUALS',
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  GREATER_EQUAL = 'GREATER_EQUAL',
+  LESS_EQUAL = 'LESS_EQUAL',
+
+  // String methods
+  CONTAINS = 'CONTAINS',
+  STARTS_WITH = 'STARTS_WITH',
+
+  // Logical operators
+  AND = 'AND',
+  OR = 'OR',
+
+  // Punctuation
+  DOT = 'DOT',
+  LPAREN = 'LPAREN',
+  RPAREN = 'RPAREN',
+  COMMA = 'COMMA',
+
+  // End marker
+  EOF = 'EOF'
+}
+
+/**
+ * Represents a single token with its type, value, and position
+ */
+export interface Token {
+  type: TokenType
+  value: string
+  position: number
+}
+
+/**
+ * Tokenizes CEL expressions into a sequence of tokens
+ */
+export class CelTokenizer {
+  private input: string
+  private position = 0
+
+  constructor(input: string) {
+    this.input = input.trim()
+  }
+
+  /**
+   * Tokenizes the input string into an array of tokens
+   * @returns Array of tokens including EOF marker at the end
+   */
+  tokenize(): Token[] {
+    const tokens: Token[] = []
+    this.position = 0
+
+    while (this.position < this.input.length) {
+      this.skipWhitespace()
+      if (this.position >= this.input.length) break
+
+      const startPos = this.position
+      const token = this.readNextToken()
+      tokens.push({ ...token, position: startPos })
+    }
+
+    tokens.push({ type: TokenType.EOF, value: '', position: this.position })
+    return tokens
+  }
+
+  /**
+   * Reads and returns the next token from the input
+   */
+  private readNextToken(): Omit<Token, 'position'> {
+    // Multi-character operators first
+    const twoCharToken = this.tryReadTwoCharOperator()
+    if (twoCharToken) return twoCharToken
+
+    const char = this.currentChar()
+
+    // Single character tokens
+    const singleCharToken = this.tryReadSingleCharToken(char)
+    if (singleCharToken) return singleCharToken
+
+    // Complex tokens that require parsing
+    if (char === '"') return { type: TokenType.STRING, value: this.readStringLiteral() }
+    if (this.isDigit(char)) return { type: TokenType.NUMBER, value: this.readNumber() }
+    if (this.isIdentifierStart(char)) {
+      const identifier = this.readIdentifier()
+      return { type: this.classifyIdentifier(identifier), value: identifier }
+    }
+
+    throw new CelParseError(`Unexpected character '${char}'`, this.position)
+  }
+
+  /**
+   * Skips whitespace characters
+   */
+  private skipWhitespace(): void {
+    while (this.position < this.input.length && /\s/.test(this.currentChar())) {
+      this.position++
+    }
+  }
+
+  /**
+   * Attempts to read a two-character operator
+   */
+  private tryReadTwoCharOperator(): Omit<Token, 'position'> | null {
+    if (this.position + 1 >= this.input.length) return null
+
+    const twoChar = this.input.slice(this.position, this.position + 2)
+    const tokenType = this.getTwoCharOperatorType(twoChar)
+    
+    if (tokenType) {
+      this.position += 2
+      return { type: tokenType, value: twoChar }
+    }
+    
+    return null
+  }
+
+  /**
+   * Maps two-character sequences to their token types
+   */
+  private getTwoCharOperatorType(twoChar: string): TokenType | null {
+    const operators: Record<string, TokenType> = {
+      '==': TokenType.EQUALS,
+      '!=': TokenType.NOT_EQUALS,
+      '>=': TokenType.GREATER_EQUAL,
+      '<=': TokenType.LESS_EQUAL,
+      '&&': TokenType.AND,
+      '||': TokenType.OR
+    }
+    return operators[twoChar] || null
+  }
+
+  /**
+   * Attempts to read a single-character token
+   */
+  private tryReadSingleCharToken(char: string): Omit<Token, 'position'> | null {
+    const tokenType = this.getSingleCharTokenType(char)
+    if (tokenType) {
+      this.position++
+      return { type: tokenType, value: char }
+    }
+    return null
+  }
+
+  /**
+   * Maps single characters to their token types
+   */
+  private getSingleCharTokenType(char: string): TokenType | null {
+    const tokens: Record<string, TokenType> = {
+      '(': TokenType.LPAREN,
+      ')': TokenType.RPAREN,
+      '.': TokenType.DOT,
+      ',': TokenType.COMMA,
+      '>': TokenType.GREATER_THAN,
+      '<': TokenType.LESS_THAN
+    }
+    return tokens[char] || null
+  }
+
+  /**
+   * Classifies an identifier as a keyword.
+   */
+  private classifyIdentifier(identifier: string): TokenType {
+    const keywords: Record<string, TokenType> = {
+      'true': TokenType.BOOLEAN,
+      'false': TokenType.BOOLEAN,
+      'null': TokenType.NULL,
+      'contains': TokenType.CONTAINS,
+      'startsWith': TokenType.STARTS_WITH
+    }
+    return keywords[identifier] || TokenType.IDENTIFIER
+  }
+
+  /**
+   * Reads a string literal, handling escape sequences
+   */
+  private readStringLiteral(): string {
+    this.position++ // Skip opening quote
+    let value = ''
+
+    while (this.position < this.input.length && this.currentChar() !== '"') {
+      if (this.currentChar() === '\\' && this.position + 1 < this.input.length) {
+        this.position++
+        value += this.readEscapeSequence(this.currentChar())
+      } else {
+        value += this.currentChar()
+      }
+      this.position++
+    }
+
+    if (this.position >= this.input.length) {
+      throw new CelParseError('Unterminated string literal', this.position - value.length - 1)
+    }
+
+    this.position++ // Skip closing quote
+    return value
+  }
+
+  /**
+   * Converts escape sequences to their actual characters
+   */
+  private readEscapeSequence(char: string): string {
+    const escapeChars: Record<string, string> = {
+      'n': '\n',
+      't': '\t',
+      'r': '\r',
+      '\\': '\\',
+      '"': '"'
+    }
+    return escapeChars[char] || char
+  }
+
+  /**
+   * Reads a numeric literal (integer or float)
+   */
+  private readNumber(): string {
+    let value = ''
+    let hasDecimal = false
+
+    while (this.position < this.input.length) {
+      const char = this.currentChar()
+      if (this.isDigit(char)) {
+        value += char
+        this.position++
+      } else if (char === '.' && !hasDecimal) {
+        hasDecimal = true
+        value += char
+        this.position++
+      } else {
+        break
+      }
+    }
+
+    return value
+  }
+
+  /**
+   * Reads an identifier (variable name, function name, etc.)
+   */
+  private readIdentifier(): string {
+    let value = ''
+
+    while (this.position < this.input.length && this.isIdentifierChar(this.currentChar())) {
+      value += this.currentChar()
+      this.position++
+    }
+
+    return value
+  }
+
+  /**
+   * Gets the current character without advancing position
+   */
+  private currentChar(): string {
+    return this.input[this.position]
+  }
+
+  /**
+   * Checks if a character is a digit
+   */
+  private isDigit(char: string): boolean {
+    return /\d/.test(char)
+  }
+
+  /**
+   * Checks if a character can start an identifier
+   */
+  private isIdentifierStart(char: string): boolean {
+    return /[a-zA-Z_]/.test(char)
+  }
+
+  /**
+   * Checks if a character can be part of an identifier
+   */
+  private isIdentifierChar(char: string): boolean {
+    return /[a-zA-Z0-9_]/.test(char)
+  }
+}

--- a/frontend/dashboard/app/utils/cel/conditions.ts
+++ b/frontend/dashboard/app/utils/cel/conditions.ts
@@ -1,0 +1,68 @@
+export interface EventCondition {
+    id: string
+    type: string
+    attrs: Array<{
+        id: string,
+        key: string,
+        type: string,
+        value: string | boolean | number,
+        hint?: string,
+        operator?: string,
+        hasError?: boolean,
+        errorMessage?: string
+    }>,
+    ud_attrs: Array<{
+        id: string,
+        key: string,
+        type: string,
+        value: string | boolean | number,
+        hint?: string,
+        operator?: string,
+        hasError?: boolean,
+        errorMessage?: string
+    }>
+}
+
+export interface SessionCondition {
+    id: string
+    attrs: Array<{
+        id: string,
+        key: string,
+        type: string,
+        value: string | boolean | number,
+        hint?: string,
+        operator?: string,
+        hasError?: boolean,
+        errorMessage?: string
+    }>
+}
+
+export interface TraceCondition {
+    id: string
+    spanName: string
+    operator: string
+    ud_attrs: Array<{
+        id: string,
+        key: string,
+        type: string,
+        value: string | boolean | number,
+        operator?: string,
+        hasError?: boolean,
+        errorMessage?: string
+    }>
+}
+
+export interface EventConditions {
+    conditions: EventCondition[]
+    operators: ('AND' | 'OR')[]
+}
+
+export interface SessionConditions {
+    conditions: SessionCondition[]
+    operators: ('AND' | 'OR')[]
+}
+
+export interface TraceConditions {
+    conditions: TraceCondition[]
+    operators: ('AND' | 'OR')[]
+}

--- a/frontend/dashboard/package-lock.json
+++ b/frontend/dashboard/package-lock.json
@@ -5462,6 +5462,7 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/self-host/postgres/20250918150308_create_session_targeting_rules_table.sql
+++ b/self-host/postgres/20250918150308_create_session_targeting_rules_table.sql
@@ -1,0 +1,30 @@
+-- migrate:up
+create table if not exists measure.session_targeting_rules (
+    id uuid primary key not null,
+    team_id uuid not null,
+    app_id uuid not null,
+    name text not null,
+    status integer not null,
+    sampling_rate numeric(9, 6) not null,
+    rule text not null,
+    created_at timestamptz not null default now(),
+    created_by uuid not null,
+    updated_at timestamptz not null default now(),
+    updated_by uuid not null
+);
+
+comment on table measure.session_targeting_rules is 'table storing session targeting rules';
+comment on column measure.session_targeting_rules.team_id is 'id of team to which the rule belongs';
+comment on column measure.session_targeting_rules.app_id is 'app_id of the app to which the rule belongs';
+comment on column measure.session_targeting_rules.id is 'id of the rule';
+comment on column measure.session_targeting_rules.name is 'name of the rule';
+comment on column measure.session_targeting_rules.status is 'whether the rule is active or not';
+comment on column measure.session_targeting_rules.sampling_rate is 'the percentage sampling rate applied';
+comment on column measure.session_targeting_rules.rule is 'the rule represented as a CEL expression';
+comment on column measure.session_targeting_rules.created_at is 'utc timestamp at the time of rule creation';
+comment on column measure.session_targeting_rules.created_by is ' id of the user who created the rule';
+comment on column measure.session_targeting_rules.updated_at is 'utc timestamp at the time of rule update';
+comment on column measure.session_targeting_rules.updated_by is 'id of the user who updated the rule';
+
+-- migrate:down
+drop table if exists measure.session_targeting_rules;


### PR DESCRIPTION
## Description

Implements frontend and backend for session targeting.

- Creates a new section under settings to navigate to "Session Targeting" overview page.
- Implements the Session Targeting Overview page.
- Implements the Session Targeting create/edit pages.
- Implements `utils/cel` for converting from UI state to CEL expression and vice-versa.
- Implements `GET /sessionTargetingRules` API.
- Implements `GET /sessionTargetingRule/:ruleId` API.
- Implements `POST /sessionTargetingRules` API.
- Implements `PATCH /sessionTargetingRules/:ruleId` API.
- Implements `GET /config` SDK API.
- Create a new postgres table `session-targeting-rules`.
- Updates dashboard API documentation.
- Updates SDK API documentation.

> [!IMPORTANT]
> The session targeting tab has been intentionally hidden in the UI as the SDKs are yet to implement this feature.

## Related issue
References #2569 


