### PR TITLE
fix(backend): populate session attributes for trace only sessions

### DIFF
--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -150,12 +150,18 @@ type TraceDisplay struct {
 }
 
 type TraceSessionTimelineDisplay struct {
-	TraceID    string        `json:"trace_id" binding:"required"`
-	TraceName  string        `json:"trace_name" binding:"required"`
-	ThreadName string        `json:"thread_name"`
-	StartTime  time.Time     `json:"start_time" binding:"required"`
-	EndTime    time.Time     `json:"end_time" binding:"required"`
-	Duration   time.Duration `json:"duration" binding:"required"`
+	TraceID            string        `json:"trace_id" binding:"required"`
+	TraceName          string        `json:"trace_name" binding:"required"`
+	AppVersion         string        `json:"-"`
+	AppBuild           string        `json:"-"`
+	UserID             string        `json:"-"`
+	ThreadName         string        `json:"thread_name"`
+	DeviceManufacturer string        `json:"-"`
+	DeviceModel        string        `json:"-"`
+	NetworkType        string        `json:"-"`
+	StartTime          time.Time     `json:"start_time" binding:"required"`
+	EndTime            time.Time     `json:"end_time" binding:"required"`
+	Duration           time.Duration `json:"duration" binding:"required"`
 }
 
 type SpanMetricsPlotInstance struct {


### PR DESCRIPTION
## Summary

This PR fixes the condition where session's attributes were not shown in session detail page for trace only sessions.

## Tasks

- [x] Populate session's attributes from traces
- [x] Populate session's duration from traces

## See also

- fixes #3194