### PR TITLE
fix(backend): crash/anr groups list api would return inaccurate results sometimes

### DIFF
--- a/backend/api/group/group.go
+++ b/backend/api/group/group.go
@@ -215,8 +215,8 @@ func (a *ANRGroup) Insert(ctx context.Context) (err error) {
 		Expr("timestamp").
 		Clause(")").
 		Clause("select").
-		Expr("?", teamId).
-		Expr("?", a.AppID).
+		Expr("toUUID(?)", teamId).
+		Expr("toUUID(?)", a.AppID).
 		Expr("?", a.ID).
 		Expr("(?, ?)", a.Attribute.AppVersion, a.Attribute.AppBuild).
 		Expr("?", a.Type).

--- a/self-host/clickhouse/20260224015026_alter_unhandled_exception_groups_table.sql
+++ b/self-host/clickhouse/20260224015026_alter_unhandled_exception_groups_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+alter table unhandled_exception_groups
+  modify column if exists timestamp SimpleAggregateFunction(max, DateTime64(3, 'UTC'))
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table unhandled_exception_groups
+  modify column if exists timestamp DateTime64(3, 'UTC')
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260224115209_alter_anr_groups_table.sql
+++ b/self-host/clickhouse/20260224115209_alter_anr_groups_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+alter table anr_groups
+  modify column if exists timestamp SimpleAggregateFunction(max, DateTime64(3, 'UTC'))
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table anr_groups
+  modify column if exists timestamp DateTime64(3, 'UTC')
+settings mutations_sync = 2;


### PR DESCRIPTION
## Summary

This PR fixes an issue where the GET `/apps/:id/crashGroups`/`apps/:id/anrGroups` API may return inaccurate results for some cases.

## See also

- fixes #3208

