### PR TITLE
fix(backend): move to async ingestion flow for higher throughput

### DIFF
--- a/backend/api/concur/wait.go
+++ b/backend/api/concur/wait.go
@@ -1,0 +1,9 @@
+package concur
+
+import "sync"
+
+// GlobalWg is a process wide wait group.
+//
+// Used for synchronizing various concurrent
+// operations.
+var GlobalWg sync.WaitGroup

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -3,6 +3,7 @@ package measure
 import (
 	"backend/api/ambient"
 	"backend/api/chrono"
+	"backend/api/concur"
 	"backend/api/event"
 	"backend/api/filter"
 	"backend/api/group"
@@ -37,6 +38,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/leporo/sqlf"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
 )
 
 // maxBatchSize is the maximum allowed payload
@@ -84,7 +86,7 @@ type eventreq struct {
 	// teamId is the id of the team
 	teamId uuid.UUID
 	// seen indicates whether this request batch
-	// was prevously ingested
+	// was previously ingested
 	seen bool
 	// osName is operating system runtime of the SDK
 	osName string
@@ -97,7 +99,7 @@ type eventreq struct {
 	// exceptionIds is a list of all unhandled exception
 	// event ids
 	exceptionIds []int
-	// anrIds is a list of all ANR event ids
+	// anrIds is a list of all ANR event IDs
 	anrIds []int
 	// size keeps track of the ingest payload size
 	size int64
@@ -736,6 +738,15 @@ func (e *eventreq) countMetrics() (sessionCount, eventCount, spanCount, traceCou
 	return sessionCount, eventCount, spanCount, traceCount, attachmentCount
 }
 
+// onboardable determines if the ingest batch
+// meets the conditions for onboarding the app.
+func (e eventreq) onboardable() (ok bool) {
+	if len(e.events) > 0 || len(e.spans) > 0 {
+		ok = true
+	}
+	return
+}
+
 // remember stores the ingest batch record for future idempotency
 func (e eventreq) remember(ctx context.Context) (err error) {
 	stmt := sqlf.InsertInto("ingested_batches").
@@ -772,6 +783,36 @@ func (e eventreq) hasAttachmentBlobs() bool {
 // contains attachment upload infos to be processed.
 func (e eventreq) hasAttachmentUploadInfos() bool {
 	return len(e.attachmentUploadInfos) > 0
+}
+
+// getOSName extracts the operating system name
+// of the app from ingest batch.
+func (e eventreq) getOSName() (osName string) {
+	if len(e.events) > 0 {
+		return strings.ToLower(e.events[0].Attribute.OSName)
+	}
+
+	return strings.ToLower(e.spans[0].Attributes.OSName)
+}
+
+// getOSVersion extracts the operating system version
+// of the app from ingest batch.
+func (e eventreq) getOSVersion() (osVersion string) {
+	if len(e.events) > 0 {
+		return strings.ToLower(e.events[0].Attribute.OSVersion)
+	}
+
+	return strings.ToLower(e.spans[0].Attributes.OSVersion)
+}
+
+// getAppUniqueID extracts the app's unique identifier from
+// ingest batch.
+func (e eventreq) getAppUniqueID() (appUniqueID string) {
+	if len(e.events) > 0 {
+		return strings.ToLower(e.events[0].Attribute.AppUniqueID)
+	}
+
+	return strings.ToLower(e.spans[0].Attributes.AppUniqueID)
 }
 
 // getUnhandledExceptions returns unhandled exceptions
@@ -2395,9 +2436,15 @@ func PutEvents(c *gin.Context) {
 		return
 	}
 
-	ctx = ambient.WithTeamId(context.Background(), app.TeamId)
-	ingestCtx, cancel := context.WithTimeout(ctx, ingestCtxTimeout)
-	defer cancel()
+	if isJsonRequest {
+		c.JSON(http.StatusOK, IngestResponse{
+			AttachmentUploadInfo: eventReq.attachmentUploadInfos,
+		})
+	} else {
+		c.JSON(http.StatusAccepted, gin.H{"ok": "accepted"})
+	}
+
+	ingestCtx := ambient.WithTeamId(context.Background(), app.TeamId)
 
 	ingestTracer := otel.Tracer("ingest-tracer")
 	ingestCtx, ingestSpan := ingestTracer.Start(ingestCtx, "ingest")
@@ -2538,197 +2585,180 @@ func PutEvents(c *gin.Context) {
 		genSignedURLsSpan.End()
 	}
 
-	_, ingestEventsSpan := ingestTracer.Start(ingestCtx, "ingest-events")
-	defer ingestEventsSpan.End()
+	concur.GlobalWg.Add(1)
 
-	if err := eventReq.ingestEvents(ingestCtx); err != nil {
-		msg := `failed to ingest events`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
+	go func() {
+		defer concur.GlobalWg.Done()
 
-	ingestEventsSpan.End()
+		var ingestGroup errgroup.Group
 
-	_, ingestSpansSpan := ingestTracer.Start(ingestCtx, "ingest-spans")
-	defer ingestSpansSpan.End()
+		ingestGroup.Go(func() error {
+			_, ingestEventsSpan := ingestTracer.Start(ingestCtx, "ingest-events")
+			defer ingestEventsSpan.End()
+			if err := eventReq.ingestEvents(ingestCtx); err != nil {
+				fmt.Println(`failed to ingest events`, err)
+				return err
+			}
 
-	if err := eventReq.ingestSpans(ingestCtx); err != nil {
-		msg := `failed to ingest spans`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	ingestSpansSpan.End()
-
-	// start span to trace bucketing unhandled exceptions
-	_, bucketUnhandledExceptionsSpan := ingestTracer.Start(ingestCtx, "bucket-unhandled-exceptions")
-
-	defer bucketUnhandledExceptionsSpan.End()
-
-	if err := eventReq.bucketUnhandledExceptions(ingestCtx); err != nil {
-		msg := `failed to bucket unhandled exceptions`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	bucketUnhandledExceptionsSpan.End()
-
-	// start span to trace bucketing ANRs
-	_, bucketAnrsSpan := ingestTracer.Start(ingestCtx, "bucket-anrs")
-
-	defer bucketAnrsSpan.End()
-
-	if err := eventReq.bucketANRs(ingestCtx); err != nil {
-		msg := `failed to bucket anrs`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	bucketAnrsSpan.End()
-
-	if !app.Onboarded && len(eventReq.events) > 0 {
-		_, onboardAppSpan := ingestTracer.Start(ingestCtx, "onboard-app")
-		defer onboardAppSpan.End()
-
-		tx, err := server.Server.PgPool.BeginTx(ingestCtx, pgx.TxOptions{
-			IsoLevel: pgx.ReadCommitted,
+			return nil
 		})
 
-		if err != nil {
-			msg := `failed to acquire transaction while onboarding app`
-			fmt.Println(msg, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
+		ingestGroup.Go(func() error {
+			_, ingestSpansSpan := ingestTracer.Start(ingestCtx, "ingest-spans")
+			defer ingestSpansSpan.End()
+			if err := eventReq.ingestSpans(ingestCtx); err != nil {
+				fmt.Println(`failed to ingest spans`, err)
+				return err
+			}
+
+			return nil
+		})
+
+		if err := ingestGroup.Wait(); err != nil {
+			fmt.Println("failed to ingest", err)
 			return
 		}
 
-		defer tx.Rollback(ingestCtx)
+		var bucketGroup errgroup.Group
+		bucketGroup.Go(func() error {
+			// start span to trace bucketing unhandled exceptions
+			_, bucketUnhandledExceptionsSpan := ingestTracer.Start(ingestCtx, "bucket-unhandled-exceptions")
 
-		firstEvent := eventReq.events[0]
-		uniqueID := firstEvent.Attribute.AppUniqueID
-		osName := strings.ToLower(firstEvent.Attribute.OSName)
-		version := firstEvent.Attribute.AppVersion
+			defer bucketUnhandledExceptionsSpan.End()
 
-		if err := app.Onboard(ingestCtx, &tx, uniqueID, osName, version); err != nil {
-			msg := `failed to onboard app`
-			fmt.Println(msg, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
+			if err := eventReq.bucketUnhandledExceptions(ingestCtx); err != nil {
+				fmt.Println(`failed to bucket unhandled exceptions`, err)
+				return err
+			}
+
+			return nil
+		})
+
+		bucketGroup.Go(func() error {
+			// start span to trace bucketing ANRs
+			_, bucketAnrsSpan := ingestTracer.Start(ingestCtx, "bucket-anrs")
+			defer bucketAnrsSpan.End()
+
+			if err := eventReq.bucketANRs(ingestCtx); err != nil {
+				fmt.Println(`failed to bucket anrs`, err)
+				return err
+			}
+
+			return nil
+		})
+
+		if err := bucketGroup.Wait(); err != nil {
+			fmt.Println("failed to bucket issues", err)
 			return
 		}
+	}()
 
-		if err := tx.Commit(ingestCtx); err != nil {
-			msg := `failed to commit app onboard transaction`
-			fmt.Println(msg, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
+	if eventReq.onboardable() && !app.Onboarded {
+		concur.GlobalWg.Add(1)
+		go func() {
+			defer concur.GlobalWg.Done()
+			_, onboardAppSpan := ingestTracer.Start(ingestCtx, "onboard-app")
+			defer onboardAppSpan.End()
+
+			tx, err := server.Server.PgPool.BeginTx(ingestCtx, pgx.TxOptions{
+				IsoLevel: pgx.ReadCommitted,
 			})
-			return
+			defer tx.Rollback(ingestCtx)
+
+			if err != nil {
+				fmt.Println(`failed to acquire transaction while onboarding app`, err)
+				return
+			}
+
+			uniqueID := eventReq.getAppUniqueID()
+			osName := eventReq.getOSName()
+			version := eventReq.getOSVersion()
+
+			if err := app.Onboard(ingestCtx, &tx, uniqueID, osName, version); err != nil {
+				fmt.Println(`failed to onboard app`, err)
+				return
+			}
+
+			if err := tx.Commit(ingestCtx); err != nil {
+				fmt.Println(`failed to commit app onboard transaction`, err)
+				return
+			}
+		}()
+	}
+
+	var metricsGroup errgroup.Group
+
+	metricsGroup.Go(func() error {
+		_, retentionPeriodSpan := ingestTracer.Start(ingestCtx, "get-retention-period")
+		defer retentionPeriodSpan.End()
+
+		// get retention period for app
+		var retentionPeriod int
+		retentionPeriodQuery := sqlf.PostgreSQL.From("app_settings").
+			Select("retention_period").
+			Where("app_id = ?", app.ID)
+		defer retentionPeriodQuery.Close()
+
+		if err := server.Server.PgPool.QueryRow(ingestCtx, retentionPeriodQuery.String(), retentionPeriodQuery.Args()...).Scan(&retentionPeriod); err != nil {
+			fmt.Println(`failed to get app retention period`, err)
+			return err
 		}
 
-		onboardAppSpan.End()
-	}
+		retentionPeriodSpan.End()
 
-	_, retentionPeriodSpan := ingestTracer.Start(ingestCtx, "get-retention-period")
-	defer retentionPeriodSpan.End()
+		_, ingestMetricsSpan := ingestTracer.Start(ingestCtx, "ingest-metrics")
+		defer ingestMetricsSpan.End()
 
-	// get retention period for app
-	var retentionPeriod int
-	retentionPeriodQuery := sqlf.PostgreSQL.From("app_settings").
-		Select("retention_period").
-		Where("app_id = ?", app.ID)
-	defer retentionPeriodQuery.Close()
+		sessionCount, eventCount, spanCount, traceCount, attachmentCount := eventReq.countMetrics()
+		sessionCountDays := sessionCount * uint32(retentionPeriod)
+		eventCountDays := eventCount * uint32(retentionPeriod)
+		spanCountDays := spanCount * uint32(retentionPeriod)
+		traceCountDays := traceCount * uint32(retentionPeriod)
+		attachmentCountDays := attachmentCount * uint32(retentionPeriod)
 
-	if err := server.Server.PgPool.QueryRow(ingestCtx, retentionPeriodQuery.String(), retentionPeriodQuery.Args()...).Scan(&retentionPeriod); err != nil {
-		msg := `failed to get app retention period`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
+		// insert metrics into clickhouse table
+		insertMetricsIngestionSelectStmt := sqlf.
+			Select("? AS team_id", eventReq.teamId).
+			Select("? AS app_id", app.ID).
+			Select("? AS timestamp", time.Now()).
+			Select("sumState(CAST(? AS UInt32)) AS session_count", sessionCount).
+			Select("sumState(CAST(? AS UInt32)) AS event_count", eventCount).
+			Select("sumState(CAST(? AS UInt32)) AS span_count", spanCount).
+			Select("sumState(CAST(? AS UInt32)) AS trace_count", traceCount).
+			Select("sumState(CAST(? AS UInt32)) AS attachment_count", attachmentCount).
+			Select("sumState(CAST(? AS UInt32)) AS session_count_days", sessionCountDays).
+			Select("sumState(CAST(? AS UInt32)) AS event_count_days", eventCountDays).
+			Select("sumState(CAST(? AS UInt32)) AS span_count_days", spanCountDays).
+			Select("sumState(CAST(? AS UInt32)) AS trace_count_days", traceCountDays).
+			Select("sumState(CAST(? AS UInt32)) AS attachment_count_days", attachmentCountDays)
+		selectSQL := insertMetricsIngestionSelectStmt.String()
+		args := insertMetricsIngestionSelectStmt.Args()
+		defer insertMetricsIngestionSelectStmt.Close()
+		insertMetricsIngestionFullStmt := "INSERT INTO ingestion_metrics " + selectSQL
+
+		if err := server.Server.ChPool.AsyncInsert(ingestCtx, insertMetricsIngestionFullStmt, true, args...); err != nil {
+			fmt.Println(`failed to insert ingestion metrics`, err)
+			return err
+		}
+		return nil
+	})
+
+	if err := metricsGroup.Wait(); err != nil {
+		fmt.Println(`failed to count ingestion metrics`, err)
 		return
 	}
 
-	retentionPeriodSpan.End()
+	concur.GlobalWg.Add(1)
+	go func() {
+		defer concur.GlobalWg.Done()
+		_, rememberIngestSpan := ingestTracer.Start(ingestCtx, "remember-ingest")
+		defer rememberIngestSpan.End()
 
-	_, ingestMetricsSpan := ingestTracer.Start(ingestCtx, "ingest-metrics")
-	defer ingestMetricsSpan.End()
-
-	sessionCount, eventCount, spanCount, traceCount, attachmentCount := eventReq.countMetrics()
-	sessionCountDays := sessionCount * uint32(retentionPeriod)
-	eventCountDays := eventCount * uint32(retentionPeriod)
-	spanCountDays := spanCount * uint32(retentionPeriod)
-	traceCountDays := traceCount * uint32(retentionPeriod)
-	attachmentCountDays := attachmentCount * uint32(retentionPeriod)
-
-	// insert metrics into clickhouse table
-	insertMetricsIngestionSelectStmt := sqlf.
-		Select("? AS team_id", eventReq.teamId).
-		Select("? AS app_id", app.ID).
-		Select("? AS timestamp", time.Now()).
-		Select("sumState(CAST(? AS UInt32)) AS session_count", sessionCount).
-		Select("sumState(CAST(? AS UInt32)) AS event_count", eventCount).
-		Select("sumState(CAST(? AS UInt32)) AS span_count", spanCount).
-		Select("sumState(CAST(? AS UInt32)) AS trace_count", traceCount).
-		Select("sumState(CAST(? AS UInt32)) AS attachment_count", attachmentCount).
-		Select("sumState(CAST(? AS UInt32)) AS session_count_days", sessionCountDays).
-		Select("sumState(CAST(? AS UInt32)) AS event_count_days", eventCountDays).
-		Select("sumState(CAST(? AS UInt32)) AS span_count_days", spanCountDays).
-		Select("sumState(CAST(? AS UInt32)) AS trace_count_days", traceCountDays).
-		Select("sumState(CAST(? AS UInt32)) AS attachment_count_days", attachmentCountDays)
-	selectSQL := insertMetricsIngestionSelectStmt.String()
-	args := insertMetricsIngestionSelectStmt.Args()
-	defer insertMetricsIngestionSelectStmt.Close()
-	insertMetricsIngestionFullStmt := "INSERT INTO ingestion_metrics " + selectSQL
-
-	if err := server.Server.ChPool.AsyncInsert(ingestCtx, insertMetricsIngestionFullStmt, true, args...); err != nil {
-		msg := `failed to insert ingestion metrics`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	ingestMetricsSpan.End()
-
-	_, rememberIngestSpan := ingestTracer.Start(ingestCtx, "remember-ingest")
-	defer rememberIngestSpan.End()
-
-	// Remember that this batch was ingested, so if same
-	// batch is seen again, we can skip ingesting it.
-	if err := eventReq.remember(ingestCtx); err != nil {
-		msg := `failed to remember event request`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   msg,
-			"details": err,
-		})
-		return
-	}
-
-	rememberIngestSpan.End()
-
-	if isJsonRequest {
-		c.JSON(http.StatusOK, IngestResponse{
-			AttachmentUploadInfo: eventReq.attachmentUploadInfos,
-		})
-	} else {
-		c.JSON(http.StatusAccepted, gin.H{"ok": "accepted"})
-	}
+		// Remember that this batch was ingested, so if same
+		// batch is seen again, we can skip ingesting it.
+		if err := eventReq.remember(ingestCtx); err != nil {
+			fmt.Println(`failed to remember event request`, err)
+			return
+		}
+	}()
 }

--- a/backend/api/measure/event_test.go
+++ b/backend/api/measure/event_test.go
@@ -1,0 +1,167 @@
+package measure
+
+import (
+	"backend/api/event"
+	"backend/api/span"
+	"testing"
+)
+
+func TestEventReqOnboardable(t *testing.T) {
+	// Not onboardable when no events or spans
+	{
+		eventReq := &eventreq{}
+
+		if eventReq.onboardable() {
+			t.Errorf("Expected eventReq to be not onboardable")
+		}
+	}
+
+	// Onboardable when at least 1 event
+	{
+		eventReq := &eventreq{
+			events: []event.EventField{
+				{
+					Type: event.TypeString,
+				},
+			},
+		}
+
+		if !eventReq.onboardable() {
+			t.Errorf("Expected eventReq to be onboardable")
+		}
+	}
+
+	// Onboardable when at least 1 span
+	{
+		eventReq := &eventreq{
+			spans: []span.SpanField{
+				{
+					SpanName: "some-span",
+				},
+			},
+		}
+
+		if !eventReq.onboardable() {
+			t.Errorf("Expected eventReq to be onboardable")
+		}
+	}
+}
+
+func TestEventReqGetOSName(t *testing.T) {
+	// Can extract os name from ingest batch containing
+	// only events.
+	{
+		eventReq := &eventreq{
+			events: []event.EventField{
+				{
+					Type: event.TypeString,
+					Attribute: event.Attribute{
+						OSName: "Android",
+					},
+				},
+			},
+		}
+
+		osName := eventReq.getOSName()
+		if osName != "android" {
+			t.Errorf("Expected OS name to be 'android', got '%s'", osName)
+		}
+	}
+
+	// Can extract os version from ingest batch containing
+	// only events.
+	{
+		eventReq := &eventreq{
+			events: []event.EventField{
+				{
+					Type: event.TypeString,
+					Attribute: event.Attribute{
+						OSVersion: "33",
+					},
+				},
+			},
+		}
+
+		osVersion := eventReq.getOSVersion()
+		if osVersion != "33" {
+			t.Errorf("Expected OS version to be '33', got '%s'", osVersion)
+		}
+	}
+
+	// Can extract app unique id from ingest batch
+	// containing only events.
+	{
+		eventReq := &eventreq{
+			events: []event.EventField{
+				{
+					Type: event.TypeString,
+					Attribute: event.Attribute{
+						AppUniqueID: "sh.measure.test",
+					},
+				},
+			},
+		}
+
+		appUniqueID := eventReq.getAppUniqueID()
+		if appUniqueID != "sh.measure.test" {
+			t.Errorf("Expected app unique id to be 'sh.measure.test', got '%s'", appUniqueID)
+		}
+	}
+
+	// Can extract os name from ingest batch containing
+	// only spans.
+	{
+		eventReq := &eventreq{
+			spans: []span.SpanField{
+				{
+					Attributes: span.SpanAttributes{
+						OSName: "Android",
+					},
+				},
+			},
+		}
+
+		osName := eventReq.getOSName()
+		if osName != "android" {
+			t.Errorf("Expected OS Name to be 'android', got '%s'", osName)
+		}
+	}
+
+	// Can extract os version from ingest batch containing
+	// only spans.
+	{
+		eventReq := &eventreq{
+			spans: []span.SpanField{
+				{
+					Attributes: span.SpanAttributes{
+						OSVersion: "33",
+					},
+				},
+			},
+		}
+
+		osVersion := eventReq.getOSVersion()
+		if osVersion != "33" {
+			t.Errorf("Expected OS version to be '33', got '%s'", osVersion)
+		}
+	}
+
+	// Can extract app unique id from ingest batch
+	// containing only spans.
+	{
+		eventReq := &eventreq{
+			spans: []span.SpanField{
+				{
+					Attributes: span.SpanAttributes{
+						AppUniqueID: "sh.measure.test",
+					},
+				},
+			},
+		}
+
+		appUniqueID := eventReq.getAppUniqueID()
+		if appUniqueID != "sh.measure.test" {
+			t.Errorf("Expected app unique id to be 'sh.measure.test', got '%s'", appUniqueID)
+		}
+	}
+}

--- a/self-host/compose.prod.yml
+++ b/self-host/compose.prod.yml
@@ -136,3 +136,5 @@ services:
       options:
         max-size: 10m
         max-file: 5
+
+  clickstack: !reset

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -445,6 +445,14 @@ services:
         source: ./clickhouse/config/config.xml
         target: /etc/clickhouse-server/config.d/config.xml
 
+  clickstack:
+    image: docker.hyperdx.io/hyperdx/hyperdx-local
+    profiles:
+      - debug
+    ports:
+      - 9090:8080
+      - 4317:4317
+
 volumes:
   clickhouse-volume:
   migrator-volume:


### PR DESCRIPTION
## Summary

This PR moves to an asynchronous ingestion pipeline to decrease latency and increase throughput.

## Tasks

- [x] Clients receive response earlier in PUT `/events`
- [x] Clients don't receive 500 responses once validation succeeds and ingestion is queued
- [x] Ingestion now happens concurrently without losing dependency of operations
- [x] App onboarding now happens for events or spans both
- [x] API service now shuts down gracefully on receiving `SIGTERM`, while waiting for all background operations to complete for a limited duration
- [x] Tracing in ingestion pipeline is more granular, tracing all major operations
- [x] Add ClickStack behind `debug` profile in compose for easy observability
- [x] Add tests for new app onboarding methods

## See also

- fixes #2947 
- fixes #2617