### PR TITLE
refactor(android): remove usused config

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -30,7 +30,6 @@ internal data class Config(
     override val maxUserDefinedAttributesPerEvent: Int = 100
     override val maxUserDefinedAttributeKeyLength: Int = 256 // 256 chars
     override val maxUserDefinedAttributeValueLength: Int = 256 // 256 chars
-    override val eventTypeExportAllowList: List<EventType> = listOf(EventType.SESSION_START)
     override val maxSpanNameLength: Int = 64
     override val maxCheckpointNameLength: Int = 64
     override val maxCheckpointsPerSpan: Int = 100

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -1,7 +1,5 @@
 package sh.measure.android.config
 
-import sh.measure.android.events.EventType
-
 internal interface ConfigProvider :
     IMeasureConfig,
     InternalConfig,
@@ -75,7 +73,6 @@ internal class ConfigProviderImpl(defaultConfig: Config) : ConfigProvider {
     override val enableLogging: Boolean = defaultConfig.enableLogging
     override val screenshotMaskHexColor: String = defaultConfig.screenshotMaskHexColor
     override val screenshotCompressionQuality: Int = defaultConfig.screenshotCompressionQuality
-    override val eventTypeExportAllowList: List<EventType> = defaultConfig.eventTypeExportAllowList
     override val batchExportIntervalMs: Long = defaultConfig.batchExportIntervalMs
     override val attachmentExportIntervalMs: Long = defaultConfig.attachmentExportIntervalMs
     override val defaultHttpHeadersBlocklist: List<String> =

--- a/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/InternalConfig.kt
@@ -62,12 +62,6 @@ internal interface InternalConfig {
     val screenshotCompressionQuality: Int
 
     /**
-     * All [EventType]'s that are always exported, regardless of other filters like session
-     * sampling rate and whether the session crashed or not.
-     */
-    val eventTypeExportAllowList: List<EventType>
-
-    /**
      * Max length of a span name. Defaults to 64.
      */
     val maxSpanNameLength: Int

--- a/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -102,8 +102,8 @@ internal class ExporterImpl(
 
     private fun exportBatches(batches: List<String>): Boolean {
         var success = true
-        batches.forEachIndexed { index, batch ->
-            val batch = database.getBatch(batch)
+        batches.forEachIndexed { index, batchId ->
+            val batch = database.getBatch(batchId)
 
             if (!exportBatch(batch)) {
                 success = false

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -5,13 +5,11 @@ import sh.measure.android.config.ConfigProvider
 import sh.measure.android.config.DynamicConfig
 import sh.measure.android.config.MsrRequestHeadersProvider
 import sh.measure.android.config.ScreenshotMaskLevel
-import sh.measure.android.events.EventType
 
 internal class FakeConfigProvider : ConfigProvider {
     override val enableLogging: Boolean = false
     override var screenshotMaskHexColor: String = "#222222"
     override var screenshotCompressionQuality: Int = 25
-    override val eventTypeExportAllowList: List<EventType> = emptyList()
     override var trackActivityIntentData: Boolean = false
     override var batchExportIntervalMs: Long = 3_000 // 3 seconds
     override var attachmentExportIntervalMs: Long = 500 // 500ms


### PR DESCRIPTION
# Description

Remove an unused config from `InternalConfig`.
