### PR TITLE
fix(frontend): fix date filters

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -615,23 +615,29 @@ const Filters = forwardRef<{ refresh: () => void }, FiltersProps>(
         ? sessionPersistedFilters.dateRange
         : DateRange.Last6Hours
     const [selectedDateRange, setSelectedDateRange] = useState(initDateRange)
+
     const [selectedStartDate, setSelectedStartDate] = useState(
-      urlFilters.startDate
-        ? urlFilters.startDate
-        : sessionPersistedFilters
-          ? sessionPersistedFilters.dateRange === DateRange.Custom
-            ? sessionPersistedFilters.startDate
-            : mapDateRangeToDate(initDateRange)!.toISO()
-          : DateTime.now().minus({ hours: 6 }).toISO(),
+      urlFilters.dateRange ?
+        mapDateRangeToDate(initDateRange)!.toISO() :
+        urlFilters.startDate
+          ? urlFilters.startDate
+          : sessionPersistedFilters
+            ? sessionPersistedFilters.dateRange === DateRange.Custom
+              ? sessionPersistedFilters.startDate
+              : mapDateRangeToDate(initDateRange)!.toISO()
+            : DateTime.now().minus({ hours: 6 }).toISO(),
     )
+
     const [selectedEndDate, setSelectedEndDate] = useState(
-      urlFilters.endDate
-        ? urlFilters.endDate
-        : sessionPersistedFilters
-          ? sessionPersistedFilters.dateRange === DateRange.Custom
-            ? sessionPersistedFilters.endDate
-            : DateTime.now().toISO()
-          : DateTime.now().toISO(),
+      urlFilters.dateRange ?
+        DateTime.now().toISO() :
+        urlFilters.endDate
+          ? urlFilters.endDate
+          : sessionPersistedFilters
+            ? sessionPersistedFilters.dateRange === DateRange.Custom
+              ? sessionPersistedFilters.endDate
+              : DateTime.now().toISO()
+            : DateTime.now().toISO(),
     )
 
     const getApps = async (appIdToSelect?: string) => {


### PR DESCRIPTION
# Description

When date range and start/end date are both present in URL, start and end date should set their values according to the date range and ignore the start and end dates. This was not happening perviously leading to date range showing one value and the actual dates being older values. This commit fixes this behaviour by ensuring that date range value is prioritised over url param defined start and end dates if both are present.

## Related issue
Fixes #3115 



