### PR TITLE
feat(ios): expose measure init api for cpp app delegate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,18 +16,9 @@ let package = Package(
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2")
     ],
     targets: [
-        // ObjC target
-        .target(
-            name: "MeasureObjC",
-            path: "ios/Sources/MeasureSDK/ObjC",
-            publicHeadersPath: "include"
-        ),
-
-        // Swift target, depends on ObjC + CrashReporter
         .target(
             name: "Measure",
             dependencies: [
-                "MeasureObjC",
                 .product(name: "CrashReporter", package: "plcrashreporter")
             ],
             path: "ios/Sources/MeasureSDK/Swift",
@@ -36,6 +27,14 @@ let package = Package(
                 .process("XCDataModel/MeasureModelV1ToV2.xcmappingmodel"),
                 .copy("Resources/PrivacyInfo.xcprivacy")
             ]
+        ),
+        .target(
+            name: "MeasureObjC",
+            dependencies: [
+                "Measure"
+            ],
+            path: "ios/Sources/MeasureSDK/ObjC",
+            publicHeadersPath: "include"
         ),
 
         // Tests

--- a/ios/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/ios/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -7,14 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C9FA806A15BCB89D30447C9E /* Pods_DemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA44E3287417EB36A40797 /* Pods_DemoApp.framework */; };
+		56FF46B98A2BFB3C9D114CE5 /* libPods-DemoApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE0CED9DDFF78CD7BF7B0203 /* libPods-DemoApp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0F410ABC14E1216E170E70F1 /* Pods-DemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoApp.release.xcconfig"; path = "Target Support Files/Pods-DemoApp/Pods-DemoApp.release.xcconfig"; sourceTree = "<group>"; };
 		16AD39D064EC3C19B60117CD /* Pods-DemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoApp.debug.xcconfig"; path = "Target Support Files/Pods-DemoApp/Pods-DemoApp.debug.xcconfig"; sourceTree = "<group>"; };
+		BE0CED9DDFF78CD7BF7B0203 /* libPods-DemoApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DemoApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF5AA24B2E5F2952008993F9 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D8AA44E3287417EB36A40797 /* Pods_DemoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -43,7 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9FA806A15BCB89D30447C9E /* Pods_DemoApp.framework in Frameworks */,
+				56FF46B98A2BFB3C9D114CE5 /* libPods-DemoApp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,7 +53,7 @@
 		525B533876A56B42DFE35D8D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D8AA44E3287417EB36A40797 /* Pods_DemoApp.framework */,
+				BE0CED9DDFF78CD7BF7B0203 /* libPods-DemoApp.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.h
+++ b/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.h
@@ -6,7 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <Measure/MSRViewController.h>
+#import "MSRViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/DemoApp/Podfile
+++ b/ios/DemoApp/Podfile
@@ -3,7 +3,7 @@
 
 target 'DemoApp' do
   # Comment the next line if you don't want to use dynamic frameworks
-  use_frameworks!
+  # use_frameworks!
 
   # Pods for DemoApp
   pod 'measure-sh', :path => '../../'

--- a/ios/DemoApp/Podfile.lock
+++ b/ios/DemoApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - measure-sh (0.7.1):
+  - measure-sh (0.8.1):
     - PLCrashReporter (= 1.11.2)
   - PLCrashReporter (1.11.2)
 
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  measure-sh: 72ce5bd6aad7f50adccb11856d876397f1b1e3cf
+  measure-sh: dbc4c2c505a1392817127d1adc580fdbf2a227eb
   PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
 
-PODFILE CHECKSUM: eca229ccc523688877a34e50f11f504a0fe75bed
+PODFILE CHECKSUM: 828d9701ce9dd588cdabe7bc1a8cb829d2a17f97
 
 COCOAPODS: 1.16.2

--- a/ios/DemoAppSwiftUI/DemoAppSwiftUI.xcodeproj/project.pbxproj
+++ b/ios/DemoAppSwiftUI/DemoAppSwiftUI.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 			isa = PBXGroup;
 			children = (
 				CF9234982E5F3D8D00815D9E /* DemoAppSwiftUI */,
