### PR TITLE
Add funnel event tracking across Android, iOS, Flutter, and React Nat…

### DIFF
--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -168,7 +168,26 @@ object Measure {
     }
 
     /**
-     * Track a handled exception.
+     * Track a funnel event.
+     *
+     * Funnel events represent a user reaching a specific step in a defined conversion funnel.
+     * Sequences of funnel events within a session are used by the backend to compute funnel
+     * analytics and visualize conversion rates.
+     *
+     * Example usage:
+     * ```kotlin
+     * Measure.trackFunnelEvent("checkout_started")
+     * ```
+     *
+     * @param name The name of the funnel step.
+     * @param attributes Optional key-value pairs providing additional context to the event.
+     */
+    @JvmStatic
+    fun trackFunnelEvent(name: String, attributes: Map<String, AttributeValue> = emptyMap()) {
+        if (isInitialized.get()) {
+            measure.trackFunnelEvent(name, attributes)
+        }
+    }
      *
      * Handled exceptions are exceptions that are caught and handled in the app code. These do not
      * cause a crash but can, at times, have implication on the user experience. Tracking these

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -165,6 +165,10 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         measure.userTriggeredEventCollector.trackScreenView(screenName, attributes)
     }
 
+    fun trackFunnelEvent(name: String, attributes: Map<String, AttributeValue>) {
+        measure.userTriggeredEventCollector.trackFunnelEvent(name, attributes)
+    }
+
     fun trackHandledException(throwable: Throwable, attributes: Map<String, AttributeValue>) {
         measure.userTriggeredEventCollector.trackHandledException(throwable, attributes)
     }

--- a/android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -20,6 +20,7 @@ internal enum class EventType(val value: String) {
     TRIM_MEMORY("trim_memory"),
     CPU_USAGE("cpu_usage"),
     SCREEN_VIEW("screen_view"),
+    FUNNEL("funnel"),
     CUSTOM("custom"),
     BUG_REPORT("bug_report"),
     SESSION_START("session_start"),

--- a/android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
+++ b/android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
@@ -7,6 +7,7 @@ import sh.measure.android.config.ConfigProvider
 import sh.measure.android.exceptions.ExceptionFactory
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.funnels.FunnelData
 import sh.measure.android.navigation.ScreenViewData
 import sh.measure.android.okhttp.HttpData
 import sh.measure.android.toEventAttachment
@@ -17,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal interface UserTriggeredEventCollector {
     fun trackHandledException(throwable: Throwable, attributes: Map<String, AttributeValue>)
     fun trackScreenView(screenName: String, attributes: Map<String, AttributeValue>)
+    fun trackFunnelEvent(name: String, attributes: Map<String, AttributeValue>)
     fun register()
     fun unregister()
     fun trackBugReport(
@@ -200,5 +202,18 @@ internal class UserTriggeredEventCollectorImpl(
             userDefinedAttributes = attributes,
         )
         logger.log(LogLevel.Debug, "Screen view event received")
+    }
+
+    override fun trackFunnelEvent(name: String, attributes: Map<String, AttributeValue>) {
+        if (!enabled.get()) {
+            return
+        }
+        signalProcessor.trackUserTriggered(
+            data = FunnelData(name = name),
+            timestamp = timeProvider.now(),
+            type = EventType.FUNNEL,
+            userDefinedAttributes = attributes,
+        )
+        logger.log(LogLevel.Debug, "Funnel event received")
     }
 }

--- a/android/measure/src/main/java/sh/measure/android/funnels/FunnelData.kt
+++ b/android/measure/src/main/java/sh/measure/android/funnels/FunnelData.kt
@@ -1,0 +1,11 @@
+package sh.measure.android.funnels
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a funnel event triggered when a user reaches a specific step in a funnel.
+ */
+@Serializable
+internal data class FunnelData(
+    val name: String,
+)

--- a/flutter/packages/measure_flutter/lib/measure_flutter.dart
+++ b/flutter/packages/measure_flutter/lib/measure_flutter.dart
@@ -401,6 +401,29 @@ class Measure implements MeasureApi {
     }
   }
 
+  /// Tracks a funnel event.
+  ///
+  /// Call this method when the user reaches a specific step in a conversion funnel.
+  /// Sequences of funnel events within a session are used to compute funnel analytics
+  /// and visualize conversion rates.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// Measure.instance.trackFunnelEvent(name: 'checkout_started');
+  /// ```
+  ///
+  /// - [name]: The name of the funnel step.
+  /// - [attributes]: Optional key-value pairs providing additional context to the event.
+  @override
+  void trackFunnelEvent({
+    required String name,
+    Map<String, AttributeValue> attributes = const {},
+  }) {
+    if (_isInitialized) {
+      _measure.trackFunnelEvent(name: name, attributes: attributes);
+    }
+  }
+
   /// Tracks HTTP network requests with detailed timing and response information.
   ///
   /// This method is typically called automatically by HTTP interceptors,

