### PR TITLE
chore(backend): remove proxy symbol method from ingest service

### DIFF
--- a/backend/ingest/measure/build.go
+++ b/backend/ingest/measure/build.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -423,64 +422,4 @@ func PutBuilds(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"mappings": build.Mappings,
 	})
-}
-
-// ProxySymbol proxies presigned S3 URLs to an S3-like
-// server.
-//
-// We parse the payload from the incoming request's query
-// string, then construct a new URL by replacing the S3 origin.
-// Next, we create a reverse proxy and configure it to pipe
-// response back to the original caller.
-//
-// The original S3 origin used when constructing the presigned
-// URL must match the proxied presigned URL.
-func ProxySymbol(c *gin.Context) {
-	payload := c.Query("payload")
-	if payload == "" {
-		msg := `need payload for proxying to object store`
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	config := server.Server.Config
-	presignedUrl := payload
-
-	// if the payload already contains origin, then
-	// don't prepend the origin.
-	if !strings.HasPrefix(payload, config.AWSEndpoint) {
-		presignedUrl = config.AWSEndpoint + payload
-	}
-
-	parsed, err := url.Parse(presignedUrl)
-	if err != nil {
-		msg := "failed to parse reconstructed presigned url"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	proxy := httputil.NewSingleHostReverseProxy(parsed)
-	proxy.Director = func(req *http.Request) {
-		req.URL.Scheme = parsed.Scheme
-		req.URL.Host = parsed.Host
-		req.URL.Path = parsed.Path
-		req.URL.RawQuery = parsed.RawQuery
-		req.Host = parsed.Host
-
-		req.Header = c.Request.Header
-	}
-
-	proxy.ModifyResponse = func(resp *http.Response) error {
-		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Symbol proxy http status: %s\n", resp.Status)
-		}
-		return nil
-	}
-
-	proxy.ServeHTTP(c.Writer, c.Request)
 }


### PR DESCRIPTION
## Summary

This PR removes the unused `ProxySymbol` function from Ingest service.

## See also

- fixes #3275