### PR TITLE
chore(backend): use dynamic time groupings for plots

### DIFF
--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -30,7 +30,7 @@ func seedCrashSpike(ctx context.Context, t *testing.T, teamID, appID string, ses
 	now := time.Now().UTC()
 	th.SeedGenericEvents(ctx, t, teamID, appID, sessionCount, now.Add(-30*time.Minute))
 	for i := 0; i < crashCount; i++ {
-		th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, now.Add(-5*time.Minute))
+		th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, false, now.Add(-5*time.Minute))
 	}
 	th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
 }
@@ -41,7 +41,7 @@ func seedAnrSpike(ctx context.Context, t *testing.T, teamID, appID string, sessi
 	now := time.Now().UTC()
 	th.SeedGenericEvents(ctx, t, teamID, appID, sessionCount, now.Add(-30*time.Minute))
 	for i := 0; i < anrCount; i++ {
-		th.SeedUnhandledEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, now.Add(-5*time.Minute))
+		th.SeedIssueEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, false, now.Add(-5*time.Minute))
 	}
 	th.SeedAnrGroup(ctx, t, teamID, appID, testAnrFingerprint)
 }
@@ -86,7 +86,7 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
 		// Seed 50 crashes — below minCrashOrAnrCountThreshold (100)
 		for i := 0; i < 50; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, false, now.Add(-5*time.Minute))
 		}
 		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
 
@@ -168,10 +168,10 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		now := time.Now().UTC()
 		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
 		for i := 0; i < 110; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, false, now.Add(-5*time.Minute))
 		}
 		for i := 0; i < 110; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, false, now.Add(-5*time.Minute))
 		}
 		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
 		th.SeedAnrGroup(ctx, t, teamID, appID, testAnrFingerprint)
@@ -327,7 +327,7 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		now := time.Now().UTC()
 		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
 		for i := 0; i < 50; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, false, now.Add(-5*time.Minute))
 		}
 		th.SeedAnrGroup(ctx, t, teamID, appID, testAnrFingerprint)
 
@@ -355,7 +355,7 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		// 100 crashes / 20 101 total sessions ≈ 0.497% < 0.5% threshold
 		now := time.Now().UTC()
 		for i := 0; i < 100; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, false, now.Add(-5*time.Minute))
 		}
 		th.SeedGenericEvents(ctx, t, teamID, appID, 20001, now.Add(-30*time.Minute))
 		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
@@ -384,7 +384,7 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		// 100 ANRs / 20 101 total sessions ≈ 0.497% < 0.5% threshold
 		now := time.Now().UTC()
 		for i := 0; i < 100; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "anr", testAnrFingerprint, false, now.Add(-5*time.Minute))
 		}
 		th.SeedGenericEvents(ctx, t, teamID, appID, 20001, now.Add(-30*time.Minute))
 		th.SeedAnrGroup(ctx, t, teamID, appID, testAnrFingerprint)
@@ -415,8 +415,8 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		now := time.Now().UTC()
 		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
 		for i := 0; i < 110; i++ {
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, now.Add(-5*time.Minute))
-			th.SeedUnhandledEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint2, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint, false, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", testCrashFingerprint2, false, now.Add(-5*time.Minute))
 		}
 		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
 		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint2)
@@ -446,7 +446,7 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
 		// 150 handled exceptions — these must NOT count toward the crash threshold
 		for i := 0; i < 150; i++ {
-			th.SeedHandledException(ctx, t, teamID, appID, now.Add(-5*time.Minute))
+			th.SeedIssueEvent(ctx, t, teamID, appID, "exception", "", true, now.Add(-5*time.Minute))
 		}
 
 		CreateCrashAndAnrAlerts(ctx)

--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -73,6 +73,10 @@ type AppFilter struct {
 	// client
 	Timezone string `form:"timezone"`
 
+	// PlotTimeGroup represents time bucketing granularity
+	// for plot APIs.
+	PlotTimeGroup string `form:"plot_time_group"`
+
 	// FilterShortCode represents a short code for list
 	// filters.
 	FilterShortCode string `form:"filter_short_code"`
@@ -194,6 +198,20 @@ type AppFilter struct {
 	// BiGraph represents if journey plot
 	// constructions should be bidirectional.
 	BiGraph bool `form:"bigraph"`
+}
+
+const (
+	PlotTimeGroupMinutes = "minutes"
+	PlotTimeGroupHours   = "hours"
+	PlotTimeGroupDays    = "days"
+	PlotTimeGroupMonths  = "months"
+)
+
+var validPlotTimeGroups = map[string]struct{}{
+	PlotTimeGroupMinutes: {},
+	PlotTimeGroupHours:   {},
+	PlotTimeGroupDays:    {},
+	PlotTimeGroupMonths:  {},
 }
 
 // FilterList holds various filter parameter values that are
@@ -415,6 +433,12 @@ func (af *AppFilter) Validate() error {
 		}
 	}
 
+	if af.HasPlotTimeGroup() {
+		if _, ok := validPlotTimeGroups[af.PlotTimeGroup]; !ok {
+			return fmt.Errorf("`plot_time_group` must be one of: %s, %s, %s, %s", PlotTimeGroupMinutes, PlotTimeGroupHours, PlotTimeGroupDays, PlotTimeGroupMonths)
+		}
+	}
+
 	return nil
 }
 
