### PR TITLE
chore(android): prepare sdk release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [android-v0.13.0] - 2025-10-21
 
 ### :sparkles: New features
 
@@ -2183,7 +2183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**webapp**): Replace team/:id/invite docs with /auth/invite docs by @anupcowkur in #367
 - (**webapp**): Add API docs for crash & ANR groups APIs by @anupcowkur in #350
 
-[unreleased]: https://github.com/measure-sh/measure/compare/v0.8.2..HEAD
+[android-v0.13.0]: https://github.com/measure-sh/measure/compare/v0.8.2..android-v0.13.0
 [0.8.2]: https://github.com/measure-sh/measure/compare/v0.8.1..v0.8.2
 [0.8.1]: https://github.com/measure-sh/measure/compare/v0.8.0..v0.8.1
 [0.8.0]: https://github.com/measure-sh/measure/compare/v0.7.0..v0.8.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.13.0-SNAPSHOT
+MEASURE_VERSION_NAME=0.13.0
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ junit-platform-launcher = "1.10.2"
 kotlin = "1.9.21"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests
-measure-android = "0.13.0-SNAPSHOT"
+measure-android = "0.13.0"
 androidx-activity-compose = "1.7.2"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -181,13 +181,13 @@ measure {
 Add the following to your app's `build.gradle.kts` file.
 
 ```kotlin
-implementation("sh.measure:measure-android:0.12.0")
+implementation("sh.measure:measure-android:0.13.0")
 ```
 
 or, add the following to your app's `build.gradle` file.
 
 ```groovy
-implementation 'sh.measure:measure-android:0.12.0'
+implementation 'sh.measure:measure-android:0.13.0'
 ```
 
 ### Initialize the SDK


### PR DESCRIPTION
This PR prepares the Android SDK for release version 0.13.0.

Changes:
- Updated version to 0.13.0 in gradle.properties
- Updated version to 0.13.0 in libs.versions.toml
- Generated changelog for version 0.13.0
- Updated version in README.md