### PR TITLE
chore(android): export existing events when a new session starts

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -145,6 +145,7 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
             // always sample session start event
             isSampled = true,
         )
+        measure.exporter.flush()
     }
 
     fun setUserId(userId: String) {

--- a/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -19,7 +19,17 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface Exporter {
+    /**
+     * Exports existing batches and attachments,
+     * creates new batches if needed and exports
+     * them one by one.
+     */
     fun export()
+
+    /**
+     * Exports existing batches and attachments.
+     */
+    fun flush()
 }
 
 internal class ExporterImpl(
@@ -53,24 +63,21 @@ internal class ExporterImpl(
         }
     }
 
+    override fun flush() {
+        if (isExporting.compareAndSet(false, true)) {
+            eventExportService.submit {
+                exportExistingBatches()
+                exportAttachments()
+            }
+        }
+    }
+
     private fun exportEvents() {
         try {
             eventExportService.submit {
                 try {
                     // First export existing batches
-                    val existingBatches = database.getBatchIds()
-                    if (existingBatches.isNotEmpty()) {
-                        logger.log(
-                            LogLevel.Debug,
-                            "Exporter: found ${existingBatches.size} existing batches, exporting",
-                        )
-
-                        val success = exportBatches(existingBatches)
-                        if (!success) {
-                            // abort if no batches found or export failed
-                            return@submit
-                        }
-                    }
+                    if (exportExistingBatches()) return@submit
 
                     // Then create new batches and export
                     val batchesCreatedCount = database.batchSessions(
@@ -98,6 +105,22 @@ internal class ExporterImpl(
         } catch (e: RejectedExecutionException) {
             logger.log(LogLevel.Error, "Exporter: failed to submit export task", e)
         }
+    }
+
+    private fun exportExistingBatches(): Boolean {
+        val existingBatches = database.getBatchIds()
+        if (existingBatches.isNotEmpty()) {
+            logger.log(
+                LogLevel.Debug,
+                "Exporter: found ${existingBatches.size} existing batches, exporting",
+            )
+
+            val success = exportBatches(existingBatches)
+            if (!success) {
+                return true
+            }
+        }
+        return false
     }
 
     private fun exportBatches(batches: List<String>): Boolean {

--- a/android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
@@ -396,6 +396,14 @@ class MeasureInternalTest {
         )
     }
 
+    @Test
+    fun `session start callback triggers export for existing batches`() {
+        val initializer = mockMeasureInitializer()
+        val measureInternal = MeasureInternal(initializer)
+        measureInternal.onSessionStart("session-id", 123456789L)
+        verify(initializer.exporter).flush()
+    }
+
     private fun initWithValidCredentials(): MeasureInitializer {
         val initializer = mockMeasureInitializer()
         val manifest = ManifestMetadata("https://api.measure.sh", "msrsh_123")

--- a/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -80,6 +80,67 @@ internal class ExporterTest {
     }
 
     @Test
+    fun `flush skips when already exporting`() {
+        exporter.isExporting.set(true)
+
+        exporter.flush()
+
+        verify(networkClient, never()).execute(any(), any(), any())
+    }
+
+    @Test
+    fun `flush exports existing batches`() {
+        whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
+
+        insertSessionInDb("session1")
+        insertEventInDb("session1", "event1", sampled = true)
+        insertBatchInDb("batch1", eventIds = setOf("event1"))
+
+        exporter.flush()
+
+        verify(networkClient).execute(
+            eq("batch1"),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `flush exports attachments`() {
+        val responseJson = attachmentResponseJson("attachment-1")
+        whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success(responseJson))
+        whenever(httpClient.uploadFile(any(), any(), anyOrNull(), any(), any(), any())).thenReturn(HttpResponse.Success())
+
+        val attachmentFile = createTempAttachmentFile("attachment-1")
+        insertSessionInDb("session1")
+        insertEventInDb(
+            sessionId = "session1",
+            eventId = "event1",
+            sampled = true,
+            attachments = listOf(
+                AttachmentEntity(
+                    id = "attachment-1",
+                    type = "screenshot",
+                    path = attachmentFile.absolutePath,
+                    name = "screenshot.png",
+                ),
+            ),
+        )
+        insertBatchInDb("batch1", eventIds = setOf("event1"))
+
+        exporter.flush()
+
+        verify(httpClient).uploadFile(
+            eq("https://example.com/upload/attachment-1"),
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
     fun `exports existing batches in order`() {
         whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
 


### PR DESCRIPTION
# Description

Improve delivery of existing batches by flushing existing batches and attachments as soon as a session is created.

## Related issue
Closes #3337 


