### PR TITLE
chore(backend): dispatch deploy on main push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish OCI images
 on:
   push:
     branches:
+      - main
       - "cloud*"
 
 permissions:


### PR DESCRIPTION
## Summary

This PR updates the publish images workflow trigger to dispatch a deploy when `main` branch receives new push.

## Tasks

- [x] Modify publish images workflow to dispatch a deploy for main branch

