### PR TITLE
chore(backend): ingest session start time attribute for events and spans

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -4,6 +4,7 @@ import (
 	"backend/api/opsys"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -118,6 +119,10 @@ type Attribute struct {
 	// - 5g
 	// - unknown
 	NetworkGeneration string `json:"network_generation"`
+
+	// SessionStartTime is the time when the session
+	// containing this event started at.
+	SessionStartTime time.Time `json:"session_start_time"`
 }
 
 // Validate validates an event's attributes.

--- a/backend/api/measure/event.go
+++ b/backend/api/measure/event.go
@@ -1016,6 +1016,8 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			attachments = string(marshalledAttachments)
 		}
 
+		sessionStartTime := e.events[i].Attribute.SessionStartTime.Format(chrono.MSTimeFormat)
+
 		row := stmt.NewRow().
 			Set(`id`, e.events[i].ID).
 			Set(`team_id`, e.teamId).
@@ -1057,6 +1059,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			Set(`attribute.network_type`, e.events[i].Attribute.NetworkType).
 			Set(`attribute.network_generation`, e.events[i].Attribute.NetworkGeneration).
 			Set(`attribute.network_provider`, e.events[i].Attribute.NetworkProvider).
+			Set(`attribute.session_start_time`, sessionStartTime).
 
 			// user defined attribute
 			Set(`user_defined_attribute`, e.events[i].UserDefinedAttribute.Parameterize()).
@@ -1543,6 +1546,8 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 		b.WriteString("]")
 		formattedCheckpoints := b.String()
 
+		spanSessionStartTime := e.spans[i].Attributes.SessionStartTime.Format(chrono.MSTimeFormat)
+
 		stmt.NewRow().
 			Set(`team_id`, e.teamId).
 			Set(`app_id`, e.spans[i].AppID).
@@ -1573,6 +1578,7 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 			Set(`attribute.device_locale`, e.spans[i].Attributes.DeviceLocale).
 			Set(`attribute.device_low_power_mode`, e.spans[i].Attributes.LowPowerModeEnabled).
 			Set(`attribute.device_thermal_throttling_enabled`, e.spans[i].Attributes.ThermalThrottlingEnabled).
+			Set(`attribute.session_start_time`, spanSessionStartTime).
 			// user defined attribute
 			Set(`user_defined_attribute`, e.spans[i].UserDefinedAttribute.Parameterize())
 	}

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -99,6 +99,7 @@ type SpanAttributes struct {
 	DeviceLocale             string    `json:"device_locale"`
 	LowPowerModeEnabled      bool      `json:"device_low_power_mode"`
 	ThermalThrottlingEnabled bool      `json:"device_thermal_throttling_enabled"`
+	SessionStartTime         time.Time `json:"session_start_time"`
 }
 
 type RootSpanDisplay struct {

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -565,6 +565,7 @@ Events can contain the following attributes, some of which are mandatory.
 | `network_provider`                  | string  | No       | Example: airtel, T-mobile or "unknown" if unavailable.                      |
 | `network_generation`                | string  | No       | One of:<br/>- 2g<br/>- 3g<br/>- 4g<br/>- 5g<br/>- unknown                   |
 | `device_cpu_arch`                   | string  | No       | The CPU architecture, eg. arm64                                             |
+| `session_start_time`                | string  | Yes      | The ISO-8601 timestamp when the session containing this event started       |
 
 ### User Defined Attributes
 

--- a/self-host/clickhouse/20260226113936_alter_events_table.sql
+++ b/self-host/clickhouse/20260226113936_alter_events_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table events
+  add column if not exists `attribute.session_start_time` DateTime64(3, 'UTC') comment 'start time of the session containing this event' CODEC(DoubleDelta, ZSTD(3)) after `attribute.network_provider`;
+
+-- migrate:down
+alter table events
+drop column if exists `attribute.session_start_time`;

--- a/self-host/clickhouse/20260227164651_alter_spans_table.sql
+++ b/self-host/clickhouse/20260227164651_alter_spans_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table spans
+  add column if not exists `attribute.session_start_time` DateTime64(3, 'UTC') comment 'start time of the session containing this span' CODEC(DoubleDelta, ZSTD(3)) after `attribute.network_provider`;
+
+-- migrate:down
+alter table spans
+	drop column if exists `attribute.session_start_time`;


### PR DESCRIPTION
# Description

- Ingests a new attribute `session_start_time` for events and spans.

**Events table:**
<img width="806" height="72" alt="image" src="https://github.com/user-attachments/assets/db8a1385-a671-4f5a-98a8-ce997bd74fd2" />

**Spans table:**
<img width="400" height="131" alt="image" src="https://github.com/user-attachments/assets/6e02f2d2-70ba-48d1-9ae8-318ce72ac902" />


## Related issue
Closes #3232  


