### PR TITLE
fix(flutter): avoid mutating caller's header maps in HttpCollector

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
@@ -40,27 +40,30 @@ class HttpCollector {
     if (!_enabled) {
       return;
     }
-
     if (!configProvider.shouldTrackHttpUrl(url)) {
       return;
     }
 
-    requestHeaders?.removeWhere(
+    final filteredRequestHeaders =
+        requestHeaders != null ? Map.of(requestHeaders) : null;
+    final filteredResponseHeaders =
+        responseHeaders != null ? Map.of(responseHeaders) : null;
+
+    filteredRequestHeaders?.removeWhere(
       (key, value) => !configProvider.shouldTrackHttpHeader(key),
     );
-    responseHeaders?.removeWhere(
+    filteredResponseHeaders?.removeWhere(
       (key, value) => !configProvider.shouldTrackHttpHeader(key),
     );
 
-    if (!configProvider.shouldTrackHttpBody(
-        url, requestHeaders?['Content-Type'])) {
-      requestBody = null;
-    }
-
-    if (!configProvider.shouldTrackHttpBody(
-        url, responseHeaders?['Content-Type'])) {
-      responseBody = null;
-    }
+    final trackedRequestBody = configProvider.shouldTrackHttpBody(
+            url, filteredRequestHeaders?['Content-Type'])
+        ? requestBody
+        : null;
+    final trackedResponseBody = configProvider.shouldTrackHttpBody(
+            url, filteredResponseHeaders?['Content-Type'])
+        ? responseBody
+        : null;
 
     final data = HttpData(
       url: url,
@@ -70,10 +73,10 @@ class HttpCollector {
       endTime: endTime,
       failureReason: failureReason,
       failureDescription: failureDescription,
-      requestHeaders: requestHeaders,
-      responseHeaders: responseHeaders,
-      requestBody: requestBody,
-      responseBody: responseBody,
+      requestHeaders: filteredRequestHeaders,
+      responseHeaders: filteredResponseHeaders,
+      requestBody: trackedRequestBody,
+      responseBody: trackedResponseBody,
       client: client ?? 'unknown',
     );
     signalProcessor.trackEvent(


### PR DESCRIPTION
# Description

`trackHttpEvent` was calling `removeWhere` directly on the caller's request/response header maps, mutating them as a side effect. This copies the maps before filtering so the caller's data is left untouched.

## Related issue
Fixes #3129
