### PR TITLE
chore(android): allow configuring sample app credentials

### DIFF
--- a/.github/workflows/android-build-sample.yml
+++ b/.github/workflows/android-build-sample.yml
@@ -1,0 +1,64 @@
+name: Build Android Sample App
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_key:
+        description: 'API Key'
+        required: true
+        type: string
+      api_url:
+        description: 'API URL'
+        required: true
+        type: string
+
+env:
+  JAVA_VERSION: 21
+  JAVA_DISTRIBUTION: 'temurin'
+
+jobs:
+  validate-inputs:
+    name: Validate inputs
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Validate API Key
+        run: |
+          if [[ ! "${{ inputs.api_key }}" =~ ^msrsh ]]; then
+            echo "::error::API Key must start with 'msrsh'"
+            exit 1
+          fi
+
+  build-sample:
+    name: Build sample APK
+    needs: validate-inputs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: 'gradle'
+      - name: Set credentials in AndroidManifest.xml
+        env:
+          API_KEY: ${{ inputs.api_key }}
+          API_URL: ${{ inputs.api_url }}
+        run: |
+          sed -i '/android:name="sh.measure.android.API_KEY"/{n;s|android:value="[^"]*"|android:value="'"$API_KEY"'"|;}' sample/src/main/AndroidManifest.xml
+          sed -i '/android:name="sh.measure.android.API_URL"/{n;s|android:value="[^"]*"|android:value="'"$API_URL"'"|;}' sample/src/main/AndroidManifest.xml
+      - name: Build release APK
+        run: ./gradlew :sample:assembleRelease --no-daemon --no-parallel --no-configuration-cache --stacktrace --info
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: sample-release-apk
+          path: android/sample/build/outputs/apk/release/*.apk
+          retention-days: 7

--- a/android/sample/proguard-rules.pro
+++ b/android/sample/proguard-rules.pro
@@ -19,3 +19,21 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep Measure SDK internals accessed via reflection by MeasureConfigurator
+-keepclassmembers class sh.measure.android.Measure {
+    private <fields>;
+}
+-keepclassmembers class sh.measure.android.MeasureInternal {
+    private <fields>;
+}
+-keepclassmembers class sh.measure.android.MeasureInitializerImpl {
+    <fields>;
+}
+-keepclassmembers class sh.measure.android.exporter.NetworkClientImpl {
+    <fields>;
+    public void init(java.lang.String, java.lang.String);
+}
+-keepclassmembers class sh.measure.android.config.ConfigProviderImpl {
+    public void setMeasureUrl(java.lang.String);
+}

--- a/android/sample/src/main/AndroidManifest.xml
+++ b/android/sample/src/main/AndroidManifest.xml
@@ -60,6 +60,9 @@
             android:name=".OkHttpActivity"
             android:exported="false" />
         <activity
+            android:name=".ConfigureCredentialsActivity"
+            android:exported="false" />
+        <activity
             android:name=".ComposeActivity"
             android:exported="false" />
         <activity

--- a/android/sample/src/main/java/sh/measure/sample/ConfigureCredentialsActivity.kt
+++ b/android/sample/src/main/java/sh/measure/sample/ConfigureCredentialsActivity.kt
@@ -1,0 +1,139 @@
+package sh.measure.sample
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.widget.ScrollView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+
+class ConfigureCredentialsActivity : AppCompatActivity() {
+
+    companion object {
+        private const val PREFS_NAME = "measure_credential_overrides"
+        private const val KEY_API_URL = "api_url"
+        private const val KEY_API_KEY = "api_key"
+
+        fun getSavedApiUrl(context: Context): String? {
+            return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_API_URL, null)
+        }
+
+        fun getSavedApiKey(context: Context): String? {
+            return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_API_KEY, null)
+        }
+    }
+
+    private lateinit var etApiUrl: TextInputEditText
+    private lateinit var etApiKey: TextInputEditText
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_configure_credentials)
+        handleEdgeToEdgeDisplay()
+
+        etApiUrl = findViewById(R.id.et_api_url)
+        etApiKey = findViewById(R.id.et_api_key)
+
+        loadCurrentValues()
+
+        findViewById<MaterialButton>(R.id.btn_save).setOnClickListener {
+            save()
+        }
+    }
+
+    private fun loadCurrentValues() {
+        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val savedUrl = prefs.getString(KEY_API_URL, null)
+        val savedKey = prefs.getString(KEY_API_KEY, null)
+
+        if (savedUrl != null && savedKey != null) {
+            etApiUrl.setText(savedUrl)
+            etApiKey.setText(savedKey)
+        } else {
+            val (manifestUrl, manifestKey) = readManifestCredentials()
+            etApiUrl.setText(manifestUrl)
+            etApiKey.setText(manifestKey)
+        }
+    }
+
+    private fun save() {
+        val apiUrl = etApiUrl.text?.toString()?.trim().orEmpty()
+        val apiKey = etApiKey.text?.toString()?.trim().orEmpty()
+
+        if (apiUrl.isEmpty()) {
+            etApiUrl.error = "API URL cannot be empty"
+            return
+        }
+        if (!apiKey.startsWith("msrsh")) {
+            etApiKey.error = "API Key must start with \"msrsh\""
+            return
+        }
+
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
+            .putString(KEY_API_URL, apiUrl)
+            .putString(KEY_API_KEY, apiKey)
+            .apply()
+
+        val success = MeasureConfigurator.swapCredentials(apiUrl, apiKey)
+        if (success) {
+            Toast.makeText(this, "Credentials saved and applied", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, "Saved, but failed to apply (SDK not initialized?)", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun readManifestCredentials(): Pair<String?, String?> {
+        return try {
+            val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getApplicationInfo(
+                    packageName,
+                    PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            }
+            val metaData = appInfo.metaData
+            val url = metaData?.getString("sh.measure.android.API_URL")
+            val key = metaData?.getString("sh.measure.android.API_KEY")
+            Pair(url, key)
+        } catch (e: PackageManager.NameNotFoundException) {
+            Pair(null, null)
+        }
+    }
+
+    private fun handleEdgeToEdgeDisplay() {
+        val container = findViewById<ScrollView>(R.id.sv_container)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            ViewCompat.setOnApplyWindowInsetsListener(container) { view, windowInsets ->
+                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+                view.updatePadding(
+                    left = insets.left,
+                    top = insets.top,
+                    right = insets.right,
+                    bottom = insets.bottom,
+                )
+                windowInsets
+            }
+        } else {
+            ViewCompat.setOnApplyWindowInsetsListener(container) { view, windowInsets ->
+                @Suppress("DEPRECATION") val insets = windowInsets.systemWindowInsets
+                view.updatePadding(
+                    left = insets.left,
+                    top = insets.top,
+                    right = insets.right,
+                    bottom = insets.bottom,
+                )
+                windowInsets
+            }
+        }
+    }
+}

--- a/android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
+++ b/android/sample/src/main/java/sh/measure/sample/ExceptionDemoActivity.kt
@@ -34,6 +34,9 @@ class ExceptionDemoActivity : AppCompatActivity(), MsrShakeListener {
         val span = Measure.startSpan("activity.onCreate")
         setContentView(R.layout.activity_exception_demo)
         handleEdgeToEdgeDisplay()
+        findViewById<MaterialTextView>(R.id.btn_configure_credentials).setOnClickListener {
+            startActivity(Intent(this, ConfigureCredentialsActivity::class.java))
+        }
         findViewById<MaterialTextView>(R.id.btn_single_exception).setOnClickListener {
             throw IllegalAccessException("This is a new exception")
         }

--- a/android/sample/src/main/java/sh/measure/sample/MeasureConfigurator.kt
+++ b/android/sample/src/main/java/sh/measure/sample/MeasureConfigurator.kt
@@ -1,0 +1,93 @@
+package sh.measure.sample
+
+import android.util.Log
+import sh.measure.android.Measure
+
+/**
+ * Uses reflection to hot-swap Measure SDK credentials at runtime.
+ * This is a sample-app-only utility — no SDK code is modified.
+ *
+ * Reflection path:
+ *   Measure (object)
+ *     └─ measure: MeasureInternal          (private field)
+ *          └─ measure: MeasureInitializer   (private constructor param)
+ *               ├─ networkClient: NetworkClient  → call init(newUrl, newApiKey)
+ *               └─ configProvider: ConfigProvider → call setMeasureUrl(newUrl)
+ */
+object MeasureConfigurator {
+    private const val TAG = "MeasureConfigurator"
+
+    /**
+     * Hot-swaps the SDK's API URL and API key using reflection.
+     * Returns true on success, false if reflection fails.
+     */
+    fun swapCredentials(apiUrl: String, apiKey: String): Boolean {
+        return try {
+            val initializer = getMeasureInitializer() ?: return false
+
+            val networkClient = initializer.javaClass.getDeclaredField("networkClient").apply {
+                isAccessible = true
+            }.get(initializer)!!
+
+            // Call networkClient.init(apiUrl, apiKey)
+            networkClient.javaClass.getMethod("init", String::class.java, String::class.java)
+                .invoke(networkClient, apiUrl, apiKey)
+
+            val configProvider = initializer.javaClass.getDeclaredField("configProvider").apply {
+                isAccessible = true
+            }.get(initializer)!!
+
+            // Call configProvider.setMeasureUrl(apiUrl)
+            configProvider.javaClass.getMethod("setMeasureUrl", String::class.java)
+                .invoke(configProvider, apiUrl)
+
+            Log.d(TAG, "Credentials swapped successfully")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to swap credentials", e)
+            false
+        }
+    }
+
+    /**
+     * Reads the current baseUrl and apiKey from NetworkClientImpl via reflection.
+     * Returns (baseUrl, apiKey) or (null, null) if reflection fails.
+     */
+    fun getCurrentCredentials(): Pair<String?, String?> {
+        return try {
+            val initializer = getMeasureInitializer() ?: return Pair(null, null)
+
+            val networkClient = initializer.javaClass.getDeclaredField("networkClient").apply {
+                isAccessible = true
+            }.get(initializer)!!
+
+            val baseUrl = networkClient.javaClass.getDeclaredField("baseUrl").apply {
+                isAccessible = true
+            }.get(networkClient)?.toString()
+
+            val apiKey = networkClient.javaClass.getDeclaredField("apiKey").apply {
+                isAccessible = true
+            }.get(networkClient) as? String
+
+            Pair(baseUrl, apiKey)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read credentials", e)
+            Pair(null, null)
+        }
+    }
+
+    private fun getMeasureInitializer(): Any? {
+        // Measure (companion object) -> measure: MeasureInternal
+        val measureClass = Measure::class.java
+        val measureInternalField = measureClass.getDeclaredField("measure").apply {
+            isAccessible = true
+        }
+        val measureInternal = measureInternalField.get(Measure) ?: return null
+
+        // MeasureInternal -> measure: MeasureInitializer
+        val initializerField = measureInternal.javaClass.getDeclaredField("measure").apply {
+            isAccessible = true
+        }
+        return initializerField.get(measureInternal)
+    }
+}

