### PR TITLE
fix(flutter): bump measure flutter package in dio

### DIFF
--- a/flutter/packages/measure_dio/pubspec.yaml
+++ b/flutter/packages/measure_dio/pubspec.yaml
@@ -2,7 +2,7 @@ name: measure_dio
 repository: https://github.com/measure-sh/measure/tree/main/flutter/packages/measure_dio
 issue_tracker: https://github.com/measure-sh/measure/issues
 description: Provides interceptors for monitoring http requests made using Dio library using measure.sh.
-version: 0.3.0
+version: 0.4.0
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   dio: ^5.3.4
-  measure_flutter: ^0.3.1
+  measure_flutter: ^0.4.0
 
 dependency_overrides:
   measure_flutter:


### PR DESCRIPTION
# Description

Update `measure_dio` dependency spec with `measure_flutter` bumped up to `0.4.0`.

## Related issue
Fixes #3315 