### PR TITLE
chore(flutter): update measure config and default event collection

### DIFF
--- a/flutter/packages/measure_flutter/example/pubspec.lock
+++ b/flutter/packages/measure_flutter/example/pubspec.lock
@@ -341,7 +341,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.2.1"
   meta:
     dependency: transitive
     description:

--- a/flutter/packages/measure_flutter/lib/src/config/config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config.dart
@@ -16,24 +16,22 @@ class Config implements InternalConfig, IMeasureConfig {
     this.trackActivityIntentData = DefaultConfig.trackActivityIntentData,
     this.samplingRateForErrorFreeSessions = DefaultConfig.sessionSamplingRate,
     this.traceSamplingRate = DefaultConfig.traceSamplingRate,
-    this.trackActivityLoadTime = DefaultConfig.trackActivityLoadTime,
-    this.trackFragmentLoadTime = DefaultConfig.trackFragmentLoadTime,
-    this.trackViewControllerLoadTime =
-        DefaultConfig.trackViewControllerLoadTime,
     this.maxCheckpointNameLength = DefaultConfig.maxCheckpointNameLength,
     this.maxSpanNameLength = DefaultConfig.maxSpanNameLength,
     this.maxCheckpointsPerSpan = DefaultConfig.maxCheckpointsPerSpan,
     this.maxAttachmentsInBugReport = DefaultConfig.maxAttachmentsInBugReport,
-    this.maxDescriptionLengthInBugReport =
-        DefaultConfig.maxDescriptionLengthInBugReport,
-    this.screenshotCompressionQuality =
-        DefaultConfig.screenshotCompressionQuality,
+    this.maxDescriptionLengthInBugReport = DefaultConfig.maxDescriptionLengthInBugReport,
+    this.screenshotCompressionQuality = DefaultConfig.screenshotCompressionQuality,
     this.maxEventNameLength = DefaultConfig.maxEventNameLength,
     this.customEventNameRegex = DefaultConfig.customEventNameRegex,
     this.maxDiskUsageInMb = DefaultConfig.maxDiskUsageInMb,
     this.maxUserDefinedAttributeKeyLength = DefaultConfig.maxUserDefinedAttributeKeyLength,
     this.maxUserDefinedAttributeValueLength = DefaultConfig.maxUserDefinedAttributeValueLength,
     this.maxUserDefinedAttributesPerEvent = DefaultConfig.maxUserDefinedAttributesPerEvent,
+    this.coldLaunchSamplingRate = DefaultConfig.coldLaunchSamplingRate,
+    this.warmLaunchSamplingRate = DefaultConfig.warmLaunchSamplingRate,
+    this.hotLaunchSamplingRate = DefaultConfig.hotLaunchSamplingRate,
+    this.journeySamplingRate = DefaultConfig.journeySamplingRate,
   });
 
   @override
