### PR TITLE
chore(backend): no waiting for background tasks in debug

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -174,8 +174,13 @@ func main() {
 	<-quit
 	fmt.Println("Shutting down API service...")
 
+	shutdownTimeout := 9 * time.Second
+	if gin.Mode() == gin.DebugMode {
+		shutdownTimeout = 0 * time.Second
+	}
+
 	// Graceful shutdown with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
## Summary

This PR prevents waiting for API service background tasks to finish when shutting down server in debug mode.

## Tasks

- [x] Don't wait for background tasks to finish when shutting down server in debug mode

## See also

- fixes #2977