### PR TITLE
chore(backend): modify validation of ingest batch size

### DIFF
--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -31,7 +31,7 @@ import (
 
 // maxBatchSize is the maximum allowed payload
 // size of event request in bytes.
-var maxBatchSize = 20 * 1024 * 1024
+var maxBatchSize = 10 * 1024 * 1024
 
 var ingestBatchPublishCount metric.Int64Counter
 


### PR DESCRIPTION
## Summary

This PR modifies the validation limit of ingest payload's batch size to 10 MiB.

## Tasks

- [x] Modify max batch size limit to 10 MiB

## See also

- fixes #3379