### PR TITLE
fix(backend): add `team_id` to app retention query in cleanup

### DIFF
--- a/backend/cleanup/cleanup/cleanup.go
+++ b/backend/cleanup/cleanup/cleanup.go
@@ -622,6 +622,7 @@ func fetchAppRetentions(ctx context.Context) (retentions []AppRetention, err err
 	stmt := sqlf.PostgreSQL.
 		From("apps").
 		Select("id").
+		Select("team_id").
 		Select("retention")
 
 	defer stmt.Close()


### PR DESCRIPTION
## Summary

This PR fixes a small issue in cleanup service where team_id was not being queried while fetching app retentions from apps table.

## See also

- fixes #3235
