### PR TITLE
ci: update workflow dependency versions

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/alerts
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/alerts

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/api
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/api

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/cleanup
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/cleanup

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/ingest
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/ingest

--- a/.github/workflows/metering.yml
+++ b/.github/workflows/metering.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/metering
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/metering

--- a/.github/workflows/migrator.yml
+++ b/.github/workflows/migrator.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/migrator
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/migrator

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/ingest
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/api

--- a/.github/workflows/symboloader.yml
+++ b/.github/workflows/symboloader.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/symboloader
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x"]
+        go-version: ["1.25.x", "1.26.x"]
     defaults:
       run:
         working-directory: backend/symboloader


### PR DESCRIPTION
## Summary

This PR updates workflow dependency to `actions/setup-go@v6` for all workflows using the go toolchain.