+				CFA732262EF1D1130092CBCF /* Frameworks */,
 				CF9234972E5F3D8D00815D9E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -48,6 +49,13 @@
 				CF9234962E5F3D8D00815D9E /* DemoAppSwiftUI.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CFA732262EF1D1130092CBCF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -101,7 +109,6 @@
 			mainGroup = CF92348D2E5F3D8D00815D9E;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				CF9234A42E5F3DF600815D9E /* XCLocalSwiftPackageReference "../../../measure" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CF9234972E5F3D8D00815D9E /* Products */;
@@ -333,13 +340,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		CF9234A42E5F3DF600815D9E /* XCLocalSwiftPackageReference "../../../measure" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../../measure;
-		};
-/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		CF9234A52E5F3DF600815D9E /* Measure */ = {

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -270,6 +270,11 @@
 		CFB8382F2DB1597B0023592B /* SpanOb+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */; };
 		CFBF626F2DB7ADA200D5ADFB /* SwizzlingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF626E2DB7ADA200D5ADFB /* SwizzlingUtility.swift */; };
 		CFBF62712DB7B38100D5ADFB /* SwizzlingUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF62702DB7B38100D5ADFB /* SwizzlingUtilityTests.swift */; };
+		CFC7CFD82EF1A0EF00F569AA /* MeasureSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = CFC7CFD62EF1A0EF00F569AA /* MeasureSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFC7CFD92EF1A0EF00F569AA /* MeasureSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = CFC7CFD72EF1A0EF00F569AA /* MeasureSDK.m */; };
+		CFC7CFE02EF1A21D00F569AA /* MSRConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CFC7CFDE2EF1A21D00F569AA /* MSRConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFC7CFE12EF1A21D00F569AA /* MSRConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = CFC7CFDF2EF1A21D00F569AA /* MSRConfig.m */; };
+		CFC7CFE32EF1A2CC00F569AA /* ScreenshotMaskingLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = CFC7CFE22EF1A2CC00F569AA /* ScreenshotMaskingLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CFD88C6E2D9E94B40095115E /* SpanProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD88C6B2D9E94B40095115E /* SpanProcessor.swift */; };
 		CFD88C6F2D9E94B40095115E /* MsrSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD88C692D9E94B40095115E /* MsrSpan.swift */; };
 		CFD88C702D9E94B40095115E /* Span.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD88C6A2D9E94B40095115E /* Span.swift */; };
@@ -617,6 +622,11 @@
 		CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		CFBF626E2DB7ADA200D5ADFB /* SwizzlingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlingUtility.swift; sourceTree = "<group>"; };
 		CFBF62702DB7B38100D5ADFB /* SwizzlingUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlingUtilityTests.swift; sourceTree = "<group>"; };
+		CFC7CFD62EF1A0EF00F569AA /* MeasureSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeasureSDK.h; sourceTree = "<group>"; };
+		CFC7CFD72EF1A0EF00F569AA /* MeasureSDK.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MeasureSDK.m; sourceTree = "<group>"; };
+		CFC7CFDE2EF1A21D00F569AA /* MSRConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSRConfig.h; sourceTree = "<group>"; };
+		CFC7CFDF2EF1A21D00F569AA /* MSRConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSRConfig.m; sourceTree = "<group>"; };
+		CFC7CFE22EF1A2CC00F569AA /* ScreenshotMaskingLevel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenshotMaskingLevel.h; sourceTree = "<group>"; };
 		CFD88C692D9E94B40095115E /* MsrSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrSpan.swift; sourceTree = "<group>"; };
 		CFD88C6A2D9E94B40095115E /* Span.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Span.swift; sourceTree = "<group>"; };
 		CFD88C6B2D9E94B40095115E /* SpanProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanProcessor.swift; sourceTree = "<group>"; };
@@ -698,6 +708,9 @@
 			isa = PBXGroup;
 			children = (
 				526D17922D5A1913009A2E90 /* MSRViewController.h */,
+				CFC7CFDE2EF1A21D00F569AA /* MSRConfig.h */,
+				CFC7CFD62EF1A0EF00F569AA /* MeasureSDK.h */,
+				CFC7CFE22EF1A2CC00F569AA /* ScreenshotMaskingLevel.h */,
 			);
 			path = include;
 			sourceTree = "<group>";
@@ -709,6 +722,8 @@
 				526D17942D5A1913009A2E90 /* MSRViewController.m */,
 				CF5AA0682E5ED97A008993F9 /* LifecycleEvent.h */,
 				52B7F19B2D76B423001498BC /* LifecycleManager_Internal.h */,
