### PR TITLE
Update consumer-rules.pro to modify keep attributes

### DIFF
--- a/android/measure/consumer-rules.pro
+++ b/android/measure/consumer-rules.pro
@@ -1,5 +1,4 @@
 -keepattributes SourceFile,LineNumberTable
--renamesourcefileattribute SourceFile
 -keep class sh.measure.android.NativeBridgeImpl { *; }
 
 # Required to check if okhttp is present in runtime classpath


### PR DESCRIPTION
# Description

Fix for:

> The consumer keep rules at measure-android-0.14.0/proguard.txt (from sh.measure:measure-android:0.14.0) contains a global option which should not be specified in library consumer rules: -renamesourcefileattribute



