### PR TITLE
chore(backend): upgrade to clickhouse v25.12

### DIFF
--- a/backend/alerts/server/server.go
+++ b/backend/alerts/server/server.go
@@ -193,7 +193,7 @@ func Init(config *ServerConfig) {
 
 	chOpts.Settings = clickhouse.Settings{
 		// read more: https://clickhouse.com/docs/operations/settings/settings#compatibility
-		"compatibility": "25.10",
+		"compatibility": "25.12",
 	}
 
 	chPool, err = clickhouse.Open(chOpts)

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -448,7 +448,7 @@ func Init(config *ServerConfig) {
 
 	if gin.Mode() == gin.ReleaseMode {
 		// read more: https://clickhouse.com/docs/operations/settings/settings#compatibility
-		compatibility := "25.10"
+		compatibility := "25.12"
 		chOpts.Settings = clickhouse.Settings{
 			"wait_for_async_insert":         1,
 			"wait_for_async_insert_timeout": 1000,

--- a/backend/ingest/server/server.go
+++ b/backend/ingest/server/server.go
@@ -277,7 +277,7 @@ func Init(config *ServerConfig) {
 		chOpts.Settings = clickhouse.Settings{
 			"wait_for_async_insert":         1,
 			"wait_for_async_insert_timeout": 1000,
-			"compatibility":                 "25.10",
+			"compatibility":                 "25.12",
 		}
 
 		chOpts.Compression = &clickhouse.Compression{

--- a/backend/testinfra/testinfra.go
+++ b/backend/testinfra/testinfra.go
@@ -24,7 +24,7 @@ import (
 const (
 	// Test database credentials.
 	postgresImage   = "postgres:16.3-alpine"
-	clickhouseImage = "clickhouse/clickhouse-server:25.10-alpine"
+	clickhouseImage = "clickhouse/clickhouse-server:25.12-alpine"
 	valkeyImage     = "valkey/valkey:8-alpine"
 	testDBUser      = "test"
 	testDBPassword  = "test"

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -546,7 +546,7 @@ services:
       - ./postgres/init-postgres.sh:/docker-entrypoint-initdb.d/init-postgres.sh
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.10-alpine
+    image: clickhouse/clickhouse-server:25.12-alpine
     environment:
       - CLICKHOUSE_DB=measure
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}


### PR DESCRIPTION
## Summary

This PR upgrades to clickhouse v25.12 across all environments including local, test & production. Additionally, sets the default compatibility to 25.12 as well.

## See also

- fixes #3306

