### PR TITLE
doc: Correct placeholder key from measureUrlKey to measureApiUrl

### DIFF
--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -80,11 +80,11 @@ android {
     buildTypes {
         debug {
             manifestPlaceholders["measureApiKey"] = "YOUR_API_KEY"
-            manifestPlaceholders["measureUrlKey"] = "YOUR_API_URL"
+            manifestPlaceholders["measureApiUrl"] = "YOUR_API_URL"
         }
         release {
             manifestPlaceholders["measureApiKey"] = "YOUR_API_KEY"
-            manifestPlaceholders["measureUrlKey"] = "YOUR_API_URL"
+            manifestPlaceholders["measureApiUrl"] = "YOUR_API_URL"
         }
     }
 }


### PR DESCRIPTION
As Title Says, The key expected was different, creating a mismatch, which is fixed by this PR.