### PR TITLE
Add enableDiagnosticMode to iOS and React Native SDKs

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		52B7F19C2D76B423001498BC /* LifecycleManager_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B7F19B2D76B423001498BC /* LifecycleManager_Internal.h */; };
 		52C844B92CB68A2D004BFE71 /* Measure.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524CC5BA2C6A4B11001AB506 /* Measure.framework */; platformFilter = ios; };
 		52C844BA2CB68A2D004BFE71 /* Measure.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 524CC5BA2C6A4B11001AB506 /* Measure.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5AAA6E9A2B385E59DE532B92 /* SdkDebugLogWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB461E1A0024AE3ED045D91E /* SdkDebugLogWriter.swift */; };
 		69694F0F2DE0461E008D1AF1 /* Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69694F0E2DE04619008D1AF1 /* Framework.swift */; };
 		69C449692DA9266400E44CF4 /* InternalSignalCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C449682DA9266400E44CF4 /* InternalSignalCollector.swift */; };
 		69C4496B2DACC7C700E44CF4 /* InternalSignalCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C4496A2DACC7BE00E44CF4 /* InternalSignalCollectorTests.swift */; };
@@ -632,10 +633,21 @@
 		CFEC97EC2D9A7642000CFB68 /* MeasureInternalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureInternalTests.swift; sourceTree = "<group>"; };
 		CFF2E6972F69246A003B5A66 /* Data+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extension.swift"; sourceTree = "<group>"; };
 		CFF5AE8F2ED5E912003BCA79 /* MeasureConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureConfigTests.swift; sourceTree = "<group>"; };
+		DB461E1A0024AE3ED045D91E /* SdkDebugLogWriter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SdkDebugLogWriter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		6907519B2DC0F0B20085FDBA /* CrashReports */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CrashReports; sourceTree = "<group>"; };
+		6907519B2DC0F0B20085FDBA /* CrashReports */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = CrashReports;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1013,6 +1025,7 @@
 				CFD88C6D2D9E94B40095115E /* Tracing */,
 				526D18132D5A1913009A2E90 /* Utils */,
 				526D18152D5A1913009A2E90 /* XCDataModel */,
+				5B8FA40AEF4B8A9568BB900E /* Logger */,
 			);
 			path = Swift;
 			sourceTree = "<group>";
@@ -1245,6 +1258,15 @@
 				524576782CC260FE00B288E5 /* CoreTelephony.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5B8FA40AEF4B8A9568BB900E /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				DB461E1A0024AE3ED045D91E /* SdkDebugLogWriter.swift */,
