### PR TITLE
chore(ios): improve iOS crash reports for KMP

### DIFF
--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2
+// swift-compiler-version: Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface
 import AVKit
 import CoreData
 import CoreMotion
@@ -38,37 +38,33 @@ extension Measure.AttributeValue : Swift.Codable {
   public init(from decoder: any Swift.Decoder) throws
 }
 public typealias SessionObCoreDataClassSet = Foundation.NSSet
-@_inheritsConvenienceInitializers @objc(SessionOb) nonisolated public class SessionOb : CoreData.NSManagedObject {
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc override nonisolated dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
-  #endif
+@_inheritsConvenienceInitializers @objc(SessionOb) public class SessionOb : CoreData.NSManagedObject {
+  @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
   @objc deinit
 }
 public typealias SessionObCoreDataPropertiesSet = Foundation.NSSet
 extension Measure.SessionOb {
   @nonobjc public class func fetchRequest() -> CoreData.NSFetchRequest<Measure.SessionOb>
-  @objc @NSManaged nonisolated dynamic public var crashed: Swift.Bool {
+  @objc @NSManaged dynamic public var crashed: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var createdAt: Swift.Int64 {
+  @objc @NSManaged dynamic public var createdAt: Swift.Int64 {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var needsReporting: Swift.Bool {
+  @objc @NSManaged dynamic public var needsReporting: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var pid: Swift.Int32 {
+  @objc @NSManaged dynamic public var pid: Swift.Int32 {
     @objc get
     @objc set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc @NSManaged nonisolated dynamic public var sessionId: Swift.String? {
+  @objc @NSManaged dynamic public var sessionId: Swift.String? {
     @objc get
     @objc set
   }
-  #endif
 }
 @objc final public class BaseMeasureConfig : ObjectiveC.NSObject, Swift.Codable {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -84,9 +80,7 @@ extension Measure.SessionOb {
 public protocol Span {
   var traceId: Swift.String { get }
   var spanId: Swift.String { get }
-  #if compiler(>=5.3) && $NonescapableTypes
   var parentId: Swift.String? { get }
-  #endif
   var isSampled: Swift.Bool { get }
   @discardableResult
   func setStatus(_ status: Measure.SpanStatus) -> any Measure.Span
@@ -119,9 +113,7 @@ public enum SpanStatus : Swift.Int64, Swift.Codable {
   case unset
   case ok
   case error
-  #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.Int64)
-  #endif
   public typealias RawValue = Swift.Int64
   public var rawValue: Swift.Int64 {
     get
@@ -140,9 +132,7 @@ public protocol SpanBuilder {
   final public let galleryButton: Swift.String
   final public let exitScreenshotMode: Swift.String
   public init(reportBugTitle: Swift.String, descriptionPlaceholder: Swift.String, sendButton: Swift.String, screenshotButton: Swift.String, galleryButton: Swift.String, exitScreenshotMode: Swift.String)
-  #if compiler(>=5.3) && $NonescapableTypes
   public func update(reportBugTitle: Swift.String? = nil, descriptionPlaceholder: Swift.String? = nil, sendButton: Swift.String? = nil, screenshotButton: Swift.String? = nil, galleryButton: Swift.String? = nil, exitScreenshotMode: Swift.String? = nil) -> Measure.MsrText
-  #endif
   @objc deinit
 }
 @objc final public class ClientInfo : ObjectiveC.NSObject, Swift.Codable {
@@ -156,9 +146,7 @@ public protocol SpanBuilder {
   final public let button: UIKit.UIFont
   final public let placeholder: UIKit.UIFont
   public init(title: UIKit.UIFont, button: UIKit.UIFont, placeholder: UIKit.UIFont)
-  #if compiler(>=5.3) && $NonescapableTypes
   public func update(title: UIKit.UIFont? = nil, button: UIKit.UIFont? = nil, placeholder: UIKit.UIFont? = nil) -> Measure.MsrFonts
-  #endif
   @objc deinit
 }
 @_inheritsConvenienceInitializers @objc(LifecycleManagerInternal) public class LifecycleManagerInternal : ObjectiveC.NSObject {
@@ -172,9 +160,7 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   case allText
   case allTextExceptClickable
   case sensitiveFieldsOnly
-  #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
-  #endif
   public typealias AllCases = [Measure.ScreenshotMaskLevel]
   public typealias RawValue = Swift.String
   nonisolated public static var allCases: [Measure.ScreenshotMaskLevel] {
@@ -189,9 +175,7 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   case allText
   case allTextExceptClickable
   case sensitiveFieldsOnly
-  #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.Int)
-  #endif
   public typealias RawValue = Swift.Int
   public var rawValue: Swift.Int {
     get
@@ -246,9 +230,7 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
     get
   }
   public init(darkBackground: UIKit.UIColor, lightBackground: UIKit.UIColor, darkButtonBackground: UIKit.UIColor, lightButtonBackground: UIKit.UIColor, darkText: UIKit.UIColor, lightText: UIKit.UIColor, darkPlaceholder: UIKit.UIColor, lightPlaceholder: UIKit.UIColor, darkFloatingButtonBackground: UIKit.UIColor, lightFloatingButtonBackground: UIKit.UIColor, darkFloatingButtonIcon: UIKit.UIColor, lightFloatingButtonIcon: UIKit.UIColor, darkfloatingExitButtonText: UIKit.UIColor, lightfloatingExitButtonText: UIKit.UIColor, badgeColor: UIKit.UIColor, badgeTextColor: UIKit.UIColor, isDarkMode: Swift.Bool)
-  #if compiler(>=5.3) && $NonescapableTypes
   public func update(darkBackground: UIKit.UIColor? = nil, lightBackground: UIKit.UIColor? = nil, darkButtonBackground: UIKit.UIColor? = nil, lightButtonBackground: UIKit.UIColor? = nil, darkText: UIKit.UIColor? = nil, lightText: UIKit.UIColor? = nil, darkPlaceholder: UIKit.UIColor? = nil, lightPlaceholder: UIKit.UIColor? = nil, darkFloatingButtonBackground: UIKit.UIColor? = nil, lightFloatingButtonBackground: UIKit.UIColor? = nil, darkFloatingButtonIcon: UIKit.UIColor? = nil, lightFloatingButtonIcon: UIKit.UIColor? = nil, darkfloatingExitButtonText: UIKit.UIColor? = nil, lightfloatingExitButtonText: UIKit.UIColor? = nil, badgeColor: UIKit.UIColor? = nil, badgeTextColor: UIKit.UIColor? = nil, isDarkMode: Swift.Bool? = nil) -> Measure.MsrColors
-  #endif
   @objc deinit
 }
 @objc public protocol MsrRequestHeadersProvider : ObjectiveC.NSObjectProtocol {
@@ -265,9 +247,7 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   case initWithCoder = 7
   case loadView = 8
   case vcDeinit = 9
-  #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.Int)
-  #endif
   public typealias RawValue = Swift.Int
   public var rawValue: Swift.Int {
     get
@@ -280,9 +260,7 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   public var path: Swift.String?
   public var size: Swift.Int64
   public var id: Swift.String
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(name: Swift.String, type: Measure.AttachmentType, size: Swift.Int64, id: Swift.String, bytes: Foundation.Data? = nil, path: Swift.String? = nil)
-  #endif
   @objc deinit
   public func encode(to encoder: any Swift.Encoder) throws
   required public init(from decoder: any Swift.Decoder) throws
@@ -290,16 +268,12 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
 @objc public class MsrDimensions : ObjectiveC.NSObject {
   final public let topPadding: CoreFoundation.CGFloat
   public init(topPadding: CoreFoundation.CGFloat)
-  #if compiler(>=5.3) && $NonescapableTypes
   public func update(topPadding: CoreFoundation.CGFloat? = nil) -> Measure.MsrDimensions
-  #endif
   @objc deinit
 }
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 @_Concurrency.MainActor @preconcurrency public struct MsrMoniterView<Content> : SwiftUICore.View where Content : SwiftUICore.View {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_Concurrency.MainActor @preconcurrency public init(_ viewName: Swift.String? = nil, content: @escaping () -> Content)
-  #endif
   @_Concurrency.MainActor @preconcurrency public var body: some SwiftUICore.View {
     get
   }
@@ -308,24 +282,17 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
 }
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 extension SwiftUICore.View {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_Concurrency.MainActor @preconcurrency public func moniterWithMsr(_ viewName: Swift.String? = nil) -> some SwiftUICore.View
   
-  #endif
 }
 @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc final public class Measure : ObjectiveC.NSObject {
   @objc deinit
 }
 extension Measure.Measure {
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func initialize(with client: Measure.ClientInfo, config: Measure.BaseMeasureConfig? = nil)
-  #endif
   @objc public static func start()
   @objc public static func stop()
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func getSessionId() -> Swift.String?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func internalTrackEvent(data: inout [Swift.String : Any?], type: Swift.String, timestamp: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], userTriggered: Swift.Bool, sessionId: Swift.String?, threadName: Swift.String?, attachments: [Measure.MsrAttachment])
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
@@ -333,71 +300,32 @@ extension Measure.Measure {
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   public static func internalTrackSpan(name: Swift.String, traceId: Swift.String, spanId: Swift.String, parentId: Swift.String?, startTime: Swift.Int64, endTime: Swift.Int64, duration: Swift.Int64, status: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], checkpoints: [Swift.String : Swift.Int64], hasEnded: Swift.Bool, isSampled: Swift.Bool)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackEvent(name: Swift.String, attributes: [Swift.String : Measure.AttributeValue], timestamp: Swift.Int64? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackEvent(_ name: Swift.String, attributes: [Swift.String : Any], timestamp: Foundation.NSNumber? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackScreenView(_ screenName: Swift.String, attributes: [Swift.String : Measure.AttributeValue]?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackScreenView(_ screenName: Swift.String, attributes: [Swift.String : Any]?)
-  #endif
   @objc public static func setUserId(_ userId: Swift.String)
   @objc public static func clearUserId()
   @objc public static func getCurrentTime() -> Swift.Int64
   public static func startSpan(name: Swift.String) -> any Measure.Span
   public static func startSpan(name: Swift.String, timestamp: Swift.Int64) -> any Measure.Span
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func createSpanBuilder(name: Swift.String) -> (any Measure.SpanBuilder)?
-  #endif
   public static func getTraceParentHeaderValue(span: any Measure.Span) -> Swift.String
   public static func getTraceParentHeaderKey() -> Swift.String
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Measure.AttributeValue]? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Any]? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func onShake(_ handler: (() -> Swift.Void)?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Measure.AttributeValue]? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Any]? = nil)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func captureScreenshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func captureLayoutSnapshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackError(_ error: any Swift.Error, attributes: [Swift.String : Measure.AttributeValue]? = nil, collectStackTraces: Swift.Bool = false)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackError(_ error: Foundation.NSError, attributes: [Swift.String : Any]? = nil, collectStackTraces: Swift.Bool = false)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Measure.AttributeValue]? = nil, collectStackTraces: Swift.Bool = false)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @objc public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Any]? = nil, collectStackTraces: Swift.Bool = false)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func internalGetAttachmentDirectory() -> Swift.String?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func internalGetDynamicConfigPath() -> Swift.String?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func trackHttpEvent(url: Swift.String, method: Swift.String, startTime: Swift.UInt64, endTime: Swift.UInt64, client: Swift.String = "unknown", statusCode: Swift.Int? = nil, error: (any Swift.Error)? = nil, requestHeaders: [Swift.String : Swift.String]? = nil, responseHeaders: [Swift.String : Swift.String]? = nil, requestBody: Swift.String? = nil, responseBody: Swift.String? = nil)
-  #endif
 }
 @_inheritsConvenienceInitializers @objc public class MSRNetworkInterceptor : ObjectiveC.NSObject {
   @objc(enableOn:) public static func enable(on sessionConfiguration: Foundation.URLSessionConfiguration)
@@ -408,9 +336,7 @@ public enum AttachmentType : Swift.String, Swift.Codable {
   case screenshot
   case layoutSnapshot
   case layoutSnapshotJson
-  #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
-  #endif
   public typealias RawValue = Swift.String
   public var rawValue: Swift.String {
     get
@@ -419,12 +345,8 @@ public enum AttachmentType : Swift.String, Swift.Codable {
 @objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency open class MsrViewController : UIKit.UIViewController {
   @_Concurrency.MainActor @preconcurrency @objc override dynamic open func loadView()
   @objc deinit
-  #if compiler(>=5.3) && $NonescapableTypes
   @_Concurrency.MainActor @preconcurrency @objc override dynamic public init(nibName nibNameOrNil: Swift.String?, bundle nibBundleOrNil: Foundation.Bundle?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   @_Concurrency.MainActor @preconcurrency @objc required dynamic public init?(coder: Foundation.NSCoder)
-  #endif
 }
 extension Measure.SpanStatus : Swift.Equatable {}
 extension Measure.SpanStatus : Swift.Hashable {}

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -121,10 +121,9 @@ final class CrashDataFormatter {
         let objAddr   = frame["object_addr"]      as? UInt64
         let symAddr   = frame["symbol_addr"]      as? UInt64
         let objName   = frame["object_name"]      as? String
-
         let offset: Int? = (instrAddr != nil && symAddr != nil)
-            ? Int(instrAddr! - symAddr!)
-            : nil
+                ? Int(instrAddr! - symAddr!)
+                : nil
 
         return StackFrame(binaryName: objName,
                           binaryAddress: objAddr.map { hexString($0) },

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
@@ -5,6 +5,11 @@
 //  Created by Adwin Ross on 16/09/24.
 //
 
+#if canImport(KSCrashRecording)
+import KSCrashRecording
+#elseif canImport(KSCrash)
+import KSCrash
+#endif
 import Foundation
 
 protocol CrashReportManager {
@@ -13,6 +18,8 @@ protocol CrashReportManager {
 }
 
 final class BaseCrashReportingManager: CrashReportManager {
+    private static let kotlinCrashMarker = "msr_kmp_kotlin_crash"
+    
     private var crashReporter: SystemCrashReporter
     private let logger: Logger
     private let signalProcessor: SignalProcessor
@@ -49,7 +56,11 @@ final class BaseCrashReportingManager: CrashReportManager {
             return
         }
 
-        let exceptionData = processCrashReport()
+        // Kotlin crashes embed "msr_kmp_kotlin_crash" in the NSException's userInfo.
+        // KSCrash stores this as a string in the crash report. If found, use the
+        // Kotlin-specific processing which picks the NSException report and skips
+        // the duplicate SIGABRT report. Otherwise, process as a native iOS crash.
+        let exceptionData = processKotlinCrashReport() ?? processCrashReport()
         guard var exception = exceptionData.exception, let date = exceptionData.date else {
             crashReporter.clearCrashData()
             crashDataPersistence.clearCrashData()
@@ -75,6 +86,31 @@ final class BaseCrashReportingManager: CrashReportManager {
         crashReporter.clearCrashData()
         crashDataPersistence.clearCrashData()
         completion?()
+    }
+
+    /// Searches crash reports for a Kotlin-originated crash. Kotlin crashes embed
+    /// "msr_kmp_kotlin_crash" in the NSException's userInfo. KSCrash stores this as
+    /// a string in the report, so a substring check is sufficient.
+    /// Returns nil if no Kotlin crash report is found.
+    private func processKotlinCrashReport() -> (exception: Exception?, date: Date?)? {
+        for reportDict in crashReporter.loadAllCrashReports() {
+            let crashDict = reportDict["crash"] as? [String: Any] ?? [:]
+            let errorDict = crashDict["error"] as? [String: Any] ?? [:]
+
+            guard let nsExceptionDict = errorDict["nsexception"] as? [String: Any],
+                  let userInfo = nsExceptionDict["userInfo"] as? String,
+                  userInfo.contains(Self.kotlinCrashMarker) else {
+                continue
+            }
+
+            let formatter = CrashDataFormatter(reportDict)
+            let exception = formatter.getException()
+            let timestamp = (reportDict["report"] as? [String: Any])?["timestamp"] as? TimeInterval
+            let date = timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()
+            return (exception, date)
+        }
+
+        return nil
     }
 
     private func processCrashReport() -> (exception: Exception?, date: Date?) {

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
@@ -18,6 +18,7 @@ protocol SystemCrashReporter {
     func enable() throws
     func clearCrashData()
     func loadCrashReport() throws -> [String: Any]
+    func loadAllCrashReports() -> [[String: Any]]
 }
 
 final class BaseSystemCrashReporter: SystemCrashReporter {
@@ -75,6 +76,11 @@ final class BaseSystemCrashReporter: SystemCrashReporter {
             throw CrashReporterError.noPendingReport
         }
         return report.value
+    }
+
+    func loadAllCrashReports() -> [[String: Any]] {
+        guard let store = KSCrash.shared.reportStore else { return [] }
+        return store.reportIDs.compactMap { store.report(for: Int64(truncating: $0))?.value }
     }
 }
 

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashReportManagerTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashReportManagerTests.swift
@@ -215,6 +215,87 @@ final class CrashReportingManagerTests: XCTestCase {
         XCTAssertNil(persistence.attribute)
     }
 
+    func test_trackException_detectsKotlinCrashFromUserInfo() {
+        reporter.hasPendingCrashReport = true
+        reporter.allReportsToReturn = [makeKotlinCrashReport()]
+        reporter.reportToReturn = makeReportDict()
+        trackException()
+        XCTAssertEqual(signalProcessor.type, .exception)
+    }
+
+    func test_trackException_kotlinCrashSkipsSIGABRTDuplicate() {
+        reporter.hasPendingCrashReport = true
+        // SIGABRT report first, then NSException report with Kotlin marker
+        reporter.allReportsToReturn = [makeSignalReport(), makeKotlinCrashReport()]
+        reporter.reportToReturn = makeReportDict()
+        trackException()
+        XCTAssertEqual(signalProcessor.type, .exception)
+        // loadCrashReport should NOT be called since Kotlin path was used
+        XCTAssertFalse(reporter.loadCrashReportCalled)
+    }
+
+    func test_trackException_fallsBackToNativeWhenNoKotlinMarker() {
+        reporter.hasPendingCrashReport = true
+        // Reports without Kotlin marker
+        reporter.allReportsToReturn = [makeSignalReport()]
+        reporter.reportToReturn = makeReportDict()
+        trackException()
+        XCTAssertTrue(reporter.loadCrashReportCalled)
+    }
+
+    func test_trackException_nativeNSExceptionWithoutKotlinMarkerUsesNativePath() {
+        let nativeNSExceptionReport: [String: Any] = [
+            "crash": [
+                "error": [
+                    "nsexception": [
+                        "name": "NSInvalidArgumentException"
+                    ] as [String: Any]
+                ] as [String: Any],
+                "threads": []
+            ] as [String: Any],
+            "binary_images": [],
+            "system": [:],
+            "report": ["timestamp": 1_700_000_000]
+        ]
+        reporter.hasPendingCrashReport = true
+        reporter.allReportsToReturn = [nativeNSExceptionReport]
+        reporter.reportToReturn = makeReportDict()
+        trackException()
+        // No Kotlin marker, so falls back to native path
+        XCTAssertTrue(reporter.loadCrashReportCalled)
+    }
+    
+     private func makeKotlinCrashReport(timestamp: TimeInterval = 1_700_000_000) -> [String: Any] {
+         return [
+             "crash": [
+                 "error": [
+                     "nsexception": [
+                         "name": "kotlin.IllegalStateException",
+                         "userInfo": "{\n    \"msr_kmp_kotlin_crash\" = 1;\n}"
+                     ] as [String: Any]
+                 ] as [String: Any],
+                 "threads": []
+             ] as [String: Any],
+             "binary_images": [],
+             "system": [:],
+             "report": ["timestamp": timestamp]
+         ]
+     }
+
+     private func makeSignalReport(timestamp: TimeInterval = 1_700_000_000) -> [String: Any] {
+         return [
+             "crash": [
+                 "error": [
+                     "signal": ["name": "SIGABRT"] as [String: Any]
+                 ] as [String: Any],
+                 "threads": []
+             ] as [String: Any],
+             "binary_images": [],
+             "system": [:],
+             "report": ["timestamp": timestamp]
+         ]
+     }
+
     private func trackException() {
         crashReportingManager = BaseCrashReportingManager(logger: logger,
                                                           signalProcessor: signalProcessor,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSystemCrashReporter.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSystemCrashReporter.swift
@@ -14,6 +14,7 @@ final class MockSystemCrashReporter: SystemCrashReporter {
     var enableShouldThrow = false
     var clearCrashDataCalled = false
     var reportToReturn: [String: Any]? = nil
+    var allReportsToReturn: [[String: Any]] = []
     var loadCrashReportCalled = false
 
     func enable() throws {
@@ -34,5 +35,9 @@ final class MockSystemCrashReporter: SystemCrashReporter {
             throw NSError(domain: "MockSystemCrashReporter", code: -2, userInfo: [NSLocalizedDescriptionKey: "No report available"])
         }
         return report
+    }
+
+    func loadAllCrashReports() -> [[String: Any]] {
+        return allReportsToReturn
     }
 }

--- a/kmp/measure-kmp/.gitignore
+++ b/kmp/measure-kmp/.gitignore
@@ -1,0 +1,10 @@
+*.iml
+.gradle
+.idea
+.DS_Store
+local.properties
+**/build/
+.kotlin/
+gradle/
+gradlew
+gradlew.bat

--- a/kmp/measure-kmp/README.md
+++ b/kmp/measure-kmp/README.md
@@ -1,0 +1,54 @@
+# Measure KMP SDK
+
+Kotlin Multiplatform support for measure.sh.
+
+## KMP iOS Crash Collection Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant KMP as Kotlin (KMP)
+    participant Bridge as Exception Bridge
+    participant SDK as iOS SDK (KSCrash)
+
+    Note over KMP,SDK: Crash Time
+
+    KMP->>Bridge: Unhandled Kotlin Exception
+    Bridge->>SDK: Convert to NSException (tagged)
+    SDK->>SDK: Capture & persist reports (NSException + SIGABRT)
+
+    Note over KMP,SDK: App Restarts
+
+    SDK->>SDK: Process reports → keep tagged NSException, drop duplicate SIGABRT
+```
+
+## Key design decisions
+
+#### 1.Deduplicating crash reports
+
+When a Kotlin exception crashes the app, two things happen in sequence:
+1. We send NSException directly to KSCrash handler which writes a crash report.
+2. After KSCrash's handler returns, Kotlin's runtime calls `terminateWithUnhandledException`,
+   which sends a SIGABRT signal. KSCrash catches this too and writes a second report.
+
+The first one contains the correct Kotlin frames while the second does not. To ensure the correct
+report is sent to the server. The Kotlin-created `NSException` includes `"msr_kmp_kotlin_crash"` 
+in its `userInfo` dictionary. KSCrash stores this as a string in the crash report 
+under `crash.error.nsexception.userInfo`.
+
+On next app launch after the crash, `CrashReportingManager` iterates all reports looking for one 
+whose `nsexception.userInfo` contains `"msr_kmp_kotlin_crash"`. If found, only the `NSException`
+report is processed, discarding the SIGABRT report.
+
+If no Kotlin crash report is found, it's a native iOS crash, and  the first available report is
+processed normally.
+
+#### 2. Stack trace address filtering 
+
+When Kotlin creates an exception object, the stack trace
+includes constructor frames (`kfun:Class#<init>`) that point to the exception's own
+initialization, not the code that caused the crash. These are filtered out before forwarding to
+KSCrash. For exceptions with a cause chain (e.g. `IOException` caused by `SocketException`), each
+cause's stack addresses are appended, but common tail frames shared between the exception and its
+cause are deduplicated.

--- a/kmp/measure-kmp/build.gradle.kts
+++ b/kmp/measure-kmp/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("multiplatform") version "2.1.20"
+}
+
+group = "sh.measure"
+version = "0.1.0"
+
+kotlin {
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "MeasureKMP"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        appleMain.dependencies {
+        }
+    }
+}

--- a/kmp/measure-kmp/settings.gradle.kts
+++ b/kmp/measure-kmp/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "measure-kmp"

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/MeasureUnhandledExceptionHook.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/MeasureUnhandledExceptionHook.kt
@@ -1,0 +1,20 @@
+package sh.measure.kmp
+
+import sh.measure.kmp.nsexception.asNSException
+import sh.measure.kmp.nsexception.reportUnhandledException
+import sh.measure.kmp.nsexception.wrapUnhandledExceptionHook
+
+/**
+ * Sets the unhandled exception hook such that all unhandled Kotlin exceptions
+ * are reported to the Measure iOS SDK as fatal crashes.
+ *
+ * This must be called after [Measure.initialize] so that KSCrash's
+ * NSUncaughtExceptionHandler is already installed.
+ *
+ * If an unhandled exception hook was already set, that hook will be invoked
+ * after the exception is reported. Once the exception is reported the program
+ * will be terminated.
+ */
+fun setMeasureUnhandledExceptionHook(): Unit = wrapUnhandledExceptionHook { throwable ->
+    reportUnhandledException(throwable.asNSException(appendCausedBy = true))
+}

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/CrashReporter.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/CrashReporter.kt
@@ -1,0 +1,19 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package sh.measure.kmp.nsexception
+
+import kotlinx.cinterop.invoke
+import platform.Foundation.NSException
+import platform.Foundation.NSGetUncaughtExceptionHandler
+
+/**
+ * Reports an unhandled Kotlin exception to the native crash reporter (KSCrash).
+ *
+ * The NSException created from the Kotlin Throwable includes "msr_kmp_kotlin_crash"
+ * in its userInfo, allowing the iOS SDK to identify this as a Kotlin-originated crash
+ * when processing KSCrash reports on the next launch.
+ */
+internal fun reportUnhandledException(exception: NSException) {
+    val handler = NSGetUncaughtExceptionHandler()
+    handler?.invoke(exception)
+}

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/NSException.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/NSException.kt
@@ -1,0 +1,77 @@
+// https://github.com/rickclephas/NSExceptionKt/blob/master/nsexception-kt-core/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/core/NSException.kt
+//
+// Copyright (c) 2022 Rick Clephas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+package sh.measure.kmp.nsexception
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import platform.Foundation.NSException
+import platform.Foundation.NSNumber
+import platform.darwin.NSUInteger
+import kotlin.reflect.KClass
+
+private const val kotlinCrashMarker = "msr_kmp_kotlin_crash"
+
+/**
+ * Returns a [NSException] representing `this` [Throwable].
+ * If [appendCausedBy] is `true` then the name, message and stack trace
+ * of the [causes][Throwable.cause] will be appended, else causes are ignored.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun Throwable.asNSException(appendCausedBy: Boolean = false): NSException {
+    val returnAddresses = getFilteredStackTraceAddresses().let { addresses ->
+        if (!appendCausedBy) return@let addresses
+        addresses.toMutableList().apply {
+            for (cause in causes) {
+                addAll(cause.getFilteredStackTraceAddresses(true, addresses))
+            }
+        }
+    }.map {
+        NSNumber(unsignedInteger = it.convert<NSUInteger>())
+    }
+    return ThrowableNSException(name, getReason(appendCausedBy), returnAddresses)
+}
+
+/**
+ * Returns the [qualifiedName][KClass.qualifiedName] or [simpleName][KClass.simpleName] of `this` throwable.
+ * If both are `null` then "Throwable" is returned.
+ */
+internal val Throwable.name: String
+    get() = this::class.qualifiedName ?: this::class.simpleName ?: "Throwable"
+
+/**
+ * Returns the [message][Throwable.message] of this throwable.
+ * If [appendCausedBy] is `true` then caused by lines with the format
+ * "Caused by: $[name]: $[message][Throwable.message]" will be appended.
+ */
+internal fun Throwable.getReason(appendCausedBy: Boolean = false): String? {
+    if (!appendCausedBy) return message
+    return buildString {
+        message?.let(::append)
+        for (cause in causes) {
+            if (isNotEmpty()) appendLine()
+            append("Caused by: ")
+            append(cause.name)
+            cause.message?.let { append(": $it") }
+        }
+    }.takeIf { it.isNotEmpty() }
+}
+
+internal class ThrowableNSException(
+    name: String,
+    reason: String?,
+    private val returnAddresses: List<NSNumber>
+) : NSException(name, reason, mapOf(kotlinCrashMarker to true)) {
+    override fun callStackReturnAddresses(): List<NSNumber> = returnAddresses
+}

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/Throwable.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/Throwable.kt
@@ -1,0 +1,86 @@
+// https://github.com/rickclephas/NSExceptionKt/blob/master/nsexception-kt-core/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/core/Throwable.kt
+//
+// Copyright (c) 2022 Rick Clephas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+@file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+
+package sh.measure.kmp.nsexception
+
+/**
+ * Returns a list with all the [causes][Throwable.cause].
+ * The first element will be the cause, the second the cause of the cause, etc.
+ * This function stops once a reference cycles is detected.
+ */
+internal val Throwable.causes: List<Throwable> get() = buildList {
+    val causes = mutableSetOf<Throwable>()
+    var cause = cause
+    while (cause != null && causes.add(cause)) {
+        add(cause)
+        cause = cause.cause
+    }
+}
+
+/**
+ * Returns a list of stack trace addresses representing
+ * the stack trace of the constructor call to `this` [Throwable].
+ * @param keepLastInit `true` to preserve the last constructor call, `false` to drop all constructor calls.
+ * @param commonAddresses a list of addresses used to drop the last common addresses.
+ * @see getStackTraceAddresses
+ */
+internal fun Throwable.getFilteredStackTraceAddresses(
+    keepLastInit: Boolean = false,
+    commonAddresses: List<Long> = emptyList()
+): List<Long> = getStackTraceAddresses().dropInitAddresses(
+    qualifiedClassName = this::class.qualifiedName ?: Throwable::class.qualifiedName!!,
+    stackTrace = getStackTrace(),
+    keepLast = keepLastInit
+).dropCommonAddresses(commonAddresses)
+
+/**
+ * Returns a list containing all addresses expect for the first addresses
+ * matching the constructor call of the [qualifiedClassName].
+ * If [keepLast] is `true` the last constructor call won't be dropped.
+ */
+internal fun List<Long>.dropInitAddresses(
+    qualifiedClassName: String,
+    stackTrace: Array<String>,
+    keepLast: Boolean = false
+): List<Long> {
+    val exceptionInit = "kfun:$qualifiedClassName#<init>"
+    var dropCount = 0
+    var foundInit = false
+    for (i in stackTrace.indices) {
+        if (stackTrace[i].contains(exceptionInit)) {
+            foundInit = true
+        } else if (foundInit) {
+            dropCount = i
+            break
+        }
+    }
+    if (keepLast) dropCount--
+    return drop(kotlin.math.max(0, dropCount))
+}
+
+/**
+ * Returns a list containing all addresses expect for the last addresses that match with the [commonAddresses].
+ */
+internal fun List<Long>.dropCommonAddresses(
+    commonAddresses: List<Long>
+): List<Long> {
+    var i = commonAddresses.size
+    if (i == 0) return this
+
+    return dropLastWhile {
+        i-- > 0 && commonAddresses[i] == it
+    }
+}

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/UnhandledExceptionHook.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/nsexception/UnhandledExceptionHook.kt
@@ -1,0 +1,36 @@
+// https://github.com/rickclephas/NSExceptionKt/blob/master/nsexception-kt-core/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/core/UnhandledExceptionHook.kt
+//
+// Copyright (c) 2022 Rick Clephas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+package sh.measure.kmp.nsexception
+
+import kotlin.concurrent.AtomicReference
+import kotlin.experimental.ExperimentalNativeApi
+
+/**
+ * Wraps the unhandled exception hook such that the provided [hook] is invoked
+ * before the currently set unhandled exception hook is invoked.
+ * Note: once the unhandled exception hook returns the program will be terminated.
+ * @see setUnhandledExceptionHook
+ * @see terminateWithUnhandledException
+ */
+@OptIn(ExperimentalNativeApi::class)
+internal fun wrapUnhandledExceptionHook(hook: (Throwable) -> Unit) {
+    val prevHook = AtomicReference<ReportUnhandledExceptionHook?>(null)
+    val wrappedHook: ReportUnhandledExceptionHook = {
+        hook(it)
+        prevHook.value?.invoke(it)
+        terminateWithUnhandledException(it)
+    }
+    prevHook.value = setUnhandledExceptionHook(wrappedHook)
+}


### PR DESCRIPTION
# Description

- Create a KMP library which helps create iOS crashes that contain Kotlin Native symbols when a crash occurs in KN. 
- Add demo to trigger a crash in platform code or shared Kotlin code to verify symbolication
- Add setup to release KMP library to maven.


## Related issue
References #1024 



