### PR TITLE
fix(backend): handle panic for unsolvable malformed sdk request

### DIFF
--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -270,26 +270,38 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 			return err
 		}
 
-		// debug null exception in payload cases
+		// debug null anr/exception in payload cases
 		//
-		// suspicion: this happens for the payload
+		// suspicion: this happens for these payloads
 		// {
 		//   "id": "<uuid>,
 		//   "session_id: "<uuid>",
 		//   "type": "exception",
 		//   "exception": null,
 		// }
+		// {
+		//   "id": "<uuid>,
+		//   "session_id: "<uuid>",
+		//   "type": "anr",
+		//   "anr": null,
+		// }
 		//
-		// to better track what's going on, for now
-		// handle the condition to prevent panic
-		// downstream. if we don't see any more panics
-		// then that means it's an SDK side issue.
+		// most likely, these orginiate from Android 11, 12
+		// & 13 Redmi devices with user agent as "Dalvik/2.1.0 (Linux; U; Android 11; 2201116SI Build/RKQ1.211001.001)".
 		//
-		// FIXME: improve & refactor later.
+		// since, the SDK has no fix for this issue, we handle
+		// the panic & send a 400 - which would eventually lead
+		// the SDK to delete such events.
+		//
+		// has been observed for exception & ANRs, but other
+		// event types may be affected as well.
 		//
 		// see: https://github.com/measure-sh/measure/issues/2965
 		if ev.IsException() && ev.Exception == nil {
 			return fmt.Errorf(`%q must not be null`, `exception`)
+		}
+		if ev.IsANR() && ev.ANR == nil {
+			return fmt.Errorf(`%q must not be null`, `anr`)
 		}
 
 		// discard batch if duplicate
@@ -431,26 +443,38 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 	for i := range payload.Events {
 		ev := payload.Events[i]
 
-		// debug null exception in payload cases
+		// debug null anr/exception in payload cases
 		//
-		// suspicion: this happens for the payload
+		// suspicion: this happens for these payloads
 		// {
 		//   "id": "<uuid>,
 		//   "session_id: "<uuid>",
 		//   "type": "exception",
 		//   "exception": null,
 		// }
+		// {
+		//   "id": "<uuid>,
+		//   "session_id: "<uuid>",
+		//   "type": "anr",
+		//   "anr": null,
+		// }
 		//
-		// to better track what's going on, for now
-		// handle the condition to prevent panic
-		// downstream. if we don't see any more panics
-		// then that means it's an SDK side issue.
+		// most likely, these orginiate from Android 11, 12
+		// & 13 Redmi devices with user agent as "Dalvik/2.1.0 (Linux; U; Android 11; 2201116SI Build/RKQ1.211001.001)".
 		//
-		// FIXME: improve & refactor later.
+		// since, the SDK has no fix for this issue, we handle
+		// the panic & send a 400 - which would eventually lead
+		// the SDK to delete such events.
+		//
+		// has been observed for exception & ANRs, but other
+		// event types may be affected as well.
 		//
 		// see: https://github.com/measure-sh/measure/issues/2965
 		if ev.IsException() && ev.Exception == nil {
 			return fmt.Errorf(`%q must not be null`, `exception`)
+		}
+		if ev.IsANR() && ev.ANR == nil {
+			return fmt.Errorf(`%q must not be null`, `anr`)
 		}
 
 		// discard batch if duplicate event ids found


### PR DESCRIPTION
## Summary

This PR extends ingest validation to respond with a `400 Bad Request` for a malformed request originating from an unresolvable SDK issue.

This panic occurs roughly 200 times in 24 hours.

<img width="1280" height="741" alt="image" src="https://github.com/user-attachments/assets/aa76b105-12d7-4650-a06d-373a8f7aca85" />

## Tasks

- [x] Detect invalid request during JSON read & respond with 400
- [x] Detect invalid request during multipart read & respond with 400

## See also

- fixes #3277
- #3029 
- #3030
- #2965

