### PR TITLE
chore(backend): update go image tag

### DIFF
--- a/backend/alerts/dockerfile
+++ b/backend/alerts/dockerfile
@@ -1,5 +1,5 @@
-#build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
+# build stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app

--- a/backend/api/dockerfile
+++ b/backend/api/dockerfile
@@ -1,5 +1,5 @@
-#build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
+# build stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app

--- a/backend/cleanup/dockerfile
+++ b/backend/cleanup/dockerfile
@@ -1,5 +1,5 @@
-#build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
+# build stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app

--- a/backend/metering/dockerfile
+++ b/backend/metering/dockerfile
@@ -1,5 +1,5 @@
-#build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
+# build stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app

--- a/backend/migrator/dockerfile
+++ b/backend/migrator/dockerfile
@@ -1,4 +1,4 @@
-#build stage
+# build stage
 FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app

--- a/backend/symboloader/dockerfile
+++ b/backend/symboloader/dockerfile
@@ -1,5 +1,5 @@
-#build stage
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25.0-alpine AS builder
+# build stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/app -v .
 
-#final stage
+# final stage
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app


### PR DESCRIPTION
## Summary

This PR updates the go image tag to the latest stable alpine version for `api`, `alerts`, `cleanup`, `symboloader` & `metering` services. Earlier we needed to pin to go@1.25.0 because of a bug introduced in go@1.25.2 which was fixed in go@1.25.3

## Tasks

- [x] Use latest go alpine tag for api
- [x] Use latest go alpine tag for alerts
- [x] Use latest go alpine tag for symboloader
- [x] Use latest go alpine tag for metering
- [x] Use latest go alpine tag for cleanup
