### PR TITLE
fix(frontend): prevent stale router.replace during team switch

### DIFF
--- a/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
@@ -625,3 +625,40 @@ describe('Alerts — auth failure', () => {
         }, { timeout: 5000 })
     })
 })
+
+describe('Alerts — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<AlertsOverview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<AlertsOverview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -1590,3 +1590,40 @@ describe('Bug Report Detail (MSW integration)', () => {
         })
     })
 })
+
+describe('Bug reports — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<BugReportsOverview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('App crashes when tapping checkout button')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<BugReportsOverview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/integration/exceptions_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/exceptions_msw_test.tsx
@@ -1070,3 +1070,40 @@ describe.each([
         })
     })
 })
+
+describe('Exceptions — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<ExceptionsOverview exceptionsType={ExceptionsType.Crash} teamId="team-with-apps" />)
+
+        await waitFor(() => {
+            expect(screen.getByText('CheckoutActivity.kt: onClick()')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<ExceptionsOverview exceptionsType={ExceptionsType.Crash} teamId="team-no-apps" />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/integration/network_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/network_msw_test.tsx
@@ -1028,3 +1028,40 @@ describe('Network — auth failure', () => {
         }, { timeout: 5000 })
     })
 })
+
+describe('Network — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<NetworkOverview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Explore endpoint')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<NetworkOverview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
@@ -1614,6 +1614,46 @@ describe('Overview page — concurrent and re-render scenarios', () => {
 })
 
 // ====================================================================
+// TEAM SWITCH — team with apps → team with no apps
+// ====================================================================
+describe('Overview page — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<Overview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('99.1%')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<Overview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})
+
+// ====================================================================
 // DEMO MODE
 // ====================================================================
 describe('Overview page — demo mode', () => {

--- a/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
@@ -1430,3 +1430,40 @@ describe('Session Timelines Overview — additional coverage', () => {
         })
     })
 })
+
+describe('Session timelines — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<SessionTimelinesOverview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText(/Session ID: sess-001/)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<SessionTimelinesOverview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -1503,3 +1503,40 @@ describe('Traces — auth failure', () => {
         }, { timeout: 5000 })
     })
 })
