### PR TITLE
fix(backend): prevent SSRF in proxy attachment and symbol endpoints

### DIFF
--- a/backend/api/measure/attachment.go
+++ b/backend/api/measure/attachment.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
-	"strings"
 
 	"backend/api/server"
 
@@ -33,20 +31,12 @@ func ProxyAttachment(c *gin.Context) {
 	}
 
 	config := server.Server.Config
-	presignedUrl := payload
 
-	// if the payload already contains origin, then
-	// don't prepend the origin.
-	if !strings.HasPrefix(payload, config.AWSEndpoint) {
-		presignedUrl = config.AWSEndpoint + payload
-	}
-
-	parsed, err := url.Parse(presignedUrl)
+	parsed, err := validateProxyPayload(payload, config.AWSEndpoint)
 	if err != nil {
-		msg := "failed to parse reconstructed presigned url"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
+		fmt.Println("attachment proxy validation failed:", err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid proxy payload",
 		})
 		return
 	}

--- a/backend/api/measure/build.go
+++ b/backend/api/measure/build.go
@@ -469,20 +469,12 @@ func ProxySymbol(c *gin.Context) {
 	}
 
 	config := server.Server.Config
-	presignedUrl := payload
 
-	// if the payload already contains origin, then
-	// don't prepend the origin.
-	if !strings.HasPrefix(payload, config.AWSEndpoint) {
-		presignedUrl = config.AWSEndpoint + payload
-	}
-
-	parsed, err := url.Parse(presignedUrl)
+	parsed, err := validateProxyPayload(payload, config.AWSEndpoint)
 	if err != nil {
-		msg := "failed to parse reconstructed presigned url"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
+		fmt.Println("symbol proxy validation failed:", err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid proxy payload",
 		})
 		return
 	}

--- a/backend/api/measure/proxy_helper.go
+++ b/backend/api/measure/proxy_helper.go
@@ -1,0 +1,38 @@
+package measure
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// validateProxyPayload validates and resolves a proxy payload
+// URL against the configured AWS endpoint. It rejects requests
+// when no endpoint is configured and verifies the resolved URL
+// targets the expected host.
+func validateProxyPayload(payload, endpoint string) (*url.URL, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("object store endpoint not configured")
+	}
+
+	presignedUrl := payload
+	if !strings.HasPrefix(payload, endpoint) {
+		presignedUrl = endpoint + payload
+	}
+
+	parsed, err := url.Parse(presignedUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse presigned url: %w", err)
+	}
+
+	endpointParsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
+	}
+
+	if parsed.Host != endpointParsed.Host {
+		return nil, fmt.Errorf("payload host does not match endpoint")
+	}
+
+	return parsed, nil
+}

--- a/backend/api/measure/proxy_helper_test.go
+++ b/backend/api/measure/proxy_helper_test.go
@@ -1,0 +1,94 @@
+package measure
+
+import (
+	"testing"
+)
+
+func TestValidateProxyPayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  string
+		endpoint string
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name:     "valid full url matching endpoint",
+			payload:  "http://minio:9000/bucket/key?X-Amz-Signature=abc",
+			endpoint: "http://minio:9000",
+			wantHost: "minio:9000",
+		},
+		{
+			name:     "valid path-only payload gets endpoint prepended",
+			payload:  "/bucket/key?X-Amz-Signature=abc",
+			endpoint: "http://minio:9000",
+			wantHost: "minio:9000",
+		},
+		{
+			name:     "empty endpoint rejected",
+			payload:  "http://169.254.169.254/latest/meta-data/",
+			endpoint: "",
+			wantErr:  true,
+		},
+		{
+			name:     "ssrf via subdomain prefix bypass rejected",
+			payload:  "http://minio:9000.attacker.com/evil",
+			endpoint: "http://minio:9000",
+			wantErr:  true,
+		},
+		{
+			name:     "ssrf to arbitrary host rejected",
+			payload:  "http://evil.com/steal",
+			endpoint: "http://minio:9000",
+			wantErr:  true,
+		},
+		{
+			name:     "ssrf to imds rejected",
+			payload:  "http://169.254.169.254/latest/meta-data/",
+			endpoint: "http://minio:9000",
+			wantErr:  true,
+		},
+		{
+			name:     "different port rejected",
+			payload:  "http://minio:8080/bucket/key",
+			endpoint: "http://minio:9000",
+			wantErr:  true,
+		},
+		{
+			name:     "scheme mismatch with same host rejected",
+			payload:  "https://minio:9000/bucket/key",
+			endpoint: "http://minio:9000",
+			wantErr:  true,
+		},
+		{
+			name:     "endpoint with trailing slash",
+			payload:  "http://minio:9000/bucket/key?sig=abc",
+			endpoint: "http://minio:9000/",
+			wantHost: "minio:9000",
+		},
+		{
+			name:     "endpoint without port",
+			payload:  "http://minio/bucket/key",
+			endpoint: "http://minio",
+			wantHost: "minio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateProxyPayload(tt.payload, tt.endpoint)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil with URL %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", got.Host, tt.wantHost)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Validates proxy payload URLs against the configured AWS endpoint using strict host matching instead of a prefix check. Rejects requests when no endpoint is configured. Previously, an empty `AWS_ENDPOINT_URL` allowed proxying to arbitrary hosts, and a set endpoint could be bypassed via subdomain tricks (e.g. `http://minio:9000.attacker.com`). Extracts validation into `proxy_helper.go` with tests and applied to both `ProxyAttachment` and `ProxySymbol`.



