### PR TITLE
chore(ios): send attachment size in the event payload

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
@@ -121,9 +121,10 @@ final class BaseNetworkClient: NetworkClient {
                 return [:]
             }
 
+            fullEventDict.removeValue(forKey: "timestampInMillis")
             if let attachments = fullEventDict["attachments"] as? [[String: Any]] {
                 let cleanedAttachments = attachments.map { attachment in
-                    let requiredKeys: Set<String> = ["id", "name", "type"]
+                    let requiredKeys: Set<String> = ["id", "name", "type", "size"]
                     return attachment.filter { requiredKeys.contains($0.key) }
                 }
 


### PR DESCRIPTION
# Description

This PR update the events payload. Below changes are made:

- send attachment size in the event payload
- remove timestampInMillis from the event payload

## Related issue
Closes #3328 
References #3329 