--- a/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
+++ b/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
@@ -32,5 +32,12 @@ class SampleApp : Application() {
             .put("float", Float.MAX_VALUE).put("boolean", false)
             .build()
         Measure.trackEvent(name = "custom-app-start", attributes = attributes)
+
+        // Re-apply saved credential overrides (if any) after SDK init
+        val savedUrl = ConfigureCredentialsActivity.getSavedApiUrl(this)
+        val savedKey = ConfigureCredentialsActivity.getSavedApiKey(this)
+        if (savedUrl != null && savedKey != null) {
+            MeasureConfigurator.swapCredentials(savedUrl, savedKey)
+        }
     }
 }

--- a/android/sample/src/main/res/layout/activity_configure_credentials.xml
+++ b/android/sample/src/main/res/layout/activity_configure_credentials.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/sv_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/api_url"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_api_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textUri" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/api_key"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_api_key"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_save"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/save" />
+
+
+    </LinearLayout>
+</ScrollView>

--- a/android/sample/src/main/res/layout/activity_exception_demo.xml
+++ b/android/sample/src/main/res/layout/activity_exception_demo.xml
@@ -44,6 +44,30 @@
             android:fontFamily="sans-serif-condensed-medium"
             android:paddingHorizontal="8dp"
             android:paddingTop="8dp"
