### PR TITLE
fix(backend): run cleanup job at the strike of each hour

### DIFF
--- a/backend/cleanup/main.go
+++ b/backend/cleanup/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -65,7 +66,14 @@ func main() {
 
 func initCron(ctx context.Context) *cron.Cron {
 	cron := cron.New()
-	cron.AddFunc("@hourly", func() { cleanup.DeleteStaleData(ctx) })
+
+	// run every hour
+	if _, err := cron.AddFunc("0 * * * *", func() { cleanup.DeleteStaleData(ctx) }); err != nil {
+		fmt.Printf("Failed to schedule stale data cleanup job: %v\n", err)
+	}
+
+	fmt.Println("Scheduled stale data cleanup job")
+
 	cron.Start()
 	return cron
 }


### PR DESCRIPTION
## Summary

This PR changes the schedule timing of cleanup job to run at the strike of each hour, regardless of process start time.

## Tasks

- [x] Change cron syntax to run at the strike of each hour
- [x] Improve error handling
- [x] Improve logging

## See also

- fixes #2857
