### PR TITLE
chore(backend): update daily summary time range and email

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -247,7 +247,8 @@ func CreateBugReportAlerts(ctx context.Context) {
 func CreateDailySummary(ctx context.Context) {
 	fmt.Println("Creating daily summary...")
 
-	date := time.Now().UTC()
+	// Daily summary runs at 06:00 UTC and reports the previous UTC calendar day.
+	date := time.Now().UTC().AddDate(0, 0, -1)
 
 	teams, err := getTeams(ctx)
 	if err != nil {

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -1805,7 +1805,7 @@ func TestCreateDailySummary(t *testing.T) {
 		}
 	})
 
-	t.Run("events today populate metrics and produce a summary email", func(t *testing.T) {
+	t.Run("events yesterday populate metrics and produce a summary email", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)
 		defer cleanupAll(ctx, t)
@@ -1819,9 +1819,9 @@ func TestCreateDailySummary(t *testing.T) {
 		th.SeedTeamMembership(ctx, t, teamID, userID, "owner")
 		th.SeedApp(ctx, t, appID, teamID, "Summary App", 30)
 
-		// Seed events today — the app_metrics_mv fires on insert and populates app_metrics
-		now := time.Now().UTC()
-		th.SeedGenericEvents(ctx, t, teamID, appID, 5, now)
+		// Seed events for the previous UTC day; CreateDailySummary reports yesterday.
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, appID, 5, summaryDate)
 
 		CreateDailySummary(ctx)
 
@@ -1845,8 +1845,8 @@ func TestCreateDailySummary(t *testing.T) {
 		th.SeedApp(ctx, t, appID, teamID, "Slack Summary App", 30)
 		th.SeedTeamSlack(ctx, t, teamID, []string{"C0SUMMARY"})
 
-		now := time.Now().UTC()
-		th.SeedGenericEvents(ctx, t, teamID, appID, 5, now)
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, appID, 5, summaryDate)
 
 		CreateDailySummary(ctx)
 
@@ -1889,9 +1889,9 @@ func TestCreateDailySummary(t *testing.T) {
 		th.SeedApp(ctx, t, app1, teamID, "App One", 30)
 		th.SeedApp(ctx, t, app2, teamID, "App Two", 30)
 
-		now := time.Now().UTC()
-		th.SeedGenericEvents(ctx, t, teamID, app1, 5, now)
-		th.SeedGenericEvents(ctx, t, teamID, app2, 5, now)
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, app1, 5, summaryDate)
+		th.SeedGenericEvents(ctx, t, teamID, app2, 5, summaryDate)
 
 		CreateDailySummary(ctx)
 
@@ -1915,8 +1915,8 @@ func TestCreateDailySummary(t *testing.T) {
 		th.SeedApp(ctx, t, appID, teamID, "Summary App", 30)
 		th.SeedTeamSlack(ctx, t, teamID, []string{"C0SUM1", "C0SUM2"})
 
-		now := time.Now().UTC()
-		th.SeedGenericEvents(ctx, t, teamID, appID, 5, now)
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, appID, 5, summaryDate)
 
 		CreateDailySummary(ctx)
 
@@ -1940,8 +1940,8 @@ func TestCreateDailySummary(t *testing.T) {
 		th.SeedApp(ctx, t, appID, teamID, "Summary App", 30)
 		th.SeedTeamSlack(ctx, t, teamID, []string{})
 
-		now := time.Now().UTC()
-		th.SeedGenericEvents(ctx, t, teamID, appID, 5, now)
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, appID, 5, summaryDate)
 
 		CreateDailySummary(ctx)
 

--- a/backend/email/email.go
+++ b/backend/email/email.go
@@ -210,6 +210,8 @@ func UsageLimitContent(message string, threshold int, usageFormatted, maxUnitsFo
 // for daily summary emails.
 func DailySummaryContent(appName string, date time.Time, metrics []MetricData) string {
 	formattedDate := date.Format("January 2, 2006")
+	formattedDateShort := date.Format("Jan 2, 2006")
+	comparisonDateShort := date.AddDate(0, 0, -1).Format("Jan 2, 2006")
 
 	metricsHTML := ""
 	for _, metric := range metrics {
@@ -251,14 +253,17 @@ func DailySummaryContent(appName string, date time.Time, metrics []MetricData) s
             <!-- Date Header -->
             <div style="text-align: center; margin-bottom: 32px;">
                 <h2 style="margin: 0; font-size: 18px; color: #2d3748; font-family: 'Josefin Sans', sans-serif; font-weight: 600;">
-                    %s (Last 24 hours)
+                    Summary for %s
                 </h2>
+                <p style="margin: 8px 0 0 0; font-size: 12px; color: #718096;">
+                    Comparisons are between %s (12:00 AM UTC to 11:59 PM UTC) and %s (12:00 AM UTC to 11:59 PM UTC).
+                </p>
             </div>
 
             <!-- Metrics Grid -->
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; margin-bottom: 32px;">
                 %s
-            </div>`, formattedDate, metricsHTML)
+            </div>`, formattedDate, formattedDateShort, comparisonDateShort, metricsHTML)
 }
 
 func getProgressBarColor(threshold int) string {

--- a/backend/email/email_test.go
+++ b/backend/email/email_test.go
@@ -107,7 +107,8 @@ func TestDailySummaryContent(t *testing.T) {
 		contain string
 	}{
 		{"date", "February 15, 2026"},
-		{"last 24h", "Last 24 hours"},
+		{"summary label", "Summary for February 15, 2026"},
+		{"comparison label", "Comparisons are between Feb 15, 2026 (12:00 AM UTC to 11:59 PM UTC) and Feb 14, 2026 (12:00 AM UTC to 11:59 PM UTC)."},
 		{"sessions value", "1,234"},
 		{"sessions label", "Sessions"},
 		{"crash free value", "99.5%"},


### PR DESCRIPTION
# Description

Daily summary is currently calculated as target day so far (6 AM UTC) vs full day of pervious day.

This commit makes it so that it generates summary for full previous day and compares it against full day before that.

When job is triggered at `6 AM UTC` on `23rd Feb 2026`, summary will be for `22nd Feb, 2026 12:00 AM UTC - 11:59 PM UTC` compared to `21st Feb, 2026 12:00 AM UTC - 11:59 PM UTC`.

Email is updated to reflect this.

<img width="699" height="1099" alt="Screenshot 2026-02-23 at 1 16 46 PM" src="https://github.com/user-attachments/assets/db1b3b7f-de92-473a-95c6-50e61976a33c" />

## Related issue
Closes #3197



