### PR TITLE
fix(backend): use correct field names for span attrs

### DIFF
--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -261,27 +261,27 @@ func (s *SpanField) Validate(opts ...ingest.ValidationOptions) error {
 	}
 
 	if s.Attributes.InstallationID == uuid.Nil {
-		return fmt.Errorf(`%q must be a valid UUID`, `attribute.installation_id`)
+		return fmt.Errorf(`%q must be a valid UUID`, `attributes.installation_id`)
 	}
 
 	if s.Attributes.MeasureSDKVersion == "" {
-		return fmt.Errorf(`%q must not be empty`, `attribute.measure_sdk_version`)
+		return fmt.Errorf(`%q must not be empty`, `attributes.measure_sdk_version`)
 	}
 
 	if s.Attributes.AppVersion == "" {
-		return fmt.Errorf(`%q must not be empty`, `attribute.app_version`)
+		return fmt.Errorf(`%q must not be empty`, `attributes.app_version`)
 	}
 
 	if s.Attributes.AppBuild == "" {
-		return fmt.Errorf(`%q must not be empty`, `attribute.app_build`)
+		return fmt.Errorf(`%q must not be empty`, `attributes.app_build`)
 	}
 
 	if s.Attributes.AppUniqueID == "" {
-		return fmt.Errorf(`%q must not be empty`, `attribute.app_unique_id`)
+		return fmt.Errorf(`%q must not be empty`, `attributes.app_unique_id`)
 	}
 
 	if len(s.Attributes.AppUniqueID) > maxAppUniqueIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.app_unique_id`, maxAppUniqueIDChars)
 	}
 
 	if len(s.Attributes.UserID) > maxUserIDChars {
@@ -319,7 +319,7 @@ func (s *SpanField) Validate(opts ...ingest.ValidationOptions) error {
 	switch opsys.ToFamily(s.Attributes.OSName) {
 	case opsys.Android, opsys.AppleFamily:
 	default:
-		return fmt.Errorf(`%q does not contain a valid OS value`, `attribute.os_name`)
+		return fmt.Errorf(`%q does not contain a valid OS value`, `attributes.os_name`)
 	}
 
 	if len(s.Attributes.ThreadName) > maxThreadNameChars {

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -93,12 +93,12 @@ Ingests a batch of events, which can be of different types and can range across 
     - `status`
     - `start_time`
     - `end_time`
-    - `attribute.installation_id`
-    - `attribute.measure_sdk_version`
-    - `attribute.platform`
-    - `attribute.app_version`
-    - `attribute.os_version`
-    - `attribute.app_unique_id`
+    - `attributes.installation_id`
+    - `attributes.measure_sdk_version`
+    - `attributes.platform`
+    - `attributes.app_version`
+    - `attributes.os_version`
+    - `attributes.app_unique_id`
 
 - At least 1 event must be present in the `events` array field or 1 span must be present in the `spans` array field. Both arrays must
 not be empty.
@@ -1092,7 +1092,7 @@ example of a `app_startup` span:
      "timestamp": "2023-08-24T14:51:38.000000634Z"
    }
  ],
- "attribute": {
+ "attributes": {
    // snip attributes fields
  }
 }


### PR DESCRIPTION
# Description

Fixes the incorrect attributes field names for spans in validation messages and in docs.

## Related issue
Fixes #3461



