### PR TITLE
chore(backend): fix shebang in clickhouse init script

### DIFF
--- a/self-host/clickhouse/init-clickhouse.sh
+++ b/self-host/clickhouse/init-clickhouse.sh
@@ -1,4 +1,4 @@
-#!/usr/env/bin bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

This PR fixes the incorrect shebang in `init-clickhouse.sh` script.


## See also

- fixes #2915