@@ -540,6 +564,18 @@ func (af AppFilter) HasDeviceNames() bool {
 // is requested.
 func (af AppFilter) HasTimezone() bool {
 	return af.Timezone != ""
+}
+
+// HasPlotTimeGroup returns true if a plot time group
+// is provided.
+func (af AppFilter) HasPlotTimeGroup() bool {
+	return af.PlotTimeGroup != ""
+}
+
+// SetDefaultPlotTimeGroup sets the default plot time
+// grouping granularity.
+func (af *AppFilter) SetDefaultPlotTimeGroup() {
+	af.PlotTimeGroup = PlotTimeGroupDays
 }
 
 // HasFreeText returns true if a free text

--- a/backend/api/measure/plot_test.go
+++ b/backend/api/measure/plot_test.go
@@ -1,0 +1,849 @@
+//go:build integration
+
+package measure
+
+import (
+	"backend/api/event"
+	"backend/api/filter"
+	"backend/api/server"
+	"backend/api/session"
+	"backend/api/span"
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type plotCase struct {
+	name       string
+	group      string
+	timestamps []time.Time
+}
+
+type plotFixture struct {
+	ctx    context.Context
+	teamID uuid.UUID
+	appID  uuid.UUID
+	app    App
+}
+
+func newPlotFixture(t *testing.T) plotFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	server.Server.ChPool = th.ChConn
+	cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	return plotFixture{
+		ctx:    ctx,
+		teamID: teamID,
+		appID:  appID,
+		app:    App{ID: &appID, TeamId: teamID},
+	}
+}
+
+func (f plotFixture) appFilter(from, to time.Time, timezone, plotTimeGroup string) *filter.AppFilter {
+	af := &filter.AppFilter{
+		AppID:    f.appID,
+		From:     from,
+		To:       to,
+		Timezone: timezone,
+		Limit:    filter.DefaultPaginationLimit,
+	}
+	if plotTimeGroup != "" {
+		af.PlotTimeGroup = plotTimeGroup
+	}
+	return af
+}
+
+func (f plotFixture) teamIDStr() string { return f.teamID.String() }
+func (f plotFixture) appIDStr() string  { return f.appID.String() }
+
+func requireSingleDateBucket[T any](t *testing.T, items []T, gotDate, expectedDate, source string) {
+	t.Helper()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 row for %s, got %d", source, len(items))
+	}
+	if gotDate != expectedDate {
+		t.Fatalf("expected timezone-shifted day bucket %s, got %q", expectedDate, gotDate)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Grouping behavior
+// --------------------------------------------------------------------------
+
+func TestPlotMethodsGroupByPlotTimeGroup(t *testing.T) {
+	f := newPlotFixture(t)
+
+	groups := []plotCase{
+		{
+			name:  "minutes",
+			group: filter.PlotTimeGroupMinutes,
+			timestamps: []time.Time{
+				time.Date(2026, 1, 5, 10, 15, 10, 0, time.UTC),
+				time.Date(2026, 1, 5, 10, 15, 40, 0, time.UTC),
+				time.Date(2026, 1, 5, 10, 16, 5, 0, time.UTC),
+			},
+		},
+		{
+			name:  "hours",
+			group: filter.PlotTimeGroupHours,
+			timestamps: []time.Time{
+				time.Date(2026, 1, 5, 10, 5, 0, 0, time.UTC),
+				time.Date(2026, 1, 5, 10, 45, 0, 0, time.UTC),
+				time.Date(2026, 1, 5, 11, 2, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:  "days",
+			group: filter.PlotTimeGroupDays,
+			timestamps: []time.Time{
+				time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 5, 22, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 6, 1, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:  "months",
+			group: filter.PlotTimeGroupMonths,
+			timestamps: []time.Time{
+				time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 20, 22, 0, 0, 0, time.UTC),
+				time.Date(2026, 2, 1, 1, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range groups {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cleanupAll(f.ctx, t)
+
+			from := tc.timestamps[0].Add(-time.Hour)
+			to := tc.timestamps[len(tc.timestamps)-1].Add(time.Hour)
+			af := f.appFilter(from, to, "UTC", tc.group)
+
+			t.Run("exception_group_plot", func(t *testing.T) {
+				fingerprint := "12345678901234567890123456789012"
+				for _, ts := range tc.timestamps {
+					seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", fingerprint, false, ts)
+				}
+
+				items, err := f.app.GetExceptionGroupPlotInstances(f.ctx, fingerprint, af)
+				if err != nil {
+					t.Fatalf("GetExceptionGroupPlotInstances: %v", err)
+				}
+
+				assertIssueBuckets(t, items, expectedCounts(tc.timestamps, tc.group, false))
+			})
+
+			t.Run("exception_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+				for _, ts := range tc.timestamps {
+					seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", "", false, ts)
+				}
+
+				items, err := f.app.GetExceptionPlotInstances(f.ctx, af)
+				if err != nil {
+					t.Fatalf("GetExceptionPlotInstances: %v", err)
+				}
+
+				assertIssueBuckets(t, items, expectedCounts(tc.timestamps, tc.group, false))
+			})
+
+			t.Run("anr_group_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+				fingerprint := "abcdefabcdefabcdefabcdefabcdefab"
+				for _, ts := range tc.timestamps {
+					seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", fingerprint, false, ts)
+				}
+
+				items, err := f.app.GetANRGroupPlotInstances(f.ctx, fingerprint, af)
+				if err != nil {
+					t.Fatalf("GetANRGroupPlotInstances: %v", err)
+				}
+
+				assertIssueBuckets(t, items, expectedCounts(tc.timestamps, tc.group, false))
+			})
+
+			t.Run("anr_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+				for _, ts := range tc.timestamps {
+					seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", "", false, ts)
+				}
+
+				items, err := f.app.GetANRPlotInstances(f.ctx, af)
+				if err != nil {
+					t.Fatalf("GetANRPlotInstances: %v", err)
+				}
+
+				assertIssueBuckets(t, items, expectedCounts(tc.timestamps, tc.group, false))
+			})
+
+			t.Run("sessions_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+				seedGenericEvents(f.ctx, t, f.teamIDStr(), f.appIDStr(), 2, tc.timestamps[0])
+				seedGenericEvents(f.ctx, t, f.teamIDStr(), f.appIDStr(), 1, tc.timestamps[2])
+
+				items, err := f.app.GetSessionsInstancesPlot(f.ctx, af)
+				if err != nil {
+					t.Fatalf("GetSessionsInstancesPlot: %v", err)
+				}
+
+				assertSessionBuckets(t, items, expectedCounts([]time.Time{tc.timestamps[0], tc.timestamps[0], tc.timestamps[2]}, tc.group, false))
+			})
+
+			t.Run("span_metrics_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+
+				spanTimes := spanMetricTimesForGroup(tc.group)
+				afSpan := f.appFilter(spanTimes[0].Add(-time.Hour), spanTimes[len(spanTimes)-1].Add(time.Hour), "UTC", tc.group)
+				for _, ts := range spanTimes {
+					seedSpan(
+						f.ctx, t, f.teamIDStr(), f.appIDStr(),
+						"http_request", 1,
+						ts, ts.Add(750*time.Millisecond),
+						"v1", "1",
+					)
+				}
+
+				items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", afSpan)
+				if err != nil {
+					t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+				}
+
+				assertSpanBuckets(t, items, expectedUniqueBuckets(spanTimes, tc.group, true))
+			})
+
+			t.Run("bug_report_plot", func(t *testing.T) {
+				cleanupAll(f.ctx, t)
+				for _, ts := range tc.timestamps {
+					seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", ts)
+				}
+
+				items, err := f.app.GetBugReportInstancesPlot(f.ctx, af)
+				if err != nil {
+					t.Fatalf("GetBugReportInstancesPlot: %v", err)
+				}
+
+				assertBugReportBuckets(t, items, expectedCounts(tc.timestamps, tc.group, false))
+			})
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// Default behavior when plot_time_group is omitted
+// --------------------------------------------------------------------------
+
+func TestExceptionPlotDefaultsToDaysWhenPlotTimeGroupMissing(t *testing.T) {
+	f := newPlotFixture(t)
+
+	t1 := time.Date(2026, 1, 5, 10, 15, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 5, 22, 15, 0, 0, time.UTC)
+	t3 := time.Date(2026, 1, 6, 1, 15, 0, 0, time.UTC)
+	for _, ts := range []time.Time{t1, t2, t3} {
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", "", false, ts)
+	}
+
+	af := f.appFilter(t1.Add(-time.Hour), t3.Add(time.Hour), "UTC", "")
+
+	items, err := f.app.GetExceptionPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetExceptionPlotInstances: %v", err)
+	}
+
+	assertIssueBuckets(t, items, expectedCounts([]time.Time{t1, t2, t3}, filter.PlotTimeGroupDays, false))
+}
+
+func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
+	f := newPlotFixture(t)
+	now := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	t.Run("missing timezone returns error", func(t *testing.T) {
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "", filter.PlotTimeGroupDays)
+
+		if _, err := f.app.GetExceptionPlotInstances(f.ctx, af); err == nil {
+			t.Fatalf("expected error for missing timezone in exception plot")
+		}
+		if _, err := f.app.GetExceptionGroupPlotInstances(f.ctx, "12345678901234567890123456789012", af); err == nil {
+			t.Fatalf("expected error for missing timezone in exception group plot")
+		}
+		if _, err := f.app.GetANRPlotInstances(f.ctx, af); err == nil {
+			t.Fatalf("expected error for missing timezone in anr plot")
+		}
+		if _, err := f.app.GetANRGroupPlotInstances(f.ctx, "abcdefabcdefabcdefabcdefabcdefab", af); err == nil {
+			t.Fatalf("expected error for missing timezone in anr group plot")
+		}
+		if _, err := f.app.GetSessionsInstancesPlot(f.ctx, af); err == nil {
+			t.Fatalf("expected error for missing timezone in sessions plot")
+		}
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, af); err == nil {
+			t.Fatalf("expected error for missing timezone in bug report plot")
+		}
+		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af); err == nil {
+			t.Fatalf("expected error for missing timezone in span metrics plot")
+		}
+	})
+
+	t.Run("unsupported plot_time_group returns error", func(t *testing.T) {
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", "weeks")
+		if _, err := f.app.GetExceptionPlotInstances(f.ctx, af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group")
+		}
+		if _, err := f.app.GetExceptionGroupPlotInstances(f.ctx, "12345678901234567890123456789012", af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in exception group plot")
+		}
+		if _, err := f.app.GetANRPlotInstances(f.ctx, af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in anr plot")
+		}
+		if _, err := f.app.GetANRGroupPlotInstances(f.ctx, "abcdefabcdefabcdefabcdefabcdefab", af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in anr group plot")
+		}
+		if _, err := f.app.GetSessionsInstancesPlot(f.ctx, af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in sessions plot")
+		}
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in bug report plot")
+		}
+		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af); err == nil {
+			t.Fatalf("expected error for unsupported plot_time_group in span metrics plot")
+		}
+	})
+
+	t.Run("returns empty results when no matching data", func(t *testing.T) {
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+
+		ex, err := f.app.GetExceptionPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetExceptionPlotInstances: %v", err)
+		}
+		if len(ex) != 0 {
+			t.Fatalf("expected empty exception plot, got %d rows", len(ex))
+		}
+
+		anr, err := f.app.GetANRPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetANRPlotInstances: %v", err)
+		}
+		if len(anr) != 0 {
+			t.Fatalf("expected empty anr plot, got %d rows", len(anr))
+		}
+
+		sessions, err := f.app.GetSessionsInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetSessionsInstancesPlot: %v", err)
+		}
+		if len(sessions) != 0 {
+			t.Fatalf("expected empty sessions plot, got %d rows", len(sessions))
+		}
+
+		spans, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		if len(spans) != 0 {
+			t.Fatalf("expected empty spans plot, got %d rows", len(spans))
+		}
+
+		bugReports, err := f.app.GetBugReportInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetBugReportInstancesPlot: %v", err)
+		}
+		if len(bugReports) != 0 {
+			t.Fatalf("expected empty bug report plot, got %d rows", len(bugReports))
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// Timezone behavior
+// --------------------------------------------------------------------------
+
+func TestExceptionPlotRespectsTimezoneBucketing(t *testing.T) {
+	f := newPlotFixture(t)
+
+	// 2026-01-05T23:30Z becomes 2026-01-06 in Asia/Kolkata (+05:30).
+	ts := time.Date(2026, 1, 5, 23, 30, 0, 0, time.UTC)
+	seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", "", false, ts)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
+	items, err := f.app.GetExceptionPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetExceptionPlotInstances: %v", err)
+	}
+	requireSingleDateBucket(t, items, items[0].DateTime, "2026-01-06", "exception plot")
+}
+
+func TestNonExceptionPlotsRespectTimezoneBucketing(t *testing.T) {
+	f := newPlotFixture(t)
+
+	// 2026-01-05T23:30Z becomes 2026-01-06 in Asia/Kolkata (+05:30).
+	ts := time.Date(2026, 1, 5, 23, 30, 0, 0, time.UTC)
+
+	t.Run("sessions", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedGenericEvents(f.ctx, t, f.teamIDStr(), f.appIDStr(), 1, ts)
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
+		items, err := f.app.GetSessionsInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetSessionsInstancesPlot: %v", err)
+		}
+		requireSingleDateBucket(t, items, items[0].DateTime, "2026-01-06", "sessions plot")
+	})
+
+	t.Run("span metrics", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, ts, ts.Add(750*time.Millisecond), "v1", "1")
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		requireSingleDateBucket(t, items, items[0].DateTime, "2026-01-06", "span metrics plot")
+	})
+
+	t.Run("bug reports", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "tz bug report", ts)
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetBugReportInstancesPlot: %v", err)
+		}
+		requireSingleDateBucket(t, items, items[0].DateTime, "2026-01-06", "bug report plot")
+	})
+}
+
+func TestPlotMethodsDefaultToDaysWhenPlotTimeGroupMissing(t *testing.T) {
+	f := newPlotFixture(t)
+	t1 := time.Date(2026, 1, 5, 10, 15, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 6, 1, 15, 0, 0, time.UTC)
+
+	t.Run("exception group", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		fp := "12345678901234567890123456789012"
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", fp, false, t1)
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", fp, false, t2)
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetExceptionGroupPlotInstances(f.ctx, fp, af)
+		if err != nil {
+			t.Fatalf("GetExceptionGroupPlotInstances: %v", err)
+		}
+		assertIssueBuckets(t, items, expectedCounts([]time.Time{t1, t2}, filter.PlotTimeGroupDays, false))
+	})
+
+	t.Run("anr group", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		fp := "abcdefabcdefabcdefabcdefabcdefab"
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", fp, false, t1)
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", fp, false, t2)
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetANRGroupPlotInstances(f.ctx, fp, af)
+		if err != nil {
+			t.Fatalf("GetANRGroupPlotInstances: %v", err)
+		}
+		assertIssueBuckets(t, items, expectedCounts([]time.Time{t1, t2}, filter.PlotTimeGroupDays, false))
+	})
+
+	t.Run("anr overview", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", "", false, t1)
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "anr", "", false, t2)
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetANRPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetANRPlotInstances: %v", err)
+		}
+		assertIssueBuckets(t, items, expectedCounts([]time.Time{t1, t2}, filter.PlotTimeGroupDays, false))
+	})
+
+	t.Run("sessions", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedGenericEvents(f.ctx, t, f.teamIDStr(), f.appIDStr(), 1, t1)
+		seedGenericEvents(f.ctx, t, f.teamIDStr(), f.appIDStr(), 1, t2)
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetSessionsInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetSessionsInstancesPlot: %v", err)
+		}
+		assertSessionBuckets(t, items, expectedCounts([]time.Time{t1, t2}, filter.PlotTimeGroupDays, false))
+	})
+
+	t.Run("span metrics", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, t1, t1.Add(time.Second), "v1", "1")
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, t2, t2.Add(time.Second), "v1", "1")
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		assertSpanBuckets(t, items, expectedUniqueBuckets([]time.Time{t1, t2}, filter.PlotTimeGroupDays, true))
+	})
+
+	t.Run("bug reports", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", t1)
+		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", t2)
+		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetBugReportInstancesPlot: %v", err)
+		}
+		assertBugReportBuckets(t, items, expectedCounts([]time.Time{t1, t2}, filter.PlotTimeGroupDays, false))
+	})
+}
+
+// --------------------------------------------------------------------------
+// Optional filter behavior
+// --------------------------------------------------------------------------
+
+func TestPlotMethodsRespectOptionalFilters(t *testing.T) {
+	f := newPlotFixture(t)
+	now := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	t.Run("exception versions filter", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedIssueEvent(f.ctx, t, f.teamIDStr(), f.appIDStr(), "exception", "", false, now)
+
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.Versions = []string{"v1"}
+		af.VersionCodes = []string{"1"}
+
+		items, err := f.app.GetExceptionPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetExceptionPlotInstances: %v", err)
+		}
+		if len(items) == 0 {
+			t.Fatalf("expected non-empty result for matching version filters")
+		}
+
+		af.VersionCodes = []string{"999"}
+		items, err = f.app.GetExceptionPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetExceptionPlotInstances mismatch filter: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("expected empty result for non-matching version filters")
+		}
+	})
+
+	t.Run("span status filter", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, now, now.Add(time.Second), "v1", "1")
+
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.SpanStatuses = []int8{1}
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		if len(items) == 0 {
+			t.Fatalf("expected non-empty span metrics for matching status")
+		}
+
+		af.SpanStatuses = []int8{2}
+		items, err = f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter mismatch status: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("expected empty span metrics for non-matching status")
+		}
+	})
+
+	t.Run("bug report status filter", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", now)
+
+		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.BugReportStatuses = []int8{1}
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetBugReportInstancesPlot: %v", err)
+		}
+		if len(items) == 0 {
+			t.Fatalf("expected non-empty bug report plot for matching status")
+		}
+
+		af.BugReportStatuses = []int8{0}
+		items, err = f.app.GetBugReportInstancesPlot(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetBugReportInstancesPlot mismatch status: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("expected empty bug report plot for non-matching status")
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// Span quantile aggregation behavior
+// --------------------------------------------------------------------------
+
+func TestSpanMetricsPlotQuantilesForUniformDurations(t *testing.T) {
+	f := newPlotFixture(t)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	// Same duration for all rows in one bucket/version should make all quantiles
+	// collapse to the same value.
+	for i := 0; i < 5; i++ {
+		start := base.Add(time.Duration(i) * time.Minute)
+		end := start.Add(3 * time.Second)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, end, "v1", "1")
+	}
+
+	af := f.appFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", filter.PlotTimeGroupHours)
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+	if err != nil {
+		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 span-metrics row, got %d", len(items))
+	}
+
+	p50, p90, p95, p99 := spanQuantiles(t, items[0], "uniform-duration row")
+	if p50 != p90 || p90 != p95 || p95 != p99 {
+		t.Fatalf("expected equal quantiles for uniform durations, got p50=%.2f p90=%.2f p95=%.2f p99=%.2f", p50, p90, p95, p99)
+	}
+	// We use a small tolerance for quantile assertions because results are
+	// produced through aggregate-state merges and floating-point math
+	// (quantileMerge + round), where tiny representation differences can appear
+	// across runs/engines even for deterministic inputs.
+	assertApprox(t, p50, 3000.0, 0.01, "uniform p50")
+	assertApprox(t, p90, 3000.0, 0.01, "uniform p90")
+	assertApprox(t, p95, 3000.0, 0.01, "uniform p95")
+	assertApprox(t, p99, 3000.0, 0.01, "uniform p99")
+}
+
+func TestSpanMetricsPlotQuantilesAreMonotonicAndVersionIsolated(t *testing.T) {
+	f := newPlotFixture(t)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	// Version v1 has lower uniform durations.
+	for i := 0; i < 4; i++ {
+		secs := 2
+		start := base.Add(time.Duration(secs) * time.Minute)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, start.Add(time.Duration(secs)*time.Second), "v1", "1")
+	}
+	// Version v2 has higher uniform durations.
+	for i := 0; i < 4; i++ {
+		secs := 8
+		start := base.Add(time.Duration(secs) * time.Minute)
+		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, start.Add(time.Duration(secs)*time.Second), "v2", "2")
+	}
+
+	af := f.appFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", filter.PlotTimeGroupHours)
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, "http_request", af)
+	if err != nil {
+		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 span-metrics rows (one per version), got %d", len(items))
+	}
+
+	byVersion := map[string]span.SpanMetricsPlotInstance{}
+	for _, item := range items {
+		byVersion[item.Version] = item
+	}
+
+	v1, ok := byVersion["v1 (1)"]
+	if !ok {
+		t.Fatalf("missing v1 (1) row in %#v", byVersion)
+	}
+	v2, ok := byVersion["v2 (2)"]
+	if !ok {
+		t.Fatalf("missing v2 (2) row in %#v", byVersion)
+	}
+
+	v1p50, v1p90, v1p95, v1p99 := spanQuantiles(t, v1, "v1 row")
+	v2p50, v2p90, v2p95, v2p99 := spanQuantiles(t, v2, "v2 row")
+
+	assertMonotonicQuantiles(t, v1p50, v1p90, v1p95, v1p99, "v1 row")
+	assertMonotonicQuantiles(t, v2p50, v2p90, v2p95, v2p99, "v2 row")
+	assertApprox(t, v1p50, 2000.0, 0.01, "v1 p50")
+	assertApprox(t, v1p90, 2000.0, 0.01, "v1 p90")
+	assertApprox(t, v1p95, 2000.0, 0.01, "v1 p95")
+	assertApprox(t, v1p99, 2000.0, 0.01, "v1 p99")
+	assertApprox(t, v2p50, 8000.0, 0.01, "v2 p50")
+	assertApprox(t, v2p90, 8000.0, 0.01, "v2 p90")
+	assertApprox(t, v2p95, 8000.0, 0.01, "v2 p95")
+	assertApprox(t, v2p99, 8000.0, 0.01, "v2 p99")
+
+	// Higher-duration version should retain higher quantiles.
+	if !(v2p50 > v1p50 && v2p95 > v1p95 && v2p99 > v1p99) {
+		t.Fatalf("expected v2 quantiles to be greater than v1: v1=[%.2f %.2f %.2f %.2f], v2=[%.2f %.2f %.2f %.2f]",
+			v1p50, v1p90, v1p95, v1p99, v2p50, v2p90, v2p95, v2p99)
+	}
+}
+
+// expectedCounts returns aggregated per-bucket counts for synthetic seed times.
+// withSpanPreBucket=true models span_metrics_mv behavior where rows are first
+// bucketed to 15-minute windows before query-time grouping is applied.
+func expectedCounts(timestamps []time.Time, group string, withSpanPreBucket bool) map[string]uint64 {
+	out := map[string]uint64{}
+	for _, ts := range timestamps {
+		bucketTS := ts.UTC()
+		if withSpanPreBucket {
+			bucketTS = bucketTS.Truncate(15 * time.Minute)
+		}
+		key := formatBucket(bucketTS, group)
+		out[key]++
+	}
+	return out
+}
+
+// expectedUniqueBuckets is similar to expectedCounts but keeps only distinct
+// bucket keys. Span metric assertions use this when value aggregation itself is
+// not part of the behavior under test.
+func expectedUniqueBuckets(timestamps []time.Time, group string, withSpanPreBucket bool) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, ts := range timestamps {
+		bucketTS := ts.UTC()
+		if withSpanPreBucket {
+			bucketTS = bucketTS.Truncate(15 * time.Minute)
+		}
+		out[formatBucket(bucketTS, group)] = struct{}{}
+	}
+	return out
+}
+
+// formatBucket mirrors the backend format returned by each plot_time_group.
+// It normalizes timestamps to UTC and expected output formats used in API rows.
+func formatBucket(ts time.Time, group string) string {
+	switch group {
+	case filter.PlotTimeGroupMinutes:
+		return ts.Truncate(time.Minute).Format("2006-01-02T15:04:05")
+	case filter.PlotTimeGroupHours:
+		return ts.Truncate(time.Hour).Format("2006-01-02T15:04:05")
+	case filter.PlotTimeGroupMonths:
+		return time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+	case filter.PlotTimeGroupDays:
+		fallthrough
+	default:
+		return time.Date(ts.Year(), ts.Month(), ts.Day(), 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+	}
+}
+
+// spanMetricTimesForGroup picks timestamps that intentionally cross boundaries
+// for each grouping mode. This makes accidental grouping regressions obvious.
+func spanMetricTimesForGroup(group string) []time.Time {
+	switch group {
+	case filter.PlotTimeGroupMinutes:
+		return []time.Time{
+			time.Date(2026, 1, 5, 10, 15, 10, 0, time.UTC),
+			time.Date(2026, 1, 5, 10, 19, 0, 0, time.UTC),
+			time.Date(2026, 1, 5, 10, 30, 0, 0, time.UTC),
+		}
+	case filter.PlotTimeGroupHours:
+		return []time.Time{
+			time.Date(2026, 1, 5, 10, 2, 0, 0, time.UTC),
+			time.Date(2026, 1, 5, 10, 14, 0, 0, time.UTC),
+			time.Date(2026, 1, 5, 11, 1, 0, 0, time.UTC),
+		}
+	case filter.PlotTimeGroupMonths:
+		return []time.Time{
+			time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 1, 20, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC),
+		}
+	default:
+		return []time.Time{
+			time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC),
+			time.Date(2026, 1, 6, 1, 0, 0, 0, time.UTC),
+		}
+	}
+}
+
+func assertIssueBuckets(t *testing.T, items []event.IssueInstance, expected map[string]uint64) {
+	t.Helper()
+	got := map[string]uint64{}
+	for _, item := range items {
+		got[item.DateTime] += *item.Instances
+	}
+	assertBucketCounts(t, got, expected)
+}
+
+func assertSessionBuckets(t *testing.T, items []session.SessionInstance, expected map[string]uint64) {
+	t.Helper()
+	got := map[string]uint64{}
+	for _, item := range items {
+		got[item.DateTime] += *item.Instances
+	}
+	assertBucketCounts(t, got, expected)
+}
+
+func assertSpanBuckets(t *testing.T, items []span.SpanMetricsPlotInstance, expected map[string]struct{}) {
+	t.Helper()
+	got := map[string]struct{}{}
+	for _, item := range items {
+		got[item.DateTime] = struct{}{}
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("bucket count mismatch: got %d buckets (%v), want %d buckets (%v)", len(got), got, len(expected), expected)
+	}
+
+	for key := range expected {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("missing expected bucket %q in got %v", key, got)
+		}
+	}
+}
+
+func assertBugReportBuckets(t *testing.T, items []BugReportInstance, expected map[string]uint64) {
+	t.Helper()
+	got := map[string]uint64{}
+	for _, item := range items {
+		got[item.DateTime] += *item.Instances
+	}
+	assertBucketCounts(t, got, expected)
+}
+
+func assertBucketCounts(t *testing.T, got, expected map[string]uint64) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("bucket count mismatch: got %d buckets (%v), want %d buckets (%v)", len(got), got, len(expected), expected)
+	}
+
+	for key, expectedValue := range expected {
+		value, ok := got[key]
+		if !ok {
+			t.Fatalf("missing expected bucket %q in got %v", key, got)
+		}
+		if value != expectedValue {
+			t.Fatalf("bucket %q mismatch: got %d want %d", key, value, expectedValue)
+		}
+	}
+}
+
+func spanQuantiles(t *testing.T, item span.SpanMetricsPlotInstance, source string) (float64, float64, float64, float64) {
+	t.Helper()
+	if item.P50 == nil || item.P90 == nil || item.P95 == nil || item.P99 == nil {
+		t.Fatalf("expected all quantiles to be non-nil for %s, got p50=%v p90=%v p95=%v p99=%v", source, item.P50, item.P90, item.P95, item.P99)
+	}
+	return *item.P50, *item.P90, *item.P95, *item.P99
+}
+
+func assertMonotonicQuantiles(t *testing.T, p50, p90, p95, p99 float64, source string) {
+	t.Helper()
+	if !(p50 <= p90 && p90 <= p95 && p95 <= p99) {
+		t.Fatalf("expected monotonic quantiles for %s, got p50=%.2f p90=%.2f p95=%.2f p99=%.2f", source, p50, p90, p95, p99)
+	}
+}
+
+func assertApprox(t *testing.T, got, want, tol float64, source string) {
+	t.Helper()
+	// Keep quantile checks strict but stable: allow tiny float deltas caused by
+	// aggregate-state merge/float representation noise.
+	if math.Abs(got-want) > tol {
+		t.Fatalf("unexpected %s: got %.4f want %.4f (tol=%.4f)", source, got, want, tol)
+	}
+}

