### PR TITLE
perf(backend): fetch user defined attribute keys concurrently

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -5028,15 +5028,9 @@ func GetAppFilters(c *gin.Context) {
 		"key_types":      nil,
 	}
 
+	// set user defined attribute keys only if
+	// requested
 	if af.UDAttrKeys {
-		if err := af.GetUserDefinedAttrKeys(ctx, &fl); err != nil {
-			msg := `failed to query user defined attribute keys`
-			fmt.Println(msg, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-			return
-		}
 		udAttrs["operator_types"] = event.GetUDAttrsOpMap()
 		udAttrs["key_types"] = fl.UDKeyTypes
 	}


### PR DESCRIPTION
## Summary

This PR optimizes the fetching of user defined attribute keys of the GET `/apps/:id/filters` API to fetch user defined attribute keys concurrently (if requested) instead of sequentially. This should reduce the response time of the network request.

## Tasks

- [x] Fetch events/spans user defined attribute keys concurrently

## Details

**Why not issue a single combined query?**

After some research I figured there is not much advantage in total response times if a combined SQL query is issued instead of individual SQL queries made concurrently. The reasons for this are:

- clickhouse-go's connection pool already should be working, so there is no advantage to reap at layer 4.
- individual queries are parallelized better in clickhouse as each of them gets their own `max_threads` setting. moreover, each individual query can be tuned further.
- not all queries share the same grouping & ordering requirements. doing a combined query also means, we lose grouping & ordering from clickhouse. this would have to be done at the app level. better avoided.

## See also

- fixes #3185