### PR TITLE
chore(backend): update retention periods

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -5392,6 +5392,13 @@ func UpdateAppSettings(c *gin.Context) {
 
 	appSettings.RetentionPeriod = payload.RetentionPeriod
 
+	if appSettings.RetentionPeriod < 30 || appSettings.RetentionPeriod > 365 {
+		msg := `retention period must be between 30 and 365 days`
+		fmt.Println(msg)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
 	appSettings.update()
 
 	c.JSON(http.StatusOK, gin.H{"ok": "done"})

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -129,8 +129,6 @@ export default function Apps({ params }: { params: { teamId: string } }) {
   }
 
   const retentionPeriodToDisplayTextMap = new Map([
-    [7, '7 days'],
-    [15, '15 days'],
     [30, '1 month'],
     [90, '3 months'],
     [180, '6 months'],
@@ -138,8 +136,6 @@ export default function Apps({ params }: { params: { teamId: string } }) {
   )
 
   const displayTextToRetentionPeriodMap = new Map([
-    ['7 days', 7],
-    ['15 days', 15],
     ['1 month', 30],
     ['3 months', 90],
     ['6 months', 180],

--- a/self-host/postgres/20260114110547_update_app_settings_table.sql
+++ b/self-host/postgres/20260114110547_update_app_settings_table.sql
@@ -1,0 +1,18 @@
+-- migrate:up
+-- 1. Update existing records where retention is less than 30
+UPDATE measure.app_settings
+SET retention_period = 30
+WHERE retention_period < 30;
+
+-- 2. Change the default value to 30 for new records
+ALTER TABLE measure.app_settings
+ALTER COLUMN retention_period SET DEFAULT 30;
+
+
+-- migrate:down
+-- Revert the default value back to 90
+ALTER TABLE measure.app_settings
+ALTER COLUMN retention_period SET DEFAULT 90;
+
+-- Note: We cannot revert the UPDATE (data change) in the down migration 
+-- because the original values (e.g., 7, 15) are lost after the update.


### PR DESCRIPTION
# Description

- migrates app_settings table to have default retention period of 30 days instead of 90
- migrates app_settings table to set any retention below 30 days to 30 days
- updates dashboard UI to show 1,3,6 months and 1 year options
- adds an backend validation to check if retention is between 30 and 365 days

## Related issue
Closes #2962 



