### PR TITLE
chore(ios): limit http data body size to 256 kb

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/BaseConfigProvider.swift
@@ -49,6 +49,10 @@ final class BaseConfigProvider: ConfigProvider {
         return self.httpUrlBlocklist
     }()
 
+    var maxBodySizeBytes: Int {
+        return getMergedConfig(\.maxBodySizeBytes)
+    }
+
     var maxAttachmentsInBatch: Int {
         return getMergedConfig(\.maxAttachmentsInBatch)
     }

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -62,6 +62,7 @@ struct Config: InternalConfig, MeasureConfig {
     let estimatedEventSizeInKb: Int
     let maxExportJitterInterval: Int
     let maxAttachmentsInBatch: Int
+    let maxBodySizeBytes: Int
 
     internal init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
                   samplingRateForErrorFreeSessions: Float = DefaultConfig.sessionSamplingRate,
@@ -156,5 +157,6 @@ struct Config: InternalConfig, MeasureConfig {
         self.estimatedEventSizeInKb = 10 // 10 KB
         self.maxExportJitterInterval = 20
         self.maxAttachmentsInBatch = 10
+        self.maxBodySizeBytes = 256 * 1024 // 256 KB
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/InternalConfig.swift
@@ -107,4 +107,7 @@ protocol InternalConfig {
 
     /// The maximum number of attachment to export in API. Defaults to 10.
     var maxAttachmentsInBatch: Int { get }
+
+    /// The maximum size of response or request body in `HttpData`. Defaults to 256 x 1024 bytes
+    var maxBodySizeBytes: Int { get }
 }

--- a/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
@@ -159,8 +159,8 @@ extension NetworkInterceptorProtocol: URLSessionDataDelegate {
                 failureDescription: error?.localizedDescription,
                 requestHeaders: configProvider.trackHttpHeaders ? request.allHTTPHeaderFields?.filter { !defaultHttpHeadersBlocklist.contains($0.key) } : nil,
                 responseHeaders: configProvider.trackHttpHeaders ? extractHeaders(from: httpResponse)?.filter { !defaultHttpHeadersBlocklist.contains($0.key) } : nil,
-                requestBody: configProvider.trackHttpBody ? requestBody?.sanitizeRequestBody() : nil,
-                responseBody: configProvider.trackHttpBody ? responseString?.sanitizeRequestBody() : nil,
+                requestBody: configProvider.trackHttpBody ? httpEventValidator.validateAndTrimBody(requestBody?.sanitizeRequestBody(), maxBodySizeBytes: configProvider.maxBodySizeBytes) : nil,
+                responseBody: configProvider.trackHttpBody ? httpEventValidator.validateAndTrimBody(responseString?.sanitizeRequestBody(), maxBodySizeBytes: configProvider.maxBodySizeBytes) : nil,
                 client: "URLSession")
 
             httpInterceptorCallbacks.onHttpCompletion(data: httpData)

--- a/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
@@ -113,8 +113,8 @@ final class URLSessionTaskInterceptor {
                 failureDescription: failureDescription,
                 requestHeaders: configProvider.trackHttpHeaders ? requestHeaders.filter { !defaultHttpHeadersBlocklist.contains($0.key) } : nil,
                 responseHeaders: configProvider.trackHttpHeaders ? responseHeaders.filter { !defaultHttpHeadersBlocklist.contains($0.key) } : nil,
-                requestBody: configProvider.trackHttpBody ? requestBody?.sanitizeRequestBody() : nil,
-                responseBody: configProvider.trackHttpBody ? responseBody?.sanitizeRequestBody() : nil,
+                requestBody: configProvider.trackHttpBody ? httpEventValidator.validateAndTrimBody(requestBody?.sanitizeRequestBody(), maxBodySizeBytes: configProvider.maxBodySizeBytes) : nil,
+                responseBody: configProvider.trackHttpBody ? httpEventValidator.validateAndTrimBody(responseBody?.sanitizeRequestBody(), maxBodySizeBytes: configProvider.maxBodySizeBytes) : nil,
                 client: client)
 
             taskStartTimes.removeValue(forKey: task)

--- a/ios/Tests/MeasureSDKTests/Http/HttpEventValidatorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Http/HttpEventValidatorTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class HttpEventValidatorTests: XCTestCase {
     private var validator: HttpEventValidator!
+    private let maxBodySize = 256 * 1024
 
     override func setUp() {
         super.setUp()
@@ -50,5 +51,61 @@ class HttpEventValidatorTests: XCTestCase {
         let result = validator.shouldTrackHttpEvent(nil, contentType: "application/json", requestUrl: "https://example.com", allowedDomains: ["example.com"], ignoredDomains: ["ignored.com"])
 
         XCTAssertTrue(result, "Request should be tracked when allowed domains is non-empty even if ignored domains exist")
+    }
+
+    func test_validateAndTrimBody_nilBody() {
+        let result = validator.validateAndTrimBody(nil, maxBodySizeBytes: maxBodySize)
+        XCTAssertNil(result, "Nil body should return nil")
+    }
+
+    func test_validateAndTrimBody_emptyBody() {
+        let result = validator.validateAndTrimBody("", maxBodySizeBytes: maxBodySize)
+        XCTAssertNil(result, "Empty body should return nil")
+    }
+
+    func test_validateAndTrimBody_atLimit() {
+        let bodyAtLimit = String(repeating: "a", count: maxBodySize)
+
+        let result = validator.validateAndTrimBody(bodyAtLimit, maxBodySizeBytes: maxBodySize)
+
+        XCTAssertEqual(result, bodyAtLimit, "Body at the limit should not be truncated")
+        XCTAssertEqual(result?.data(using: .utf8)?.count, maxBodySize, "Byte count should be max size")
+    }
+
+    func test_validateAndTrimBody_underLimit() {
+        let bodyUnderLimit = String(repeating: "b", count: maxBodySize - 1)
+
+        let result = validator.validateAndTrimBody(bodyUnderLimit, maxBodySizeBytes: maxBodySize)
+
+        XCTAssertEqual(result, bodyUnderLimit, "Body under the limit should not be truncated")
+        XCTAssertEqual(result?.data(using: .utf8)?.count, maxBodySize - 1, "Byte count should be correct")
+    }
+
+    func test_validateAndTrimBody_overLimit_singleByte() {
+        let bodyOverLimit = String(repeating: "c", count: maxBodySize + 1)
+        let result = validator.validateAndTrimBody(bodyOverLimit, maxBodySizeBytes: maxBodySize)
+
+        XCTAssertNotNil(result, "Trimming an oversized body should not return nil")
+
+        let truncationNotice = "\n... [Body truncated - exceeded 256KB limit]"
+        XCTAssertTrue(result!.hasSuffix(truncationNotice), "Trimmed body must contain the truncation notice")
+
+        let trimmedContent = result!.replacingOccurrences(of: truncationNotice, with: "")
+        XCTAssertEqual(trimmedContent.data(using: .utf8)?.count, maxBodySize, "The pre-notice content size should be exactly maxBodySize")
+    }
+
+    func test_validateAndTrimBody_overLimit_multiByte() {
+        let threeByteChar = "€"
+
+        let baseBody = String(repeating: "a", count: maxBodySize - 1)
+        let bodyWithMultiByteCutoff = baseBody + threeByteChar
+
+        let result = validator.validateAndTrimBody(bodyWithMultiByteCutoff, maxBodySizeBytes: maxBodySize)
+        XCTAssertNotNil(result, "Trimming multi-byte body should not return nil")
+
+        let truncationNotice = "\n... [Body truncated - exceeded 256KB limit]"
+        let trimmedContent = result!.replacingOccurrences(of: truncationNotice, with: "")
+        XCTAssertLessThanOrEqual(trimmedContent.data(using: .utf8)?.count ?? 0, maxBodySize, "The final trimmed content size must be less than or equal to maxBodySize")
+        XCTAssertEqual(trimmedContent.suffix(1), "a", "The last character should be a valid, single-byte character from the original string.")
     }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
@@ -9,6 +9,7 @@ import Foundation
 @testable import Measure
 
 final class MockConfigProvider: ConfigProvider {
+    var maxBodySizeBytes: Int
     var maxAttachmentsInBatch: Int
     var lifecycleViewControllerExcludeList: [String]
     var cpuTrackingIntervalMs: UnsignedNumber
@@ -116,7 +117,8 @@ final class MockConfigProvider: ConfigProvider {
          maxDiskUsageInMb: Int = 50,
          estimatedEventSizeInKb: Int = 10,
          maxExportJitterInterval: Int = 20,
-         maxAttachmentsInBatch: Int = 10) {
+         maxAttachmentsInBatch: Int = 10,
+         maxBodySizeBytes: Int = 256 * 1024) {
         self.enableLogging = enableLogging
         self.trackScreenshotOnCrash = trackScreenshotOnCrash
         self.samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions
@@ -184,6 +186,7 @@ final class MockConfigProvider: ConfigProvider {
         self.maxAttachmentsInBatch = maxAttachmentsInBatch
         self.combinedHttpHeadersBlocklist = self.defaultHttpHeadersBlocklist + self.httpHeadersBlocklist
         self.combinedHttpUrlBlocklist = self.httpUrlBlocklist
+        self.maxBodySizeBytes = maxBodySizeBytes
     }
 
     func loadNetworkConfig() {}


### PR DESCRIPTION
# Description

This PR will limit http response/request body size to 256 kb.

Below changes have been added:

- Add `maxBodySizeBytes` to InternalConfig
- Add `validateAndTrimBody` function to HttpEventValidator
- Add tests

## Related issue
Closes #2678 