### PR TITLE
feat(rn): expose api to get session id

### DIFF
--- a/ios/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/ios/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -164,9 +164,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-DemoApp/Pods-DemoApp-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-DemoApp/Pods-DemoApp-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -233,6 +237,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.measure.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DemoApp/Controller/DemoApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -266,6 +271,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.measure.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DemoApp/Controller/DemoApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -367,7 +367,7 @@ extension Measure {
 
     /// Returns the session ID for the current session, or nil if the SDK has not been initialized.
     ///
-    /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 20-minute period.
+    /// A session represents a continuous period of activity in the app. A new session begins when the app is launched for the first time, or when there's been no activity for a 5-minute period.
     /// A single session can continue across multiple app background and foreground events; brief interruptions will not cause a new session to be created.
     /// - Returns: The session ID if the SDK is initialized, or nil otherwise.
     @objc public static func getSessionId() -> String? {

--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -184,6 +184,21 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun getSessionId(promise: Promise) {
+        try {
+            val sessionId = Measure.getSessionId()
+
+            if (sessionId != null) {
+                promise.resolve(sessionId)
+            } else {
+                promise.resolve(null)
+            }
+        } catch (e: Exception) {
+            promise.reject("GET_SESSION_ID_FAILED", e)
+        }
+    }
+
+    @ReactMethod
     fun trackHttpEvent(
         url: String,
         method: String,

--- a/react-native/example/expo/src/HomeScreen.tsx
+++ b/react-native/example/expo/src/HomeScreen.tsx
@@ -156,12 +156,31 @@ export default function HomeScreen() {
     navigation.navigate('TracesScreen');
   };
 
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  const showCurrentSessionId = async () => {
+    try {
+      const id = await Measure.getSessionId();
+      setSessionId(id);
+    } catch (e) {
+      console.error('Failed to fetch session id', e);
+      setSessionId(null);
+    }
+  };
+
   const sections = [
     {
       title: 'Session & Init',
       data: [
         { id: 'start-sdk', title: 'Start SDK', onPress: startMeasure },
         { id: 'stop-sdk', title: 'Stop SDK', onPress: stopMeasure },
+        {
+          id: 'current-session',
+          title: sessionId
+            ? `Current Session ID: ${sessionId}`
+            : 'Show Current Session ID',
+          onPress: showCurrentSessionId,
+        },
       ],
     },
     {

--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -265,6 +265,18 @@ class MeasureModule: NSObject, RCTBridgeModule {
             }
         }
     }
+
+    @objc
+    func getSessionId(_ resolve: @escaping RCTPromiseResolveBlock,
+                     rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let sessionId = Measure.getSessionId()
+
+        if let sessionId = sessionId {
+            resolve(sessionId)
+        } else {
+            resolve(nil)
+        }
+    }
     
     @objc
     func trackBugReport(_ description: NSString,

--- a/react-native/ios/MeasureModuleBridge.m
+++ b/react-native/ios/MeasureModuleBridge.m
@@ -71,4 +71,6 @@ RCT_EXTERN_METHOD(trackBugReport:(NSString *)description
                   attributes:(NSDictionary *)attributes
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 @end

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -465,4 +465,21 @@ export const Measure = {
 
     return _measureInternal.trackBugReport(description, attachments, attributes);
   },
+
+  /**
+   * Returns the current session ID, or null if the SDK is not initialized.
+   *
+   * A session represents a continuous period of activity in the app.
+   * A new session begins when the app is launched for the first time, or when there's been no activity for a 5-minute period.
+   * A session represents a continuous period of app usage.
+   */
+  getSessionId(): Promise<string | null> {
+    if (!_measureInternal) {
+      return Promise.reject(
+        new Error('Measure is not initialized. Call init() first.')
+      );
+    }
+
+    return _measureInternal.getSessionId();
+  },
 };

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -273,3 +273,13 @@ export function trackBugReport(
 
   return MeasureModule.trackBugReport(description, attachments, attributes);
 }
+
+export function getSessionId(): Promise<string | null> {
+  if (!MeasureModule.getSessionId) {
+    return Promise.reject(
+      new Error('getSessionId native method not available.')
+    );
+  }
+
+  return MeasureModule.getSessionId();
+}


### PR DESCRIPTION
# Description

Expose api to get session id.

```js
const id = Measure.getSessionId();
```

## Related issue
Closes #3041 