### PR TITLE
fix(backend): show first available user ID in session timeline

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -1522,6 +1522,7 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 	}
 
 	var session Session
+	var firstUserID string
 
 	for rows.Next() {
 		var ev event.EventField
@@ -1798,6 +1799,11 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			return nil, err
 		}
 
+		// Capture first non-empty user ID (add this after the scan)
+		if firstUserID == "" && ev.Attribute.UserID != "" {
+			firstUserID = ev.Attribute.UserID
+		}
+
 		// populate user defined attribute
 		if len(userDefAttr) > 0 {
 			ev.UserDefinedAttribute.Scan(userDefAttr)
@@ -1955,6 +1961,10 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 	// as the session's attributes
 	if len(session.Events) > 0 {
 		attr := session.Events[0].Attribute
+		// Override with the first non-empty user ID we found
+		if firstUserID != "" {
+			attr.UserID = firstUserID
+		}
 		session.Attribute = &attr
 	}
 


### PR DESCRIPTION
# Description

We were defaulting to User ID of the first event in the session. In some sessions, the User ID may not be set at the time of the first event resulting in an empty user ID even if the following events have it.

This commit fixes this by keeping tracking of first available User ID and setting it as the User ID for the session.

## Before

<img width="1181" height="718" alt="before" src="https://github.com/user-attachments/assets/84f278d4-f4c6-4b15-894a-7d566ec09bd6" />

## After

<img width="1193" height="731" alt="after" src="https://github.com/user-attachments/assets/69302344-a396-487c-a3ba-f78037326558" />

## Related issue
Fixes #2642 



