### PR TITLE
fix(frontend): fix illegible text colour in user profile initials

### DIFF
--- a/frontend/dashboard/app/components/user_avatar.tsx
+++ b/frontend/dashboard/app/components/user_avatar.tsx
@@ -78,7 +78,7 @@ const UserAvatar: React.FC<UserAvatarProps> = ({ onLogoutClick }) => {
                     onError={() => setImageError(true)}
                   />
                 ) : (
-                  <span className="text-sm">
+                  <span className="text-sm text-primary-foreground">
                     {getInitials(session.user.name)}
                   </span>
                 )}


### PR DESCRIPTION
# Description

Fixes illegible text colour in user profile initials which we show when we can't fetch profile picture.

## Related issue
Fixes #3239 


