### PR TITLE
chore(android): prepare next development version 0.18.0-SNAPSHOT

### DIFF
--- a/.github/workflows/android-prepare-next.yml
+++ b/.github/workflows/android-prepare-next.yml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Next SNAPSHOT version (e.g., 0.10.0-SNAPSHOT)'
+        description: "Next SNAPSHOT version (e.g., 0.10.0-SNAPSHOT)"
         required: true
         type: string
 
 env:
   JAVA_VERSION: 21
-  JAVA_DISTRIBUTION: 'temurin'
+  JAVA_DISTRIBUTION: "temurin"
 
 jobs:
   prepare-next:
@@ -22,12 +22,12 @@ jobs:
       contents: write
       pull-requests: write
     timeout-minutes: 15
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: 'main'
+          ref: "main"
           fetch-depth: 0
           token: ${{ secrets.SDK_RELEASE }}
 
@@ -70,16 +70,14 @@ jobs:
           title: "chore(android): prepare next development version ${{ inputs.version }}"
           body: |
             This PR prepares the next development version of the Android SDK.
-            
+
             **Changes:**
             - Updated version to `${{ inputs.version }}` in gradle.properties
             - Updated version to `${{ inputs.version }}` in libs.versions.toml
-            
+
             **Version:** ${{ inputs.version }}
           base: main
-          labels: |
-            android
-            version-update
+          labels: android
           assignees: abhaysood
           add-paths: |
             android/gradle.properties

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.17.0
+MEASURE_VERSION_NAME=0.18.0-SNAPSHOT
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ android-tools = "31.13.0"
 kotlin = "1.9.21"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests
-measure-android = "0.17.0"
+measure-android = "0.18.0-SNAPSHOT"
 androidx-navigation = "2.9.5"
 androidx-activity = "1.10.1"
 androidx-fragment-ktx = "1.8.9"


### PR DESCRIPTION
This PR prepares the next development version of the Android SDK.

**Changes:**
- Updated version to `0.18.0-SNAPSHOT` in gradle.properties
- Updated version to `0.18.0-SNAPSHOT` in libs.versions.toml

**Version:** 0.18.0-SNAPSHOT