### PR TITLE
ci(backend): remove fly deploy

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -123,21 +123,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-  deploy:
-    name: Deploy to fly.io
-    if: github.ref == 'refs/heads/main'
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend/api
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

This PR removes unused fly.io deploy integration from CI.

## Tasks

- [x] Remove deploy to fly job

## See also

- fixes #2714