### PR TITLE
chore(backend): add missing additional contexts for docker builds

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           context: backend/alerts
           file: backend/alerts/dockerfile
+          build-contexts: |
+            libs=backend/libs
+            email=backend/email
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: |

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -110,6 +110,10 @@ jobs:
         with:
           context: backend/api
           file: backend/api/dockerfile
+          build-contexts: |
+            libs=backend/libs
+            email=backend/email
+            billing=backend/billing
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: |

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -113,6 +113,7 @@ jobs:
           context: backend/ingest
           file: backend/ingest/dockerfile
           build-contexts: |
+            libs=backend/libs
             api=backend/api
             email=backend/email
             billing=backend/billing

--- a/.github/workflows/metering.yml
+++ b/.github/workflows/metering.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           context: backend/metering
           file: backend/metering/dockerfile
+          build-contexts: |
+            email=backend/email
+            billing=backend/billing
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: |


### PR DESCRIPTION
## Summary

This PR adds additional build contexts for various services that were missing for successful docker builds.

## Tasks

- [x] Add additional build contexts for `alerts`
- [x] Add additional build contexts for `api`
- [x] Add additional build contexts for `ingest`
- [x] Add additional build contexts for `metering`



