### PR TITLE
fix(backend): escape & unescape single quote in user def attr strings

### DIFF
--- a/backend/api/event/userdefattr.go
+++ b/backend/api/event/userdefattr.go
@@ -584,6 +584,10 @@ func (u *UDAttribute) Parameterize() (attr map[string]string) {
 			// but let's handle it just in case
 			val = strconv.FormatInt(v, 10)
 		case string:
+			// escape any single quote, if any
+			// if not escaped, ClickHouse insert will
+			// throw errors.
+			v = strings.ReplaceAll(v, "'", "\\'")
 			val = v
 		}
 
@@ -610,6 +614,10 @@ func (u *UDAttribute) Scan(attrMap map[string][]any) {
 			u.keyTypes[key] = AttrBool
 		case AttrString.String():
 			u.keyTypes[key] = AttrString
+			if value, ok := tuple[1].(string); ok {
+				// unescape single quotes if any
+				tuple[1] = strings.ReplaceAll(value, "\\'", "'")
+			}
 		case AttrInt64.String():
 			u.keyTypes[key] = AttrInt64
 		case AttrFloat64.String():

--- a/backend/api/event/userdefattr_test.go
+++ b/backend/api/event/userdefattr_test.go
@@ -678,6 +678,7 @@ func TestParameterize(t *testing.T) {
 			"zero_int64":               float64(0),
 			"regular_bool":             true,
 			"regular_string":           "lorem ipsum",
+			"single_quote":             "lorem 'ipsum",
 		},
 		keyTypes: map[string]AttrType{
 			"max_int32":                AttrInt64,
@@ -696,6 +697,7 @@ func TestParameterize(t *testing.T) {
 			"zero_int64":               AttrInt64,
 			"regular_bool":             AttrBool,
 			"regular_string":           AttrString,
+			"single_quote":             AttrString,
 		},
 	}
 
@@ -716,6 +718,7 @@ func TestParameterize(t *testing.T) {
 		"zero_int64":               fmt.Sprintf(`('%s', '0')`, AttrInt64.String()),
 		"regular_bool":             fmt.Sprintf(`('%s', 'true')`, AttrBool.String()),
 		"regular_string":           fmt.Sprintf(`('%s', 'lorem ipsum')`, AttrString.String()),
+		"single_quote":             fmt.Sprintf(`('%s', 'lorem \'ipsum')`, AttrString.String()),
 	}
 	got := udAttr.Parameterize()
 
@@ -742,6 +745,7 @@ func TestScan(t *testing.T) {
 		"zero_int64":               {AttrInt64.String(), 0},
 		"regular_bool":             {AttrBool.String(), true},
 		"regular_string":           {AttrString.String(), "lorem ipsum"},
+		"single_quote":             {AttrString.String(), "lorem \\'ipsum"},
 	}
 	var udAttr UDAttribute
 
@@ -762,6 +766,7 @@ func TestScan(t *testing.T) {
 		"zero_int64":               AttrInt64,
 		"regular_bool":             AttrBool,
 		"regular_string":           AttrString,
+		"single_quote":             AttrString,
 	}
 	expectedRawAttrs := map[string]any{
 		"max_int32":                2147483647,
@@ -780,6 +785,7 @@ func TestScan(t *testing.T) {
 		"zero_int64":               0,
 		"regular_bool":             true,
 		"regular_string":           "lorem ipsum",
+		"single_quote":             "lorem 'ipsum",
 	}
 
 	udAttr.Scan(attrMap)


### PR DESCRIPTION
## Summary

This PR fixes an issue where ingest would fail if user defined attribute string values contained single quote characters. This fix would unescape/escape such string values properly during read/write from and to ClickHouse.

## Tasks

- [x] Escape single quote characters in user defined attribute strings during ingest
- [x] Unescape single quote characters in user defined attribute strings during read
- [x] Update user defined attribute tests

## See also

- fixes #2831
