### PR TITLE
feat(frontend): add llms.txt and llms-full.txt

### DIFF
--- a/frontend/dashboard/.gitignore
+++ b/frontend/dashboard/.gitignore
@@ -38,3 +38,5 @@ next-env.d.ts
 /content/
 /public/docs/
 /public/sitemap.xml
+/public/llms.txt
+/public/llms-full.txt

--- a/frontend/dashboard/__tests__/scripts/generate_llms_txts_test.ts
+++ b/frontend/dashboard/__tests__/scripts/generate_llms_txts_test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+
+const {
+  slugToFilePath,
+  flattenNavSlugs,
+  generateLlmsTxt,
+  generateLlmsFullTxt,
+  rewriteRelativeLinks,
+} = require('@/scripts/generate_llms_txts')
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+let tmpDir: string
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copy_docs_test_'))
+
+  // README.md (root)
+  fs.writeFileSync(
+    path.join(tmpDir, 'README.md'),
+    '# Documentation\n\nOverview content here.\n\nSee [Guide](guide.md) for more.'
+  )
+
+  // guide.md with relative links and images
+  fs.writeFileSync(
+    path.join(tmpDir, 'guide.md'),
+    '# Guide\n\nSome [link](features/foo.md) to foo.\n\n![screenshot](assets/pic.png)\n\nAlso see [bar](features/bar.md#setup).'
+  )
+
+  // features/
+  fs.mkdirSync(path.join(tmpDir, 'features'))
+  fs.writeFileSync(
+    path.join(tmpDir, 'features', 'README.md'),
+    '# Features\n\n* [Foo](foo.md)\n* [Bar](bar.md)'
+  )
+  fs.writeFileSync(
+    path.join(tmpDir, 'features', 'foo.md'),
+    '# Foo Feature\n\n<!-- internal comment -->\n\nFoo content here.'
+  )
+  fs.writeFileSync(
+    path.join(tmpDir, 'features', 'bar.md'),
+    '# Bar Feature\n\nBar content here.\n\nSee [Foo](foo.md) for related info.'
+  )
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// ─── slugToFilePath ────────────────────────────────────────────────────────
+
+describe('slugToFilePath', () => {
+  it('returns root README.md for /docs slug', () => {
+    const result = slugToFilePath(tmpDir, '/docs')
+
+    expect(result).toBe(path.join(tmpDir, 'README.md'))
+  })
+
+  it('returns root README.md for /docs/ slug with trailing slash', () => {
+    const result = slugToFilePath(tmpDir, '/docs/')
+
+    expect(result).toBe(path.join(tmpDir, 'README.md'))
+  })
+
+  it('returns direct .md file when it exists', () => {
+    const result = slugToFilePath(tmpDir, '/docs/guide')
+
+    expect(result).toBe(path.join(tmpDir, 'guide.md'))
+  })
+
+  it('falls back to README.md inside directory', () => {
+    const result = slugToFilePath(tmpDir, '/docs/features')
+
+    expect(result).toBe(path.join(tmpDir, 'features', 'README.md'))
+  })
+
+  it('resolves nested file paths', () => {
+    const result = slugToFilePath(tmpDir, '/docs/features/foo')
+
+    expect(result).toBe(path.join(tmpDir, 'features', 'foo.md'))
+  })
+
+  it('returns null for non-existent slug', () => {
+    const result = slugToFilePath(tmpDir, '/docs/nonexistent')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-existent nested slug', () => {
+    const result = slugToFilePath(tmpDir, '/docs/features/nonexistent')
+
+    expect(result).toBeNull()
+  })
+})
+
+// ─── flattenNavSlugs ───────────────────────────────────────────────────────
+
+describe('flattenNavSlugs', () => {
+  it('returns ["/docs"] for empty nav', () => {
+    const result = flattenNavSlugs([])
+
+    expect(result).toEqual(['/docs'])
+  })
+
+  it('flattens single-level items', () => {
+    const nav = [
+      { title: 'A', slug: '/docs/a' },
+      { title: 'B', slug: '/docs/b' },
+    ]
+    const result = flattenNavSlugs(nav)
+
+    expect(result).toEqual(['/docs', '/docs/a', '/docs/b'])
+  })
+
+  it('recursively flattens nested children', () => {
+    const nav = [
+      {
+        title: 'Group',
+        children: [
+          { title: 'A', slug: '/docs/a' },
+          { title: 'B', slug: '/docs/b' },
+        ],
+      },
+    ]
+    const result = flattenNavSlugs(nav)
+
+    expect(result).toEqual(['/docs', '/docs/a', '/docs/b'])
+  })
+
+  it('handles mixed items with and without children', () => {
+    const nav = [
+      { title: 'Solo', slug: '/docs/solo' },
+      {
+        title: 'Group',
+        children: [
+          { title: 'C1', slug: '/docs/c1' },
+          { title: 'C2', slug: '/docs/c2' },
+        ],
+      },
+      { title: 'Another', slug: '/docs/another' },
+    ]
+    const result = flattenNavSlugs(nav)
+
+    expect(result).toEqual(['/docs', '/docs/solo', '/docs/c1', '/docs/c2', '/docs/another'])
+  })
+
+  it('handles deeply nested children', () => {
+    const nav = [
+      {
+        title: 'L1',
+        children: [
+          {
+            title: 'L2',
+            children: [
+              { title: 'L3', slug: '/docs/deep' },
+            ],
+          },
+        ],
+      },
+    ]
+    const result = flattenNavSlugs(nav)
+
+    expect(result).toEqual(['/docs', '/docs/deep'])
+  })
+
+  it('skips items with neither slug nor children', () => {
+    const nav = [
+      { title: 'No slug or children' },
+      { title: 'Has slug', slug: '/docs/a' },
+    ]
+    const result = flattenNavSlugs(nav)
+
+    expect(result).toEqual(['/docs', '/docs/a'])
+  })
+})
+
+// ─── generateLlmsTxt ──────────────────────────────────────────────────────
+
+describe('generateLlmsTxt', () => {
+  it('starts with # measure.sh heading', () => {
+    const result = generateLlmsTxt([])
+
+    expect(result).toMatch(/^# measure\.sh\n/)
+  })
+
+  it('contains blockquote description', () => {
+    const result = generateLlmsTxt([])
+
+    expect(result).toContain('> ')
+    expect(result).toContain('mobile analytics')
+  })
+
+  it('produces H2 sections for items with children', () => {
+    const nav = [
+      {
+        title: 'Features',
+        children: [
+          { title: 'Crash Reporting', slug: '/docs/features/crash' },
+          { title: 'ANR Reporting', slug: '/docs/features/anr' },
+        ],
+      },
+    ]
+    const result = generateLlmsTxt(nav)
+
+    expect(result).toContain('## Features')
+    expect(result).toContain('- [Crash Reporting](https://measure.sh/docs/features/crash)')
+    expect(result).toContain('- [ANR Reporting](https://measure.sh/docs/features/anr)')
+  })
+
+  it('collects standalone items under ## Docs', () => {
+    const nav = [
+      { title: 'Guide', slug: '/docs/guide' },
+      { title: 'FAQ', slug: '/docs/faq' },
+    ]
+    const result = generateLlmsTxt(nav)
+
+    expect(result).toContain('## Docs')
+    expect(result).toContain('- [Guide](https://measure.sh/docs/guide)')
+    expect(result).toContain('- [FAQ](https://measure.sh/docs/faq)')
+  })
+
+  it('flattens nested grandchildren into the parent H2 section', () => {
+    const nav = [
+      {
+        title: 'Features',
+        children: [
+          {
+            title: 'Bug Reporting',
+            children: [
+              { title: 'Android', slug: '/docs/features/bug-android' },
+              { title: 'iOS', slug: '/docs/features/bug-ios' },
+            ],
+          },
+        ],
+      },
+    ]
+    const result = generateLlmsTxt(nav)
+
+    expect(result).toContain('## Features')
+    expect(result).toContain('- [Android](https://measure.sh/docs/features/bug-android)')
+    expect(result).toContain('- [iOS](https://measure.sh/docs/features/bug-ios)')
+  })
+
+  it('ends with ## Optional section linking to llms-full.txt', () => {
+    const result = generateLlmsTxt([])
+
+    expect(result).toContain('## Optional')
+    expect(result).toContain('- [llms-full.txt](https://measure.sh/llms-full.txt)')
+  })
+
+  it('all URLs are absolute', () => {
+    const nav = [
+      { title: 'A', slug: '/docs/a' },
+      {
+        title: 'Group',
+        children: [{ title: 'B', slug: '/docs/b' }],
+      },
+    ]
+    const result = generateLlmsTxt(nav)
+
+    const linkRegex = /\]\(([^)]+)\)/g
+    let match
+    while ((match = linkRegex.exec(result)) !== null) {
+      expect(match[1]).toMatch(/^https:\/\/measure\.sh/)
+    }
+  })
+
+  it('produces valid structure with empty nav', () => {
+    const result = generateLlmsTxt([])
+
+    expect(result).toContain('# measure.sh')
+    expect(result).toContain('> ')
+    expect(result).toContain('## Optional')
+    expect(result).not.toContain('## Docs')
+  })
+})
+
+// ─── rewriteRelativeLinks ──────────────────────────────────────────────────
+
+describe('rewriteRelativeLinks', () => {
+  it('rewrites relative .md links to absolute URLs', () => {
+    const input = 'See [Crash Reporting](features/feature-crash-reporting.md) for details.'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe(
+      'See [Crash Reporting](https://measure.sh/docs/features/feature-crash-reporting) for details.'
+    )
+  })
+
+  it('rewrites .md links with anchors', () => {
+    const input = 'See [Config](features/configuration-options.md#sdk-options) for details.'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toContain('https://measure.sh/docs/features/configuration-options')
+  })
+
+  it('rewrites relative image paths', () => {
+    const input = '![screenshot](assets/pic.png)'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe('![screenshot](https://measure.sh/docs/assets/pic.png)')
+  })
+
+  it('rewrites image paths with ./ prefix', () => {
+    const input = '![screenshot](./assets/pic.png)'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe('![screenshot](https://measure.sh/docs/assets/pic.png)')
+  })
+
+  it('does not rewrite absolute URLs', () => {
+    const input = 'See [GitHub](https://github.com/example/repo) for source.'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe(input)
+  })
+
+  it('does not rewrite anchor-only links', () => {
+    const input = 'See [section](#some-section) above.'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe(input)
+  })
+
+  it('handles README.md links', () => {
+    const input = 'See [Hosting](hosting/README.md) for details.'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toBe('See [Hosting](https://measure.sh/docs/hosting) for details.')
+  })
+
+  it('handles multiple links in the same line', () => {
+    const input = 'See [A](a.md) and [B](b.md).'
+    const result = rewriteRelativeLinks(input)
+
+    expect(result).toContain('https://measure.sh/docs/a')
+    expect(result).toContain('https://measure.sh/docs/b')
+  })
+})
+
+// ─── generateLlmsFullTxt ──────────────────────────────────────────────────
+
+describe('generateLlmsFullTxt', () => {
+  const simpleNav = [
+    { title: 'Guide', slug: '/docs/guide' },
+    {
+      title: 'Features',
+      children: [
+        { title: 'Foo', slug: '/docs/features/foo' },
+        { title: 'Bar', slug: '/docs/features/bar' },
+      ],
+    },
+  ]
+
+  it('starts with the root doc', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+
+    expect(result).toMatch(/^---\nSource: https:\/\/measure\.sh\/docs\n---/)
+    expect(result).toContain('# Documentation')
+  })
+
+  it('includes all docs in nav order', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+    const sourceLines = result.match(/Source: .+/g) || []
+    const sources = sourceLines.map((l: string) => l.replace('Source: ', ''))
+
+    expect(sources).toEqual([
+      'https://measure.sh/docs',
+      'https://measure.sh/docs/guide',
+      'https://measure.sh/docs/features/foo',
+      'https://measure.sh/docs/features/bar',
+    ])
+  })
+
+  it('separates docs with --- markers', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+    const separators = result.match(/^---$/gm) || []
+
+    // Each doc has opening and closing --- lines (2 per doc)
+    expect(separators.length).toBe(8) // 4 docs * 2
+  })
+
+  it('strips HTML comments from content', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+
+    expect(result).not.toContain('<!-- internal comment -->')
+    expect(result).toContain('Foo content here.')
+  })
+
+  it('rewrites relative .md links to absolute URLs', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+
+    expect(result).not.toMatch(/\]\([^)]*\.md\)/)
+    expect(result).toContain('https://measure.sh/docs/features/foo')
+  })
+
+  it('rewrites relative image paths to absolute URLs', () => {
+    const result = generateLlmsFullTxt(tmpDir, simpleNav)
+
+    expect(result).not.toContain('](assets/')
+    expect(result).toContain('https://measure.sh/docs/assets/pic.png')
+  })
+
+  it('does not crash on non-existent slugs', () => {
+    const nav = [{ title: 'Missing', slug: '/docs/nonexistent' }]
+    const result = generateLlmsFullTxt(tmpDir, nav)
+
+    // Should still have the root doc
+    expect(result).toContain('Source: https://measure.sh/docs')
+    // Should not have the missing doc
+    expect(result).not.toContain('Source: https://measure.sh/docs/nonexistent')
+  })
+
+  it('deduplicates slugs', () => {
+    const nav = [
+      { title: 'Guide', slug: '/docs/guide' },
+      { title: 'Guide Again', slug: '/docs/guide' },
+    ]
+    const result = generateLlmsFullTxt(tmpDir, nav)
+    const guideMatches = result.match(/Source: https:\/\/measure\.sh\/docs\/guide$/gm) || []
+
+    expect(guideMatches.length).toBe(1)
+  })
+
+  it('produces output with empty nav (root doc only)', () => {
+    const result = generateLlmsFullTxt(tmpDir, [])
+
+    expect(result).toContain('Source: https://measure.sh/docs')
+    expect(result).toContain('# Documentation')
+  })
+})

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "prebuild": "node ./scripts/copy_docs.js && node ./scripts/generate_sitemap.js",
-    "dev": "node ./scripts/copy_docs.js && next dev",
-    "build": "node ./scripts/copy_docs.js && node ./scripts/generate_sitemap.js && next build",
+    "prebuild": "node ./scripts/copy_docs.js && node ./scripts/generate_llms_txts.js && node ./scripts/generate_sitemap.js",
+    "dev": "node ./scripts/copy_docs.js && node ./scripts/generate_llms_txts.js && next dev",
+    "build": "node ./scripts/copy_docs.js && node ./scripts/generate_llms_txts.js && node ./scripts/generate_sitemap.js && next build",
     "start": "next start",
     "lint": "next lint",
     "generate:sitemap": "node ./scripts/generate_sitemap.js",

