### PR TITLE
chore(android): refactor sdk diagnostic log writing

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -138,7 +138,7 @@ internal class MeasureInitializerImpl(
         fileStorage = fileStorage,
         configProvider = configProvider,
     ),
-    override val idProvider: IdProvider = IdProviderImpl(randomizer),
+    private val idProvider: IdProvider = IdProviderImpl(randomizer),
     override val processInfoProvider: ProcessInfoProvider = ProcessInfoProviderImpl(),
     private val prefsStorage: PrefsStorage = PrefsStorageImpl(
         context = application,
@@ -494,6 +494,5 @@ internal interface MeasureInitializer {
     val internalSignalCollector: InternalSignalCollector
     val spanAttributeProcessors: List<AttributeProcessor>
     val fileStorage: FileStorage
-    val idProvider: IdProvider
     val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler
 }

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -13,6 +13,7 @@ import sh.measure.android.logger.SdkDebugLogWriter
 import sh.measure.android.tracing.Span
 import sh.measure.android.tracing.SpanBuilder
 import sh.measure.android.utils.AttachmentHelper
+import sh.measure.android.utils.iso8601Timestamp
 
 /**
  * Initializes the Measure SDK and hides the internal dependencies from public API.
@@ -34,16 +35,20 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
     fun init() {
         try {
             if (measure.configProvider.enableDiagnosticMode) {
-                val writer = SdkDebugLogWriter(
-                    logsDir = measure.fileStorage.getSdkDebugLogsDirectory(),
-                    sdkVersion = BuildConfig.MEASURE_SDK_VERSION,
-                    timestamp = measure.timeProvider.now(),
-                    fileId = measure.idProvider.uuid(),
-                    ioExecutor = measure.executorServiceRegistry.ioExecutor(),
-                )
-                writer.start()
-                measure.logger.setLogCallback { level, message, throwable ->
-                    writer.writeLog(level, message, throwable)
+                val logsDir = measure.fileStorage.getSdkDebugLogsDirectory()
+                if (logsDir != null) {
+                    val now = measure.timeProvider.now()
+                    val writer = SdkDebugLogWriter(
+                        logsDir = logsDir,
+                        sdkVersion = BuildConfig.MEASURE_SDK_VERSION,
+                        fileName = now.toString(),
+                        timestamp = now.iso8601Timestamp(),
+                        ioExecutor = measure.executorServiceRegistry.ioExecutor(),
+                    )
+                    writer.start()
+                    measure.logger.setLogCallback { level, message, throwable ->
+                        writer.writeLog(level, message, throwable)
+                    }
                 }
             }
         } catch (_: Exception) {

--- a/android/measure/src/main/java/sh/measure/android/logger/SdkDebugLogWriter.kt
+++ b/android/measure/src/main/java/sh/measure/android/logger/SdkDebugLogWriter.kt
@@ -15,10 +15,10 @@ import java.util.concurrent.TimeUnit
  * All file I/O (including [sink] access) runs exclusively on the single-threaded [ioExecutor].
  */
 internal class SdkDebugLogWriter(
-    private val logsDir: String,
+    private val logsDir: File,
     private val sdkVersion: String,
-    private val timestamp: Long,
-    private val fileId: String,
+    private val fileName: String,
+    private val timestamp: String,
     private val ioExecutor: MeasureExecutorService,
 ) {
     private val buffer = mutableListOf<LogEntry>()
@@ -30,9 +30,7 @@ internal class SdkDebugLogWriter(
     fun start() {
         ioExecutor.submit {
             try {
-                val dir = File(logsDir)
-                if (!dir.exists()) dir.mkdirs()
-                val file = File(dir, fileId)
+                val file = File(logsDir, fileName)
                 sink = file.sink().buffer()
                 sink?.writeUtf8("$sdkVersion $timestamp\n")?.flush()
             } catch (_: Exception) {

--- a/android/measure/src/main/java/sh/measure/android/storage/DataCleanupService.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/DataCleanupService.kt
@@ -14,6 +14,7 @@ internal interface DataCleanupService {
 }
 
 private const val DB_DELETION_BATCH_SIZE = 1000
+private const val MAX_SDK_DEBUG_LOG_FILES = 5
 
 /**
  * Cleans up stale data from the database and file storage.
@@ -43,6 +44,7 @@ internal class DataCleanupServiceImpl(
                     deleteBugReports(currentSessionId)
                     deleteEmptySessions(currentSessionId)
                     trimMemoryUsage(currentSessionId)
+                    trimSdkDebugLogs()
                 },
             )
         }
@@ -173,6 +175,23 @@ internal class DataCleanupServiceImpl(
                 }
             },
         )
+    }
+
+    private fun trimSdkDebugLogs() {
+        try {
+            val dir = fileStorage.getSdkDebugLogsDirectory() ?: return
+            val files = dir.listFiles() ?: return
+            if (files.size <= MAX_SDK_DEBUG_LOG_FILES) return
+
+            val filesToDelete = files.sortedBy { it.name }.dropLast(MAX_SDK_DEBUG_LOG_FILES)
+            logger.log(
+                LogLevel.Debug,
+                "Cleanup: Deleting ${filesToDelete.size} old SDK debug log files",
+            )
+            filesToDelete.forEach { it.delete() }
+        } catch (e: Exception) {
+            logger.log(LogLevel.Debug, "Cleanup: Failed to clean up SDK debug log files", e)
+        }
     }
 
     private fun trimMemoryUsage(currentSessionId: String) {

--- a/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/FileStorage.kt
@@ -101,9 +101,9 @@ internal interface FileStorage {
     fun validateFile(path: String): Boolean
 
     /**
-     * Returns the directory where SDK debug log files are stored.
+     * Returns the directory where SDK debug log files are stored, or null if it doesn't exist.
      */
-    fun getSdkDebugLogsDirectory(): String
+    fun getSdkDebugLogsDirectory(): File?
 }
 
 private const val MEASURE_DIR = "measure"
@@ -205,18 +205,17 @@ internal class FileStorageImpl(
 
     override fun getConfigPath(): String = "$rootDir/$MEASURE_DIR/$CONFIG_FILE_NAME"
 
-    override fun getSdkDebugLogsDirectory(): String {
-        val dirPath = "$rootDir/$MEASURE_DIR/$SDK_DEBUG_LOGS_DIR"
-        val dir = File(dirPath)
-        try {
+    override fun getSdkDebugLogsDirectory(): File? {
+        val dir = File("$rootDir/$MEASURE_DIR/$SDK_DEBUG_LOGS_DIR")
+        return try {
             if (!dir.exists()) {
                 dir.mkdirs()
             }
+            if (dir.exists()) dir else null
         } catch (e: SecurityException) {
             logger.log(LogLevel.Debug, "Failed to create sdk debug logs directory", e)
-            return dirPath
+            null
         }
-        return dirPath
     }
 
     override fun validateFile(path: String): Boolean {

--- a/android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
@@ -287,5 +287,55 @@ class DataCleanupServiceTest {
         val bugReportsDir = mock<File>()
         `when`(fileStorage.getBugReportDir()).thenReturn(bugReportsDir)
         `when`(bugReportsDir.exists()).thenReturn(false)
+
+        // Default mocks for trimSdkDebugLogs
+        `when`(fileStorage.getSdkDebugLogsDirectory()).thenReturn(null)
+    }
+
+    @Test
+    fun `trimSdkDebugLogs deletes oldest files when more than 5 exist`() {
+        tempTestDir = createTempDirectory("sdk-debug-logs-test").toFile()
+        // Create 7 files with timestamp names (sorted by name = sorted by time)
+        val files = (1L..7L).map { ts ->
+            File(tempTestDir!!, ts.toString()).apply { writeText("log") }
+        }
+
+        setupDefaultMocks()
+        `when`(fileStorage.getSdkDebugLogsDirectory()).thenReturn(tempTestDir)
+
+        dataCleanupService.cleanup()
+
+        // Oldest 2 should be deleted, newest 5 kept
+        assertFalse(files[0].exists())
+        assertFalse(files[1].exists())
+        assertTrue(files[2].exists())
+        assertTrue(files[3].exists())
+        assertTrue(files[4].exists())
+        assertTrue(files[5].exists())
+        assertTrue(files[6].exists())
+    }
+
+    @Test
+    fun `trimSdkDebugLogs does nothing when 5 or fewer files exist`() {
+        tempTestDir = createTempDirectory("sdk-debug-logs-test").toFile()
+        val files = (1L..5L).map { ts ->
+            File(tempTestDir!!, ts.toString()).apply { writeText("log") }
+        }
+
+        setupDefaultMocks()
+        `when`(fileStorage.getSdkDebugLogsDirectory()).thenReturn(tempTestDir)
+
+        dataCleanupService.cleanup()
+
+        files.forEach { assertTrue(it.exists()) }
+    }
+
+    @Test
+    fun `trimSdkDebugLogs handles null directory gracefully`() {
+        setupDefaultMocks()
+        `when`(fileStorage.getSdkDebugLogsDirectory()).thenReturn(null)
+
+        // Should not throw
+        dataCleanupService.cleanup()
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/storage/FileStorageTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/FileStorageTest.kt
@@ -93,4 +93,22 @@ class FileStorageTest {
         assertTrue(file.exists())
         assertTrue(file.isDirectory)
     }
+
+    @Test
+    fun `getSdkDebugLogsDirectory creates and returns directory`() {
+        val dir = fileStorage.getSdkDebugLogsDirectory()
+        assertNotNull(dir)
+        assertTrue(dir!!.exists())
+        assertTrue(dir.isDirectory)
+        assertTrue(dir.path.endsWith("measure/sdk_debug_logs"))
+    }
+
+    @Test
+    fun `getSdkDebugLogsDirectory returns existing directory on subsequent calls`() {
+        val dir1 = fileStorage.getSdkDebugLogsDirectory()
+        val dir2 = fileStorage.getSdkDebugLogsDirectory()
+        assertNotNull(dir1)
+        assertNotNull(dir2)
+        assertTrue(dir1!!.path == dir2!!.path)
+    }
 }

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -233,6 +233,9 @@ storage costs if done at scale in production.
 
 ## `enableDiagnosticMode`
 
+> [!WARNING]
+> These files only contain Measure SDK logs, not your app's logs. This option should only be enabled in debug builds.
+
 _Applies only to Android._
 
 Enables diagnostic mode which writes all internal SDK logs to a file on disk. The log file can be
@@ -242,17 +245,16 @@ Log files are stored in the app's internal storage at `files/measure/sdk_debug_l
 named with a unique ID and contains a header line with the SDK version and timestamp, followed by all
 SDK log entries.
 
-Defaults to `false`.
+Only the 5 most recent files are kept, rest are cleaned up automatically.
 
-> [!NOTE]
-> These files only contain Measure SDK logs, not your app's logs.
+Defaults to `false`.
 
 #### Pulling log files via adb
 
 To pull all log files to your local machine:
 
 ```shell
-adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+adb shell "run-as <your.package.name> tar czf - measure/sdk_debug_logs/" > sdk_debug_logs.tar.gz
 ```
 
 To delete all diagnostic log files:

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -567,3 +567,50 @@ For example: set the API URL to `https://measure-api.<your-domain>.com`, replaci
 If none of the above steps resolve the issue, feel free to reach out to us on [Discord](https://discord.gg/f6zGkBCt42)
 for further
 assistance.
+
+### Enable Diagnostic Mode (Android only)
+
+If you're experiencing issues with the SDK and need to share detailed logs with us, enable diagnostic mode.
+This writes all internal SDK logs to files on disk which can then be pulled from the device and shared
+when reporting a bug.
+
+> [!NOTE]
+> These files only contain Measure SDK logs, not your app's logs.
+
+#### Step 1: Enable diagnostic mode
+
+```kotlin
+val config = MeasureConfig(enableDiagnosticMode = true)
+Measure.init(context, config)
+```
+
+#### Step 2: Reproduce the issue
+
+Run the app and reproduce the issue you're facing. The SDK will write logs to files in the
+app's internal storage.
+
+#### Step 3: Pull the log files
+
+Use `adb` to retrieve the log files from the device:
+
+```shell
+# List all diagnostic log files
+adb shell run-as <your.package.name> ls files/measure/sdk_debug_logs/
+
+# Pull all log files as a tar.gz archive
+adb shell "run-as <your.package.name> tar czf - files/measure/sdk_debug_logs/" > /tmp/sdk_debug_logs.tar.gz
+```
+
+#### Step 4: Share the files
+
+Share the pulled log files on [Discord](https://discord.gg/f6zGkBCt42) or send them to us via email
+for us to investigate.
+
+#### Step 5: Disable diagnostic mode
+
+Once you've collected the logs, disable diagnostic mode by removing the `enableDiagnosticMode` flag
+or setting it to `false`. You can also delete the log files from the device:
+
+```shell
+adb shell run-as <your.package.name> rm -rf files/measure/sdk_debug_logs/
+```


### PR DESCRIPTION
# Description

  - Add cleanup for SDK diagnostic log files, keeping a maximum of 5 files and deleting the oldest during periodic cleanup
  - Use timestamp-based file naming for diagnostic logs instead of UUID
  - Add troubleshooting guide for diagnostic mode with step-by-step instructions for pulling log files via adb
  - Sync buffer to file every second to reduce the data lost for app crashes/ANRs 

## Related issue
References #3332 



