### PR TITLE
chore(backend): use go 1.25.0-alpine for api service

### DIFF
--- a/backend/api/dockerfile
+++ b/backend/api/dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app


### PR DESCRIPTION
## Summary

This PR pins the go version of the docker image used when building API service to v1.25.0. Pinning the version prevents from unwanted regression to creep in automatically due to language security patches or tooling changes.

This also increases the maintenance burden unfortunately to upgrade to the correct versions regularly to use the latest features and security patches.

## Tasks

- [x] Pin go version of api service to prevent from sudden regressions or broken outcomes due to security fixes to the go language or tooling.

## See also

- fixes #2712
