### PR TITLE
chore(backend): make slack creds prompt optional

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -157,7 +157,7 @@ Optionally, you can set up a Slack app if you want to recieve alert notications 
 
 - [Set up Slack Integration](./slack.md)
 
-Once your slack integration is set up, copy the values and enter in the relevant prompts. If you wish to ignore it, enter dummy values and proceed.
+Once your slack integration is set up, copy the values and enter in the relevant prompts. If you wish to ignore it, enter empty values and proceed.
 
 Once completed, the install script will attempt to start all the Measure docker compose services. You should see a similar output.
 

--- a/self-host/config.sh
+++ b/self-host/config.sh
@@ -579,9 +579,9 @@ END
     EMAIL_DOMAIN=$(prompt_optional_value_manual "Enter email domain (optional): ")
 
     echo -e "\nSet Slack credentials"
-    echo -e "Set up a Slack app to get API credentials. See https://github.com/measure-sh/measure/blob/main/docs/hosting/slack.md for more details. If you wish to ignore this, enter dummy values."
-    SLACK_CLIENT_ID=$(prompt_value_manual "Enter Slack client ID: ")
-    SLACK_CLIENT_SECRET=$(prompt_password_manual "Enter Slack client secret: ")
+    echo -e "Set up a Slack app to get API credentials. See https://github.com/measure-sh/measure/blob/main/docs/hosting/slack.md for more details. If you wish to ignore this, enter empty values."
+    SLACK_CLIENT_ID=$(prompt_optional_value_manual "Enter Slack client ID: ")
+    SLACK_CLIENT_SECRET=$(prompt_optional_value_manual "Enter Slack client secret: ")
     echo -e "Generated secure Slack OAuth State Salt"
     SLACK_OAUTH_STATE_SALT=$(generate_password 44)
 


### PR DESCRIPTION
# Description

Updates slack credentials prompt while self hosting to be optional instead of mandatory.



