### PR TITLE
chore(backend): update invite validity to 7 days & show it in email

### DIFF
--- a/backend/api/measure/team.go
+++ b/backend/api/measure/team.go
@@ -66,7 +66,7 @@ type MemberWithAuthz struct {
 	MemberAuthz `json:"authz"`
 }
 
-const teamInviteValidity = 48 * time.Hour
+const teamInviteValidity = 7 * 24 * time.Hour // 7 days
 
 func (t *Team) getApps(ctx context.Context) ([]App, error) {
 	var apps []App
@@ -964,7 +964,12 @@ func InviteMembers(c *gin.Context) {
 		// Send emails to new invitees
 		for _, invitee := range newInvitees {
 			title := "Invitation to join Measure"
-			msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>!", *user.Email, invitee.Role, *team.Name)
+			days := int(teamInviteValidity.Hours() / 24)
+			dayStr := "day"
+			if days != 1 {
+				dayStr = "days"
+			}
+			msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>! <br/><br/>This invite is valid for <b>%d %s</b>.", *user.Email, invitee.Role, *team.Name, days, dayStr)
 			url := server.Server.Config.SiteOrigin + "/auth/login"
 			body := formatTeamEmailBody(title, msg, url, "Join Team")
 			emailInfo := &email.EmailInfo{

--- a/backend/cleanup/cleanup/cleanup.go
+++ b/backend/cleanup/cleanup/cleanup.go
@@ -121,7 +121,7 @@ func deleteStaleShortenedFilters(ctx context.Context) {
 // deleteStaleInvites deletes stale invites that
 // have passed the expiry threshold
 func deleteStaleInvites(ctx context.Context) {
-	threshold := time.Now().Add(-48 * time.Hour) // 48 hour expiry
+	threshold := time.Now().Add(-7 * 24 * time.Hour) // 7 day expiry
 	stmt := sqlf.PostgreSQL.DeleteFrom("invites").
 		Where("updated_at < ?", threshold)
 


### PR DESCRIPTION
# Description

Updates invite validity to 7 days & show it in email

## Related issue
Closes #2836 



