### PR TITLE
ci(android): fix changelog generation

### DIFF
--- a/.github/workflows/android-prepare-release.yml
+++ b/.github/workflows/android-prepare-release.yml
@@ -54,9 +54,10 @@ jobs:
           sed -i "s/measure-android = \".*\"/measure-android = \"${{ inputs.version }}\"/" gradle/libs.versions.toml
 
       - name: Generate changelog
-        run: |
-          cd ..
-          git cliff --output android/CHANGELOG.md --tag android-v${{ inputs.version }}
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md --tag android-v${{ inputs.version }}
 
       - name: Update version in README
         run: |

--- a/.github/workflows/gradle-plugin-prepare-release.yml
+++ b/.github/workflows/gradle-plugin-prepare-release.yml
@@ -50,9 +50,10 @@ jobs:
           sed -i "s/MEASURE_PLUGIN_VERSION_NAME=.*/MEASURE_PLUGIN_VERSION_NAME=${{ inputs.version }}/" measure-android-gradle/gradle.properties
 
       - name: Generate changelog
-        run: |
-          cd ..
-          git cliff --output android/measure-android-gradle/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: measure-android-gradle/cliff.toml
+          args: --output measure-android-gradle/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
 
       - name: Update version in README
         run: |


### PR DESCRIPTION
# Description

Use git cliff action instead of command. This should fix the failure encountered in the GitHub action job: https://github.com/measure-sh/measure/actions/runs/18683134591/job/53269470265