+				CFC7CFD72EF1A0EF00F569AA /* MeasureSDK.m */,
+				CFC7CFDF2EF1A21D00F569AA /* MSRConfig.m */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -1385,7 +1400,10 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CFC7CFE02EF1A21D00F569AA /* MSRConfig.h in Headers */,
 				52B7F19C2D76B423001498BC /* LifecycleManager_Internal.h in Headers */,
+				CFC7CFD82EF1A0EF00F569AA /* MeasureSDK.h in Headers */,
+				CFC7CFE32EF1A2CC00F569AA /* ScreenshotMaskingLevel.h in Headers */,
 				CF5AA0692E5ED97A008993F9 /* LifecycleEvent.h in Headers */,
 				526D18212D5A1913009A2E90 /* MSRViewController.h in Headers */,
 			);
@@ -1648,6 +1666,7 @@
 				526D18512D5A1913009A2E90 /* StackFrame.swift in Sources */,
 				526D184C2D5A1913009A2E90 /* EventType.swift in Sources */,
 				526D187C2D5A1913009A2E90 /* String+Extension.swift in Sources */,
+				CFC7CFD92EF1A0EF00F569AA /* MeasureSDK.m in Sources */,
 				526D187E2D5A1913009A2E90 /* UIDevice+Extension.swift in Sources */,
 				CF1BB4962DCC7FE300588506 /* BugReportCollector.swift in Sources */,
 				CFD88D0D2DA7968E0095115E /* SpanBuilder.swift in Sources */,
@@ -1692,6 +1711,7 @@
 				526D18882D5A1913009A2E90 /* SignPost.swift in Sources */,
 				529B319B2D5B85FC007A8E45 /* BinaryImage.swift in Sources */,
 				CF1BB4ED2DDB474100588506 /* ScreenshotMaskLevel.swift in Sources */,
+				CFC7CFE12EF1A21D00F569AA /* MSRConfig.m in Sources */,
 				526D18842D5A1913009A2E90 /* LifecycleObserver.swift in Sources */,
 				526D18502D5A1913009A2E90 /* ExceptionDetail.swift in Sources */,
 				526D182E2D5A1913009A2E90 /* NetworkStateAttributeProcessor.swift in Sources */,
@@ -1937,7 +1957,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -2005,7 +2025,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -2045,6 +2065,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2091,6 +2112,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2228,7 +2250,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -2275,6 +2297,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -351,8 +351,10 @@ extension Measure.Measure {
   public static func trackHttpEvent(url: Swift.String, method: Swift.String, startTime: Swift.UInt64, endTime: Swift.UInt64, client: Swift.String = "unknown", statusCode: Swift.Int? = nil, error: (any Swift.Error)? = nil, requestHeaders: [Swift.String : Swift.String]? = nil, responseHeaders: [Swift.String : Swift.String]? = nil, requestBody: Swift.String? = nil, responseBody: Swift.String? = nil)
   #endif
 }
