### PR TITLE
feat(backend): implement app api key rotation

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -136,6 +136,7 @@ func main() {
 		apps.GET(":id/retention", measure.GetAppRetention)
 		apps.PATCH(":id/retention", measure.UpdateAppRetention)
 		apps.PATCH(":id/rename", measure.RenameApp)
+		apps.PATCH(":id/apiKey", measure.RotateApiKey)
 
 		// filters
 		apps.POST(":id/shortFilters", measure.CreateShortFilters)

--- a/backend/api/measure/apikey_test.go
+++ b/backend/api/measure/apikey_test.go
@@ -1,0 +1,565 @@
+//go:build integration
+
+package measure
+
+import (
+	"backend/api/cipher"
+	"backend/api/server"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func mustRawAPIKey(t *testing.T, value string) string {
+	t.Helper()
+	checksum, err := cipher.ComputeChecksum([]byte(value))
+	if err != nil {
+		t.Fatalf("compute checksum: %v", err)
+	}
+	return fmt.Sprintf("%s_%s_%s", APIKeyPrefix, value, *checksum)
+}
+
+func TestAPIKeyString(t *testing.T) {
+	k := &APIKey{keyPrefix: APIKeyPrefix, keyValue: "abc", checksum: "def"}
+	if got, want := k.String(), "msrsh_abc_def"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIKeyMarshalJSON(t *testing.T) {
+	t.Run("without last seen", func(t *testing.T) {
+		createdAt := time.Now().UTC().Truncate(time.Second)
+		k := APIKey{keyPrefix: APIKeyPrefix, keyValue: "abc", checksum: "def", revoked: false, createdAt: createdAt}
+
+		b, err := k.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON: %v", err)
+		}
+
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if m["key"] != "msrsh_abc_def" {
+			t.Fatalf("key = %v, want %q", m["key"], "msrsh_abc_def")
+		}
+		if m["revoked"] != false {
+			t.Fatalf("revoked = %v, want false", m["revoked"])
+		}
+		if m["last_seen"] != nil {
+			t.Fatalf("last_seen = %v, want nil", m["last_seen"])
+		}
+	})
+
+	t.Run("with last seen", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Second)
+		k := APIKey{keyPrefix: APIKeyPrefix, keyValue: "abc", checksum: "def", revoked: true, createdAt: now, lastSeen: now}
+
+		b, err := k.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON: %v", err)
+		}
+
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if m["revoked"] != true {
+			t.Fatalf("revoked = %v, want true", m["revoked"])
+		}
+		if m["last_seen"] == nil {
+			t.Fatalf("last_seen = nil, want value")
+		}
+	})
+}
+
+func TestNewAPIKey(t *testing.T) {
+	appID := uuid.New()
+	k, err := NewAPIKey(appID)
+	if err != nil {
+		t.Fatalf("NewAPIKey: %v", err)
+	}
+	if k.appId != appID {
+		t.Fatalf("appId = %s, want %s", k.appId, appID)
+	}
+	if k.keyPrefix != APIKeyPrefix {
+		t.Fatalf("keyPrefix = %q, want %q", k.keyPrefix, APIKeyPrefix)
+	}
+	if len(k.keyValue) != 64 {
+		t.Fatalf("keyValue len = %d, want 64", len(k.keyValue))
+	}
+	if len(k.checksum) == 0 {
+		t.Fatalf("checksum empty")
+	}
+	if k.createdAt.IsZero() {
+		t.Fatalf("createdAt is zero")
+	}
+}
+
+func TestAPIKeyDBOps(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("saveTx inserts api key", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		tx, err := server.Server.PgPool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback(ctx)
+
+		k, err := NewAPIKey(appID)
+		if err != nil {
+			t.Fatalf("NewAPIKey: %v", err)
+		}
+		if err := k.saveTx(tx); err != nil {
+			t.Fatalf("saveTx: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+
+		row := getAPIKeyByValue(ctx, t, k.keyValue)
+		if row == nil {
+			t.Fatalf("api key row not found")
+		}
+		if row.AppID != appID {
+			t.Fatalf("app_id = %s, want %s", row.AppID, appID)
+		}
+	})
+
+	t.Run("updateLastSeenForApiKey updates timestamp", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		k := "value-last-seen"
+		raw := mustRawAPIKey(t, k)
+		parts := raw[len(APIKeyPrefix)+1:]
+		checksum := parts[len(k)+1:]
+		seedAPIKey(ctx, t, appID, APIKeyPrefix, k, checksum, false, nil, time.Now().UTC())
+
+		row := getAPIKeyByValue(ctx, t, k)
+		if row == nil {
+			t.Fatalf("seeded row missing")
+		}
+
+		if err := updateLastSeenForApiKey(ctx, row.ID); err != nil {
+			t.Fatalf("updateLastSeenForApiKey: %v", err)
+		}
+
+		updated := getAPIKeyByValue(ctx, t, k)
+		if updated == nil || updated.LastSeen == nil {
+			t.Fatalf("last_seen not set")
+		}
+	})
+
+	t.Run("saveTx fails for non-existent app id", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		tx, err := server.Server.PgPool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer tx.Rollback(ctx)
+
+		k := &APIKey{
+			appId:     uuid.New(),
+			keyPrefix: APIKeyPrefix,
+			keyValue:  "fk-violation-value",
+			checksum:  "checksum1",
+			createdAt: time.Now().UTC(),
+		}
+
+		if err := k.saveTx(tx); err == nil {
+			t.Fatalf("expected saveTx error for non-existent app id")
+		}
+	})
+}
+
+func TestDecodeAPIKey(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid key formats", func(t *testing.T) {
+		cases := []string{"", "abc", "bad_prefix_x_y", "msrsh_only_two_parts", "msrsh_value_badchecksum"}
+		for _, tc := range cases {
+			_, err := DecodeAPIKey(ctx, tc)
+			if err == nil {
+				t.Fatalf("DecodeAPIKey(%q) expected error", tc)
+			}
+		}
+	})
+
+	t.Run("valid format but unknown key returns nil app", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		raw := mustRawAPIKey(t, "unknownvalue")
+		appID, err := DecodeAPIKey(ctx, raw)
+		if err != nil {
+			t.Fatalf("DecodeAPIKey: %v", err)
+		}
+		if appID != nil {
+			t.Fatalf("appID = %v, want nil", appID)
+		}
+	})
+
+	t.Run("revoked key returns nil app", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		value := "revoked-value"
+		raw := mustRawAPIKey(t, value)
+		parts := raw[len(APIKeyPrefix)+1:]
+		checksum := parts[len(value)+1:]
+		seedAPIKey(ctx, t, appID, APIKeyPrefix, value, checksum, true, nil, time.Now().UTC())
+
+		decoded, err := DecodeAPIKey(ctx, raw)
+		if err != nil {
+			t.Fatalf("DecodeAPIKey: %v", err)
+		}
+		if decoded != nil {
+			t.Fatalf("decoded appID = %v, want nil", decoded)
+		}
+
+		row := getAPIKeyByValue(ctx, t, value)
+		if row == nil {
+			t.Fatalf("row missing")
+		}
+		if row.LastSeen != nil {
+			t.Fatalf("revoked key last_seen = %v, want nil", row.LastSeen)
+		}
+	})
+
+	t.Run("active key returns app and updates last_seen", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		value := "active-value"
+		raw := mustRawAPIKey(t, value)
+		parts := raw[len(APIKeyPrefix)+1:]
+		checksum := parts[len(value)+1:]
+		seedAPIKey(ctx, t, appID, APIKeyPrefix, value, checksum, false, nil, time.Now().UTC())
+
+		decoded, err := DecodeAPIKey(ctx, raw)
+		if err != nil {
+			t.Fatalf("DecodeAPIKey: %v", err)
+		}
+		if decoded == nil || *decoded != appID {
+			t.Fatalf("decoded appID = %v, want %s", decoded, appID)
+		}
+
+		row := getAPIKeyByValue(ctx, t, value)
+		if row == nil || row.LastSeen == nil {
+			t.Fatalf("last_seen not updated")
+		}
+	})
+
+	t.Run("wrong prefix but valid checksum format is invalid", func(t *testing.T) {
+		_, err := DecodeAPIKey(ctx, "badprefix_value_12345678")
+		if err == nil {
+			t.Fatalf("expected error for wrong prefix")
+		}
+	})
+}
+
+func TestRotateAPIKeyMethod(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates first key when no existing keys", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		app := App{ID: &appID}
+		newKey, err := app.rotateAPIKey()
+		if err != nil {
+			t.Fatalf("rotateAPIKey: %v", err)
+		}
+		if newKey == nil {
+			t.Fatalf("new key is nil")
+		}
+
+		rows := getAPIKeysByAppID(ctx, t, appID)
+		if len(rows) != 1 {
+			t.Fatalf("api key count = %d, want 1", len(rows))
+		}
+		if rows[0].Revoked {
+			t.Fatalf("new key is revoked, want active")
+		}
+	})
+
+	t.Run("revokes all previous keys and keeps only new key active", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		oldValue := "old-active"
+		oldRaw := mustRawAPIKey(t, oldValue)
+		oldChecksum := oldRaw[len(APIKeyPrefix)+1+len(oldValue)+1:]
+		seedAPIKey(ctx, t, appID, APIKeyPrefix, oldValue, oldChecksum, false, nil, time.Now().UTC().Add(-2*time.Hour))
+
+		revokedValue := "old-revoked"
+		revokedRaw := mustRawAPIKey(t, revokedValue)
+		revokedChecksum := revokedRaw[len(APIKeyPrefix)+1+len(revokedValue)+1:]
+		seedAPIKey(ctx, t, appID, APIKeyPrefix, revokedValue, revokedChecksum, true, nil, time.Now().UTC().Add(-time.Hour))
+
+		app := App{ID: &appID}
+		newKey, err := app.rotateAPIKey()
+		if err != nil {
+			t.Fatalf("rotateAPIKey: %v", err)
+		}
+		if newKey == nil {
+			t.Fatalf("new key is nil")
+		}
+
+		rows := getAPIKeysByAppID(ctx, t, appID)
+		if len(rows) != 3 {
+			t.Fatalf("api key count = %d, want 3", len(rows))
+		}
+
+		activeCount := 0
+		for _, r := range rows {
+			if !r.Revoked {
+				activeCount++
+				if r.KeyValue != newKey.keyValue {
+					t.Fatalf("unexpected active key value = %s, want %s", r.KeyValue, newKey.keyValue)
+				}
+			}
+		}
+		if activeCount != 1 {
+			t.Fatalf("active key count = %d, want 1", activeCount)
+		}
+	})
+
+	t.Run("handles multiple active keys and leaves one active", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		for _, value := range []string{"active-a", "active-b", "active-c"} {
+			raw := mustRawAPIKey(t, value)
+			checksum := raw[len(APIKeyPrefix)+1+len(value)+1:]
+			seedAPIKey(ctx, t, appID, APIKeyPrefix, value, checksum, false, nil, time.Now().UTC())
+		}
+
+		app := App{ID: &appID}
+		newKey, err := app.rotateAPIKey()
+		if err != nil {
+			t.Fatalf("rotateAPIKey: %v", err)
+		}
+
+		rows := getAPIKeysByAppID(ctx, t, appID)
+		if len(rows) != 4 {
+			t.Fatalf("api key count = %d, want 4", len(rows))
+		}
+
+		activeCount := 0
+		for _, r := range rows {
+			if !r.Revoked {
+				activeCount++
+				if r.KeyValue != newKey.keyValue {
+					t.Fatalf("unexpected active key value = %s, want %s", r.KeyValue, newKey.keyValue)
+				}
+			}
+		}
+		if activeCount != 1 {
+			t.Fatalf("active key count = %d, want 1", activeCount)
+		}
+	})
+
+	t.Run("fails when app does not exist", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		missingAppID := uuid.New()
+		app := App{ID: &missingAppID}
+		if _, err := app.rotateAPIKey(); err == nil {
+			t.Fatalf("expected rotateAPIKey error for non-existent app")
+		}
+	})
+}
+
+func TestRotateApiKeyHandler(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid app id", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		c, w := newTestGinContext(http.MethodPatch, "/apps/invalid/apiKey", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: "invalid"}}
+
+		RotateApiKey(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		wantJSONContains(t, w, "error", "app id invalid or missing")
+	})
+
+	t.Run("app has no team", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		appID := uuid.New()
+		c, w := newTestGinContext(http.MethodPatch, "/apps/"+appID.String()+"/apiKey", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		RotateApiKey(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		wantJSONContains(t, w, "error", "no team exists for app")
+	})
+
+	t.Run("no membership returns auth error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedUser(ctx, t, userID, "noauth-apikey@test.com")
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		c, w := newTestGinContext(http.MethodPatch, "/apps/"+appID.String()+"/apiKey", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		RotateApiKey(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+		wantJSONContains(t, w, "error", "couldn't perform authorization checks")
+	})
+
+	t.Run("all roles authz behavior", func(t *testing.T) {
+		testCases := []struct {
+			name       string
+			role       string
+			wantStatus int
+		}{
+			{name: "viewer forbidden", role: "viewer", wantStatus: http.StatusForbidden},
+			{name: "developer can rotate", role: "developer", wantStatus: http.StatusOK},
+			{name: "admin can rotate", role: "admin", wantStatus: http.StatusOK},
+			{name: "owner can rotate", role: "owner", wantStatus: http.StatusOK},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+
+				userID := uuid.New().String()
+				teamID := uuid.New()
+				appID := uuid.New()
+				seedUser(ctx, t, userID, fmt.Sprintf("%s-apikey@test.com", tc.role))
+				seedTeam(ctx, t, teamID, "team", true)
+				seedTeamMembership(ctx, t, teamID, userID, tc.role)
+				seedApp(ctx, t, appID, teamID, 30)
+
+				oldValue := "handler-old-active"
+				oldRaw := mustRawAPIKey(t, oldValue)
+				oldChecksum := oldRaw[len(APIKeyPrefix)+1+len(oldValue)+1:]
+				seedAPIKey(ctx, t, appID, APIKeyPrefix, oldValue, oldChecksum, false, nil, time.Now().UTC().Add(-time.Hour))
+
+				c, w := newTestGinContext(http.MethodPatch, "/apps/"+appID.String()+"/apiKey", nil)
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+				RotateApiKey(c)
+
+				if w.Code != tc.wantStatus {
+					t.Fatalf("status = %d, want %d, body: %s", w.Code, tc.wantStatus, w.Body.String())
+				}
+
+				if tc.wantStatus == http.StatusForbidden {
+					wantJSONContains(t, w, "error", "don't have permissions")
+					return
+				}
+
+				wantJSON(t, w, "ok", "done")
+
+				var resp map[string]any
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("unmarshal resp: %v", err)
+				}
+				apiKeyObj, ok := resp["api_key"].(map[string]any)
+				if !ok {
+					t.Fatalf("api_key missing in response")
+				}
+				if _, ok := apiKeyObj["key"].(string); !ok {
+					t.Fatalf("api_key.key missing in response")
+				}
+				if gotRevoked, ok := apiKeyObj["revoked"].(bool); !ok || gotRevoked {
+					t.Fatalf("api_key.revoked = %v, want false", apiKeyObj["revoked"])
+				}
+				if _, ok := apiKeyObj["created_at"].(string); !ok {
+					t.Fatalf("api_key.created_at missing in response")
+				}
+
+				rows := getAPIKeysByAppID(ctx, t, appID)
+				activeCount := 0
+				for _, r := range rows {
+					if !r.Revoked {
+						activeCount++
+					}
+				}
+				if activeCount != 1 {
+					t.Fatalf("active key count = %d, want 1", activeCount)
+				}
+			})
+		}
+	})
+
+	t.Run("missing user id in context returns auth error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "team", true)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		c, w := newTestGinContext(http.MethodPatch, "/apps/"+appID.String()+"/apiKey", nil)
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		RotateApiKey(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+		wantJSONContains(t, w, "error", "couldn't perform authorization checks")
+	})
+}

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -3390,7 +3390,7 @@ func (a *App) getWithTeam(id uuid.UUID) (*App, error) {
 	stmt := sqlf.PostgreSQL.
 		Select(strings.Join(cols, ",")).
 		From("apps").
-		LeftJoin("api_keys", "api_keys.app_id = apps.id").
+		LeftJoin("api_keys", "api_keys.app_id = apps.id and api_keys.revoked = false").
 		Where("apps.id = ? and apps.team_id = ?", nil, nil)
 
 	defer stmt.Close()

--- a/backend/api/measure/team.go
+++ b/backend/api/measure/team.go
@@ -85,7 +85,7 @@ func (t *Team) getApps(ctx context.Context) ([]App, error) {
 		Select(`apps.created_at`, nil).
 		Select(`apps.updated_at`, nil).
 		From(`apps`).
-		LeftJoin(`api_keys`, `api_keys.app_Id = apps.id`).
+		LeftJoin(`api_keys`, `api_keys.app_Id = apps.id and api_keys.revoked = false`).
 		Where(`apps.team_id = ?`, nil).
 		OrderBy(`apps.app_name`)
 

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -159,6 +159,25 @@ func (h *TestHelper) SeedTeamIngestBlocked(ctx context.Context, t *testing.T, te
 	}
 }
 
+func (h *TestHelper) SeedAPIKey(
+	ctx context.Context,
+	t *testing.T,
+	appID, keyPrefix, keyValue, checksum string,
+	revoked bool,
+	lastSeen *time.Time,
+	createdAt time.Time,
+) {
+	t.Helper()
+
+	_, err := h.PgPool.Exec(ctx,
+		`INSERT INTO api_keys (app_id, key_prefix, key_value, checksum, revoked, last_seen, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		appID, keyPrefix, keyValue, checksum, revoked, lastSeen, createdAt)
+	if err != nil {
+		t.Fatalf("seed api_key: %v", err)
+	}
+}
+
 func (h *TestHelper) SeedBillingMetricsReporting(ctx context.Context, t *testing.T, teamID string, reportDate time.Time, events, spans, metrics uint64, reported bool) {
 	t.Helper()
 	var reportedAt interface{}

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -141,175 +141,180 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-22)
     - [Response Body](#response-body-25)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-25)
-  - [GET `/apps/:id/retention`](#get-appsidretention)
+  - [PATCH `/apps/:id/apiKey`](#patch-appsidapikey)
     - [Usage Notes](#usage-notes-26)
     - [Authorization \& Content Type](#authorization--content-type-23)
     - [Response Body](#response-body-26)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-26)
-  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
+  - [GET `/apps/:id/retention`](#get-appsidretention)
     - [Usage Notes](#usage-notes-27)
-    - [Request body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-24)
     - [Response Body](#response-body-27)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-27)
-  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
+  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
     - [Usage Notes](#usage-notes-28)
-    - [Request body](#request-body-6)
+    - [Request body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-25)
     - [Response Body](#response-body-28)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-28)
-  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
+  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
     - [Usage Notes](#usage-notes-29)
+    - [Request body](#request-body-6)
     - [Authorization \& Content Type](#authorization--content-type-26)
     - [Response Body](#response-body-29)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-29)
-  - [GET `/apps/:id/spans`](#get-appsidspans)
+  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
     - [Usage Notes](#usage-notes-30)
     - [Authorization \& Content Type](#authorization--content-type-27)
     - [Response Body](#response-body-30)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-30)
-  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
+  - [GET `/apps/:id/spans`](#get-appsidspans)
     - [Usage Notes](#usage-notes-31)
     - [Authorization \& Content Type](#authorization--content-type-28)
     - [Response Body](#response-body-31)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-31)
-  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
+  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
     - [Usage Notes](#usage-notes-32)
     - [Authorization \& Content Type](#authorization--content-type-29)
     - [Response Body](#response-body-32)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-32)
-  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
+  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
     - [Usage Notes](#usage-notes-33)
     - [Authorization \& Content Type](#authorization--content-type-30)
     - [Response Body](#response-body-33)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-33)
-  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
+  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
     - [Usage Notes](#usage-notes-34)
     - [Authorization \& Content Type](#authorization--content-type-31)
     - [Response Body](#response-body-34)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-34)
-  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
     - [Usage Notes](#usage-notes-35)
     - [Authorization \& Content Type](#authorization--content-type-32)
     - [Response Body](#response-body-35)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-35)
-  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-36)
-    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-33)
     - [Response Body](#response-body-36)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-36)
-  - [GET `/apps/:id/alerts`](#get-appsidalerts)
+  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-37)
+    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-34)
     - [Response Body](#response-body-37)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-37)
-- [Teams](#teams)
-  - [POST `/teams`](#post-teams)
-    - [Authorization \& Content Type](#authorization--content-type-35)
-    - [Request Body](#request-body-8)
+  - [GET `/apps/:id/alerts`](#get-appsidalerts)
     - [Usage Notes](#usage-notes-38)
+    - [Authorization \& Content Type](#authorization--content-type-35)
     - [Response Body](#response-body-38)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-38)
-  - [GET `/teams`](#get-teams)
+- [Teams](#teams)
+  - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-36)
+    - [Request Body](#request-body-8)
+    - [Usage Notes](#usage-notes-39)
     - [Response Body](#response-body-39)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-39)
-  - [GET `/teams/:id/apps`](#get-teamsidapps)
-    - [Usage Notes](#usage-notes-39)
+  - [GET `/teams`](#get-teams)
     - [Authorization \& Content Type](#authorization--content-type-37)
     - [Response Body](#response-body-40)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-40)
-  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
+  - [GET `/teams/:id/apps`](#get-teamsidapps)
     - [Usage Notes](#usage-notes-40)
     - [Authorization \& Content Type](#authorization--content-type-38)
     - [Response Body](#response-body-41)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-41)
-  - [POST `/teams/:id/apps`](#post-teamsidapps)
+  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
     - [Usage Notes](#usage-notes-41)
-    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-39)
     - [Response Body](#response-body-42)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-42)
-  - [GET `/teams/:id/invites`](#get-teamsidinvites)
+  - [POST `/teams/:id/apps`](#post-teamsidapps)
     - [Usage Notes](#usage-notes-42)
+    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-40)
     - [Response Body](#response-body-43)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-43)
-  - [POST `/teams/:id/invite`](#post-teamsidinvite)
+  - [GET `/teams/:id/invites`](#get-teamsidinvites)
     - [Usage Notes](#usage-notes-43)
-    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-41)
     - [Response Body](#response-body-44)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-44)
-  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
+  - [POST `/teams/:id/invite`](#post-teamsidinvite)
     - [Usage Notes](#usage-notes-44)
+    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-42)
     - [Response Body](#response-body-45)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-45)
-  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
+  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
     - [Usage Notes](#usage-notes-45)
     - [Authorization \& Content Type](#authorization--content-type-43)
     - [Response Body](#response-body-46)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-46)
-  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
+  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
     - [Usage Notes](#usage-notes-46)
-    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-44)
     - [Response Body](#response-body-47)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-47)
-  - [GET `/teams/:id/members`](#get-teamsidmembers)
+  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
     - [Usage Notes](#usage-notes-47)
+    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-45)
     - [Response Body](#response-body-48)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-48)
-  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
+  - [GET `/teams/:id/members`](#get-teamsidmembers)
     - [Usage Notes](#usage-notes-48)
     - [Authorization \& Content Type](#authorization--content-type-46)
     - [Response Body](#response-body-49)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-49)
-  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
+  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
     - [Usage Notes](#usage-notes-49)
-    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-47)
     - [Response Body](#response-body-50)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-50)
-  - [GET `/teams/:id/authz`](#get-teamsidauthz)
+  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
     - [Usage Notes](#usage-notes-50)
+    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-48)
     - [Response Body](#response-body-51)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-51)
-  - [GET `/teams/:id/usage`](#get-teamsidusage)
+  - [GET `/teams/:id/authz`](#get-teamsidauthz)
     - [Usage Notes](#usage-notes-51)
     - [Authorization \& Content Type](#authorization--content-type-49)
     - [Response Body](#response-body-52)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-52)
-  - [GET `/teams/:id/slack`](#get-teamsidslack)
+  - [GET `/teams/:id/usage`](#get-teamsidusage)
     - [Usage Notes](#usage-notes-52)
     - [Authorization \& Content Type](#authorization--content-type-50)
     - [Response Body](#response-body-53)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-53)
-  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+  - [GET `/teams/:id/slack`](#get-teamsidslack)
     - [Usage Notes](#usage-notes-53)
-    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-51)
     - [Response Body](#response-body-54)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-54)
-  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
     - [Usage Notes](#usage-notes-54)
+    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-52)
     - [Response Body](#response-body-55)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-55)
-  - [GET `/teams/:id/config`](#get-teamsidconfig)
+  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
     - [Usage Notes](#usage-notes-55)
     - [Authorization \& Content Type](#authorization--content-type-53)
     - [Response Body](#response-body-56)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-56)
-  - [PATCH `/teams/:id/config`](#patch-teamsidconfig)
+  - [GET `/apps/:id/config`](#get-appsidconfig)
     - [Usage Notes](#usage-notes-56)
     - [Authorization \& Content Type](#authorization--content-type-54)
     - [Response Body](#response-body-57)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-57)
+  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+    - [Usage Notes](#usage-notes-57)
+    - [Authorization \& Content Type](#authorization--content-type-55)
+    - [Response Body](#response-body-58)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-58)
 
 ## Auth
 
@@ -771,6 +776,7 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/alertPrefs`**](#get-appsidalertprefs) - Fetch an app's alert preferences for current user.
 - [**PATCH `/apps/:id/alertPrefs`**](#patch-appsidalertprefs) - Update an app's alert preferences for current user.
 - [**PATCH `/apps/:id/rename`**](#patch-appsidrename) - Modify the name of an app.
+- [**PATCH `/apps/:id/apiKey`**](#patch-appsidapikey) - Rotate an app's API key and revoke all previously active keys.
 - [**GET `/apps/:id/retention`**](#get-appsidretention) - Fetch an app's retention period in days. Must be between 30 and 365. Default is 30.
 - [**PATCH `/apps/:id/retention`**](#patch-appsidretention) - Update an app's retention period in days. Must be between 30 and 365.
 - [**POST `/apps/:id/shortFilters`**](#post-appsidshortfilters) - Create a shortcode to represent a combination of various app filters.
@@ -4130,6 +4136,74 @@ List of HTTP status codes for success and failures.
 | **Status**                  | **Meaning**                                                                                                            |
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### PATCH `/apps/:id/apiKey`
+
+Rotate an app's API key. All previously active API keys for the app are revoked. Only the newly generated key stays active.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI
+- This endpoint does not require a request body
+- Existing clients using previously issued API keys will stop being able to ingest data until updated with the new key
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+  {
+    "apiKey": "msr_a5Hn7x..."
+  }
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes & Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, new API key returned and previous keys revoked.                                                   |
 | `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
 | `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
 | `403 Forbidden`             | Requester does not have access to this resource.                                                                       |

--- a/frontend/dashboard/__tests__/pages/apps_test.tsx
+++ b/frontend/dashboard/__tests__/pages/apps_test.tsx
@@ -1,0 +1,879 @@
+import Apps from '@/app/[teamId]/apps/page'
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import * as React from 'react'
+
+const mockToastPositive = jest.fn()
+const mockToastNegative = jest.fn()
+const mockRefreshFilters = jest.fn()
+
+const baseMockApp = {
+  id: 'app-1',
+  team_id: 'team-1',
+  name: 'Demo App',
+  api_key: {
+    created_at: '2025-01-01T00:00:00Z',
+    key: 'msrsh_key_checksum',
+    last_seen: null,
+    revoked: false,
+  },
+  onboarded: true,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+  os_name: 'Android',
+  onboarded_at: '2025-01-01T00:00:00Z',
+  unique_identifier: 'com.example.app',
+}
+
+let mockCurrentApp = { ...baseMockApp, api_key: { ...baseMockApp.api_key } }
+
+const getAppPayload = () => ({
+  ...mockCurrentApp,
+  api_key: { ...mockCurrentApp.api_key },
+})
+
+jest.mock('@/app/utils/use_toast', () => ({
+  toastPositive: (...args: any[]) => mockToastPositive(...args),
+  toastNegative: (...args: any[]) => mockToastNegative(...args),
+}))
+
+jest.mock('@/app/auth/measure_auth', () => ({
+  measureAuth: {
+    getSession: jest.fn(() =>
+      Promise.resolve({
+        session: { user: { id: 'user-1' } },
+        error: null,
+      })
+    ),
+  },
+}))
+
+jest.mock('@/app/utils/env_utils', () => ({
+  isCloud: jest.fn(() => false),
+}))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  AuthzAndMembersApiStatus: {
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  FetchBillingInfoApiStatus: {
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  FetchAppRetentionApiStatus: {
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  SdkConfigApiStatus: {
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  UpdateAppRetentionApiStatus: {
+    Init: 'init',
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  AppNameChangeApiStatus: {
+    Init: 'init',
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  AppApiKeyChangeApiStatus: {
+    Init: 'init',
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    Cancelled: 'cancelled',
+  },
+  FilterSource: {
+    Events: 'events',
+  },
+  emptyAppRetention: {
+    retention: 30,
+  },
+  fetchAuthzAndMembersFromServer: jest.fn(() =>
+    Promise.resolve({
+      status: 'success',
+      data: {
+        members: [
+          { id: 'user-1', role: 'admin' },
+          { id: 'user-2', role: 'developer' },
+        ],
+      },
+    })
+  ),
+  fetchBillingInfoFromServer: jest.fn(() => Promise.resolve({ status: 'success', data: { plan: 'free' } })),
+  fetchAppRetentionFromServer: jest.fn(() =>
+    Promise.resolve({
+      status: 'success',
+      data: {
+        retention: 30,
+      },
+    })
+  ),
+  updateAppRetentionFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
+  fetchSdkConfigFromServer: jest.fn(() =>
+    Promise.resolve({
+      status: 'success',
+      data: {
+        session_sampling_rate: 100,
+      },
+    })
+  ),
+  changeAppNameFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
+  changeAppApiKeyFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
+}))
+
+jest.mock('@/app/components/filters', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: React.forwardRef((props: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        refresh: () => {
+          mockRefreshFilters()
+          mockCurrentApp = {
+            ...mockCurrentApp,
+            api_key: {
+              ...mockCurrentApp.api_key,
+              key: 'msrsh_rotated_key_checksum',
+            },
+          }
+          props.onFiltersChanged({
+            ready: true,
+            app: getAppPayload(),
+            serialisedFilters: 'app=app-1',
+          })
+        },
+      }))
+
+      return (
+        <div data-testid="filters-mock">
+          <button
+            data-testid="update-filters"
+            onClick={() =>
+              props.onFiltersChanged({
+                ready: true,
+                app: getAppPayload(),
+                serialisedFilters: 'app=app-1',
+              })
+            }
+          >
+            Update Filters
+          </button>
+        </div>
+      )
+    }),
+    AppVersionsInitialSelectionType: { All: 'all' },
+    defaultFilters: { ready: false, app: null, serialisedFilters: '' },
+  }
+})
+
+jest.mock('@/app/components/button', () => ({
+  Button: ({ children, loading, disabled, ...props }: any) => (
+    <button disabled={disabled || loading} {...props}>{children}</button>
+  ),
+}))
+
+jest.mock('@/app/components/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+jest.mock('@/app/components/dropdown_select', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="dropdown-select-mock">
+      <span>{props.title}</span>
+      <button
+        data-testid="retention-select-90"
+        disabled={props.disabled}
+        onClick={() => props.onChangeSelected('3 months')}
+      >
+        Set 3 months
+      </button>
+    </div>
+  ),
+  DropdownSelectType: { SingleString: 'single' },
+}))
+
+jest.mock('@/app/components/create_app', () => ({
+  __esModule: true,
+  default: () => <div data-testid="create-app-mock" />,
+}))
+
+jest.mock('@/app/components/loading_spinner', () => () => <div data-testid="loading-spinner-mock" />)
+
+jest.mock('@/app/components/sdk_configurator', () => ({
+  __esModule: true,
+  default: () => <div data-testid="sdk-configurator-mock" />,
+}))
+
+jest.mock('@/app/components/danger_confirmation_dialog', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    if (!props.open) return null
+
+    return (
+      <div data-testid={`danger-dialog-${props.affirmativeText}`}>
+        {props.body}
+        <button onClick={props.onAffirmativeAction}>{props.affirmativeText}</button>
+        <button onClick={props.onCancelAction}>{props.cancelText}</button>
+      </div>
+    )
+  },
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+const renderLoadedPage = async () => {
+  render(<Apps params={{ teamId: 'team-1' }} />)
+
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('update-filters'))
+  })
+}
+
+const openRotateDialog = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Rotate' }))
+  })
+}
+
+const openRenameDialog = async () => {
+  const renameInput = screen.getByDisplayValue('Demo App')
+  await act(async () => {
+    fireEvent.change(renameInput, { target: { value: 'Renamed App' } })
+  })
+
+  const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+  await act(async () => {
+    fireEvent.click(saveButtons[1])
+  })
+}
+
+const openRetentionDialog = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('retention-select-90'))
+  })
+
+  const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+  await act(async () => {
+    fireEvent.click(saveButtons[0])
+  })
+}
+
+describe('Apps Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCurrentApp = { ...baseMockApp, api_key: { ...baseMockApp.api_key } }
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.measure.sh'
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    })
+  })
+
+  it('renders main settings sections after app filters load', async () => {
+    await renderLoadedPage()
+
+    expect(await screen.findByText('Configure Data Retention')).toBeInTheDocument()
+    expect(screen.getByText('Change App Name')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Rotate' })).toBeInTheDocument()
+    expect(screen.getByTestId('sdk-configurator-mock')).toBeInTheDocument()
+  })
+
+  it('does not render settings sections before filters are ready', async () => {
+    render(<Apps params={{ teamId: 'team-1' }} />)
+
+    expect(screen.queryByText('Configure Data Retention')).not.toBeInTheDocument()
+    expect(screen.queryByText('Change App Name')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rotate API key')).not.toBeInTheDocument()
+  })
+
+  it('shows loading state while app settings are being fetched', async () => {
+    const { fetchAppRetentionFromServer } = require('@/app/api/api_calls')
+
+    let resolvePromise: (value: any) => void
+    const loadingPromise = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+
+    fetchAppRetentionFromServer.mockImplementationOnce(() => loadingPromise)
+
+    render(<Apps params={{ teamId: 'team-1' }} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('update-filters'))
+    })
+
+    expect(screen.getByTestId('loading-spinner-mock')).toBeInTheDocument()
+
+    await act(async () => {
+      resolvePromise!({ status: 'success', data: { retention: 30 } })
+    })
+  })
+
+  it('shows error message when app settings fetch fails', async () => {
+    const { fetchSdkConfigFromServer } = require('@/app/api/api_calls')
+    fetchSdkConfigFromServer.mockImplementationOnce(() =>
+      Promise.resolve({ status: 'error' })
+    )
+
+    await renderLoadedPage()
+
+    expect(await screen.findByText(/Error fetching app settings/)).toBeInTheDocument()
+  })
+
+  it('shows rotate button for admin users', async () => {
+    await renderLoadedPage()
+
+    expect(await screen.findByRole('button', { name: 'Rotate' })).toBeInTheDocument()
+  })
+
+  it('shows rotate button for owner users', async () => {
+    const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+    fetchAuthzAndMembersFromServer.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 'success',
+        data: {
+          members: [
+            { id: 'user-1', role: 'owner' },
+          ],
+        },
+      })
+    )
+
+    await renderLoadedPage()
+
+    expect(await screen.findByRole('button', { name: 'Rotate' })).toBeInTheDocument()
+  })
+
+  it('hides rotate button for non-admin users', async () => {
+    const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+    fetchAuthzAndMembersFromServer.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 'success',
+        data: {
+          members: [
+            { id: 'user-1', role: 'developer' },
+          ],
+        },
+      })
+    )
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument()
+  })
+
+  it('keeps retention and rename save disabled for non-admin users', async () => {
+    const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+    fetchAuthzAndMembersFromServer.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 'success',
+        data: {
+          members: [
+            { id: 'user-1', role: 'developer' },
+          ],
+        },
+      })
+    )
+
+    await renderLoadedPage()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    const renameInput = screen.getByDisplayValue('Demo App')
+    await act(async () => {
+      fireEvent.change(renameInput, { target: { value: 'Renamed App' } })
+    })
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    expect(saveButtons[0]).toBeDisabled()
+    expect(saveButtons[1]).toBeDisabled()
+  })
+
+  it('handles authz API error by not showing rotate button', async () => {
+    const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+    fetchAuthzAndMembersFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'error' }))
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument()
+  })
+
+  it('handles session fetch error by not showing rotate button', async () => {
+    const { measureAuth } = require('@/app/auth/measure_auth')
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { })
+
+    measureAuth.getSession.mockImplementationOnce(() => Promise.resolve({ session: null, error: 'bad session' }))
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('handles missing current user in members list', async () => {
+    const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+    fetchAuthzAndMembersFromServer.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 'success',
+        data: {
+          members: [{ id: 'user-2', role: 'admin' }],
+        },
+      })
+    )
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument()
+  })
+
+  it('opens rotate confirmation dialog with warning text', async () => {
+    await renderLoadedPage()
+
+    await openRotateDialog()
+
+    expect(screen.getByText(/won't be able to send data anymore/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Yes, rotate key' })).toBeInTheDocument()
+  })
+
+  it('cancels rotate and does not call API', async () => {
+    const { changeAppApiKeyFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRotateDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+
+    expect(changeAppApiKeyFromServer).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Yes, rotate key' })).not.toBeInTheDocument()
+  })
+
+  it('rotates API key successfully, reloads filters, and updates displayed key', async () => {
+    const { changeAppApiKeyFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRotateDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, rotate key' }))
+    })
+
+    expect(changeAppApiKeyFromServer).toHaveBeenCalledWith('app-1')
+    expect(mockToastPositive).toHaveBeenCalledWith('API key rotated')
+    expect(mockRefreshFilters).toHaveBeenCalled()
+    expect(await screen.findAllByDisplayValue('msrsh_rotated_key_checksum')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: 'Yes, rotate key' })).not.toBeInTheDocument()
+  })
+
+  it('shows failure toast when API key rotation fails', async () => {
+    const { changeAppApiKeyFromServer } = require('@/app/api/api_calls')
+    changeAppApiKeyFromServer.mockImplementationOnce(() =>
+      Promise.resolve({ status: 'error' })
+    )
+
+    await renderLoadedPage()
+    await openRotateDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, rotate key' }))
+    })
+
+    expect(mockToastNegative).toHaveBeenCalledWith('Error rotating API key')
+    expect(mockRefreshFilters).not.toHaveBeenCalled()
+  })
+
+  it('handles cancelled rotate without toasts', async () => {
+    const { changeAppApiKeyFromServer } = require('@/app/api/api_calls')
+    changeAppApiKeyFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'cancelled' }))
+
+    await renderLoadedPage()
+    await openRotateDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, rotate key' }))
+    })
+
+    expect(mockToastPositive).not.toHaveBeenCalled()
+    expect(mockToastNegative).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Rotate' })).not.toBeDisabled()
+  })
+
+
+  it('disables rotate button while rotation is in progress and prevents repeated submit', async () => {
+    const { changeAppApiKeyFromServer } = require('@/app/api/api_calls')
+
+    let resolvePromise: (value: any) => void
+    const pendingPromise = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+
+    changeAppApiKeyFromServer.mockImplementationOnce(() => pendingPromise)
+
+    await renderLoadedPage()
+    await openRotateDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, rotate key' }))
+    })
+
+    const rotateButton = screen.getByRole('button', { name: 'Rotate' })
+    expect(rotateButton).toBeDisabled()
+
+    await act(async () => {
+      fireEvent.click(rotateButton)
+    })
+
+    expect(screen.queryByRole('button', { name: 'Yes, rotate key' })).not.toBeInTheDocument()
+    expect(changeAppApiKeyFromServer).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvePromise!({ status: 'success' })
+    })
+  })
+
+  it('enables rename save only when name changes', async () => {
+    await renderLoadedPage()
+
+    const renameInput = screen.getByDisplayValue('Demo App')
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const renameSaveButton = saveButtons[1]
+
+    expect(renameSaveButton).toBeDisabled()
+
+    await act(async () => {
+      fireEvent.change(renameInput, { target: { value: 'Renamed App' } })
+    })
+
+    expect(renameSaveButton).not.toBeDisabled()
+  })
+
+  it('renames app successfully', async () => {
+    const { changeAppNameFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRenameDialog()
+
+    expect(screen.getByText(/Are you sure you want to rename app/i)).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(changeAppNameFromServer).toHaveBeenCalledWith('app-1', 'Renamed App')
+    expect(mockToastPositive).toHaveBeenCalledWith('App name changed')
+    expect(mockRefreshFilters).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: "Yes, I'm sure" })).not.toBeInTheDocument()
+  })
+
+  it('disables rename actions while rename is in progress and prevents double submit', async () => {
+    const { changeAppNameFromServer } = require('@/app/api/api_calls')
+
+    let resolvePromise: (value: any) => void
+    const pendingPromise = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    changeAppNameFromServer.mockImplementationOnce(() => pendingPromise)
+
+    await renderLoadedPage()
+    await openRenameDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    const renameSaveButton = screen.getAllByRole('button', { name: 'Save' })[1]
+    expect(renameSaveButton).toBeDisabled()
+    expect(changeAppNameFromServer).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      fireEvent.click(renameSaveButton)
+    })
+    expect(changeAppNameFromServer).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvePromise!({ status: 'success' })
+    })
+  })
+
+  it('shows rename error toast on failure', async () => {
+    const { changeAppNameFromServer } = require('@/app/api/api_calls')
+    changeAppNameFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'error' }))
+
+    await renderLoadedPage()
+    await openRenameDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(mockToastNegative).toHaveBeenCalledWith('Error changing app name')
+  })
+
+  it('handles cancelled rename without toasts', async () => {
+    const { changeAppNameFromServer } = require('@/app/api/api_calls')
+    changeAppNameFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'cancelled' }))
+
+    await renderLoadedPage()
+    await openRenameDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(mockToastPositive).not.toHaveBeenCalled()
+    expect(mockToastNegative).not.toHaveBeenCalled()
+  })
+
+
+  it('cancels rename and does not call API', async () => {
+    const { changeAppNameFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRenameDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+
+    expect(changeAppNameFromServer).not.toHaveBeenCalled()
+  })
+
+  it('enables retention save when retention period changes', async () => {
+    await renderLoadedPage()
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const retentionSaveButton = saveButtons[0]
+
+    expect(retentionSaveButton).toBeDisabled()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    expect(retentionSaveButton).not.toBeDisabled()
+  })
+
+  it('updates retention successfully', async () => {
+    const { updateAppRetentionFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRetentionDialog()
+
+    expect(screen.getByText(/change the retention period/i)).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(updateAppRetentionFromServer).toHaveBeenCalledWith('app-1', { retention: 90 })
+    expect(mockToastPositive).toHaveBeenCalledWith('Your app settings have been saved')
+    expect(screen.queryByRole('button', { name: "Yes, I'm sure" })).not.toBeInTheDocument()
+  })
+
+  it('disables retention actions while update is in progress and prevents double submit', async () => {
+    const { updateAppRetentionFromServer } = require('@/app/api/api_calls')
+
+    let resolvePromise: (value: any) => void
+    const pendingPromise = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    updateAppRetentionFromServer.mockImplementationOnce(() => pendingPromise)
+
+    await renderLoadedPage()
+    await openRetentionDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    const retentionSaveButton = screen.getAllByRole('button', { name: 'Save' })[0]
+    expect(retentionSaveButton).toBeDisabled()
+    expect(updateAppRetentionFromServer).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      fireEvent.click(retentionSaveButton)
+    })
+    expect(updateAppRetentionFromServer).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvePromise!({ status: 'success' })
+    })
+  })
+
+  it('shows retention error toast on failure', async () => {
+    const { updateAppRetentionFromServer } = require('@/app/api/api_calls')
+    updateAppRetentionFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'error', error: 'bad retention' }))
+
+    await renderLoadedPage()
+    await openRetentionDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(mockToastNegative).toHaveBeenCalledWith('Error saving app settings', 'bad retention')
+  })
+
+  it('handles cancelled retention update without toasts', async () => {
+    const { updateAppRetentionFromServer } = require('@/app/api/api_calls')
+    updateAppRetentionFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'cancelled' }))
+
+    await renderLoadedPage()
+    await openRetentionDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Yes, I'm sure" }))
+    })
+
+    expect(mockToastPositive).not.toHaveBeenCalled()
+    expect(mockToastNegative).not.toHaveBeenCalled()
+  })
+
+
+  it('cancels retention update and does not call API', async () => {
+    const { updateAppRetentionFromServer } = require('@/app/api/api_calls')
+
+    await renderLoadedPage()
+    await openRetentionDialog()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+
+    expect(updateAppRetentionFromServer).not.toHaveBeenCalled()
+  })
+
+  it('copies API URL from copy sdk variables section', async () => {
+    await renderLoadedPage()
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy' })
+
+    await act(async () => {
+      fireEvent.click(copyButtons[0])
+    })
+
+    expect((navigator.clipboard.writeText as jest.Mock)).toHaveBeenCalledWith('https://api.measure.sh')
+    expect(mockToastPositive).toHaveBeenCalledWith('Base URL copied to clipboard')
+  })
+
+  it('copy buttons are scoped to Copy SDK Variables section', async () => {
+    await renderLoadedPage()
+
+    const copySdkHeader = screen.getByText('Copy SDK Variables')
+    const section = copySdkHeader.parentElement as HTMLElement
+    const copyButtons = within(section).getAllByRole('button', { name: 'Copy' })
+    expect(copyButtons).toHaveLength(2)
+  })
+
+  it('copies API key from copy sdk variables section', async () => {
+    await renderLoadedPage()
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy' })
+
+    await act(async () => {
+      fireEvent.click(copyButtons[1])
+    })
+
+    expect((navigator.clipboard.writeText as jest.Mock)).toHaveBeenCalledWith('msrsh_key_checksum')
+    expect(mockToastPositive).toHaveBeenCalledWith('API key copied to clipboard')
+  })
+
+  it('retention save is disabled when retention change is not allowed', async () => {
+    const { isCloud } = require('@/app/utils/env_utils')
+    const { fetchBillingInfoFromServer } = require('@/app/api/api_calls')
+    isCloud.mockReturnValueOnce(true)
+    fetchBillingInfoFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'success', data: { plan: 'free' } }))
+
+    await renderLoadedPage()
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const retentionSaveButton = saveButtons[0]
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    expect(retentionSaveButton).toBeDisabled()
+  })
+
+  it('retention save remains disabled when billing info fetch fails in cloud mode', async () => {
+    const { isCloud } = require('@/app/utils/env_utils')
+    const { fetchBillingInfoFromServer } = require('@/app/api/api_calls')
+    isCloud.mockReturnValueOnce(true)
+    fetchBillingInfoFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'error' }))
+
+    await renderLoadedPage()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const retentionSaveButton = saveButtons[0]
+    expect(retentionSaveButton).toBeDisabled()
+  })
+
+  it('retention save remains disabled when billing info fetch is cancelled in cloud mode', async () => {
+    const { isCloud } = require('@/app/utils/env_utils')
+    const { fetchBillingInfoFromServer } = require('@/app/api/api_calls')
+    isCloud.mockReturnValueOnce(true)
+    fetchBillingInfoFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'cancelled' }))
+
+    await renderLoadedPage()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const retentionSaveButton = saveButtons[0]
+    expect(retentionSaveButton).toBeDisabled()
+  })
+
+  it('retention save can be enabled for paid plan in cloud', async () => {
+    const { isCloud } = require('@/app/utils/env_utils')
+    const { fetchBillingInfoFromServer } = require('@/app/api/api_calls')
+    isCloud.mockReturnValueOnce(true)
+    fetchBillingInfoFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'success', data: { plan: 'pro' } }))
+
+    await renderLoadedPage()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('retention-select-90'))
+    })
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const retentionSaveButton = saveButtons[0]
+
+    await waitFor(() => {
+      expect(retentionSaveButton).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -200,6 +200,14 @@ export enum AppNameChangeApiStatus {
   Cancelled,
 }
 
+export enum AppApiKeyChangeApiStatus {
+  Init,
+  Loading,
+  Success,
+  Error,
+  Cancelled,
+}
+
 export enum RoleChangeApiStatus {
   Init,
   Loading,
@@ -2331,6 +2339,23 @@ export const changeAppNameFromServer = async (
     return { status: AppNameChangeApiStatus.Success }
   } catch {
     return { status: AppNameChangeApiStatus.Cancelled }
+  }
+}
+
+export const changeAppApiKeyFromServer = async (appId: string) => {
+  const opts = {
+    method: "PATCH",
+  }
+
+  try {
+    const res = await measureAuth.fetchMeasure(`/api/apps/${appId}/apiKey`, opts)
+    if (!res.ok) {
+      return { status: AppApiKeyChangeApiStatus.Error }
+    }
+
+    return { status: AppApiKeyChangeApiStatus.Success }
+  } catch {
+    return { status: AppApiKeyChangeApiStatus.Cancelled }
   }
 }
 


### PR DESCRIPTION
# Description

Implements app api key rotation

## Demo video

https://github.com/user-attachments/assets/230858ce-44da-454a-8499-2d1cc596bd08


## Details

- Implements app API key rotation endpoint `PATCH /apps/:id/apiKey in
  backend/api/measure/apikey.go`, and wires route in `backend/api/main.go`.
- Implements rotation logic to create a new key and revoke all other keys,
  enforcing exactly one active API key per app.
- Adds backend authorization check for rotation using ScopeAppAll in handler.
- Audits ingest/API key validation flow to ensure revoked keys are rejected.
- Adds frontend API client method changeAppApiKeyFromServer in
  `frontend/dashboard/app/api/api_calls.ts`.
- Adds Rotate API key section on Apps page under Change App Name with
  destructive confirmation dialog and warning copy.
- Adds rotate UX with success/failure toasts and admin+ UI gating; button is
  labeled Rotate.
- Adds API key display in rotate section like SDK variables, replacing copy
  action with rotate action.
- Refactors API key handler/function placement from `app.go` to `apikey.go`.
- Adds comprehensive backend tests in `backend/api/measure/apikey_test.go`
  covering units, handlers, roles/scopes, and rotation/revocation behavior.
- Adds frontend Apps page tests in
  `frontend/dashboard/__tests__/pages/apps_test.tsx` for all flows and behavior.
- Adds dashboard API docs for `PATCH /apps/:id/apiKey` in
  `docs/api/dashboard/README.md`, updates TOC numbering, and fixes anchors.


## Related issue
Closes #2886



