### PR TITLE
docs(backend): update self host guide with updated nginx config info

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -450,13 +450,18 @@ In the above setup, only authorized VPN users will be able to access the Measure
 
 ### Q. I'm using nginx as a reverse proxy. What configurations should I change?
 
-When using nginx, make sure to increase the `client_max_body_size` to sufficiently large value like `1024M` (1 GiB). This ensures large debug mapping files, like proguard and macho files will not fail to upload.
+When using nginx, configure the following directives.
+
+- **`client_max_body_size`**. Set it to sufficiently large like `1024M` (1 GiB) to ensure large debug mapping files, like proguard & dSYM file uploads will succeed.
+
+- **`ignore_invalid_headers`**. Set this to `off`, otherwise uploading builds or mapping files like proguard & dSYM files may fail.
 
 ```
-http {
+server {
   # other configuration
 
   client_max_body_size 1024M;
+  ignore_invalid_headers off;
 
   # other configuration
 }


### PR DESCRIPTION
## Summary

This PR updates the FAQ entry in Self Host guide for the nginx entry with updated information on nginx configuration.

## Tasks

- [x] Update the FAQ entry for nginx with updated configuration suggestion

## See also

- #2805 
- fixes #2820
