### PR TITLE
fix(ios): update network interceptor to generate proper request body

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
@@ -146,7 +146,7 @@ extension NetworkInterceptorProtocol: URLSessionDataDelegate {
             } else if let requestBodyData = request.httpBody, let requestBodyString = String(data: requestBodyData, encoding: .utf8) {
                 requestBody = requestBodyString
             }
-            requestBody = nil
+
             let responseString = responseBody.map { String(data: $0, encoding: .utf8) } ?? nil
 
             let httpData = HttpData(


### PR DESCRIPTION
# Description

This PR fixes request body always being nil when using MSRNetworkInterceptor. 

## Related issue
Fixes #2888 