+            android:text="@string/configuration"
+            android:textAppearance="?attr/textAppearanceCaption" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="8dp"
+            app:cardCornerRadius="0dp">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/btn_configure_credentials"
+                style="@style/Widget.Material3.TextView.SettingsItem"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/configure_credentials"
+                app:drawableEndCompat="@drawable/ic_chevron_right" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif-condensed-medium"
+            android:paddingHorizontal="8dp"
+            android:paddingTop="8dp"
             android:text="@string/exception_tests"
             android:textAppearance="?attr/textAppearanceCaption" />
 

--- a/android/sample/src/main/res/values/strings.xml
+++ b/android/sample/src/main/res/values/strings.xml
@@ -41,4 +41,9 @@
     <string name="enable_shake">Enable shake to report</string>
     <string name="custom_shake_handler">Custom shake handler</string>
     <string name="set_user">Set User</string>
+    <string name="configuration">Configuration</string>
+    <string name="configure_credentials">Configure Credentials</string>
+    <string name="api_url">API URL</string>
+    <string name="api_key">API Key</string>
+    <string name="save">Save</string>
 </resources>


### PR DESCRIPTION
# Description

- Add a Configure Credentials screen to the sample app that allows hot-swapping the Measure SDK's API URL and API key at   runtime via reflection, without rebuilding
- Add a GitHub Actions workflow (android-build-sample.yml) to build the sample APK on demand with custom credentials via `workflow_dispatch`
- Replace time-based versionCode generation with git commit count (git rev-list --count HEAD) for deterministic,
  monotonically increasing version codes

New option in sample app to configure credentials:

<img width="414" height="113" alt="image" src="https://github.com/user-attachments/assets/feca2753-af38-4082-be07-483ad6938d49" />

