### PR TITLE
chore(android): increase read and connection timeout

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
@@ -41,8 +41,8 @@ internal interface HttpClient {
  * body in memory.
  */
 internal class HttpUrlConnectionClient(private val logger: Logger) : HttpClient {
-    private val connectionTimeoutMs = 30_000
-    private val readTimeoutMs = 10_000
+    private val connectionTimeoutMs = 60_000
+    private val readTimeoutMs = 60_000
     private val maxRedirects = 5
 
     override fun sendJsonRequest(


### PR DESCRIPTION
# Description

Increases read and connection timeout to be 60s.

## Related issue
Closes #3334 


