### PR TITLE
fix(backend): migrate ingestion metrics synchronously

### DIFF
--- a/self-host/clickhouse/20260119094537_alter_ingestion_metrics_table.sql
+++ b/self-host/clickhouse/20260119094537_alter_ingestion_metrics_table.sql
@@ -10,11 +10,12 @@ ALTER TABLE measure.ingestion_metrics
     DROP COLUMN span_count_days,
     DROP COLUMN trace_count_days,
     DROP COLUMN attachment_count_days,
-    ADD COLUMN `metrics` AggregateFunction(sum, UInt32) COMMENT 'aggregated number of metrics ingested' CODEC(ZSTD(3));
+    ADD COLUMN `metrics` AggregateFunction(sum, UInt32) COMMENT 'aggregated number of metrics ingested' CODEC(ZSTD(3))
+    SETTINGS mutations_sync = 2;
 
 -- migrate:down
 ALTER TABLE measure.ingestion_metrics
-    DROP COLUMN metricsm
+    DROP COLUMN metrics
     ADD COLUMN `trace_count` AggregateFunction(sum, UInt32) CODEC(ZSTD(3)),
     ADD COLUMN `session_count_days` AggregateFunction(sum, UInt32) CODEC(ZSTD(3)),
     ADD COLUMN `event_count_days` AggregateFunction(sum, UInt32) CODEC(ZSTD(3)),
@@ -24,4 +25,5 @@ ALTER TABLE measure.ingestion_metrics
     RENAME COLUMN sessions TO session_count,
     RENAME COLUMN events TO event_count,
     RENAME COLUMN spans TO span_count,
-    RENAME COLUMN attachments TO attachment_count;
+    RENAME COLUMN amttachments TO attachment_count
+    SETTINGS mutations_sync = 2;


### PR DESCRIPTION
## Summary

This PR fixes a backdated migration of rename & drop of columns in `ingestion_metrics` table synchronously to prevent cases of partial migrations when running in a replicated clickhouse environment.

Running migrations in a fresh replicated ClickHouse environment should now succeed with this fix.

## Tasks

- [x] Fix `self-host/clickhouse/20260119094537_alter_ingestion_metrics_table.sql` migration
- [x] Fix a typo in column name

## See also

- fixes #3178