### PR TITLE
fix(backend): add missing libs in alerts dockerfile

### DIFF
--- a/backend/alerts/dockerfile
+++ b/backend/alerts/dockerfile
@@ -6,12 +6,14 @@ ARG TARGETTYPE
 WORKDIR /go/src
 
 # Copy dependency modules first for caching
+COPY --from=libs go.mod go.sum ../libs/
 COPY --from=email go.mod go.sum ../email/
 COPY ["go.mod", "go.sum", "./"]
 
 RUN go mod download
 
 # Copy source
+COPY --from=libs . ../libs/
 COPY --from=email . ../email/
 COPY . .
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,6 +33,7 @@ target "alerts" {
   inherits = ["docker-metadata-action"]
   context = "backend/alerts"
   contexts = {
+    libs = "backend/libs"
     email = "backend/email"
   }
   dockerfile = "dockerfile"


### PR DESCRIPTION
## Summary

This PR updates alerts dockerfile to add the `libs` module to meet requirements for successful docker build.