### PR TITLE
fix(backend): update daily summary email

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -342,8 +342,6 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, appID uuid.UUID
                 WHEN cd.cold_launch_p95_ms > pd.cold_launch_p95_ms THEN concat(toString(round(cd.cold_launch_p95_ms / pd.cold_launch_p95_ms, 2)), 'x worse than yesterday')
                 ELSE 'No change from yesterday'
             END AS cold_launch_subtitle,
-            (isNaN(cd.cold_launch_p95_ms) = 0 AND cd.cold_launch_p95_ms > 2000 AND cd.cold_launch_p95_ms > 0) AS cold_launch_has_warning,
-            (isNaN(cd.cold_launch_p95_ms) = 0 AND cd.cold_launch_p95_ms > 3000 AND cd.cold_launch_p95_ms > 0) AS cold_launch_has_error,
 
             -- Warm Launch
             CASE
@@ -357,8 +355,6 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, appID uuid.UUID
                 WHEN cd.warm_launch_p95_ms > pd.warm_launch_p95_ms THEN concat(toString(round(cd.warm_launch_p95_ms / pd.warm_launch_p95_ms, 2)), 'x worse than yesterday')
                 ELSE 'No change from yesterday'
             END AS warm_launch_subtitle,
-            (isNaN(cd.warm_launch_p95_ms) = 0 AND cd.warm_launch_p95_ms > 1000 AND cd.warm_launch_p95_ms > 0) AS warm_launch_has_warning,
-            (isNaN(cd.warm_launch_p95_ms) = 0 AND cd.warm_launch_p95_ms > 1500 AND cd.warm_launch_p95_ms > 0) AS warm_launch_has_error,
 
             -- Hot Launch
             CASE
@@ -371,9 +367,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, appID uuid.UUID
                 WHEN cd.hot_launch_p95_ms < pd.hot_launch_p95_ms THEN concat(toString(round(cd.hot_launch_p95_ms / pd.hot_launch_p95_ms, 2)), 'x better than yesterday')
                 WHEN cd.hot_launch_p95_ms > pd.hot_launch_p95_ms THEN concat(toString(round(cd.hot_launch_p95_ms / pd.hot_launch_p95_ms, 2)), 'x worse than yesterday')
                 ELSE 'No change from yesterday'
-            END AS hot_launch_subtitle,
-            (isNaN(cd.hot_launch_p95_ms) = 0 AND cd.hot_launch_p95_ms > 800 AND cd.hot_launch_p95_ms > 0) AS hot_launch_has_warning,
-            (isNaN(cd.hot_launch_p95_ms) = 0 AND cd.hot_launch_p95_ms > 1200 AND cd.hot_launch_p95_ms > 0) AS hot_launch_has_error
+            END AS hot_launch_subtitle
 
 
         FROM current_day cd
@@ -858,13 +852,21 @@ func formatDailySummaryEmailBody(appName, dashboardURL string, date time.Time, m
 	for _, metric := range metrics {
 		icon := ""
 		if metric.HasError {
-			icon = `<div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background-color: #e7000b; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-				<span style="color: white; font-size: 12px; font-weight: bold;">!</span>
-			</div>`
+			icon = `<div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background-color: #e7000b; border-radius: 50%;">
+   						<table style="width: 100%; height: 100%; margin: 0; padding: 0; border: 0;" cellpadding="0" cellspacing="0">
+        					<tr>
+            					<td style="text-align: center; vertical-align: middle; color: #ffffff; font-size: 12px; font-weight: bold;">!</td>
+        					</tr>
+    					</table>
+					</div>`
 		} else if metric.HasWarning {
-			icon = `<div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background-color: #d08700; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-				<span style="color: white; font-size: 12px; font-weight: bold;">!</span>
-			</div>`
+			icon = `<div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background-color: #d08700; border-radius: 50%;">
+   						<table style="width: 100%; height: 100%; margin: 0; padding: 0; border: 0;" cellpadding="0" cellspacing="0">
+        					<tr>
+            					<td style="text-align: center; vertical-align: middle; color: #ffffff; font-size: 12px; font-weight: bold;">!</td>
+        					</tr>
+    					</table>
+					</div>`
 		}
 
 		metricsHTML += fmt.Sprintf(`


### PR DESCRIPTION
# Description

- Removes warning and error for launch times since they don't make sense in daily summary context. On dashboard, we compare them with unselected versions. In daily summary, we were comparing them to absolute baseline values which creates confusion.
- Uses table html elements to ensure warning and error icons are centered correctly in gmail
- Uses explicit colors in warning and error icons for compatibility across email clients

## Related issue
Closes #2855 



