### PR TITLE
chore(backend): only deploy on staging on backend changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
       - "cloud*"
+    paths:
+      # run on backend changes
+      - "backend/**/dockerfile"
+      - "backend/**/*.go"
+      - "backend/**/*.mod"
+      - "backend/**/*.sum"
+      - ".github/workflows/publish.yml"
+
+      # don't run on markdown changes
+      - "!**/*.md"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This PR modifies the workflow that triggers a cloud deploy on staging only when backend changes are involved.

## See also

- fixes #2727