### PR TITLE
chore(backend): implements custom error thresholds

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -159,6 +159,8 @@ func main() {
 		teams.GET(":id/members", measure.GetTeamMembers)
 		teams.DELETE(":id/members/:memberId", measure.RemoveTeamMember)
 		teams.GET(":id/usage", measure.GetUsage)
+		teams.GET(":id/thresholdPrefs", measure.GetTeamThresholdPrefs)
+		teams.PATCH(":id/thresholdPrefs", measure.UpdateTeamThresholdPrefs)
 		teams.GET(":id/slack", measure.GetTeamSlack)
 		teams.PATCH(":id/slack/status", measure.UpdateTeamSlackStatus)
 		teams.POST(":id/slack/test", measure.SendTestSlackAlert)

--- a/backend/api/measure/authz.go
+++ b/backend/api/measure/authz.go
@@ -83,6 +83,8 @@ var (
 	ScopeTeamRead                  = newScope("team", "read")
 	ScopeTeamInviteSameOrLower     = newScope("team", "inviteSameOrLower")
 	ScopeTeamChangeRoleSameOrLower = newScope("team", "changeRoleSameOrLower")
+	ScopeTeamThresholdPrefsAll     = newScope("teamThresholdPrefs", "*")
+	ScopeTeamThresholdPrefsRead    = newScope("teamThresholdPrefs", "read")
 	ScopeAlertAll                  = newScope("alert", "*")
 	ScopeAlertRead                 = newScope("alert", "read")
 	ScopeAppAll                    = newScope("app", "*")
@@ -114,10 +116,10 @@ func (s scope) getRolesSameOrLower(r rank) []rank {
 }
 
 var scopeMap = map[rank][]scope{
-	owner:     {*ScopeBillingAll, *ScopeTeamAll, *ScopeAlertAll, *ScopeAppAll},
-	admin:     {*ScopeBillingAll, *ScopeAlertAll, *ScopeAppAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
-	developer: {*ScopeBillingRead, *ScopeAlertAll, *ScopeAppRead, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
-	viewer:    {*ScopeBillingRead, *ScopeAlertRead, *ScopeTeamRead, *ScopeTeamInviteSameOrLower, *ScopeAppRead},
+	owner:     {*ScopeBillingAll, *ScopeTeamAll, *ScopeTeamThresholdPrefsAll, *ScopeAlertAll, *ScopeAppAll},
+	admin:     {*ScopeBillingAll, *ScopeTeamThresholdPrefsAll, *ScopeAlertAll, *ScopeAppAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
+	developer: {*ScopeBillingRead, *ScopeTeamThresholdPrefsRead, *ScopeAlertAll, *ScopeAppRead, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
+	viewer:    {*ScopeBillingRead, *ScopeTeamThresholdPrefsRead, *ScopeAlertRead, *ScopeTeamRead, *ScopeTeamInviteSameOrLower, *ScopeAppRead},
 }
 
 var roleMap = map[string]rank{
@@ -199,6 +201,21 @@ func PerformAuthz(uid string, rid string, scope scope) (bool, error) {
 		return false, nil
 	case *ScopeTeamAll:
 		if slices.Contains(roleScope, *ScopeTeamAll) {
+			return true, nil
+		}
+
+		return false, nil
+	case *ScopeTeamThresholdPrefsAll:
+		if slices.Contains(roleScope, *ScopeTeamThresholdPrefsAll) {
+			return true, nil
+		}
+
+		return false, nil
+	case *ScopeTeamThresholdPrefsRead:
+		if slices.Contains(roleScope, *ScopeTeamThresholdPrefsAll) {
+			return true, nil
+		}
+		if slices.Contains(roleScope, *ScopeTeamThresholdPrefsRead) {
 			return true, nil
 		}
 
@@ -309,17 +326,19 @@ func GetAuthzRoles(c *gin.Context) {
 	canWriteSdkConfig := slices.Contains(scopeMap[userRole], *ScopeAppAll)
 	canRenameTeam := slices.Contains(scopeMap[userRole], *ScopeTeamAll)
 	canManageSlack := slices.Contains(scopeMap[userRole], *ScopeTeamAll)
+	canChangeTeamThresholdPrefs := slices.Contains(scopeMap[userRole], *ScopeTeamThresholdPrefsAll)
 
 	c.JSON(http.StatusOK, gin.H{
-		"can_invite_roles":     inviteeRoles,
-		"can_change_billing":   canChangeBilling,
-		"can_create_app":       canCreateApp,
-		"can_rename_app":       canRenameApp,
-		"can_change_retention": canChangeRetention,
-		"can_rotate_api_key":   canRotateApiKey,
-		"can_write_sdk_config": canWriteSdkConfig,
-		"can_rename_team":      canRenameTeam,
-		"can_manage_slack":     canManageSlack,
-		"members":              membersWithAuthz,
+		"can_invite_roles":                inviteeRoles,
+		"can_change_billing":              canChangeBilling,
+		"can_create_app":                  canCreateApp,
+		"can_rename_app":                  canRenameApp,
+		"can_change_retention":            canChangeRetention,
+		"can_rotate_api_key":              canRotateApiKey,
+		"can_write_sdk_config":            canWriteSdkConfig,
+		"can_rename_team":                 canRenameTeam,
+		"can_manage_slack":                canManageSlack,
+		"can_change_team_threshold_prefs": canChangeTeamThresholdPrefs,
+		"members":                         membersWithAuthz,
 	})
 }

--- a/backend/api/measure/team_threshold_prefs.go
+++ b/backend/api/measure/team_threshold_prefs.go
@@ -1,0 +1,198 @@
+package measure
+
+import (
+	"backend/api/server"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/leporo/sqlf"
+)
+
+const (
+	defaultErrorGoodThreshold    = 95.0
+	defaultErrorCautionThreshold = 85.0
+)
+
+type TeamThresholdPrefs struct {
+	TeamID                uuid.UUID `json:"team_id"`
+	ErrorGoodThreshold    float64   `json:"error_good_threshold"`
+	ErrorCautionThreshold float64   `json:"error_caution_threshold"`
+	CreatedAt             time.Time `json:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
+}
+
+type TeamThresholdPrefsPayload struct {
+	ErrorGoodThreshold    float64 `json:"error_good_threshold"`
+	ErrorCautionThreshold float64 `json:"error_caution_threshold"`
+}
+
+type teamThresholdPrefsRequest struct {
+	ErrorGoodThreshold    *float64 `json:"error_good_threshold"`
+	ErrorCautionThreshold *float64 `json:"error_caution_threshold"`
+}
+
+func defaultTeamThresholdPrefs(teamID uuid.UUID) TeamThresholdPrefs {
+	now := time.Now().UTC()
+	return TeamThresholdPrefs{
+		TeamID:                teamID,
+		ErrorGoodThreshold:    defaultErrorGoodThreshold,
+		ErrorCautionThreshold: defaultErrorCautionThreshold,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+}
+
+func validateTeamThresholdPrefs(good, caution float64) error {
+	if good <= caution {
+		return fmt.Errorf("error_good_threshold must be greater than error_caution_threshold")
+	}
+	if good <= 0 || good > 100 {
+		return fmt.Errorf("error_good_threshold must be between 0 and 100")
+	}
+	if caution < 0 || caution >= 100 {
+		return fmt.Errorf("error_caution_threshold must be between 0 and 100")
+	}
+	return nil
+}
+
+func getTeamThresholdPrefsByTeamID(ctx context.Context, teamID uuid.UUID) (TeamThresholdPrefs, error) {
+	prefs := TeamThresholdPrefs{}
+	stmt := sqlf.PostgreSQL.
+		From("measure.team_threshold_prefs").
+		Select("team_id").
+		Select("error_good_threshold").
+		Select("error_caution_threshold").
+		Select("created_at").
+		Select("updated_at").
+		Where("team_id = ?", teamID)
+	defer stmt.Close()
+
+	err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(
+		&prefs.TeamID,
+		&prefs.ErrorGoodThreshold,
+		&prefs.ErrorCautionThreshold,
+		&prefs.CreatedAt,
+		&prefs.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return defaultTeamThresholdPrefs(teamID), nil
+		}
+		return TeamThresholdPrefs{}, err
+	}
+
+	return prefs, nil
+}
+
+func upsertTeamThresholdPrefs(ctx context.Context, teamID uuid.UUID, payload TeamThresholdPrefsPayload) error {
+	stmt := sqlf.PostgreSQL.
+		InsertInto("measure.team_threshold_prefs").
+		Set("team_id", teamID).
+		Set("error_good_threshold", payload.ErrorGoodThreshold).
+		Set("error_caution_threshold", payload.ErrorCautionThreshold).
+		Set("created_at", time.Now().UTC()).
+		Set("updated_at", time.Now().UTC())
+	defer stmt.Close()
+
+	query := stmt.String() + ` ON CONFLICT (team_id) DO UPDATE SET
+		error_good_threshold = EXCLUDED.error_good_threshold,
+		error_caution_threshold = EXCLUDED.error_caution_threshold,
+		updated_at = NOW()`
+
+	_, err := server.Server.PgPool.Exec(ctx, query, stmt.Args()...)
+	return err
+}
+
+func GetTeamThresholdPrefs(c *gin.Context) {
+	ctx := c.Request.Context()
+	userID := c.GetString("userId")
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `team id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	if ok, err := PerformAuthz(userID, teamID.String(), *ScopeTeamThresholdPrefsRead); err != nil {
+		msg := `couldn't perform authorization checks`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	} else if !ok {
+		msg := fmt.Sprintf(`you don't have permissions for team [%s]`, teamID)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
+	prefs, err := getTeamThresholdPrefsByTeamID(ctx, teamID)
+	if err != nil {
+		msg := fmt.Sprintf("error occurred while querying team threshold prefs: %s", teamID)
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	c.JSON(http.StatusOK, prefs)
+}
+
+func UpdateTeamThresholdPrefs(c *gin.Context) {
+	ctx := c.Request.Context()
+	userID := c.GetString("userId")
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `team id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	if ok, err := PerformAuthz(userID, teamID.String(), *ScopeTeamThresholdPrefsAll); err != nil {
+		msg := `couldn't perform authorization checks`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	} else if !ok {
+		msg := fmt.Sprintf(`you don't have permissions for team [%s]`, teamID)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
+	var req teamThresholdPrefsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		msg := `invalid request payload`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	if req.ErrorGoodThreshold == nil || req.ErrorCautionThreshold == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "error_good_threshold and error_caution_threshold are required"})
+		return
+	}
+
+	payload := TeamThresholdPrefsPayload{
+		ErrorGoodThreshold:    *req.ErrorGoodThreshold,
+		ErrorCautionThreshold: *req.ErrorCautionThreshold,
+	}
+
+	if err := validateTeamThresholdPrefs(payload.ErrorGoodThreshold, payload.ErrorCautionThreshold); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := upsertTeamThresholdPrefs(ctx, teamID, payload); err != nil {
+		msg := fmt.Sprintf("error occurred while updating team threshold prefs: %s", teamID)
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": "done"})
+}

--- a/backend/api/measure/team_threshold_prefs_test.go
+++ b/backend/api/measure/team_threshold_prefs_test.go
@@ -1,0 +1,393 @@
+//go:build integration
+
+package measure
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func TestGetTeamThresholdPrefs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns defaults when row missing", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/thresholdPrefs", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+		GetTeamThresholdPrefs(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got["error_good_threshold"] != float64(95) {
+			t.Fatalf("error_good_threshold = %v, want 95", got["error_good_threshold"])
+		}
+		if got["error_caution_threshold"] != float64(85) {
+			t.Fatalf("error_caution_threshold = %v, want 85", got["error_caution_threshold"])
+		}
+	})
+
+	t.Run("returns stored values when row exists", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		th.SeedTeamThresholdPrefs(ctx, t, teamID.String(), 98.5, 91.2)
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/thresholdPrefs", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+		GetTeamThresholdPrefs(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got["error_good_threshold"] != 98.5 {
+			t.Fatalf("error_good_threshold = %v, want 98.5", got["error_good_threshold"])
+		}
+		if got["error_caution_threshold"] != 91.2 {
+			t.Fatalf("error_caution_threshold = %v, want 91.2", got["error_caution_threshold"])
+		}
+	})
+
+	t.Run("all team roles can read", func(t *testing.T) {
+		for _, role := range []string{"owner", "admin", "developer", "viewer"} {
+			role := role
+			t.Run(role, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, role)
+
+				c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/thresholdPrefs", nil)
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+				GetTeamThresholdPrefs(c)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+				}
+			})
+		}
+	})
+
+	t.Run("missing membership returns internal server error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, userID, "threshold-no-membership@test.com")
+		seedTeam(ctx, t, teamID, "threshold-team", true)
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/thresholdPrefs", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+		GetTeamThresholdPrefs(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		}
+	})
+
+	t.Run("invalid team id returns bad request", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		c, w := newTestGinContext("GET", "/teams/not-a-uuid/thresholdPrefs", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+
+		GetTeamThresholdPrefs(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+func TestUpdateTeamThresholdPrefs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner and admin can create and then update preferences", func(t *testing.T) {
+		for _, role := range []string{"owner", "admin"} {
+			role := role
+			t.Run(role, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, role)
+
+				first := TeamThresholdPrefsPayload{ErrorGoodThreshold: 97, ErrorCautionThreshold: 88}
+				b, _ := json.Marshal(first)
+				c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b))
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+				UpdateTeamThresholdPrefs(c)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+				}
+
+				second := TeamThresholdPrefsPayload{ErrorGoodThreshold: 99, ErrorCautionThreshold: 94}
+				b2, _ := json.Marshal(second)
+				c2, w2 := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b2))
+				c2.Set("userId", userID)
+				c2.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+				UpdateTeamThresholdPrefs(c2)
+				if w2.Code != http.StatusOK {
+					t.Fatalf("status = %d, want %d, body: %s", w2.Code, http.StatusOK, w2.Body.String())
+				}
+
+				var good, caution float64
+				err := th.PgPool.QueryRow(ctx,
+					`SELECT error_good_threshold, error_caution_threshold FROM measure.team_threshold_prefs WHERE team_id = $1`,
+					teamID,
+				).Scan(&good, &caution)
+				if err != nil {
+					t.Fatalf("query threshold prefs: %v", err)
+				}
+				if good != 99 || caution != 94 {
+					t.Fatalf("stored thresholds = (%v,%v), want (99,94)", good, caution)
+				}
+			})
+		}
+	})
+
+	t.Run("developer and viewer cannot update", func(t *testing.T) {
+		for _, role := range []string{"developer", "viewer"} {
+			role := role
+			t.Run(role, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, role)
+
+				payload := TeamThresholdPrefsPayload{ErrorGoodThreshold: 97, ErrorCautionThreshold: 88}
+				b, _ := json.Marshal(payload)
+				c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b))
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+
+				UpdateTeamThresholdPrefs(c)
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusForbidden, w.Body.String())
+				}
+
+				var count int
+				err := th.PgPool.QueryRow(ctx,
+					`SELECT COUNT(*) FROM measure.team_threshold_prefs WHERE team_id = $1`,
+					teamID,
+				).Scan(&count)
+				if err != nil {
+					t.Fatalf("query threshold prefs count: %v", err)
+				}
+				if count != 0 {
+					t.Fatalf("forbidden update must not mutate DB, found %d rows", count)
+				}
+			})
+		}
+	})
+
+	t.Run("missing membership returns internal server error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, userID, "threshold-update-no-membership@test.com")
+		seedTeam(ctx, t, teamID, "threshold-team", true)
+
+		b, _ := json.Marshal(TeamThresholdPrefsPayload{ErrorGoodThreshold: 95, ErrorCautionThreshold: 85})
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b))
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		UpdateTeamThresholdPrefs(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		}
+	})
+
+	t.Run("invalid team id returns bad request", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, _ := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newTestGinContext("PATCH", "/teams/not-a-uuid/thresholdPrefs", bytes.NewReader([]byte(`{"error_good_threshold":95,"error_caution_threshold":85}`)))
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+		UpdateTeamThresholdPrefs(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("malformed JSON returns bad request", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader([]byte(`{`)))
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		UpdateTeamThresholdPrefs(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("missing required fields returns bad request", func(t *testing.T) {
+		cases := []struct {
+			name string
+			body string
+		}{
+			{name: "missing both fields", body: `{}`},
+			{name: "missing caution", body: `{"error_good_threshold":95}`},
+			{name: "missing good", body: `{"error_caution_threshold":85}`},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+				c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader([]byte(tc.body)))
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+				UpdateTeamThresholdPrefs(c)
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+				}
+
+				var got map[string]any
+				if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if got["error"] != "error_good_threshold and error_caution_threshold are required" {
+					t.Fatalf("error = %v, want %q", got["error"], "error_good_threshold and error_caution_threshold are required")
+				}
+			})
+		}
+	})
+
+	t.Run("invalid JSON field types return bad request", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		cases := []string{
+			`{"error_good_threshold":"95","error_caution_threshold":85}`,
+			`{"error_good_threshold":95,"error_caution_threshold":"85"}`,
+		}
+
+		for _, body := range cases {
+			c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader([]byte(body)))
+			c.Set("userId", userID)
+			c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+			UpdateTeamThresholdPrefs(c)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+		}
+	})
+
+	t.Run("invalid threshold combinations return bad request", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			payload TeamThresholdPrefsPayload
+			wantErr string
+		}{
+			{
+				name:    "good must be greater than caution",
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 80, ErrorCautionThreshold: 90},
+				wantErr: "error_good_threshold must be greater than error_caution_threshold",
+			},
+			{
+				name:    "good must be greater than zero",
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 0, ErrorCautionThreshold: 0},
+				wantErr: "error_good_threshold must be greater than error_caution_threshold",
+			},
+			{
+				name:    "good must not exceed 100",
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 101, ErrorCautionThreshold: 90},
+				wantErr: "error_good_threshold must be between 0 and 100",
+			},
+			{
+				name:    "caution must be non-negative",
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 90, ErrorCautionThreshold: -1},
+				wantErr: "error_caution_threshold must be between 0 and 100",
+			},
+			{
+				name:    "caution must be below 100",
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 100, ErrorCautionThreshold: 100},
+				wantErr: "error_good_threshold must be greater than error_caution_threshold",
+			},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+				b, _ := json.Marshal(tc.payload)
+				c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b))
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+				UpdateTeamThresholdPrefs(c)
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+				}
+
+				var got map[string]any
+				if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if got["error"] != tc.wantErr {
+					t.Fatalf("error = %v, want %q", got["error"], tc.wantErr)
+				}
+			})
+		}
+	})
+
+	t.Run("out of range but ordered values return bound errors", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		cases := []struct {
+			payload TeamThresholdPrefsPayload
+			wantErr string
+		}{
+			{
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: -1, ErrorCautionThreshold: -2},
+				wantErr: "error_good_threshold must be between 0 and 100",
+			},
+			{
+				payload: TeamThresholdPrefsPayload{ErrorGoodThreshold: 99.9, ErrorCautionThreshold: 100},
+				wantErr: "error_good_threshold must be greater than error_caution_threshold",
+			},
+		}
+
+		for _, tc := range cases {
+			b, _ := json.Marshal(tc.payload)
+			c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/thresholdPrefs", bytes.NewReader(b))
+			c.Set("userId", userID)
+			c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+			UpdateTeamThresholdPrefs(c)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got["error"] != tc.wantErr {
+				t.Fatalf("error = %v, want %q", got["error"], tc.wantErr)
+			}
+		}
+	})
+}

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -383,6 +383,18 @@ func (h *TestHelper) SeedTeamSlack(ctx context.Context, t *testing.T, teamID str
 	}
 }
 
