### PR TITLE
chore(backend): add missing libs to alerts in compose.yml

### DIFF
--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -283,6 +283,7 @@ services:
       dockerfile: dockerfile
       context: ../backend/alerts
       additional_contexts:
+        libs: ../backend/libs
         email: ../backend/email
       args:
         TARGETTYPE: debug


### PR DESCRIPTION
# Description

Adds `libs` to `compose.yml` to fix docker compose build. Introduced in #3062.

