### PR TITLE
fix(backend): order crash/ANR details by descending timestamp

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -726,7 +726,7 @@ func (a App) GetExceptionsWithFilter(ctx context.Context, fingerprint string, af
 		stmt.Offset(uint64(af.Offset))
 	}
 
-	stmt.OrderBy("timestamp")
+	stmt.OrderBy("timestamp desc")
 
 	defer stmt.Close()
 
@@ -1313,7 +1313,7 @@ func (a App) GetANRsWithFilter(ctx context.Context, fingerprint string, af *filt
 		stmt.Offset(uint64(af.Offset))
 	}
 
-	stmt.OrderBy("timestamp")
+	stmt.OrderBy("timestamp desc")
 
 	defer stmt.Close()
 


### PR DESCRIPTION
# Description

Orders crash/ANR details by descending timestamp

## Related issue
Closes #3392



