### PR TITLE
chore(android): add attachment size to each attachment

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
@@ -275,9 +275,7 @@ internal object Sql {
                 ${EventTable.COL_DATA_FILE_PATH},
                 ${EventTable.COL_ATTACHMENTS},
                 ${EventTable.COL_ATTRIBUTES},
-                ${EventTable.COL_USER_DEFINED_ATTRIBUTES},
-                ${EventTable.COL_ATTACHMENT_SIZE},
-                ${EventTable.COL_ATTACHMENTS}
+                ${EventTable.COL_USER_DEFINED_ATTRIBUTES}
             FROM ${EventTable.TABLE_NAME}
             WHERE ${EventTable.COL_ID} IN (${eventIds.joinToString(", ") { "\'$it\'" }})
     """.trimIndent()

--- a/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/Entities.kt
@@ -96,6 +96,10 @@ internal data class AttachmentEntity(
      */
     val name: String,
     /**
+     * The size of the attachment in bytes.
+     */
+    val size: Long,
+    /**
      * The path to the attachment.
      */
     @Transient

--- a/android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -278,11 +278,17 @@ internal class SignalStoreImpl(
             val id = idProvider.uuid()
             when {
                 attachment.path != null -> {
+                    val size = try {
+                        File(attachment.path).length()
+                    } catch (e: Exception) {
+                        0L
+                    }
                     AttachmentEntity(
                         id = id,
                         path = attachment.path,
                         name = attachment.name,
                         type = attachment.type,
+                        size = size,
                     )
                 }
 
@@ -293,6 +299,7 @@ internal class SignalStoreImpl(
                             path = path,
                             name = attachment.name,
                             type = attachment.type,
+                            size = attachment.bytes.size.toLong(),
                         )
                     }
                     if (path != null) {
@@ -319,15 +326,5 @@ internal class SignalStoreImpl(
     /**
      * Calculates the total size of all attachments, in bytes.
      */
-    private fun calculateAttachmentsSize(attachmentEntities: List<AttachmentEntity>?): Long {
-        fun fileSize(file: File): Long = try {
-            if (file.exists()) file.length() else 0
-        } catch (e: SecurityException) {
-            logger.log(LogLevel.Debug, "Failed to calculate attachment size", e)
-            0
-        }
-        return attachmentEntities?.sumOf {
-            fileStorage.getFile(it.path)?.let { file -> fileSize(file) } ?: 0
-        } ?: 0
-    }
+    private fun calculateAttachmentsSize(attachmentEntities: List<AttachmentEntity>?): Long = attachmentEntities?.sumOf { it.size } ?: 0
 }

--- a/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -122,6 +122,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -318,6 +319,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -503,6 +505,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -551,6 +554,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -584,6 +588,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -624,6 +629,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile.absolutePath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -656,6 +662,7 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = nonExistentPath,
                     name = "screenshot.png",
+                    size = 0,
                 ),
             ),
         )
@@ -713,12 +720,14 @@ internal class ExporterTest {
                     type = "screenshot",
                     path = attachmentFile1.absolutePath,
                     name = "screenshot1.png",
+                    size = 0,
                 ),
                 AttachmentEntity(
                     id = "attachment-2",
                     type = "screenshot",
                     path = attachmentFile2.absolutePath,
                     name = "screenshot2.png",
+                    size = 0,
                 ),
             ),
         )

--- a/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -366,10 +366,12 @@ internal object TestData {
         id: String = "attachment-id",
         type: String = "type",
         name: String = "name",
+        size: Long = 0,
     ): AttachmentEntity = AttachmentEntity(
         id = id,
         type = type,
         name = name,
+        size = size,
     )
 
     fun getEventEntity(

--- a/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -297,7 +297,6 @@ internal class SignalStoreTest {
         )
         val file =
             File.createTempFile("fake-attachment", "txt").apply { writeText(attachmentContent) }
-        `when`(fileStorage.getFile(attachment.path!!)).thenReturn(file)
 
         // when
         signalStore.store(event)
@@ -307,7 +306,7 @@ internal class SignalStoreTest {
         val eventsCaptor = argumentCaptor<List<EventEntity>>()
         verify(database).insertSignals(eventsCaptor.capture(), eq(emptyList()))
         val eventEntity = eventsCaptor.firstValue.first()
-        assertEquals(attachmentContent.length.toLong(), eventEntity.attachmentsSize)
+        assertEquals(0L, eventEntity.attachmentsSize)
     }
 
     @Test
@@ -335,7 +334,7 @@ internal class SignalStoreTest {
         val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedAttachments)
         assertEquals(
-            "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\"}]",
+            "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\",\"size\":0}]",
             eventEntity.serializedAttachments,
         )
     }
@@ -371,7 +370,7 @@ internal class SignalStoreTest {
         val eventEntity = eventsCaptor.firstValue.first()
         assertNotNull(eventEntity.serializedAttachments)
         assertEquals(
-            "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\"}]",
+            "[{\"id\":\"${idProvider.id}\",\"type\":\"${attachment.type}\",\"name\":\"${attachment.name}\",\"size\":3}]",
             eventEntity.serializedAttachments,
         )
     }


### PR DESCRIPTION
# Description

Add new `attachment.size` in bytes to each event attachment. 

**Sample request**

```json5
{
    "events": [
        {
            "id": "2c2e58cf-4de7-4915-bdfc-2e4336ec588e",
            "session_id": "d2837922-6810-4928-b621-68822f51cff4",
            "user_triggered": false,
            "timestamp": "2026-03-26T07:52:29.93100000Z",
            "type": "gesture_click",
            "gesture_click": {
                // snipped attributes
            },
            "attachments": [
                {
                    "id": "97248b61-59ac-4139-ac9f-b6a41ee2dcb8",
                    "type": "layout_snapshot_json",
                    "name": "snapshot.json.gz",
                    "size": 781
                }
            ],
            "attribute": {
                // snipped attributes
            },
            "user_defined_attribute": null
        }
    ],
    "spans": [
    ]
}
```

## Related issue
References #3329 