### PR TITLE
fix: mask React Native views in screenshots

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/screenshot/ScreenshotMask.kt
+++ b/android/measure/src/main/java/sh/measure/android/screenshot/ScreenshotMask.kt
@@ -53,6 +53,15 @@ internal class ScreenshotMask(private val configProvider: ConfigProvider) {
                 findComposableRectsToMask(view, rectsToMask)
             }
 
+            isReactNativeImageView(view) -> {
+                if (configProvider.screenshotMaskLevel == ScreenshotMaskLevel.AllTextAndMedia) {
+                    val rect = Rect()
+                    if (view.getGlobalVisibleRect(rect)) {
+                        rectsToMask.add(rect)
+                    }
+                }
+            }
+
             view is ViewGroup -> {
                 (0 until view.childCount).forEach {
                     recursivelyFindRectsToMask(view.getChildAt(it), rectsToMask)
@@ -98,6 +107,11 @@ internal class ScreenshotMask(private val configProvider: ConfigProvider) {
     ) != null
 
     private fun isExoplayerView(view: View): Boolean = view.javaClass.name.equals("androidx.media3.ui.PlayerView")
+
+    private fun isReactNativeImageView(view: View): Boolean =
+        view.javaClass.name.let { name ->
+            name.contains("ReactImageView") || name.contains("DraweeView")
+        }
 
     private fun androidx.compose.ui.geometry.Rect.toRect(): Rect = Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
 }

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
@@ -25,7 +25,17 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
     private let logger: Logger
     private let attachmentProcessor: AttachmentProcessor
     private let userPermissionManager: UserPermissionManager
-    private let maskedClassNameFragments: [String] = ["RCTParagraphTextView"]
+    private let maskedMediaClassNameFragments: [String] = [
+        "RCTImageView",
+        "RCTImageComponentView"
+    ]
+    private let maskedTextClassNameFragments: [String] = [
+        "RCTParagraphTextView",
+        "RCTTextView",
+        "RCTBaseTextInputView",
+        "RCTUITextField",
+        "RCTTextInputComponentView"
+    ]
 
     init(configProvider: ConfigProvider,
          logger: Logger,
@@ -98,18 +108,28 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
 
     private func findSensitiveFrames(in view: UIView, rootView: UIView, types: [UIView.Type]) -> [CGRect] {
         var sensitiveFrames: [CGRect] = []
+        let level = configProvider.screenshotMaskLevel
 
+        // UIKit type matching
         for type in types {
             if view.isKind(of: type) {
                 let frameInRootView = view.convert(view.bounds, to: rootView)
                 sensitiveFrames.append(frameInRootView)
                 break
             }
-            let className = String(describing: view)
-            if maskedClassNameFragments.contains(where: { className.contains($0) }) {
-                let frameInRootView = view.convert(view.bounds, to: rootView)
-                sensitiveFrames.append(frameInRootView)
-                break
+        }
+
+        // React Native class-name matching (outside type loop, respects mask level)
+        if sensitiveFrames.isEmpty {
+            let className = String(describing: type(of: view))
+            let isMediaMatch = maskedMediaClassNameFragments.contains(where: { className.contains($0) })
+            let isTextMatch = maskedTextClassNameFragments.contains(where: { className.contains($0) })
+
+            if isMediaMatch && level == .allTextAndMedia {
+                sensitiveFrames.append(view.convert(view.bounds, to: rootView))
+            } else if isTextMatch && (level == .allTextAndMedia || level == .allText ||
+                      level == .allTextExceptClickable || level == .sensitiveFieldsOnly) {
+                sensitiveFrames.append(view.convert(view.bounds, to: rootView))
             }
         }
 


### PR DESCRIPTION
# Description

ReactImageView (extends Fresco's GenericDraweeView) was not detected by the Android when-block, which only checked for ImageView/VideoView. On iOS, maskedClassNameFragments only covered RCTParagraphTextView, the fragment check was nested inside the type loop (running once per UIKit type instead of once per view), and mask level was ignored for RN views.

Android: add isReactNativeImageView() class-name check mirroring the existing isExoplayerView() pattern; insert branch before ViewGroup catch-all so RN image views are masked at AllTextAndMedia level.

iOS: split fragments into maskedMediaClassNameFragments and maskedTextClassNameFragments; move check outside type loop; respect screenshotMaskLevel for each category.

## Related issue
Fixes #3036



