### PR TITLE
fix(backend): enable ScreenView sequential chaining in journey

### DIFF
--- a/backend/api/journey/android.go
+++ b/backend/api/journey/android.go
@@ -217,6 +217,26 @@ func (j *JourneyAndroid) buildGraph() {
 			}
 		}
 
+		// ScreenView nodes should also update lastParent to enable
+		// sequential chaining (ScreenView1 -> ScreenView2 -> ScreenView3)
+		if currNode.IsScreenView {
+			lastParent = i
+
+			// if going from screen view to activity, we find the
+			// last activity and set that as the next activity's
+			// parent node.
+			if nextNode.IsActivity {
+				parentNode := j.GetLastActivity(&currNode)
+				if parentNode != nil {
+					lastParent = parentNode.ID
+				} else {
+					// did not find a parent activity
+					// will not create an edge
+					continue
+				}
+			}
+		}
+
 		vkey := j.Nodes[lastParent].Name
 		wkey := nextNode.Name
 		v := j.nodelut[vkey]
@@ -553,6 +573,7 @@ func NewJourneyAndroid(events []event.EventField, opts *Options) (journey *Journ
 			c := i
 			for {
 				c--
+				
 
 				// reached the end, we're done
 				if c < 0 {

--- a/backend/api/journey/android_events_four.json
+++ b/backend/api/journey/android_events_four.json
@@ -1,53 +1,161 @@
 [
   {
-    "id": "da1fd321-fdd7-4dc5-983d-fb148d10b545",
-    "session_id": "1d72df05-44ea-4d6f-8306-7b9b5a5b600e",
-    "timestamp": "2024-09-18T16:15:25.422Z",
-    "type": "lifecycle_activity",
-    "lifecycle_activity": {
-      "type": "created",
-      "class_name": "sh.measure.sample.ComposeNavigationActivity",
-      "intent": "",
-      "saved_instance_state": false
-    }
-  },
-  {
-    "id": "c23260a4-e767-4153-b242-020da4f3bbf4",
-    "session_id": "1d72df05-44ea-4d6f-8306-7b9b5a5b600e",
-    "timestamp": "2024-09-18T16:15:25.437Z",
+    "id": "00000000-0000-0000-0000-000000000001",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.400Z",
     "type": "lifecycle_activity",
     "lifecycle_activity": {
       "type": "resumed",
-      "class_name": "sh.measure.sample.ComposeNavigationActivity",
+      "class_name": "com.example.ActivityA1",
       "intent": "",
       "saved_instance_state": false
     }
   },
   {
-    "id": "084d900a-41fb-43ac-b74a-8053853cae6b",
-    "session_id": "1d72df05-44ea-4d6f-8306-7b9b5a5b600e",
-    "timestamp": "2024-09-18T16:15:25.452Z",
-    "type": "screen_view",
-    "screen_view": {
-      "name": "home"
+    "id": "00000000-0000-0000-0000-000000000002",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.410Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF1",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "",
+      "tag": ""
     }
   },
   {
-    "id": "084d900a-41fb-43ac-b74a-8053853cae6c",
-    "session_id": "1d72df05-44ea-4d6f-8306-7b9b5a5b600e",
-    "timestamp": "2024-09-18T16:15:25.457Z",
-    "type": "screen_view",
-    "screen_view": {
-      "name": "order"
+    "id": "00000000-0000-0000-0000-000000000003",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.420Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF2",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "com.example.FragmentF1",
+      "tag": ""
     }
   },
   {
-    "id": "084d900a-41fb-43ac-b74a-8053853cae6d",
-    "session_id": "1d72df05-44ea-4d6f-8306-7b9b5a5b600e",
-    "timestamp": "2024-09-18T16:15:25.462Z",
+    "id": "00000000-0000-0000-0000-000000000004",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.430Z",
     "type": "screen_view",
     "screen_view": {
-      "name": "checkout"
+      "name": "screen_s1"
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000005",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.440Z",
+    "type": "screen_view",
+    "screen_view": {
+      "name": "screen_s2"
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000006",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.450Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF1",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "",
+      "tag": ""
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000007",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.460Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF2",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "com.example.FragmentF1",
+      "tag": ""
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000008",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.470Z",
+    "type": "screen_view",
+    "screen_view": {
+      "name": "screen_s3"
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000009",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.480Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF2",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "com.example.FragmentF1",
+      "tag": ""
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000010",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.490Z",
+    "type": "lifecycle_fragment",
+    "lifecycle_fragment": {
+      "type": "resumed",
+      "class_name": "com.example.FragmentF1",
+      "parent_activity": "com.example.ActivityA1",
+      "parent_fragment": "",
+      "tag": ""
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000011",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.500Z",
+    "type": "screen_view",
+    "screen_view": {
+      "name": "screen_s2"
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000012",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.510Z",
+    "type": "lifecycle_activity",
+    "lifecycle_activity": {
+      "type": "resumed",
+      "class_name": "com.example.ActivityA2",
+      "intent": "",
+      "saved_instance_state": false
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000013",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.520Z",
+    "type": "lifecycle_activity",
+    "lifecycle_activity": {
+      "type": "resumed",
+      "class_name": "com.example.ActivityA3",
+      "intent": "",
+      "saved_instance_state": false
+    }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000014",
+    "session_id": "10000000-0000-0000-0000-000000000001",
+    "timestamp": "2024-09-18T16:15:25.530Z",
+    "type": "screen_view",
+    "screen_view": {
+      "name": "screen_s2"
     }
   }
 ]

--- a/backend/api/journey/ios_test.go
+++ b/backend/api/journey/ios_test.go
@@ -88,16 +88,27 @@ func TestNewJourneyiOSWithScreenViews(t *testing.T) {
 		}
 	}
 
-	expectedGraphString := "4 [(0 1) (0 2) (0 3)]"
+	expectedGraphString := "4 [(0 1) (1 2) (2 3)]"
 	gotGraphString := journey.Graph.String()
 
 	if expectedGraphString != gotGraphString {
 		t.Errorf("Expected graph %q, got %q", expectedGraphString, gotGraphString)
 	}
 
-	for screenName, screenVertex := range screenViewNodes {
-		if !journey.Graph.Edge(viewControllerVertex, screenVertex) {
-			t.Errorf("Expected edge from ControlsViewController to %s screen view", screenName)
-		}
+	// Verify sequential edges
+	homeVertex := screenViewNodes["home"]
+	orderVertex := screenViewNodes["order"]
+	checkoutVertex := screenViewNodes["checkout"]
+
+	if !journey.Graph.Edge(viewControllerVertex, homeVertex) {
+		t.Errorf("Expected edge from ControlsViewController to home screen view")
+	}
+
+	if !journey.Graph.Edge(homeVertex, orderVertex) {
+		t.Errorf("Expected edge from home to order screen view (sequential)")
+	}
+
+	if !journey.Graph.Edge(orderVertex, checkoutVertex) {
+		t.Errorf("Expected edge from order to checkout screen view (sequential)")
 	}
 }


### PR DESCRIPTION
# Description

Enable ScreenView sequential chaining in journey. Earlier, for a sequence like:

``` 
Activity A -> Screen View S1 -> Screen View S2.
```

The current output would link all screen views to the last Activity or View Controller:

```
A -> S1
A -> S2
```

This PR changes it to maintain the sequence:

```
A -> S1 -> S2
```

The logic for multiple Activities or View Controller still remains same. The logic treats Activities and View Controllers to be containers for any Fragment or "Screen". Therefore all incoming links to `Activity` or `View Controller` always originate from another `Activity` or `View Controller`.

```
A1 -> S1 -> S2 -> A2 -> S1
```

Will produce:

```
A1 -> S1 -> S2
A1 -> A2 -> S1
```

## Related issue
Fixes  #2825

