### PR TITLE
chore(android): update session configs

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -44,7 +44,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
     override var sessionEndLastEventThresholdMs: Long = 1_000_000
-    override var maxSessionDurationMs: Long = 6_000_000
+    override var maxSessionDurationMs: Long = 1_000_000
     override var maxEventNameLength: Int = 64
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+\$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -44,7 +44,6 @@ internal class FakeConfigProvider : ConfigProvider {
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
     override var sessionEndLastEventThresholdMs: Long = 1_000_000
-    override var maxSessionDurationMs: Long = 1_000_000
     override var maxEventNameLength: Int = 64
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+\$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/android/measure/src/androidTest/java/sh/measure/android/SessionTest.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/SessionTest.kt
@@ -96,24 +96,4 @@ class SessionTest {
             Assert.assertEquals(2, sessionCount)
         }
     }
-
-    @Test
-    fun createsNewSessionOnInitializationWhenMaxSessionDurationForPreviousSessionHasBeenReached() {
-        // Given
-        robot.initializeMeasure(MeasureConfig(enableLogging = true))
-        robot.setSessionMaxDurationConfig(5000L)
-        robot.setSessionEndThresholdConfig(10000L)
-        ActivityScenario.launch(TestActivity::class.java).use {
-            // When
-            it.moveToState(Lifecycle.State.RESUMED)
-            robot.moveAppToBackground()
-            robot.incrementTimeBeyondMaxSessionDuration()
-            robot.openAppFromRecent()
-            it.moveToState(Lifecycle.State.RESUMED)
-
-            // Then
-            val sessionCount = robot.getSessionCount()
-            Assert.assertEquals(2, sessionCount)
-        }
-    }
 }

--- a/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
@@ -56,10 +56,6 @@ class SessionTestRobot {
         testClock.advance(configProvider.sessionEndLastEventThresholdMs - 1000)
     }
 
