### PR TITLE
chore(android): add jitter to each export pulse

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -40,6 +40,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override val traceSamplingRate: Float = 1f
     override var maxAttachmentSizeInEventsBatchInBytes: Int = 1_000_000
     override var eventsBatchingIntervalMs: Long = 1_000_000
+    override var eventsBatchingJitterMs: Long = 1_000_000
     override var maxEventsInBatch: Int = 1_000_000
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()

--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -130,7 +130,7 @@ internal class TestMeasureInitializer(
     override val logger: Logger = AndroidLogger(configProvider.enableLogging),
     override val timeProvider: TimeProvider = AndroidTimeProvider(AndroidSystemClock()),
     override val executorServiceRegistry: ExecutorServiceRegistry = ExecutorServiceRegistryImpl(),
-    private val fileStorage: FileStorage = FileStorageImpl(
+    override val fileStorage: FileStorage = FileStorageImpl(
         rootDir = application.filesDir.path,
         logger = logger,
     ),
@@ -375,7 +375,6 @@ internal class TestMeasureInitializer(
         logger,
         timeProvider,
         configProvider,
-        tracer,
     ),
     override val appLaunchCollector: AppLaunchCollector = AppLaunchCollector(
         application = application,
@@ -426,8 +425,8 @@ internal class TestMeasureInitializer(
     override val shakeBugReportCollector: ShakeBugReportCollector = ShakeBugReportCollector(
         shakeDetector = AccelerometerShakeDetector(
             sensorManager = systemServiceProvider.sensorManager,
-            timeProvider = timeProvider,
             configProvider = configProvider,
+            logger = logger,
         ),
     ),
     override val internalSignalCollector: InternalSignalCollector = InternalSignalCollector(

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -293,6 +293,7 @@ internal class MeasureInitializerImpl(
     private val periodicHeartbeat: Heartbeat = HeartbeatImpl(
         logger,
         executorServiceRegistry.defaultExecutor(),
+        randomizer,
     ),
     override val periodicExporter: PeriodicExporter = PeriodicExporterImpl(
         logger = logger,

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -26,6 +26,7 @@ internal data class Config(
     override val screenshotCompressionQuality: Int = 25
     override val maxAttachmentSizeInEventsBatchInBytes: Int = 3_000_000 // 3 MB
     override val eventsBatchingIntervalMs: Long = 30_000 // 30 seconds
+    override val eventsBatchingJitterMs: Long = 20_000 // 20 seconds
     override val maxEventsInBatch: Int = 500
     override val httpContentTypeAllowlist: List<String> = listOf("application/json")
     override val defaultHttpHeadersBlocklist: List<String> = listOf(

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -77,6 +77,8 @@ internal class ConfigProviderImpl(
         get() = getMergedConfig { traceSamplingRate }
     override val eventsBatchingIntervalMs: Long
         get() = getMergedConfig { eventsBatchingIntervalMs }
+    override val eventsBatchingJitterMs: Long
+        get() = getMergedConfig { eventsBatchingJitterMs }
     override val maxEventsInBatch: Int
         get() = getMergedConfig { maxEventsInBatch }
     override val httpContentTypeAllowlist: List<String>

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -14,6 +14,11 @@ internal interface InternalConfig {
     val eventsBatchingIntervalMs: Long
 
     /**
+     * The jitter to add to [eventsBatchingIntervalMs]. Defaults to 20000ms.
+     */
+    val eventsBatchingJitterMs: Long
+
+    /**
      * The maximum number of events to export in /events API. Defaults to 500.
      */
     val maxEventsInBatch: Int

--- a/android/measure/src/main/java/sh/measure/android/exporter/Heartbeat.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/Heartbeat.kt
@@ -4,17 +4,17 @@ import androidx.annotation.VisibleForTesting
 import sh.measure.android.executors.MeasureExecutorService
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.utils.Randomizer
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.TimeUnit
 
 internal interface HeartbeatListener {
     fun pulse()
 }
 
 internal interface Heartbeat {
-    fun start(intervalMs: Long, initialDelayMs: Long = 0)
+    fun start(intervalMs: Long, jitterMs: Long)
     fun stop()
     fun addListener(listener: HeartbeatListener)
 }
@@ -25,6 +25,7 @@ internal interface Heartbeat {
 internal class HeartbeatImpl(
     private val logger: Logger,
     private val scheduler: MeasureExecutorService,
+    private val randomizer: Randomizer,
 ) : Heartbeat {
     @Volatile
     private var future: Future<*>? = null
@@ -36,22 +37,48 @@ internal class HeartbeatImpl(
         listeners.add(listener)
     }
 
-    override fun start(intervalMs: Long, initialDelayMs: Long) {
+    override fun start(intervalMs: Long, jitterMs: Long) {
         if (future != null) {
             return
         }
+
+        val randomJitterMs = randomizer.nextInt((jitterMs + 1).toInt()).toLong()
+        val delayWithJitter = intervalMs + randomJitterMs
+        logger.log(LogLevel.Debug, "Heartbeat starting, next pulse in ${delayWithJitter}ms")
+
         try {
-            future = scheduler.scheduleAtFixedRate(
+            future = scheduler.schedule(
                 {
                     listeners.forEach(HeartbeatListener::pulse)
+                    scheduleNextPulse(intervalMs, jitterMs)
                 },
-                initialDelayMs,
-                intervalMs,
-                TimeUnit.MILLISECONDS,
+                delayWithJitter,
             )
         } catch (e: RejectedExecutionException) {
             logger.log(LogLevel.Debug, "Failed to start exporter heartbeat", e)
             return
+        }
+    }
+
+    private fun scheduleNextPulse(intervalMs: Long, jitterMs: Long) {
+        if (future?.isCancelled == true) {
+            return
+        }
+
+        val randomJitterMs = randomizer.nextInt((jitterMs + 1).toInt()).toLong()
+        val delayWithJitter = intervalMs + randomJitterMs
+        logger.log(LogLevel.Debug, "Heartbeat scheduling next pulse in ${delayWithJitter}ms")
+
+        try {
+            future = scheduler.schedule(
+                {
+                    listeners.forEach(HeartbeatListener::pulse)
+                    scheduleNextPulse(intervalMs, jitterMs)
+                },
+                delayWithJitter,
+            )
+        } catch (e: RejectedExecutionException) {
+            logger.log(LogLevel.Debug, "Failed to schedule next heartbeat pulse", e)
         }
     }
 

--- a/android/measure/src/main/java/sh/measure/android/exporter/PeriodicExporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/PeriodicExporter.kt
@@ -43,11 +43,17 @@ internal class PeriodicExporterImpl(
     }
 
     override fun register() {
-        heartbeat.start(intervalMs = configProvider.eventsBatchingIntervalMs)
+        heartbeat.start(
+            intervalMs = configProvider.eventsBatchingIntervalMs,
+            jitterMs = configProvider.eventsBatchingJitterMs,
+        )
     }
 
     override fun resume() {
-        heartbeat.start(intervalMs = configProvider.eventsBatchingIntervalMs)
+        heartbeat.start(
+            intervalMs = configProvider.eventsBatchingIntervalMs,
+            jitterMs = configProvider.eventsBatchingJitterMs,
+        )
     }
 
     override fun unregister() {

--- a/android/measure/src/main/java/sh/measure/android/utils/Randomizer.kt
+++ b/android/measure/src/main/java/sh/measure/android/utils/Randomizer.kt
@@ -12,6 +12,11 @@ internal interface Randomizer {
      * Returns the next pseudorandom, uniformly distributed long value.
      */
     fun nextLong(): Long
+
+    /**
+     * Returns a random int between 0 (inclusive) and the specified bound (exclusive).
+     */
+    fun nextInt(bound: Int): Int
 }
 
 internal class RandomizerImpl : Randomizer {
@@ -23,5 +28,9 @@ internal class RandomizerImpl : Randomizer {
 
     override fun nextLong(): Long {
         return random.nextLong()
+    }
+
+    override fun nextInt(bound: Int): Int {
+        return random.nextInt(bound)
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/exporter/HeartbeatTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/HeartbeatTest.kt
@@ -1,18 +1,52 @@
 package sh.measure.android.exporter
 
-import androidx.concurrent.futures.ResolvableFuture
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import sh.measure.android.fakes.ImmediateExecutorService
+import sh.measure.android.executors.MeasureExecutorService
+import sh.measure.android.fakes.FakeRandomizer
 import sh.measure.android.fakes.NoopLogger
+import java.util.concurrent.Callable
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 internal class HeartbeatTest {
     private val logger = NoopLogger()
-    private val executorService = ImmediateExecutorService(ResolvableFuture.create<Any>())
+    private val fakeRandomizer = FakeRandomizer()
+
+    private val testExecutor = object : MeasureExecutorService {
+        var capturedCallable: Callable<*>? = null
+
+        override fun <T> submit(callable: Callable<T>): Future<T> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T> schedule(callable: Callable<T>, delayMillis: Long): Future<T> {
+            capturedCallable = callable
+            return object : Future<T> {
+                override fun cancel(mayInterruptIfRunning: Boolean) = true
+                override fun isCancelled() = false
+                override fun isDone() = true
+                override fun get(): T? = null
+                override fun get(timeout: Long, unit: TimeUnit): T? = null
+            }
+        }
+
+        override fun scheduleAtFixedRate(
+            runnable: Runnable,
+            initialDelay: Long,
+            delayMillis: Long,
+            delayUnit: TimeUnit,
+        ): Future<*> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun shutdown() {}
+    }
 
     @Test
     fun `sets a listener`() {
-        val heartbeat = HeartbeatImpl(logger, executorService)
+        fakeRandomizer.randomInt = 0
+        val heartbeat = HeartbeatImpl(logger, testExecutor, fakeRandomizer)
         heartbeat.addListener(object : HeartbeatListener {
             override fun pulse() {
             }
@@ -22,20 +56,42 @@ internal class HeartbeatTest {
 
     @Test
     fun `invokes listeners`() {
-        // Given
         val intervalMs = 1000L
-        val initialDelayMs = 0L
+        fakeRandomizer.randomInt = 0
 
         var pulseInvokedCount = 0
 
-        val heartbeat = HeartbeatImpl(logger, executorService)
+        val heartbeat = HeartbeatImpl(logger, testExecutor, fakeRandomizer)
         heartbeat.addListener(object : HeartbeatListener {
             override fun pulse() {
                 pulseInvokedCount++
             }
         })
 
-        heartbeat.start(intervalMs, initialDelayMs)
+        heartbeat.start(intervalMs, 0)
+        testExecutor.capturedCallable?.call()
+
+        assertEquals(1, pulseInvokedCount)
+    }
+
+    @Test
+    fun `applies jitter to interval`() {
+        val intervalMs = 1000L
+        val jitterMs = 15000L
+        val jitterValue = 10000
+        fakeRandomizer.randomInt = jitterValue
+
+        var pulseInvokedCount = 0
+        val heartbeat = HeartbeatImpl(logger, testExecutor, fakeRandomizer)
+        heartbeat.addListener(object : HeartbeatListener {
+            override fun pulse() {
+                pulseInvokedCount++
+            }
+        })
+
+        heartbeat.start(intervalMs, jitterMs)
+        testExecutor.capturedCallable?.call()
+
         assertEquals(1, pulseInvokedCount)
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -26,6 +26,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override var samplingRateForErrorFreeSessions: Float = 1.0f
     override var maxAttachmentSizeInEventsBatchInBytes: Int = 3
     override var eventsBatchingIntervalMs: Long = 30_000 // 30 seconds
+    override var eventsBatchingJitterMs: Long = 20_000 // 20 seconds
     override var maxEventsInBatch: Int = 100
     override var httpContentTypeAllowlist: List<String> = emptyList()
     override var defaultHttpHeadersBlocklist: List<String> = emptyList()

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeRandomizer.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeRandomizer.kt
@@ -11,11 +11,17 @@ internal class FakeRandomizer : Randomizer {
 
     var randomLong: Long = 100L
 
+    var randomInt: Int = 10
+
     override fun random(): Double {
         return randomDouble
     }
 
     override fun nextLong(): Long {
         return randomLong
+    }
+
+    override fun nextInt(bound: Int): Int {
+        return randomInt
     }
 }


### PR DESCRIPTION
# Description

- Adds a 20s jitter while exporting event batches.
- A random jitter between 0-20s is added to each pulse.

## Related issue
Fixes #2656 
