### PR TITLE
docs(backend): fix typo and format slack guide

### DIFF
--- a/docs/hosting/slack.md
+++ b/docs/hosting/slack.md
@@ -1,4 +1,4 @@
-# Set up Slack integraton
+# Set up Slack integration
 
 Set up Slack integration to receive alert notifications on Slack.
 
@@ -6,10 +6,11 @@ Set up Slack integration to receive alert notifications on Slack.
 
 2. Go to `Basic Information` section and copy client id, client secret and signing secret and paste them into the prompts. (If you're upgrading an existing Measure installation you will paste these variables into your environment variables file. See section for existing users below)
 
-3. Go to the `Oauth & Permissions` section of your app and under `Redirect URLs`, add a url for receiving OAuth callbacks. This should be `yourdomain.com/auth/callback/slack-app`.
+3. Go to the `OAuth & Permissions` section of your app and under `Redirect URLs`, add a url for receiving OAuth callbacks. This should be `yourdomain.com/auth/callback/slack-app`.
 
-4. In the same `Oauth & Permissions` section of your app, under `Scopes`, request the following permissions:
-```json
+4. In the same `OAuth & Permissions` section of your app, under `Scopes`, request the following permissions:
+
+```txt
 channels:read
 chat:write
 commands
@@ -17,22 +18,26 @@ groups:read
 ```
 
 5. Go to `Slash Commands` section. Create the commands as follows:
+
 ```
-Command: /subscribe-alerts 
+Command: /subscribe-alerts
 Request URL: yourdomain.com/slack/events
 Short Description: Registers current channel to receive alert notifications
 
-Command: /stop-alerts 
+Command: /stop-alerts
 Request URL: yourdomain.com/slack/events
 Short Description: Stops current channel from receiving alert notifications
 
-Command: /list-alert-channels 
+Command: /list-alert-channels
 Request URL: yourdomain.com/slack/events
 Short Description: Lists channels currently registered to receive alert notifications
 ```
 
-*Note:* Slack does not send event and oauth callbacks to localhost and dev environments reliably. In order to run and test Slack integration while doing local development, you will need to use a tunneling service such as Ngrok or Cloudflare tunnels and use that url to proxy to your localhost. See this [guide](https://docs.slack.dev/tools/node-slack-sdk/tutorials/local-development/#using-a-local-request-url-for-development) for more information.
-
+> [!NOTE]
+>
+> Slack does not send event and OAuth callbacks to localhost and dev environments reliably. In order to run and test Slack integration while doing local development, you will need to use a tunneling service such as ngrok or Cloudflare tunnels and use that url to proxy to your localhost.
+>
+> See this [guide](https://docs.slack.dev/tools/node-slack-sdk/tutorials/local-development/#using-a-local-request-url-for-development) for more information.
 
 ## Configure Slack settings for existing users
 
@@ -48,7 +53,7 @@ and restart the services.
     SLACK_CLIENT_SECRET=your-slack-client-secret        # change this
     ```
 
-3. Generate a random 44 character salt and add it as an environment variable. You can use any password generator to generate it. 
+3. Generate a random 44 character salt and add it as an environment variable. You can use any password generator to generate it.
 
     ```sh
     SLACK_OAUTH_STATE_SALT=your-slack-oauth-state-salt  # change this


### PR DESCRIPTION
## Summary

This PR fixes a typo and improves overall formatting of the Slack integration guide.