### PR TITLE
chore(android): fix incorrect export flag handling

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -245,7 +245,6 @@ internal class TestMeasureInitializer(
         idProvider = idProvider,
         configProvider = configProvider,
         eventExportService = executorServiceRegistry.eventExportExecutor(),
-        attachmentExportService = executorServiceRegistry.attachmentExportExecutor(),
         httpClient = HttpUrlConnectionClient(logger),
         timeProvider = timeProvider,
         sleeper = DefaultSleeper(),

--- a/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -269,7 +269,6 @@ internal class MeasureInitializerImpl(
         httpClient = httpClient,
         configProvider = configProvider,
         eventExportService = executorServiceRegistry.eventExportExecutor(),
-        attachmentExportService = executorServiceRegistry.attachmentExportExecutor(),
     ),
     override val signalProcessor: SignalProcessor = SignalProcessorImpl(
         logger = logger,

--- a/android/measure/src/main/java/sh/measure/android/executors/ExecutorServiceRegistry.kt
+++ b/android/measure/src/main/java/sh/measure/android/executors/ExecutorServiceRegistry.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ThreadFactory
  */
 internal interface ExecutorServiceRegistry {
     /**
-     * An executor service dedicated to long running background tasks. Example a database
+     * An executor service dedicated to long-running background tasks. Example a database
      * query or a disk read/write, etc. For exporting data to network, use [eventExportExecutor].
      */
     fun ioExecutor(): MeasureExecutorService
@@ -19,12 +19,7 @@ internal interface ExecutorServiceRegistry {
     fun eventExportExecutor(): MeasureExecutorService
 
     /**
-     * Returns an executor service dedicated to exporting attachments to network.
-     */
-    fun attachmentExportExecutor(): MeasureExecutorService
-
-    /**
-     * An executor for running short lived tasks. Example: processing an event.
+     * An executor for running short-lived tasks. Example: processing an event.
      */
     fun defaultExecutor(): MeasureExecutorService
 }
@@ -47,11 +42,6 @@ internal class ExecutorServiceRegistryImpl : ExecutorServiceRegistry {
         MeasureExecutorServiceImpl(threadFactory)
     }
 
-    override fun attachmentExportExecutor(): MeasureExecutorService = executors.getOrPut(ExecutorServiceName.AttachmentExportExecutor) {
-        val threadFactory = namedThreadFactory("msr-attachment-export")
-        MeasureExecutorServiceImpl(threadFactory)
-    }
-
     private fun namedThreadFactory(threadName: String) = ThreadFactory { runnable: Runnable ->
         Executors.defaultThreadFactory().newThread(runnable).apply {
             this.name = threadName
@@ -63,5 +53,4 @@ private enum class ExecutorServiceName {
     IOExecutor,
     DefaultExecutor,
     EventExportExecutor,
-    AttachmentExportExecutor,
 }

--- a/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -43,7 +43,6 @@ internal class ExporterImpl(
     private val httpClient: HttpClient,
     private val configProvider: ConfigProvider,
     private val eventExportService: MeasureExecutorService,
-    private val attachmentExportService: MeasureExecutorService,
 ) : Exporter {
     @VisibleForTesting
     internal val isExporting = AtomicBoolean(false)
@@ -51,11 +50,15 @@ internal class ExporterImpl(
     override fun export() {
         if (isExporting.compareAndSet(false, true)) {
             try {
-                exportEvents()
-                exportAttachments()
-            } catch (e: Exception) {
-                logger.log(LogLevel.Error, "Exporter: failed to export", e)
-            } finally {
+                eventExportService.submit {
+                    try {
+                        exportEvents()
+                        exportAttachments()
+                    } finally {
+                        isExporting.set(false)
+                    }
+                }
+            } catch (_: RejectedExecutionException) {
                 isExporting.set(false)
             }
         } else {
@@ -65,45 +68,49 @@ internal class ExporterImpl(
 
     override fun flush() {
         if (isExporting.compareAndSet(false, true)) {
-            eventExportService.submit {
-                exportExistingBatches()
-                exportAttachments()
+            try {
+                eventExportService.submit {
+                    try {
+                        exportExistingBatches()
+                        exportAttachments()
+                    } finally {
+                        isExporting.set(false)
+                    }
+                }
+            } catch (_: RejectedExecutionException) {
+                isExporting.set(false)
             }
+        } else {
+            logger.log(LogLevel.Debug, "Exporter: export already in progress, skipping")
         }
     }
 
     private fun exportEvents() {
         try {
-            eventExportService.submit {
-                try {
-                    // First export existing batches
-                    if (exportExistingBatches()) return@submit
+            // First export existing batches
+            if (exportExistingBatches()) return
 
-                    // Then create new batches and export
-                    val batchesCreatedCount = database.batchSessions(
-                        idProvider,
-                        timeProvider,
-                        configProvider.maxEventsInBatch,
-                        1000,
-                    )
-                    if (batchesCreatedCount > 0) {
-                        logger.log(
-                            LogLevel.Debug,
-                            "Exporter: created $batchesCreatedCount new batches, exporting",
-                        )
-                        val newBatches = database.getBatchIds()
-                        if (newBatches.isNotEmpty()) {
-                            exportBatches(newBatches)
-                        }
-                    } else {
-                        logger.log(LogLevel.Debug, "Exporter: no batches to export")
-                    }
-                } catch (e: Exception) {
-                    logger.log(LogLevel.Error, "Exporter: failed to export", e)
+            // Then create new batches and export
+            val batchesCreatedCount = database.batchSessions(
+                idProvider,
+                timeProvider,
+                configProvider.maxEventsInBatch,
+                1000,
+            )
+            if (batchesCreatedCount > 0) {
+                logger.log(
+                    LogLevel.Debug,
+                    "Exporter: created $batchesCreatedCount new batches, exporting",
+                )
+                val newBatches = database.getBatchIds()
+                if (newBatches.isNotEmpty()) {
+                    exportBatches(newBatches)
                 }
+            } else {
+                logger.log(LogLevel.Debug, "Exporter: no batches to export")
             }
-        } catch (e: RejectedExecutionException) {
-            logger.log(LogLevel.Error, "Exporter: failed to submit export task", e)
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Exporter: failed to export", e)
         }
     }
 
@@ -124,20 +131,18 @@ internal class ExporterImpl(
     }
 
     private fun exportBatches(batches: List<String>): Boolean {
-        var success = true
-        batches.forEachIndexed { index, batchId ->
+        for ((index, batchId) in batches.withIndex()) {
             val batch = database.getBatch(batchId)
 
             if (!exportBatch(batch)) {
-                success = false
-                return@forEachIndexed
+                return false
             }
 
             if (index < batches.size - 1) {
                 sleeper.sleep(configProvider.batchExportIntervalMs)
             }
         }
-        return success
+        return true
     }
 
     private fun exportBatch(batch: Batch): Boolean {
@@ -190,31 +195,29 @@ internal class ExporterImpl(
     }
 
     private fun exportAttachments() {
-        attachmentExportService.submit {
-            while (true) {
-                val attachments = database.getAttachmentsToUpload(5)
+        while (true) {
+            val attachments = database.getAttachmentsToUpload(5)
 
-                if (attachments.isEmpty()) {
-                    logger.log(
-                        LogLevel.Debug,
-                        "Exporter: no attachments to upload, exiting",
-                    )
-                    return@submit
+            if (attachments.isEmpty()) {
+                logger.log(
+                    LogLevel.Debug,
+                    "Exporter: no attachments to upload, exiting",
+                )
+                return
+            }
+
+            attachments.forEachIndexed { index, attachment ->
+                logger.log(
+                    LogLevel.Debug,
+                    "Exporter: attachment uploading ${attachment.id}",
+                )
+                val success = uploadAttachment(attachment)
+                if (!success) {
+                    return
                 }
 
-                attachments.forEachIndexed { index, attachment ->
-                    logger.log(
-                        LogLevel.Debug,
-                        "Exporter: attachment uploading ${attachment.id}",
-                    )
-                    val success = uploadAttachment(attachment)
-                    if (!success) {
-                        return@submit
-                    }
-
-                    if (index < attachments.size - 1) {
-                        sleeper.sleep(configProvider.attachmentExportIntervalMs)
-                    }
+                if (index < attachments.size - 1) {
+                    sleeper.sleep(configProvider.attachmentExportIntervalMs)
                 }
             }
         }

--- a/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -66,7 +66,6 @@ internal class ExporterTest {
         idProvider = idProvider,
         httpClient = httpClient,
         sleeper = sleeper,
-        attachmentExportService = attachmentExecutorService,
         eventExportService = eventExecutorService,
     )
 


### PR DESCRIPTION
# Description

A recent change #3338 introduced an issue with how the `isExporting` flag was being set. This PR simplifies the threading logic in export and removes the dedicated attachment upload thread.

## Related issue
References #3338 



