### PR TITLE
fix(frontend): fix plot render errors

### DIFF
--- a/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
@@ -107,4 +107,20 @@ describe('BugReportsOverviewPlot', () => {
     expect(r1.container.textContent).toContain('Bug Report')
     expect(r2.container.textContent).toContain('Bug Reports')
   })
+
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 2 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<BugReportsOverviewPlot filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(<BugReportsOverviewPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
@@ -150,4 +150,22 @@ describe('ExceptionsDetailsPlot', () => {
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
     expect(lastLineProps.axisBottom.format).toBe('%b %Y')
   })
+
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2025-02-01', instances: 7 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={filters} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(
+      <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
@@ -134,4 +134,20 @@ describe('ExceptionsOverviewPlot', () => {
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
     expect(lastLineProps.axisBottom.format).toBe('%b %Y')
   })
+
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: 'v', data: [{ datetime: '2026-01-02', instances: 2 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-01-01T06:00:00Z' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
@@ -139,4 +139,20 @@ describe('SessionTimelinesOverviewPlot', () => {
     expect(container.textContent).toContain('Date:')
     expect(container.textContent).toContain('session timelines')
   })
+
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-03-01', instances: 2 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2026-02-23T00:00:00Z', endDate: '2026-02-23T06:00:00Z' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
@@ -158,4 +158,20 @@ describe('SessionsVsExceptionsPlot', () => {
     expect(lastLineProps.colors({ id: 'Unknown' })).toBe('#888')
     expect(lastLineProps.pointBorderColor({ serieId: 'Unknown' })).toBe('#888')
   })
+
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: 'Sessions', data: [{ id: 's1', x: '2026-03-01', y: 10 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2026-01-01T00:00:00Z', endDate: '2026-03-15T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T06:00:00Z' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -145,4 +145,20 @@ describe('SpanMetricsPlot', () => {
     expect(thrown).toBe('Invalid quantile selected')
   })
 
+  it('hides stale chart while new range data is loading', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 'success', data: [{ id: 'v1', data: [{ datetime: '2026-02-10T01:00:00', p50: 10, p90: 20, p95: 30, p99: 40 }] }] })
+      .mockImplementationOnce(() => new Promise(() => { }))
+
+    const { rerender } = render(<SpanMetricsPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-06T00:00:00Z' }} />)
+    await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
+
+    rerender(<SpanMetricsPlot filters={{ ...filters, startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-01T08:00:00Z' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('line-mock')).not.toBeInTheDocument()
+    })
+  })
+
 })

--- a/frontend/dashboard/app/components/session_timelines_overview_plot.tsx
+++ b/frontend/dashboard/app/components/session_timelines_overview_plot.tsx
@@ -26,9 +26,12 @@ type SessionTimelinesOverviewPlot = {
 const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> = ({ filters }) => {
   const [sessionTimelinesOverviewPlotApiStatus, setSessionTimelinesOverviewPlotApiStatus] = useState(SessionTimelinesOverviewPlotApiStatus.Loading)
   const [plot, setPlot] = useState<SessionTimelinesOverviewPlot>()
+  const [plotDataKey, setPlotDataKey] = useState<string | null>(null)
   const { theme } = useTheme()
   const plotTimeGroup = getPlotTimeGroupForRange(filters.startDate, filters.endDate)
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup)
+  const currentPlotKey = `${filters.startDate}|${filters.endDate}|${plotTimeGroup}`
+  const shouldRenderPlot = sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Success && plot !== undefined && plotDataKey === currentPlotKey
 
   const getSessionTimelinesOverviewPlot = async () => {
     // Don't try to fetch plot if filters aren't ready
@@ -43,9 +46,11 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
     switch (result.status) {
       case SessionTimelinesOverviewPlotApiStatus.Error:
         setSessionTimelinesOverviewPlotApiStatus(SessionTimelinesOverviewPlotApiStatus.Error)
+        setPlotDataKey(null)
         break
       case SessionTimelinesOverviewPlotApiStatus.NoData:
         setSessionTimelinesOverviewPlotApiStatus(SessionTimelinesOverviewPlotApiStatus.NoData)
+        setPlotDataKey(null)
         break
       case SessionTimelinesOverviewPlotApiStatus.Success:
         setSessionTimelinesOverviewPlotApiStatus(SessionTimelinesOverviewPlotApiStatus.Success)
@@ -61,6 +66,7 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
         }))
 
         setPlot(newPlot)
+        setPlotDataKey(currentPlotKey)
         break
     }
   }
@@ -71,10 +77,10 @@ const SessionTimelinesOverviewPlot: React.FC<SessionTimelinesOverviewPlotProps> 
 
   return (
     <div className="flex font-body items-center justify-center w-full h-[36rem]">
-      {sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Loading && <LoadingSpinner />}
+      {(sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Loading || (sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Success && !shouldRenderPlot)) && <LoadingSpinner />}
       {sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Error && <p className="text-lg font-display text-center p-4">Error fetching plot, please change filters or refresh page to try again</p>}
       {sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.NoData && <p className="text-lg font-display text-center p-4">No Data</p>}
-      {sessionTimelinesOverviewPlotApiStatus === SessionTimelinesOverviewPlotApiStatus.Success &&
+      {shouldRenderPlot &&
         <ResponsiveLine
           data={plot!}
           curve="monotoneX"


### PR DESCRIPTION
# Description

Fixes plot render errors.

On date-range change, plotTimeGroup updates immediately, but existing chart data (from previous range) could render for one frame with a different time parser config.That stale/config mismatch can make date parsing fail inside Nivo internals, leading to setMilliseconds on null.


