### PR TITLE
chore(backend): stop Slack channel removal on `channel_not_found`

### DIFF
--- a/backend/alerts/slack/slack.go
+++ b/backend/alerts/slack/slack.go
@@ -74,8 +74,8 @@ type SlackMessage struct {
 
 // List of errors that require channel removal
 var errorsToRemoveMessageAndChannel = map[string]bool{
-	"access_denied":     true,
-	"channel_not_found": true,
+	"access_denied": true,
+	// "channel_not_found": true,
 	"is_archived":       true,
 	"no_permission":     true,
 	"ekm_access_denied": true,


### PR DESCRIPTION
# Description

Stops Slack channel removal on `channel_not_found`

## Related issue
Closes #2899



