### PR TITLE
chore(backend): remove redis command from production compose

### DIFF
--- a/self-host/compose.prod.yml
+++ b/self-host/compose.prod.yml
@@ -137,18 +137,12 @@ services:
         max-size: 10m
         max-file: 5
 
-  clickstack: !reset
-
   redis:
-    command: >
-      valkey-server
-      --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
-      --appendonly yes
-      --appendfsync everysec
     restart: unless-stopped
     logging:
       driver: local
       options:
         max-size: 10m
         max-file: 5
+
+  clickstack: !reset


### PR DESCRIPTION
## Summary

This PR removes unnecessary valkey command from production compose file.

## See also

- fixes #2975