### PR TITLE
chore(backend): add usage threshold banners

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -165,6 +165,7 @@ func main() {
 		teams.PATCH(":id/slack/status", measure.UpdateTeamSlackStatus)
 		teams.POST(":id/slack/test", measure.SendTestSlackAlert)
 		teams.GET(":id/billing/info", measure.GetTeamBilling)
+		teams.GET(":id/billing/usageThreshold", measure.GetBillingUsageThreshold)
 		teams.PATCH(":id/billing/checkout", measure.CreateCheckoutSession)
 		teams.PATCH(":id/billing/downgrade", measure.CancelAndDowngradeToFreePlan)
 	}

--- a/backend/api/measure/test_helpers_test.go
+++ b/backend/api/measure/test_helpers_test.go
@@ -83,6 +83,18 @@ func seedTeamIngestBlocked(ctx context.Context, t *testing.T, teamID uuid.UUID, 
 	th.SeedTeamIngestBlocked(ctx, t, teamID.String(), reason)
 }
 
+func seedIngestionUsage(ctx context.Context, t *testing.T, teamID, appID string, ts time.Time, events, spans, metrics uint32) {
+	th.SeedIngestionUsage(ctx, t, teamID, appID, ts, events, spans, metrics)
+}
+
+func seedCurrentMonthIngestionUsage(ctx context.Context, t *testing.T, teamID string, totalUnits uint64) {
+	t.Helper()
+	appID := uuid.New().String()
+	events := uint32(totalUnits / 2)
+	spans := uint32(totalUnits - uint64(events))
+	seedIngestionUsage(ctx, t, teamID, appID, time.Now().UTC(), events, spans, 0)
+}
+
 func seedAPIKey(
 	ctx context.Context,
 	t *testing.T,

--- a/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
+++ b/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
@@ -1,0 +1,218 @@
+import UsageThresholdBanner from '@/app/components/usage_threshold_banner'
+import '@testing-library/jest-dom'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+const mockFetchBillingUsageThresholdFromServer = jest.fn()
+
+jest.mock('@/app/utils/feature_flag_utils', () => ({
+  isBillingEnabled: jest.fn(),
+}))
+
+jest.mock('@/app/api/api_calls', () => ({
+  __esModule: true,
+  FetchBillingUsageThresholdApiStatus: {
+    Loading: 'Loading',
+    Success: 'Success',
+    Error: 'Error',
+    Cancelled: 'Cancelled',
+  },
+  fetchBillingUsageThresholdFromServer: (...args: unknown[]) => mockFetchBillingUsageThresholdFromServer(...args),
+}))
+
+jest.mock('next/link', () => {
+  return function MockLink({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) {
+    return <a href={href} className={className}>{children}</a>
+  }
+})
+
+const { isBillingEnabled } = require('@/app/utils/feature_flag_utils')
+const { FetchBillingUsageThresholdApiStatus } = require('@/app/api/api_calls')
+
+const successResponse = (threshold: number) => ({
+  status: FetchBillingUsageThresholdApiStatus.Success,
+  data: { threshold },
+})
+
+const errorResponse = () => ({
+  status: FetchBillingUsageThresholdApiStatus.Error,
+  data: null,
+})
+
+describe('UsageThresholdBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('When billing is disabled', () => {
+    it('renders nothing and does not call the API', async () => {
+      isBillingEnabled.mockReturnValue(false)
+
+      const { container } = render(<UsageThresholdBanner teamId="team-1" />)
+
+      expect(container.firstChild).toBeNull()
+      expect(mockFetchBillingUsageThresholdFromServer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('When the API returns threshold 0', () => {
+    it('renders nothing', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(0))
+
+      const { container } = render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(mockFetchBillingUsageThresholdFromServer).toHaveBeenCalledWith('team-1')
+      })
+
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('When the API call fails', () => {
+    it('renders nothing gracefully', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(errorResponse())
+
+      const { container } = render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(mockFetchBillingUsageThresholdFromServer).toHaveBeenCalled()
+      })
+
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('When threshold is 75', () => {
+    it('shows yellow banner with 75% message', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(75))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('75% of free plan used.')).toBeInTheDocument()
+      })
+
+      const banner = screen.getByText('75% of free plan used.').parentElement!
+      expect(banner).toHaveClass('bg-yellow-300')
+      expect(banner).toHaveClass('text-primary-foreground')
+    })
+
+    it('shows Upgrade to Pro link pointing to usage page', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(75))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /Upgrade to Pro/i })
+        expect(link).toHaveAttribute('href', '/team-1/usage')
+      })
+    })
+  })
+
+  describe('When threshold is 90', () => {
+    it('shows orange banner with 90% message', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(90))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('90% of free plan used.')).toBeInTheDocument()
+      })
+
+      const banner = screen.getByText('90% of free plan used.').parentElement!
+      expect(banner).toHaveClass('bg-orange-600')
+      expect(banner).toHaveClass('text-accent-foreground')
+    })
+
+    it('shows Upgrade to Pro link pointing to usage page', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(90))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /Upgrade to Pro/i })
+        expect(link).toHaveAttribute('href', '/team-1/usage')
+      })
+    })
+  })
+
+  describe('When threshold is 100', () => {
+    it('shows red banner with ingest blocked message', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(100))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('100% of free plan used — event ingestion blocked.')).toBeInTheDocument()
+      })
+
+      const banner = screen.getByText('100% of free plan used — event ingestion blocked.').parentElement!
+      expect(banner).toHaveClass('bg-red-500')
+      expect(banner).toHaveClass('text-accent-foreground')
+    })
+
+    it('shows Upgrade to Pro link pointing to usage page', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(100))
+
+      render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /Upgrade to Pro/i })
+        expect(link).toHaveAttribute('href', '/team-1/usage')
+      })
+    })
+  })
+
+  describe('When teamId changes', () => {
+    it('re-fetches data for the new team', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(75))
+
+      const { rerender } = render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        expect(mockFetchBillingUsageThresholdFromServer).toHaveBeenCalledWith('team-1')
+      })
+
+      await act(async () => {
+        rerender(<UsageThresholdBanner teamId="team-2" />)
+      })
+
+      await waitFor(() => {
+        expect(mockFetchBillingUsageThresholdFromServer).toHaveBeenCalledWith('team-2')
+      })
+
+      expect(mockFetchBillingUsageThresholdFromServer).toHaveBeenCalledTimes(2)
+    })
+
+    it('updates the upgrade link href for the new team', async () => {
+      isBillingEnabled.mockReturnValue(true)
+      mockFetchBillingUsageThresholdFromServer.mockResolvedValue(successResponse(75))
+
+      const { rerender } = render(<UsageThresholdBanner teamId="team-1" />)
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /Upgrade to Pro/i })
+        expect(link).toHaveAttribute('href', '/team-1/usage')
+      })
+
+      await act(async () => {
+        rerender(<UsageThresholdBanner teamId="team-2" />)
+      })
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /Upgrade to Pro/i })
+        expect(link).toHaveAttribute('href', '/team-2/usage')
+      })
+    })
+  })
+})

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -24,6 +24,7 @@ import TeamSwitcher, { TeamsSwitcherStatus } from "../components/team_switcher"
 import { ThemeToggle } from "../components/theme_toggle"
 import UserAvatar from "../components/user_avatar"
 import { isCloud } from "../utils/env_utils"
