### PR TITLE
fix(android): collect screenshots with ANRs

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -33,7 +33,7 @@ internal class AnrCollector(
             data = toMeasureException(anrError),
             timestamp = anrError.timestamp,
             type = EventType.ANR,
-            takeScreenshot = false,
+            takeScreenshot = true,
         )
     }
 

--- a/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -67,7 +67,7 @@ class AnrCollectorTest {
             userDefinedAttributes = userDefinedAttributeCaptor.capture(),
             attachments = attachmentsCaptor.capture(),
             threadName = eq(null),
-            takeScreenshot = eq(false),
+            takeScreenshot = eq(true),
         )
 
         assertEquals(EventType.ANR, typeCaptor.firstValue)


### PR DESCRIPTION
# Description

Fixes a bad code change which disabled screenshots for ANRs.

## Related issue
Fixes #2724 