### PR TITLE
chore(android): fix error when inserting event for cleaned up session

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -445,6 +445,7 @@ internal class MeasureInitializerImpl(
         ioExecutor = executorServiceRegistry.ioExecutor(),
         sessionManager = sessionManager,
         configProvider = configProvider,
+        prefsStorage = prefsStorage,
     ),
     override val customEventCollector: CustomEventCollector = CustomEventCollector(
         logger = logger,

--- a/android/measure/src/main/java/sh/measure/android/storage/PrefsStorage.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/PrefsStorage.kt
@@ -16,6 +16,7 @@ internal interface PrefsStorage {
     fun setRecentSessionCrashed()
     fun setRecentSessionEventTime(timestamp: Long)
     fun getRecentSession(): RecentSession?
+    fun deleteRecentSession()
 }
 
 internal class PrefsStorageImpl(private val context: Context) : PrefsStorage {
@@ -86,5 +87,15 @@ internal class PrefsStorageImpl(private val context: Context) : PrefsStorage {
             crashed = crashed,
             versionCode = versionCode,
         )
+    }
+
+    override fun deleteRecentSession() {
+        sharedPreferences.edit {
+            remove(RECENT_SESSION_ID)
+            remove(RECENT_SESSION_CREATED_AT)
+            remove(RECENT_SESSION_EVENT_TIME)
+            remove(RECENT_SESSION_CRASHED)
+            remove(RECENT_SESSION_VERSION_CODE)
+        }
     }
 }


### PR DESCRIPTION
# Description

Fixes the handled exception which occurs when an event is attempted to be inserted for an already cleaned up session.

## Related issue
Closes #2931 


