### PR TITLE
fix(ios): send lifecycle app event reliably

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/AppLaunch/LaunchTracker.swift
+++ b/ios/Sources/MeasureSDK/Swift/AppLaunch/LaunchTracker.swift
@@ -25,6 +25,7 @@ protocol LaunchTracker {
     func applicationWillEnterForeground()
     func applicationDidBecomeActive()
     func applicationWillResignActive()
+    func setOnAppLaunchCallback(_ callback: @escaping () -> Void)
 }
 
 final class BaseLaunchTracker: LaunchTracker {
@@ -36,6 +37,7 @@ final class BaseLaunchTracker: LaunchTracker {
     private let currentAppVersion: String
     private var state: LaunchState
     private var willEnterForegroundTimestamp: UnsignedNumber?
+    private var onAppLaunchCallback: (() -> Void)?
 
     init(launchCallbacks: LaunchCallbacks,
          timeProvider: TimeProvider,
@@ -84,6 +86,10 @@ final class BaseLaunchTracker: LaunchTracker {
         if state != .launching {
             state = .foregrounded
         }
+    }
+
+    func setOnAppLaunchCallback(_ callback: @escaping () -> Void) {
+        self.onAppLaunchCallback = callback
     }
 
     private func processAppLaunchData() {
@@ -138,6 +144,7 @@ final class BaseLaunchTracker: LaunchTracker {
                                             hasSavedState: false,
                                             intentData: nil)
         launchCallbacks.onColdLaunch(data: coldLaunchData)
+        onAppLaunchCallback?()
     }
 
     private func generateWarmLaunchData(appVisibleUptime: UnsignedNumber, onNextDrawUptime: UnsignedNumber) {
@@ -147,6 +154,7 @@ final class BaseLaunchTracker: LaunchTracker {
                                             hasSavedState: false,
                                             intentData: nil)
         launchCallbacks.onWarmLaunch(data: warmLaunchData)
+        onAppLaunchCallback?()
     }
 
     private func removeObserver() {

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/LifecycleCollector.swift
@@ -13,6 +13,7 @@ protocol LifecycleCollector {
     func applicationDidEnterBackground()
     func applicationWillEnterForeground()
     func applicationWillTerminate()
+    func applicationDidLaunch()
     func processControllerLifecycleEvent(_ vcLifecycleType: VCLifecycleEventType, for viewController: UIViewController)
     func processSwiftUILifecycleEvent(_ swiftUILifecycleType: SwiftUILifecycleType, for viewName: String)
     func enable()
@@ -29,6 +30,7 @@ final class BaseLifecycleCollector: LifecycleCollector {
     private var activeSpans: [String: Span] = [:]
     private let sessionManager: SessionManager
     private let signalSampler: SignalSampler
+    private var isAppLaunchForegroundTriggered = false
 
     init(signalProcessor: SignalProcessor,
          timeProvider: TimeProvider,
@@ -65,7 +67,14 @@ final class BaseLifecycleCollector: LifecycleCollector {
     }
 
     func applicationWillEnterForeground() {
+        guard isAppLaunchForegroundTriggered else { return }
         trackEvent(ApplicationLifecycleData(type: .foreground), type: .lifecycleApp)
+    }
+
+    func applicationDidLaunch() {
+        guard !isAppLaunchForegroundTriggered else { return }
+        trackEvent(ApplicationLifecycleData(type: .foreground), type: .lifecycleApp)
+        isAppLaunchForegroundTriggered = true
     }
 
     func applicationWillTerminate() {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -159,6 +159,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     private var measureDispatchQueue: MeasureDispatchQueue {
         return measureInitializer.measureDispatchQueue
     }
+    private var launchTracker: LaunchTracker {
+        return measureInitializer.launchTracker
+    }
     private let lifecycleObserver: LifecycleObserver
     var isStarted: Bool = false
     var previousSessionCrashed = false
@@ -166,6 +169,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     init(_ measureInitializer: MeasureInitializer) {
         self.measureInitializer = measureInitializer
         self.lifecycleObserver = LifecycleObserver()
+        self.launchTracker.setOnAppLaunchCallback {
+            self.lifecycleCollector.applicationDidLaunch()
+        }
         if configProvider.enableDiagnosticMode {
             let logWriter = SdkDebugLogWriter(fileManager: systemFileManager,
                                              sdkVersion: FrameworkInfo.version,

--- a/ios/Tests/MeasureSDKTests/Lifecycle/LifecycleCollectorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Lifecycle/LifecycleCollectorTests.swift
@@ -68,24 +68,66 @@ final class LifecycleCollectorTests: XCTestCase {
         XCTAssertTrue(mockLogger.logs.contains("LifecycleCollector disabled."))
     }
 
-    func testApplicationDidEnterBackground() {
-        lifecycleCollector.applicationDidEnterBackground()
+    func testEnable_isIdempotent() {
+        lifecycleCollector.enable()
+        lifecycleCollector.enable()
+        let enableLogs = mockLogger.logs.filter { $0 == "LifecycleCollector enabled." }
+        XCTAssertEqual(enableLogs.count, 1, "enable() should only log once even if called multiple times")
+    }
+
+    func testDisable_whenNotEnabled_doesNothing() {
+        lifecycleCollector.disable()
+        XCTAssertFalse(mockLogger.logs.contains("LifecycleCollector disabled."))
+    }
+
+    func testApplicationDidLaunch_tracksForegroundEvent() {
+        lifecycleCollector.applicationDidLaunch()
 
         XCTAssertNotNil(mockSignalProcessor.data)
         if let lifecycleData = mockSignalProcessor.data as? ApplicationLifecycleData {
-            XCTAssertEqual(lifecycleData.type, .background)
+            XCTAssertEqual(lifecycleData.type, .foreground)
         } else {
             XCTFail("Data should be of type ApplicationLifecycleData")
         }
         XCTAssertEqual(mockSignalProcessor.type, .lifecycleApp)
     }
 
-    func testApplicationWillEnterForeground() {
+    func testApplicationDidLaunch_calledTwice_tracksOnlyOnce() {
+        lifecycleCollector.applicationDidLaunch()
+        let countAfterFirst = mockSignalProcessor.trackEventCallCount
+
+        lifecycleCollector.applicationDidLaunch()
+        let countAfterSecond = mockSignalProcessor.trackEventCallCount
+
+        XCTAssertEqual(countAfterFirst, countAfterSecond, "applicationDidLaunch should only track once regardless of how many times it is called")
+    }
+
+    func testApplicationWillEnterForeground_beforeApplicationDidLaunch_doesNotTrack() {
+        lifecycleCollector.applicationWillEnterForeground()
+
+        XCTAssertNil(mockSignalProcessor.data, "applicationWillEnterForeground should not track before applicationDidLaunch is called")
+    }
+
+    func testApplicationWillEnterForeground_afterApplicationDidLaunch_tracksForegroundEvent() {
+        lifecycleCollector.applicationDidLaunch()
+
         lifecycleCollector.applicationWillEnterForeground()
 
         XCTAssertNotNil(mockSignalProcessor.data)
         if let lifecycleData = mockSignalProcessor.data as? ApplicationLifecycleData {
             XCTAssertEqual(lifecycleData.type, .foreground)
+        } else {
+            XCTFail("Data should be of type ApplicationLifecycleData")
+        }
+        XCTAssertEqual(mockSignalProcessor.type, .lifecycleApp)
+    }
+
+    func testApplicationDidEnterBackground() {
+        lifecycleCollector.applicationDidEnterBackground()
+
+        XCTAssertNotNil(mockSignalProcessor.data)
+        if let lifecycleData = mockSignalProcessor.data as? ApplicationLifecycleData {
+            XCTAssertEqual(lifecycleData.type, .background)
         } else {
             XCTFail("Data should be of type ApplicationLifecycleData")
         }
@@ -160,7 +202,22 @@ final class LifecycleCollectorTests: XCTestCase {
         XCTAssertEqual(mockSignalProcessor.type, .lifecycleViewController)
     }
 
-    func testProcessSwiftUILifecycleEvent() {
+    func testProcessControllerLifecycleEvent_whenDisabled_doesNotTrack() {
+        lifecycleCollector.processControllerLifecycleEvent(.viewDidLoad, for: mockViewController)
+
+        XCTAssertNil(mockSignalProcessor.data, "VC lifecycle events should not be tracked when collector is disabled")
+    }
+
+    func testProcessControllerLifecycleEvent_whenInExcludeList_doesNotTrack() {
+        lifecycleCollector.enable()
+        mockConfigProvider.lifecycleViewControllerExcludeList = ["MockViewController"]
+
+        lifecycleCollector.processControllerLifecycleEvent(.viewDidLoad, for: mockViewController)
+
+        XCTAssertNil(mockSignalProcessor.data, "VC lifecycle events should not be tracked for excluded view controllers")
+    }
+
+    func testProcessSwiftUILifecycleEvent_onAppear() {
         let className = "TestView"
         lifecycleCollector.processSwiftUILifecycleEvent(.onAppear, for: className)
 
@@ -199,5 +256,21 @@ final class LifecycleCollectorTests: XCTestCase {
 
         // Verify span was ended with OK status
         XCTAssertEqual(mockTracer.lastSpan?.status, .ok)
+    }
+
+    func testTrackEvent_whenSamplerReturnsFalse_needsReportingIsFalse() {
+        mockSignalSampler.shouldTrackLaunchEventsReturnValue = false
+
+        lifecycleCollector.applicationDidEnterBackground()
+
+        XCTAssertEqual(mockSignalProcessor.needsReporting, false, "needsReporting should be false when signal sampler returns false")
+    }
+
+    func testTrackEvent_whenSamplerReturnsTrue_needsReportingIsTrue() {
+        mockSignalSampler.shouldTrackLaunchEventsReturnValue = true
+
+        lifecycleCollector.applicationDidEnterBackground()
+
+        XCTAssertEqual(mockSignalProcessor.needsReporting, true, "needsReporting should be true when signal sampler returns true")
     }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSignalProcessor.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSignalProcessor.swift
@@ -19,6 +19,7 @@ final class MockSignalProcessor: SignalProcessor {
     var spanData: SpanData?
     var needsReporting: Bool?
     var trackSpanCallCount = 0
+    var trackEventCallCount = 0
     var synchronous: Bool?
 
     func track<T>(data: T, // swiftlint:disable:this function_parameter_count
@@ -40,6 +41,7 @@ final class MockSignalProcessor: SignalProcessor {
         self.userDefinedAttributes = userDefinedAttributes
         self.needsReporting = needsReporting
         self.synchronous = synchronous
+        trackEventCallCount += 1
     }
 
     func trackUserTriggered<T>(data: T,  // swiftlint:disable:this function_parameter_count


### PR DESCRIPTION
# Description

The lifecycle app foreground event was not being tracked on app launch in Flutter. This was happening because Flutter's initialisation skips the background-to-foreground transition on launch, which meant `applicationWillEnterForeground` was never triggered. In a standard iOS app, the launch sequence transitions through background to foreground, firing `applicationWillEnterForeground`. Flutter skips this transition and starts the app directly in the active state, so the notification is never posted.

Instead of relying solely on `applicationWillEnterForeground` for the initial foreground event, we now use the app launch callback to track the foreground event on launch. Subsequent background-to-foreground transitions continue to use `applicationWillEnterForeground` as before.

## Related issue
Fixes #3457 