### PR TITLE
fix(android): fixes screenshot masking

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/utils/BitmapHelper.kt
+++ b/android/measure/src/main/java/sh/measure/android/utils/BitmapHelper.kt
@@ -202,7 +202,6 @@ internal object BitmapHelper {
         val canvas = Canvas(bitmap)
         rectsToMask.forEach { rect ->
             val rectF = RectF(rect)
-            canvas.clipRect(rectF)
             canvas.drawRoundRect(rectF, DEFAULT_MASK_RADIUS, DEFAULT_MASK_RADIUS, maskPaint)
         }
     }


### PR DESCRIPTION
# Description

Removes unnecessary clip rect was causing only one rect to be drawn on the canvas

## Related issue
Fixes #3052 
References #3036 


