### PR TITLE
chore(ios): enable internal logging based on macro

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Utils/Logger.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Logger.swift
@@ -64,8 +64,8 @@ final class MeasureLogger: Logger {
     }
 
     func internalLog(level: LogLevel, message: String, error: Error? = nil, data: Encodable? = nil) {
-//#if INTERNAL_LOGGING
+#if INTERNAL_LOGGING
         log(level: level, message: "Internal: \(message)", error: error, data: data)
-//#endif
+#endif
     }
 }


### PR DESCRIPTION
# Description

Enable internal logging only when the ENABLE_LOGGING macro is true.