### PR TITLE
fix(backend): drop and recreate public schema after successful migration

### DIFF
--- a/self-host/migrations/v0.9.x-sync-databases.sh
+++ b/self-host/migrations/v0.9.x-sync-databases.sh
@@ -40,7 +40,7 @@ set_docker_compose() {
 # Shutdown if measure compose services are up
 shutdown_measure_services() {
   local running_services
-  running_services=$("$DOCKER_COMPOSE" ps -a -q | wc -l)
+  running_services=$($DOCKER_COMPOSE ps -a -q | wc -l)
   if [[ "$running_services" -gt 0 ]]; then
     echo "Shutting down measure services..."
     $DOCKER_COMPOSE \


### PR DESCRIPTION
## Summary

This PR updates the `self-host/migrations/v0.9.x-sync-databases.sh` script to drop and recreate the default postgres database's public schema. Additionally, it makes the creation process of the `measure` database idempotent.

If a failure occurs while running the script, the user can safely invoke the script again and again.

## Tasks

- [x] Drop and recreate the default postgres database public schema once postgres migration is successful
- [x] Made the postgres measure database creation idempotent
- [x] Fix an issue with `self-host/migrations/v0.9.x-sync-databases.sh` script where it would fail to recognize & shutdown running measure services

## See also

- fixes #2629