### PR TITLE
fix(frontend): show full date in monthly plot x-axis labels

### DIFF
--- a/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
@@ -77,7 +77,7 @@ describe('BugReportsOverviewPlot', () => {
     render(<BugReportsOverviewPlot filters={filters} />)
 
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('uses minute/day configs for shorter ranges', async () => {

--- a/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_details_plot_test.tsx
@@ -148,7 +148,7 @@ describe('ExceptionsDetailsPlot', () => {
       <ExceptionsDetailsPlot exceptionsType={'crash' as any} exceptionsGroupId="g1" filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />
     )
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('hides stale chart while new range data is loading', async () => {

--- a/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/exceptions_overview_plot_test.tsx
@@ -132,7 +132,7 @@ describe('ExceptionsOverviewPlot', () => {
 
     rerender(<ExceptionsOverviewPlot exceptionsType={'crash' as any} filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('hides stale chart while new range data is loading', async () => {

--- a/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timelines_overview_plot_test.tsx
@@ -114,7 +114,7 @@ describe('SessionTimelinesOverviewPlot', () => {
     fetchMock.mockResolvedValue({ status: 'success', data: [{ id: '1.0.0', data: [{ datetime: '2026-01-01', instances: 2 }] }] })
     render(<SessionTimelinesOverviewPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('renders tooltip with expected labels', async () => {

--- a/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/sessions_vs_exceptions_overview_plot_test.tsx
@@ -92,7 +92,7 @@ describe('SessionsVsExceptionsPlot', () => {
 
     rerender(<SessionsVsExceptionsPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('renders tooltip in Sessions, Crashes, ANRs order', async () => {

--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -128,7 +128,7 @@ describe('SpanMetricsPlot', () => {
 
     rerender(<SpanMetricsPlot filters={{ ...filters, startDate: '2025-01-01T00:00:00Z', endDate: '2026-01-01T00:00:00Z' }} />)
     await waitFor(() => expect(screen.getByTestId('line-mock')).toBeInTheDocument())
-    expect(lastLineProps.axisBottom.format).toBe('%b %Y')
+    expect(lastLineProps.axisBottom.format).toBe('%d %b, %Y')
   })
 
   it('throws for invalid quantile selection', async () => {

--- a/frontend/dashboard/__tests__/utils/time_utils.test.ts
+++ b/frontend/dashboard/__tests__/utils/time_utils.test.ts
@@ -288,7 +288,7 @@ describe('plot time group utils', () => {
         expect(getPlotTimeGroupNivoConfig('minutes').xScalePrecision).toBe('minute')
         expect(getPlotTimeGroupNivoConfig('hours').xScalePrecision).toBe('hour')
         expect(getPlotTimeGroupNivoConfig('days').axisBottomFormat).toBe('%b %d, %Y')
-        expect(getPlotTimeGroupNivoConfig('months').axisBottomFormat).toBe('%b %Y')
+        expect(getPlotTimeGroupNivoConfig('months').axisBottomFormat).toBe('%d %b, %Y')
 
         expect(formatPlotTooltipDate('2026-02-01T10:00:00', 'minutes')).toBe('1 Feb, 2026, 10:00 AM')
         expect(formatPlotTooltipDate('2026-02-01T10:00:00', 'hours')).toBe('1 Feb, 2026, 10:00 AM')

--- a/frontend/dashboard/app/utils/time_utils.ts
+++ b/frontend/dashboard/app/utils/time_utils.ts
@@ -191,7 +191,7 @@ export function getPlotTimeGroupNivoConfig(plotTimeGroup: PlotTimeGroup): PlotTi
         xFormat: "time:%Y-%m-%d",
         xScaleFormat: "%Y-%m-%d",
         xScalePrecision: "day",
-        axisBottomFormat: "%b %Y",
+        axisBottomFormat: "%d %b, %Y",
       }
     case "days":
     default:


### PR DESCRIPTION
# Description

Changes `axisBottomFormat` for the "months" time group from
"%b %Y" to "%d %b, %Y" so that x-axis tick labels include the day. Previously, when there were few data points spanning a month, all intermediate ticks displayed the same "Mar 2026" label.



