### PR TITLE
chore(android): use correct session start time in sessions table

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -105,7 +105,7 @@ internal class SessionManagerImpl(
 
     override fun onAppForeground() {
         if (appBackgroundTime == 0L) {
-            // happens when app hasn't gone to background yet
+            // happens when app hasn't gone to background, yet
             // it's coming to foreground for the first time.
             return
         }
@@ -142,10 +142,7 @@ internal class SessionManagerImpl(
     }
 
     override fun onConfigLoaded() {
-        val currentSessionId = sessionId
-        if (currentSessionId == null) {
-            return
-        }
+        val currentSessionId = sessionId ?: return
         if (sampler.shouldTrackJourneyForSession(currentSessionId)) {
             try {
                 ioExecutor.submit {
@@ -176,11 +173,11 @@ internal class SessionManagerImpl(
         this.sessionId = id
         this.sessionStartTime = startTime
         sessionStartListener?.onSessionStart(id, startTime)
-        storeSession(id)
+        storeSession(id, startTime)
         return id
     }
 
-    private fun storeSession(id: String) {
+    private fun storeSession(id: String, startTime: Long) {
         try {
             ioExecutor.submit {
                 InternalTrace.trace(
@@ -191,7 +188,7 @@ internal class SessionManagerImpl(
                             SessionEntity(
                                 id,
                                 pid,
-                                timeProvider.now(),
+                                startTime,
                                 supportsAppExit = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R,
                                 appVersion = packageInfoProvider.appVersion,
                                 appBuild = packageInfoProvider.getVersionCode(),


### PR DESCRIPTION
# Description

Resolves a discrepancy in the start time used for session start event and what gets stored in sessions table locally. This had no real impact on the functionality of the app but can be confusing while debugging.

## Related issue
Closes #3336 



