### PR TITLE
docs(backend): improve slack integration guide

### DIFF
--- a/docs/hosting/slack.md
+++ b/docs/hosting/slack.md
@@ -1,75 +1,75 @@
-# Set up Slack integration
+# Set up Slack integration <!-- omit in toc -->
 
-Set up Slack integration to receive alert notifications on Slack.
+Use this guide to setup Slack integration to receive Measure alert notifications on Slack.
 
-1. You will need to create a Slack app following the official [Slack guide](https://docs.slack.dev/quickstart/). You may choose any name, logo and description you wish for your app.
+## Contents <!-- omit in toc -->
+- [Configure Slack settings for new installation](#configure-slack-settings-for-new-installation)
+- [Configure Slack settings for existing installation](#configure-slack-settings-for-existing-installation)
 
-2. Go to `Basic Information` section and copy client id, client secret and signing secret and paste them into the prompts. (If you're upgrading an existing Measure installation you will paste these variables into your environment variables file. See section for existing users below)
+## Configure Slack settings for new installation
 
-3. Go to the `OAuth & Permissions` section of your app and under `Redirect URLs`, add a url for receiving OAuth callbacks. This should be `yourdomain.com/auth/callback/slack-app`.
+1. **Slack App**. Create a Slack app following the official [Slack guide](https://docs.slack.dev/quickstart/). You may choose any name, logo and description you wish for your app.
+
+2. **Basic Information**. Go to `Basic Information` section and copy client id, client secret and signing secret and paste them into the prompts. (If you're upgrading an existing Measure installation you will paste these variables into your environment variables file. See section for existing users below)
+
+3. **OAuth & Permissions**. Go to the `OAuth & Permissions` section of your app and under `Redirect URLs`, add your Measure Slack authentication callback URL. This should be something like `https://[measure.yourcompany.com]/auth/callback/slack`. Replace **`[measure.yourcompany.com]`** with your actual Measure Dashboard domain.
 
 4. In the same `OAuth & Permissions` section of your app, under `Scopes`, request the following permissions:
 
-```txt
-channels:read
-chat:write
-commands
-groups:read
-```
+    - **channels:read**
+    - **chat:write**
+    - **groups:read**
+    - **commands**
 
-5. Go to `Slash Commands` section. Create the commands as follows:
-
-```
-Command: /subscribe-alerts
-Request URL: measure-api.yourcompany.com/slack/events
-Short Description: Registers current channel to receive alert notifications
-
-Command: /stop-alerts
-Request URL: measure-api.yourcompany.com/slack/events
-Short Description: Stops current channel from receiving alert notifications
-
-Command: /list-alert-channels
-Request URL: measure-api.yourcompany.com/slack/events
-Short Description: Lists channels currently registered to receive alert notifications
-```
+5. **Slash Commands**. Go to `Slash Commands` section. Create the commands as follows:
 
 > [!NOTE]
 >
-> Slack does not send event and OAuth callbacks to localhost and dev environments reliably. In order to run and test Slack integration while doing local development, you will need to use a tunneling service such as ngrok or Cloudflare tunnels and use that url to proxy to your localhost.
+> Please note that you need to use the **Measure API domain** in the below step and not the Measure Dashboard domain.
 >
-> See this [guide](https://docs.slack.dev/tools/node-slack-sdk/tutorials/local-development/#using-a-local-request-url-for-development) for more information.
+> If this URL is incorrect, you'll get a `dispatch_failure` error when connecting your Measure Team to your Slack Workspace.
+>
+> Assuming your API domain is something like `measure-api.yourcompany.com`, you should put in something like `https://[measure-api.yourcompany.com]/slack/events` in the below step.
+>
+> Replace **`[measure-api.yourcompany.com]`** with your actual Measure API domain.
 
-## Configure Slack settings for existing users
+| Command              | Request URL                                                                                                                                   | Short Description                                                  |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| /subscribe-alerts    | https://[measure-api.yourcompany.com]/slack/events<br /><br />Replace **[measure-api.yourcompany.com]** with your actual Measure API domain.  | Registers current channel to receive alert notifications           |
+| /stop-alerts         | https://[measure-api.yourcompany.com]/slack/events <br /><br />Replace **[measure-api.yourcompany.com]** with your actual Measure API domain. | Stops current channel from receiving alert notifications           |
+| /list-alert-channels | https://[measure-api.yourcompany.com]/slack/events<br /><br />Replace **[measure-api.yourcompany.com]** with your actual Measure API domain.  | Lists channels currently registered to receive alert notifications |
+
+## Configure Slack settings for existing installation
 
 If you are upgrading from v0.8.2 or below, you would need to manually update the environment variables. After you've followed the above steps, instead of entering the client id and secrets in a terminal prompt, you will need to edit your environment variables file
 and restart the services.
 
-1. Edit the `self-host/.env` file.
+> [!NOTE]
+>
+> Slack cannot send event and OAuth callbacks to your local dev environments. In order to run and test Slack integration while developing or testing locally, you will need to use a tunneling service such as [ngrok](https://ngrok.com) or [Cloudflare tunnels](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) and use that URL to proxy to your localhost.
+>
+> See this [guide](https://docs.slack.dev/tools/node-slack-sdk/tutorials/local-development/#using-a-local-request-url-for-development) for more information.
 
-2. Add the following environment variables as obtained from your Slack app page.
+1. **Slack Client Credentials**. Open the `self-host/.env` file & add the following environment variables as obtained from your Slack app page.
 
     ```sh
     SLACK_CLIENT_ID=your-slack-client-id                # change this
     SLACK_CLIENT_SECRET=your-slack-client-secret        # change this
     ```
 
-3. Generate a random 44 character salt and add it as an environment variable. You can use any password generator to generate it.
+2. **State Salt**. Generate a random 44 character salt. Use the command `openssl rand -hex 22` to generate a random salt.
 
     ```sh
     SLACK_OAUTH_STATE_SALT=your-slack-oauth-state-salt  # change this
     ```
 
-4. Run the following command to shutdown all services.
+3. **Shutdown**. Run the following command to shutdown all services.
 
     ```sh
-    sudo docker compose \
-      -f compose.yml \
-      -f compose.prod.yml \
-      --profile migrate \
-      down
+    sudo docker compose -f compose.yml -f compose.prod.yml --profile migrate down
     ```
 
-5. Finally, run the `install.sh` script for the configuration to take effect.
+4. **Startup**. Finally, run the `install.sh` script for the configuration to take effect.
 
     ```sh
     sudo ./install.sh


### PR DESCRIPTION
## Summary

This PR overhauls and improves the Slack Integration guide as sub part of the Self Hosting Guide.

## Tasks

- [x] Improved formatting
- [x] Improved presentation and language
- [x] Replaced code fence with tables wherever appropriate
- [x] Used topical lists wherever appropriate
- [x] Improved contents of notes
- [x] Shared command to generate state salt using `openssl`
- [x] Made it clear when to use API vs Dashboard domains
- [x] Added a Table of Contents

## See also

- fixes #2808

