### PR TITLE
fix(backend): fix google login for some users

### DIFF
--- a/backend/api/measure/auth.go
+++ b/backend/api/measure/auth.go
@@ -545,8 +545,10 @@ func SigninGoogle(c *gin.Context) {
 
 	// Google may not return the picture claim for some
 	// users.
-	if _, ok := payload.Claims["picture"]; ok {
-		googUser.Picture = payload.Claims["picture"].(string)
+	if picture, ok := payload.Claims["picture"]; ok && picture != nil {
+		if pictureStr, ok := picture.(string); ok {
+			googUser.Picture = pictureStr
+		}
 	}
 
 	// TODO: Remove allowlist filter when appropriate


### PR DESCRIPTION
## Summary

This PR fixes failing authentication for some Google accounts that lack the picture claim in the Google authentication response.

## Tasks

- [x] Fixed an issue where google login may fail for some google accounts missing the picture claim

## See also

- fixes #2640