### PR TITLE
fix(android): discard events with data in an invalid or empty file

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
@@ -89,6 +89,11 @@ internal interface FileStorage {
      * Returns the file where the [sh.measure.android.config.DynamicConfig] is stored.
      */
     fun getConfigFile(): File?
+
+    /**
+     * Validates that the file exists.
+     */
+    fun validateFile(path: String): Boolean
 }
 
 private const val MEASURE_DIR = "measure"
@@ -186,6 +191,11 @@ internal class FileStorageImpl(
     }
 
     override fun getConfigFile(): File? = getOrCreateFile(CONFIG_FILE_NAME)
+
+    override fun validateFile(path: String): Boolean {
+        val file = getFile(path)
+        return file != null && file.exists() && file.length() > 0
+    }
 
     override fun getFile(path: String): File? {
         val file = File(path)


### PR DESCRIPTION
# Description

The server reported a few exception events which with event data as `null`. The data is serialized and stored in a file. However, there can be rare scenarios that this file no longer exists or we're unable to access it while sending.

In such scenarios, the stacktrace for the exception is not available and hence the exception is not useful to report. We now discard such events before sending them to server if we're unable to access the file or if it's empty.

## Related issue
Fixes: #3030 