### PR TITLE
chore(backend): skip all alerts for ingestion blocked teams

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -92,7 +92,7 @@ type AppThresholdPrefs struct {
 
 func CreateCrashAndAnrAlerts(ctx context.Context) {
 	fmt.Println("Checking for Crash and ANR alerts...")
-	teams, err := getTeams(ctx)
+	teams, err := getActiveTeams(ctx)
 	if err != nil {
 		fmt.Printf("Error fetching teams: %v\n", err)
 		return
@@ -153,7 +153,7 @@ func CreateCrashAndAnrAlerts(ctx context.Context) {
 
 func CreateBugReportAlerts(ctx context.Context) {
 	fmt.Println("Checking for new Bug Report alerts...")
-	teams, err := getTeams(ctx)
+	teams, err := getActiveTeams(ctx)
 	if err != nil {
 		fmt.Printf("Error fetching teams: %v\n", err)
 		return
@@ -270,7 +270,7 @@ func CreateDailySummary(ctx context.Context) {
 	// Daily summary runs at 06:00 UTC and reports the previous UTC calendar day.
 	date := time.Now().UTC().AddDate(0, 0, -1)
 
-	teams, err := getTeams(ctx)
+	teams, err := getActiveTeams(ctx)
 	if err != nil {
 		fmt.Printf("Error fetching teams: %v\n", err)
 		return
@@ -304,11 +304,12 @@ func CreateDailySummary(ctx context.Context) {
 	}
 }
 
-func getTeams(ctx context.Context) ([]Team, error) {
+func getActiveTeams(ctx context.Context) ([]Team, error) {
 	teams := []Team{}
 	stmt := sqlf.PostgreSQL.
 		Select("id").
-		From("teams")
+		From("teams").
+		Where("allow_ingest = true")
 
 	defer stmt.Close()
 

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -2296,6 +2296,34 @@ func TestCreateDailySummary(t *testing.T) {
 			t.Fatalf("expected slack payload to include error status icon for custom thresholds")
 		}
 	})
+
+	t.Run("team with blocked ingestion produces no summary notifications", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		userID := uuid.New().String()
+
+		th.SeedTeam(ctx, t, teamID, "Blocked Team", false)
+		th.SeedUser(ctx, t, userID, "owner@example.com")
+		th.SeedTeamMembership(ctx, t, teamID, userID, "owner")
+		th.SeedApp(ctx, t, appID, teamID, "Blocked App", 30)
+		th.SeedTeamSlack(ctx, t, teamID, []string{"C0BLOCKED"})
+
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, appID, 5, summaryDate)
+
+		CreateDailySummary(ctx)
+
+		if got := countPendingByChannel(ctx, t, "email"); got != 0 {
+			t.Errorf("want 0 emails for blocked team, got %d", got)
+		}
+		if got := countPendingByChannel(ctx, t, "slack"); got != 0 {
+			t.Errorf("want 0 slack messages for blocked team, got %d", got)
+		}
+	})
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Skips all alerts for ingestion blocked teams

## Related issue
Closes #3472