+import UsageThresholdBanner from "../components/usage_threshold_banner"
 
 const initNavData = {
   navMain: [
@@ -288,6 +289,8 @@ export default function DashboardLayout({
           />
           <ThemeToggle />
         </header>
+
+        {selectedTeam && <UsageThresholdBanner teamId={selectedTeam.id} />}
 
         <main className="md:overflow-auto flex justify-center">
           <div className="w-full max-w-[1100px] px-4 pb-24">{children}</div>

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -377,6 +377,13 @@ export enum FetchBillingInfoApiStatus {
   Cancelled,
 }
 
+export enum FetchBillingUsageThresholdApiStatus {
+  Loading,
+  Success,
+  Error,
+  Cancelled,
+}
+
 export enum BugReportsOverviewApiStatus {
   Loading,
   Success,
@@ -2453,6 +2460,22 @@ export const fetchBillingInfoFromServer = async (teamId: string) => {
     return { status: FetchBillingInfoApiStatus.Success, data: data }
   } catch {
     return { status: FetchBillingInfoApiStatus.Cancelled, data: null }
+  }
+}
+
+export const fetchBillingUsageThresholdFromServer = async (teamId: string) => {
+  try {
+    const res = await measureAuth.fetchMeasure(`/api/teams/${teamId}/billing/usageThreshold`)
+
+    if (!res.ok) {
+      return { status: FetchBillingUsageThresholdApiStatus.Error, data: null }
+    }
+
+    const data = await res.json()
+
+    return { status: FetchBillingUsageThresholdApiStatus.Success, data: data as { threshold: number } }
+  } catch {
+    return { status: FetchBillingUsageThresholdApiStatus.Cancelled, data: null }
   }
 }
 

--- a/frontend/dashboard/app/components/usage_threshold_banner.tsx
+++ b/frontend/dashboard/app/components/usage_threshold_banner.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { FetchBillingUsageThresholdApiStatus, fetchBillingUsageThresholdFromServer } from '@/app/api/api_calls'
+import { isBillingEnabled } from '@/app/utils/feature_flag_utils'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+type UsageThresholdBannerProps = {
+  teamId: string
+}
+
+export default function UsageThresholdBanner({ teamId }: UsageThresholdBannerProps) {
+  const [threshold, setThreshold] = useState<number>(0)
+
+  useEffect(() => {
+    if (!isBillingEnabled()) {
+      return
+    }
+
+    const fetchData = async () => {
+      const result = await fetchBillingUsageThresholdFromServer(teamId)
+      if (result.status !== FetchBillingUsageThresholdApiStatus.Success) {
+        return
+      }
+      setThreshold(result.data?.threshold ?? 0)
+    }
+
+    fetchData()
+  }, [teamId])
+
+  if (threshold === 0) {
+    return null
+  }
+
+  const usagePageUrl = `/${teamId}/usage`
+
+  let message: string
+  let bannerClass: string
+
+  if (threshold >= 100) {
+    message = '100% of free plan used — event ingestion blocked.'
+    bannerClass = 'bg-red-500 text-accent-foreground'
+  } else if (threshold >= 90) {
+    message = '90% of free plan used.'
+    bannerClass = 'bg-orange-600 text-accent-foreground'
+  } else {
+    message = '75% of free plan used.'
+    bannerClass = 'bg-yellow-300 text-primary-foreground'
+  }
+
+  return (
+    <div className={`w-full px-4 py-2 font-body text-sm flex items-center justify-between mb-8 ${bannerClass}`}>
+      <span>{message}</span>
+      <Link href={usagePageUrl} className="font-semibold underline ml-4 whitespace-nowrap">
+        Upgrade to Pro →
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
# Description

Adds usage threshold banners on dashboard for pro plan users.

<img width="1512" height="829" alt="Screenshot 2026-02-25 at 7 37 01 PM" src="https://github.com/user-attachments/assets/5565edbb-5a50-474f-8e06-124e47ba7b7b" />
<img width="1512" height="830" alt="Screenshot 2026-02-25 at 7 39 57 PM" src="https://github.com/user-attachments/assets/4919d002-3ce6-4da1-9279-04d93e06e2a1" />
<img width="1512" height="829" alt="Screenshot 2026-02-25 at 7 40 16 PM" src="https://github.com/user-attachments/assets/7b78e9cf-5052-4e88-a106-9394383c068e" />


## Related issue
Closes #3221



