### PR TITLE
chore(backend): pin go version for all services

### DIFF
--- a/backend/alerts/dockerfile
+++ b/backend/alerts/dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app

--- a/backend/cleanup/dockerfile
+++ b/backend/cleanup/dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app

--- a/backend/metering/dockerfile
+++ b/backend/metering/dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app

--- a/backend/symboloader/dockerfile
+++ b/backend/symboloader/dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app


### PR DESCRIPTION
## Summary

This PR pins the go version of rest of the services to use `v1.25.0-alpine` docker image. API service is already pinned on the same version.

## Tasks

- [x] Pin golang:1.25.0-alpine for cleanup
- [x] Pin golang:1.25.0-alpine for metering
- [x] Pin golang:1.25.0-alpine for alerts
- [x] Pin golang:1.25.0-alpine for symboloader

## See also

- fixes #2712

