### PR TITLE
chore(backend): pin go version for all modules

### DIFF
--- a/backend/alerts/go.mod
+++ b/backend/alerts/go.mod
@@ -1,6 +1,6 @@
 module backend/alerts
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/email v0.0.0

--- a/backend/api/go.mod
+++ b/backend/api/go.mod
@@ -1,6 +1,6 @@
 module backend/api
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/billing v0.0.0

--- a/backend/billing/go.mod
+++ b/backend/billing/go.mod
@@ -1,6 +1,6 @@
 module backend/billing
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/email v0.0.0

--- a/backend/cleanup/go.mod
+++ b/backend/cleanup/go.mod
@@ -1,6 +1,6 @@
 module backend/cleanup
 
-go 1.25.7
+go 1.26
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.20.2

--- a/backend/email/go.mod
+++ b/backend/email/go.mod
@@ -1,6 +1,6 @@
 module backend/email
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0

--- a/backend/ingest-worker/go.mod
+++ b/backend/ingest-worker/go.mod
@@ -1,6 +1,6 @@
 module backend/ingest-worker
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/api v0.0.0

--- a/backend/ingest/go.mod
+++ b/backend/ingest/go.mod
@@ -1,6 +1,6 @@
 module backend/ingest
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/api v0.0.0

--- a/backend/libs/go.mod
+++ b/backend/libs/go.mod
@@ -1,6 +1,6 @@
 module backend/libs
 
-go 1.25.7
+go 1.26
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/backend/metering/go.mod
+++ b/backend/metering/go.mod
@@ -1,6 +1,6 @@
 module backend/metering
 
-go 1.25.7
+go 1.26
 
 require (
 	backend/billing v0.0.0

--- a/backend/migrator/go.mod
+++ b/backend/migrator/go.mod
@@ -1,6 +1,6 @@
 module migrator
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/backend/symboloader/go.mod
+++ b/backend/symboloader/go.mod
@@ -1,6 +1,6 @@
 module symboloader
 
-go 1.25.7
+go 1.26
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.20.2

--- a/backend/testinfra/go.mod
+++ b/backend/testinfra/go.mod
@@ -1,6 +1,6 @@
 module backend/testinfra
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.44.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.7
+go 1.26.1
 
 use (
 	./backend/alerts

--- a/self-host/sessionator/go.mod
+++ b/self-host/sessionator/go.mod
@@ -1,6 +1,6 @@
 module sessionator
 
-go 1.25.7
+go 1.26.1
 
 require (
 	backend/api v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary

This PR pins the go version in `go.work` & all individual module's `go.mod` files for a consistent execution environment.