### PR TITLE
feat(android): add diagnostic mode for SDK logging

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -174,9 +174,10 @@ public abstract interface class sh/measure/android/bugreport/MsrShakeListener {
 public final class sh/measure/android/config/MeasureConfig : sh/measure/android/config/IMeasureConfig {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZIZZLsh/measure/android/config/MsrRequestHeadersProvider;Z)V
-	public synthetic fun <init> (ZIZZLsh/measure/android/config/MsrRequestHeadersProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZIZZLsh/measure/android/config/MsrRequestHeadersProvider;ZZ)V
+	public synthetic fun <init> (ZIZZLsh/measure/android/config/MsrRequestHeadersProvider;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAutoStart ()Z
+	public fun getEnableDiagnosticMode ()Z
 	public fun getEnableFullCollectionMode ()Z
 	public fun getEnableLogging ()Z
 	public fun getMaxDiskUsageInMb ()I

--- a/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -46,6 +46,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override val requestHeadersProvider: MsrRequestHeadersProvider? = null
     override val journeySamplingRate: Float = 0.01f
     override val enableFullCollectionMode: Boolean = true
+    override val enableDiagnosticMode: Boolean = false
 
     override val crashTimelineDurationSeconds: Int = 300
     override val anrTimelineDurationSeconds: Int = 300

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -119,6 +119,7 @@ internal class MeasureInitializerImpl(
             maxDiskUsageInMb = inputConfig.maxDiskUsageInMb,
             trackActivityIntentData = inputConfig.trackActivityIntentData,
             enableFullCollectionMode = inputConfig.enableFullCollectionMode,
+            enableDiagnosticMode = inputConfig.enableDiagnosticMode,
             requestHeadersProvider = inputConfig.requestHeadersProvider,
         ),
     ),
@@ -137,7 +138,7 @@ internal class MeasureInitializerImpl(
         fileStorage = fileStorage,
         configProvider = configProvider,
     ),
-    private val idProvider: IdProvider = IdProviderImpl(randomizer),
+    override val idProvider: IdProvider = IdProviderImpl(randomizer),
     override val processInfoProvider: ProcessInfoProvider = ProcessInfoProviderImpl(),
     private val prefsStorage: PrefsStorage = PrefsStorageImpl(
         context = application,
@@ -494,5 +495,6 @@ internal interface MeasureInitializer {
     val internalSignalCollector: InternalSignalCollector
     val spanAttributeProcessors: List<AttributeProcessor>
     val fileStorage: FileStorage
+    val idProvider: IdProvider
     val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler
 }

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -9,6 +9,7 @@ import sh.measure.android.bugreport.MsrShakeListener
 import sh.measure.android.events.EventType
 import sh.measure.android.lifecycle.AppLifecycleListener
 import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.SdkDebugLogWriter
 import sh.measure.android.tracing.Span
 import sh.measure.android.tracing.SpanBuilder
 import sh.measure.android.utils.AttachmentHelper
@@ -31,6 +32,24 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
     private val lock = Any()
 
     fun init() {
+        try {
+            if (measure.configProvider.enableDiagnosticMode) {
+                val writer = SdkDebugLogWriter(
+                    logsDir = measure.fileStorage.getSdkDebugLogsDirectory(),
+                    sdkVersion = BuildConfig.MEASURE_SDK_VERSION,
+                    timestamp = measure.timeProvider.now(),
+                    fileId = measure.idProvider.uuid(),
+                    ioExecutor = measure.executorServiceRegistry.ioExecutor(),
+                )
+                writer.start()
+                measure.logger.setLogCallback { level, message, throwable ->
+                    writer.writeLog(level, message, throwable)
+                }
+            }
+        } catch (_: Exception) {
+            // Silently ignore to avoid affecting SDK initialization
+        }
+
         if (!setupNetworkClient()) {
             return
         }

--- a/android/measure/src/main/java/sh/measure/android/config/Config.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/Config.kt
@@ -10,6 +10,7 @@ internal data class Config(
     override val trackActivityIntentData: Boolean = DefaultConfig.TRACK_ACTIVITY_INTENT_DATA,
     override val requestHeadersProvider: MsrRequestHeadersProvider? = null,
     override val enableFullCollectionMode: Boolean = DefaultConfig.ENABLE_FULL_COLLECTION_MODE,
+    override val enableDiagnosticMode: Boolean = DefaultConfig.ENABLE_DIAGNOSTIC_MODE,
 ) : InternalConfig,
     IMeasureConfig {
     override val screenshotMaskHexColor: String = "#222222"

--- a/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -107,6 +107,7 @@ internal class ConfigProviderImpl(defaultConfig: Config) : ConfigProvider {
     override val requestHeadersProvider: MsrRequestHeadersProvider? =
         defaultConfig.requestHeadersProvider
     override val enableFullCollectionMode: Boolean = defaultConfig.enableFullCollectionMode
+    override val enableDiagnosticMode: Boolean = defaultConfig.enableDiagnosticMode
 
     // Dynamic config properties - use getters so they reflect current dynamicConfig state
     override val maxEventsInBatch: Int

--- a/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/DefaultConfig.kt
@@ -10,6 +10,7 @@ internal object DefaultConfig {
     val DISALLOWED_CUSTOM_HEADERS: List<String> =
         listOf("Content-Type", "msr-req-id", "Authorization", "Content-Length")
     const val ENABLE_FULL_COLLECTION_MODE: Boolean = false
+    const val ENABLE_DIAGNOSTIC_MODE: Boolean = false
     val JOURNEY_EVENTS = listOf(
         EventType.LIFECYCLE_ACTIVITY,
         EventType.LIFECYCLE_FRAGMENT,

--- a/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
+++ b/android/measure/src/main/java/sh/measure/android/config/MeasureConfig.kt
@@ -14,6 +14,7 @@ internal interface IMeasureConfig {
     val trackActivityIntentData: Boolean
     val requestHeadersProvider: MsrRequestHeadersProvider?
     val enableFullCollectionMode: Boolean
+    val enableDiagnosticMode: Boolean
 }
 
 /**
@@ -76,4 +77,15 @@ class MeasureConfig(
      * only be enabled for debug mode.
      */
     override val enableFullCollectionMode: Boolean = DefaultConfig.ENABLE_FULL_COLLECTION_MODE,
+
+    /**
+     * Enables diagnostic mode which writes all SDK logs to a file. The log file can be attached
+     * when reporting a bug to help with debugging SDK issues. Defaults to `false`.
+     *
+     * To pull all log files from a device:
+     * ```
+     * adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+     * ```
+     */
+    override val enableDiagnosticMode: Boolean = DefaultConfig.ENABLE_DIAGNOSTIC_MODE,
 ) : IMeasureConfig

--- a/android/measure/src/main/java/sh/measure/android/logger/AndroidLogger.kt
+++ b/android/measure/src/main/java/sh/measure/android/logger/AndroidLogger.kt
@@ -7,12 +7,18 @@ import android.util.Log
  */
 internal class AndroidLogger(override val enabled: Boolean) : Logger {
     private val tag = "Measure"
+    private var logCallback: ((LogLevel, String, Throwable?) -> Unit)? = null
 
     override fun log(level: LogLevel, message: String, throwable: Throwable?) {
+        logCallback?.invoke(level, message, throwable)
         if (!enabled) return
         when (level) {
             LogLevel.Debug -> Log.d(tag, message, throwable)
             LogLevel.Error -> Log.e(tag, message, throwable)
         }
+    }
+
+    override fun setLogCallback(callback: ((LogLevel, String, Throwable?) -> Unit)?) {
+        logCallback = callback
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/logger/Logger.kt
+++ b/android/measure/src/main/java/sh/measure/android/logger/Logger.kt
@@ -9,6 +9,7 @@ internal interface Logger {
      */
     val enabled: Boolean
     fun log(level: LogLevel, message: String, throwable: Throwable? = null)
+    fun setLogCallback(callback: ((LogLevel, String, Throwable?) -> Unit)?)
 }
 
 /**

--- a/android/measure/src/main/java/sh/measure/android/logger/SdkDebugLogWriter.kt
+++ b/android/measure/src/main/java/sh/measure/android/logger/SdkDebugLogWriter.kt
@@ -1,0 +1,83 @@
+package sh.measure.android.logger
+
+import okio.BufferedSink
+import okio.buffer
+import okio.sink
+import sh.measure.android.executors.MeasureExecutorService
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Writes SDK debug logs to a file. Logs are buffered in memory and flushed to disk every 3 seconds
+ * on the IO executor thread. The file sink is kept open for the lifetime of the writer.
+ *
+ * Thread safety: [writeLog] can be called from any thread. The buffer is guarded by [lock].
+ * All file I/O (including [sink] access) runs exclusively on the single-threaded [ioExecutor].
+ */
+internal class SdkDebugLogWriter(
+    private val logsDir: String,
+    private val sdkVersion: String,
+    private val timestamp: Long,
+    private val fileId: String,
+    private val ioExecutor: MeasureExecutorService,
+) {
+    private val buffer = mutableListOf<LogEntry>()
+    private val lock = Any()
+
+    // Only accessed from ioExecutor thread
+    private var sink: BufferedSink? = null
+
+    fun start() {
+        ioExecutor.submit {
+            try {
+                val dir = File(logsDir)
+                if (!dir.exists()) dir.mkdirs()
+                val file = File(dir, fileId)
+                sink = file.sink().buffer()
+                sink?.writeUtf8("$sdkVersion $timestamp\n")?.flush()
+            } catch (_: Exception) {
+                // No-op
+            }
+        }
+        ioExecutor.scheduleAtFixedRate(
+            { flush() },
+            initialDelay = 3000L,
+            delayMillis = 3000L,
+            delayUnit = TimeUnit.MILLISECONDS,
+        )
+    }
+
+    fun writeLog(level: LogLevel, message: String, throwable: Throwable?) {
+        synchronized(lock) {
+            buffer.add(LogEntry(level, message, throwable))
+        }
+    }
+
+    private fun flush() {
+        val entries: List<LogEntry>
+        synchronized(lock) {
+            if (buffer.isEmpty()) return
+            entries = buffer.toList()
+            buffer.clear()
+        }
+        try {
+            val s = sink ?: return
+            entries.forEach { entry ->
+                s.writeUtf8("${entry.level.name} ${entry.message}")
+                if (entry.throwable != null) {
+                    s.writeUtf8(" ${entry.throwable.stackTraceToString()}")
+                }
+                s.writeUtf8("\n")
+            }
+            s.flush()
+        } catch (_: Exception) {
+            // No-op
+        }
+    }
+
+    private data class LogEntry(
+        val level: LogLevel,
+        val message: String,
+        val throwable: Throwable?,
+    )
+}

--- a/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
@@ -99,10 +99,16 @@ internal interface FileStorage {
      * Validates that the file exists.
      */
     fun validateFile(path: String): Boolean
+
+    /**
+     * Returns the directory where SDK debug log files are stored.
+     */
+    fun getSdkDebugLogsDirectory(): String
 }
 
 private const val MEASURE_DIR = "measure"
 private const val BUG_REPORTS_DIR = "bug_reports"
+private const val SDK_DEBUG_LOGS_DIR = "sdk_debug_logs"
 private const val CONFIG_FILE_NAME = "config.json"
 
 internal class FileStorageImpl(
@@ -198,6 +204,20 @@ internal class FileStorageImpl(
     override fun getConfigFile(): File? = getOrCreateFile(CONFIG_FILE_NAME)
 
     override fun getConfigPath(): String = "$rootDir/$MEASURE_DIR/$CONFIG_FILE_NAME"
+
+    override fun getSdkDebugLogsDirectory(): String {
+        val dirPath = "$rootDir/$MEASURE_DIR/$SDK_DEBUG_LOGS_DIR"
+        val dir = File(dirPath)
+        try {
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+        } catch (e: SecurityException) {
+            logger.log(LogLevel.Debug, "Failed to create sdk debug logs directory", e)
+            return dirPath
+        }
+        return dirPath
+    }
 
     override fun validateFile(path: String): Boolean {
         val file = getFile(path)

--- a/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -37,6 +37,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override var estimatedEventSizeInKb: Int = 2
     override var maxDiskUsageInMb: Int = 50
     override var enableFullCollectionMode: Boolean = true
+    override var enableDiagnosticMode: Boolean = false
     override var maxEventsInBatch: Int = 1000
     override var crashTimelineDurationSeconds: Int = 300
     override var anrTimelineDurationSeconds: Int = 300

--- a/android/measure/src/test/java/sh/measure/android/fakes/NoopLogger.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/NoopLogger.kt
@@ -9,4 +9,8 @@ internal class NoopLogger : Logger {
     override fun log(level: LogLevel, message: String, throwable: Throwable?) {
         // No-op
     }
+
+    override fun setLogCallback(callback: ((LogLevel, String, Throwable?) -> Unit)?) {
+        // No-op
+    }
 }

--- a/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
+++ b/android/sample/src/main/java/sh/measure/sample/SampleApp.kt
@@ -17,6 +17,7 @@ class SampleApp : Application() {
                 autoStart = true,
                 maxDiskUsageInMb = 1500,
                 enableFullCollectionMode = false,
+                enableDiagnosticMode = true,
             )
         )
         val appOnCreateSpan = Measure.startSpan("SampleApp.onCreate", timestamp = startTime)

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -21,6 +21,7 @@ available in two ways:
     * [**requestHeadersProvider**](#requestHeadersProvider)
     * [**maxDiskUsageInMb**](#maxDiskUsageInMb)
     * [**enableFullCollectionMode**](#enableFullCollectionMode)
+    * [**enableDiagnosticMode**](#enableDiagnosticMode)
 * [**Remote Configuration Options**](#remote-configuration-options)
     * [**Crash Reporting**](#crash-reporting)
     * [**ANR Reporting**](#anr-reporting)
@@ -47,6 +48,7 @@ Measure.init(
         trackActivityIntentData = true,
         requestHeadersProvider = customRequestHeadersProvider,
         enableFullCollectionMode = false,
+        enableDiagnosticMode = false,
     )
 )
 ```
@@ -228,6 +230,36 @@ space for new data.
 Overrides all sampling configurations and enables full data collection for all sessions. Use this option for debugging
 and testing purposes. Defaults to `false`. Use this option with caution as it can lead to high data collection and
 storage costs if done at scale in production.
+
+## `enableDiagnosticMode`
+
+_Applies only to Android._
+
+Enables diagnostic mode which writes all internal SDK logs to a file on disk. The log file can be
+attached when reporting a bug to help with debugging SDK issues.
+
+Log files are stored in the app's internal storage at `files/measure/sdk_debug_logs/`. Each file is
+named with a unique ID and contains a header line with the SDK version and timestamp, followed by all
+SDK log entries.
+
+Defaults to `false`.
+
+> [!NOTE]
+> These files only contain Measure SDK logs, not your app's logs.
+
+#### Pulling log files via adb
+
+To pull all log files to your local machine:
+
+```shell
+adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+```
+
+To delete all diagnostic log files:
+
+```shell
+adb shell run-as <your.package.name> rm -rf files/measure/sdk_debug_logs/
+```
 
 # Remote Configuration Options
 


### PR DESCRIPTION
# Description

Implements a new diagnostic mode. Which, when enabled, writes all Measure SDK logs to a file. This allows users to easily share information when submitting bug reports.

## Related issue
References #3332 