--- a/flutter/packages/measure_flutter/lib/src/events/event_type.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/event_type.dart
@@ -2,6 +2,7 @@ final class EventType {
   static final String custom = "custom";
   static final String exception = "exception";
   static final String screenView = "screen_view";
+  static final String funnel = "funnel";
   static final String http = "http";
   static final String bugReport = "bug_report";
   static final String gestureClick = "gesture_click";

--- a/flutter/packages/measure_flutter/lib/src/events/funnel_data.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/funnel_data.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../serialization/json_serializable.dart';
+
+part 'funnel_data.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class FunnelData implements JsonSerialized {
+  final String name;
+
+  const FunnelData({
+    required this.name,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => _$FunnelDataToJson(this);
+
+  factory FunnelData.fromJson(Map<String, dynamic> json) =>
+      _$FunnelDataFromJson(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FunnelData &&
+          runtimeType == other.runtimeType &&
+          name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+}

--- a/flutter/packages/measure_flutter/lib/src/events/funnel_data.g.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/funnel_data.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'funnel_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FunnelData _$FunnelDataFromJson(Map<String, dynamic> json) =>
+    FunnelData(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$FunnelDataToJson(FunnelData instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };

--- a/flutter/packages/measure_flutter/lib/src/measure_api.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_api.dart
@@ -36,6 +36,11 @@ abstract class MeasureApi {
     bool userTriggered = true,
   });
 
+  void trackFunnelEvent({
+    required String name,
+    Map<String, AttributeValue> attributes = const {},
+  });
+
   bool shouldTrackHttpRequestBody(String url);
 
   bool shouldTrackHttpResponseBody(String url);

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -4,6 +4,8 @@ import 'package:measure_flutter/src/bug_report/bug_report_collector.dart';
 import 'package:measure_flutter/src/bug_report/shake_detector.dart';
 import 'package:measure_flutter/src/config/config_loader.dart';
 import 'package:measure_flutter/src/events/custom_event_collector.dart';
+import 'package:measure_flutter/src/events/event_type.dart';
+import 'package:measure_flutter/src/events/funnel_data.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/gestures/click_data.dart';
 import 'package:measure_flutter/src/gestures/gesture_collector.dart';
@@ -123,6 +125,19 @@ final class MeasureInternal {
       name: name,
       userTriggered: userTriggered,
       attributes: attributes,
+    );
+  }
+
+  void trackFunnelEvent({
+    required String name,
+    Map<String, AttributeValue> attributes = const {},
+  }) {
+    initializer.signalProcessor.trackEvent(
+      data: FunnelData(name: name),
+      type: EventType.funnel,
+      timestamp: initializer.timeProvider.now(),
+      userDefinedAttrs: attributes,
+      userTriggered: true,
     );
   }
 

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -343,6 +343,12 @@ extension Measure.Measure {
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackScreenView(_ screenName: Swift.String, attributes: [Swift.String : Any]?)
   #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func trackFunnelEvent(_ name: Swift.String, attributes: [Swift.String : Measure.AttributeValue]?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public static func trackFunnelEvent(_ name: Swift.String, attributes: [Swift.String : Any]?)
+  #endif
   @objc public static func setUserId(_ userId: Swift.String)
   @objc public static func clearUserId()
   @objc public static func getCurrentTime() -> Swift.Int64

--- a/ios/Sources/MeasureSDK/Swift/Events/EventType.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/EventType.swift
@@ -24,6 +24,7 @@ enum EventType: String, Codable {
     case networkChange = "network_change"
     case custom
     case screenView = "screen_view"
+    case funnel
     case bugReport = "bug_report"
     case sessionStart = "session_start"
 }

--- a/ios/Sources/MeasureSDK/Swift/Events/FunnelData.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/FunnelData.swift
@@ -1,0 +1,11 @@
+//
+//  FunnelData.swift
+//  MeasureSDK
+//
+
+import Foundation
+
+/// Represents a funnel event triggered when a user reaches a specific step in a funnel.
+struct FunnelData: Codable {
+    let name: String
+}

--- a/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol UserTriggeredEventCollector {
     func trackScreenView(_ screenName: String, attributes: [String: AttributeValue]?)
+    func trackFunnelEvent(_ name: String, attributes: [String: AttributeValue]?)
     func trackError(_ error: Error, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
     func trackError(_ error: NSError, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
     func trackException(_ exception: NSException, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
@@ -76,6 +77,16 @@ final class BaseUserTriggeredEventCollector: UserTriggeredEventCollector {
               type: .screenView,
               userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes),
               needsReporting: signalSampler.shouldTrackJourneyForSession(sessionId: sessionManager.sessionId))
+    }
+
+    func trackFunnelEvent(_ name: String, attributes: [String: AttributeValue]? = nil) {
+        guard isEnabled.get() else { return }
+        guard attributeValueValidator.validateAttributes(name: name, attributes: attributes) else { return }
+
+        track(FunnelData(name: name),
+              type: .funnel,
+              userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes),
+              needsReporting: false)
     }
 
     func trackError(_ error: Error, attributes: [String: AttributeValue]?, collectStackTraces: Bool) {

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -154,6 +154,18 @@ import UIKit
         measureInternal.trackScreenView(screenName, attributes: attributes)
     }
 
+    func trackFunnelEvent(_ name: String, attributes: [String: AttributeValue]?) {
+        guard let measureInternal = measureInternal else { return }
+
+        measureInternal.trackFunnelEvent(name, attributes: attributes)
+    }
+
+    @objc func trackFunnelEvent(_ name: String, attributes: [String: Any]?) {
+        guard let measureInternal = measureInternal else { return }
+
+        measureInternal.trackFunnelEvent(name, attributes: attributes)
+    }
+
     @objc func setUserId(_ userId: String) {
         guard let measureInternal = measureInternal else { return }
         measureInternal.setUserId(userId)
@@ -549,6 +561,33 @@ extension Measure {
     ///   - attributes: Optional key-value pairs providing additional context to the event.
     @objc public static func trackScreenView(_ screenName: String, attributes: [String: Any]?) {
         Measure.shared.trackScreenView(screenName, attributes: attributes)
+    }
+
+    /// Track a funnel event.
+    ///
+    /// Call this method when the user reaches a specific step in a conversion funnel. Sequences of
+    /// funnel events within a session are used to compute funnel analytics and visualize conversion rates.
+    ///
+    /// Example usage:
+    ///
+    /// ```swift
+    /// Measure.trackFunnelEvent("checkout_started")
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - name: The name of the funnel step.
+    ///   - attributes: Optional key-value pairs providing additional context to the event.
+    public static func trackFunnelEvent(_ name: String, attributes: [String: AttributeValue]? = nil) {
+        Measure.shared.trackFunnelEvent(name, attributes: attributes)
+    }
+
+    /// Track a funnel event (Objective-C compatible).
+    ///
+    /// - Parameters:
+    ///   - name: The name of the funnel step.
+    ///   - attributes: Optional key-value pairs providing additional context to the event.
+    @objc public static func trackFunnelEvent(_ name: String, attributes: [String: Any]?) {
+        Measure.shared.trackFunnelEvent(name, attributes: attributes)
     }
 
     /// Sets the user ID for the current user.

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -253,6 +253,20 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         userTriggeredEventCollector.trackScreenView(screenName, attributes: transformedAttributes)
     }
 
+    func trackFunnelEvent(_ name: String, attributes: [String: AttributeValue]?) {
+        guard isStarted else { return }
+
+        userTriggeredEventCollector.trackFunnelEvent(name, attributes: attributes)
+    }
+
+    func trackFunnelEvent(_ name: String, attributes: [String: Any]?) {
+        guard isStarted else { return }
+
+        let transformedAttributes = transformAttributes(attributes)
+
+        userTriggeredEventCollector.trackFunnelEvent(name, attributes: transformedAttributes)
+    }
+
     func setUserId(_ userId: String) {
         userAttributeProcessor.setUserId(userId)
     }

--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -332,6 +332,18 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun trackFunnelEvent(name: String, attributes: ReadableMap?, promise: Promise) {
+        try {
+            val attrs =
+                attributes?.let { MapUtils.toAttributeValueMap(it) } ?: mutableMapOf()
+            Measure.trackFunnelEvent(name, attrs)
+            promise.resolve("Funnel event tracked successfully")
+        } catch (e: Exception) {
+            promise.reject("TRACK_FUNNEL_EVENT_ERROR", "Failed to track funnel event", e)
+        }
+    }
+
+    @ReactMethod
     fun trackBugReport(
         description: String,
         attachments: ReadableArray?,

--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -244,6 +244,16 @@ class MeasureModule: NSObject, RCTBridgeModule {
     }
     
     @objc
+    func trackFunnelEvent(_ name: NSString,
+                          attributes: NSDictionary?,
+                          resolver resolve: @escaping RCTPromiseResolveBlock,
+                          rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let attrDict = attributes as? [String: Any] ?? [:]
+        Measure.trackFunnelEvent(name as String, attributes: attrDict)
+        resolve("Funnel event tracked successfully")
+    }
+
+    @objc
     func trackBugReport(_ description: NSString,
                         attachments: NSArray,
                         attributes: NSDictionary,

--- a/react-native/ios/MeasureModuleBridge.m
+++ b/react-native/ios/MeasureModuleBridge.m
@@ -63,6 +63,10 @@ RCT_EXTERN_METHOD(trackBugReport:(NSString *)description
                   attributes:(NSDictionary *)attributes
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(trackFunnelEvent:(NSString *)name
+                  attributes:(NSDictionary * _Nullable)attributes
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getDynamicConfig:(RCTPromiseResolveBlock)resolve

--- a/react-native/src/events/eventType.ts
+++ b/react-native/src/events/eventType.ts
@@ -4,4 +4,5 @@
 export enum EventType {
   Custom = 'custom',
   ScreenView = 'screen_view',
+  Funnel = 'funnel',
 }

--- a/react-native/src/events/userTriggeredEventCollector.ts
+++ b/react-native/src/events/userTriggeredEventCollector.ts
@@ -38,6 +38,17 @@ export interface IUserTriggeredEventCollector {
   isEnabled(): boolean;
 
   /**
+   * Tracks a funnel event.
+   *
+   * @param name - The name of the funnel step.
+   * @param attributes - Optional key-value pairs providing context.
+   */
+  trackFunnelEvent(
+    name: string,
+    attributes?: Record<string, ValidAttributeValue>
+  ): Promise<void>;
+
+  /**
    * Tracks an HTTP event manually.
    *
    * Designed for apps using custom HTTP clients.
@@ -124,6 +135,47 @@ export class UserTriggeredEventCollector implements IUserTriggeredEventCollector
 
   isEnabled(): boolean {
     return this.enabled;
+  }
+
+  async trackFunnelEvent(
+    name: string,
+    attributes?: Record<string, ValidAttributeValue>
+  ): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
+    if (!name || name.length === 0) {
+      this.logger.log('error', 'Invalid funnel event: name is empty');
+      return;
+    }
+
+    const isValidAttributes = validateAttributes(attributes ?? {});
+    if (!isValidAttributes) {
+      this.logger.log(
+        'error',
+        `Invalid attributes provided for funnel event(${name}). Dropping the event.`
+      );
+      return;
+    }
+
+    try {
+      this.signalProcessor.trackEvent(
+        { name },
+        EventType.Funnel,
+        this.timeProvider.now(),
+        {},
+        attributes,
+        true,
+        undefined,
+        undefined,
+        []
+      );
+
+      this.logger.log('info', `Successfully tracked funnel event: ${name}`);
+    } catch (err) {
+      this.logger.log('error', `Failed to track funnel event ${name}: ${err}`);
+    }
   }
 
   async trackHttpEvent(params: {

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -162,6 +162,38 @@ export const Measure = {
   },
 
   /**
+   * Tracks a funnel event with optional attributes.
+   *
+   * Use this method to track steps in a conversion funnel, such as
+   * onboarding flows, checkout processes, or any multi-step user journey.
+   *
+   * @param name - The name of the funnel step.
+   * @param attributes - Optional key-value pairs providing additional context.
+   *
+   * @example
+   * ```ts
+   * import { Measure } from '@measure/react-native';
+   *
+   * Measure.trackFunnelEvent("checkout_started", {
+   *   cart_value: 49.99,
+   *   item_count: 3,
+   * });
+   * ```
+   */
+  trackFunnelEvent(
+    name: string,
+    attributes?: Record<string, ValidAttributeValue>
+  ): Promise<void> {
+    if (!_measureInternal) {
+      return Promise.reject(
+        new Error('Measure is not initialized. Call init() first.')
+      );
+    }
+
+    return _measureInternal.trackFunnelEvent(name, attributes);
+  },
+
+  /**
    * Returns the current time in milliseconds since epoch (Int64 equivalent).
    *
    * @returns The current time in milliseconds since epoch.

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -121,6 +121,15 @@ export class MeasureInternal {
       attributes ?? {}
     );
 
+  trackFunnelEvent = (
+    name: string,
+    attributes?: Record<string, ValidAttributeValue>
+  ): Promise<void> =>
+    this.measureInitializer.userTriggeredEventCollector.trackFunnelEvent(
+      name,
+      attributes ?? {}
+    );
+
   launchBugReport = (
     takeScreenshot: boolean = true,
     bugReportConfig: Record<string, any> = {},


### PR DESCRIPTION
# Description

Implements issue #3175. Adds a new `funnel` event type and `trackFunnelEvent(name, attributes?)` public API to all four SDKs. Funnel events are sequenced by the backend to compute conversion funnel analytics within a session.

## Related issue
Closes #3175


