### PR TITLE
chore(android): continue existing attachment export on unregister

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/exporter/AttachmentExporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/AttachmentExporter.kt
@@ -65,7 +65,6 @@ internal class DefaultAttachmentExporter(
         if (isRegistered.compareAndSet(true, false)) {
             logger.log(LogLevel.Debug, "Attachment export: unregistered")
         }
-        cancelExport()
     }
 
     override fun onNewAttachmentsAvailable() {
@@ -216,10 +215,5 @@ internal class DefaultAttachmentExporter(
                 false
             }
         }
-    }
-
-    private fun cancelExport() {
-        exportFuture?.cancel(true)
-        exportFuture = null
     }
 }


### PR DESCRIPTION
# Description

Existing attachment export loop should not get canceled when unregister is called to improve delivery rate for attachments.



