### PR TITLE
chore(backend): add smtp related env vars for upgrading users

### DIFF
--- a/self-host/config.sh
+++ b/self-host/config.sh
@@ -733,6 +733,22 @@ ensure() {
     add_env_variable "SYMBOLOADER_ORIGIN" "$symboloader_origin" "API_BASE_URL"
   fi
 
+  if ! check_env_variable "SMTP_HOST"; then
+    add_env_variable "SMTP_HOST" ""
+  fi
+
+  if ! check_env_variable "SMTP_PORT"; then
+    add_env_variable "SMTP_PORT" ""
+  fi
+
+  if ! check_env_variable "SMTP_USER"; then
+    add_env_variable "SMTP_USER" ""
+  fi
+
+  if ! check_env_variable "SMTP_PASSWORD"; then
+    add_env_variable "SMTP_PASSWORD" ""
+  fi
+
   if ! check_env_variable "EMAIL_DOMAIN"; then
     add_env_variable "EMAIL_DOMAIN" "" "SMTP_PASSWORD"
   fi


### PR DESCRIPTION
## Summary

This PR adds the SMTP related environment variables as empty strings for self host users on <0.8.x, otherwise they'll see compose missing variables warning.

## Tasks

- [x] Add previously added SMTP related environment variables for self host users on <0.8.x

## See also

- fixes #2762