@@ -61,12 +59,6 @@ class Config implements InternalConfig, IMeasureConfig {
   @override
   final double traceSamplingRate;
   @override
-  final bool trackActivityLoadTime;
-  @override
-  final bool trackFragmentLoadTime;
-  @override
-  final bool trackViewControllerLoadTime;
-  @override
   final int maxCheckpointNameLength;
   @override
   final int maxSpanNameLength;
@@ -90,10 +82,17 @@ class Config implements InternalConfig, IMeasureConfig {
   final int maxUserDefinedAttributeKeyLength;
   @override
   final int maxUserDefinedAttributeValueLength;
+  @override
+  final double coldLaunchSamplingRate;
+  @override
+  final double warmLaunchSamplingRate;
+  @override
+  final double hotLaunchSamplingRate;
+  @override
+  final double journeySamplingRate;
 
   @override
-  List<String> get defaultHttpContentTypeAllowlist =>
-      const ["application/json"];
+  List<String> get defaultHttpContentTypeAllowlist => const ["application/json"];
 
   @override
   List<String> get defaultHttpHeadersBlocklist => const [
@@ -119,26 +118,27 @@ class Config implements InternalConfig, IMeasureConfig {
     bool? trackActivityLoadTime,
     bool? trackFragmentLoadTime,
     int? maxDiskUsageInMb,
+    double? coldLaunchSamplingRate,
+    double? warmLaunchSamplingRate,
+    double? hotLaunchSamplingRate,
+    double? journeySamplingRate,
   }) {
     return Config(
       enableLogging: enableLogging ?? this.enableLogging,
-      autoInitializeNativeSDK:
-          autoInitializeNativeSDK ?? this.autoInitializeNativeSDK,
+      autoInitializeNativeSDK: autoInitializeNativeSDK ?? this.autoInitializeNativeSDK,
       trackHttpHeaders: trackHttpHeaders ?? this.trackHttpHeaders,
       trackHttpBody: trackHttpBody ?? this.trackHttpBody,
       httpHeadersBlocklist: httpHeadersBlocklist ?? this.httpHeadersBlocklist,
       httpUrlAllowlist: httpUrlAllowlist ?? this.httpUrlAllowlist,
       httpUrlBlocklist: httpUrlBlocklist ?? this.httpUrlBlocklist,
-      trackActivityIntentData:
-          trackActivityIntentData ?? this.trackActivityIntentData,
-      samplingRateForErrorFreeSessions: samplingRateForErrorFreeSessions ??
-          this.samplingRateForErrorFreeSessions,
+      trackActivityIntentData: trackActivityIntentData ?? this.trackActivityIntentData,
+      samplingRateForErrorFreeSessions: samplingRateForErrorFreeSessions ?? this.samplingRateForErrorFreeSessions,
       traceSamplingRate: traceSamplingRate ?? this.traceSamplingRate,
-      trackActivityLoadTime:
-          trackActivityLoadTime ?? this.trackActivityLoadTime,
-      trackFragmentLoadTime:
-          trackFragmentLoadTime ?? this.trackFragmentLoadTime,
       maxDiskUsageInMb: maxDiskUsageInMb ?? this.maxDiskUsageInMb,
+      coldLaunchSamplingRate: coldLaunchSamplingRate ?? this.coldLaunchSamplingRate,
+      warmLaunchSamplingRate: warmLaunchSamplingRate ?? this.warmLaunchSamplingRate,
+      hotLaunchSamplingRate: hotLaunchSamplingRate ?? this.hotLaunchSamplingRate,
+      journeySamplingRate: journeySamplingRate ?? this.journeySamplingRate,
     );
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
@@ -66,16 +66,6 @@ class ConfigProviderImpl implements ConfigProvider {
   bool get trackActivityIntentData => _defaultConfig.trackActivityIntentData;
 
   @override
-  bool get trackActivityLoadTime => _defaultConfig.trackActivityLoadTime;
-
-  @override
-  bool get trackFragmentLoadTime => _defaultConfig.trackFragmentLoadTime;
-
-  @override
-  bool get trackViewControllerLoadTime =>
-      _defaultConfig.trackViewControllerLoadTime;
-
-  @override
   int get maxCheckpointsPerSpan => _defaultConfig.maxCheckpointsPerSpan;
 
   @override
@@ -112,6 +102,18 @@ class ConfigProviderImpl implements ConfigProvider {
 
   @override
   int get maxUserDefinedAttributesPerEvent => _defaultConfig.maxUserDefinedAttributesPerEvent;
+
+  @override
+  double get coldLaunchSamplingRate => _defaultConfig.coldLaunchSamplingRate;
+
+  @override
+  double get warmLaunchSamplingRate => _defaultConfig.warmLaunchSamplingRate;
+
+  @override
+  double get hotLaunchSamplingRate => _defaultConfig.hotLaunchSamplingRate;
+
+  @override
+  double get journeySamplingRate => _defaultConfig.journeySamplingRate;
 
   @override
   bool shouldTrackHttpBody(String url, String? contentType) {

--- a/flutter/packages/measure_flutter/lib/src/config/default_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/default_config.dart
@@ -10,10 +10,7 @@ class DefaultConfig {
   static const List<String> httpUrlAllowlist = [];
   static const bool trackActivityIntentData = false;
   static const double sessionSamplingRate = 1.0;
-  static const double traceSamplingRate = 0.1;
-  static const bool trackActivityLoadTime = true;
-  static const bool trackFragmentLoadTime = true;
-  static const bool trackViewControllerLoadTime = true;
+  static const double traceSamplingRate = 0.0001;
   static const int maxCheckpointsPerSpan = 100;
   static const int maxSpanNameLength = 64;
   static const int maxCheckpointNameLength = 64;
@@ -26,4 +23,8 @@ class DefaultConfig {
   static const int maxUserDefinedAttributesPerEvent = 100;
   static const int maxUserDefinedAttributeKeyLength = 256;
   static const int maxUserDefinedAttributeValueLength = 256;
+  static const double coldLaunchSamplingRate = 0.0001;
+  static const double warmLaunchSamplingRate = 0.0001;
+  static const double hotLaunchSamplingRate = 0.0001;
+  static const double journeySamplingRate = 0;
 }

--- a/flutter/packages/measure_flutter/lib/src/config/measure_config.g.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/measure_config.g.dart
@@ -38,15 +38,19 @@ MeasureConfig _$MeasureConfigFromJson(Map<String, dynamic> json) =>
               DefaultConfig.sessionSamplingRate,
       traceSamplingRate: (json['traceSamplingRate'] as num?)?.toDouble() ??
           DefaultConfig.traceSamplingRate,
-      trackActivityLoadTime: json['trackActivityLoadTime'] as bool? ??
-          DefaultConfig.trackActivityLoadTime,
-      trackFragmentLoadTime: json['trackFragmentLoadTime'] as bool? ??
-          DefaultConfig.trackFragmentLoadTime,
       maxDiskUsageInMb: (json['maxDiskUsageInMb'] as num?)?.toInt() ??
           DefaultConfig.maxDiskUsageInMb,
-      trackViewControllerLoadTime:
-          json['trackViewControllerLoadTime'] as bool? ??
-              DefaultConfig.trackViewControllerLoadTime,
+      coldLaunchSamplingRate:
+          (json['coldLaunchSamplingRate'] as num?)?.toDouble() ??
+              DefaultConfig.coldLaunchSamplingRate,
+      warmLaunchSamplingRate:
+          (json['warmLaunchSamplingRate'] as num?)?.toDouble() ??
+              DefaultConfig.warmLaunchSamplingRate,
+      hotLaunchSamplingRate:
+          (json['hotLaunchSamplingRate'] as num?)?.toDouble() ??
+              DefaultConfig.hotLaunchSamplingRate,
+      journeySamplingRate: (json['journeySamplingRate'] as num?)?.toDouble() ??
+          DefaultConfig.journeySamplingRate,
     );
 
 Map<String, dynamic> _$MeasureConfigToJson(MeasureConfig instance) =>
@@ -64,8 +68,9 @@ Map<String, dynamic> _$MeasureConfigToJson(MeasureConfig instance) =>
       'samplingRateForErrorFreeSessions':
           instance.samplingRateForErrorFreeSessions,
       'traceSamplingRate': instance.traceSamplingRate,
-      'trackActivityLoadTime': instance.trackActivityLoadTime,
-      'trackFragmentLoadTime': instance.trackFragmentLoadTime,
-      'trackViewControllerLoadTime': instance.trackViewControllerLoadTime,
       'maxDiskUsageInMb': instance.maxDiskUsageInMb,
+      'coldLaunchSamplingRate': instance.coldLaunchSamplingRate,
+      'warmLaunchSamplingRate': instance.warmLaunchSamplingRate,
+      'hotLaunchSamplingRate': instance.hotLaunchSamplingRate,
+      'journeySamplingRate': instance.journeySamplingRate,
     };

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -102,9 +102,9 @@ final class MeasureInitializer {
         samplingRateForErrorFreeSessions:
             inputConfig.samplingRateForErrorFreeSessions,
         traceSamplingRate: inputConfig.traceSamplingRate,
-        trackActivityLoadTime: inputConfig.trackActivityLoadTime,
-        trackFragmentLoadTime: inputConfig.trackFragmentLoadTime,
-        trackViewControllerLoadTime: inputConfig.trackViewControllerLoadTime,
+        coldLaunchSamplingRate: inputConfig.coldLaunchSamplingRate,
+        warmLaunchSamplingRate: inputConfig.warmLaunchSamplingRate,
+        hotLaunchSamplingRate: inputConfig.hotLaunchSamplingRate,
         autoStart: inputConfig.autoStart,
       ),
     );

--- a/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
@@ -15,11 +15,8 @@ class FakeConfigProvider implements ConfigProvider {
   double _samplingRateForErrorFreeSessions = 0.0;
   double _traceSamplingRate = 0.0;
   bool _trackActivityIntentData = false;
-  bool _trackActivityLoadTime = false;
-  bool _trackFragmentLoadTime = false;
   bool _trackHttpBody = false;
   bool _trackHttpHeaders = false;
-  bool _trackViewControllerLoadTime = false;
   bool _autoStart = true;
   int _maxAttachmentsInBugReport = 5;
   int _maxDescriptionLengthInBugReport = 1000;
@@ -30,6 +27,10 @@ class FakeConfigProvider implements ConfigProvider {
   int _maxUserDefinedAttributeValueLength = 100;
   int _maxUserDefinedAttributeKeyLength = 256;
   int _maxUserDefinedAttributesPerEvent = 256;
+  double _coldLaunchSamplingRate = 0.01;
+  double _warmLaunchSamplingRate = 0.01;
+  double _hotLaunchSamplingRate = 0.01;
+  double _journeySamplingRate = 0;
 
   // Getters
   @override
@@ -77,19 +78,10 @@ class FakeConfigProvider implements ConfigProvider {
   bool get trackActivityIntentData => _trackActivityIntentData;
 
   @override
-  bool get trackActivityLoadTime => _trackActivityLoadTime;
-
-  @override
-  bool get trackFragmentLoadTime => _trackFragmentLoadTime;
-
-  @override
   bool get trackHttpBody => _trackHttpBody;
 
   @override
   bool get trackHttpHeaders => _trackHttpHeaders;
-
-  @override
-  bool get trackViewControllerLoadTime => _trackViewControllerLoadTime;
 
   @override
   int get maxAttachmentsInBugReport => _maxAttachmentsInBugReport;
@@ -117,6 +109,18 @@ class FakeConfigProvider implements ConfigProvider {
 
   @override
   int get maxUserDefinedAttributesPerEvent => _maxUserDefinedAttributesPerEvent;
+
+  @override
+  double get coldLaunchSamplingRate => _coldLaunchSamplingRate;
+
+  @override
+  double get warmLaunchSamplingRate => _warmLaunchSamplingRate;
+
+  @override
+  double get hotLaunchSamplingRate => _hotLaunchSamplingRate;
+
+  @override
+  double get journeySamplingRate => _journeySamplingRate;
 
   // Setters
   set autoInitializeNativeSDK(bool value) => _autoInitializeNativeSDK = value;
@@ -153,16 +157,9 @@ class FakeConfigProvider implements ConfigProvider {
 
   set trackActivityIntentData(bool value) => _trackActivityIntentData = value;
 
-  set trackActivityLoadTime(bool value) => _trackActivityLoadTime = value;
-
-  set trackFragmentLoadTime(bool value) => _trackFragmentLoadTime = value;
-
   set trackHttpBody(bool value) => _trackHttpBody = value;
 
   set trackHttpHeaders(bool value) => _trackHttpHeaders = value;
-
-  set trackViewControllerLoadTime(bool value) =>
-      _trackViewControllerLoadTime = value;
 
   set autoStart(bool value) => _autoStart = value;
 
@@ -186,6 +183,14 @@ class FakeConfigProvider implements ConfigProvider {
   set maxUserDefinedAttributeKeyLength(int value) => _maxUserDefinedAttributeKeyLength = value;
 
   set maxUserDefinedAttributesPerEvent(int value) => _maxUserDefinedAttributesPerEvent = value;
+
+  set coldLaunchSamplingRate(double value) => _coldLaunchSamplingRate = value;
+
+  set warmLaunchSamplingRate(double value) => _warmLaunchSamplingRate = value;
+
+  set hotLaunchSamplingRate(double value) => _hotLaunchSamplingRate = value;
+
+  set journeySamplingRate(double value) => _journeySamplingRate = value;
 
   // Methods
   @override


### PR DESCRIPTION
# Description

- Adds `coldLaunchSamplingRate` to config, defaults to 0.0001 which is 0.01%.
- Adds `warmLaunchSamplingRate` to config, defaults to 0.0001 which is 0.01%.
- Adds `hotLaunchSamplingRate` to config, defaults to 0.0001 which is 0.01%.
- Adds `journeySamplingRate` to config, defaults to 0.
- Removes `trackActivityLoadTime` from config, standard traceSampingRate applies.
- Removes `trackFragmentLoadTime` from config, standard traceSampingRate applies.
- Removes `trackViewControllerLoadTime` from config, standard traceSampingRate applies.


## Related issue
References #2919 



