### PR TITLE
fix/ios-add-pre-warm-field-to-warm-launch

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/AppLaunch/AppLaunchEvents.swift
+++ b/ios/Sources/MeasureSDK/Swift/AppLaunch/AppLaunchEvents.swift
@@ -33,6 +33,7 @@ struct WarmLaunchData: Codable {
     let launchedActivity: String
     let hasSavedState: Bool
     let intentData: String?
+    let isPreWarm: Bool
 
     enum CodingKeys: String, CodingKey {
         case appVisibleUptime = "app_visible_uptime"
@@ -40,6 +41,7 @@ struct WarmLaunchData: Codable {
         case launchedActivity = "launched_activity"
         case hasSavedState = "has_saved_state"
         case intentData = "intent_data"
+        case isPreWarm = "is_pre_warm"
     }
 }
 

--- a/ios/Sources/MeasureSDK/Swift/AppLaunch/LaunchTracker.swift
+++ b/ios/Sources/MeasureSDK/Swift/AppLaunch/LaunchTracker.swift
@@ -93,13 +93,14 @@ final class BaseLaunchTracker: LaunchTracker {
             return
         }
 
-        guard !isActivePrewarm else {
-            logger.log(level: .error, message: "Skipping launch data collection as app is prewarmed.", error: nil, data: nil)
-            return
-        }
-
         let now = UnsignedNumber(timeProvider.now())
         let currentLaunchData = LaunchData(appVersion: currentAppVersion, timeSinceLastBoot: currentSystemBootTime)
+
+        guard !isActivePrewarm else {
+            generateWarmLaunchData(appVisibleUptime: processStart, onNextDrawUptime: now, isPreWarm: true)
+            userDefaultStorage.setRecentLaunchData(currentLaunchData)
+            return
+        }
 
         // Mark a launch as cold launch if recent launch data is not available
         guard let recentLaunch = userDefaultStorage.getRecentLaunchData() else {
@@ -111,7 +112,7 @@ final class BaseLaunchTracker: LaunchTracker {
         if recentLaunch.appVersion != currentAppVersion { // if app is updated, mark it as a cold launch
             generateColdLaunchData(processStartUptime: processStart, onNextDrawUptime: now)
         } else if recentLaunch.timeSinceLastBoot == currentSystemBootTime { // if the device boot time is same as previous launch, mark it as a warm launch
-            generateWarmLaunchData(appVisibleUptime: processStart, onNextDrawUptime: now)
+            generateWarmLaunchData(appVisibleUptime: processStart, onNextDrawUptime: now, isPreWarm: false)
         } else if currentSystemBootTime > recentLaunch.timeSinceLastBoot { // if the current device boot time is more recent than previous launch, mark it as a cold launch
             generateColdLaunchData(processStartUptime: processStart, onNextDrawUptime: now)
         } else { // This else case will only be executed in case of clock skew.
@@ -140,12 +141,13 @@ final class BaseLaunchTracker: LaunchTracker {
         launchCallbacks.onColdLaunch(data: coldLaunchData)
     }
 
-    private func generateWarmLaunchData(appVisibleUptime: UnsignedNumber, onNextDrawUptime: UnsignedNumber) {
+    private func generateWarmLaunchData(appVisibleUptime: UnsignedNumber, onNextDrawUptime: UnsignedNumber, isPreWarm: Bool) {
         let warmLaunchData = WarmLaunchData(appVisibleUptime: appVisibleUptime,
                                             onNextDrawUptime: onNextDrawUptime,
                                             launchedActivity: getViewControllerName(),
                                             hasSavedState: false,
-                                            intentData: nil)
+                                            intentData: nil,
+                                            isPreWarm: isPreWarm)
         launchCallbacks.onWarmLaunch(data: warmLaunchData)
     }
 


### PR DESCRIPTION
# Description

fix(ios): add is_pre_warm field to warm launch event

Previously, pre-warmed app launches (detected via the `ActivePrewarm` environment variable) were silently skipped. This meant the backend had no visibility into pre-warm launches at all.

Instead of skipping, emit a warm launch event with `is_pre_warm: true` so the backend can distinguish pre-warmed launches from regular warm launches. Normal warm launches include `is_pre_warm: false`.

Please add a summary of the changes

## Related issue
Fixes #1576


