### PR TITLE
chore(backend): remove max_threads setting

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -4609,7 +4609,6 @@ func GetAppJourney(c *gin.Context) {
 
 	settings := clickhouse.Settings{
 		"log_comment": lc.String(),
-		"max_threads": 32,
 	}
 
 	ctx = logcomment.WithSettingsPut(ctx, settings, lc, logcomment.Name, "journey_events")


### PR DESCRIPTION
## Summary

This PR removes an unneeded `max_threads` setting from clickhouse settings from the journey API query.