--- a/frontend/dashboard/scripts/generate_llms_txts.js
+++ b/frontend/dashboard/scripts/generate_llms_txts.js
@@ -1,0 +1,221 @@
+/**
+ * Generates llms.txt and llms-full.txt for LLM consumption.
+ *
+ * Reads the nav tree from content/docs_nav.json (produced by copy_docs.js)
+ * and the markdown files from content/docs/ to produce:
+ * - public/llms.txt: structured index with links to all doc pages
+ * - public/llms-full.txt: all documentation concatenated into a single file
+ *
+ * Must run after copy_docs.js.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { stripHtmlComments, mdPathToSlug } = require("./copy_docs");
+
+const rootDir = path.resolve(__dirname, "..");
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://measure.sh";
+
+function getDocsDirectory() {
+  const contentDir = path.join(rootDir, "content", "docs");
+  if (fs.existsSync(contentDir)) {
+    return contentDir;
+  }
+  // Local dev fallback
+  return path.resolve(rootDir, "..", "..", "docs");
+}
+
+/**
+ * Resolve a /docs/... slug to a markdown file path.
+ * e.g. "/docs/guide" -> "<docsDir>/guide.md" or "<docsDir>/guide/README.md"
+ */
+function slugToFilePath(docsDir, slug) {
+  const rel = slug.replace(/^\/docs\/?/, "");
+  if (rel === "") {
+    return path.join(docsDir, "README.md");
+  }
+  const directPath = path.join(docsDir, `${rel}.md`);
+  if (fs.existsSync(directPath)) {
+    return directPath;
+  }
+  const readmePath = path.join(docsDir, rel, "README.md");
+  if (fs.existsSync(readmePath)) {
+    return readmePath;
+  }
+  return null;
+}
+
+/**
+ * Recursively flatten nav tree into an ordered list of slugs.
+ * Starts with "/docs" (root page) then follows the nav ordering.
+ */
+function flattenNavSlugs(navData) {
+  const slugs = ["/docs"];
+  function walk(items) {
+    for (const item of items) {
+      if (item.slug) {
+        slugs.push(item.slug);
+      }
+      if (item.children) {
+        walk(item.children);
+      }
+    }
+  }
+  walk(navData);
+  return slugs;
+}
+
+/**
+ * Generate llms.txt content following the llms.txt spec.
+ * Produces a markdown file with H1 title, blockquote description,
+ * and organized links to all doc pages.
+ */
+function generateLlmsTxt(navData) {
+  const lines = [];
+  lines.push("# measure.sh");
+  lines.push("");
+  lines.push(
+    "> Open-source, privacy-focused mobile analytics and crash reporting for Android, iOS, and Flutter apps."
+  );
+  lines.push("");
+
+  const standaloneItems = [];
+
+  for (const item of navData) {
+    if (item.children) {
+      lines.push(`## ${item.title}`);
+      lines.push("");
+      for (const child of item.children) {
+        if (child.children) {
+          // Nested group (e.g. Bug Reporting with Android/iOS/Flutter)
+          for (const grandchild of child.children) {
+            if (grandchild.slug) {
+              lines.push(
+                `- [${grandchild.title}](${SITE_URL}${grandchild.slug})`
+              );
+            }
+          }
+        } else if (child.slug) {
+          lines.push(`- [${child.title}](${SITE_URL}${child.slug})`);
+        }
+      }
+      lines.push("");
+    } else if (item.slug) {
+      standaloneItems.push(item);
+    }
+  }
+
+  if (standaloneItems.length > 0) {
+    lines.push("## Docs");
+    lines.push("");
+    for (const item of standaloneItems) {
+      lines.push(`- [${item.title}](${SITE_URL}${item.slug})`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Optional");
+  lines.push("");
+  lines.push(
+    `- [llms-full.txt](${SITE_URL}/llms-full.txt): Complete documentation in a single file`
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Rewrite relative markdown links and image paths to absolute URLs.
+ */
+function rewriteRelativeLinks(content) {
+  return content
+    .replace(
+      /\[([^\]]+)\]\((?!https?:\/\/)([^)]+\.md(?:#[^)]*)?)\)/g,
+      (match, text, href) => {
+        const slug = mdPathToSlug(href);
+        return `[${text}](${SITE_URL}${slug})`;
+      }
+    )
+    .replace(
+      /!\[([^\]]*)\]\((?:\.\/)?assets\/([^)]+)\)/g,
+      (match, alt, assetPath) => {
+        return `![${alt}](${SITE_URL}/docs/assets/${assetPath})`;
+      }
+    );
+}
+
+/**
+ * Generate llms-full.txt with all documentation concatenated.
+ * Follows the nav ordering, strips HTML comments, and rewrites
+ * relative links to absolute URLs.
+ */
+function generateLlmsFullTxt(docsDir, navData) {
+  const slugs = flattenNavSlugs(navData);
+  const seen = new Set();
+  const sections = [];
+
+  for (const slug of slugs) {
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+
+    const filePath = slugToFilePath(docsDir, slug);
+    if (!filePath) {
+      continue;
+    }
+
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const cleaned = stripHtmlComments(raw);
+    const rewritten = rewriteRelativeLinks(cleaned);
+    const sourceUrl =
+      slug === "/docs" ? `${SITE_URL}/docs` : `${SITE_URL}${slug}`;
+
+    sections.push(`---\nSource: ${sourceUrl}\n---\n\n${rewritten}`);
+  }
+
+  return sections.join("\n\n");
+}
+
+// Exports for testing
+module.exports = {
+  slugToFilePath,
+  flattenNavSlugs,
+  generateLlmsTxt,
+  generateLlmsFullTxt,
+  rewriteRelativeLinks,
+  SITE_URL,
+};
+
+// Main — only runs when executed directly, not when required by tests
+if (require.main === module) {
+  const docsDir = getDocsDirectory();
+  const navPath = path.join(rootDir, "content", "docs_nav.json");
+
+  if (!fs.existsSync(navPath)) {
+    console.error(
+      "Error: docs_nav.json not found. Run copy_docs.js first."
+    );
+    process.exit(1);
+  }
+
+  const navData = JSON.parse(fs.readFileSync(navPath, "utf-8"));
+
+  // Generate llms.txt
+  console.log("Generating llms.txt...");
+  const llmsTxt = generateLlmsTxt(navData);
+  const llmsTxtDest = path.join(rootDir, "public", "llms.txt");
+  fs.mkdirSync(path.dirname(llmsTxtDest), { recursive: true });
+  fs.writeFileSync(llmsTxtDest, llmsTxt);
+  console.log("llms.txt generated.");
+
+  // Generate llms-full.txt
+  console.log("Generating llms-full.txt...");
+  const llmsFullTxt = generateLlmsFullTxt(docsDir, navData);
+  const llmsFullTxtDest = path.join(rootDir, "public", "llms-full.txt");
+  fs.writeFileSync(llmsFullTxtDest, llmsFullTxt);
+  console.log("llms-full.txt generated.");
+
+  console.log("Done!");
+}

--- a/frontend/dashboard/scripts/generate_sitemap.js
+++ b/frontend/dashboard/scripts/generate_sitemap.js
@@ -4,7 +4,7 @@ const path = require('path')
 const ROOT = path.resolve(__dirname, '..')
 const APP_DIR = path.join(ROOT, 'app')
 const PUBLIC_DIR = path.join(ROOT, 'public')
-const SITE_URL = 'https://measure.sh'
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://measure.sh'
 
 function walk(dir) {
     const files = []


### PR DESCRIPTION
# Description

- adds llms.txt and llms-full.txt for providing docs to agents
- generate files as part of npm build
- uses site url to reference varialbes instead of hardcoding measure.sh in both new files and sitemap

## Related issue
Closes #3242



