### PR TITLE
feat(rn): add diagnostic mode for SDK logging

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -24,6 +24,7 @@ public final class sh/measure/android/Measure {
 	public static final fun init (Landroid/content/Context;)V
 	public static final fun init (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;)V
 	public static synthetic fun init$default (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;ILjava/lang/Object;)V
+	public final fun internalAddLog (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun internalGetAttachmentDirectory ()Ljava/lang/String;
 	public final fun internalTrackEvent (Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun internalTrackEvent$default (Lsh/measure/android/Measure;Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -652,7 +652,7 @@ object Measure {
     }
 
     /**
-     * An internal method that adds logs Measure logger. 
+     * An internal method that adds logs Measure logger.
      * This method is not intended for public usage.
      */
     fun internalAddLog(platform: String, message: String, throwable: Throwable?) {

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -652,6 +652,16 @@ object Measure {
     }
 
     /**
+     * An internal method that adds logs Measure logger. 
+     * This method is not intended for public usage.
+     */
+    fun internalAddLog(platform: String, message: String, throwable: Throwable?) {
+        if (isInitialized.get()) {
+            measure.internalAddLog(platform, message, throwable)
+        }
+    }
+
+    /**
      * Returns the path to the dynamic config file if available. The SDK must be initialized
      * before calling this method.
      */

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -306,6 +306,14 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
 
     fun getAttachmentDirectory(): String? = measure.fileStorage.getAttachmentDirectory()
 
+    fun internalAddLog(platform: String, message: String, throwable: Throwable?) {
+        measure.logger.log(
+            LogLevel.Debug,
+            "[$platform] $message",
+            throwable,
+        )
+    }
+
     fun trackHttpEvent(
         url: String,
         method: String,

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -469,7 +469,7 @@ Measure.init(context, config)
 
 ```swift
 let config = BaseMeasureConfig(
-    enableFullCollectionMode: 1
+    enableFullCollectionMode: true
 )
 Measure.initialize(with: clientInfo, config: config)
 ```
@@ -599,7 +599,7 @@ If none of the above steps resolve the issue, feel free to reach out to us on [D
 for further
 assistance.
 
-### Enable Diagnostic Mode (Android only)
+### Enable Diagnostic Mode
 
 If you're experiencing issues with the SDK and need to share detailed logs with us, enable diagnostic mode.
 This writes all internal SDK logs to files on disk which can then be pulled from the device and shared
@@ -610,10 +610,29 @@ when reporting a bug.
 
 #### Step 1: Enable diagnostic mode
 
+<details>
+    <summary>Android</summary>
+
+Enable diagnostic mode during SDK initialization.
+
 ```kotlin
 val config = MeasureConfig(enableDiagnosticMode = true)
 Measure.init(context, config)
 ```
+
+</details>
+
+<details>
+    <summary>iOS</summary>
+
+Enable diagnostic mode during SDK initialization. iOS provides an additional option called `enableDiagnosticModeGesture`. When this flag is enabled, you can use double finger double tap gesture to open share sheet and send logs immediately.
+
+```swift
+let config = BaseMeasureConfig(enableDiagnosticMode: true, enableDiagnosticModeGesture: true)
+Measure.initialize(with: clientInfo, config: config)
+```
+
+</details>
 
 #### Step 2: Reproduce the issue
 
@@ -621,6 +640,9 @@ Run the app and reproduce the issue you're facing. The SDK will write logs to fi
 app's internal storage.
 
 #### Step 3: Pull the log files
+
+<details>
+    <summary>Android</summary>
 
 Use `adb` to retrieve the log files from the device:
 
@@ -632,6 +654,22 @@ adb shell run-as <your.package.name> ls files/measure/sdk_debug_logs/
 adb shell "run-as <your.package.name> tar czf - files/measure/sdk_debug_logs/" > /tmp/sdk_debug_logs.tar.gz
 ```
 
+</details>
+
+<details>
+    <summary>iOS</summary>
+
+iOS provides an option called `enableDiagnosticModeGesture`. When this flag is enabled, you can use double finger double tap gesture to open share sheet and send logs immediately.
+
+```swift
+let config = BaseMeasureConfig(enableDiagnosticMode: true, enableDiagnosticModeGesture: true)
+Measure.initialize(with: clientInfo, config: config)
+```
+
+</details>
+
+
+
 #### Step 4: Share the files
 
 Share the pulled log files on [Discord](https://discord.gg/f6zGkBCt42) or send them to us via email
@@ -642,6 +680,11 @@ for us to investigate.
 Once you've collected the logs, disable diagnostic mode by removing the `enableDiagnosticMode` flag
 or setting it to `false`. You can also delete the log files from the device:
 
+
+<details>
+    <summary>Android</summary>
+
 ```shell
 adb shell run-as <your.package.name> rm -rf files/measure/sdk_debug_logs/
 ```
+</details>

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -329,6 +329,9 @@ extension Measure.Measure {
   public static func internalTrackEvent(data: inout [Swift.String : Any?], type: Swift.String, timestamp: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], userTriggered: Swift.Bool, sessionId: Swift.String?, threadName: Swift.String?, attachments: [Measure.MsrAttachment])
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
+  public static func internalAddLog(platform: Swift.String, message: Swift.String, error: (any Swift.Error)?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public static func internalTrackSpan(name: Swift.String, traceId: Swift.String, spanId: Swift.String, parentId: Swift.String?, startTime: Swift.Int64, endTime: Swift.Int64, duration: Swift.Int64, status: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], checkpoints: [Swift.String : Swift.Int64], hasEnded: Swift.Bool, isSampled: Swift.Bool)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -107,6 +107,12 @@ import UIKit
                                           attachments: attachments)
     }
 
+    func internalAddLog(platform: String, message: String, error: Error?) {
+        guard let measureInternal = measureInternal else { return }
+
+        measureInternal.internalAddLog(platform: platform, message: message, error: error)
+    }
+
     func internalTrackSpan(name: String, // swiftlint:disable:this function_parameter_count
                            traceId: String,
                            spanId: String,
@@ -432,6 +438,15 @@ extension Measure {
                                           sessionId: sessionId,
                                           threadName: threadName,
                                           attachments: attachments)
+    }
+    
+    /// An internal method that adds logs to the Apple unified logging system.
+    /// - Parameters:
+    ///   - platform: The platform sending the log. `react-native` for React native project or `flutter` for Flutter project.
+    ///   - message: Message to log
+    ///   - error: Error object to log
+    public static func internalAddLog(platform: String, message: String, error: Error?) {
+        Measure.shared.internalAddLog(platform: platform, message: message, error: error)
     }
 
     /// An internal method to track spans from cross-platform frameworks

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -438,6 +438,10 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
                                                           responseBody: responseBody)
     }
 
+    func internalAddLog(platform: String, message: String, error: Error?) {
+        logger.log(level: .info, message: "[\(platform)] \(message)", error: error, data: nil)
+    }
+
     private func applicationDidEnterBackground() {
         self.crashDataPersistence.isForeground = false
         self.internalSignalCollector.isForeground = false

--- a/react-native/android/build.gradle.kts
+++ b/react-native/android/build.gradle.kts
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     implementation("com.facebook.react:react-native:+")
-    compileOnly("sh.measure:measure-android:0.17.0")
+    compileOnly("sh.measure:measure-android:0.18.0-SNAPSHOT")
 }

--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -357,6 +357,17 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun internalAddLog(platform: String, message: String, errorMessage: String?, promise: Promise) {
+        val throwable = errorMessage?.let { Exception(it) }
+        Measure.internalAddLog(
+            platform = platform,
+            message = message,
+            throwable = throwable
+        )
+        promise.resolve(null)
+    }
+
+    @ReactMethod
     fun getDynamicConfig(promise: Promise) {
         try {
             val path = Measure.getDynamicConfigPath()

--- a/react-native/example/expo/src/App.tsx
+++ b/react-native/example/expo/src/App.tsx
@@ -24,6 +24,7 @@ export default function App() {
         enableLogging: true,
         autoStart: true,
         enableFullCollectionMode: false,
+        enableDiagnosticMode: true,
       });
 
       await Measure.init(measureConfig);

--- a/react-native/example/rnExample/App.tsx
+++ b/react-native/example/rnExample/App.tsx
@@ -35,9 +35,11 @@ const App = (): React.JSX.Element => {
 
   const initializeMeasure = async () => {
     const measureConfig = new MeasureConfig({
-      enableLogging: true,
-      autoStart: true,
-    });
+        enableLogging: true,
+        autoStart: true,
+        enableFullCollectionMode: false,
+        enableDiagnosticMode: true,
+      });
 
     await Measure.init(measureConfig);
 

--- a/react-native/example/rnExample/android/app/build.gradle
+++ b/react-native/example/rnExample/android/app/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:flipper-integration")
     implementation project(':measuresh-react-native')
-    implementation("sh.measure:measure-android:0.17.0-SNAPSHOT")
+    implementation("sh.measure:measure-android:0.18.0-SNAPSHOT")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/react-native/example/rnExample/android/app/src/main/java/com/rnexample/MainApplication.kt
+++ b/react-native/example/rnExample/android/app/src/main/java/com/rnexample/MainApplication.kt
@@ -53,6 +53,7 @@ class MainApplication : Application(), ReactApplication {
         autoStart = true,
         maxDiskUsageInMb = 1500,
         enableFullCollectionMode = false,
+        enableDiagnosticMode = true,
       )
     )
     SoLoader.init(this, false)

--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -264,6 +264,23 @@ class MeasureModule: NSObject, RCTBridgeModule {
     }
     
     @objc
+    func internalAddLog(_ platform: NSString,
+                        message: NSString,
+                        errorMessage: NSString?,
+                        resolver resolve: @escaping RCTPromiseResolveBlock,
+                        rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let nsError: NSError? = errorMessage.map {
+            NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: $0 as String])
+        }
+        Measure.internalAddLog(
+            platform: platform as String,
+            message: message as String,
+            error: nsError
+        )
+        resolve(nil)
+    }
+    
+    @objc
     func getDynamicConfig(_ resolve: @escaping RCTPromiseResolveBlock,
                           rejecter reject: @escaping RCTPromiseRejectBlock) {
 

--- a/react-native/ios/MeasureModuleBridge.m
+++ b/react-native/ios/MeasureModuleBridge.m
@@ -63,6 +63,11 @@ RCT_EXTERN_METHOD(trackBugReport:(NSString *)description
                   attributes:(NSDictionary *)attributes
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(internalAddLog:(NSString *)platform
+                  message:(NSString *)message
+                  errorMessage:(nullable NSString *)errorMessage
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getDynamicConfig:(RCTPromiseResolveBlock)resolve

--- a/react-native/src/config/config.ts
+++ b/react-native/src/config/config.ts
@@ -6,6 +6,7 @@ export class Config implements InternalConfig, IMeasureConfig {
   enableLogging: boolean;
   autoStart: boolean;
   enableFullCollectionMode: boolean;
+  enableDiagnosticMode: boolean;
   maxCheckpointsPerSpan: number;
   maxCheckpointNameLength: number;
   maxSpanNameLength: number;
@@ -15,11 +16,13 @@ export class Config implements InternalConfig, IMeasureConfig {
   constructor(
     enableLogging?: boolean,
     autoStart?: boolean,
-    enableFullCollectionMode?: boolean
+    enableFullCollectionMode?: boolean,
+    enableDiagnosticMode?: boolean
   ) {
     this.enableLogging = enableLogging ?? DefaultConfig.enableLogging;
     this.autoStart = autoStart ?? DefaultConfig.autoStart;
     this.enableFullCollectionMode = enableFullCollectionMode ?? DefaultConfig.enableFullCollectionMode;
+    this.enableDiagnosticMode = enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode;
     this.maxEventNameLength = 64;
     this.customEventNameRegex = DefaultConfig.customEventNameRegex;
     this.maxSpanNameLength = 64;

--- a/react-native/src/config/configProvider.ts
+++ b/react-native/src/config/configProvider.ts
@@ -10,7 +10,10 @@ import type { ScreenshotMaskLevel } from './screenshotMaskLevel';
  * Configuration Provider for the Measure SDK.
  * See `BaseConfigProvider` for details.
  */
-export interface IConfigProvider extends IMeasureConfig, InternalConfig, IDynamicConfig {
+export interface IConfigProvider
+  extends IMeasureConfig,
+    InternalConfig,
+    IDynamicConfig {
   setDynamicConfig(config: IDynamicConfig): void;
 }
 
@@ -31,7 +34,7 @@ export class ConfigProvider implements IConfigProvider {
   constructor(defaultConfig: Config) {
     this.defaultConfig = defaultConfig;
   }
-  
+
   get maxEventsInBatch(): number {
     return this.dynamicConfig.maxEventsInBatch;
   }
@@ -110,6 +113,10 @@ export class ConfigProvider implements IConfigProvider {
 
   get enableFullCollectionMode(): boolean {
     return this.defaultConfig.enableFullCollectionMode;
+  }
+
+  get enableDiagnosticMode(): boolean {
+    return this.defaultConfig.enableDiagnosticMode;
   }
 
   get maxEventNameLength(): number {

--- a/react-native/src/config/defaultConfig.ts
+++ b/react-native/src/config/defaultConfig.ts
@@ -3,5 +3,6 @@ export const DefaultConfig = {
   enableLogging: false,
   autoStart: true,
   enableFullCollectionMode: false,
+  enableDiagnosticMode: false,
   customEventNameRegex: "^[a-zA-Z0-9_-]+\$",
 };

--- a/react-native/src/config/measureConfig.ts
+++ b/react-native/src/config/measureConfig.ts
@@ -17,11 +17,26 @@ export interface IMeasureConfig {
    */
   autoStart: boolean;
 
-  /** 
+  /**
    * Override all sampling configs and track all events and traces.
    * **Note** that enabling this flag can significantly increase the cost and should typically only be enabled for debug mode.
-  */
+   */
   enableFullCollectionMode: boolean;
+
+  /**
+   * Enables diagnostic mode which writes all SDK logs to a file. The log file can be attached
+   * when reporting a bug to help with debugging SDK issues.
+   *
+   * Defaults to `false`.
+   *
+   * To pull all log files from an android device:
+   * ```
+   * adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+   * ```
+   * To pull all log files from an iOS device, you can enable the `enableDiagnosticModeGesture` option on MeasureConfig.
+   * This will allow you to trigger share sheet when you use the double finger double tap gesture.
+   */
+  enableDiagnosticMode: boolean;
 }
 
 /**
@@ -31,16 +46,23 @@ export class MeasureConfig implements IMeasureConfig {
   enableLogging: boolean;
   autoStart: boolean;
   enableFullCollectionMode: boolean;
+  enableDiagnosticMode: boolean;
 
   /**
    * Configuration options for the Measure SDK. Used to customize the behavior of the SDK on initialization.
    *
    * @param enableLogging Enable or disable internal SDK logs. Defaults to `false`.
    * @param autoStart Set this to false to delay starting the SDK, by default initializing the SDK also starts tracking.
+   * @param enableFullCollectionMode Override all sampling configs and track all events and traces.
+   * @param enableDiagnosticMode Enables diagnostic mode which writes all SDK logs to a file.
    */
   constructor(options: Partial<IMeasureConfig> = {}) {
     this.enableLogging = options.enableLogging ?? DefaultConfig.enableLogging;
     this.autoStart = options.autoStart ?? DefaultConfig.autoStart;
-    this.enableFullCollectionMode = options.enableFullCollectionMode ?? DefaultConfig.enableFullCollectionMode;
+    this.enableFullCollectionMode =
+      options.enableFullCollectionMode ??
+      DefaultConfig.enableFullCollectionMode;
+    this.enableDiagnosticMode =
+      options.enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode;
   }
 }

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -37,10 +37,12 @@ export const Measure = {
    * ts
    * import { Measure, BaseMeasureConfig } from '@measure/react-native';
    *
-   * const measureConfig = new MeasureConfig(
-   * true,   // enableLogging
-   * false,  // autoStart
-   * );
+   * const measureConfig = new MeasureConfig({
+   *       enableLogging: true,
+   *       autoStart: true,
+   *       enableFullCollectionMode: false,
+   *       enableDiagnosticMode: true,
+   *     });
    *
    * Measure.init(client, measureConfig);
    *

--- a/react-native/src/measureInitializer.ts
+++ b/react-native/src/measureInitializer.ts
@@ -37,6 +37,7 @@ import {
 } from './bugReport/bugReportCollector';
 import { ScreenshotCollector, type IScreenshotCollector } from './screenshot/screenshotCollector';
 import { LayoutSnapshotCollector, type ILayoutSnapshotCollector } from './layoutSnapshot/layoutSnapshotCollector';
+import { DefaultConfig } from './config/defaultConfig';
 
 export interface IMeasureInitializer {
   logger: Logger;
@@ -84,13 +85,15 @@ export class MeasureInitializer implements IMeasureInitializer {
   constructor(config: MeasureConfig | null) {
     this.logger = new MeasureLogger(
       'Measure',
-      config?.enableLogging ?? true,
-      true
+      config?.enableLogging ?? DefaultConfig.enableLogging,
+      true,
+      config?.enableDiagnosticMode ?? DefaultConfig.enableDiagnosticMode
     );
     this.config = new Config(
       config?.enableLogging,
       config?.autoStart,
-      config?.enableFullCollectionMode
+      config?.enableFullCollectionMode,
+      config?.enableDiagnosticMode
     );
     this.configLoader = new ConfigLoader(this.logger);
     this.configProvider = new ConfigProvider(this.config);

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -237,6 +237,20 @@ export function trackBugReport(
   return MeasureModule.trackBugReport(description, attachments, attributes);
 }
 
+export function internalAddLog(
+  platform: string,
+  message: string,
+  errorMessage?: string | null
+): Promise<void> {
+  if (!MeasureModule.internalAddLog || isDisabled()) {
+    return Promise.reject(
+      new Error('internalAddLog native method not available.')
+    );
+  }
+
+  return MeasureModule.internalAddLog(platform, message, errorMessage ?? null);
+}
+
 export function getSessionId(): Promise<string | null> {
   if (!MeasureModule.getSessionId || isDisabled()) {
     return Promise.reject(

--- a/react-native/src/utils/logger.ts
+++ b/react-native/src/utils/logger.ts
@@ -1,20 +1,39 @@
+import { internalAddLog } from '../native/measureBridge';
+
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'fatal';
 
 export interface Logger {
   enabled: boolean;
-  log: (level: LogLevel, message: string, error?: unknown, data?: unknown) => void;
-  internalLog: (level: LogLevel, message: string, error?: unknown, data?: unknown) => void;
+  log: (
+    level: LogLevel,
+    message: string,
+    error?: unknown,
+    data?: unknown
+  ) => void;
+  internalLog: (
+    level: LogLevel,
+    message: string,
+    error?: unknown,
+    data?: unknown
+  ) => void;
 }
 
 export class MeasureLogger implements Logger {
   enabled: boolean;
   private internalLogging: boolean;
+  private enableDiagnosticMode: boolean;
   private tag: string;
 
-  constructor(tag: string, enabled: boolean, internalLogging: boolean) {
+  constructor(
+    tag: string,
+    enabled: boolean,
+    internalLogging: boolean,
+    enableDiagnosticMode: boolean
+  ) {
     this.tag = tag;
     this.enabled = enabled;
     this.internalLogging = internalLogging;
+    this.enableDiagnosticMode = enableDiagnosticMode;
   }
 
   log(level: LogLevel, message: string, error?: unknown, data?: unknown) {
@@ -22,8 +41,21 @@ export class MeasureLogger implements Logger {
 
     const prefix = `[${this.tag}]`;
     const dataStr = data ? JSON.stringify(data) : '';
-    const errorStr = error ? (error instanceof Error ? error.message : String(error)) : '';
+    const errorStr = error
+      ? error instanceof Error
+        ? error.message
+        : String(error)
+      : '';
     const output = `${prefix} ${message} ${dataStr} ${errorStr}`.trim();
+
+    if (this.enableDiagnosticMode) {
+      const errorStr = error
+        ? error instanceof Error
+          ? error.message
+          : String(error)
+        : null;
+      internalAddLog('react-native', message, errorStr).catch(() => {});
+    }
 
     switch (level) {
       case 'debug':
@@ -42,7 +74,12 @@ export class MeasureLogger implements Logger {
     }
   }
 
-  internalLog(level: LogLevel, message: string, error?: unknown, data?: unknown) {
+  internalLog(
+    level: LogLevel,
+    message: string,
+    error?: unknown,
+    data?: unknown
+  ) {
     if (this.internalLogging) {
       this.log(level, `Internal: ${message}`, error, data);
     }


### PR DESCRIPTION
# Description

This PR contains below changes:
- Add `enableDiagnosticMode` to MeasureConfig.
- Add `internalAddLog` api to both iOS and Android to log react native logs.
- Create a native module bridge function to send logs from RN to native side.
- Sent logs to native platforms when `enableDiagnosticMode` flag is true..

## Related issue
References #3435 



