### PR TITLE
chore(ios): delete expired attachments on cleanup

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		CF9D75792E66C0FA007D6D30 /* SessionStartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */; };
 		CF9EDCFA2F0E2BAA00029281 /* RecentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9EDCF92F0E2BAA00029281 /* RecentSession.swift */; };
 		CF9EDD062F0E6DE100029281 /* DynamicConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9EDD052F0E6DE100029281 /* DynamicConfig.swift */; };
+		CFB5756E2F599359000DB70B /* AttachmentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB5756D2F599359000DB70B /* AttachmentStoreTests.swift */; };
 		CFB838212DAFEF780023592B /* SpanProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB838202DAFEF780023592B /* SpanProcessorTests.swift */; };
 		CFB8382C2DB1597B0023592B /* SpanOb+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */; };
 		CFB8382D2DB1597B0023592B /* SpanOb+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */; };
@@ -605,6 +606,7 @@
 		CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStartData.swift; sourceTree = "<group>"; };
 		CF9EDCF92F0E2BAA00029281 /* RecentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSession.swift; sourceTree = "<group>"; };
 		CF9EDD052F0E6DE100029281 /* DynamicConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicConfig.swift; sourceTree = "<group>"; };
+		CFB5756D2F599359000DB70B /* AttachmentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentStoreTests.swift; sourceTree = "<group>"; };
 		CFB838202DAFEF780023592B /* SpanProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanProcessorTests.swift; sourceTree = "<group>"; };
 		CFB8382A2DB1597B0023592B /* SpanOb+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CFB8382B2DB1597B0023592B /* SpanOb+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpanOb+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -1065,6 +1067,7 @@
 		52B7F0E92D757F81001498BC /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				CFB5756D2F599359000DB70B /* AttachmentStoreTests.swift */,
 				52B7F0E52D757F81001498BC /* BatchStoreTests.swift */,
 				52B7F0E62D757F81001498BC /* DataCleanupServiceTests.swift */,
 				52B7F0E72D757F81001498BC /* EventStoreTests.swift */,
@@ -1867,6 +1870,7 @@
 				52B7F1682D757F81001498BC /* MockSysCtl.swift in Sources */,
 				CFD88D662DAE36D30095115E /* BatchOb+CoreDataClass.swift in Sources */,
 				CF7CABB32F261DA800A9DC30 /* MockSessionStore.swift in Sources */,
+				CFB5756E2F599359000DB70B /* AttachmentStoreTests.swift in Sources */,
 				CFD88D672DAE36D30095115E /* BatchOb+CoreDataProperties.swift in Sources */,
 				52B7F1752D757F81001498BC /* SessionManagerTests.swift in Sources */,
 				52B7F13A2D757F81001498BC /* DataCleanupServiceTests.swift in Sources */,

--- a/ios/Sources/MeasureSDK/Swift/CoreData/AttachmentStore.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/AttachmentStore.swift
@@ -14,6 +14,7 @@ protocol AttachmentStore {
     func getAttachmentsForUpload(batchSize: Number) -> [MsrUploadAttachment]
     func deleteAttachments(forSessionIds sessionIds: [String])
     func getAllAttachmentPaths() -> Set<String>
+    func deleteExpiredAttachments()
 }
 
 final class BaseAttachmentStore: AttachmentStore {
@@ -225,6 +226,59 @@ final class BaseAttachmentStore: AttachmentStore {
         }
 
         return paths
+    }
+
+    func deleteExpiredAttachments() {
+        guard let context = coreDataManager.backgroundContext else {
+            logger.internalLog(level: .error, message: "Background context not available", error: nil, data: nil)
+            return
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let now = Date()
+
+        var attachmentsToDeleteFromFS = [String]()
+
+        context.performAndWait {
+            let fetchRequest: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "expires_at != nil")
+
+            do {
+                let attachments = try context.fetch(fetchRequest)
+                let expired = attachments.filter {
+                    guard let expiresAtString = $0.expires_at,
+                          let expiresAt = formatter.date(from: expiresAtString) else { return false }
+                    return expiresAt < now
+                }
+
+                guard !expired.isEmpty else { return }
+
+                logger.internalLog(
+                    level: .debug,
+                    message: "Cleanup Service: Deleting \(expired.count) expired attachments",
+                    error: nil,
+                    data: nil
+                )
+
+                expired.forEach {
+                    if let path = $0.path {
+                        attachmentsToDeleteFromFS.append(path)
+                    }
+                    context.delete($0)
+                }
+                try context.saveIfNeeded()
+            } catch {
+                logger.internalLog(
+                    level: .error,
+                    message: "Failed to delete expired attachments.",
+                    error: error,
+                    data: nil
+                )
+            }
+        }
+
+        attachmentsToDeleteFromFS.forEach { systemFileManager.deleteFile(atPath: $0) }
     }
 }
 

