### PR TITLE
chore(frontend): fix landing header button spacing for mobile

### DIFF
--- a/frontend/dashboard/app/components/landing_header.tsx
+++ b/frontend/dashboard/app/components/landing_header.tsx
@@ -45,7 +45,7 @@ export default function LandingHeader() {
             alt={'Github logo'} />
           <p className='mt-1'>Self Host</p>
         </Link>}
-        {isMeasureHost() && <div className="px-2" />}
+        {isMeasureHost() && <div className="px-0 md:px-2 py-2 md:py-0" />}
         <Link
           href="/auth/login"
           className={cn(


### PR DESCRIPTION
# Description

Fixes landing header button spacing for mobile

## Before
<img width="253" height="402" alt="before" src="https://github.com/user-attachments/assets/f073e513-538b-4e60-9a4f-49ca572520df" />

## After
<img width="253" height="422" alt="after" src="https://github.com/user-attachments/assets/8972db95-b92e-4941-87cb-ec25db002565" />

## Related issue
Closes #2815 



