### PR TITLE
chore(flutter): expose measure-android SDK as api dependency

### DIFF
--- a/flutter/packages/measure_flutter/android/build.gradle
+++ b/flutter/packages/measure_flutter/android/build.gradle
@@ -47,7 +47,7 @@ android {
     }
 
     dependencies {
-        implementation("sh.measure:measure-android:0.14.0-SNAPSHOT")
+        api("sh.measure:measure-android:0.14.0-SNAPSHOT")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
     }
 


### PR DESCRIPTION
# Description

We recommend initializing the native Android SDK along with the Flutter SDK. To make this setup easier, expose the bundled native SDK in `measure_flutter` as `api`. This allows developers to not worry about which version to pair with `measure_flutter`.

## Related issue
Closes #2827

