### PR TITLE
fix(backend): skip daily snapshots for non-billable teams

### DIFF
--- a/backend/billing/meter.go
+++ b/backend/billing/meter.go
@@ -153,11 +153,14 @@ func snapshotExists(ctx context.Context, pool *pgxpool.Pool, date time.Time) boo
 // getAppRetentionWindows returns all apps with their retention and cutoff date.
 func getAppRetentionWindows(ctx context.Context, pool *pgxpool.Pool) ([]AppRetentionWindow, error) {
 	query := sqlf.PostgreSQL.
-		Select("team_id").
-		Select("id").
-		Select("retention").
-		Select("data_cutoff_date").
-		From("apps")
+		Select("a.team_id").
+		Select("a.id").
+		Select("a.retention").
+		Select("a.data_cutoff_date").
+		From("apps a").
+		Join("team_billing tb", "a.team_id = tb.team_id").
+		Where("tb.plan = 'pro'").
+		Where("tb.stripe_customer_id IS NOT NULL")
 	defer query.Close()
 
 	rows, err := pool.Query(ctx, query.String(), query.Args()...)

--- a/backend/billing/meter_test.go
+++ b/backend/billing/meter_test.go
@@ -449,7 +449,7 @@ func TestTakeStorageSnapshot(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		seedTeam(ctx, t, teamID, "SnapTeam", true)
-		seedTeamBilling(ctx, t, teamID, "free", nil, nil)
+		seedTeamBilling(ctx, t, teamID, "pro", strPtr("cus_snap"), nil)
 		seedApp(ctx, t, appID, teamID, 30)
 
 		yesterday := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -1)
@@ -484,6 +484,74 @@ func TestTakeStorageSnapshot(t *testing.T) {
 		}
 		if bytesIn != 3*1024*1024 {
 			t.Errorf("bytes_in = %d, want %d", bytesIn, 3*1024*1024)
+		}
+	})
+
+	t.Run("skips free-plan teams", func(t *testing.T) {
+		t.Cleanup(func() { cleanupAll(ctx, t) })
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "FreeTeam", true)
+		seedTeamBilling(ctx, t, teamID, "free", strPtr("cus_free"), nil)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		yesterday := time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, -1)
+
+		cutoff := yesterday.AddDate(0, 0, -30)
+		setAppDataCutoffDate(ctx, t, appID, cutoff)
+
+		seedIngestionUsage(ctx, t, teamID.String(), appID.String(), yesterday.Add(12*time.Hour), 5, 3, 0, 1*1024*1024)
+
+		deps := testDeps()
+		err := takeStorageSnapshot(ctx, deps, yesterday)
+		if err != nil {
+			t.Fatalf("takeStorageSnapshot: %v", err)
+		}
+
+		var count int
+		err = th.PgPool.QueryRow(ctx,
+			"SELECT count(*) FROM billing_metrics_reporting WHERE team_id = $1",
+			teamID.String()).Scan(&count)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected no snapshot rows for free team, got %d", count)
+		}
+	})
+
+	t.Run("skips pro teams without stripe customer", func(t *testing.T) {
+		t.Cleanup(func() { cleanupAll(ctx, t) })
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "ProNoStripe", true)
+		seedTeamBilling(ctx, t, teamID, "pro", nil, nil)
+		seedApp(ctx, t, appID, teamID, 30)
+
+		yesterday := time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, -1)
+
+		cutoff := yesterday.AddDate(0, 0, -30)
+		setAppDataCutoffDate(ctx, t, appID, cutoff)
+
+		seedIngestionUsage(ctx, t, teamID.String(), appID.String(), yesterday.Add(12*time.Hour), 5, 3, 0, 1*1024*1024)
+
+		deps := testDeps()
+		err := takeStorageSnapshot(ctx, deps, yesterday)
+		if err != nil {
+			t.Fatalf("takeStorageSnapshot: %v", err)
+		}
+
+		var count int
+		err = th.PgPool.QueryRow(ctx,
+			"SELECT count(*) FROM billing_metrics_reporting WHERE team_id = $1",
+			teamID.String()).Scan(&count)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected no snapshot rows for pro team without stripe customer, got %d", count)
 		}
 	})
 }
@@ -737,7 +805,7 @@ func TestBillingCycle_RetentionDecrease(t *testing.T) {
 	teamID := uuid.New()
 	appID := uuid.New()
 	seedTeam(ctx, t, teamID, "RetDecTeam", true)
-	seedTeamBilling(ctx, t, teamID, "pro", nil, nil)
+	seedTeamBilling(ctx, t, teamID, "pro", strPtr("cus_retdec"), nil)
 	seedApp(ctx, t, appID, teamID, 5)
 
 	today := time.Now().UTC().Truncate(24 * time.Hour)
@@ -807,7 +875,7 @@ func TestBillingCycle_RetentionIncrease(t *testing.T) {
 	teamID := uuid.New()
 	appID := uuid.New()
 	seedTeam(ctx, t, teamID, "RetIncTeam", true)
-	seedTeamBilling(ctx, t, teamID, "pro", nil, nil)
+	seedTeamBilling(ctx, t, teamID, "pro", strPtr("cus_retinc"), nil)
 	seedApp(ctx, t, appID, teamID, 2)
 
 	today := time.Now().UTC().Truncate(24 * time.Hour)


### PR DESCRIPTION
# Description

`getAppRetentionWindows` fetched all apps regardless of billing plan, causing `billing_metrics_reporting` rows to accumulate for free-plan teams. When a free team upgraded to pro, those old unreported rows would be sent to Stripe, retroactively billing for free-period usage.

Filters `getAppRetentionWindows` to only include apps belonging to teams with plan = 'pro' and a Stripe customer ID, matching the guards already present in `getUnreportedUsage`.



