### PR TITLE
fix(ios): resolve Swift APIs unavailable in ObjC for static library i…

### DIFF
--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)
+// swift-compiler-version: Apple Swift version 6.2.4 effective-5.10 (swiftlang-6.2.4.1.4 clang-1700.6.4.2)
 // swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2.4
 import AVKit
 import CoreData
 import CoreMotion

--- a/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
+++ b/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
@@ -10,6 +10,8 @@
 #import <Measure/Measure-Swift.h>
 #elif __has_include("Measure-Swift.h")
 #import "Measure-Swift.h"
+#elif __has_include(<Measure-Swift.h>)
+#import <Measure-Swift.h>
 #else
 #warning "Measure-Swift.h not found. Swift integration may not work."
 #endif

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -14,7 +14,8 @@ Pod::Spec.new do |spec|
   spec.source_files = "ios/Sources/MeasureSDK/Swift/**/*.{swift}", "ios/Sources/MeasureSDK/ObjC/**/*.{h,m}"
   spec.public_header_files = "ios/Sources/MeasureSDK/ObjC/include/**/*.h"
   spec.pod_target_xcconfig = {
-    "DEFINES_MODULE" => "YES"
+    "DEFINES_MODULE"                   => "YES",
+    "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "Measure-Swift.h"
   }
   spec.resources    = [
     "ios/Sources/MeasureSDK/Swift/XCDataModel/MeasureModel.xcdatamodeld",


### PR DESCRIPTION
# Description

When the SDK is integrated via CocoaPods with `static_framework = true`, the auto-generated Swift-ObjC bridging header is not accessible via the framework- bundle path `<Measure/Measure-Swift.h>`. Additionally, CocoaPods derives the header filename from the pod name (`measure-sh-Swift.h`) rather than the module name (`Measure-Swift.h`), causing all import fallbacks to miss.

Two fixes:
- MeasureSDK.m: add `#elif __has_include(<Measure-Swift.h>)` fallback for the flat header search path used in static library builds
- measure-sh.podspec: add `SWIFT_OBJC_INTERFACE_HEADER_NAME = Measure-Swift.h` to `pod_target_xcconfig` to pin the generated header filename to the module name regardless of pod name or CocoaPods version

## Related issue
Fixes #3008



