### PR TITLE
ci(android): fix cliff.toml path for changelog generation

### DIFF
--- a/.github/workflows/android-prepare-release.yml
+++ b/.github/workflows/android-prepare-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:
-          config: cliff.toml
+          config: android/cliff.toml
           args: --output CHANGELOG.md --tag android-v${{ inputs.version }}
 
       - name: Update version in README

--- a/.github/workflows/gradle-plugin-prepare-release.yml
+++ b/.github/workflows/gradle-plugin-prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:
-          config: measure-android-gradle/cliff.toml
+          config: android/measure-android-gradle/cliff.toml
           args: --output measure-android-gradle/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
 
       - name: Update version in README


### PR DESCRIPTION
# Description

Attempts to fix changelog generation by providing complete path for `cliff.toml`. The following action ended up using the root `cliff.toml` config.

https://github.com/measure-sh/measure/actions/runs/18687539095/job/53284166539



