### PR TITLE
fix(frontend): suppress theme change hydration warnings

### DIFF
--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -71,25 +71,23 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
-      <html lang="en">
-        <body className={`${josefin_sans.variable} ${work_sans.variable} ${fira_code.variable}`}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            <PostHogProvider>
-              <CookieBanner />
-              <div className='bg-background text-foreground'>
-                {children}
-              </div>
-            </PostHogProvider>
-            <Toaster />
-          </ThemeProvider>
-        </body>
-      </html>
-    </>
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${josefin_sans.variable} ${work_sans.variable} ${fira_code.variable}`}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <PostHogProvider>
+            <CookieBanner />
+            <div className='bg-background text-foreground'>
+              {children}
+            </div>
+          </PostHogProvider>
+          <Toaster />
+        </ThemeProvider>
+      </body>
+    </html>
   )
 }


### PR DESCRIPTION
# Description

`next-themes` injects theme info into html after hydration causing these warnings. Suppressing them is the recommended fix: https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app

## Related issue
Closes #3100



