### PR TITLE
Replace handled boolean with type string in exception payloads

### DIFF
--- a/android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
@@ -445,7 +445,7 @@ class EventsTest {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                type = "fatal",
                 foreground = true,
             ),
             timestamp = 987654321L,
@@ -459,7 +459,7 @@ class EventsTest {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                type = "fatal",
                 foreground = true,
             ),
             timestamp = 987654321L,

--- a/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
+++ b/android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
@@ -80,7 +80,7 @@ class SessionTestRobot {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                type = "fatal",
                 foreground = true,
             ),
             timestamp = 987654321L,

--- a/android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -47,7 +47,7 @@ internal class AnrCollector(
 
     private fun toMeasureException(anr: AnrError): ExceptionData = ExceptionFactory.createMeasureException(
         throwable = anr,
-        handled = false,
+        type = "fatal",
         thread = anr.thread,
         foreground = processInfo.isForegroundProcess(),
     )

--- a/android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
@@ -81,7 +81,7 @@ internal class InternalSignalCollector(
                         )
                     }
                     val extractedData = extractExceptionEventData(data)
-                    if (!extractedData.handled) {
+                    if (extractedData.type != "handled") {
                         // ignoring session ID and user triggered properties
                         // this should be safe as handled exceptions are not tracked in
                         // a separate session and are not user triggered.

--- a/android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
@@ -178,7 +178,7 @@ internal class UserTriggeredEventCollectorImpl(
         signalProcessor.trackUserTriggered(
             data = ExceptionFactory.createMeasureException(
                 throwable = throwable,
-                handled = true,
+                type = "handled",
                 thread = thread,
                 foreground = processInfoProvider.isForegroundProcess(),
             ),

--- a/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
@@ -18,9 +18,9 @@ internal data class ExceptionData(
     val threads: List<MeasureThread>,
 
     /**
-     * Whether the exception was handled or not.
+     * The type of exception: "handled", "unhandled", or "fatal".
      */
-    val handled: Boolean,
+    val type: String,
 
     /**
      * Whether the app was in the foreground or not when the exception occurred.

--- a/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
@@ -5,11 +5,11 @@ internal object ExceptionFactory {
      * Creates [ExceptionData] from a [Throwable].
      *
      * @param throwable The [Throwable] to create the [ExceptionData] from.
-     * @param handled Whether the exception was handled or not.
+     * @param type The type of exception: "handled", "unhandled", or "fatal".
      */
     fun createMeasureException(
         throwable: Throwable,
-        handled: Boolean,
+        type: String,
         thread: Thread,
         foreground: Boolean,
         framework: String? = ExceptionFramework.JVM,
@@ -57,7 +57,7 @@ internal object ExceptionFactory {
         return ExceptionData(
             exceptions,
             threads = threads,
-            handled = handled,
+            type = type,
             foreground = foreground,
             framework = framework,
         )

--- a/android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
@@ -40,7 +40,7 @@ internal class UnhandledExceptionCollector(
             signalProcessor.trackCrash(
                 data = ExceptionFactory.createMeasureException(
                     throwable,
-                    handled = false,
+                    type = "fatal",
                     thread = thread,
                     foreground = processInfo.isForegroundProcess(),
                 ),

--- a/android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -76,7 +76,7 @@ internal class SignalStoreImpl(
                 return
             }
             val isCrashEvent =
-                eventEntity.type == EventType.EXCEPTION && !(event.data as ExceptionData).handled
+                eventEntity.type == EventType.EXCEPTION && (event.data as ExceptionData).type != "handled"
             val isAnrEvent = eventEntity.type == EventType.ANR
             val isBugReportEvent = eventEntity.type == EventType.BUG_REPORT
 

--- a/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -75,7 +75,7 @@ class AnrCollectorTest {
 
         assertEquals(EventType.ANR, typeCaptor.firstValue)
         assertEquals(expectedAnrError.timestamp, timestampCaptor.firstValue)
-        assertEquals(false, dataCaptor.firstValue.handled)
+        assertEquals("fatal", dataCaptor.firstValue.type)
         assertEquals(processInfo.isForegroundProcess(), dataCaptor.firstValue.foreground)
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
@@ -294,7 +294,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks un-obfuscated flutter exception event`() {
-        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(handled = false)
+        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(type = "fatal")
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION
@@ -331,7 +331,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks obfuscated flutter exception event`() {
-        val exceptionData = TestData.getObfuscatedFlutterExceptionData(handled = false)
+        val exceptionData = TestData.getObfuscatedFlutterExceptionData(type = "fatal")
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION
@@ -368,7 +368,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks handled flutter exception event`() {
-        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(handled = true)
+        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(type = "handled")
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION

--- a/android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
@@ -1,7 +1,6 @@
 package sh.measure.android.exceptions
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -15,7 +14,7 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            type = "handled",
             thread = thread,
             foreground = true,
         )
@@ -40,7 +39,7 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            type = "handled",
             thread = thread,
             foreground = true,
         )
@@ -61,7 +60,7 @@ class ExceptionFactoryTest {
     }
 
     @Test
-    fun `ExceptionFactory sets handled to true when the exception is handled`() {
+    fun `ExceptionFactory sets type to handled when the exception is handled`() {
         // Given
         val exception = IllegalArgumentException("Test exception")
         val thread = Thread.currentThread()
@@ -69,17 +68,17 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            type = "handled",
             thread = thread,
             foreground = true,
         )
 
         // Then
-        assertTrue(measureException.handled)
+        assertEquals("handled", measureException.type)
     }
 
     @Test
-    fun `ExceptionFactory sets handled to false when the exception is unhandled`() {
+    fun `ExceptionFactory sets type to fatal when the exception is unhandled`() {
         // Given
         val exception = IllegalArgumentException("Test exception")
         val thread = Thread.currentThread()
@@ -87,12 +86,12 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = false,
+            type = "fatal",
             thread = thread,
             foreground = true,
         )
 
         // Then
-        assertFalse(measureException.handled)
+        assertEquals("fatal", measureException.type)
     }
 }

--- a/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -50,18 +50,18 @@ internal object TestData {
 
     fun getExceptionData(
         exception: Exception = IllegalArgumentException("Test exception"),
-        handled: Boolean = true,
+        type: String = "handled",
         thread: Thread = Thread.currentThread(),
         foreground: Boolean = true,
     ): ExceptionData = ExceptionFactory.createMeasureException(
         exception,
-        handled,
+        type,
         thread,
         foreground,
     )
 
     fun getUnObfuscatedFlutterExceptionData(
-        handled: Boolean = false,
+        type: String = "fatal",
         foreground: Boolean = true,
     ): ExceptionData = ExceptionData(
         exceptions = listOf(
@@ -99,13 +99,13 @@ internal object TestData {
                 ),
             ),
         ),
-        handled = handled,
+        type = type,
         threads = listOf(),
         foreground = foreground,
     )
 
     fun getObfuscatedFlutterExceptionData(
-        handled: Boolean = false,
+        type: String = "fatal",
         foreground: Boolean = true,
     ): ExceptionData = ExceptionData(
         exceptions = listOf(
@@ -126,7 +126,7 @@ internal object TestData {
                 ),
             ),
         ),
-        handled = handled,
+        type = type,
         threads = listOf(),
         foreground = foreground,
     )

--- a/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -42,7 +42,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores exception event data in file storage and stores the path in database`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         val eventsCaptor = argumentCaptor<EventEntity>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
@@ -459,7 +459,7 @@ internal class SignalStoreTest {
         // given
         val crashTimelineDuration = 30
         configProvider.crashTimelineDurationSeconds = crashTimelineDuration
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)
@@ -585,7 +585,7 @@ internal class SignalStoreTest {
     @Test
     fun `given event insertion in db fails, deletes event and attachment data from file storage`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(
             type = EventType.EXCEPTION,
             attachments = mutableListOf(
@@ -607,7 +607,7 @@ internal class SignalStoreTest {
     @Test
     fun `given event data fails to write to file storage, does not insert event in db`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(
             type = EventType.EXCEPTION,
             attachments = mutableListOf(
@@ -645,7 +645,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores handled exception event in queue`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = true)
+        val exceptionData = TestData.getExceptionData(type = "handled")
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
@@ -665,7 +665,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores unhandled exception event immediately without queuing`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)
@@ -681,7 +681,7 @@ internal class SignalStoreTest {
     fun `marks timeline for reporting on crash`() {
         // given
         sampler.isCrashTimelineSampled = true
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(type = "fatal")
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)

--- a/flutter/packages/measure_flutter/lib/measure_flutter.dart
+++ b/flutter/packages/measure_flutter/lib/measure_flutter.dart
@@ -547,7 +547,7 @@ class Measure implements MeasureApi {
   }) {
     if (_isInitialized) {
       final details = FlutterErrorDetails(exception: error, stack: stack);
-      return _measure.trackError(details, handled: true, attributes: attributes);
+      return _measure.trackError(details, type: "handled", attributes: attributes);
     }
     return Future.value();
   }
@@ -1044,7 +1044,7 @@ class Measure implements MeasureApi {
   Future<void> _initFlutterOnError() async {
     final originalHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) async {
-      await _measure.trackError(details, handled: false);
+      await _measure.trackError(details, type: "fatal");
       if (originalHandler != null) {
         originalHandler(details);
       }
@@ -1057,7 +1057,7 @@ class Measure implements MeasureApi {
         exception: exception,
         stack: stackTrace,
       );
-      _measure.trackError(details, handled: false);
+      _measure.trackError(details, type: "fatal");
       return false;
     };
   }

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
@@ -45,11 +45,11 @@ final class ExceptionCollector {
 
   Future<void> trackError(
     FlutterErrorDetails details, {
-    required bool handled,
+    required String type,
     required Map<String, AttributeValue> attributes,
   }) async {
     if (!_enabled) return;
-    final ExceptionData? exceptionData = ExceptionFactory.from(details, handled);
+    final ExceptionData? exceptionData = ExceptionFactory.from(details, type);
     if (exceptionData == null) {
       logger.log(LogLevel.error, "Failed to parse exception");
       return;
@@ -57,7 +57,7 @@ final class ExceptionCollector {
 
     final attachments = <MsrAttachment>[];
 
-    if (configProvider.crashTakeScreenshot && !handled) {
+    if (configProvider.crashTakeScreenshot && type != "handled") {
       await _addScreenshot(attachments);
     }
 

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_data.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_data.dart
@@ -9,8 +9,8 @@ class ExceptionData implements JsonSerialized {
   /// A list of exceptions that were thrown. Multiple exceptions represent "chained" exceptions.
   final List<ExceptionUnit> exceptions;
 
-  /// Whether the exception was handled or not.
-  final bool handled;
+  /// The type of exception: "handled", "unhandled", or "fatal".
+  final String type;
 
   /// The stacktrace of all the threads at the time of the exception.
   final List<MeasureThread> threads;
@@ -26,7 +26,7 @@ class ExceptionData implements JsonSerialized {
 
   ExceptionData({
     required this.exceptions,
-    required this.handled,
+    required this.type,
     required this.threads,
     required this.foreground,
     required this.binaryImages,
@@ -45,7 +45,7 @@ class ExceptionData implements JsonSerialized {
       other is ExceptionData &&
           runtimeType == other.runtimeType &&
           exceptions == other.exceptions &&
-          handled == other.handled &&
+          type == other.type &&
           threads == other.threads &&
           foreground == other.foreground &&
           binaryImages == other.binaryImages &&
@@ -54,7 +54,7 @@ class ExceptionData implements JsonSerialized {
   @override
   int get hashCode =>
       exceptions.hashCode ^
-      handled.hashCode ^
+      type.hashCode ^
       threads.hashCode ^
       foreground.hashCode ^
       binaryImages.hashCode ^

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_data.g.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_data.g.dart
@@ -11,7 +11,7 @@ ExceptionData _$ExceptionDataFromJson(Map<String, dynamic> json) =>
       exceptions: (json['exceptions'] as List<dynamic>)
           .map((e) => ExceptionUnit.fromJson(e as Map<String, dynamic>))
           .toList(),
-      handled: json['handled'] as bool,
+      type: json['type'] as String,
       threads: (json['threads'] as List<dynamic>)
           .map((e) => MeasureThread.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -25,7 +25,7 @@ ExceptionData _$ExceptionDataFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$ExceptionDataToJson(ExceptionData instance) =>
     <String, dynamic>{
       'exceptions': instance.exceptions.map((e) => e.toJson()).toList(),
-      'handled': instance.handled,
+      'type': instance.type,
       'threads': instance.threads.map((e) => e.toJson()).toList(),
       'foreground': instance.foreground,
       'binary_images': instance.binaryImages.map((e) => e.toJson()).toList(),

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_factory.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_factory.dart
@@ -12,24 +12,24 @@ final class ExceptionFactory {
   static final _buildIdRegex = RegExp(r"build_id: *'([A-Fa-f0-9]+)'");
   static final _archRegex = RegExp(r'arch[:=] *([A-Za-z0-9]+)');
 
-  static ExceptionData? from(FlutterErrorDetails details, bool handled) {
+  static ExceptionData? from(FlutterErrorDetails details, String type) {
     var stackTrace = details.stack;
     if (stackTrace == null) {
       return null;
     }
     final result = _parseStackTrace(stackTrace);
     final List<Trace> traces = result.traces;
-    final type = details.exception.runtimeType.toString();
-    final message = _getMessage(details, type);
+    final exceptionType = details.exception.runtimeType.toString();
+    final message = _getMessage(details, exceptionType);
     final List<ExceptionUnit> exceptions = [];
 
     if (traces.isNotEmpty) {
       final firstTrace = traces.first;
       final List<MsrFrame> primaryFrames = _createMsrFrames(firstTrace.frames);
       exceptions.add(
-          ExceptionUnit(frames: primaryFrames, type: type, message: message));
+          ExceptionUnit(frames: primaryFrames, type: exceptionType, message: message));
     } else {
-      exceptions.add(ExceptionUnit(frames: [], type: type, message: message));
+      exceptions.add(ExceptionUnit(frames: [], type: exceptionType, message: message));
     }
     final remainingTraces = traces.skip(1);
     for (Trace trace in remainingTraces) {
@@ -43,7 +43,7 @@ final class ExceptionFactory {
     // in Flutter.
     return ExceptionData(
       exceptions: exceptions,
-      handled: handled,
+      type: type,
       threads: [],
       foreground: true,
       binaryImages: _createBinaryImage(stackTrace),

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -104,10 +104,10 @@ final class MeasureInternal {
 
   Future<void> trackError(
     FlutterErrorDetails details, {
-    required bool handled,
+    required String type,
     Map<String, AttributeValue> attributes = const {},
   }) {
-    return _exceptionCollector.trackError(details, handled: handled, attributes: attributes);
+    return _exceptionCollector.trackError(details, type: type, attributes: attributes);
   }
 
   void triggerNativeCrash() {

--- a/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
@@ -110,7 +110,7 @@ void main() {
             ],
           ),
         ],
-        handled: false,
+        type: "fatal",
         threads: [],
         foreground: true,
         binaryImages: [],
@@ -120,7 +120,7 @@ void main() {
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        type: "fatal",
         attributes: {},
       );
 
@@ -161,7 +161,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
             ],
           ),
         ],
-        handled: false,
+        type: "fatal",
         threads: [],
         foreground: true,
         binaryImages: [
@@ -177,7 +177,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        type: "fatal",
         attributes: {},
       );
 
@@ -234,7 +234,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
             ],
           ),
         ],
-        handled: false,
+        type: "fatal",
         threads: [],
         foreground: true,
         binaryImages: [],
@@ -244,7 +244,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        type: "fatal",
         attributes: {},
       );
 
@@ -270,7 +270,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        type: "fatal",
         attributes: attributes,
       );
 

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)
+// swift-compiler-version: Apple Swift version 6.2.4 effective-5.10 (swiftlang-6.2.4.1.4 clang-1700.6.4.2)
 // swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2.4
 import AVKit
 import CoreData
 import CoreMotion

--- a/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
@@ -35,7 +35,7 @@ final class BaseSignalStore: SignalStore {
         let eventEntity = EventEntity(event, needsReporting: needsReporting)
 
         var isCrashEvent = false
-        if let exception = event.exception, !exception.handled {
+        if let exception = event.exception, exception.type != "handled" {
             isCrashEvent = true
         }
         let isBugReportEvent = event.type == .bugReport

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -25,7 +25,7 @@ final class CrashDataFormatter {
         self.isLp64 = resolveIsLp64(binaryImageDicts: binaryImageDicts)
     }
 
-    func getException(_ handled: Bool = false, error: MsrError? = nil) -> Exception {
+    func getException(_ type: String = "fatal", error: MsrError? = nil) -> Exception {
         let crashedThreadDict = threadDicts.first { $0["crashed"] as? Bool == true || $0["crashed"] as? Int == 1 }
         let otherThreadDicts  = threadDicts.filter { $0["crashed"] as? Bool != true && $0["crashed"] as? Int != 1 }
 
@@ -34,7 +34,7 @@ final class CrashDataFormatter {
         let otherThreads    = otherThreadDicts.map { parseThread($0) }
 
         guard let crashedThread else {
-            return Exception(handled: handled,
+            return Exception(type: type,
                              exceptions: [exceptionDetail],
                              foreground: parseForeground(),
                              threads: nil,
@@ -46,7 +46,7 @@ final class CrashDataFormatter {
         let allThreads   = [crashedThread] + otherThreads
         let binaryImages = parseBinaryImages(threads: allThreads)
 
-        return Exception(handled: handled,
+        return Exception(type: type,
                          exceptions: [exceptionDetail],
                          foreground: parseForeground(),
                          threads: otherThreads,

--- a/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct Exception: Codable {
-    /// A boolean indicating whether the exception was handled.
-    let handled: Bool
+    /// The type of exception: "handled", "unhandled", or "fatal".
+    let type: String
 
     /// An array of `ExceptionDetail` objects representing the exceptions.
     let exceptions: [ExceptionDetail]
@@ -30,7 +30,7 @@ struct Exception: Codable {
     let error: MsrError?
 
     enum CodingKeys: String, CodingKey {
-        case handled
+        case type
         case exceptions
         case foreground
         case threads

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -59,7 +59,7 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
 
         let formatter = CrashDataFormatter(report.value)
-        let result = formatter.getException(true, error: msrError)
+        let result = formatter.getException("handled", error: msrError)
         store.deleteReport(with: Int64(truncating: reportID))
         crashDataPersistence.clearCrashData()
 

--- a/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
@@ -79,7 +79,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testMarksTimelineForCrashEvent() {
-        let exception = Exception(handled: false, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
+        let exception = Exception(type: "fatal", exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 
@@ -102,7 +102,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testDoesNotMarkTimelineForHandledException() {
-        let exception = Exception(handled: true, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
+        let exception = Exception(type: "handled", exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
@@ -555,16 +555,16 @@ final class CrashDataFormatterTests: XCTestCase {
         XCTAssertEqual(parsed?.first?.path, fullPath)
     }
 
-    func test_getException_setsHandledFlag() {
+    func test_getException_setsHandledType() {
         let sut = makeFormatter()
-        let result = sut.getException(true)
-        XCTAssertTrue(result.handled)
+        let result = sut.getException("handled")
+        XCTAssertEqual(result.type, "handled")
     }
 
-    func test_getException_setsFalseHandledFlag() {
+    func test_getException_setsFatalType() {
         let sut = makeFormatter()
-        let result = sut.getException(false)
-        XCTAssertFalse(result.handled)
+        let result = sut.getException("fatal")
+        XCTAssertEqual(result.type, "fatal")
     }
 
     func test_getException_putsCrashedThreadFramesInExceptionDetail() {
@@ -617,7 +617,7 @@ final class CrashDataFormatterTests: XCTestCase {
     func test_getException_passesMsrErrorThrough() {
         let sut = makeFormatter()
         let msrError = MsrError(numcode: 100, code: "Error", meta: nil)
-        let result = sut.getException(false, error: msrError)
+        let result = sut.getException("fatal", error: msrError)
         XCTAssertNotNil(result.error)
         XCTAssertEqual(result.error?.numcode, 100)
         XCTAssertEqual(result.error?.code, "Error")

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashReports/abort.json
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashReports/abort.json
@@ -156,7 +156,7 @@
       "name" : "Thread 3"
     }
   ],
-  "handled" : false,
+  "type" : "fatal",
   "exceptions" : [
     {
       "thread_sequence" : 0,

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashReports/backgroundThreadException.json
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashReports/backgroundThreadException.json
@@ -139,7 +139,7 @@
       "os_build_number" : "23F79"
     }
   ],
-  "handled" : false,
+  "type" : "fatal",
   "threads" : [
     {
       "name" : "Thread 0",

--- a/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_background.json
+++ b/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_background.json
@@ -1,6 +1,6 @@
 {
     "foreground": false,
-    "handled": true,
+    "type": "handled",
     "threads": [],
     "exceptions": [
         {

--- a/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_handled.json
+++ b/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_handled.json
@@ -1,6 +1,6 @@
 {
   "foreground" : true,
-  "handled": true,
+  "type": "handled",
   "threads" : [],
   "exceptions": [
       {

--- a/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_obfuscated.json
+++ b/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_obfuscated.json
@@ -1,6 +1,6 @@
 {
   "foreground" : true,
-  "handled": false,
+  "type": "fatal",
   "threads" : [],
   "framework": "ios",
   "exceptions": [

--- a/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_unobfuscated.json
+++ b/ios/Tests/MeasureSDKTests/Event/CrashReports/flutter_unobfuscated.json
@@ -1,6 +1,6 @@
 {
   "foreground" : true,
-  "handled": false,
+  "type": "fatal",
   "threads" : [],
   "framework": "ios",
   "exceptions": [

--- a/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
@@ -209,7 +209,7 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
         )
 
         let exception = Exception(
-            handled: false,
+            type: "fatal",
             exceptions: [exceptionDetail],
             foreground: true,
             threads: [ThreadDetail(name: "main", frames: [stackFrame], sequence: 1)],
@@ -243,7 +243,7 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
             let jsonDict = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
 
             if let exceptionDict = jsonDict?["exception"] as? [String: Any] {
-                XCTAssertEqual(exceptionDict["handled"] as? Bool, false)
+                XCTAssertEqual(exceptionDict["type"] as? String, "fatal")
                 XCTAssertEqual(exceptionDict["foreground"] as? Bool, true)
 
                 if let exceptionDetails = exceptionDict["exceptions"] as? [[String: Any]],

--- a/ios/Tests/MeasureSDKTests/Helper/Exception+Extension.swift
+++ b/ios/Tests/MeasureSDKTests/Helper/Exception+Extension.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Exception: Equatable {
     public static func == (lhs: Exception, rhs: Exception) -> Bool {
-        guard lhs.handled == rhs.handled else { return false }
+        guard lhs.type == rhs.type else { return false }
 
         guard lhs.exceptions.count == rhs.exceptions.count else { return false }
         for (lhsException, rhsException) in zip(lhs.exceptions, rhs.exceptions) {

--- a/react-native/src/__tests__/exception/exceptionBuilder.test.ts
+++ b/react-native/src/__tests__/exception/exceptionBuilder.test.ts
@@ -6,13 +6,13 @@ describe("buildExceptionPayload", () => {
     err.stack = `Error: Something went wrong
     at myFunc (/src/index.js:12:34)`;
 
-    const payload = buildExceptionPayload(err, true);
+    const payload = buildExceptionPayload(err, "handled");
 
     expect(payload.exceptions).toBeDefined();
     expect(payload.exceptions.length).toBeGreaterThan(0);
 
     const exception = payload.exceptions[0];
-    expect(payload.handled).toBe(true);
+    expect(payload.type).toBe("handled");
     expect(exception).toBeDefined();
     expect(exception?.message).toBe("Something went wrong");
     expect(exception?.frames && exception.frames[0]).toMatchObject({
@@ -26,13 +26,13 @@ describe("buildExceptionPayload", () => {
   });
 
   it("handles non-Error inputs", () => {
-    const payload = buildExceptionPayload("plain string error", false);
+    const payload = buildExceptionPayload("plain string error", "fatal");
 
     expect(payload.exceptions).toBeDefined();
     expect(payload.exceptions.length).toBeGreaterThan(0);
-    
+
     const exception = payload.exceptions[0];
-    expect(payload.handled).toBe(false);
+    expect(payload.type).toBe("fatal");
     expect(exception).toBeDefined();
     expect(exception!.type).toBe("string");
     expect(exception!.frames).toEqual([]);

--- a/react-native/src/__tests__/exception/measureErrorHandlers.test.ts
+++ b/react-native/src/__tests__/exception/measureErrorHandlers.test.ts
@@ -45,7 +45,7 @@ describe("errorHandlers", () => {
 
     setHandler(err, true);
 
-    expect(buildExceptionPayload).toHaveBeenCalledWith(err, false);
+    expect(buildExceptionPayload).toHaveBeenCalledWith(err, "fatal");
     expect(logger.log).toHaveBeenCalledWith(
       "fatal",
       "Fatal exception",

--- a/react-native/src/exception/exceptionBuilder.ts
+++ b/react-native/src/exception/exceptionBuilder.ts
@@ -33,7 +33,7 @@ export interface ThreadDetail {
 }
 
 export interface ExceptionPayload {
-  handled: boolean;
+  type: string;
   exceptions: ExceptionDetail[];
   foreground?: boolean;
   threads?: ThreadDetail[];
@@ -46,7 +46,7 @@ export interface ExceptionPayload {
  */
 export function buildExceptionPayload(
   error: unknown,
-  handled: boolean
+  type: string
 ): ExceptionPayload {
   const parsed = parseStacktrace(error);
 
@@ -76,7 +76,7 @@ export function buildExceptionPayload(
   };
 
   return {
-    handled,
+    type,
     exceptions: [exceptionDetail],
     foreground: true,
     threads: [thread],

--- a/react-native/src/exception/measureErrorHandlers.ts
+++ b/react-native/src/exception/measureErrorHandlers.ts
@@ -42,7 +42,7 @@ export function setupErrorHandlers(options: Options): void {
  */
 function captureException(error: unknown, isFatal: boolean, timeProvider: TimeProvider, logger: Logger, signalProcessor: ISignalProcessor): void {
   try {
-    const exceptionPayload = buildExceptionPayload(error, false);
+    const exceptionPayload = buildExceptionPayload(error, isFatal ? "fatal" : "unhandled");
 
     logger.log(
       isFatal ? "fatal" : "error",


### PR DESCRIPTION
# Description

Replaces the `handled: Bool/boolean` field with `type: String` in exception/error JSON payloads across all four SDKs (iOS, Android, Flutter, React Native).

Type values:
- "handled"   — user-caught exceptions
- "fatal"     — crashes, ANR, uncaught errors
- "unhandled" — unhandled promise rejections (React Native)

Fixes #3193

## Related issue
Fixes #3193
