### PR TITLE
fix(backend): size metrics compute will fail sometimes

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -558,7 +558,7 @@ func (a App) GetSizeMetrics(ctx context.Context, af *filter.AppFilter, versions 
 
 	avgSizeStmt := sqlf.PostgreSQL.
 		From("build_sizes").
-		Select("round(avg(build_size), 0) as average_size").
+		Select("round(coalesce(avg(build_size), 2), 0) as average_size").
 		Where("app_id = ?", af.AppID)
 
 	if versions.HasVersions() {


### PR DESCRIPTION
## Summary

This PR fixes an issue where GET `/apps/:id/metrics` API would fail sometimes while computing size metrics.

## Tasks

- [x] Detect & handle edge condition when computing size metrics
