### PR TITLE
chore(backend): update self-host gitignore

### DIFF
--- a/self-host/.gitignore
+++ b/self-host/.gitignore
@@ -1,1 +1,2 @@
 .env
+compose.override.yml


### PR DESCRIPTION
## Summary

This PR adds `compose.override.yml` to `self-host/.gitignore` providing flexibility to tweak local development environments & persist them.

## Tasks

- [x] Add `self-host/.gitignore` file to ignore compose override file to let anyone add their local docker tweaks and persist only for them