### PR TITLE
fix(backend): allow more characters for screen view event

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -63,7 +63,7 @@ const (
 	maxNavigationToChars                      = 128
 	maxNavigationFromChars                    = 128
 	maxNavigationSourceChars                  = 128
-	maxScreenViewNameChars                    = 128
+	maxScreenViewNameChars                    = 1024
 	maxCustomNameChars                        = 64
 	maxLayoutElementIDChars                   = 512
 	maxLayoutElementLabelChars                = 512


### PR DESCRIPTION
## Summary

This PR increases maximum allowed characters for the `screen_view`.`name` event field.

## See also

- fixes #2476

