### PR TITLE
chore(backend): use attachment size from SDK when available

### DIFF
--- a/backend/api/event/attachment.go
+++ b/backend/api/event/attachment.go
@@ -69,6 +69,7 @@ type Attachment struct {
 	ID       uuid.UUID `json:"id"`
 	Name     string    `json:"name" binding:"required"`
 	Type     string    `json:"type" binding:"required"`
+	Size     int64     `json:"size"`
 	Reader   io.Reader `json:"-"`
 	Key      string    `json:"key"`
 	Location string    `json:"location"`

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -527,11 +527,14 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 
 			e.attachmentUploadInfos = append(e.attachmentUploadInfos, attachmentUploadInfo)
 
-			// Estimate attachment size for billing since JSON
-			// requests upload attachments out-of-band via
-			// signed URLs and actual size is unknown at ingest
-			// time.
-			e.bumpSize(estimateAttachmentSize(attachment.Name))
+			// Use actual attachment size for billing if provided
+			// by newer SDKs. Fall back to estimates for older
+			// SDKs that don't send size.
+			if attachment.Size > 0 {
+				e.bumpSize(attachment.Size)
+			} else {
+				e.bumpSize(estimateAttachmentSize(attachment.Name))
+			}
 		}
 
 		// compute launch timings


### PR DESCRIPTION
# Description

Newer SDKs now send a size field in attachment metadata. Tis commit uses it directly for ingestion metrics instead of estimating based on file extension. Falls back to extension-based estimates for older SDKs that don't send the field.

## Related issue
Closes #3352 



