### PR TITLE
chore(backend): fix dashboard docker build

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -79,6 +79,8 @@ jobs:
         with:
           context: frontend/dashboard
           file: frontend/dashboard/dockerfile
+          build-contexts: |
+            docs=docs
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: |


### PR DESCRIPTION
## Summary

This PR fixes the dashboard docker image build by defining the `docs` context as an additional build context.

## Tasks

- [x] Add `docs` as an additional build context