### PR TITLE
chore(backend): reset free plan limit to 1M units

### DIFF
--- a/backend/billing/billing.go
+++ b/backend/billing/billing.go
@@ -21,7 +21,7 @@ import (
 const (
 	FreePlanMaxRetentionDays = 30
 	MaxRetentionDays         = 365
-	FreePlanMaxUnits         = 1000
+	FreePlanMaxUnits         = 1000000
 
 	ingestCacheKeyPrefix = "ingest_allowed:"
 	ingestCacheAllowed   = "1"


### PR DESCRIPTION
# Description

Resets free plan limit to 1M units



