### PR TITLE
chore(android): revert min sdk back to 21

### DIFF
--- a/android/measure/build.gradle.kts
+++ b/android/measure/build.gradle.kts
@@ -59,7 +59,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
         testOptions.targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"

--- a/android/sample/build.gradle.kts
+++ b/android/sample/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     val measureSdkVersion = libs.versions.measure.android.get()
     defaultConfig {
         applicationId = "sh.measure.sample"
-        minSdk = 23
+        minSdk = 21
         targetSdk = 36
         versionCode = computeVersionCode()
         versionName = measureSdkVersion

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -35,11 +35,11 @@ in later steps.
 <details>
   <summary>Minimum Requirements</summary>
 
-| Name                  | Version            |
-|-----------------------|--------------------|
-| Android Gradle Plugin | `8.0.2`            |
-| Min SDK               | `23` (Marshmallow) |
-| Target SDK            | `35`               |
+| Name                  | Version         |
+|-----------------------|-----------------|
+| Android Gradle Plugin | `8.0.2`         |
+| Min SDK               | `21` (Lollipop) |
+| Target SDK            | `35`            |
 
 </details>
 


### PR DESCRIPTION
# Description

As part of #2806 we had incorrectly assumed that API 21 cannot be supported with rest of the dependency upgrades. But that assumption was incorrect, we can safely continue to support API 21.

## Related issue
https://github.com/measure-sh/measure/issues/2447



