### PR TITLE
chore(flutter): fix layout snapshots for release builds

### DIFF
--- a/flutter/example/.gitignore
+++ b/flutter/example/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# iOS export
+ExportOptions.plist

--- a/flutter/packages/measure_flutter/lib/src/gestures/README.md
+++ b/flutter/packages/measure_flutter/lib/src/gestures/README.md
@@ -1,0 +1,62 @@
+# Layout Snapshot
+
+The layout snapshot algorithm walks the Flutter element tree and produces a simplified snapshot of widgets with their screen positions.
+
+## Tree traversal & child promotion
+
+The element tree in Flutter is deep — most elements are invisible wrappers (themes, navigators, padding, etc.) that don't correspond to meaningful UI. The algorithm does a depth-first traversal and keeps only elements that have a `RenderBox` _and_ match the widget filter. Everything else is skipped, and its children are "promoted" up to the nearest kept ancestor.
+
+**Example: a screen with a button**
+
+The actual Flutter element tree:
+
+```
+MaterialApp
+  └─ Theme
+       └─ Navigator
+            └─ Overlay
+                 └─ Scaffold
+                      └─ Center
+                           └─ Padding
+                                └─ ElevatedButton
+                                     └─ Text("Click me")
+```
+
+Most of these elements either lack a render box or don't match the widget filter. The snapshot output collapses them:
+
+```
+MaterialApp
+  └─ Scaffold
+       └─ ElevatedButton
+            └─ Text("Click me")
+```
+
+The rule: if an element doesn't have a valid render box, or doesn't match the widget filter, it is skipped and its children are promoted to the parent. Elements that are invisible (offstage, zero opacity, excluded semantics) are dropped entirely along with their subtree.
+
+## Route filtering
+
+When a new dialog or bottom sheet opens, the widgets behind it are no longer relevant. The algorithm uses Flutter's `BlockSemantics` signal to detect this.
+
+**Example: a dialog opens on top of a home screen**
+
+The Overlay's children before filtering:
+
+```
+Overlay
+  ├─ Entry 0: HomeScreen (Scaffold → Button "Home")
+  ├─ Entry 1: ModalBarrier (BlockSemantics, blocking = true)
+  └─ Entry 2: AlertDialog (Scaffold → Button "OK")
+```
+
+When processing the Overlay's children left to right, the algorithm encounters the modal barrier with `blocking = true`. This clears all previously collected siblings — the home screen's widgets are discarded. The result:
+
+```
+AlertDialog
+  └─ Button "OK"
+```
+
+Only the topmost route's widgets appear in the snapshot.
+
+## Gesture detection
+
+During traversal, each element's global bounds are computed and hit-tested against a position. The deepest interactive widget that contains the tap point is marked as the gesture target in the snapshot output.

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:developer' as developer;
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:measure_flutter/src/bug_report/bug_report_collector.dart';
@@ -225,7 +222,6 @@ final class MeasureInternal {
   }
 
   Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot) async {
-    developer.log("snapshot: ${json.encode(snapshot?.toJson())}");
     _gestureCollector.trackGestureClick(
       clickData,
       snapshot: snapshot,

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_capture_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_capture_test.dart
@@ -435,6 +435,48 @@ void main() {
       expect(_containsWidgetType(result!.snapshot, 'CustomWidget'), isTrue);
     });
 
+    testWidgets('filters previous route when dialog is shown', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                key: const ValueKey('home-button'),
+                onPressed: () {},
+                child: const Text('Home Button'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Push a dialog which uses BlockSemantics via its modal barrier
+      showDialog(
+        context: tester.element(find.byType(Scaffold)),
+        builder: (context) => AlertDialog(
+          title: const Text('Dialog Title'),
+          content: const Text('Dialog Content'),
+          actions: [
+            TextButton(
+              key: const ValueKey('dialog-button'),
+              onPressed: () {},
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final element = tester.element(find.byType(MaterialApp));
+      final result = LayoutSnapshotCapture.capture(element);
+
+      expect(result, isNotNull);
+      // The home route's button should be filtered out
+      expect(_containsWidgetType(result!.snapshot, 'ElevatedButton'), isFalse);
+      // The dialog's button should be present
+      expect(_containsWidgetType(result.snapshot, 'TextButton'), isTrue);
+    });
+
     testWidgets('sets element type for button widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
# Description

Removes a hard-coded check on widget type which failed in obfuscated builds leading to layout snapshot containing all routes instead of just the visible one. 

<img width="267" height="371" alt="image" src="https://github.com/user-attachments/assets/1b2f0a08-f7d6-4666-b884-145c0b5b45ce" />

## Related issue
References #2213 



