### PR TITLE
fix(android): filter HTTP body fields instead of discarding events

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -492,6 +492,9 @@ object Measure {
      * - Use `SystemClock.elapsedRealtime` for start and end time to avoid clock skew issues.
      * - Use `requestHeaders`, `responseHeaders`, `requestBody` and `responseBody` only when
      * required as they can increase the amount of data to be stored and sent considerably.
+     * - Request body is only tracked if the request headers contain the `Content-Type` header set
+     * to `application/json`. Similarly, response body is only tracked if the response headers
+     * contain the `Content-Type` header set to `application/json`.
      *
      * @param url The URL to which the request was made
      * @param method The HTTP method used for the request


### PR DESCRIPTION
# Description

When HTTP events are tracked manually. The current behaviour was to discard the HTTP event in the following cases:
- If request/response body is present, but trackHttpBody is disabled.
- If request/response body is present, but their respective headers do not contain `Content-Type: application/json`

This makes the API hard to understand and use. This PR changes the behaviour to only discard the request/response body in the above cases instead of discarding the event entirely.

## Related issue
Fixes #2810 


