### PR TITLE
fix(ios): use correct data type for session start time attribute

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
@@ -57,7 +57,7 @@ class Attributes: Codable {
     var deviceThermalThrottlingEnabled: Bool?
     var deviceLowPowerMode: Bool?
     var osPageSize: UInt8?
-    var sessionStartTime: Number?
+    var sessionStartTime: String?
 
     enum CodingKeys: String, CodingKey {
         case threadName = "thread_name"
@@ -120,7 +120,7 @@ class Attributes: Codable {
         deviceThermalThrottlingEnabled: Bool? = nil,
         deviceLowPowerMode: Bool? = nil,
         osPageSize: UInt8? = nil,
-        sessionStartTime: Number? = nil) {
+        sessionStartTime: String? = nil) {
            self.threadName = threadName
            self.deviceName = deviceName
            self.deviceModel = deviceModel
@@ -181,6 +181,6 @@ class Attributes: Codable {
         self.deviceThermalThrottlingEnabled = dict["device_thermal_throttling_enabled"] as? Bool
         self.deviceLowPowerMode = dict["device_low_power_mode"] as? Bool
         self.osPageSize = dict["os_page_size"] as? UInt8
-        self.sessionStartTime = dict["session_start_time"] as? Number
+        self.sessionStartTime = dict["session_start_time"] as? String
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Attribute/SessionAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/SessionAttributeProcessor.swift
@@ -9,12 +9,16 @@ import Foundation
 
 final class SessionAttributeProcessor: AttributeProcessor {
     private let sessionManager: SessionManager
+    private let timeProvider: TimeProvider
     
-    init(sessionManager: SessionManager) {
+    init(sessionManager: SessionManager, timeProvider: TimeProvider) {
         self.sessionManager = sessionManager
+        self.timeProvider = timeProvider
     }
 
     func appendAttributes(_ attribute: Attributes) {
-        attribute.sessionStartTime = sessionManager.getSessionStartTime()
+        if let sessionStartTime = sessionManager.getSessionStartTime() {
+            attribute.sessionStartTime = timeProvider.iso8601Timestamp(timeInMillis: sessionStartTime)
+        }
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -274,7 +274,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
         self.networkStateAttributeProcessor = NetworkStateAttributeProcessor(measureDispatchQueue: measureDispatchQueue)
         self.userAttributeProcessor = UserAttributeProcessor(userDefaultStorage: userDefaultStorage,
                                                              measureDispatchQueue: measureDispatchQueue)
-        self.sessionAttributeProcessor = SessionAttributeProcessor(sessionManager: sessionManager)
+        self.sessionAttributeProcessor = SessionAttributeProcessor(sessionManager: sessionManager, timeProvider: timeProvider)
         self.attributeProcessors = [appAttributeProcessor,
                                     deviceAttributeProcessor,
                                     installationIdAttributeProcessor,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -189,7 +189,7 @@ final class MockMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
         self.networkStateAttributeProcessor = networkStateAttributeProcessor ?? NetworkStateAttributeProcessor(measureDispatchQueue: self.measureDispatchQueue)
         self.userAttributeProcessor = userAttributeProcessor ?? UserAttributeProcessor(userDefaultStorage: self.userDefaultStorage,
                                                              measureDispatchQueue: self.measureDispatchQueue)
-        self.sessionAttributeProcessor = sessionAttributeProcessor ?? SessionAttributeProcessor(sessionManager: self.sessionManager)
+        self.sessionAttributeProcessor = sessionAttributeProcessor ?? SessionAttributeProcessor(sessionManager: self.sessionManager, timeProvider: self.timeProvider)
         self.attributeProcessors = [
             self.appAttributeProcessor,
             self.deviceAttributeProcessor,


### PR DESCRIPTION
# Description

Use correct data type for session start time attribute