-public struct MSRNetworkInterceptor {
-  public static func enable(on sessionConfiguration: Foundation.URLSessionConfiguration)
+@_inheritsConvenienceInitializers @objc public class MSRNetworkInterceptor : ObjectiveC.NSObject {
+  @objc(enableOn:) public static func enable(on sessionConfiguration: Foundation.URLSessionConfiguration)
+  @objc override dynamic public init()
+  @objc deinit
 }
 public enum AttachmentType : Swift.String, Swift.Codable {
   case screenshot

--- a/ios/Sources/MeasureSDK/ObjC/MSRConfig.m
+++ b/ios/Sources/MeasureSDK/ObjC/MSRConfig.m
@@ -1,0 +1,51 @@
+//
+//  MSRConfig.m
+//  Measure
+//
+//  Created by Adwin Ross on 16/12/25.
+//
+
+#import "MSRConfig.h"
+
+@implementation MSRConfig
+
+- (instancetype)initWithEnableLogging:(BOOL)enableLogging
+        samplingRateForErrorFreeSessions:(float)samplingRateForErrorFreeSessions
+                     traceSamplingRate:(float)traceSamplingRate
+              coldLaunchSamplingRate:(float)coldLaunchSamplingRate
+              warmLaunchSamplingRate:(float)warmLaunchSamplingRate
+                hotLaunchSamplingRate:(float)hotLaunchSamplingRate
+                  journeySamplingRate:(float)journeySamplingRate
+                    trackHttpHeaders:(BOOL)trackHttpHeaders
+                       trackHttpBody:(BOOL)trackHttpBody
+               httpHeadersBlocklist:(NSArray<NSString *> *)httpHeadersBlocklist
+                    httpUrlBlocklist:(NSArray<NSString *> *)httpUrlBlocklist
+                   httpUrlAllowlist:(NSArray<NSString *> *)httpUrlAllowlist
+                           autoStart:(BOOL)autoStart
+                screenshotMaskLevel:(ScreenshotMaskingLevel)screenshotMaskLevel
+             requestHeadersProvider:(id<MsrRequestHeadersProvider>)requestHeadersProvider
+                 maxDiskUsageInMb:(NSNumber *)maxDiskUsageInMb {
+
+    self = [super init];
+    if (self) {
+        _enableLogging = enableLogging;
+        _samplingRateForErrorFreeSessions = samplingRateForErrorFreeSessions;
+        _traceSamplingRate = traceSamplingRate;
+        _coldLaunchSamplingRate = coldLaunchSamplingRate;
+        _warmLaunchSamplingRate = warmLaunchSamplingRate;
+        _hotLaunchSamplingRate = hotLaunchSamplingRate;
+        _journeySamplingRate = journeySamplingRate;
+        _autoStart = autoStart;
+        _trackHttpHeaders = trackHttpHeaders;
+        _trackHttpBody = trackHttpBody;
+        _httpHeadersBlocklist = [httpHeadersBlocklist copy];
+        _httpUrlBlocklist = [httpUrlBlocklist copy];
+        _httpUrlAllowlist = [httpUrlAllowlist copy];
+        _screenshotMaskLevel = screenshotMaskLevel;
+        _requestHeadersProvider = requestHeadersProvider;
+        _maxDiskUsageInMb = maxDiskUsageInMb;
+    }
+    return self;
+}
+
+@end

--- a/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
+++ b/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
@@ -1,0 +1,49 @@
+//
+//  MeasureSDK.m
+//  Measure
+//
+//  Created by Adwin Ross on 16/12/25.
+//
+
+#import "MeasureSDK.h"
+#if __has_include(<Measure/Measure-Swift.h>)
+#import <Measure/Measure-Swift.h>
+#elif __has_include("Measure-Swift.h")
+#import "Measure-Swift.h"
+#else
+#warning "Measure-Swift.h not found. Swift integration may not work."
+#endif
+
+@implementation MeasureSDK
+
++ (void)initializeWithApiKey:(NSString *)apiKey
+                      apiUrl:(NSString *)apiUrl
+                      config:(MSRConfig *)config
+{
+    ClientInfo *client = [[ClientInfo alloc] initWithApiKey:apiKey apiUrl:apiUrl];
+
+    BaseMeasureConfig *swiftConfig = nil;
+    if (config != nil) {
+        swiftConfig = [[BaseMeasureConfig alloc]
+            initWithEnableLogging:config.enableLogging
+            samplingRateForErrorFreeSessions:config.samplingRateForErrorFreeSessions
+            traceSamplingRate:config.traceSamplingRate
+            coldLaunchSamplingRate:config.coldLaunchSamplingRate
+            warmLaunchSamplingRate:config.warmLaunchSamplingRate
+            hotLaunchSamplingRate:config.hotLaunchSamplingRate
+            journeySamplingRate:config.journeySamplingRate
+            trackHttpHeaders:config.trackHttpHeaders
+            trackHttpBody:config.trackHttpBody
+            httpHeadersBlocklist:config.httpHeadersBlocklist
+            httpUrlBlocklist:config.httpUrlBlocklist
+            httpUrlAllowlist:config.httpUrlAllowlist
+            autoStart:config.autoStart
+            screenshotMaskLevel:config.screenshotMaskLevel
+            requestHeadersProvider:config.requestHeadersProvider
+            maxDiskUsageInMb:config.maxDiskUsageInMb];
+    }
+
+    [Measure initializeWith:client config:swiftConfig];
+}
+
+@end

--- a/ios/Sources/MeasureSDK/ObjC/include/MSRConfig.h
+++ b/ios/Sources/MeasureSDK/ObjC/include/MSRConfig.h
@@ -1,0 +1,140 @@
+//
+//  MSRConfig.h
+//  Measure
+//
+//  Created by Adwin Ross on 16/12/25.
+//
+
+#import <Foundation/Foundation.h>
+#if __has_include(<Measure/ScreenshotMaskingLevel.h>)
+#import <Measure/ScreenshotMaskingLevel.h>
+#elif __has_include("ScreenshotMaskingLevel.h")
+#import "ScreenshotMaskingLevel.h"
+#else
+#warning "ScreenshotMaskingLevel.h not found. Swift integration may not work."
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MsrRequestHeadersProvider;
+
+/// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
+@interface MSRConfig : NSObject
+
+/// Whether to enable internal SDK logging. Defaults to `false`.
+@property (nonatomic) BOOL enableLogging;
+
+/// The sampling rate for non-crashed sessions. Must be between 0.0 and 1.0. Defaults to 0.
+@property (nonatomic) float samplingRateForErrorFreeSessions;
+
+/// The sampling rate for traces. Must be between 0.0 and 1.0. Defaults to 0.0001.
+/// For example, a value of `0.1` will export only 10% of all traces, a value of `0` will disable exporting of traces.
+@property (nonatomic) float traceSamplingRate;
+
+/// The sampling rate for cold launch times. Must be between 0.0 and 1.0. Defaults to 0.01.
+@property (nonatomic) float coldLaunchSamplingRate;
+
+/// The sampling rate for warm launch times. Must be between 0.0 and 1.0. Defaults to 0.01.
+@property (nonatomic) float warmLaunchSamplingRate;
+
+/// The sampling rate for hot launch times. Must be between 0.0 and 1.0. Defaults to 0.01.
+@property (nonatomic) float hotLaunchSamplingRate;
+
+/// Configures sampling rate for sessions that track "user journeys". This feature shows traffic of users across different screens of the app.
+/// When set to 0, the journey will only be generated from crashed sessions or sessions collected using `samplingRateForErrorFreeSessions`
+///
+/// Defaults to 0.
+///
+/// If a value of 0.1 is set, then 10% of the sessions will contain events required to build the journey which includes screen view, lifecycle view controller.
+@property (nonatomic) float journeySamplingRate;
+
+/// Set to false to delay starting the SDK, by default initializing the SDK also starts tracking. Defaults to true.
+@property (nonatomic) BOOL autoStart;
+
+/// Whether to capture http headers of a network request and response. Defaults to `false`.
+@property (nonatomic) BOOL trackHttpHeaders;
+
+/// Whether to capture http body of a network request and response. Defaults to `false`.
+@property (nonatomic) BOOL trackHttpBody;
+
+/// List of HTTP headers to not collect with the `http` event for both request and response.
+/// Defaults to an empty list. The following headers are always excluded:
+/// - * Authorization
+/// - * Cookie
+/// - * Set-Cookie
+/// - * Proxy-Authorization
+/// - * WWW-Authenticate
+/// - * X-Api-Key
+///
+@property (nonatomic, copy) NSArray<NSString *> *httpHeadersBlocklist;
+
+/// Allows disabling collection of `http` events for certain URLs. This is useful to setup if you do not want to collect data for certain endpoints.
+///
+/// Note that this config is ignored if [httpUrlAllowlist] is set.
+///
+/// You can:
+/// - Disables a domain, eg. example.com
+/// - Disable a subdomain, eg. api.example.com
+/// - Disable a particular path, eg. example.com/order
+///
+@property (nonatomic, copy) NSArray<NSString *> *httpUrlBlocklist;
+
+/// Allows enabling collection of `http` events for only certain URLs. This is useful to setup if you do not want to collect data for all endpoints except for a few.
+///
+/// You can:
+/// - Disables a domain, eg. example.com
+/// - Disable a subdomain, eg. api.example.com
+/// - Disable a particular path, eg. example.com/order
+///
+@property (nonatomic, copy) NSArray<NSString *> *httpUrlAllowlist;
+
+/// Allows changing the masking level of screenshots to prevent sensitive information from leaking.
+/// Defaults to [ScreenshotMaskLevel.allTextAndMedia].
+@property (nonatomic) ScreenshotMaskingLevel screenshotMaskLevel;
+
+/// Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API.
+///
+/// This is useful only for self-hosted clients who may require additional headers for requests in their infrastructure.
+@property (nonatomic, strong, nullable) id<MsrRequestHeadersProvider> requestHeadersProvider;
+
+/// Configures the maximum disk usage in megabytes that the Measure SDK is allowed to use.
+///
+/// This is useful to control the amount of disk space used by the SDK for storing session data,
+/// crash reports, and other collected information.
+///
+/// Defaults to `50MB`. Allowed values are between `20MB` and `1500MB`. Any value outside this
+/// range will be clamped to the nearest limit.
+///
+/// All Measure SDKs store data to disk and upload it to the server in batches. While the app is
+/// in foreground, the data is synced periodically and usually the disk space used by the SDK is
+/// low. However, if the device is offline or the server is unreachable, the SDK will continue to
+/// store data on disk until it reaches the maximum disk usage limit.
+///
+/// Note that the storage usage is not exact and works on estimates and typically the SDK will
+/// use much less disk space than the configured limit. When the SDK reaches the maximum disk
+/// usage limit, it will start deleting the oldest data to make space for new data.
+@property (nonatomic) NSNumber *maxDiskUsageInMb;
+
+/// Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
+- (instancetype)initWithEnableLogging:(BOOL)enableLogging
+        samplingRateForErrorFreeSessions:(float)samplingRateForErrorFreeSessions
+                     traceSamplingRate:(float)traceSamplingRate
+              coldLaunchSamplingRate:(float)coldLaunchSamplingRate
+              warmLaunchSamplingRate:(float)warmLaunchSamplingRate
+                hotLaunchSamplingRate:(float)hotLaunchSamplingRate
+                  journeySamplingRate:(float)journeySamplingRate
+                    trackHttpHeaders:(BOOL)trackHttpHeaders
+                       trackHttpBody:(BOOL)trackHttpBody
+               httpHeadersBlocklist:(NSArray<NSString *> *)httpHeadersBlocklist
+                    httpUrlBlocklist:(NSArray<NSString *> *)httpUrlBlocklist
+                   httpUrlAllowlist:(NSArray<NSString *> *)httpUrlAllowlist
+                           autoStart:(BOOL)autoStart
+                screenshotMaskLevel:(ScreenshotMaskingLevel)screenshotMaskLevel
+             requestHeadersProvider:(nullable id<MsrRequestHeadersProvider>)requestHeadersProvider
+                 maxDiskUsageInMb:(NSNumber *)maxDiskUsageInMb NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Sources/MeasureSDK/ObjC/include/MeasureSDK.h
+++ b/ios/Sources/MeasureSDK/ObjC/include/MeasureSDK.h
@@ -1,0 +1,27 @@
+//
+//  MeasureSDK.h
+//  Measure
+//
+//  Created by Adwin Ross on 16/12/25.
+//
+
+#import <Foundation/Foundation.h>
+#if __has_include(<Measure/MSRConfig.h>)
+#import <Measure/MSRConfig.h>
+#elif __has_include("MSRConfig.h")
+#import "MSRConfig.h"
+#else
+#warning "MSRConfig.h not found. Swift integration may not work."
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MeasureSDK : NSObject
+
++ (void)initializeWithApiKey:(NSString *)apiKey
+                      apiUrl:(NSString *)apiUrl
+                      config:(nullable MSRConfig *)config;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Sources/MeasureSDK/ObjC/include/ScreenshotMaskingLevel.h
+++ b/ios/Sources/MeasureSDK/ObjC/include/ScreenshotMaskingLevel.h
@@ -1,0 +1,33 @@
+//
+//  ScreenshotMaskLevelObjc.h
+//  Measure
+//
+//  Created by Adwin Ross on 16/12/25.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The level of masking to apply to screenshots captured by the Measure SDK.
+///
+/// This enum controls how aggressively sensitive content is redacted
+/// when screenshots are captured for bug reports or diagnostics.
+typedef NS_ENUM(NSInteger, ScreenshotMaskingLevel) {
+
+    /// The strictest level of masking.
+    /// Masks all text, input fields, images, and videos.
+    ScreenshotMaskingLevelAllTextAndMedia = 0,
+
+    /// Masks all text and input fields, including clickable elements.
+    ScreenshotMaskingLevelAllText,
+
+    /// Masks all text and input fields, excluding clickable elements.
+    ScreenshotMaskingLevelAllTextExceptClickable,
+
+    /// The most lenient level of masking.
+    /// Only masks sensitive input fields such as passwords, email, and phone numbers.
+    ScreenshotMaskingLevelSensitiveFieldsOnly
+};
+
+NS_ASSUME_NONNULL_END

--- a/react-native/MeasureReactNative.podspec
+++ b/react-native/MeasureReactNative.podspec
@@ -7,10 +7,9 @@ Pod::Spec.new do |s|
     s.license          = { :type => "Apache 2.0", :file => "LICENSE" }
     s.author           = "measure.sh"
     s.source           = { :path => "." }
-  
     s.platform     = :ios, "12.0"
     s.swift_version = "5.0"
-  
+    s.static_framework = true
     s.source_files = "ios/**/*.{swift,h,m}"
     s.dependency "React-Core"
     s.dependency 'measure-sh'

--- a/react-native/example/rnExample/ios/rnExample.xcodeproj/project.pbxproj
+++ b/react-native/example/rnExample/ios/rnExample.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		2186DDB002ACD3BC8FC4B8FF /* libPods-rnExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D8FD1A5065AF6675DAD82E23 /* libPods-rnExample.a */; };
-		814F992F4D5B6B10B6253904 /* libPods-rnExample-rnExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D02E9BEB15F2C340281056E6 /* libPods-rnExample-rnExampleTests.a */; };
+		563672071BF99240F7D416DA /* libPods-rnExample-rnExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB5488DF7D10D9E0B9AC289E /* libPods-rnExample-rnExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		8FA79140A01F3E6A4F2192CD /* libPods-rnExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BBF5B280B12E35223CD6129 /* libPods-rnExample.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,20 +30,20 @@
 		00E356EE1AD99517003FC87E /* rnExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = rnExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* rnExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = rnExampleTests.m; sourceTree = "<group>"; };
-		09C412073F179A777A0C5E2B /* Pods-rnExample-rnExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample-rnExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		0B42EDF52B109C9930D45D4C /* Pods-rnExample-rnExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample-rnExampleTests.release.xcconfig"; path = "Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* rnExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = rnExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = rnExample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = rnExample/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = rnExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = rnExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = rnExample/main.m; sourceTree = "<group>"; };
+		4BBF5B280B12E35223CD6129 /* libPods-rnExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rnExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = rnExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8FF06E91024B96C30AC23148 /* Pods-rnExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample.release.xcconfig"; path = "Target Support Files/Pods-rnExample/Pods-rnExample.release.xcconfig"; sourceTree = "<group>"; };
-		9C2B2EAA91B1F60AFF450516 /* Pods-rnExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample.debug.xcconfig"; path = "Target Support Files/Pods-rnExample/Pods-rnExample.debug.xcconfig"; sourceTree = "<group>"; };
-		D02E9BEB15F2C340281056E6 /* libPods-rnExample-rnExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rnExample-rnExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D29A068E281536E2C4431AEF /* Pods-rnExample-rnExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample-rnExampleTests.release.xcconfig"; path = "Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		D8FD1A5065AF6675DAD82E23 /* libPods-rnExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rnExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB5488DF7D10D9E0B9AC289E /* libPods-rnExample-rnExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rnExample-rnExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3C2212A81715D7E17F75660 /* Pods-rnExample-rnExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample-rnExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E7D264B05C54787D606E6784 /* Pods-rnExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample.debug.xcconfig"; path = "Target Support Files/Pods-rnExample/Pods-rnExample.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		EF4B405EBCF0079B45131BDD /* Pods-rnExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rnExample.release.xcconfig"; path = "Target Support Files/Pods-rnExample/Pods-rnExample.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,7 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				814F992F4D5B6B10B6253904 /* libPods-rnExample-rnExampleTests.a in Frameworks */,
+				563672071BF99240F7D416DA /* libPods-rnExample-rnExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2186DDB002ACD3BC8FC4B8FF /* libPods-rnExample.a in Frameworks */,
+				8FA79140A01F3E6A4F2192CD /* libPods-rnExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,8 +100,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				D8FD1A5065AF6675DAD82E23 /* libPods-rnExample.a */,
-				D02E9BEB15F2C340281056E6 /* libPods-rnExample-rnExampleTests.a */,
+				4BBF5B280B12E35223CD6129 /* libPods-rnExample.a */,
+				BB5488DF7D10D9E0B9AC289E /* libPods-rnExample-rnExampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -140,10 +140,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9C2B2EAA91B1F60AFF450516 /* Pods-rnExample.debug.xcconfig */,
-				8FF06E91024B96C30AC23148 /* Pods-rnExample.release.xcconfig */,
-				09C412073F179A777A0C5E2B /* Pods-rnExample-rnExampleTests.debug.xcconfig */,
-				D29A068E281536E2C4431AEF /* Pods-rnExample-rnExampleTests.release.xcconfig */,
+				E7D264B05C54787D606E6784 /* Pods-rnExample.debug.xcconfig */,
+				EF4B405EBCF0079B45131BDD /* Pods-rnExample.release.xcconfig */,
+				D3C2212A81715D7E17F75660 /* Pods-rnExample-rnExampleTests.debug.xcconfig */,
+				0B42EDF52B109C9930D45D4C /* Pods-rnExample-rnExampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -155,12 +155,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "rnExampleTests" */;
 			buildPhases = (
-				FE4D5FE359B81E255D0D64BE /* [CP] Check Pods Manifest.lock */,
+				031063763F35BF6D6E42E4F4 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				45E6E7DE71B35F59793BF0BF /* [CP] Embed Pods Frameworks */,
-				526ADCE9DD810A373CF3141D /* [CP] Copy Pods Resources */,
+				0FAD0B64BB193742DAD00A93 /* [CP] Embed Pods Frameworks */,
+				B9794906445FCD0956694F7D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -176,13 +176,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "rnExample" */;
 			buildPhases = (
-				5031A988E60C333FFCCA1AAC /* [CP] Check Pods Manifest.lock */,
+				CD9D45084B806444ACB11AD7 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				D963E1EC930286A525758C66 /* [CP] Embed Pods Frameworks */,
-				E6CD13C2B1BEC6EC8E751111 /* [CP] Copy Pods Resources */,
+				E423D0F900FBBF12D08E68DB /* [CP] Embed Pods Frameworks */,
+				A163BF5DD93557796483486A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -265,7 +265,29 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		45E6E7DE71B35F59793BF0BF /* [CP] Embed Pods Frameworks */ = {
+		031063763F35BF6D6E42E4F4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-rnExample-rnExampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0FAD0B64BB193742DAD00A93 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -282,7 +304,41 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5031A988E60C333FFCCA1AAC /* [CP] Check Pods Manifest.lock */ = {
+		A163BF5DD93557796483486A /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B9794906445FCD0956694F7D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CD9D45084B806444ACB11AD7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -304,24 +360,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		526ADCE9DD810A373CF3141D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample-rnExampleTests/Pods-rnExample-rnExampleTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D963E1EC930286A525758C66 /* [CP] Embed Pods Frameworks */ = {
+		E423D0F900FBBF12D08E68DB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -336,45 +375,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E6CD13C2B1BEC6EC8E751111 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-rnExample/Pods-rnExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FE4D5FE359B81E255D0D64BE /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-rnExample-rnExampleTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -410,7 +410,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 09C412073F179A777A0C5E2B /* Pods-rnExample-rnExampleTests.debug.xcconfig */;
+			baseConfigurationReference = D3C2212A81715D7E17F75660 /* Pods-rnExample-rnExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -437,7 +437,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D29A068E281536E2C4431AEF /* Pods-rnExample-rnExampleTests.release.xcconfig */;
+			baseConfigurationReference = 0B42EDF52B109C9930D45D4C /* Pods-rnExample-rnExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -461,7 +461,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9C2B2EAA91B1F60AFF450516 /* Pods-rnExample.debug.xcconfig */;
+			baseConfigurationReference = E7D264B05C54787D606E6784 /* Pods-rnExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -488,7 +488,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8FF06E91024B96C30AC23148 /* Pods-rnExample.release.xcconfig */;
+			baseConfigurationReference = EF4B405EBCF0079B45131BDD /* Pods-rnExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -560,6 +560,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -633,6 +644,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,


### PR DESCRIPTION
# Description

This PR exposes a new init api which will be accessible in C++ runtime. This is necessary as react-native create the AppDelegate as a C++ file rather than in Objc.

```objc
[MeasureSDK initializeWithApiKey:@"<apikey>" apiUrl:@"<apiUrl>" config:config];
```

This PR contains below changes:

- Expose new `init` api.
- Create `MSRConfig` as an interface for the `BaseMeasureConfig`.
- Update `Package.swift` for distribution via SPM.
- Update `MeasureReactNative.podspec` to link the react native iOS pod statically.
- Fixes tests.

## Related issue
Closes #3027 