### PR TITLE
fix(ios): track proper session duration

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -88,7 +88,7 @@ struct Config: InternalConfig, MeasureConfig {
         self.maxDiskUsageInMb = maxDiskUsageInMb
         self.eventsBatchingIntervalMs = 30000 // 30 seconds
         self.maxEventsInBatch = 500
-        self.sessionEndLastEventThresholdMs = 20 * 60 * 1000 // 20 minitues
+        self.sessionEndLastEventThresholdMs = 3 * 60 * 1000 // 3 minitues
         self.timeoutIntervalForRequest = 30 // 30 seconds
         self.longPressTimeout = 500 // 500 ms
         self.scaledTouchSlop = 3.5 // 3.5 points

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -162,6 +162,8 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.lifecycleObserver.applicationDidEnterBackground = applicationDidEnterBackground
         self.lifecycleObserver.applicationWillEnterForeground = applicationWillEnterForeground
         self.lifecycleObserver.applicationWillTerminate = applicationWillTerminate
+        self.lifecycleObserver.applicationDidBecomeActive = applicationDidBecomeActive
+        self.lifecycleObserver.applicationWillResignActive = applicationWillResignActive
         self.logger.log(level: .info, message: "Initializing Measure SDK", error: nil, data: nil)
         self.sessionManager.setPreviousSessionCrashed(crashReportManager.hasPendingCrashReport)
         self.sessionManager.start { sessionId in
@@ -332,6 +334,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     }
 
     private func applicationWillEnterForeground() {
+        self.appLaunchCollector.applicationWillEnterForeground()
         self.crashDataPersistence.isForeground = true
         self.internalSignalCollector.isForeground = true
         self.sessionManager.applicationWillEnterForeground()
@@ -343,6 +346,14 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     private func applicationWillTerminate() {
         self.sessionManager.applicationWillTerminate()
         self.lifecycleCollector.applicationWillTerminate()
+    }
+
+    private func applicationDidBecomeActive() {
+        self.appLaunchCollector.applicationDidBecomeActive()
+    }
+
+    private func applicationWillResignActive() {
+        self.appLaunchCollector.applicationWillResignActive()
     }
 
     private func registedCollectors() {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -327,9 +327,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.sessionManager.applicationDidEnterBackground()
         self.periodicExporter.applicationDidEnterBackground()
         self.lifecycleCollector.applicationDidEnterBackground()
-        self.cpuUsageCollector.pause()
-        self.memoryUsageCollector.pause()
-        self.shakeBugReportCollector.pause()
+        self.unregisterCollectors()
         self.dataCleanupService.clearStaleData {}
     }
 
@@ -339,9 +337,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.sessionManager.applicationWillEnterForeground()
         self.periodicExporter.applicationWillEnterForeground()
         self.lifecycleCollector.applicationWillEnterForeground()
-        self.cpuUsageCollector.resume()
-        self.memoryUsageCollector.resume()
-        self.shakeBugReportCollector.resume()
+        self.registedCollectors()
     }
 
     private func applicationWillTerminate() {

--- a/ios/Sources/MeasureSDK/Swift/Utils/LifecycleObserver.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/LifecycleObserver.swift
@@ -7,18 +7,22 @@
 
 import UIKit
 
-/// A class that observes key application lifecycle events: background, foreground and termination.
+/// A class that observes key application lifecycle events: background, foreground, active/inactive, and termination.
 ///
 /// - Properties:
-///   - `applicationDidEnterBackground`: A closure that is called when the application enters the background.
-///   - `applicationWillEnterForeground`: A closure that is called when the application will enter the foreground.
-///   - `applicationWillTerminate`: A closure that is called when the application is about to terminate.
+///   - `applicationDidEnterBackground`: Called when the application enters the background.
+///   - `applicationWillEnterForeground`: Called when the application will enter the foreground.
+///   - `applicationDidBecomeActive`: Called when the application becomes active.
+///   - `applicationWillResignActive`: Called when the application is about to move from active to inactive state.
+///   - `applicationWillTerminate`: Called when the application is about to terminate.
 ///
 /// - Note: Make sure to retain an instance of this class as long as you need to observe the lifecycle events.
-/// 
+///
 final class LifecycleObserver {
     var applicationDidEnterBackground: (() -> Void)?
     var applicationWillEnterForeground: (() -> Void)?
+    var applicationDidBecomeActive: (() -> Void)?
+    var applicationWillResignActive: (() -> Void)?
     var applicationWillTerminate: (() -> Void)?
 
     init() {
@@ -46,6 +50,20 @@ final class LifecycleObserver {
 
         NotificationCenter.default.addObserver(
             self,
+            selector: #selector(onAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onAppWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(onAppWillTerminate),
             name: UIApplication.willTerminateNotification,
             object: nil
@@ -58,6 +76,14 @@ final class LifecycleObserver {
 
     @objc private func onAppForegrounded() {
         applicationWillEnterForeground?()
+    }
+
+    @objc private func onAppDidBecomeActive() {
+        applicationDidBecomeActive?()
+    }
+
+    @objc private func onAppWillResignActive() {
+        applicationWillResignActive?()
     }
 
     @objc private func onAppWillTerminate() {

--- a/ios/Tests/MeasureSDKTests/Config/BaseConfigProviderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/BaseConfigProviderTests.swift
@@ -52,7 +52,7 @@ final class BaseConfigProviderTests: XCTestCase {
         XCTAssertEqual(baseConfigProvider.trackHttpHeaders, DefaultConfig.trackHttpHeaders)
         XCTAssertEqual(baseConfigProvider.httpHeadersBlocklist, DefaultConfig.httpHeadersBlocklist)
         XCTAssertEqual(baseConfigProvider.httpUrlAllowlist, DefaultConfig.httpUrlAllowlist)
-        XCTAssertEqual(baseConfigProvider.sessionEndLastEventThresholdMs, 20 * 60 * 1000) // 20 minutes
+        XCTAssertEqual(baseConfigProvider.sessionEndLastEventThresholdMs, 3 * 60 * 1000) // 3 minutes
         XCTAssertEqual(baseConfigProvider.eventsBatchingIntervalMs, 30000) // 30 seconds
         XCTAssertEqual(baseConfigProvider.maxEventsInBatch, 500)
         XCTAssertEqual(baseConfigProvider.timeoutIntervalForRequest, 30) // 30 seconds
@@ -106,7 +106,7 @@ final class BaseConfigProviderTests: XCTestCase {
 
         XCTAssertEqual(baseConfigProvider.samplingRateForErrorFreeSessions, 0.25)
         XCTAssertEqual(baseConfigProvider.enableLogging, false)
-        XCTAssertEqual(baseConfigProvider.sessionEndLastEventThresholdMs, 20 * 60 * 1000) // 20 minutes
+        XCTAssertEqual(baseConfigProvider.sessionEndLastEventThresholdMs, 3 * 60 * 1000) // 3 minutes
         XCTAssertEqual(baseConfigProvider.eventsBatchingIntervalMs, 30000) // 30 seconds
         XCTAssertEqual(baseConfigProvider.maxEventsInBatch, 500)
         XCTAssertEqual(baseConfigProvider.timeoutIntervalForRequest, 30) // 30 seconds


### PR DESCRIPTION
# Description

This PR contains the below changes

- Disable all collectors when app moves to background
- Reduce session stitching duration to 3 minutes
- Update launch time generation logic

## Related issue
Fixes #2631 