-    fun incrementTimeBeyondMaxSessionDuration() {
-        testClock.advance(configProvider.maxSessionDurationMs + 100)
-    }
-
     fun moveAppToBackground() {
         testClock.advance(1000)
         device.pressHome()
@@ -91,13 +87,5 @@ class SessionTestRobot {
             attributes = mutableMapOf(),
             attachments = mutableListOf(),
         )
-    }
-
-    fun setSessionMaxDurationConfig(maxDuration: Long) {
-        configProvider.maxSessionDurationMs = maxDuration
-    }
-
-    fun setSessionEndThresholdConfig(threshold: Long) {
-        configProvider.sessionEndLastEventThresholdMs = threshold
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -228,9 +228,6 @@ internal class SessionManagerImpl(
             // session.
             return false
         }
-        if (sessionDuration >= configProvider.maxSessionDurationMs) {
-            return false
-        }
 
         if (packageInfoProvider.getVersionCode() != recentSession.versionCode) {
             // The app version has changed since last session, create a new session.

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -36,8 +36,8 @@ internal data class Config(
         "WWW-Authenticate",
         "X-Api-Key",
     )
-    override val sessionEndLastEventThresholdMs: Long = 20 * 60 * 1000 // 20 minutes
-    override val maxSessionDurationMs: Long = 6 * 60 * 60 * 1000 // 6 hours
+    override val sessionEndLastEventThresholdMs: Long = 3 * 60 * 1000 // 3 minutes
+    override val maxSessionDurationMs: Long = 1 * 60 * 60 * 1000 // 1 hour
     override val maxEventNameLength: Int = 64 // 64 chars
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -37,7 +37,6 @@ internal data class Config(
         "X-Api-Key",
     )
     override val sessionEndLastEventThresholdMs: Long = 3 * 60 * 1000 // 3 minutes
-    override val maxSessionDurationMs: Long = 1 * 60 * 60 * 1000 // 1 hour
     override val maxEventNameLength: Int = 64 // 64 chars
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -85,8 +85,6 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { defaultHttpHeadersBlocklist }
     override val sessionEndLastEventThresholdMs: Long
         get() = getMergedConfig { sessionEndLastEventThresholdMs }
-    override val maxSessionDurationMs: Long
-        get() = getMergedConfig { maxSessionDurationMs }
     override val maxAttachmentSizeInEventsBatchInBytes: Int
         get() = getMergedConfig { maxAttachmentSizeInEventsBatchInBytes }
     override val maxEventNameLength: Int

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -30,7 +30,7 @@ internal interface InternalConfig {
     val defaultHttpHeadersBlocklist: List<String>
 
     /**
-     * The threshold after which a session is considered ended. Defaults to 20 minutes.
+     * The threshold after which a session is considered ended. Defaults to 3 minutes.
      */
     val sessionEndLastEventThresholdMs: Long
 
@@ -38,7 +38,7 @@ internal interface InternalConfig {
      * The maximum duration for a session. Used when the app comes to foreground, sessions which
      * remain in foreground for more than this time will still continue.
      *
-     * Defaults to 6 hours.
+     * Defaults to 1 hour.
      */
     val maxSessionDurationMs: Long
 

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -35,14 +35,6 @@ internal interface InternalConfig {
     val sessionEndLastEventThresholdMs: Long
 
     /**
-     * The maximum duration for a session. Used when the app comes to foreground, sessions which
-     * remain in foreground for more than this time will still continue.
-     *
-     * Defaults to 1 hour.
-     */
-    val maxSessionDurationMs: Long
-
-    /**
      * The maximum length of a custom event. Defaults to 64 chars.
      */
     val maxEventNameLength: Int

--- a/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -93,7 +93,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `creates new session when last event occurred more than 20 minutes ago`() {
+    fun `creates new session when last event occurred more than 3 minutes ago`() {
         // Given
         val initialTime = testClock.epochTime()
 
@@ -106,8 +106,8 @@ class SessionManagerTest {
         )
         `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
 
-        // Advance time beyond the 20-minute session timeout
-        testClock.advance(Duration.ofMinutes(21))
+        // Advance time beyond the 3-minute session timeout
+        testClock.advance(Duration.ofMinutes(4))
 
         // When
         sessionManager.init()
@@ -118,7 +118,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `continues previous session when last event occurred less than 20 minutes ago`() {
+    fun `continues previous session when last event occurred less than 3 minutes ago`() {
         // Given
         val initialTime = testClock.epochTime()
 
@@ -131,8 +131,8 @@ class SessionManagerTest {
         )
         `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
 
-        // Advance time beyond the 20-minute session timeout
-        testClock.advance(Duration.ofMinutes(5))
+        // Advance time beyond the 3-minute session timeout
+        testClock.advance(Duration.ofMinutes(1))
 
         // When
         sessionManager.init()
@@ -143,12 +143,12 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `creates new session if previous session happened more than 6 hours ago, even if last event happened within 20 minutes`() {
+    fun `creates new session if previous session happened more than 1 hour ago, even if last event happened within 3 minutes`() {
         // Given
         val previousSessionCreatedTime = testClock.epochTime()
-        // Last event happened within 20 minutes of next session.
+        // Last event happened within 3 minutes of next session.
         val lastEventTime =
-            previousSessionCreatedTime + Duration.ofHours(7).toMillis() - Duration.ofMinutes(5)
+            previousSessionCreatedTime + Duration.ofHours(1).toMillis() - Duration.ofMinutes(3)
                 .toMillis()
         val previousSession = RecentSession(
             id = "previous-session-id",
@@ -160,7 +160,7 @@ class SessionManagerTest {
         `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
 
         // Advance time by 7 hours
-        testClock.advance(Duration.ofHours(7))
+        testClock.advance(Duration.ofHours(1))
         // When
         sessionManager.init()
         val sessionId = sessionManager.getSessionId()
@@ -170,7 +170,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `creates new session if last session crashed, even if last event happened within 20 minutes`() {
+    fun `creates new session if last session crashed, even if last event happened within 3 minutes`() {
         // Given
         val initialTime = testClock.epochTime()
         val previousSession = RecentSession(
@@ -183,7 +183,7 @@ class SessionManagerTest {
         `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
 
         // Advance time by 10 minutes
-        testClock.advance(Duration.ofMinutes(10))
+        testClock.advance(Duration.ofMinutes(1))
         // When
         sessionManager.init()
         val sessionId = sessionManager.getSessionId()

--- a/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -143,56 +143,6 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `creates new session if previous session happened more than 1 hour ago, even if last event happened within 3 minutes`() {
-        // Given
-        val previousSessionCreatedTime = testClock.epochTime()
-        // Last event happened within 3 minutes of next session.
-        val lastEventTime =
-            previousSessionCreatedTime + Duration.ofHours(1).toMillis() - Duration.ofMinutes(3)
-                .toMillis()
-        val previousSession = RecentSession(
-            id = "previous-session-id",
-            lastEventTime = lastEventTime,
-            createdAt = previousSessionCreatedTime,
-            crashed = false,
-            versionCode = packageInfoProvider.getVersionCode(),
-        )
-        `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
-
-        // Advance time by 7 hours
-        testClock.advance(Duration.ofHours(1))
-        // When
-        sessionManager.init()
-        val sessionId = sessionManager.getSessionId()
-
-        // Then
-        assertNotEquals(previousSession.id, sessionId)
-    }
-
-    @Test
-    fun `creates new session if last session crashed, even if last event happened within 3 minutes`() {
-        // Given
-        val initialTime = testClock.epochTime()
-        val previousSession = RecentSession(
-            id = "previous-session-id",
-            lastEventTime = initialTime,
-            createdAt = initialTime - Duration.ofMinutes(3).toMillis(),
-            crashed = true,
-            versionCode = packageInfoProvider.getVersionCode(),
-        )
-        `when`(prefsStorage.getRecentSession()).thenReturn(previousSession)
-
-        // Advance time by 10 minutes
-        testClock.advance(Duration.ofMinutes(1))
-        // When
-        sessionManager.init()
-        val sessionId = sessionManager.getSessionId()
-
-        // Then
-        assertNotEquals(previousSession.id, sessionId)
-    }
-
-    @Test
     fun `updates last event time in preferences when event is triggered`() {
         // Given
         sessionManager.init()

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -29,8 +29,8 @@ internal class FakeConfigProvider : ConfigProvider {
     override var maxEventsInBatch: Int = 100
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
-    override var sessionEndLastEventThresholdMs: Long = 20 * 60 * 1000 // 20 minutes
-    override var maxSessionDurationMs: Long = 6 * 60 * 60 * 1000 // 6 hours
+    override var sessionEndLastEventThresholdMs: Long = 3 * 60 * 1000 // 3 minutes
+    override var maxSessionDurationMs: Long = 1 * 60 * 60 * 1000 // 1 hour
     override var maxEventNameLength: Int = 64
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -30,7 +30,6 @@ internal class FakeConfigProvider : ConfigProvider {
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()
     override var sessionEndLastEventThresholdMs: Long = 3 * 60 * 1000 // 3 minutes
-    override var maxSessionDurationMs: Long = 1 * 60 * 60 * 1000 // 1 hour
     override var maxEventNameLength: Int = 64
     override val customEventNameRegex: String = "^[a-zA-Z0-9_-]+$"
     override val maxUserDefinedAttributesPerEvent: Int = 100

--- a/docs/features/feature-session-monitoring.md
+++ b/docs/features/feature-session-monitoring.md
@@ -8,7 +8,7 @@
 
 ## What Is a Session?
 
-A session is a continuous period of activity within the app. A new session begins when the app is launched for the first time or after 20 minutes of inactivity. Sessions can span across app background and foreground events, so short interruptions won’t start a new session.
+A session is a continuous period of activity within the app. A new session begins when the app is launched for the first time or after 3 minutes of inactivity. Sessions can span across app background and foreground events, so short interruptions won’t start a new session.
 
 ## Session Search
 


### PR DESCRIPTION
# Description

Changes the following internal configs.

1. `sessionEndLastEventThresholdMs` from 20 mins to 3 minutes
2. Remove `maxSessionDurationMs` as it is no longer required with the reduced `sessionEndLastEventThresholdMs`.
3. Updates session documentation.

## Related issue
Closes #2586 


