### PR TITLE
fix(backend): grant sufficient permissions to clickhouse role

### DIFF
--- a/self-host/migrations/v0.9.x-sync-databases.sh
+++ b/self-host/migrations/v0.9.x-sync-databases.sh
@@ -211,7 +211,7 @@ migrate_clickhouse_database() {
     --password "$admin_password" \
     --query "create role if not exists operator;" \
     --query "create role if not exists reader;" \
-    --query "grant select, insert on measure.* to operator;" \
+    --query "grant select, insert, delete, update on measure.* to operator;" \
     --query "grant select on measure.* to reader;" \
     --query "create user if not exists ${operator_user} identified with sha256_password by '${operator_password}' default role operator default database measure;" \
     --query "create user if not exists ${reader_user} identified with sha256_password by '${reader_password}' default role reader default database measure;" \


### PR DESCRIPTION
## Summary

This PR grants appropriate permissions during self host upgrade migration to clickhouse operator role.

## Tasks

- [x] Grant `delete` permission to clickhouse role
- [x] Grant `update` permission to clickhouse role

## See also

- fixes #2734
