### PR TITLE
ci(gradle): fix changelog generation

### DIFF
--- a/.github/workflows/gradle-plugin-prepare-release.yml
+++ b/.github/workflows/gradle-plugin-prepare-release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: android/measure-android-gradle/cliff.toml
-          args: --output measure-android-gradle/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
+          args: --output android/measure-android-gradle/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
 
       - name: Update version in README
         run: |


### PR DESCRIPTION
# Description

Fixes the path for gradle plugin release changelog generation workflow.




