### PR TITLE
chore(frontend): hide cloud actions + messaging in self host

### DIFF
--- a/frontend/dashboard/__tests__/utils/url_utils.test.ts
+++ b/frontend/dashboard/__tests__/utils/url_utils.test.ts
@@ -1,0 +1,75 @@
+import { isMeasureHost } from '@/app/utils/url_utils';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('isMeasureHost', () => {
+    let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('should return true for measure.sh', () => {
+        delete (global as any).window;
+        (global as any).window = {
+            location: {
+                origin: 'https://measure.sh'
+            }
+        };
+
+        expect(isMeasureHost()).toBe(true);
+    });
+
+    it('should return true for staging.measure.sh', () => {
+        delete (global as any).window;
+        (global as any).window = {
+            location: {
+                origin: 'https://staging.measure.sh'
+            }
+        };
+
+        expect(isMeasureHost()).toBe(true);
+    });
+
+    it('should return false for other hosts', () => {
+        delete (global as any).window;
+        (global as any).window = {
+            location: {
+                origin: 'https://example.com'
+            }
+        };
+
+        expect(isMeasureHost()).toBe(false);
+    });
+
+    it('should return false when window is undefined', () => {
+        delete (global as any).window;
+
+        expect(isMeasureHost()).toBe(false);
+    });
+
+    it('should return false when window.location.origin is empty', () => {
+        delete (global as any).window;
+        (global as any).window = {
+            location: {
+                origin: ''
+            }
+        };
+
+        expect(isMeasureHost()).toBe(false);
+    });
+
+    it('should return false for invalid URL', () => {
+        delete (global as any).window;
+        (global as any).window = {
+            location: {
+                origin: 'not-a-valid-url'
+            }
+        };
+
+        expect(isMeasureHost()).toBe(false);
+    });
+});

--- a/frontend/dashboard/app/auth/login/page.tsx
+++ b/frontend/dashboard/app/auth/login/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { measureAuth, MeasureAuthSession } from "@/app/auth/measure_auth"
+import { isMeasureHost } from "@/app/utils/url_utils"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { posthog } from "posthog-js"
@@ -53,7 +54,7 @@ export default function Login({ searchParams }: { searchParams: { [key: string]:
       <div className="my-6 place-content-end" style={{ width: "400px" }}>
         {!loading && !session && !error && !message && <GitHubSignIn />}
       </div>
-      <p className="p-2 my-4 text-sm font-display text-gray-500">
+      {isMeasureHost() && <p className="p-2 my-4 text-sm font-display text-gray-500">
         Measure cloud is in limited to alpha users at the moment. Please{" "}
         <Link
           target="_blank"
@@ -63,7 +64,7 @@ export default function Login({ searchParams }: { searchParams: { [key: string]:
           contact us
         </Link>{" "}
         if you&apos;d like to be a part of it!
-      </p>
+      </p>}
       <Messages />
     </div>
   )

--- a/frontend/dashboard/app/components/landing_header.tsx
+++ b/frontend/dashboard/app/components/landing_header.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useScrollDirection } from "../utils/scroll_utils";
 import { cn } from "../utils/shadcn_utils";
+import { isMeasureHost } from "../utils/url_utils";
 import { buttonVariants } from "./button";
 
 export default function LandingHeader() {
@@ -36,15 +37,15 @@ export default function LandingHeader() {
           />
         </button>
         <div className="py-2 md:py-0 md:flex md:grow" />
-        <Link href="https://github.com/measure-sh/measure" className={cn(buttonVariants({ variant: "outline" }), "font-display border border-black rounded-md select-none")}>
+        {isMeasureHost() && <Link href="https://github.com/measure-sh/measure" className={cn(buttonVariants({ variant: "outline" }), "font-display border border-black rounded-md select-none")}>
           <Image
             src='/images/github_logo.svg'
             width={16}
             height={16}
             alt={'Github logo'} />
           <p className='mt-1'>Self Host</p>
-        </Link>
-        <div className="px-2" />
+        </Link>}
+        {isMeasureHost() && <div className="px-2" />}
         <Link
           href="/auth/login"
           className={cn(

--- a/frontend/dashboard/app/page.tsx
+++ b/frontend/dashboard/app/page.tsx
@@ -10,6 +10,7 @@ import { buttonVariants } from './components/button'
 import LandingHeader from './components/landing_header'
 import VideoPlayButton from './components/video_play_button'
 import { cn } from './utils/shadcn_utils'
+import { isMeasureHost } from './utils/url_utils'
 
 const Lottie = dynamic(() => import("lottie-react"), { ssr: false })
 
@@ -269,15 +270,15 @@ export default function Home() {
         <p className="font-body text-black text-lg leading-relaxed max-w-4xl text-center">Let&apos;s get to the root cause...</p>
         <div className="py-2" />
         <div className='flex flex-row items-center'>
-          <Link href="https://github.com/measure-sh/measure" className={cn(buttonVariants({ variant: "outline", size: "lg" }), "m-4 font-display border border-black rounded-md select-none")}>
+          {isMeasureHost() && <Link href="https://github.com/measure-sh/measure" className={cn(buttonVariants({ variant: "outline", size: "lg" }), "m-4 font-display border border-black rounded-md select-none")}>
             <Image
               src='/images/github_logo.svg'
               width={16}
               height={16}
               alt={'Github logo'} />
             <p className='mt-1'>Self Host</p>
-          </Link>
-          <div className="px-2" />
+          </Link>}
+          {isMeasureHost() && <div className="px-2" />}
           <Link
             href="/auth/login"
             className={cn(

--- a/frontend/dashboard/app/utils/url_utils.ts
+++ b/frontend/dashboard/app/utils/url_utils.ts
@@ -1,0 +1,13 @@
+export function isMeasureHost(): boolean {
+    const url =
+        typeof window !== 'undefined' && window.location.origin
+            ? window.location.origin
+            : '';
+    try {
+        const { host } = new URL(url);
+        return host === 'measure.sh' || host === 'staging.measure.sh';
+    } catch (error) {
+        console.error('Invalid URL:', error);
+        return false;
+    }
+}


### PR DESCRIPTION
# Description
- shows only login in landing page and header for self host users
- hides private alpha disclaimer on login page for self host users

## Related issue
Closes #2755



