### PR TITLE
fix(backend): grant appropriate permissions for cleanup service

### DIFF
--- a/self-host/clickhouse/init-clickhouse.sh
+++ b/self-host/clickhouse/init-clickhouse.sh
@@ -18,7 +18,7 @@ clickhouse-client -n \
   <<-EOSQL
   create role if not exists operator;
   create role if not exists reader;
-  grant select, insert on $DB_NAME.* to operator;
+  grant select, insert, delete, update on $DB_NAME.* to operator;
   grant select on $DB_NAME.* to reader;
 
   create user if not exists '${CLICKHOUSE_OPERATOR_USER}' identified with sha256_password by '${CLICKHOUSE_OPERATOR_PASSWORD}' default role operator default database $DB_NAME;


### PR DESCRIPTION
## Summary

This PR grants sufficient permissions to operator role in ClickHouse for cleanup to carry out deletions of expired data.

## Tasks

- [x] Grant sufficient permissions to operator role to perform deletes on clickhouse

## See also

- fixes #2719
