### PR TITLE
ci(android): use consistent secret tokens and harden permissions

### DIFF
--- a/.github/workflows/android-prepare-next.yml
+++ b/.github/workflows/android-prepare-next.yml
@@ -21,8 +21,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      repository-projects: write
-      issues: write
     timeout-minutes: 15
     
     steps:
@@ -31,7 +29,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SDK_RELEASE }}
 
       - name: Setup Git
         run: |
@@ -65,7 +63,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SDK_RELEASE }}
           commit-message: "chore(android): prepare next development version ${{ inputs.version }}"
           branch: prepare-next-android-${{ inputs.version }}
           delete-branch: true

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
-          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
+          token: ${{ secrets.SDK_RELEASE }}
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/gradle-plugin-prepare-next.yml
+++ b/.github/workflows/gradle-plugin-prepare-next.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
-          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
+          token: ${{ secrets.SDK_RELEASE }}
 
       - name: Setup Git
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
+          token: ${{ secrets.SDK_RELEASE }}
           commit-message: "chore(gradle): prepare next development version of plugin"
           branch: prepare-next-gradle-plugin-${{ inputs.version }}
           delete-branch: true


### PR DESCRIPTION
# Description

- Update workflows to use correct token with write permissions for creating PRs. 
Fixes this failure: https://github.com/measure-sh/measure/actions/runs/23548644244
- Hardens permissions to remove unnecessary ones left over from earlier

## Related issue
References #3346 