+
+describe('Traces — team switch to no-apps team', () => {
+    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+        // Phase 1: render with team that has apps — fully load
+        const { unmount } = renderWithProviders(<TracesOverview params={{ teamId: 'team-with-apps' }} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('ID: trace-001')).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // Confirm router.replace was called for the first team
+        expect(mockRouterReplace).toHaveBeenCalled()
+
+        // Phase 2: switch to team with no apps (404 on /apps)
+        server.use(
+            http.get('*/api/teams/:teamId/apps', () => {
+                return new HttpResponse(null, { status: 404 })
+            }),
+        )
+
+        unmount()
+        mockRouterReplace.mockClear()
+
+        renderWithProviders(<TracesOverview params={{ teamId: 'team-no-apps' }} />)
+
+        // Should show NoApps message
+        await waitFor(() => {
+            expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
+        }, { timeout: 5000 })
+
+        // router.replace must NOT have been called with stale filters
+        // from the previous team. With the real Next.js router, a stale
+        // router.replace during/after navigation corrupts the RSC flight
+        // response causing the "unparsable" crash in production builds.
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
@@ -31,6 +31,7 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -31,6 +31,7 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/exception_details_test.tsx
+++ b/frontend/dashboard/__tests__/pages/exception_details_test.tsx
@@ -156,6 +156,7 @@ jest.mock('@/app/query/hooks', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return {

--- a/frontend/dashboard/__tests__/pages/exceptions_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/exceptions_overview_test.tsx
@@ -103,6 +103,7 @@ jest.mock('@/app/query/hooks', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/network_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/network_overview_test.tsx
@@ -26,6 +26,7 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/overview_test.tsx
@@ -23,6 +23,7 @@ jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
         filters: { ready: false, serialisedFilters: '' },
+        currentTeamId: '123',
     }))
     return {
         __esModule: true,

--- a/frontend/dashboard/__tests__/pages/session_timelines_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/session_timelines_overview_test.tsx
@@ -31,6 +31,7 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -30,6 +30,7 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
+        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return {

--- a/frontend/dashboard/app/[teamId]/alerts/page.tsx
+++ b/frontend/dashboard/app/[teamId]/alerts/page.tsx
@@ -19,6 +19,7 @@ export default function AlertsOverview({ params }: { params: { teamId: string } 
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -41,8 +42,11 @@ export default function AlertsOverview({ params }: { params: { teamId: string } 
         if (!filters.ready) {
             return
         }
+        if (currentTeamId !== params.teamId) {
+            return
+        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
 
     const { data: alertsOverview = emptyAlertsOverviewResponse, status, isFetching } = useAlertsOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -20,6 +20,7 @@ export default function BugReportsOverview({ params }: { params: { teamId: strin
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -42,8 +43,11 @@ export default function BugReportsOverview({ params }: { params: { teamId: strin
         if (!filters.ready) {
             return
         }
+        if (currentTeamId !== params.teamId) {
+            return
+        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
 
     const { data: bugReportsOverview = emptyBugReportsOverviewResponse, status, isFetching } = useBugReportsOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
@@ -21,6 +21,7 @@ export default function SessionTimelinesOverview({ params }: { params: { teamId:
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -43,8 +44,11 @@ export default function SessionTimelinesOverview({ params }: { params: { teamId:
         if (!filters.ready) {
             return
         }
+        if (currentTeamId !== params.teamId) {
+            return
+        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
 
     const { data: sessionTimelinesOverview = emptySessionTimelinesOverviewResponse, status, isFetching } = useSessionTimelinesOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -20,6 +20,7 @@ export default function TracesOverview({ params }: { params: { teamId: string } 
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -42,8 +43,11 @@ export default function TracesOverview({ params }: { params: { teamId: string } 
         if (!filters.ready) {
             return
         }
+        if (currentTeamId !== params.teamId) {
+            return
+        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
 
     const { data: spans = emptySpansResponse, status, isFetching } = useSpansQuery(paginationOffset)
 

--- a/frontend/dashboard/app/components/exceptions_details.tsx
+++ b/frontend/dashboard/app/components/exceptions_details.tsx
@@ -173,6 +173,7 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
   const searchParams = useSearchParams()
 
   const filters = useFiltersStore(state => state.filters)
+  const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
   // Pagination is component-local state, initialized from URL
   const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -200,8 +201,12 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
       return
     }
 
+    if (currentTeamId !== teamId) {
+      return
+    }
+
     router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-  }, [paginationOffset, filters.ready, filters.serialisedFilters])
+  }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, teamId])
 
   // Both hooks must be called unconditionally (rules of hooks)
   const crashQuery = useCrashDetailsQuery(exceptionsGroupId!, paginationOffset)

--- a/frontend/dashboard/app/components/exceptions_overview.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview.tsx
@@ -24,6 +24,7 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
   const searchParams = useSearchParams()
 
   const filters = useFiltersStore(state => state.filters)
+  const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
   // Pagination is component-local state, initialized from URL
   const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -46,8 +47,11 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
     if (!filters.ready) {
       return
     }
+    if (currentTeamId !== teamId) {
+      return
+    }
     router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-  }, [paginationOffset, filters.ready, filters.serialisedFilters])
+  }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, teamId])
 
   const { data: exceptionsOverview = emptyExceptionsOverviewResponse, status, isFetching } = useExceptionsOverviewQuery(exceptionsType, paginationOffset)
 

--- a/frontend/dashboard/app/components/network_overview.tsx
+++ b/frontend/dashboard/app/components/network_overview.tsx
@@ -89,6 +89,7 @@ const demoTimelineData = generateDemoTimelineData()
 export default function NetworkOverview({ params, demo = false, hideDemoTitle = false }: NetworkOverviewProps) {
     const router = useRouter()
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     const domainsQuery = useNetworkDomainsQuery()
 
@@ -140,8 +141,9 @@ export default function NetworkOverview({ params, demo = false, hideDemoTitle = 
     useEffect(() => {
         if (demo) return
         if (!filters.ready) return
+        if (currentTeamId !== params?.teamId) return
         router.replace(`?${filters.serialisedFilters!}`, { scroll: false })
-    }, [filters.ready, filters.serialisedFilters])
+    }, [filters.ready, filters.serialisedFilters, currentTeamId, params?.teamId])
 
     // Update recent paths when domain or pattern changes
     useEffect(() => {

--- a/frontend/dashboard/app/components/overview.tsx
+++ b/frontend/dashboard/app/components/overview.tsx
@@ -18,15 +18,19 @@ export default function Overview({ params = { teamId: 'demo-team-id' }, demo = f
     const router = useRouter()
     const teamId = params?.teamId ?? "demo-team"
     const filters = useFiltersStore(state => state.filters)
+    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     useEffect(() => {
         if (!filters.ready) {
             return
         }
+        if (currentTeamId !== teamId) {
+            return
+        }
 
         // update url
         router.replace(`?${filters.serialisedFilters!}`, { scroll: false })
-    }, [filters.ready, filters.serialisedFilters])
+    }, [filters.ready, filters.serialisedFilters, currentTeamId, teamId])
 
     return (
         <div className="flex flex-col items-start">

--- a/frontend/dashboard/app/global-error.tsx
+++ b/frontend/dashboard/app/global-error.tsx
@@ -25,18 +25,20 @@ export default function Error({
           <div className="py-2" />
           <Link target='_blank' className={underlineLinkStyle} href='https://github.com/measure-sh/measure/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title='>Report issue</Link>
           <div className="py-8" />
-          <div className="w-fit">
-            <p className="">Error message: </p>
-            <div className="py-1" />
-            <p className="w-fit bg-red-200 border border-black selection:bg-yellow-200/50 grid text-left text-sm font-body whitespace-pre-wrap rounded-md p-4">{error.message}</p>
-            <div className="py-2" />
-            <Button
-              variant="outline"
-              className="font-display border border-black select-none"
-              onClick={() => navigator.clipboard.writeText(error.message)}
-            >Copy
-            </Button>
-          </div>
+          {error.message && (
+            <div className="w-fit">
+              <p className="">Error message: </p>
+              <div className="py-1" />
+              <p className="w-fit bg-red-200 border border-black selection:bg-yellow-200/50 grid text-left text-sm font-body whitespace-pre-wrap rounded-md p-4">{error.message}</p>
+              <div className="py-2" />
+              <Button
+                variant="outline"
+                className="font-display border border-black select-none"
+                onClick={() => navigator.clipboard.writeText(error.message)}
+              >Copy
+              </Button>
+            </div>
+          )}
         </div>
       </body>
     </html>


### PR DESCRIPTION
# Description
The Zustand filters store persists in root-level context across team navigations. When switching from a team with apps to one without, the new page mounts and reads stale filters (ready=true) from the previous team. React fires effects children-first, so the Filters component's effect resets the store, but the page component's effect has already captured the stale ready=true in its closure and calls router.replace with the old team's filter params. In production builds this collides with the in-progress router.push and corrupts the Next.js RSC flight response ("unparsable"), triggering the global error boundary.

Guard every router.replace URL-sync effect with a currentTeamId check so stale filters from a previous team are never pushed to the URL.



