### PR TITLE
fix(backend): update migration for device manufacturer attribute

### DIFF
--- a/self-host/clickhouse/20260114194938_alter_events_table.sql
+++ b/self-host/clickhouse/20260114194938_alter_events_table.sql
@@ -1,10 +1,12 @@
 -- migrate:up
 alter table events
-drop index if exists attribute_device_manufacturer_idx;
+drop index if exists attribute_device_manufacturer_idx
+settings mutations_sync = 2;
 
 -- migrate:down
 alter table events
-add index if not exists attribute_device_manufacturer_idx  `attribute.device_manufacturer` TYPE minmax GRANULARITY 2 after attribute_device_name_idx;
+add index if not exists attribute_device_manufacturer_idx  `attribute.device_manufacturer` TYPE minmax GRANULARITY 2 after attribute_device_name_idx
+settings mutations_sync = 2;
 
 -- migrate:up
 alter table events
@@ -15,8 +17,10 @@ select 1;
 
 -- migrate:up
 alter table events
-add index if not exists attribute_device_manufacturer_idx `attribute.device_manufacturer` type minmax granularity 2 after attribute_device_name_idx;
+add index if not exists attribute_device_manufacturer_idx `attribute.device_manufacturer` type minmax granularity 2 after attribute_device_name_idx
+settings mutations_sync = 2;
 
 -- migrate:down
 alter table events
-drop index if exists attribute_device_manufacturer_idx;
+drop index if exists attribute_device_manufacturer_idx
+settings mutations_sync = 2;


### PR DESCRIPTION
## Summary

This PR fixes a broken migration for increasing the character limit for device manufacturer attribute.

## Tasks

- [x] Fixed the broken migration for increasing character limit of `attribute.device_manufacturer`
- [x] Mutation migrations run in sequence synchronously

## See also

- fixes #3080
- #3094 

