### PR TITLE
chore(android): add session start time attribute to events and spans

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -13,6 +13,7 @@ import sh.measure.android.attributes.DeviceAttributeProcessor
 import sh.measure.android.attributes.InstallationIdAttributeProcessor
 import sh.measure.android.attributes.NetworkStateAttributeProcessor
 import sh.measure.android.attributes.PowerStateAttributeProcessor
+import sh.measure.android.attributes.SessionAttributeProcessor
 import sh.measure.android.attributes.SpanDeviceAttributeProcessor
 import sh.measure.android.attributes.UserAttributeProcessor
 import sh.measure.android.bugreport.AccelerometerShakeDetector
@@ -216,6 +217,9 @@ internal class MeasureInitializerImpl(
     private val powerStateAttributeProcessor: PowerStateAttributeProcessor = PowerStateAttributeProcessor(
         powerStateProvider = powerStateProvider,
     ),
+    private val sessionAttributeProcessor: SessionAttributeProcessor = SessionAttributeProcessor(
+        sessionManager = sessionManager,
+    ),
     private val attributeProcessors: List<AttributeProcessor> = listOf(
         userAttributeProcessor,
         deviceAttributeProcessor,
@@ -223,6 +227,7 @@ internal class MeasureInitializerImpl(
         installationIdAttributeProcessor,
         networkStateAttributeProcessor,
         powerStateAttributeProcessor,
+        sessionAttributeProcessor,
     ),
     private val signalStore: SignalStore = SignalStoreImpl(
         logger = logger,
@@ -348,6 +353,7 @@ internal class MeasureInitializerImpl(
         installationIdAttributeProcessor,
         networkStateAttributeProcessor,
         powerStateAttributeProcessor,
+        sessionAttributeProcessor,
     ),
     override val spanProcessor: SpanProcessor = MsrSpanProcessor(
         logger,

--- a/android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -35,6 +35,15 @@ internal interface SessionManager {
     fun getSessionId(): String
 
     /**
+     * Returns the start time of the current session.
+     *
+     * @throws IllegalArgumentException if the SDK has not been initialized and the session
+     * has not been created.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getSessionStartTime(): Long
+
+    /**
      * Called when app comes to foreground
      */
     fun onAppForeground()
@@ -68,6 +77,7 @@ internal class SessionManagerImpl(
     private val sampler: Sampler,
 ) : SessionManager {
     private var sessionId: String? = null
+    private var sessionStartTime: Long? = null
 
     @VisibleForTesting
     internal var appBackgroundTime: Long = 0
@@ -108,6 +118,14 @@ internal class SessionManagerImpl(
         return sessionId
     }
 
+    override fun getSessionStartTime(): Long {
+        val startTime = this.sessionStartTime
+        requireNotNull(startTime) {
+            "SDK must be initialized before accessing session start time"
+        }
+        return startTime
+    }
+
     override fun onConfigLoaded() {
         val currentSessionId = sessionId
         if (currentSessionId == null) {
@@ -136,6 +154,7 @@ internal class SessionManagerImpl(
     private fun createNewSession(): String {
         val id = idProvider.uuid()
         this.sessionId = id
+        this.sessionStartTime = timeProvider.now()
         storeSession(id)
         return id
     }

--- a/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
@@ -28,4 +28,5 @@ internal object Attribute {
     const val USER_ID_KEY = "user_id"
     const val DEVICE_LOW_POWER_ENABLED = "device_low_power_mode"
     const val DEVICE_THERMAL_THROTTLING_ENABLED = "device_thermal_throttling_enabled"
+    const val SESSION_START_TIME_KEY = "session_start_time"
 }

--- a/android/measure/src/main/java/sh/measure/android/attributes/SessionAttributeProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/SessionAttributeProcessor.kt
@@ -1,0 +1,15 @@
+package sh.measure.android.attributes
+
+import sh.measure.android.SessionManager
+
+/**
+ * Generates the session start time attribute. This attribute changes when a new session is created,
+ * so it is computed every time [appendAttributes] is called.
+ */
+internal class SessionAttributeProcessor(
+    private val sessionManager: SessionManager,
+) : AttributeProcessor {
+    override fun appendAttributes(attributes: MutableMap<String, Any?>) {
+        attributes.put(Attribute.SESSION_START_TIME_KEY, sessionManager.getSessionStartTime())
+    }
+}

--- a/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -58,6 +58,35 @@ class SessionManagerTest {
     }
 
     @Test
+    fun `getSessionStartTime throws when not initialized`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            sessionManager.getSessionStartTime()
+        }
+    }
+
+    @Test
+    fun `getSessionStartTime returns correct time after init`() {
+        val expectedTime = timeProvider.now()
+        sessionManager.init()
+        assertEquals(expectedTime, sessionManager.getSessionStartTime())
+    }
+
+    @Test
+    fun `getSessionStartTime updates when new session is created on foreground`() {
+        sessionManager.init()
+        val initialStartTime = sessionManager.getSessionStartTime()
+
+        sessionManager.onAppBackground()
+        testClock.advance(Duration.ofMillis(configProvider.sessionBackgroundTimeoutThresholdMs + 1))
+        idProvider.id = "next-uuid"
+
+        sessionManager.onAppForeground()
+
+        val newStartTime = sessionManager.getSessionStartTime()
+        assert(newStartTime > initialStartTime)
+    }
+
+    @Test
     fun `init creates and returns session id`() {
         val s1 = sessionManager.init()
         assertEquals(sessionManager.getSessionId(), s1)

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
@@ -4,10 +4,13 @@ import sh.measure.android.SessionManager
 
 internal class FakeSessionManager : SessionManager {
     var id = "fake-session-id"
+    var startTime: Long = 0L
 
     override fun init(): String = id
 
     override fun getSessionId(): String = id
+
+    override fun getSessionStartTime(): Long = startTime
 
     override fun onAppForeground() {
         // no-op


### PR DESCRIPTION
# Description

Adds session start time to events and spans

## Related issue
References #3226