--- a/backend/api/measure/test_helpers_test.go
+++ b/backend/api/measure/test_helpers_test.go
@@ -95,6 +95,35 @@ func seedAPIKey(
 	th.SeedAPIKey(ctx, t, appID.String(), keyPrefix, keyValue, checksum, revoked, lastSeen, createdAt)
 }
 
+func seedGenericEvents(ctx context.Context, t *testing.T, teamID, appID string, count int, ts time.Time) {
+	th.SeedGenericEvents(ctx, t, teamID, appID, count, ts)
+}
+
+func seedIssueEvent(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, eventType, fingerprint string,
+	handled bool,
+	ts time.Time,
+) {
+	th.SeedIssueEvent(ctx, t, teamID, appID, eventType, fingerprint, handled, ts)
+}
+
+func seedBugReport(ctx context.Context, t *testing.T, teamID, appID, eventID, description string, ts time.Time) {
+	th.SeedBugReport(ctx, t, teamID, appID, eventID, description, ts)
+}
+
+func seedSpan(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, spanName string,
+	status uint8,
+	startTime, endTime time.Time,
+	appVersion, appBuild string,
+) {
+	th.SeedSpan(ctx, t, teamID, appID, spanName, status, startTime, endTime, appVersion, appBuild)
+}
+
 // --------------------------------------------------------------------------
 // Gin test context
 // --------------------------------------------------------------------------

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -119,202 +119,207 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-18)
     - [Response Body](#response-body-21)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-21)
-  - [GET `/apps/:id/sessions/:id`](#get-appsidsessionsid)
+  - [GET `/apps/:id/sessions/plots/instances`](#get-appsidsessionsplotsinstances)
     - [Usage Notes](#usage-notes-22)
     - [Authorization \& Content Type](#authorization--content-type-19)
     - [Response Body](#response-body-22)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-22)
-  - [GET `/apps/:id/alertPrefs`](#get-appsidalertprefs)
+  - [GET `/apps/:id/sessions/:id`](#get-appsidsessionsid)
     - [Usage Notes](#usage-notes-23)
     - [Authorization \& Content Type](#authorization--content-type-20)
     - [Response Body](#response-body-23)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-23)
-  - [PATCH `/apps/:id/alertPrefs`](#patch-appsidalertprefs)
+  - [GET `/apps/:id/alertPrefs`](#get-appsidalertprefs)
     - [Usage Notes](#usage-notes-24)
-    - [Request body](#request-body-3)
     - [Authorization \& Content Type](#authorization--content-type-21)
     - [Response Body](#response-body-24)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-24)
-  - [PATCH `/apps/:id/rename`](#patch-appsidrename)
+  - [PATCH `/apps/:id/alertPrefs`](#patch-appsidalertprefs)
     - [Usage Notes](#usage-notes-25)
-    - [Request body](#request-body-4)
+    - [Request body](#request-body-3)
     - [Authorization \& Content Type](#authorization--content-type-22)
     - [Response Body](#response-body-25)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-25)
-  - [PATCH `/apps/:id/apiKey`](#patch-appsidapikey)
+  - [PATCH `/apps/:id/rename`](#patch-appsidrename)
     - [Usage Notes](#usage-notes-26)
+    - [Request body](#request-body-4)
     - [Authorization \& Content Type](#authorization--content-type-23)
     - [Response Body](#response-body-26)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-26)
-  - [GET `/apps/:id/retention`](#get-appsidretention)
+  - [PATCH `/apps/:id/apiKey`](#patch-appsidapikey)
     - [Usage Notes](#usage-notes-27)
     - [Authorization \& Content Type](#authorization--content-type-24)
     - [Response Body](#response-body-27)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-27)
-  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
+  - [GET `/apps/:id/retention`](#get-appsidretention)
     - [Usage Notes](#usage-notes-28)
-    - [Request body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-25)
     - [Response Body](#response-body-28)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-28)
-  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
+  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
     - [Usage Notes](#usage-notes-29)
-    - [Request body](#request-body-6)
+    - [Request body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-26)
     - [Response Body](#response-body-29)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-29)
-  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
+  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
     - [Usage Notes](#usage-notes-30)
+    - [Request body](#request-body-6)
     - [Authorization \& Content Type](#authorization--content-type-27)
     - [Response Body](#response-body-30)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-30)
-  - [GET `/apps/:id/spans`](#get-appsidspans)
+  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
     - [Usage Notes](#usage-notes-31)
     - [Authorization \& Content Type](#authorization--content-type-28)
     - [Response Body](#response-body-31)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-31)
-  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
+  - [GET `/apps/:id/spans`](#get-appsidspans)
     - [Usage Notes](#usage-notes-32)
     - [Authorization \& Content Type](#authorization--content-type-29)
     - [Response Body](#response-body-32)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-32)
-  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
+  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
     - [Usage Notes](#usage-notes-33)
     - [Authorization \& Content Type](#authorization--content-type-30)
     - [Response Body](#response-body-33)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-33)
-  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
+  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
     - [Usage Notes](#usage-notes-34)
     - [Authorization \& Content Type](#authorization--content-type-31)
     - [Response Body](#response-body-34)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-34)
-  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
+  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
     - [Usage Notes](#usage-notes-35)
     - [Authorization \& Content Type](#authorization--content-type-32)
     - [Response Body](#response-body-35)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-35)
-  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
     - [Usage Notes](#usage-notes-36)
     - [Authorization \& Content Type](#authorization--content-type-33)
     - [Response Body](#response-body-36)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-36)
-  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-37)
-    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-34)
     - [Response Body](#response-body-37)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-37)
-  - [GET `/apps/:id/alerts`](#get-appsidalerts)
+  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-38)
+    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-35)
     - [Response Body](#response-body-38)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-38)
-- [Teams](#teams)
-  - [POST `/teams`](#post-teams)
-    - [Authorization \& Content Type](#authorization--content-type-36)
-    - [Request Body](#request-body-8)
+  - [GET `/apps/:id/alerts`](#get-appsidalerts)
     - [Usage Notes](#usage-notes-39)
+    - [Authorization \& Content Type](#authorization--content-type-36)
     - [Response Body](#response-body-39)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-39)
-  - [GET `/teams`](#get-teams)
+- [Teams](#teams)
+  - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-37)
+    - [Request Body](#request-body-8)
+    - [Usage Notes](#usage-notes-40)
     - [Response Body](#response-body-40)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-40)
-  - [GET `/teams/:id/apps`](#get-teamsidapps)
-    - [Usage Notes](#usage-notes-40)
+  - [GET `/teams`](#get-teams)
     - [Authorization \& Content Type](#authorization--content-type-38)
     - [Response Body](#response-body-41)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-41)
-  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
+  - [GET `/teams/:id/apps`](#get-teamsidapps)
     - [Usage Notes](#usage-notes-41)
     - [Authorization \& Content Type](#authorization--content-type-39)
     - [Response Body](#response-body-42)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-42)
-  - [POST `/teams/:id/apps`](#post-teamsidapps)
+  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
     - [Usage Notes](#usage-notes-42)
-    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-40)
     - [Response Body](#response-body-43)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-43)
-  - [GET `/teams/:id/invites`](#get-teamsidinvites)
+  - [POST `/teams/:id/apps`](#post-teamsidapps)
     - [Usage Notes](#usage-notes-43)
+    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-41)
     - [Response Body](#response-body-44)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-44)
-  - [POST `/teams/:id/invite`](#post-teamsidinvite)
+  - [GET `/teams/:id/invites`](#get-teamsidinvites)
     - [Usage Notes](#usage-notes-44)
-    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-42)
     - [Response Body](#response-body-45)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-45)
-  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
+  - [POST `/teams/:id/invite`](#post-teamsidinvite)
     - [Usage Notes](#usage-notes-45)
+    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-43)
     - [Response Body](#response-body-46)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-46)
-  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
+  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
     - [Usage Notes](#usage-notes-46)
     - [Authorization \& Content Type](#authorization--content-type-44)
     - [Response Body](#response-body-47)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-47)
-  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
+  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
     - [Usage Notes](#usage-notes-47)
-    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-45)
     - [Response Body](#response-body-48)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-48)
-  - [GET `/teams/:id/members`](#get-teamsidmembers)
+  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
     - [Usage Notes](#usage-notes-48)
+    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-46)
     - [Response Body](#response-body-49)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-49)
-  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
+  - [GET `/teams/:id/members`](#get-teamsidmembers)
     - [Usage Notes](#usage-notes-49)
     - [Authorization \& Content Type](#authorization--content-type-47)
     - [Response Body](#response-body-50)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-50)
-  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
+  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
     - [Usage Notes](#usage-notes-50)
-    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-48)
     - [Response Body](#response-body-51)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-51)
-  - [GET `/teams/:id/authz`](#get-teamsidauthz)
+  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
     - [Usage Notes](#usage-notes-51)
+    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-49)
     - [Response Body](#response-body-52)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-52)
-  - [GET `/teams/:id/usage`](#get-teamsidusage)
+  - [GET `/teams/:id/authz`](#get-teamsidauthz)
     - [Usage Notes](#usage-notes-52)
     - [Authorization \& Content Type](#authorization--content-type-50)
     - [Response Body](#response-body-53)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-53)
-  - [GET `/teams/:id/slack`](#get-teamsidslack)
+  - [GET `/teams/:id/usage`](#get-teamsidusage)
     - [Usage Notes](#usage-notes-53)
     - [Authorization \& Content Type](#authorization--content-type-51)
     - [Response Body](#response-body-54)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-54)
-  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+  - [GET `/teams/:id/slack`](#get-teamsidslack)
     - [Usage Notes](#usage-notes-54)
-    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-52)
     - [Response Body](#response-body-55)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-55)
-  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
     - [Usage Notes](#usage-notes-55)
+    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-53)
     - [Response Body](#response-body-56)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-56)
-  - [GET `/apps/:id/config`](#get-appsidconfig)
+  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
     - [Usage Notes](#usage-notes-56)
     - [Authorization \& Content Type](#authorization--content-type-54)
     - [Response Body](#response-body-57)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-57)
-  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+  - [GET `/apps/:id/config`](#get-appsidconfig)
     - [Usage Notes](#usage-notes-57)
     - [Authorization \& Content Type](#authorization--content-type-55)
     - [Response Body](#response-body-58)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-58)
+  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+    - [Usage Notes](#usage-notes-58)
+    - [Authorization \& Content Type](#authorization--content-type-56)
+    - [Response Body](#response-body-59)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-59)
 
 ## Auth
 
@@ -772,6 +777,7 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/anrGroups/:id/plots/instances`**](#get-appsidanrgroupsidplotsinstances) - Fetch an app's ANR detail instances aggregated by date range & version.
 - [**GET `/apps/:id/anrGroups/:id/plots/journey`**](#get-appsidanrgroupsidplotsjourney) - Fetch an app's ANR journey map.
 - [**GET `/apps/:id/sessions`**](#get-appsidsessions) - Fetch an app's session timlines by applying various optional filters.
+- [**GET `/apps/:id/sessions/plots/instances`**](#get-appsidsessionsplotsinstances) - Fetch an app's sessions instances plot with optional filters.
 - [**GET `/apps/:id/sessions/:id`**](#get-appsidsessionsid) - Fetch an app's session timeline.
 - [**GET `/apps/:id/alertPrefs`**](#get-appsidalertprefs) - Fetch an app's alert preferences for current user.
 - [**PATCH `/apps/:id/alertPrefs`**](#patch-appsidalertprefs) - Update an app's alert preferences for current user.
@@ -1243,6 +1249,7 @@ Fetch an app's crash overview.
 - Accepted query parameters
   - `from` (_optional_) - Start time boundary for temporal filtering. ISO8601 Datetime string. If not passed, a default value is assumed.
   - `to` (_optional_) - End time boundary for temporal filtering. ISO8601 Datetime string. If not passed, a default value is assumed.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return crash groups that have events matching the version.
   - `version_codes` (_optional_) - List of comma separated version codes to return crash groups that have events matching the version code.
   - `key_id` (_optional_) - UUID of the last item. Used for keyset based pagination. Should be used along with `limit`.
@@ -1478,6 +1485,7 @@ Fetch an app's crash detail.
 - Accepted query parameters
   - `from` (_optional_) - ISO8601 timestamp to include crashes after this time.
   - `to` (_optional_) - ISO8601 timestamp to include crashes before this time.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return only matching crashes.
   - `version_codes` (_optional_) - List of comma separated version codes to return only matching crashes.
   - `countries` (_optional_) - List of comma separated country identifier strings to return only matching crashes.
@@ -2199,6 +2207,7 @@ Fetch an app's ANR overview instances plot aggregated by date range & version.
 - Accepted query parameters
   - `from` (_optional_) - Start time boundary for temporal filtering. ISO8601 Datetime string. If not passed, a default value is assumed.
   - `to` (_optional_) - End time boundary for temporal filtering. ISO8601 Datetime string. If not passed, a default value is assumed.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return crash groups that have events matching the version.
   - `version_codes` (_optional_) - List of comma separated version codes to return crash groups that have events matching the version code.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
@@ -2680,6 +2689,7 @@ Fetch an app's ANR detail instances aggregated by date range & version.
 - Accepted query parameters
   - `from` (_optional_) - ISO8601 timestamp to include crashes after this time.
   - `to` (_optional_) - ISO8601 timestamp to include crashes before this time.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return only matching crashes.
   - `version_codes` (_optional_) - List of comma separated version codes to return only matching crashes.
   - `countries` (_optional_) - List of comma separated country identifier strings to return only matching crashes.
@@ -3169,6 +3179,104 @@ The required headers must be present in each request.
   ```
 
 #### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### GET `/apps/:id/sessions/plots/instances`
+
+Fetch an app's sessions instances plot by applying various optional filters.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI
+- Accepted query parameters
+  - `from` (_optional_) - ISO8601 timestamp to include sessions after this time.
+  - `to` (_optional_) - ISO8601 timestamp to include sessions before this time.
+  - `timezone` (_required_) - IANA timezone used to bucket and format datetime values in the response.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
+  - `versions` (_optional_) - List of comma separated app version identifier strings to return only matching sessions.
+  - `version_codes` (_optional_) - List of comma separated app version codes to return only matching sessions.
+  - `crash` (_optional_) - Boolean true/false to control if only sessions containing at least 1 crash should be fetched.
+  - `anr` (_optional_) - Boolean true/false to control if only sessions containing at least 1 ANR should be fetched.
+  - `bug_report` (_optional_) - Boolean true/false to control if only sessions containing at least 1 bug report should be fetched.
+  - `background` (_optional_) - Boolean true/false to control if only background sessions should be fetched.
+  - `foreground` (_optional_) - Boolean true/false to control if only foreground sessions should be fetched.
+  - `user_interaction` (_optional_) - Boolean true/false to control if only sessions that contain user interactions should be fetched.
+  - `countries` (_optional_) - List of comma separated country identifier strings to return only matching sessions.
+  - `device_names` (_optional_) - List of comma separated device name identifier strings to return only matching sessions.
+  - `device_manufacturers` (_optional_) - List of comma separated device manufacturer identifier strings to return only matching sessions.
+  - `locales` (_optional_) - List of comma separated device locale identifier strings to return only matching sessions.
+  - `network_providers` (_optional_) - List of comma separated network provider identifier strings to return only matching sessions.
+  - `network_types` (_optional_) - List of comma separated network type identifier strings to return only matching sessions.
+  - `network_generations` (_optional_) - List of comma separated network generation identifier strings to return only matching sessions.
+  - `free_text` (_optional_) - A sequence of characters used to filter sessions matching various criteria.
+  - `filter_short_code` (_optional_) - Code representing combination of filters.
+  - `ud_expression` (_optional_) - JSON string expression to filter using user defined attributes.
+- For multiple comma separated fields, make sure no whitespace characters exist before or after comma.
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+  [
+    {
+      "id": "1.0 (1)",
+      "data": [
+        {
+          "datetime": "2024-10-02",
+          "instances": 12
+        }
+      ]
+    }
+  ]
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes & Troubleshooting
 
 List of HTTP status codes for success and failures.
 
@@ -4656,6 +4764,7 @@ Fetch a span's metrics plot with optional filters.
   - `span_name` (_required_) - Name of the span for which metrics plot is being fetched.
   - `from` (_optional_) - ISO8601 timestamp to include sessions after this time.
   - `to` (_optional_) - ISO8601 timestamp to include sessions before this time.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return only matching sessions.
   - `version_codes` (_optional_) - List of comma separated version codes to return only matching sessions.
   - `countries` (_optional_) - List of comma separated country identifier strings to return only matching sessions.
@@ -4844,6 +4953,7 @@ Fetch an app's bug reports by applying various optional filters.
 - Accepted query parameters
   - `from` (_optional_) - ISO8601 timestamp to include sessions after this time.
   - `to` (_optional_) - ISO8601 timestamp to include sessions before this time.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings to return only matching sessions.
   - `version_codes` (_optional_) - List of comma separated version codes to return only matching sessions.
   - `countries` (_optional_) - List of comma separated country identifier strings to return only matching sessions.

--- a/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
@@ -1,0 +1,110 @@
+import BugReportsOverviewPlot from '@/app/components/bug_reports_overview_plot'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }))
+jest.mock('@/app/components/loading_spinner', () => ({ __esModule: true, default: () => <div>loading</div> }))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  BugReportsOverviewPlotApiStatus: { Loading: 'loading', Success: 'success', Error: 'error', NoData: 'no_data' },
+  fetchBugReportsOverviewPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = { ready: true, startDate: '2025-01-01T00:00:00Z', endDate: '2025-12-31T00:00:00Z' } as any
+
+describe('BugReportsOverviewPlot', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lastLineProps = null
+  })
+
+  it('renders error state', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<BugReportsOverviewPlot filters={filters} />)
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('renders no data state', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<BugReportsOverviewPlot filters={filters} />)
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<BugReportsOverviewPlot filters={{ ...filters, ready: false }} />)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders loading state before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<BugReportsOverviewPlot filters={filters} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 1 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('maps API result shape to nivo data', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 2 }] }] })
+    render(<BugReportsOverviewPlot filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.data[0].id).toBe('v1')
+    expect(lastLineProps.data[0].data[0].y).toBe(2)
+    expect(lastLineProps.axisLeft.legend).toBe('Bug Reports')
+    expect(fetchMock).toHaveBeenCalledWith(filters)
+  })
+
+  it('uses month-style axis formatting for long range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2025-02-01', instances: 1 }] }] })
+    render(<BugReportsOverviewPlot filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+
+  it('uses minute/day configs for shorter ranges', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-02-01T01:00:00', instances: 1 }] }] })
+    const { rerender } = render(<BugReportsOverviewPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('minute')
+
+    rerender(<BugReportsOverviewPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-30T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+  })
+
+  it('pluralizes tooltip labels for singular and plural', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 2 }] }] })
+    render(<BugReportsOverviewPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const one = lastLineProps.sliceTooltip({
+      slice: { points: [{ id: 'p1', serieColor: '#111', serieId: 'v1', data: { xFormatted: '2025-02-01', yFormatted: 1 } }] },
+    })
+    const many = lastLineProps.sliceTooltip({
+      slice: { points: [{ id: 'p2', serieColor: '#111', serieId: 'v1', data: { xFormatted: '2025-02-01', yFormatted: 3 } }] },
+    })
+    const r1 = render(one)
+    const r2 = render(many)
+    expect(r1.container.textContent).toContain('Bug Report')
+    expect(r2.container.textContent).toContain('Bug Reports')
+  })
+})

--- a/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
@@ -1,0 +1,153 @@
+import ExceptionsDetailsPlot from '@/app/components/exceptions_details_plot'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }))
+jest.mock('@/app/components/loading_spinner', () => ({ __esModule: true, default: () => <div>loading</div> }))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  ExceptionsType: { Crash: 'crash', Anr: 'anr' },
+  ExceptionsDetailsPlotApiStatus: { Loading: 'loading', Success: 'success', Error: 'error', NoData: 'no_data' },
+  fetchExceptionsDetailsPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = { ready: true, startDate: '2025-01-01T00:00:00Z', endDate: '2025-07-20T00:00:00Z' } as any
+
+describe('ExceptionsDetailsPlot', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lastLineProps = null
+  })
+
+  it('uses demo data when demo=true', async () => {
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} demo />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(lastLineProps.xScale.precision).toBe('day')
+  })
+
+  it('renders error state from api', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} />)
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('renders no data state from api', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} />)
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('renders loading state before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 1 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('maps API success data and sets plot points', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 7 }] }] })
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.data[0].id).toBe('v1')
+    expect(lastLineProps.data[0].data[0].y).toBe(7)
+    expect(lastLineProps.axisLeft.legend).toBe('Crash instances')
+    expect(lastLineProps.axisLeft.legendOffset).toBe(-40)
+    expect(fetchMock).toHaveBeenCalledWith('crash', 'g1', filters)
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, ready: false }} />)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('adjusts legend offset in demo mode and uses tooltip date formatting', async () => {
+    render(<ExceptionsDetailsPlot exceptionsType={'anr' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} demo />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisLeft.legendOffset).toBe(-45)
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p1',
+          serieColor: '#222',
+          serieId: 'v1',
+          data: { xFormatted: '2026-02-01T03:00:00', y: 2 },
+        }],
+      },
+    })
+    const { container } = render(tooltip)
+    expect(container.textContent).toContain('Date:')
+    expect(container.textContent).toContain('instances')
+  })
+
+  it('uses singular tooltip label when value is 1', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 1 }] }] })
+    render(<ExceptionsDetailsPlot exceptionsType={'anr' as any} exceptionsGroupId="g1" filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisLeft.legend).toBe('ANR instances')
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p1',
+          serieColor: '#222',
+          serieId: 'v1',
+          data: { xFormatted: '2026-02-01T03:00:00', y: 1 },
+        }],
+      },
+    })
+    const { container } = render(tooltip)
+    expect(container.textContent).toContain('1 instance')
+  })
+
+  it('uses minute/hour/day/month axis config based on date range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-01T03:00:00', instances: 2 }] }] })
+
+    const { rerender } = render(
+      <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} />
+    )
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('minute')
+
+    rerender(
+      <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-06T00:00:00Z' }} />
+    )
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('hour')
+
+    rerender(
+      <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />
+    )
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+
+    rerender(
+      <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />
+    )
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+})

--- a/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
@@ -1,0 +1,137 @@
+import ExceptionsOverviewPlot from '@/app/components/exceptions_overview_plot'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }))
+jest.mock('@/app/components/loading_spinner', () => ({ __esModule: true, default: () => <div>loading</div> }))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  ExceptionsType: { Crash: 'crash', Anr: 'anr' },
+  ExceptionsOverviewPlotApiStatus: { Loading: 'loading', Success: 'success', Error: 'error', NoData: 'no_data' },
+  fetchExceptionsOverviewPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = { ready: true, startDate: '2026-01-01T00:00:00Z', endDate: '2026-01-06T00:00:00Z' } as any
+
+describe('ExceptionsOverviewPlot', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lastLineProps = null
+  })
+
+  it('renders error state', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={filters} />)
+
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('renders no data state', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={filters} />)
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, ready: false }} />)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders loading state before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={filters} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02T00:00:00', instances: 1 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('renders success with hour precision for ~days range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02T00:00:00', instances: 3 }] }] })
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('hour')
+    expect(lastLineProps.data[0].data[0].y).toBe(3)
+    expect(lastLineProps.axisLeft.legend).toBe('Crash instances')
+    expect(lastLineProps.axisLeft.format(2)).toBe(2)
+    expect(lastLineProps.axisLeft.format(1.5)).toBe('')
+    expect(fetchMock).toHaveBeenCalledWith('crash', filters)
+  })
+
+  it('sets ANR axis legend for ANR mode', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02T00:00:00', instances: 1 }] }] })
+    render(<ExceptionsOverviewPlot exceptionsType={'anr' as any} filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisLeft.legend).toBe('ANR instances')
+  })
+
+  it('pluralizes tooltip label for singular and plural values', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02T00:00:00', instances: 1 }] }] })
+    render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const singleTooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p1',
+          serieColor: '#111',
+          serieId: 'v',
+          data: { xFormatted: '2026-01-02T00:00:00', y: 1, yFormatted: 1 },
+        }],
+      },
+    })
+    const multiTooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p2',
+          serieColor: '#111',
+          serieId: 'v',
+          data: { xFormatted: '2026-01-02T00:00:00', y: 3, yFormatted: 3 },
+        }],
+      },
+    })
+
+    const { container: single } = render(singleTooltip)
+    const { container: multi } = render(multiTooltip)
+    expect(single.textContent).toContain('1 instance')
+    expect(multi.textContent).toContain('3 instances')
+    expect(single.textContent).toContain('Date:')
+    expect(multi.textContent).toContain('Date:')
+  })
+
+  it('switches axis format based on range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02T00:00:00', instances: 2 }] }] })
+    const { rerender } = render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-01-01T06:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('minute')
+
+    rerender(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+
+    rerender(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+})

--- a/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
@@ -1,0 +1,142 @@
+import SessionTimelinesOverviewPlot from '@/app/components/session_timelines_overview_plot'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}))
+
+jest.mock('@/app/components/loading_spinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading-spinner" />,
+}))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  SessionTimelinesOverviewPlotApiStatus: {
+    Loading: 'loading',
+    Success: 'success',
+    Error: 'error',
+    NoData: 'no_data',
+  },
+  fetchSessionTimelinesOverviewPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = {
+  ready: true,
+  startDate: '2026-02-23T00:00:00Z',
+  endDate: '2026-02-23T06:00:00Z',
+} as any
+
+describe('SessionTimelinesOverviewPlot', () => {
+  beforeEach(() => {
+    lastLineProps = null
+    fetchMock.mockReset()
+  })
+
+  it('renders no data state', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<SessionTimelinesOverviewPlot filters={filters} />)
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<SessionTimelinesOverviewPlot filters={{ ...filters, ready: false }} />)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders error state', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<SessionTimelinesOverviewPlot filters={filters} />)
+
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('renders loading spinner before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<SessionTimelinesOverviewPlot filters={filters} />)
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-02-23T01:00:00', instances: 2 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('maps data and uses minute x-axis for short ranges', async () => {
+    fetchMock.mockResolvedValue({
+      status: 'success',
+      data: [{ id: '1.0.0', data: [{ datetime: '2026-02-23T01:00:00', instances: 2 }] }],
+    })
+
+    render(<SessionTimelinesOverviewPlot filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('minute')
+    expect(lastLineProps.axisBottom.format).toBe('%b %d, %H:%M')
+    expect(lastLineProps.axisLeft.legend).toBe('Session Timelines')
+    expect(lastLineProps.data[0].data[0].y).toBe(2)
+    expect(fetchMock).toHaveBeenCalledWith(filters)
+  })
+
+  it('uses hour precision for medium range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-02-10T01:00:00', instances: 2 }] }] })
+    render(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-06T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('hour')
+  })
+
+  it('uses day precision for multi-month range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-03-01', instances: 2 }] }] })
+    render(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+    expect(lastLineProps.axisBottom.format).toBe('%b %d, %Y')
+  })
+
+  it('uses month formatting for long range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-01-01', instances: 2 }] }] })
+    render(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+
+  it('renders tooltip with expected labels', async () => {
+    fetchMock.mockResolvedValue({
+      status: 'success',
+      data: [{ id: '1.0.0', data: [{ datetime: '2026-02-23T01:00:00', instances: 2 }] }],
+    })
+    render(<SessionTimelinesOverviewPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p1',
+          serieColor: '#111',
+          serieId: '1.0.0',
+          data: { xFormatted: '2026-02-23T01:00:00', yFormatted: 2 },
+        }],
+      },
+    })
+    const { container } = render(tooltip)
+    expect(container.textContent).toContain('Date:')
+    expect(container.textContent).toContain('session timelines')
+  })
+})

--- a/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
@@ -1,0 +1,161 @@
+import SessionsVsExceptionsPlot from '@/app/components/sessions_vs_exceptions_overview_plot'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }))
+jest.mock('@/app/components/loading_spinner', () => ({ __esModule: true, default: () => <div>loading</div> }))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  SessionsVsExceptionsPlotApiStatus: { Loading: 'loading', Success: 'success', Error: 'error', NoData: 'no_data' },
+  fetchSessionsVsExceptionsPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = { ready: true, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' } as any
+
+describe('SessionsVsExceptionsPlot', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lastLineProps = null
+  })
+
+  it('renders no data state', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('renders error state', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<SessionsVsExceptionsPlot filters={{ ...filters, ready: false }} />)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders loading state before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('uses demo data and bypasses API in demo mode', async () => {
+    render(<SessionsVsExceptionsPlot filters={filters} demo />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(lastLineProps.data[0].id).toBe('Sessions')
+  })
+
+  it('renders data and minute precision axis for sub-12h range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] }] })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('minute')
+    expect(lastLineProps.data[0].id).toBe('Sessions')
+    expect(fetchMock).toHaveBeenCalledWith(filters)
+  })
+
+  it('uses hour/day/month axis config based on range', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] }] })
+
+    const { rerender } = render(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-06T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('hour')
+
+    rerender(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+
+    rerender(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+
+  it('renders tooltip in Sessions, Crashes, ANRs order', async () => {
+    fetchMock.mockResolvedValue({
+      status: 'success',
+      data: [
+        { id: 'ANRs', data: [{ id: 'a1', x: '2026-02-01T01:00:00', y: 1 }] },
+        { id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] },
+        { id: 'Crashes', data: [{ id: 'c1', x: '2026-02-01T01:00:00', y: 2 }] },
+      ],
+    })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [
+          { id: 'a1', serieId: 'ANRs', data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 1 } },
+          { id: 's1', serieId: 'Sessions', data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 10 } },
+          { id: 'c1', serieId: 'Crashes', data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 2 } },
+        ],
+      },
+    })
+
+    const { container } = render(tooltip)
+    const text = container.textContent || ''
+    expect(text.indexOf('Sessions')).toBeLessThan(text.indexOf('Crashes'))
+    expect(text.indexOf('Crashes')).toBeLessThan(text.indexOf('ANRs'))
+  })
+
+  it('skips missing tooltip series and keeps known ordering', async () => {
+    fetchMock.mockResolvedValue({
+      status: 'success',
+      data: [
+        { id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] },
+        { id: 'ANRs', data: [{ id: 'a1', x: '2026-02-01T01:00:00', y: 1 }] },
+      ],
+    })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [
+          { id: 'a1', serieId: 'ANRs', data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 1 } },
+          { id: 's1', serieId: 'Sessions', data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 10 } },
+        ],
+      },
+    })
+
+    const { container } = render(tooltip)
+    const text = container.textContent || ''
+    expect(text).toContain('Sessions')
+    expect(text).not.toContain('Crashes')
+    expect(text).toContain('ANRs')
+  })
+
+  it('uses fallback color for unknown series id', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'Sessions', data: [{ id: 's1', x: '2026-02-01T01:00:00', y: 10 }] }] })
+    render(<SessionsVsExceptionsPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    expect(lastLineProps.colors({ id: 'Unknown' })).toBe('#888')
+    expect(lastLineProps.pointBorderColor({ serieId: 'Unknown' })).toBe('#888')
+  })
+})