+func (h *TestHelper) SeedTeamThresholdPrefs(ctx context.Context, t *testing.T, teamID string, errorGoodThreshold, errorCautionThreshold float64) {
+	t.Helper()
+	_, err := h.PgPool.Exec(ctx,
+		`INSERT INTO measure.team_threshold_prefs
+		(team_id, error_good_threshold, error_caution_threshold, created_at, updated_at)
+		VALUES ($1, $2, $3, now(), now())`,
+		teamID, errorGoodThreshold, errorCautionThreshold)
+	if err != nil {
+		t.Fatalf("seed team_threshold_prefs: %v", err)
+	}
+}
+
 func (h *TestHelper) SeedSpans(ctx context.Context, t *testing.T, teamID, appID string, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -214,112 +214,123 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-36)
     - [Response Body](#response-body-39)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-39)
-- [Teams](#teams)
-  - [POST `/teams`](#post-teams)
-    - [Authorization \& Content Type](#authorization--content-type-37)
-    - [Request Body](#request-body-8)
+  - [GET `/apps/:id/config`](#get-appsidconfig)
     - [Usage Notes](#usage-notes-40)
+    - [Authorization \& Content Type](#authorization--content-type-37)
     - [Response Body](#response-body-40)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-40)
-  - [GET `/teams`](#get-teams)
+  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+    - [Usage Notes](#usage-notes-41)
     - [Authorization \& Content Type](#authorization--content-type-38)
     - [Response Body](#response-body-41)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-41)
-  - [GET `/teams/:id/apps`](#get-teamsidapps)
-    - [Usage Notes](#usage-notes-41)
+- [Teams](#teams)
+  - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-39)
+    - [Request Body](#request-body-8)
+    - [Usage Notes](#usage-notes-42)
     - [Response Body](#response-body-42)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-42)
-  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
-    - [Usage Notes](#usage-notes-42)
+  - [GET `/teams`](#get-teams)
     - [Authorization \& Content Type](#authorization--content-type-40)
     - [Response Body](#response-body-43)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-43)
-  - [POST `/teams/:id/apps`](#post-teamsidapps)
+  - [GET `/teams/:id/apps`](#get-teamsidapps)
     - [Usage Notes](#usage-notes-43)
-    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-41)
     - [Response Body](#response-body-44)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-44)
-  - [GET `/teams/:id/invites`](#get-teamsidinvites)
+  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
     - [Usage Notes](#usage-notes-44)
     - [Authorization \& Content Type](#authorization--content-type-42)
     - [Response Body](#response-body-45)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-45)
-  - [POST `/teams/:id/invite`](#post-teamsidinvite)
+  - [POST `/teams/:id/apps`](#post-teamsidapps)
     - [Usage Notes](#usage-notes-45)
-    - [Request body](#request-body-10)
+    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-43)
     - [Response Body](#response-body-46)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-46)
-  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
+  - [GET `/teams/:id/invites`](#get-teamsidinvites)
     - [Usage Notes](#usage-notes-46)
     - [Authorization \& Content Type](#authorization--content-type-44)
     - [Response Body](#response-body-47)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-47)
-  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
+  - [POST `/teams/:id/invite`](#post-teamsidinvite)
     - [Usage Notes](#usage-notes-47)
+    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-45)
     - [Response Body](#response-body-48)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-48)
-  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
+  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
     - [Usage Notes](#usage-notes-48)
-    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-46)
     - [Response Body](#response-body-49)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-49)
-  - [GET `/teams/:id/members`](#get-teamsidmembers)
+  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
     - [Usage Notes](#usage-notes-49)
     - [Authorization \& Content Type](#authorization--content-type-47)
     - [Response Body](#response-body-50)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-50)
-  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
+  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
     - [Usage Notes](#usage-notes-50)
+    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-48)
     - [Response Body](#response-body-51)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-51)
-  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
+  - [GET `/teams/:id/members`](#get-teamsidmembers)
     - [Usage Notes](#usage-notes-51)
-    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-49)
     - [Response Body](#response-body-52)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-52)
-  - [GET `/teams/:id/authz`](#get-teamsidauthz)
+  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
     - [Usage Notes](#usage-notes-52)
     - [Authorization \& Content Type](#authorization--content-type-50)
     - [Response Body](#response-body-53)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-53)
-  - [GET `/teams/:id/usage`](#get-teamsidusage)
+  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
     - [Usage Notes](#usage-notes-53)
+    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-51)
     - [Response Body](#response-body-54)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-54)
-  - [GET `/teams/:id/slack`](#get-teamsidslack)
+  - [GET `/teams/:id/authz`](#get-teamsidauthz)
     - [Usage Notes](#usage-notes-54)
     - [Authorization \& Content Type](#authorization--content-type-52)
     - [Response Body](#response-body-55)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-55)
-  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+  - [GET `/teams/:id/usage`](#get-teamsidusage)
     - [Usage Notes](#usage-notes-55)
-    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-53)
     - [Response Body](#response-body-56)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-56)
-  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+  - [GET `/teams/:id/thresholdPrefs`](#get-teamsidthresholdprefs)
     - [Usage Notes](#usage-notes-56)
     - [Authorization \& Content Type](#authorization--content-type-54)
     - [Response Body](#response-body-57)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-57)
-  - [GET `/apps/:id/config`](#get-appsidconfig)
+  - [PATCH `/teams/:id/thresholdPrefs`](#patch-teamsidthresholdprefs)
     - [Usage Notes](#usage-notes-57)
+    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-55)
     - [Response Body](#response-body-58)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-58)
-  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+  - [GET `/teams/:id/slack`](#get-teamsidslack)
     - [Usage Notes](#usage-notes-58)
     - [Authorization \& Content Type](#authorization--content-type-56)
     - [Response Body](#response-body-59)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-59)
+  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+    - [Usage Notes](#usage-notes-59)
+    - [Request body](#request-body-14)
+    - [Authorization \& Content Type](#authorization--content-type-57)
+    - [Response Body](#response-body-60)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-60)
+  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+    - [Usage Notes](#usage-notes-60)
+    - [Authorization \& Content Type](#authorization--content-type-58)
+    - [Response Body](#response-body-61)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-61)
 
 ## Auth
 
@@ -795,6 +806,8 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/bugReports/:bugReportId`**](#get-appsidbugreportsbugreportid) - Fetch a bug report.
 - [**PATCH `/apps/:id/bugReports/:bugReportId`**](#patch-appsidbugreportsbugreportid) - Update a bug report's status.
 - [**GET `/apps/:id/alerts`**](#get-appsidalerts) - Fetch an app's alerts with optional filters.
+- [**GET `/apps/:id/config`**](#get-appsidconfig) - Fetch an app's config.
+- [**PATCH `/apps/:id/config`**](#patch-appsidconfig) - Update an app's config.
 
 ### GET `/apps/:id/journey`
 
@@ -5690,6 +5703,170 @@ List of HTTP status codes for success and failures.
 
 </details>
 
+
+### GET `/apps/:id/config`
+
+Fetch an app's config.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+  {
+    "max_events_in_batch": 1000,
+    "crash_timeline_duration": 300,
+    "anr_timeline_duration": 300,
+    "bug_report_timeline_duration": 300,
+    "trace_sampling_rate": 0.001,
+    "journey_sampling_rate": 0.001,
+    "screenshot_mask_level": "all_text",
+    "cpu_usage_interval": 5,
+    "memory_usage_interval": 5,
+    "crash_take_screenshot": true,
+    "anr_take_screenshot": true,
+    "launch_sampling_rate": 1,
+    "gesture_click_take_snapshot": true,
+    "http_disable_event_for_urls": [],
+    "http_track_request_for_urls": [],
+    "http_track_response_for_urls": [],
+    "http_blocked_headers": []
+  }
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+
+### PATCH `/apps/:id/config`
+
+Update an app's config using a PATCH request.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI
+- One or more config fields must be passed in the request body. Only the fields present in the request body will be updated.
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Request
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+    {
+      screenshot_mask_level: "all_text"
+    }
+  ```
+
+  </details>
+
+- Response
+  <details>
+    <summary>Click to expand</summary>
+    
+    ```json
+    {
+      "message":"config updated successfully"
+    }
+    ```
+  </details>
+
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+
 ## Teams
 
 - [**POST `/teams`**](#post-teams) - Create new team. Access token holder becomes the owner.
@@ -5707,6 +5884,8 @@ List of HTTP status codes for success and failures.
 - [**PATCH `/teams/:id/members/:id/role`**](#patch-teamsidmembersid) -  Change role of a member of a team.
 - [**GET `/teams/:id/authz`**](#get-teamsidauthz) -  Fetch authorization details of access token holder for a team.
 - [**GET `/teams/:id/usage`**](#get-teamsidusage) -  Fetch data usage details for a team.
+- [**GET `/teams/:id/thresholdPrefs`**](#get-teamsidthresholdprefs) - Fetch team threshold preferences.
+- [**PATCH `/teams/:id/thresholdPrefs`**](#patch-teamsidthresholdprefs) - Update team threshold preferences.
 - [**GET `/teams/:id/slack`**](#get-teamsidslack) -  Fetch Slack details for a team.
 - [**PATCH `/teams/:id/slack/status`**](#patch-teamsidslackstatus) -  Update a team's Slack integration status to active or inactive.
 - [**POST `/teams/:id/slack/test`**](#patch-teamsidslacktest) -  Send test alerts to all registered Slack channels.
@@ -6756,6 +6935,7 @@ Fetch authorization details of members for a team. Oldest members appear first i
 - The `can_write_sdk_config` field indicates whether the current user can update SDK config for apps in the team
 - The `can_rename_team` field indicates whether the current user can rename the team
 - The `can_manage_slack` field indicates whether the current user can manage team Slack integration
+- The `can_change_team_threshold_prefs` field indicates whether the current user can update team threshold preferences
 - The `current_user_assignable_roles_for_member` field in each member's `authz` object indicates what roles the current user is allowed to assign for that particular member
 - The `current_user_can_remove_member` flag in each member's `authz` object indicates whether the current user is allowed to remove that particular member from the team
 
@@ -6799,6 +6979,7 @@ The required headers must be present in each request.
     "can_write_sdk_config": true,
     "can_rename_team": true,
     "can_manage_slack": true,
+    "can_change_team_threshold_prefs": true,
     "members": [
         {
             "id": "7737299c-82cb-4769-8fed-b313a230aa9d",
@@ -7147,6 +7328,164 @@ List of HTTP status codes for success and failures.
 
 </details>
 
+### GET `/teams/:id/thresholdPrefs`
+
+Fetch threshold preferences for a team. Returns saved preferences if present, otherwise returns default values.
+
+#### Usage Notes
+
+- Teams's UUID must be passed in the URI
+- Read access is allowed for team members (owner/admin/developer/viewer)
+
+#### Authorization &amp; Content Type
+
+1. (Optional) Set the session's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+```json
+{
+  "team_id": "099f0f9b-5ee9-47de-a8aa-e996adc049c1",
+  "error_good_threshold": 95,
+  "error_caution_threshold": 85,
+  "created_at": "2026-02-24T15:04:05Z",
+  "updated_at": "2026-02-24T15:04:05Z"
+}
+```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### PATCH `/teams/:id/thresholdPrefs`
+
+Update threshold preferences for a team.
+
+#### Usage Notes
+
+- Teams's UUID must be passed in the URI
+- Only owner/admin roles can update team threshold prefs
+- Validation rules:
+- `error_good_threshold` must be greater than `error_caution_threshold`
+- `error_good_threshold` must be in `(0, 100]`
+- `error_caution_threshold` must be in `[0, 100)`
+
+#### Request Body
+
+- Request
+
+  <details>
+    <summary>Click to expand</summary>
+
+```json
+{
+  "error_good_threshold": 95,
+  "error_caution_threshold": 85
+}
+```
+
+  </details>
+
+#### Authorization &amp; Content Type
+
+1. (Optional) Set the session's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+```json
+{
+  "ok": "done"
+}
+```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
 ### GET `/teams/:id/slack`
 
 Fetch Slack details for a team. Returns Slack workspace name and active or inactive status if team has slack connected. Returns null if team doesn't have Slack connected.
@@ -7339,168 +7678,6 @@ The required headers must be present in each request.
   ```
 
 #### Status Codes & Troubleshooting
-
-List of HTTP status codes for success and failures.
-
-<details>
-  <summary>Status Codes - Click to expand</summary>
-
-| **Status**                  | **Meaning**                                                                                                            |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `200 Ok`                    | Successful response, no errors.                                                                                        |
-| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
-| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
-| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
-| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
-| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
-
-</details>
-
-### GET `/apps/:id/config`
-
-Fetch an app's config.
-
-#### Usage Notes
-
-- App's UUID must be passed in the URI
-
-#### Authorization & Content Type
-
-1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
-
-2. Set content type as `Content-Type: application/json; charset=utf-8`
-
-The required headers must be present in each request.
-
-<details>
-  <summary>Request Headers - Click to expand</summary>
-
-| **Name**        | **Value**                        |
-| --------------- | -------------------------------- |
-| `Authorization` | Bearer &lt;user-access-token&gt; |
-| `Content-Type`  | application/json; charset=utf-8  |
-</details>
-
-#### Response Body
-
-- Response
-
-  <details>
-    <summary>Click to expand</summary>
-
-  ```json
-  {
-    "max_events_in_batch": 1000,
-    "crash_timeline_duration": 300,
-    "anr_timeline_duration": 300,
-    "bug_report_timeline_duration": 300,
-    "trace_sampling_rate": 0.001,
-    "journey_sampling_rate": 0.001,
-    "screenshot_mask_level": "all_text",
-    "cpu_usage_interval": 5,
-    "memory_usage_interval": 5,
-    "crash_take_screenshot": true,
-    "anr_take_screenshot": true,
-    "launch_sampling_rate": 1,
-    "gesture_click_take_snapshot": true,
-    "http_disable_event_for_urls": [],
-    "http_track_request_for_urls": [],
-    "http_track_response_for_urls": [],
-    "http_blocked_headers": []
-  }
-  ```
-
-  </details>
-
-- Failed requests have the following response shape
-
-  ```json
-  {
-    "error": "Error message"
-  }
-  ```
-
-#### Status Codes &amp; Troubleshooting
-
-List of HTTP status codes for success and failures.
-
-<details>
-  <summary>Status Codes - Click to expand</summary>
-
-| **Status**                  | **Meaning**                                                                                                            |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `200 Ok`                    | Successful response, no errors.                                                                                        |
-| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
-| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
-| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
-| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
-| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
-
-</details>
-
-
-### PATCH `/apps/:id/config`
-
-Update an app's config using a PATCH request.
-
-#### Usage Notes
-
-- App's UUID must be passed in the URI
-- One or more config fields must be passed in the request body. Only the fields present in the request body will be updated.
-
-#### Authorization & Content Type
-
-1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
-
-2. Set content type as `Content-Type: application/json; charset=utf-8`
-
-The required headers must be present in each request.
-
-<details>
-  <summary>Request Headers - Click to expand</summary>
-
-| **Name**        | **Value**                        |
-| --------------- | -------------------------------- |
-| `Authorization` | Bearer &lt;user-access-token&gt; |
-| `Content-Type`  | application/json; charset=utf-8  |
-</details>
-
-#### Response Body
-
-- Request
-
-  <details>
-    <summary>Click to expand</summary>
-
-  ```json
-    {
-      screenshot_mask_level: "all_text"
-    }
-  ```
-
-  </details>
-
-- Response
-  <details>
-    <summary>Click to expand</summary>
-    
-    ```json
-    {
-      "message":"config updated successfully"
-    }
-    ```
-  </details>
-
-
-- Failed requests have the following response shape
-
-  ```json
-  {
-    "error": "Error message"
-  }
-  ```
-
-#### Status Codes &amp; Troubleshooting
 
 List of HTTP status codes for success and failures.
 

--- a/frontend/dashboard/__tests__/pages/team_test.tsx
+++ b/frontend/dashboard/__tests__/pages/team_test.tsx
@@ -6,7 +6,7 @@ import { act, createEvent, fireEvent, render, screen, waitFor } from '@testing-l
 const mockToastPositive = jest.fn()
 const mockToastNegative = jest.fn()
 const mockPush = jest.fn()
-const mockSearchParamsGet = jest.fn(() => null)
+const mockSearchParamsGet = jest.fn((_: string): string | null => null)
 const mockSearchParamsToString = jest.fn(() => '')
 
 jest.mock('@/app/utils/use_toast', () => ({
@@ -48,6 +48,7 @@ const defaultAuthz = {
   can_write_sdk_config: true,
   can_rename_team: true,
   can_manage_slack: true,
+  can_change_team_threshold_prefs: true,
   members: [
     {
       id: 'user-1',
@@ -100,7 +101,13 @@ jest.mock('@/app/api/api_calls', () => ({
   FetchTeamSlackConnectUrlApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
   FetchTeamSlackStatusApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
   UpdateTeamSlackStatusApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
+  FetchTeamThresholdPrefsApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
+  UpdateTeamThresholdPrefsApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
   TestSlackAlertApiStatus: { Init: 'init', Loading: 'loading', Success: 'success', Error: 'error', Cancelled: 'cancelled' },
+  defaultTeamThresholdPrefs: {
+    error_good_threshold: 95,
+    error_caution_threshold: 85,
+  },
   defaultAuthzAndMembers: {
     can_invite_roles: ['viewer'],
     can_change_billing: false,
@@ -111,6 +118,7 @@ jest.mock('@/app/api/api_calls', () => ({
     can_write_sdk_config: false,
     can_rename_team: false,
     can_manage_slack: false,
+    can_change_team_threshold_prefs: false,
     members: [],
   },
   fetchTeamsFromServer: jest.fn(() => Promise.resolve({
@@ -127,7 +135,9 @@ jest.mock('@/app/api/api_calls', () => ({
   removePendingInviteFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
   fetchTeamSlackConnectUrlFromServer: jest.fn(() => Promise.resolve({ status: 'success', data: { url: 'https://slack/connect' } })),
   fetchTeamSlackStatusFromServer: jest.fn(() => Promise.resolve({ status: 'success', data: { slack_team_name: 'Measure', is_active: true } })),
+  fetchTeamThresholdPrefsFromServer: jest.fn(() => Promise.resolve({ status: 'success', data: { error_good_threshold: 95, error_caution_threshold: 85 } })),
   updateTeamSlackStatusFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
+  updateTeamThresholdPrefsFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
   sendTestSlackAlertFromServer: jest.fn(() => Promise.resolve({ status: 'success' })),
 }))
 
@@ -239,7 +249,9 @@ describe('Team Page', () => {
     apiCalls.removePendingInviteFromServer.mockImplementation(() => Promise.resolve({ status: 'success' }))
     apiCalls.fetchTeamSlackConnectUrlFromServer.mockImplementation(() => Promise.resolve({ status: 'success', data: { url: 'https://slack/connect' } }))
     apiCalls.fetchTeamSlackStatusFromServer.mockImplementation(() => Promise.resolve({ status: 'success', data: { slack_team_name: 'Measure', is_active: true } }))
+    apiCalls.fetchTeamThresholdPrefsFromServer.mockImplementation(() => Promise.resolve({ status: 'success', data: { error_good_threshold: 95, error_caution_threshold: 85 } }))
     apiCalls.updateTeamSlackStatusFromServer.mockImplementation(() => Promise.resolve({ status: 'success' }))
+    apiCalls.updateTeamThresholdPrefsFromServer.mockImplementation(() => Promise.resolve({ status: 'success' }))
     apiCalls.sendTestSlackAlertFromServer.mockImplementation(() => Promise.resolve({ status: 'success' }))
     mockSearchParamsGet.mockReset()
     mockSearchParamsGet.mockImplementation(() => null)
@@ -265,6 +277,7 @@ describe('Team Page', () => {
     expect(screen.getByText('Team')).toBeInTheDocument()
     expect(screen.getByText('Members')).toBeInTheDocument()
     expect(screen.getByText('Pending Invites')).toBeInTheDocument()
+    expect(screen.getByText('Change Thresholds')).toBeInTheDocument()
     expect(screen.getByText('Slack Integration')).toBeInTheDocument()
     expect(screen.getByText('Change Team Name')).toBeInTheDocument()
   })
@@ -590,6 +603,129 @@ describe('Team Page', () => {
 
     expect(screen.getByTestId('slack-switch')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Send Test Alert' })).toBeDisabled()
+  })
+
+  describe('Threshold Preferences', () => {
+    it('disables threshold actions when can_change_team_threshold_prefs is false', async () => {
+      const { fetchAuthzAndMembersFromServer } = require('@/app/api/api_calls')
+      fetchAuthzAndMembersFromServer.mockImplementationOnce(() => Promise.resolve({
+        status: 'success',
+        data: { ...defaultAuthz, can_change_team_threshold_prefs: false },
+      }))
+
+      await renderPage()
+
+      expect(screen.getByRole('button', { name: 'Save thresholds' })).toBeDisabled()
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toBeDisabled()
+      expect(inputs[1]).toBeDisabled()
+    })
+
+    it('updates threshold prefs successfully', async () => {
+      const { updateTeamThresholdPrefsFromServer } = require('@/app/api/api_calls')
+      await renderPage()
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '97' } })
+      fireEvent.change(inputs[1], { target: { value: '88' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save thresholds' }))
+
+      await waitFor(() => {
+        expect(updateTeamThresholdPrefsFromServer).toHaveBeenCalledWith('team-1', {
+          error_good_threshold: 97,
+          error_caution_threshold: 88,
+        })
+        expect(mockToastPositive).toHaveBeenCalledWith('Thresholds updated successfully')
+      })
+    })
+
+    it('enables Save for threshold changes and disables when reverted', async () => {
+      await renderPage()
+
+      const saveThresholdsButton = screen.getByRole('button', { name: 'Save thresholds' })
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(saveThresholdsButton).toBeDisabled()
+
+      fireEvent.change(inputs[0], { target: { value: '97' } })
+      expect(saveThresholdsButton).not.toBeDisabled()
+
+      fireEvent.change(inputs[0], { target: { value: '95' } })
+      expect(saveThresholdsButton).toBeDisabled()
+    })
+
+    it('normalizes leading zero threshold input on blur', async () => {
+      await renderPage()
+
+      const inputs = screen.getAllByRole('spinbutton') as HTMLInputElement[]
+      fireEvent.change(inputs[0], { target: { value: '5' } })
+      expect(inputs[0].value).toBe('5')
+
+      fireEvent.change(inputs[0], { target: { value: '0005' } })
+      fireEvent.blur(inputs[0])
+
+      expect(inputs[0].value).toBe('5')
+    })
+
+    it('clamps threshold values to [0, 100] before saving', async () => {
+      const { updateTeamThresholdPrefsFromServer } = require('@/app/api/api_calls')
+      await renderPage()
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '101' } })
+      fireEvent.change(inputs[1], { target: { value: '-1' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save thresholds' }))
+
+      await waitFor(() => {
+        expect(updateTeamThresholdPrefsFromServer).toHaveBeenCalledWith('team-1', {
+          error_good_threshold: 100,
+          error_caution_threshold: 0,
+        })
+      })
+    })
+
+    it('shows validation error when good threshold is not greater than caution threshold', async () => {
+      const { updateTeamThresholdPrefsFromServer } = require('@/app/api/api_calls')
+      await renderPage()
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '80' } })
+      fireEvent.change(inputs[1], { target: { value: '90' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save thresholds' }))
+
+      expect(updateTeamThresholdPrefsFromServer).not.toHaveBeenCalled()
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        'Error updating thresholds',
+        'Good threshold must be greater than caution threshold',
+      )
+    })
+
+    it('shows error toast when threshold update API fails', async () => {
+      const { updateTeamThresholdPrefsFromServer } = require('@/app/api/api_calls')
+      updateTeamThresholdPrefsFromServer.mockImplementationOnce(() => Promise.resolve({
+        status: 'error',
+        error: 'failed',
+      }))
+
+      await renderPage()
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '97' } })
+      fireEvent.change(inputs[1], { target: { value: '88' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save thresholds' }))
+
+      await waitFor(() => {
+        expect(mockToastNegative).toHaveBeenCalledWith('Error updating thresholds', 'failed')
+      })
+    })
+
+    it('shows threshold prefs fetch error', async () => {
+      const { fetchTeamThresholdPrefsFromServer } = require('@/app/api/api_calls')
+      fetchTeamThresholdPrefsFromServer.mockImplementationOnce(() => Promise.resolve({ status: 'error' }))
+
+      await renderPage()
+
+      expect(await screen.findByText('Error fetching team threshold preferences, please refresh page to try again')).toBeInTheDocument()
+    })
   })
 
   it('handles slack enable/disable and test alert actions', async () => {

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -287,6 +287,22 @@ export enum UpdateTeamSlackStatusApiStatus {
   Cancelled,
 }
 
+export enum FetchTeamThresholdPrefsApiStatus {
+  Init,
+  Loading,
+  Success,
+  Error,
+  Cancelled,
+}
+
+export enum UpdateTeamThresholdPrefsApiStatus {
+  Init,
+  Loading,
+  Success,
+  Error,
+  Cancelled,
+}
+
 export enum TestSlackAlertApiStatus {
   Init,
   Loading,
@@ -756,6 +772,7 @@ export const defaultAuthzAndMembers = {
   can_write_sdk_config: false,
   can_rename_team: false,
   can_manage_slack: false,
+  can_change_team_threshold_prefs: false,
   members: [
     {
       id: "",
@@ -770,6 +787,11 @@ export const defaultAuthzAndMembers = {
       },
     },
   ],
+}
+
+export const defaultTeamThresholdPrefs = {
+  error_good_threshold: 95,
+  error_caution_threshold: 85,
 }
 
 export const emptySessionTimeline = {
@@ -2199,6 +2221,47 @@ export const fetchTeamSlackStatusFromServer = async (teamId: string) => {
     return { status: FetchTeamSlackStatusApiStatus.Success, data: data }
   } catch {
     return { status: FetchTeamSlackStatusApiStatus.Cancelled, data: null }
+  }
+}
+
+export const fetchTeamThresholdPrefsFromServer = async (teamId: string) => {
+  try {
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/thresholdPrefs`)
+    const data = await res.json()
+
+    if (!res.ok) {
+      return { status: FetchTeamThresholdPrefsApiStatus.Error, error: data.error, data: null }
+    }
+
+    return { status: FetchTeamThresholdPrefsApiStatus.Success, data: data }
+  } catch {
+    return { status: FetchTeamThresholdPrefsApiStatus.Cancelled, data: null }
+  }
+}
+
+export const updateTeamThresholdPrefsFromServer = async (
+  teamId: string,
+  prefs: typeof defaultTeamThresholdPrefs,
+) => {
+  const opts = {
+    method: "PATCH",
+    body: JSON.stringify(prefs),
+  }
+
+  try {
+    const res = await measureAuth.fetchMeasure(
+      `/api/teams/${teamId}/thresholdPrefs`,
+      opts,
+    )
+    const data = await res.json()
+
+    if (!res.ok) {
+      return { status: UpdateTeamThresholdPrefsApiStatus.Error, error: data.error }
+    }
+
+    return { status: UpdateTeamThresholdPrefsApiStatus.Success }
+  } catch {
+    return { status: UpdateTeamThresholdPrefsApiStatus.Cancelled }
   }
 }
 

--- a/frontend/dashboard/app/components/metrics_card.tsx
+++ b/frontend/dashboard/app/components/metrics_card.tsx
@@ -55,24 +55,32 @@ export interface CrashFreeSessionsProps extends BaseMetricsCardProps {
     type: 'crash_free_sessions'
     value: number
     delta: number
+    errorGoodThreshold: number
+    errorCautionThreshold: number
 }
 
 export interface PerceivedCrashFreeSessionsProps extends BaseMetricsCardProps {
     type: 'perceived_crash_free_sessions'
     value: number
     delta: number
+    errorGoodThreshold: number
+    errorCautionThreshold: number
 }
 
 export interface AnrFreeSessionsProps extends BaseMetricsCardProps {
     type: 'anr_free_sessions'
     value: number
     delta: number
+    errorGoodThreshold: number
+    errorCautionThreshold: number
 }
 
 export interface PerceivedAnrFreeSessionsProps extends BaseMetricsCardProps {
     type: 'perceived_anr_free_sessions'
     value: number
     delta: number
+    errorGoodThreshold: number
+    errorCautionThreshold: number
 }
 
 export interface AppStartTimeProps extends BaseMetricsCardProps {
@@ -132,29 +140,29 @@ const StatusIconRow: React.FC<{
 )
 
 // Reusable status icon rows for metrics with thresholds
-const renderThresholdStatusIcons = () => (
+const renderThresholdStatusIcons = (goodThreshold: number, cautionThreshold: number) => (
     <>
         <StatusIconRow
             first
             icon={<CheckCircle className={`${STYLES.icon.tooltipIcon} ${STYLES.icon.green}`} />}
-            text="Good (> 95%)"
+            text={`Good (> ${goodThreshold}%)`}
         />
         <StatusIconRow
             icon={<AlertTriangle className={`${STYLES.icon.tooltipIcon} ${STYLES.icon.yellow}`} />}
-            text="Caution (> 85%)"
+            text={`Caution (> ${cautionThreshold}%)`}
         />
         <StatusIconRow
             icon={<AlertTriangle className={`${STYLES.icon.tooltipIcon} ${STYLES.icon.red}`} />}
-            text="Poor (≤ 85%)"
+            text={`Poor (≤ ${cautionThreshold}%)`}
         />
     </>
 )
 
-function getStatusIcon(value: number) {
+function getStatusIcon(value: number, goodThreshold: number, cautionThreshold: number) {
     const iconClasses = `${STYLES.icon.status}`
-    if (value > 95) {
+    if (value > goodThreshold) {
         return <CheckCircle className={`${iconClasses} ${STYLES.icon.green}`} />
-    } else if (value > 85) {
+    } else if (value > cautionThreshold) {
         return <AlertTriangle className={`${iconClasses} ${STYLES.icon.yellow}`} />
     } else {
         return <AlertTriangle className={`${iconClasses} ${STYLES.icon.red}`} />
@@ -335,6 +343,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
     }
 
     const renderTooltipContent = () => {
+        const exceptionProps = props as CrashFreeSessionsProps | PerceivedCrashFreeSessionsProps | AnrFreeSessionsProps | PerceivedAnrFreeSessionsProps
         switch (type) {
             case 'crash_free_sessions':
                 return (
@@ -345,7 +354,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
                             Delta value = Crash free sessions percentage of selected app versions / Crash free sessions percentage of unselected app versions
                         </p>
                         <br />
-                        {renderThresholdStatusIcons()}
+                        {renderThresholdStatusIcons(exceptionProps.errorGoodThreshold, exceptionProps.errorCautionThreshold)}
                     </div>
                 )
 
@@ -358,7 +367,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
                             Delta value = Perceived crash free sessions percentage of selected app versions / Perceived crash free sessions percentage of unselected app versions
                         </p>
                         <br />
-                        {renderThresholdStatusIcons()}
+                        {renderThresholdStatusIcons(exceptionProps.errorGoodThreshold, exceptionProps.errorCautionThreshold)}
                     </div>
                 )
 
@@ -371,7 +380,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
                             Delta value = ANR free sessions percentage of selected app versions / ANR free sessions percentage of unselected app versions
                         </p>
                         <br />
-                        {renderThresholdStatusIcons()}
+                        {renderThresholdStatusIcons(exceptionProps.errorGoodThreshold, exceptionProps.errorCautionThreshold)}
                     </div>
                 )
 
@@ -384,7 +393,7 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
                             Delta value = Perceived ANR free sessions percentage of selected app versions / Perceived ANR free sessions percentage of unselected app versions
                         </p>
                         <br />
-                        {renderThresholdStatusIcons()}
+                        {renderThresholdStatusIcons(exceptionProps.errorGoodThreshold, exceptionProps.errorCautionThreshold)}
                     </div>
                 )
 
@@ -454,7 +463,12 @@ const MetricsCard: React.FC<MetricsCardProps> = (props) => {
             case 'perceived_crash_free_sessions':
             case 'anr_free_sessions':
             case 'perceived_anr_free_sessions':
-                return getStatusIcon((props as CrashFreeSessionsProps | PerceivedCrashFreeSessionsProps | AnrFreeSessionsProps | PerceivedAnrFreeSessionsProps).value)
+                const exceptionProps = props as CrashFreeSessionsProps | PerceivedCrashFreeSessionsProps | AnrFreeSessionsProps | PerceivedAnrFreeSessionsProps
+                return getStatusIcon(
+                    exceptionProps.value,
+                    exceptionProps.errorGoodThreshold,
+                    exceptionProps.errorCautionThreshold,
+                )
             case 'app_start_time':
                 return getAppStartTimeStatusIcon((props as AppStartTimeProps).delta)
             case 'app_size':

--- a/self-host/postgres/20260224093641_create_team_threshold_prefs_table.sql
+++ b/self-host/postgres/20260224093641_create_team_threshold_prefs_table.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS measure.team_threshold_prefs (
+    team_id UUID PRIMARY KEY REFERENCES measure.teams(id) ON DELETE CASCADE,
+    error_good_threshold NUMERIC(5,2) NOT NULL DEFAULT 95.00,
+    error_caution_threshold NUMERIC(5,2) NOT NULL DEFAULT 85.00,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT team_threshold_prefs_good_gt_caution
+      CHECK (error_good_threshold > error_caution_threshold),
+    CONSTRAINT team_threshold_prefs_good_bounds
+        CHECK (error_good_threshold > 0 AND error_good_threshold <= 100),
+    CONSTRAINT team_threshold_prefs_caution_bounds
+        CHECK (error_caution_threshold >= 0 AND error_caution_threshold < 100)
+  );
+
+COMMENT ON TABLE measure.team_threshold_prefs IS 'Threshold preferences per team (shared across dashboard and summaries)';
+COMMENT ON COLUMN measure.team_threshold_prefs.team_id IS 'References the team these threshold preferences belong to';
+COMMENT ON COLUMN measure.team_threshold_prefs.error_good_threshold IS 'Threshold above which error-rate metrics are classified as good';
+COMMENT ON COLUMN measure.team_threshold_prefs.error_caution_threshold IS 'Threshold above which error-rate metrics are classified as caution; values at or below are poor';
+COMMENT ON COLUMN measure.team_threshold_prefs.created_at IS 'Timestamp when threshold preferences were created';
+COMMENT ON COLUMN measure.team_threshold_prefs.updated_at IS 'Timestamp when threshold preferences were last updated';
+
+-- migrate:down
+DROP TABLE IF EXISTS measure.team_threshold_prefs;

--- a/self-host/postgres/20260224093811_seed_team_threshold_prefs_table.sql
+++ b/self-host/postgres/20260224093811_seed_team_threshold_prefs_table.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+INSERT INTO measure.team_threshold_prefs (
+    team_id,
+    error_good_threshold,
+    error_caution_threshold
+)
+SELECT
+    t.id,
+    95.00,
+    85.00
+FROM measure.teams t
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM measure.team_threshold_prefs p
+    WHERE p.team_id = t.id
+);
+
+-- migrate:down
+DELETE FROM measure.team_threshold_prefs
+WHERE error_good_threshold = 95.00
+AND error_caution_threshold = 85.00;


### PR DESCRIPTION
# Description

- adds team_threshold_prefs table and seed migrations
- adds APIs to fetch and update team thresholds
- adds UX in teams page to read and update team thresholds
- updates dashboard error metrics to use custom thresholds
- updates daily summary email and slack messages to respect custom thresolds
- adds backend and frontend tests
- updates dashboard SDK docs to add new APIs
- fixes an error in dashboard SDK docs where `/apps/:id/config` were put under teams instead of apps

## Related issue
Closes #2480