--- a/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
@@ -45,6 +45,7 @@ final class BaseDataCleanupService: DataCleanupService {
     func clearStaleData() {
         trimIfDiskLimitExceeded(currentSessionId: sessionManager.sessionId)
         cleanupOrphanedAttachments()
+        attachmentStore.deleteExpiredAttachments()
 
         guard var sessionsToDelete = sessionStore.getSessionsToDelete() else {
             return

--- a/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
@@ -176,7 +176,7 @@ final class BaseExporter: Exporter {
     }
 
     private func exportAttachments() {
-        while true {
+        uploadLoop: while true {
             let attachments = attachmentStore.getAttachmentsForUpload(batchSize: 5)
             guard !attachments.isEmpty else {
                 logger.internalLog(level: .debug, message: "Exporter: no attachments to upload", error: nil, data: nil)
@@ -190,7 +190,7 @@ final class BaseExporter: Exporter {
                 let success = uploadAttachmentSync(attachment)
                 if !success {
                     logger.internalLog(level: .debug, message: "Exporter: attachment \(attachment.id) upload failed", error: nil, data: nil)
-                    break
+                    break uploadLoop
                 }
                 Thread.sleep(forTimeInterval: TimeInterval(configProvider.attachmentExportIntervalMs) / 1000)
             }

--- a/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
@@ -98,7 +98,7 @@ final class BaseHttpClient: HttpClient {
             self.logger.internalLog(level: .error, message: "Failed to send request: \(error.localizedDescription)", error: nil, data: nil)
             return .error(.unknownError(error.localizedDescription))
         } else if let httpResponse = urlResponse as? HTTPURLResponse, self.isRedirect(httpResponse.statusCode) {
-            if let location = httpResponse.allHeaderFields["Location"] as? String, let newUrl = self.resolveRedirectUrl(baseUrl: urlResponse!.url!, location: location) {
+            if let location = httpResponse.allHeaderFields["Location"] as? String, let baseUrl = urlResponse?.url, let newUrl = self.resolveRedirectUrl(baseUrl: baseUrl, location: location) {
                 self.logger.internalLog(level: .info, message: "Redirecting to: \(newUrl.absoluteString)", error: nil, data: nil)
                 return redirectHandler(newUrl)
             } else {

--- a/ios/Tests/MeasureSDKTests/CoreData/AttachmentStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/AttachmentStoreTests.swift
@@ -1,0 +1,461 @@
+//
+//  AttachmentStoreTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 05/03/26.
+//
+
+import XCTest
+@testable import Measure
+import CoreData
+
+final class AttachmentStoreTests: XCTestCase {
+    var coreDataManager: MockCoreDataManager!
+    var logger: MockLogger!
+    var attachmentStore: AttachmentStore!
+    var systemFileManager: MockSystemFileManager!
+
+    override func setUp() {
+        super.setUp()
+        coreDataManager = MockCoreDataManager()
+        logger = MockLogger()
+        systemFileManager = MockSystemFileManager()
+        attachmentStore = BaseAttachmentStore(
+            coreDataManager: coreDataManager,
+            systemFileManager: systemFileManager,
+            logger: logger
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        systemFileManager = nil
+        attachmentStore = nil
+        coreDataManager = nil
+        logger = nil
+    }
+
+    @discardableResult
+    private func insertAttachment(
+        id: String = UUID().uuidString,
+        name: String = "test.png",
+        type: String = "screenshot",
+        sessionId: String = "session-1",
+        uploadUrl: String? = nil,
+        expiresAt: String? = nil,
+        headers: Data? = nil,
+        path: String? = nil,
+        bytes: Data? = Data("test".utf8)
+    ) -> String {
+        let context = coreDataManager.backgroundContext!
+        context.performAndWait {
+            let attachment = AttachmentOb(context: context)
+            attachment.id = id
+            attachment.name = name
+            attachment.type = type
+            attachment.sessionId = sessionId
+            attachment.uploadUrl = uploadUrl
+            attachment.expires_at = expiresAt
+            attachment.headers = headers
+            attachment.path = path
+            attachment.bytes = bytes
+            let _ = try? context.saveIfNeeded()
+        }
+        return id
+    }
+
+    private func makeHeaders() -> Data {
+        try! JSONSerialization.data(withJSONObject: ["Authorization": "Bearer token"])
+    }
+
+    private func expiresAt(offsetSeconds: TimeInterval) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date().addingTimeInterval(offsetSeconds))
+    }
+
+    func test_deleteAttachments_byIds_deletesASingleAttachment() {
+        let id = insertAttachment()
+
+        attachmentStore.deleteAttachments(attachmentIds: [id])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_deleteAttachments_byIds_deletesMultipleAttachments() {
+        let id1 = insertAttachment(id: "a1")
+        let id2 = insertAttachment(id: "a2")
+        let id3 = insertAttachment(id: "a3")
+
+        attachmentStore.deleteAttachments(attachmentIds: [id1, id2, id3])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_deleteAttachments_byIds_deletesAssociatedFileFromFileSystem() {
+        let path = "attachments/test.png"
+        systemFileManager.savedFiles[path] = Data("test".utf8)
+        let id = insertAttachment(path: path)
+
+        attachmentStore.deleteAttachments(attachmentIds: [id])
+
+        XCTAssertNil(systemFileManager.savedFiles[path])
+    }
+
+    func test_deleteAttachments_byIds_doesNothingForEmptyArray() {
+        insertAttachment(id: "a1")
+        insertAttachment(id: "a2")
+
+        attachmentStore.deleteAttachments(attachmentIds: [])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_deleteAttachments_byIds_ignoresNonExistentIds() {
+        let id = insertAttachment(id: "a1")
+
+        attachmentStore.deleteAttachments(attachmentIds: ["non-existent"])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 1)
+        _ = id
+    }
+
+    func test_updateUploadDetails_updatesAllFields() {
+        let id = insertAttachment()
+        let headers = makeHeaders()
+        let expiry = expiresAt(offsetSeconds: 3600)
+
+        attachmentStore.updateUploadDetails(
+            for: id,
+            uploadUrl: "https://example.com/upload",
+            headers: headers,
+            expiresAt: expiry
+        )
+
+        let context = coreDataManager.backgroundContext!
+        var updated: AttachmentOb?
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            req.predicate = NSPredicate(format: "id == %@", id)
+            updated = try? context.fetch(req).first
+        }
+        XCTAssertEqual(updated?.uploadUrl, "https://example.com/upload")
+        XCTAssertEqual(updated?.headers, headers)
+        XCTAssertEqual(updated?.expires_at, expiry)
+    }
+
+    func test_updateUploadDetails_doesNothingForNonExistentId() {
+        insertAttachment(id: "a1", uploadUrl: "https://example.com/old")
+
+        attachmentStore.updateUploadDetails(
+            for: "non-existent",
+            uploadUrl: "https://example.com/new",
+            headers: nil,
+            expiresAt: nil
+        )
+
+        let context = coreDataManager.backgroundContext!
+        var attachment: AttachmentOb?
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            req.predicate = NSPredicate(format: "id == %@", "a1")
+            attachment = try? context.fetch(req).first
+        }
+        XCTAssertEqual(attachment?.uploadUrl, "https://example.com/old")
+    }
+
+    func test_updateUploadDetails_canSetExpiresAtToNil() {
+        let id = insertAttachment(expiresAt: expiresAt(offsetSeconds: 3600))
+
+        attachmentStore.updateUploadDetails(
+            for: id,
+            uploadUrl: "https://example.com/upload",
+            headers: nil,
+            expiresAt: nil
+        )
+
+        let context = coreDataManager.backgroundContext!
+        var attachment: AttachmentOb?
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            req.predicate = NSPredicate(format: "id == %@", id)
+            attachment = try? context.fetch(req).first
+        }
+        XCTAssertNil(attachment?.expires_at)
+    }
+
+    func test_updateUploadDetails_canSetHeadersToNil() {
+        let id = insertAttachment(headers: makeHeaders())
+
+        attachmentStore.updateUploadDetails(
+            for: id,
+            uploadUrl: "https://example.com/upload",
+            headers: nil,
+            expiresAt: nil
+        )
+
+        let context = coreDataManager.backgroundContext!
+        var attachment: AttachmentOb?
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            req.predicate = NSPredicate(format: "id == %@", id)
+            attachment = try? context.fetch(req).first
+        }
+        XCTAssertNil(attachment?.headers)
+    }
+
+    func test_getAttachmentsForUpload_returnsOnlyAttachmentsWithUploadUrl() {
+        insertAttachment(id: "a1", uploadUrl: "https://example.com/upload")
+        insertAttachment(id: "a2", uploadUrl: nil)
+
+        let results = attachmentStore.getAttachmentsForUpload(batchSize: 10)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.id, "a1")
+    }
+
+    func test_getAttachmentsForUpload_respectsBatchSizeLimit() {
+        insertAttachment(id: "a1", uploadUrl: "https://example.com/1")
+        insertAttachment(id: "a2", uploadUrl: "https://example.com/2")
+        insertAttachment(id: "a3", uploadUrl: "https://example.com/3")
+
+        let results = attachmentStore.getAttachmentsForUpload(batchSize: 2)
+
+        XCTAssertEqual(results.count, 2)
+    }
+
+    func test_getAttachmentsForUpload_returnsEmptyWhenNoUploadUrls() {
+        insertAttachment(id: "a1", uploadUrl: nil)
+        insertAttachment(id: "a2", uploadUrl: nil)
+
+        let results = attachmentStore.getAttachmentsForUpload(batchSize: 10)
+
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_getAttachmentsForUpload_excludesAttachmentsWithEmptyUploadUrl() {
+        insertAttachment(id: "a1", uploadUrl: "")
+
+        let results = attachmentStore.getAttachmentsForUpload(batchSize: 10)
+
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_deleteAttachments_forSessionIds_deletesAllAttachmentsInSession() {
+        insertAttachment(id: "a1", sessionId: "session-1")
+        insertAttachment(id: "a2", sessionId: "session-1")
+
+        attachmentStore.deleteAttachments(forSessionIds: ["session-1"])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_deleteAttachments_forSessionIds_deletesAcrossMultipleSessions() {
+        insertAttachment(id: "a1", sessionId: "session-1")
+        insertAttachment(id: "a2", sessionId: "session-2")
+        insertAttachment(id: "a3", sessionId: "session-3")
+
+        attachmentStore.deleteAttachments(forSessionIds: ["session-1", "session-2"])
+
+        let context = coreDataManager.backgroundContext!
+        var remaining: [AttachmentOb] = []
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            remaining = (try? context.fetch(req)) ?? []
+        }
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.id, "a3")
+    }
+
+    func test_deleteAttachments_forSessionIds_deletesAssociatedFilesFromFileSystem() {
+        let path = "attachments/test.png"
+        systemFileManager.savedFiles[path] = Data("test".utf8)
+        insertAttachment(id: "a1", sessionId: "session-1", path: path)
+
+        attachmentStore.deleteAttachments(forSessionIds: ["session-1"])
+
+        XCTAssertNil(systemFileManager.savedFiles[path])
+    }
+
+    func test_deleteAttachments_forSessionIds_doesNotDeleteOtherSessions() {
+        insertAttachment(id: "a1", sessionId: "session-1")
+        insertAttachment(id: "a2", sessionId: "session-2")
+
+        attachmentStore.deleteAttachments(forSessionIds: ["session-1"])
+
+        let context = coreDataManager.backgroundContext!
+        var remaining: [AttachmentOb] = []
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            remaining = (try? context.fetch(req)) ?? []
+        }
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.id, "a2")
+    }
+
+    func test_deleteAttachments_forSessionIds_doesNothingForEmptyArray() {
+        insertAttachment(id: "a1", sessionId: "session-1")
+
+        attachmentStore.deleteAttachments(forSessionIds: [])
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_getAllAttachmentPaths_returnsPathsOfAllAttachments() {
+        insertAttachment(id: "a1", path: "attachments/a.png")
+        insertAttachment(id: "a2", path: "attachments/b.png")
+
+        let paths = attachmentStore.getAllAttachmentPaths()
+
+        XCTAssertEqual(paths, Set(["attachments/a.png", "attachments/b.png"]))
+    }
+
+    func test_getAllAttachmentPaths_excludesAttachmentsWithNilPath() {
+        insertAttachment(id: "a1", path: "attachments/a.png")
+        insertAttachment(id: "a2", path: nil)
+
+        let paths = attachmentStore.getAllAttachmentPaths()
+
+        XCTAssertEqual(paths, Set(["attachments/a.png"]))
+    }
+
+    func test_getAllAttachmentPaths_returnsEmptySetWhenNoAttachments() {
+        let paths = attachmentStore.getAllAttachmentPaths()
+
+        XCTAssertTrue(paths.isEmpty)
+    }
+
+    func test_deleteExpiredAttachments_deletesExpiredAttachments() {
+        insertAttachment(id: "a1", expiresAt: expiresAt(offsetSeconds: -3600))
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_deleteExpiredAttachments_doesNotDeleteFutureAttachments() {
+        insertAttachment(id: "a1", expiresAt: expiresAt(offsetSeconds: 3600))
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_deleteExpiredAttachments_doesNotDeleteAttachmentsWithNilExpiresAt() {
+        insertAttachment(id: "a1", expiresAt: nil)
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_deleteExpiredAttachments_deletesAssociatedFilesFromFileSystem() {
+        let path = "attachments/expired.png"
+        systemFileManager.savedFiles[path] = Data("test".utf8)
+        insertAttachment(id: "a1", expiresAt: expiresAt(offsetSeconds: -3600), path: path)
+
+        attachmentStore.deleteExpiredAttachments()
+
+        XCTAssertNil(systemFileManager.savedFiles[path])
+    }
+
+    func test_deleteExpiredAttachments_doesNothingWhenNoExpiredAttachments() {
+        insertAttachment(id: "a1", expiresAt: expiresAt(offsetSeconds: 3600))
+        insertAttachment(id: "a2", expiresAt: nil)
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_deleteExpiredAttachments_ignoresMalformedExpiresAtString() {
+        insertAttachment(id: "a1", expiresAt: "not-a-valid-date")
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var count = 0
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            count = (try? context.fetch(req))?.count ?? 0
+        }
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_deleteExpiredAttachments_onlyDeletesExpiredAmongMixed() {
+        insertAttachment(id: "expired", expiresAt: expiresAt(offsetSeconds: -3600))
+        insertAttachment(id: "valid", expiresAt: expiresAt(offsetSeconds: 3600))
+        insertAttachment(id: "no-expiry", expiresAt: nil)
+
+        attachmentStore.deleteExpiredAttachments()
+
+        let context = coreDataManager.backgroundContext!
+        var remaining: [AttachmentOb] = []
+        context.performAndWait {
+            let req: NSFetchRequest<AttachmentOb> = AttachmentOb.fetchRequest()
+            remaining = (try? context.fetch(req)) ?? []
+        }
+        let remainingIds = Set(remaining.compactMap { $0.id })
+        XCTAssertEqual(remainingIds, Set(["valid", "no-expiry"]))
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockAttachmentStore.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockAttachmentStore.swift
@@ -110,4 +110,19 @@ final class MockAttachmentStore: AttachmentStore {
 
         return Set(attachments.values.compactMap { $0.attachment.path })
     }
+
+    func deleteExpiredAttachments() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let now = Date()
+
+        attachments = attachments.filter { _, stored in
+            guard let expiresAtString = stored.attachment.expiresAt,
+                  let expiresAt = formatter.date(from: expiresAtString) else { return true }
+            return expiresAt >= now
+        }
+    }
 }


### PR DESCRIPTION
# Description

Delete expired attachments on cleanup

## Related issue
References #3260