--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -1,0 +1,148 @@
+import SpanMetricsPlot from '@/app/components/span_metrics_plot'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+let lastLineProps: any = null
+let lastTabSelectProps: any = null
+const fetchMock = jest.fn()
+
+jest.mock('@nivo/line', () => ({
+  ResponsiveLine: (props: any) => {
+    lastLineProps = props
+    return <div data-testid="line-mock" />
+  },
+}))
+
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }))
+jest.mock('@/app/components/loading_spinner', () => ({ __esModule: true, default: () => <div>loading</div> }))
+
+jest.mock('@/app/components/tab_select', () => ({
+  __esModule: true,
+  default: ({ items, selected, onChangeSelected }: any) => {
+    lastTabSelectProps = { items, selected, onChangeSelected }
+    return (
+      <div>
+        {items.map((item: string) => (
+          <button key={item} data-testid={`quantile-${item}`} aria-pressed={selected === item} onClick={() => onChangeSelected(item)}>
+            {item}
+          </button>
+        ))}
+      </div>
+    )
+  },
+}))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  SpanMetricsPlotApiStatus: { Loading: 'loading', Success: 'success', Error: 'error', NoData: 'no_data' },
+  fetchSpanMetricsPlotFromServer: (...args: any[]) => fetchMock(...args),
+}))
+
+const filters = { ready: true, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T08:00:00Z' } as any
+
+describe('SpanMetricsPlot', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lastLineProps = null
+    lastTabSelectProps = null
+  })
+
+  it('renders no data state', async () => {
+    fetchMock.mockResolvedValue({ status: 'no_data', data: null })
+    render(<SpanMetricsPlot filters={filters} />)
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument()
+  })
+
+  it('renders error state', async () => {
+    fetchMock.mockResolvedValue({ status: 'error', data: null })
+    render(<SpanMetricsPlot filters={filters} />)
+    expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument()
+  })
+
+  it('does not fetch when filters are not ready', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [] })
+    render(<SpanMetricsPlot filters={{ ...filters, ready: false }} />)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders loading state before request resolves', async () => {
+    let resolvePromise: (value: any) => void = () => { }
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+    fetchMock.mockReturnValue(pending)
+
+    render(<SpanMetricsPlot filters={filters} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    resolvePromise({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-01T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+  })
+
+  it('maps quantile and updates when tab changes', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-01T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+    render(<SpanMetricsPlot filters={filters} />)
+
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.data[0].data[0].y).toBe(30)
+    expect(lastLineProps.axisLeft.legend).toBe('Duration (p95)')
+    expect(fetchMock).toHaveBeenCalledWith(filters)
+    expect(lastTabSelectProps.items).toEqual(['p50', 'p90', 'p95', 'p99'])
+    expect(lastTabSelectProps.selected).toBe('p95')
+
+    fireEvent.click(screen.getByTestId('quantile-p99'))
+    await waitFor(() => expect(lastLineProps.data[0].data[0].y).toBe(40))
+    expect(lastLineProps.axisLeft.legend).toBe('Duration (p99)')
+  })
+
+  it('renders tooltip with human readable millis', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-01T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+    render(<SpanMetricsPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    const tooltip = lastLineProps.sliceTooltip({
+      slice: {
+        points: [{
+          id: 'p1',
+          serieColor: '#111',
+          serieId: 'v1',
+          data: { xFormatted: '2026-02-01T01:00:00', yFormatted: 30 },
+        }],
+      },
+    })
+    const { container } = render(tooltip)
+    expect(container.textContent).toContain('Date:')
+    expect(container.textContent).toContain('(p95)')
+  })
+
+  it('uses hour/day/month axis configuration for larger ranges', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-10T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+    const { rerender } = render(<SpanMetricsPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-06T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('hour')
+
+    rerender(<SpanMetricsPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.xScale.precision).toBe('day')
+
+    rerender(<SpanMetricsPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+  })
+
+  it('throws for invalid quantile selection', async () => {
+    fetchMock.mockResolvedValue({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-01T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+    render(<SpanMetricsPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    let thrown: any = null
+    try {
+      lastTabSelectProps.onChangeSelected('p75')
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBe('Invalid quantile selected')
+  })
+
+})

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -3,6 +3,7 @@ import { Filters } from "../components/filters"
 import { JourneyType } from "../components/journey"
 import {
   formatUserInputDateToServerFormat,
+  getPlotTimeGroupForRange,
   getTimeZoneForServer,
 } from "../utils/time_utils"
 
@@ -1308,6 +1309,12 @@ async function applyGenericFiltersToUrl(
   return u.toString()
 }
 
+function appendPlotTimeGroupToUrl(url: string, filters: Filters): string {
+  const u = new URL(url, window.location.origin)
+  u.searchParams.set("plot_time_group", getPlotTimeGroupForRange(filters.startDate, filters.endDate))
+  return u.toString()
+}
+
 export const validateInvitesFromServer = async (inviteId: string) => {
   try {
     const res = await measureAuth.fetchMeasure(`/api/auth/validateInvite`, {
@@ -1413,6 +1420,7 @@ export const fetchSpanMetricsPlotFromServer = async (filters: Filters) => {
   var url = `/api/apps/${filters.app!.id}/spans/plots/metrics?`
 
   url = await applyGenericFiltersToUrl(url, filters, null, null)
+  url = appendPlotTimeGroupToUrl(url, filters)
 
   try {
     const res = await measureAuth.fetchMeasure(url)
@@ -1682,6 +1690,7 @@ export const fetchSessionTimelinesOverviewPlotFromServer = async (filters: Filte
   var url = `/api/apps/${filters.app!.id}/sessions/plots/instances?`
 
   url = await applyGenericFiltersToUrl(url, filters, null, null)
+  url = appendPlotTimeGroupToUrl(url, filters)
 
   try {
     const res = await measureAuth.fetchMeasure(url)
@@ -1808,6 +1817,7 @@ export const fetchExceptionsOverviewPlotFromServer = async (
   }
 
   url = await applyGenericFiltersToUrl(url, filters, null, null)
+  url = appendPlotTimeGroupToUrl(url, filters)
 
   try {
     const res = await measureAuth.fetchMeasure(url)
@@ -1841,6 +1851,7 @@ export const fetchExceptionsDetailsPlotFromServer = async (
   }
 
   url = await applyGenericFiltersToUrl(url, filters, null, null)
+  url = appendPlotTimeGroupToUrl(url, filters)
 
   try {
     const res = await measureAuth.fetchMeasure(url)
@@ -2479,6 +2490,7 @@ export const fetchBugReportsOverviewPlotFromServer = async (
   var url = `/api/apps/${filters.app!.id}/bugReports/plots/instances?`
 
   url = await applyGenericFiltersToUrl(url, filters, null, null)
+  url = appendPlotTimeGroupToUrl(url, filters)
 
   try {
     const res = await measureAuth.fetchMeasure(url)

--- a/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
+++ b/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
@@ -4,8 +4,9 @@ import { ResponsiveLine } from '@nivo/line'
 import { useTheme } from 'next-themes'
 import React, { useEffect, useState } from 'react'
 import { BugReportsOverviewPlotApiStatus, fetchBugReportsOverviewPlotFromServer } from '../api/api_calls'
+import { formatPlotTooltipDate, getPlotTimeGroupNivoConfig } from '../utils/time_utils'
 import { chartTheme } from '../utils/shared_styles'
-import { formatDateToHumanReadableDate } from '../utils/time_utils'
+import { getPlotTimeGroupForRange } from '../utils/time_utils'
 import { Filters } from './filters'
 import LoadingSpinner from './loading_spinner'
 
@@ -26,6 +27,8 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
   const [bugReportsOverviewPlotApiStatus, setBugReportsOverviewPlotApiStatus] = useState(BugReportsOverviewPlotApiStatus.Loading)
   const [plot, setPlot] = useState<BugReportsOverviewPlot>()
   const { theme } = useTheme()
+  const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
+  const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
 
   const getBugReportsOverviewPlot = async () => {
     // Don't try to fetch plot if filters aren't ready
@@ -80,10 +83,10 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
           areaOpacity={0.1}
           colors={{ scheme: theme === 'dark' ? 'tableau10' : 'nivo' }}
           margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
-          xFormat="time:%Y-%m-%d"
+          xFormat={timeConfig.xFormat}
           xScale={{
-            format: '%Y-%m-%d',
-            precision: 'day',
+            format: timeConfig.xScaleFormat,
+            precision: timeConfig.xScalePrecision,
             type: 'time',
             useUTC: false
           }}
@@ -99,7 +102,7 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
             legend: 'Date',
             tickPadding: 10,
             legendOffset: 100,
-            format: '%b %d, %Y',
+            format: timeConfig.axisBottomFormat,
             tickRotation: 45,
             legendPosition: 'middle'
           }}
@@ -131,7 +134,7 @@ const BugReportsOverviewPlot: React.FC<BugReportsOverviewPlotProps> = ({ filters
           sliceTooltip={({ slice }) => {
             return (
               <div className="bg-accent text-accent-foreground flex flex-col p-2 text-xs rounded-md">
-                <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                <p className='p-2'>Date: {formatPlotTooltipDate(slice.points[0].data.xFormatted.toString(), plotTimeGroup)}</p>
                 {slice.points.map((point) => (
                   <div className="flex flex-row items-center p-2" key={point.id}>
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />

--- a/frontend/dashboard/app/components/exceptions_details_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_details_plot.tsx
@@ -6,8 +6,9 @@ import { useTheme } from 'next-themes'
 import React, { useEffect, useState } from 'react'
 import { ExceptionsDetailsPlotApiStatus, ExceptionsType, fetchExceptionsDetailsPlotFromServer } from '../api/api_calls'
 import { numberToKMB } from '../utils/number_utils'
+import { formatPlotTooltipDate, getPlotTimeGroupNivoConfig } from '../utils/time_utils'
 import { chartTheme } from '../utils/shared_styles'
-import { formatDateToHumanReadableDate } from '../utils/time_utils'
+import { getPlotTimeGroupForRange } from '../utils/time_utils'
 import { Filters } from './filters'
 import LoadingSpinner from './loading_spinner'
 
@@ -58,6 +59,8 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ exception
   const [exceptionsDetailsPlotApiStatus, setExceptionsDetailsPlotApiStatus] = useState(ExceptionsDetailsPlotApiStatus.Loading)
   const [plot, setPlot] = useState<ExceptionsDetailsPlot>()
   const { theme } = useTheme()
+  const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
+  const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
 
   const getExceptionsDetailsPlot = async () => {
     if (demo) {
@@ -115,10 +118,10 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ exception
           areaOpacity={0.1}
           colors={{ scheme: theme === 'dark' ? 'tableau10' : 'nivo' }}
           margin={{ top: 40, right: 60, bottom: 180, left: 50 }}
-          xFormat="time:%Y-%m-%d"
+          xFormat={timeConfig.xFormat}
           xScale={{
-            format: '%Y-%m-%d',
-            precision: 'day',
+            format: timeConfig.xScaleFormat,
+            precision: timeConfig.xScalePrecision,
             type: 'time',
             useUTC: false
           }}
@@ -134,7 +137,7 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ exception
             legend: 'Date',
             tickPadding: 10,
             legendOffset: 100,
-            format: '%b %d, %Y',
+            format: timeConfig.axisBottomFormat,
             tickRotation: 60,
             legendPosition: 'middle'
           }}
@@ -166,7 +169,7 @@ const ExceptionsDetailsPlot: React.FC<ExceptionsDetailsPlotProps> = ({ exception
           sliceTooltip={({ slice }) => {
             return (
               <div className="bg-accent text-accent-foreground flex flex-col p-2 text-xs rounded-md">
-                <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                <p className='p-2'>Date: {formatPlotTooltipDate(slice.points[0].data.xFormatted.toString(), plotTimeGroup)}</p>
                 {slice.points.map((point) => (
                   <div className="flex flex-row items-center p-2" key={point.id}>
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />

--- a/frontend/dashboard/app/components/exceptions_overview_plot.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview_plot.tsx
@@ -4,8 +4,9 @@ import { ResponsiveLine } from '@nivo/line'
 import { useTheme } from 'next-themes'
 import React, { useEffect, useState } from 'react'
 import { ExceptionsOverviewPlotApiStatus, ExceptionsType, fetchExceptionsOverviewPlotFromServer } from '../api/api_calls'
+import { formatPlotTooltipDate, getPlotTimeGroupNivoConfig } from '../utils/time_utils'
 import { chartTheme } from '../utils/shared_styles'
-import { formatDateToHumanReadableDate } from '../utils/time_utils'
+import { getPlotTimeGroupForRange } from '../utils/time_utils'
 import { Filters } from './filters'
 import LoadingSpinner from './loading_spinner'
 
@@ -27,6 +28,8 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
   const [exceptionsOverviewPlotApiStatus, setExceptionsOverviewPlotApiStatus] = useState(ExceptionsOverviewPlotApiStatus.Loading)
   const [plot, setPlot] = useState<ExceptionsOverviewPlot>()
   const { theme } = useTheme()
+  const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
+  const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
 
   const getExceptionsOverviewPlot = async () => {
     // Don't try to fetch plot if filters aren't ready
@@ -81,10 +84,10 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
           areaOpacity={0.1}
           colors={{ scheme: theme === 'dark' ? 'dark2' : 'nivo' }}
           margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
-          xFormat="time:%Y-%m-%d"
+          xFormat={timeConfig.xFormat}
           xScale={{
-            format: '%Y-%m-%d',
-            precision: 'day',
+            format: timeConfig.xScaleFormat,
+            precision: timeConfig.xScalePrecision,
             type: 'time',
             useUTC: false
           }}
@@ -100,7 +103,7 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
             legend: 'Date',
             tickPadding: 10,
             legendOffset: 100,
-            format: '%b %d, %Y',
+            format: timeConfig.axisBottomFormat,
             tickRotation: 45,
             legendPosition: 'middle'
           }}
@@ -132,7 +135,7 @@ const ExceptionsOverviewPlot: React.FC<ExceptionsOverviewPlotProps> = ({ excepti
           sliceTooltip={({ slice }) => {
             return (
               <div className="bg-accent text-accent-foreground flex flex-col p-2 text-xs rounded-md">
-                <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                <p className='p-2'>Date: {formatPlotTooltipDate(slice.points[0].data.xFormatted.toString(), plotTimeGroup)}</p>
                 {slice.points.map((point) => (
                   <div className="flex flex-row items-center p-2" key={point.id}>
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />

--- a/frontend/dashboard/app/components/session_timelines_overview_plot.tsx
+++ b/frontend/dashboard/app/components/session_timelines_overview_plot.tsx
@@ -4,8 +4,9 @@ import { ResponsiveLine } from '@nivo/line'
 import { useTheme } from 'next-themes'
 import React, { useEffect, useState } from 'react'
 import { SessionTimelinesOverviewPlotApiStatus, fetchSessionTimelinesOverviewPlotFromServer } from '../api/api_calls'
+import { formatPlotTooltipDate, getPlotTimeGroupNivoConfig } from '../utils/time_utils'
 import { chartTheme } from '../utils/shared_styles'
-import { formatDateToHumanReadableDate } from '../utils/time_utils'
+import { getPlotTimeGroupForRange } from '../utils/time_utils'
 import { Filters } from './filters'
 import LoadingSpinner from './loading_spinner'
 
@@ -26,6 +27,8 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
   const [sessionTimelinesOverviewPlotApiStatus, setSessionTimelinesOverviewPlotApiStatus] = useState(SessionTimelinesOverviewPlotApiStatus.Loading)
   const [plot, setPlot] = useState<SessionTimelinesOverviewPlot>()
   const { theme } = useTheme()
+  const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
+  const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
 
   const getSessionTimelinesOverviewPlot = async () => {
     // Don't try to fetch plot if filters aren't ready
@@ -80,10 +83,10 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
           areaOpacity={0.1}
           colors={{ scheme: theme === 'dark' ? 'tableau10' : 'nivo' }}
           margin={{ top: 40, right: 40, bottom: 140, left: 100 }}
-          xFormat="time:%Y-%m-%d"
+          xFormat={timeConfig.xFormat}
           xScale={{
-            format: '%Y-%m-%d',
-            precision: 'day',
+            format: timeConfig.xScaleFormat,
+            precision: timeConfig.xScalePrecision,
             type: 'time',
             useUTC: false
           }}
@@ -99,7 +102,7 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
             legend: 'Date',
             tickPadding: 10,
             legendOffset: 100,
-            format: '%b %d, %Y',
+            format: timeConfig.axisBottomFormat,
             tickRotation: 45,
             legendPosition: 'middle'
           }}
@@ -131,7 +134,7 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
           sliceTooltip={({ slice }) => {
             return (
               <div className="bg-accent text-accent-foreground flex flex-col p-2 text-xs rounded-md">
-                <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                <p className='p-2'>Date: {formatPlotTooltipDate(slice.points[0].data.xFormatted.toString(), plotTimeGroup)}</p>
                 {slice.points.map((point) => (
                   <div className="flex flex-row items-center p-2" key={point.id}>
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />

--- a/frontend/dashboard/app/components/span_metrics_plot.tsx
+++ b/frontend/dashboard/app/components/span_metrics_plot.tsx
@@ -4,8 +4,9 @@ import { ResponsiveLine } from '@nivo/line'
 import { useTheme } from 'next-themes'
 import React, { useEffect, useState } from 'react'
 import { SpanMetricsPlotApiStatus, fetchSpanMetricsPlotFromServer } from '../api/api_calls'
+import { formatPlotTooltipDate, getPlotTimeGroupNivoConfig } from '../utils/time_utils'
 import { chartTheme } from '../utils/shared_styles'
-import { formatDateToHumanReadableDate, formatMillisToHumanReadable } from '../utils/time_utils'
+import { formatMillisToHumanReadable, getPlotTimeGroupForRange } from '../utils/time_utils'
 import { Filters } from './filters'
 import LoadingSpinner from './loading_spinner'
 import TabSelect from './tab_select'
@@ -36,6 +37,8 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
   const [spanMetricsPlotApiData, setSpanMetricsPlotApiData] = useState<any>()
   const [plot, setPlot] = useState<SpanMetricsPlot>()
   const { theme } = useTheme()
+  const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
+  const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
 
   function getYBasedOnQuantile(data: any) {
     switch (quantile) {
@@ -128,10 +131,10 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
             areaOpacity={0.1}
             colors={{ scheme: theme === 'dark' ? 'tableau10' : 'nivo' }}
             margin={{ top: 20, right: 40, bottom: 140, left: 100 }}
-            xFormat="time:%Y-%m-%d"
+            xFormat={timeConfig.xFormat}
             xScale={{
-              format: '%Y-%m-%d',
-              precision: 'day',
+              format: timeConfig.xScaleFormat,
+              precision: timeConfig.xScalePrecision,
               type: 'time',
               useUTC: false
             }}
@@ -147,7 +150,7 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
               legend: 'Date',
               tickPadding: 10,
               legendOffset: 100,
-              format: '%b %d, %Y',
+              format: timeConfig.axisBottomFormat,
               tickRotation: 45,
               legendPosition: 'middle'
             }}
@@ -178,7 +181,7 @@ const SpanMetricsPlot: React.FC<SpanMetricsPlotProps> = ({ filters }) => {
             sliceTooltip={({ slice }) => {
               return (
                 <div className="bg-accent text-accent-foreground flex flex-col p-2 text-xs rounded-md">
-                  <p className='p-2'>Date: {formatDateToHumanReadableDate(slice.points[0].data.xFormatted.toString())}</p>
+                  <p className='p-2'>Date: {formatPlotTooltipDate(slice.points[0].data.xFormatted.toString(), plotTimeGroup)}</p>
                   {slice.points.map((point) => (
                     <div className="flex flex-row items-center p-2" key={point.id}>
                       <div className="w-2 h-2 rounded-full" style={{ backgroundColor: point.serieColor }} />


### PR DESCRIPTION
# Description

This commit introduces a new `plot_time_group` filter passed by frontend that the api server uses to bucket instance plots and adds tests for plot APIs and frontend plot components.

Also adds missing dashboard API docs for
`/apps/:id/sessions/plots/instances` and updates docs for plot APIs with new filter.

## Related issues
Closes #3171, Closes #3172



