### PR TITLE
chore(android): use ISO 8601 for session start time attribute

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -42,7 +42,7 @@ internal class MeasureInternal(private val measure: MeasureInitializer) : AppLif
         // is triggered.
         measure.signalProcessor.track(
             SessionStartData,
-            timestamp = measure.timeProvider.now(),
+            timestamp = measure.sessionManager.getSessionStartTime(),
             type = EventType.SESSION_START,
             sessionId = sessionId,
             // always sample session start event

--- a/android/measure/src/main/java/sh/measure/android/attributes/SessionAttributeProcessor.kt
+++ b/android/measure/src/main/java/sh/measure/android/attributes/SessionAttributeProcessor.kt
@@ -1,6 +1,7 @@
 package sh.measure.android.attributes
 
 import sh.measure.android.SessionManager
+import sh.measure.android.utils.iso8601Timestamp
 
 /**
  * Generates the session start time attribute. This attribute changes when a new session is created,
@@ -10,6 +11,9 @@ internal class SessionAttributeProcessor(
     private val sessionManager: SessionManager,
 ) : AttributeProcessor {
     override fun appendAttributes(attributes: MutableMap<String, Any?>) {
-        attributes.put(Attribute.SESSION_START_TIME_KEY, sessionManager.getSessionStartTime())
+        attributes.put(
+            Attribute.SESSION_START_TIME_KEY,
+            sessionManager.getSessionStartTime().iso8601Timestamp(),
+        )
     }
 }


### PR DESCRIPTION
# Description

* use ISO 8601 for session start time attribute
* use same time for session start event timestamp

## Related issue
References #3226


