### PR TITLE
fix(frontend): fix overlapping text in session timeline

### DIFF
--- a/frontend/dashboard/app/components/session_timeline_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_cell.tsx
@@ -160,15 +160,15 @@ export default function SessionTimelineEventCell({
   return (
     <button className={`group w-full px-2 py-4 font-display transition-all outline-none hover:bg-accent hover:text-accent-foreground dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${selected ? 'bg-accent dark:bg-accent text-accent-foreground dark:text-accent-foreground' : 'bg-background'}`}
       onClick={() => onClick(index)}>
-      <div className="flex flex-col md:flex-row items-start  md:items-center" id={`event-cell-title-${eventType}-${index}`}>
-        <div className={`w-2 h-2 rounded-full ${getColorFromEventType()}`} />
-        <div className="py-1 md:py-0 mx-0 md:mx-1" />
-        <p className='max-w-72 text-left text-sm md:text-base'>{getTitleFromEventType()}</p>
-        <div className="py-1 md:py-0 mx-0 md:mx-1" />
+      <div className="flex flex-col md:flex-row items-start md:items-center" id={`event-cell-title-${eventType}-${index}`}>
+        <div className={`w-2 h-2 flex-shrink-0 rounded-full ${getColorFromEventType()}`} />
+        <div className="py-1 md:mx-1" />
+        <p className='line-clamp-2 text-left text-sm md:text-base'>{getTitleFromEventType()}</p>
+        <div className="py-1 md:mx-1" />
         <div className="flex grow" />
-        <div className={`rounded-full border border-border text-xs px-2 py-1 ${selected ? 'border-accent-foreground dark:border-accent-foreground' : ''}`}>{threadName}</div>
-        <div className="py-1 md:py-0 mx-0 md:mx-1" />
-        <div className={`rounded-full border border-border text-xs px-2 py-1 text-nowrap ${selected ? 'border-accent-foreground dark:border-accent-foreground' : ''}`}>{formatDateToHumanReadableDateTime(timestamp)}</div>
+        <div className={`max-w-[10ch] truncate flex-shrink-0 rounded-full border border-border text-xs px-2 py-1 ${selected ? 'border-accent-foreground dark:border-accent-foreground' : ''}`}>{threadName}</div>
+        <div className="py-1 md:mx-1" />
+        <div className={`flex-shrink-0 rounded-full border border-border text-xs px-2 py-1 text-nowrap ${selected ? 'border-accent-foreground dark:border-accent-foreground' : ''}`}>{formatDateToHumanReadableDateTime(timestamp)}</div>
       </div>
     </button>
   )


### PR DESCRIPTION
# Description

- Make thread name truncate after 10 chars
- Do not allow the circle, pills (for timestamp and thread name) to shrink
- Limit title to 2 lines
- Remove redundant `md:py-0 mx-0` from spacer divs

## Related issue
Fixes #3285

**Before**
<img width="651" height="117" alt="image" src="https://github.com/user-attachments/assets/c7282e00-f339-4b73-82f9-2271090cb99c" />

**Now**
<img width="589" height="99" alt="image" src="https://github.com/user-attachments/assets/7c71753a-8e66-4d00-b625-57ecec7faee2" />


