### PR TITLE
chore(backend): improve symbolicator error logging

### DIFF
--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -888,7 +888,6 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				return err
 			}
 			attachments = string(marshalledAttachments)
-			fmt.Println("Marshaled Attachments:", attachments)
 		}
 
 		row := stmt.NewRow().


### PR DESCRIPTION
# Description

- Remove unneeded attachment marshalled logs
- Propagate errors during symbolication and log errors
- Disable request logs.