+			);
+			name = Logger;
+			path = Logger;
 			sourceTree = "<group>";
 		};
 		CF1BB3B52DBA39CA00588506 /* Lifecycle */ = {
@@ -1779,6 +1801,7 @@
 				526D18602D5A1913009A2E90 /* HttpEventCollector.swift in Sources */,
 				526D186D2D5A1913009A2E90 /* NetworkChangeCallback.swift in Sources */,
 				CF634D4A2F61966A002B0B81 /* Exporter.swift in Sources */,
+				5AAA6E9A2B385E59DE532B92 /* SdkDebugLogWriter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)
+// swift-compiler-version: Apple Swift version 6.2.4 effective-5.10 (swiftlang-6.2.4.1.4 clang-1700.6.4.2)
 // swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2.4
 import AVKit
 import CoreData
 import CoreMotion
@@ -72,10 +72,10 @@ extension Measure.SessionOb {
 }
 @objc final public class BaseMeasureConfig : ObjectiveC.NSObject, Swift.Codable {
   #if compiler(>=5.3) && $NonescapableTypes
-  public init(enableLogging: Swift.Bool? = nil, autoStart: Swift.Bool? = nil, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)? = nil, maxDiskUsageInMb: Swift.Int? = nil, enableFullCollectionMode: Swift.Bool? = nil)
+  public init(enableLogging: Swift.Bool? = nil, autoStart: Swift.Bool? = nil, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)? = nil, maxDiskUsageInMb: Swift.Int? = nil, enableFullCollectionMode: Swift.Bool? = nil, enableDiagnosticMode: Swift.Bool? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc convenience public init(enableLogging: Swift.Bool, autoStart: Swift.Bool, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)?, maxDiskUsageInMb: Foundation.NSNumber?, enableFullCollectionMode: Swift.Bool)
+  @objc convenience public init(enableLogging: Swift.Bool, autoStart: Swift.Bool, requestHeadersProvider: (any Measure.MsrRequestHeadersProvider)?, maxDiskUsageInMb: Foundation.NSNumber?, enableFullCollectionMode: Swift.Bool, enableDiagnosticMode: Swift.Bool)
   #endif
   required public init(from decoder: any Swift.Decoder) throws
   final public func encode(to encoder: any Swift.Encoder) throws

--- a/ios/Sources/MeasureSDK/ObjC/MSRConfig.m
+++ b/ios/Sources/MeasureSDK/ObjC/MSRConfig.m
@@ -12,14 +12,16 @@
 - (instancetype)initWithEnableLogging:(BOOL)enableLogging
                             autoStart:(BOOL)autoStart
              enableFullCollectionMode:(BOOL)enableFullCollectionMode
+                 enableDiagnosticMode:(BOOL)enableDiagnosticMode
                requestHeadersProvider:(id<MsrRequestHeadersProvider>)requestHeadersProvider
                      maxDiskUsageInMb:(NSNumber *)maxDiskUsageInMb {
-    
+
     self = [super init];
     if (self) {
         _enableLogging = enableLogging;
         _autoStart = autoStart;
         _enableFullCollectionMode = enableFullCollectionMode;
+        _enableDiagnosticMode = enableDiagnosticMode;
         _requestHeadersProvider = requestHeadersProvider;
         _maxDiskUsageInMb = maxDiskUsageInMb;
     }

--- a/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
+++ b/ios/Sources/MeasureSDK/ObjC/MeasureSDK.m
@@ -28,7 +28,8 @@
                                                              autoStart:config.autoStart
                                                 requestHeadersProvider:config.requestHeadersProvider
                                                       maxDiskUsageInMb:config.maxDiskUsageInMb
-                                              enableFullCollectionMode:config.enableFullCollectionMode];
+                                              enableFullCollectionMode:config.enableFullCollectionMode
+                                                  enableDiagnosticMode:config.enableDiagnosticMode];
     }
 
     [Measure initializeWith:client config:swiftConfig];

--- a/ios/Sources/MeasureSDK/ObjC/include/MSRConfig.h
+++ b/ios/Sources/MeasureSDK/ObjC/include/MSRConfig.h
@@ -31,6 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
 @property (nonatomic) BOOL enableFullCollectionMode;
 
+/// Enable diagnostic mode to write SDK logs to a file on disk for debugging SDK issues.
+/// Defaults to `false`.
+@property (nonatomic) BOOL enableDiagnosticMode;
+
 /// Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API.
 ///
 /// This is useful only for self-hosted clients who may require additional headers for requests in their infrastructure.
@@ -58,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithEnableLogging:(BOOL)enableLogging
                            autoStart:(BOOL)autoStart
              enableFullCollectionMode:(BOOL)enableFullCollectionMode
+                 enableDiagnosticMode:(BOOL)enableDiagnosticMode
              requestHeadersProvider:(nullable id<MsrRequestHeadersProvider>)requestHeadersProvider
                  maxDiskUsageInMb:(NSNumber *)maxDiskUsageInMb NS_DESIGNATED_INITIALIZER;
 

--- a/ios/Sources/MeasureSDK/Swift/Config/Config.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/Config.swift
@@ -47,6 +47,7 @@ struct Config: InternalConfig, MeasureConfig {
     let enableLogging: Bool
     let autoStart: Bool
     let enableFullCollectionMode: Bool
+    let enableDiagnosticMode: Bool
     let requestHeadersProvider: MsrRequestHeadersProvider?
     let maxDiskUsageInMb: Number
     let httpUrlBlocklist: [String]
@@ -54,11 +55,13 @@ struct Config: InternalConfig, MeasureConfig {
     init(enableLogging: Bool = DefaultConfig.enableLogging, // swiftlint:disable:this function_body_length
          autoStart: Bool = DefaultConfig.autoStart,
          enableFullCollectionMode: Bool = DefaultConfig.enableFullCollectionMode,
+         enableDiagnosticMode: Bool = DefaultConfig.enableDiagnosticMode,
          requestHeadersProvider: MsrRequestHeadersProvider? = nil,
          maxDiskUsageInMb: Number = DefaultConfig.maxDiskUsageInMb) {
         self.enableLogging = enableLogging
         self.autoStart = autoStart
         self.enableFullCollectionMode = enableFullCollectionMode
+        self.enableDiagnosticMode = enableDiagnosticMode
         self.requestHeadersProvider = requestHeadersProvider
         self.maxDiskUsageInMb = maxDiskUsageInMb
         self.batchExportIntervalMs = 3_000 // 3 seconds

--- a/ios/Sources/MeasureSDK/Swift/Config/ConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ConfigProvider.swift
@@ -81,6 +81,7 @@ final class BaseConfigProvider: ConfigProvider {
     var enableLogging: Bool { defaultConfig.enableLogging }
     var autoStart: Bool { defaultConfig.autoStart }
     var enableFullCollectionMode: Bool { defaultConfig.enableFullCollectionMode }
+    var enableDiagnosticMode: Bool { defaultConfig.enableDiagnosticMode }
     var requestHeadersProvider: MsrRequestHeadersProvider? { defaultConfig.requestHeadersProvider }
     var maxDiskUsageInMb: Number { defaultConfig.maxDiskUsageInMb }
 

--- a/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/DefaultConfig.swift
@@ -13,6 +13,7 @@ struct DefaultConfig {
     static let autoStart = true
     static let maxDiskUsageInMb: Number = 50
     static let enableFullCollectionMode = false
+    static let enableDiagnosticMode = false
     static let disallowedCustomHeaders: [String] = ["Content-Type",
                                                     "msr-req-id",
                                                     "Authorization",

--- a/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/MeasureConfig.swift
@@ -12,6 +12,7 @@ protocol MeasureConfig {
     var enableLogging: Bool { get }
     var autoStart: Bool { get }
     var enableFullCollectionMode: Bool { get }
+    var enableDiagnosticMode: Bool { get }
     var requestHeadersProvider: MsrRequestHeadersProvider? { get }
     var maxDiskUsageInMb: Number { get }
 }
@@ -29,6 +30,10 @@ protocol MeasureConfig {
     /// Override all sampling configs and track all events and traces.
     /// **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
     let enableFullCollectionMode: Bool
+
+    /// Enable diagnostic mode to write SDK logs to a file on disk for debugging SDK issues.
+    /// Defaults to `false`.
+    let enableDiagnosticMode: Bool
 
     /// Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API. This is useful only for self-hosted clients who may require additional headers for requests in their infrastructure.
     let requestHeadersProvider: MsrRequestHeadersProvider?
@@ -58,14 +63,17 @@ protocol MeasureConfig {
     ///   - requestHeadersProvider: Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API.
     ///   - maxDiskUsageInMb: Configures the maximum disk usage in megabytes that the Measure SDK is allowed to use. Defaults to `50MB`. Allowed values are between `20MB` and `1500MB`.
     ///   - enableFullCollectionMode: Override all sampling configs and track all events and traces. **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
+    ///   - enableDiagnosticMode: Enable diagnostic mode to write SDK logs to a file on disk for debugging SDK issues. Defaults to `false`.
     public init(enableLogging: Bool? = nil,
                 autoStart: Bool? = nil,
                 requestHeadersProvider: MsrRequestHeadersProvider? = nil,
                 maxDiskUsageInMb: Int? = nil,
-                enableFullCollectionMode: Bool? = nil) {
+                enableFullCollectionMode: Bool? = nil,
+                enableDiagnosticMode: Bool? = nil) {
         self.enableLogging = enableLogging ?? DefaultConfig.enableLogging
         self.autoStart = autoStart ?? DefaultConfig.autoStart
         self.enableFullCollectionMode = enableFullCollectionMode ?? DefaultConfig.enableFullCollectionMode
+        self.enableDiagnosticMode = enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode
         self.requestHeadersProvider = requestHeadersProvider
 
         let minDiskUsage: Number = 20
@@ -93,16 +101,19 @@ protocol MeasureConfig {
     ///   - requestHeadersProvider: Allows configuring custom HTTP headers for requests made by the Measure SDK to the Measure API.
     ///   - maxDiskUsageInMb: Configures the maximum disk usage in megabytes that the Measure SDK is allowed to use. Defaults to `50MB`. Allowed values are between `20MB` and `1500MB`.
     ///   - enableFullCollectionMode: Override all sampling configs and track all events and traces. **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
+    ///   - enableDiagnosticMode: Enable diagnostic mode to write SDK logs to a file on disk for debugging SDK issues. Defaults to `false`.
     @objc public convenience init(enableLogging: Bool,
                                   autoStart: Bool,
                                   requestHeadersProvider: MsrRequestHeadersProvider?,
                                   maxDiskUsageInMb: NSNumber?,
-                                  enableFullCollectionMode: Bool) {
+                                  enableFullCollectionMode: Bool,
+                                  enableDiagnosticMode: Bool) {
         self.init(enableLogging: enableLogging,
                   autoStart: autoStart,
                   requestHeadersProvider: requestHeadersProvider,
                   maxDiskUsageInMb: maxDiskUsageInMb?.intValue,
-                  enableFullCollectionMode: enableFullCollectionMode)
+                  enableFullCollectionMode: enableFullCollectionMode,
+                  enableDiagnosticMode: enableDiagnosticMode)
         
     }
 
@@ -112,6 +123,7 @@ protocol MeasureConfig {
         enableLogging = try container.decodeIfPresent(Bool.self, forKey: .enableLogging) ?? DefaultConfig.enableLogging
         autoStart = try container.decodeIfPresent(Bool.self, forKey: .autoStart) ?? DefaultConfig.autoStart
         enableFullCollectionMode = try container.decodeIfPresent(Bool.self, forKey: .enableFullCollectionMode) ?? DefaultConfig.enableFullCollectionMode
+        enableDiagnosticMode = try container.decodeIfPresent(Bool.self, forKey: .enableDiagnosticMode) ?? DefaultConfig.enableDiagnosticMode
         requestHeadersProvider = nil // requestHeadersProvider is not encodable
 
         let minDiskUsage: Number = 20
@@ -139,6 +151,7 @@ protocol MeasureConfig {
         // requestHeadersProvider is not encodable
         case maxDiskUsageInMb
         case enableFullCollectionMode
+        case enableDiagnosticMode
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -147,5 +160,6 @@ protocol MeasureConfig {
         try container.encode(autoStart, forKey: .autoStart)
         try container.encode(maxDiskUsageInMb, forKey: .maxDiskUsageInMb)
         try container.encode(enableFullCollectionMode, forKey: .enableFullCollectionMode)
+        try container.encode(enableDiagnosticMode, forKey: .enableDiagnosticMode)
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Logger/SdkDebugLogWriter.swift
+++ b/ios/Sources/MeasureSDK/Swift/Logger/SdkDebugLogWriter.swift
@@ -1,0 +1,78 @@
+//
+//  SdkDebugLogWriter.swift
+//  MeasureSDK
+//
+
+import Foundation
+
+/// Writes SDK diagnostic logs to a file on disk. Logs are buffered in memory and flushed every 3 seconds
+/// on a background serial queue. The file handle is kept open for the lifetime of the writer.
+///
+/// Thread safety: writeLog() can be called from any thread. The buffer is dispatched to the serial queue.
+/// All file I/O runs exclusively on the serial queue.
+final class SdkDebugLogWriter {
+    private let queue: DispatchQueue
+    private var buffer: [LogEntry] = []
+    private var fileHandle: FileHandle?
+    private var timer: DispatchSourceTimer?
+
+    init(queue: DispatchQueue = DispatchQueue(label: "sh.measure.sdk.diag", qos: .background)) {
+        self.queue = queue
+    }
+
+    func start(sdkVersion: String, timestamp: Int64, logsDir: URL) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            do {
+                if !FileManager.default.fileExists(atPath: logsDir.path) {
+                    try FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true, attributes: nil)
+                }
+                let fileURL = logsDir.appendingPathComponent("\(timestamp)")
+                FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
+                self.fileHandle = try FileHandle(forWritingTo: fileURL)
+                let header = "\(sdkVersion) \(timestamp)\n"
+                if let data = header.data(using: .utf8) {
+                    self.fileHandle?.write(data)
+                }
+            } catch {
+                // Silently ignore -- never break SDK init
+            }
+        }
+
+        let t = DispatchSource.makeTimerSource(queue: queue)
+        t.schedule(deadline: .now() + 3, repeating: 3)
+        t.setEventHandler { [weak self] in self?.flush() }
+        t.resume()
+        timer = t
+    }
+
+    func writeLog(level: LogLevel, message: String, error: Error?) {
+        queue.async { [weak self] in
+            self?.buffer.append(LogEntry(level: level, message: message, error: error))
+        }
+    }
+
+    func flush() {
+        // Called on queue
+        guard !buffer.isEmpty, let handle = fileHandle else { return }
+        let entries = buffer
+        buffer.removeAll()
+        var output = ""
+        for entry in entries {
+            output += "\(entry.level.rawValue) \(entry.message)"
+            if let error = entry.error {
+                output += " \(error.localizedDescription)"
+            }
+            output += "\n"
+        }
+        if let data = output.data(using: .utf8) {
+            handle.write(data)
+        }
+    }
+
+    private struct LogEntry {
+        let level: LogLevel
+        let message: String
+        let error: Error?
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -217,6 +217,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
         let defaultConfig = Config(enableLogging: config.enableLogging,
                                    autoStart: config.autoStart,
                                    enableFullCollectionMode: config.enableFullCollectionMode,
+                                   enableDiagnosticMode: config.enableDiagnosticMode,
                                    requestHeadersProvider: config.requestHeadersProvider,
                                    maxDiskUsageInMb: config.maxDiskUsageInMb)
         self.configProvider = BaseConfigProvider(defaultConfig: defaultConfig)

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -170,6 +170,22 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.lifecycleObserver.applicationDidBecomeActive = applicationDidBecomeActive
         self.lifecycleObserver.applicationWillResignActive = applicationWillResignActive
         self.logger.log(level: .info, message: "Initializing Measure SDK", error: nil, data: nil)
+        if configProvider.enableDiagnosticMode {
+            do {
+                guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { throw NSError(domain: "Measure", code: 0) }
+                let logsDir = cachesDir.appendingPathComponent("measure/sdk_debug_logs")
+                let timestamp = timeProvider.now()
+                let writer = SdkDebugLogWriter()
+                writer.start(sdkVersion: FrameworkInfo.version,
+                             timestamp: timestamp,
+                             logsDir: logsDir)
+                logger.setLogCallback { [weak writer] level, message, error in
+                    writer?.writeLog(level: level, message: message, error: error)
+                }
+            } catch {
+                // Silently ignore
+            }
+        }
         self.sessionManager.setPreviousSessionCrashed(crashReportManager.hasPendingCrashReport)
         previousSessionCrashed = crashReportManager.hasPendingCrashReport
         self.sessionManager.setOnSessionStarted { [weak self] sessionId in

--- a/ios/Sources/MeasureSDK/Swift/Utils/Logger.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Logger.swift
@@ -23,14 +23,20 @@ protocol Logger {
 
     func log(level: LogLevel, message: String, error: Error?, data: Encodable?)
     func internalLog(level: LogLevel, message: String, error: Error?, data: Encodable?)
+    func setLogCallback(_ callback: ((LogLevel, String, Error?) -> Void)?)
 }
 
 /// A logger that logs to the Apple unified logging system (os_log).
 final class MeasureLogger: Logger {
     let enabled: Bool
+    private var logCallback: ((LogLevel, String, Error?) -> Void)?
 
     init(enabled: Bool) {
         self.enabled = enabled
+    }
+
+    func setLogCallback(_ callback: ((LogLevel, String, Error?) -> Void)?) {
+        logCallback = callback
     }
 
     /// Add logs to the Apple unified logging system (os_log)
@@ -40,6 +46,7 @@ final class MeasureLogger: Logger {
     ///   - error: Error object to log
     ///   - data: Codable object to log
     func log(level: LogLevel, message: String, error: Error? = nil, data: Encodable? = nil) {
+        logCallback?(level, message, error)
         guard enabled else { return }
 
         let logType: OSLogType

--- a/ios/Tests/MeasureSDKTests/Config/MeasureConfigTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/MeasureConfigTests.swift
@@ -41,4 +41,28 @@ final class MeasureConfigTests: XCTestCase {
         let config = BaseMeasureConfig(maxDiskUsageInMb: 300)
         XCTAssertEqual(config.maxDiskUsageInMb, 300)
     }
+
+    // MARK: - enableDiagnosticMode
+
+    func test_enableDiagnosticMode_defaultsToFalse() {
+        let config = BaseMeasureConfig()
+        XCTAssertFalse(config.enableDiagnosticMode)
+    }
+
+    func test_enableDiagnosticMode_canBeSetToTrue() {
+        let config = BaseMeasureConfig(enableDiagnosticMode: true)
+        XCTAssertTrue(config.enableDiagnosticMode)
+    }
+
+    func test_enableDiagnosticMode_encodesAndDecodesCorrectly() throws {
+        let original = BaseMeasureConfig(enableDiagnosticMode: true)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(BaseMeasureConfig.self, from: data)
+
+        XCTAssertEqual(decoded.enableDiagnosticMode, original.enableDiagnosticMode)
+    }
 }

--- a/ios/Tests/MeasureSDKTests/Logger/MeasureLoggerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Logger/MeasureLoggerTests.swift
@@ -1,0 +1,94 @@
+//
+//  MeasureLoggerTests.swift
+//  MeasureSDKTests
+//
+
+import XCTest
+@testable import Measure
+
+final class MeasureLoggerTests: XCTestCase {
+    var sut: MeasureLogger!
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - setLogCallback
+
+    func test_log_invokesCallbackBeforeEnabledGuard() {
+        sut = MeasureLogger(enabled: false)
+
+        var callbackInvoked = false
+        sut.setLogCallback { _, _, _ in
+            callbackInvoked = true
+        }
+
+        sut.log(level: .debug, message: "test", error: nil, data: nil)
+
+        XCTAssertTrue(callbackInvoked, "Callback should be invoked even when logger is disabled")
+    }
+
+    func test_log_callbackReceivesCorrectLevelAndMessage() {
+        sut = MeasureLogger(enabled: true)
+
+        var capturedLevel: LogLevel?
+        var capturedMessage: String?
+        sut.setLogCallback { level, message, _ in
+            capturedLevel = level
+            capturedMessage = message
+        }
+
+        sut.log(level: .warning, message: "something happened", error: nil, data: nil)
+
+        XCTAssertEqual(capturedLevel, .warning)
+        XCTAssertEqual(capturedMessage, "something happened")
+    }
+
+    func test_log_callbackReceivesError() {
+        sut = MeasureLogger(enabled: true)
+
+        var capturedError: Error?
+        sut.setLogCallback { _, _, error in
+            capturedError = error
+        }
+
+        let testError = NSError(domain: "test", code: 42, userInfo: nil)
+        sut.log(level: .error, message: "fail", error: testError, data: nil)
+
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual((capturedError as? NSError)?.code, 42)
+    }
+
+    func test_setLogCallback_nil_removesCallback() {
+        sut = MeasureLogger(enabled: true)
+
+        var callbackInvoked = false
+        sut.setLogCallback { _, _, _ in
+            callbackInvoked = true
+        }
+
+        // Remove the callback
+        sut.setLogCallback(nil)
+
+        sut.log(level: .debug, message: "test", error: nil, data: nil)
+
+        XCTAssertFalse(callbackInvoked, "Callback should not be invoked after being set to nil")
+    }
+
+    func test_internalLog_doesNotInvokeCallback() {
+        // internalLog is compiled out unless INTERNAL_LOGGING is defined.
+        // In normal test builds the flag is absent, so internalLog is a no-op
+        // and the callback must NOT fire.
+        sut = MeasureLogger(enabled: true)
+
+        var callbackInvoked = false
+        sut.setLogCallback { _, _, _ in
+            callbackInvoked = true
+        }
+
+        sut.internalLog(level: .debug, message: "internal", error: nil, data: nil)
+
+        XCTAssertFalse(callbackInvoked, "internalLog should not invoke callback in non-INTERNAL_LOGGING builds")
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Logger/SdkDebugLogWriterTests.swift
+++ b/ios/Tests/MeasureSDKTests/Logger/SdkDebugLogWriterTests.swift
@@ -1,0 +1,154 @@
+//
+//  SdkDebugLogWriterTests.swift
+//  MeasureSDKTests
+//
+
+import XCTest
+@testable import Measure
+
+final class SdkDebugLogWriterTests: XCTestCase {
+    var sut: SdkDebugLogWriter!
+    var logsDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        sut = SdkDebugLogWriter()
+        logsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SdkDebugLogWriterTests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() {
+        sut = nil
+        if let logsDir, FileManager.default.fileExists(atPath: logsDir.path) {
+            try? FileManager.default.removeItem(at: logsDir)
+        }
+        logsDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - start
+
+    func test_start_createsLogFileInDirectory() {
+        let timestamp: Int64 = 1234567890
+        let expectation = expectation(description: "File created on background queue")
+
+        sut.start(sdkVersion: "1.0.0", timestamp: timestamp, logsDir: logsDir)
+
+        // flush() dispatches to the serial queue; calling it ensures the start work has completed.
+        sut.flush()
+
+        // Give the serial queue time to process start + flush
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        let filePath = logsDir.appendingPathComponent("\(timestamp)").path
+        XCTAssertTrue(FileManager.default.fileExists(atPath: filePath), "Log file should exist at \(filePath)")
+    }
+
+    func test_start_writesHeaderToFile() {
+        let timestamp: Int64 = 9999999999
+        let sdkVersion = "2.3.1"
+        let expectation = expectation(description: "Header written")
+
+        sut.start(sdkVersion: sdkVersion, timestamp: timestamp, logsDir: logsDir)
+        sut.flush()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        let fileURL = logsDir.appendingPathComponent("\(timestamp)")
+        let contents = try? String(contentsOf: fileURL, encoding: .utf8)
+        XCTAssertNotNil(contents, "Should be able to read file contents")
+        XCTAssertTrue(contents?.hasPrefix("\(sdkVersion) \(timestamp)\n") == true,
+                      "First line should be '<sdkVersion> <timestamp>\\n', got: \(contents ?? "nil")")
+    }
+
+    // MARK: - writeLog + flush
+
+    func test_writeLog_thenFlushWritesEntryToFile() {
+        let timestamp: Int64 = 1111111111
+        let expectation = expectation(description: "Log entry flushed")
+
+        sut.start(sdkVersion: "1.0.0", timestamp: timestamp, logsDir: logsDir)
+        sut.writeLog(level: .debug, message: "test message", error: nil)
+        sut.flush()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        let fileURL = logsDir.appendingPathComponent("\(timestamp)")
+        let contents = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(contents.contains("Debug test message"), "File should contain the log entry, got: \(contents)")
+    }
+
+    func test_writeLog_multipleEntries_allFlushedToFile() {
+        let timestamp: Int64 = 2222222222
+        let expectation = expectation(description: "Multiple entries flushed")
+
+        sut.start(sdkVersion: "1.0.0", timestamp: timestamp, logsDir: logsDir)
+        sut.writeLog(level: .debug, message: "first", error: nil)
+        sut.writeLog(level: .info, message: "second", error: nil)
+        sut.writeLog(level: .error, message: "third", error: nil)
+        sut.flush()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        let fileURL = logsDir.appendingPathComponent("\(timestamp)")
+        let contents = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(contents.contains("Debug first"), "Should contain first entry")
+        XCTAssertTrue(contents.contains("Info second"), "Should contain second entry")
+        XCTAssertTrue(contents.contains("Error third"), "Should contain third entry")
+    }
+
+    func test_writeLog_withError_includesErrorInOutput() {
+        let timestamp: Int64 = 3333333333
+        let expectation = expectation(description: "Error entry flushed")
+
+        sut.start(sdkVersion: "1.0.0", timestamp: timestamp, logsDir: logsDir)
+
+        let testError = NSError(domain: "test.domain", code: 99, userInfo: [NSLocalizedDescriptionKey: "something broke"])
+        sut.writeLog(level: .error, message: "failed op", error: testError)
+        sut.flush()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        let fileURL = logsDir.appendingPathComponent("\(timestamp)")
+        let contents = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(contents.contains("something broke"), "File should include error description, got: \(contents)")
+    }
+
+    // MARK: - Error handling
+
+    func test_start_silentlyHandlesInvalidDirectory() {
+        let invalidDir = URL(fileURLWithPath: "/nonexistent/readonly/path")
+        let expectation = expectation(description: "No crash on invalid directory")
+
+        // Should not crash
+        sut.start(sdkVersion: "1.0.0", timestamp: 0, logsDir: invalidDir)
+        sut.flush()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+        // If we reach here without crashing, the test passes
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockConfigProvider.swift
@@ -12,6 +12,7 @@ final class MockConfigProvider: ConfigProvider {
     var enableLogging: Bool
     var autoStart: Bool
     var enableFullCollectionMode: Bool
+    var enableDiagnosticMode: Bool
     var requestHeadersProvider: MsrRequestHeadersProvider?
     var maxDiskUsageInMb: Number
     var batchExportIntervalMs: Number
@@ -75,6 +76,7 @@ final class MockConfigProvider: ConfigProvider {
     init(enableLogging: Bool = false,
          autoStart: Bool = true,
          enableFullCollectionMode: Bool = false,
+         enableDiagnosticMode: Bool = false,
          requestHeadersProvider: MsrRequestHeadersProvider? = nil,
          maxDiskUsageInMb: Number = 50,
          batchExportIntervalMs: Number = 3_000,
@@ -165,6 +167,7 @@ final class MockConfigProvider: ConfigProvider {
         self.enableLogging = enableLogging
         self.autoStart = autoStart
         self.enableFullCollectionMode = enableFullCollectionMode
+        self.enableDiagnosticMode = enableDiagnosticMode
         self.requestHeadersProvider = requestHeadersProvider
         self.maxDiskUsageInMb = maxDiskUsageInMb
         self.batchExportIntervalMs = batchExportIntervalMs

--- a/ios/Tests/MeasureSDKTests/Mocks/MockLogger.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockLogger.swift
@@ -27,4 +27,8 @@ final class MockLogger: Logger {
         print("InternalLog: level \(level) message \(message) error \(String(describing: error)) data \(data ?? "")")
         logs.append(message)
     }
+
+    func setLogCallback(_ callback: ((LogLevel, String, Error?) -> Void)?) {
+        // No-op for tests
+    }
 }

--- a/react-native/src/config/config.ts
+++ b/react-native/src/config/config.ts
@@ -6,6 +6,7 @@ export class Config implements InternalConfig, IMeasureConfig {
   enableLogging: boolean;
   autoStart: boolean;
   enableFullCollectionMode: boolean;
+  enableDiagnosticMode: boolean;
   maxCheckpointsPerSpan: number;
   maxCheckpointNameLength: number;
   maxSpanNameLength: number;
@@ -15,11 +16,13 @@ export class Config implements InternalConfig, IMeasureConfig {
   constructor(
     enableLogging?: boolean,
     autoStart?: boolean,
-    enableFullCollectionMode?: boolean
+    enableFullCollectionMode?: boolean,
+    enableDiagnosticMode?: boolean
   ) {
     this.enableLogging = enableLogging ?? DefaultConfig.enableLogging;
     this.autoStart = autoStart ?? DefaultConfig.autoStart;
     this.enableFullCollectionMode = enableFullCollectionMode ?? DefaultConfig.enableFullCollectionMode;
+    this.enableDiagnosticMode = enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode;
     this.maxEventNameLength = 64;
     this.customEventNameRegex = DefaultConfig.customEventNameRegex;
     this.maxSpanNameLength = 64;

--- a/react-native/src/config/configProvider.ts
+++ b/react-native/src/config/configProvider.ts
@@ -112,6 +112,10 @@ export class ConfigProvider implements IConfigProvider {
     return this.defaultConfig.enableFullCollectionMode;
   }
 
+  get enableDiagnosticMode(): boolean {
+    return this.defaultConfig.enableDiagnosticMode;
+  }
+
   get maxEventNameLength(): number {
     return this.defaultConfig.maxEventNameLength;
   }

--- a/react-native/src/config/defaultConfig.ts
+++ b/react-native/src/config/defaultConfig.ts
@@ -3,5 +3,6 @@ export const DefaultConfig = {
   enableLogging: false,
   autoStart: true,
   enableFullCollectionMode: false,
+  enableDiagnosticMode: false,
   customEventNameRegex: "^[a-zA-Z0-9_-]+\$",
 };

--- a/react-native/src/config/measureConfig.ts
+++ b/react-native/src/config/measureConfig.ts
@@ -17,11 +17,18 @@ export interface IMeasureConfig {
    */
   autoStart: boolean;
 
-  /** 
+  /**
    * Override all sampling configs and track all events and traces.
    * **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
   */
   enableFullCollectionMode: boolean;
+
+  /**
+   * When enabled, writes all SDK logs to a file on disk. Useful for debugging SDK issues.
+   * The log file can be found in the app's cache directory under `measure/sdk_debug_logs/`.
+   * Defaults to `false`.
+   */
+  enableDiagnosticMode: boolean;
 }
 
 /**
@@ -31,6 +38,7 @@ export class MeasureConfig implements IMeasureConfig {
   enableLogging: boolean;
   autoStart: boolean;
   enableFullCollectionMode: boolean;
+  enableDiagnosticMode: boolean;
 
   /**
    * Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
@@ -42,5 +50,6 @@ export class MeasureConfig implements IMeasureConfig {
     this.enableLogging = options.enableLogging ?? DefaultConfig.enableLogging;
     this.autoStart = options.autoStart ?? DefaultConfig.autoStart;
     this.enableFullCollectionMode = options.enableFullCollectionMode ?? DefaultConfig.enableFullCollectionMode;
+    this.enableDiagnosticMode = options.enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode;
   }
 }

--- a/react-native/src/measureInitializer.ts
+++ b/react-native/src/measureInitializer.ts
@@ -90,7 +90,8 @@ export class MeasureInitializer implements IMeasureInitializer {
     this.config = new Config(
       config?.enableLogging,
       config?.autoStart,
-      config?.enableFullCollectionMode
+      config?.enableFullCollectionMode,
+      config?.enableDiagnosticMode
     );
     this.configLoader = new ConfigLoader(this.logger);
     this.configProvider = new ConfigProvider(this.config);


### PR DESCRIPTION
# Description

When enabled, all SDK logs are written to a timestamped file at <cachesDirectory>/measure/sdk_debug_logs/<timestamp> on iOS. The log file includes an SDK version header and captures logs even when console logging (enableLogging) is disabled.

iOS changes:
- Add SdkDebugLogWriter: buffered file writer with 3s periodic flush on a background serial DispatchQueue
- Add setLogCallback hook to Logger protocol and MeasureLogger; callback fires before the enabled guard to capture all logs
- Add enableDiagnosticMode to MeasureConfig protocol, BaseMeasureConfig (Swift + ObjC inits, Codable), DefaultConfig, ConfigProvider, MSRConfig.h/.m, MeasureSDK.m, and swiftinterface
- Wire diagnostic mode in MeasureInternal.init()
- Add 14 unit tests across MeasureLoggerTests, SdkDebugLogWriterTests, and MeasureConfigTests

React Native changes:
- Plumb enableDiagnosticMode through DefaultConfig → IMeasureConfig → MeasureConfig → Config → IConfigProvider/ConfigProvider → MeasureInitializer (JS config layer)

## Related issue
Fixes #3360 