### PR TITLE
chore(backend): close readonly connection pool in api service

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -32,6 +32,10 @@ func main() {
 		if err := server.Server.ChPool.Close(); err != nil {
 			log.Fatalf("Unable to close clickhouse connection: %v", err)
 		}
+
+		if err := server.Server.RchPool.Close(); err != nil {
+			log.Fatalf("Unable to close clickhouse readonly connection: %v", err)
+		}
 	}()
 
 	// Close geo ip database at shutdown


### PR DESCRIPTION

## Summary

This PR closes the read connection pool at server shutdown in API service.