### PR TITLE
chore(frontend): handle nan for delta & value separately in launch metrics

### DIFF
--- a/frontend/dashboard/__tests__/components/metrics_card_test.tsx
+++ b/frontend/dashboard/__tests__/components/metrics_card_test.tsx
@@ -126,6 +126,7 @@ describe('MetricsCard', () => {
         type: 'app_start_time',
         status: MetricsApiStatus.Success,
         noData: false,
+        noDelta: false,
         value: 1200,
         delta: 0.8,
         launchType: 'Cold',
@@ -327,6 +328,24 @@ describe('MetricsCard', () => {
             expect(trendingDownIcon).toHaveClass('text-green-600')
             const trendingTextFaster = screen.getByText('0.7x faster')
             expect(trendingTextFaster).toHaveClass('text-green-600')
+        })
+
+        it('should not show delta trend when noDelta is true', () => {
+            // Test slower performance (delta > 1)
+            const slowerProps = createAppStartTimeProps({ delta: 1.3, noDelta: true })
+            const { rerender } = render(<MetricsCard {...slowerProps} />)
+            const trendingUpIcon = screen.queryByTestId('trending-up-icon')
+            expect(trendingUpIcon).toBeNull()
+            const trendingText = screen.queryByText('1.3x slower')
+            expect(trendingText).toBeNull()
+
+            // Test faster performance (0 < delta < 1)
+            const fasterProps = createAppStartTimeProps({ delta: 0.7, noDelta: true })
+            rerender(<MetricsCard {...fasterProps} />)
+            const trendingDownIcon = screen.queryByTestId('trending-down-icon')
+            expect(trendingDownIcon).toBeNull()
+            const trendingTextFaster = screen.queryByText('0.7x faster')
+            expect(trendingTextFaster).toBeNull()
         })
     })
 

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -469,6 +469,7 @@ export const emptyMetrics = {
     delta: 0,
     nan: false,
     p95: 0,
+    delta_nan: false,
   },
   crash_free_sessions: {
     crash_free_sessions: 0,
@@ -479,6 +480,7 @@ export const emptyMetrics = {
     delta: 0,
     nan: false,
     p95: 0,
+    delta_nan: false,
   },
   perceived_anr_free_sessions: {
     perceived_anr_free_sessions: 0,
@@ -500,6 +502,7 @@ export const emptyMetrics = {
     delta: 0,
     nan: false,
     p95: 0,
+    delta_nan: false,
   },
 }
 

--- a/frontend/dashboard/app/components/metrics_card.tsx
+++ b/frontend/dashboard/app/components/metrics_card.tsx
@@ -79,6 +79,7 @@ export interface AppStartTimeProps extends BaseMetricsCardProps {
     type: 'app_start_time'
     value: number
     delta: number
+    noDelta: boolean
     launchType: string
 }
 
@@ -273,7 +274,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
                     <>
                         <p className={STYLES.text.mainValue}> {startTimeProps.value}ms</p>
                         <div className={STYLES.layout.spacer} />
-                        {getAppStartTimeDeltaWithTrendIcon(startTimeProps.delta)}
+                        {!startTimeProps.noDelta && getAppStartTimeDeltaWithTrendIcon(startTimeProps.delta)}
                     </>
                 )
 

--- a/frontend/dashboard/app/components/metrics_overview.tsx
+++ b/frontend/dashboard/app/components/metrics_overview.tsx
@@ -86,6 +86,7 @@ const MetricsOverview: React.FC<MetricsOverviewProps> = ({ filters }) => {
         status={metricsApiStatus}
         launchType="Cold"
         noData={metrics.cold_launch.nan}
+        noDelta={metrics.cold_launch.delta_nan}
         value={metrics.cold_launch.p95}
         delta={metrics.cold_launch.delta}
       />
@@ -95,6 +96,7 @@ const MetricsOverview: React.FC<MetricsOverviewProps> = ({ filters }) => {
         status={metricsApiStatus}
         launchType="Warm"
         noData={metrics.warm_launch.nan}
+        noDelta={metrics.warm_launch.delta_nan}
         value={metrics.warm_launch.p95}
         delta={metrics.warm_launch.delta}
       />
@@ -104,6 +106,7 @@ const MetricsOverview: React.FC<MetricsOverviewProps> = ({ filters }) => {
         status={metricsApiStatus}
         launchType="Hot"
         noData={metrics.hot_launch.nan}
+        noDelta={metrics.hot_launch.delta_nan}
         value={metrics.hot_launch.p95}
         delta={metrics.hot_launch.delta}
       />


### PR DESCRIPTION
# Description

Handles `NaN` for delta & value separately in launch metrics

## Related issue
Closes #2986



