### PR TITLE
fix(frontend): reset filters store before team navigation

### DIFF
--- a/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
@@ -627,7 +627,7 @@ describe('Alerts — auth failure', () => {
 })
 
 describe('Alerts — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<AlertsOverview params={{ teamId: 'team-with-apps' }} />)
 
@@ -635,10 +635,10 @@ describe('Alerts — team switch to no-apps team', () => {
             expect(screen.getByText('Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -646,19 +646,12 @@ describe('Alerts — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<AlertsOverview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -1592,7 +1592,7 @@ describe('Bug Report Detail (MSW integration)', () => {
 })
 
 describe('Bug reports — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<BugReportsOverview params={{ teamId: 'team-with-apps' }} />)
 
@@ -1600,10 +1600,10 @@ describe('Bug reports — team switch to no-apps team', () => {
             expect(screen.getByText('App crashes when tapping checkout button')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1611,19 +1611,12 @@ describe('Bug reports — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<BugReportsOverview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/integration/exceptions_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/exceptions_msw_test.tsx
@@ -1072,7 +1072,7 @@ describe.each([
 })
 
 describe('Exceptions — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<ExceptionsOverview exceptionsType={ExceptionsType.Crash} teamId="team-with-apps" />)
 
@@ -1080,10 +1080,10 @@ describe('Exceptions — team switch to no-apps team', () => {
             expect(screen.getByText('CheckoutActivity.kt: onClick()')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1091,19 +1091,12 @@ describe('Exceptions — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<ExceptionsOverview exceptionsType={ExceptionsType.Crash} teamId="team-no-apps" />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/integration/network_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/network_msw_test.tsx
@@ -1030,7 +1030,7 @@ describe('Network — auth failure', () => {
 })
 
 describe('Network — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<NetworkOverview params={{ teamId: 'team-with-apps' }} />)
 
@@ -1038,10 +1038,10 @@ describe('Network — team switch to no-apps team', () => {
             expect(screen.getByText('Explore endpoint')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1049,19 +1049,12 @@ describe('Network — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<NetworkOverview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
@@ -1617,7 +1617,7 @@ describe('Overview page — concurrent and re-render scenarios', () => {
 // TEAM SWITCH — team with apps → team with no apps
 // ====================================================================
 describe('Overview page — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<Overview params={{ teamId: 'team-with-apps' }} />)
 
@@ -1625,10 +1625,10 @@ describe('Overview page — team switch to no-apps team', () => {
             expect(screen.getByText('99.1%')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1636,20 +1636,13 @@ describe('Overview page — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<Overview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })
 

--- a/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
@@ -1432,7 +1432,7 @@ describe('Session Timelines Overview — additional coverage', () => {
 })
 
 describe('Session timelines — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<SessionTimelinesOverview params={{ teamId: 'team-with-apps' }} />)
 
@@ -1440,10 +1440,10 @@ describe('Session timelines — team switch to no-apps team', () => {
             expect(screen.getByText(/Session ID: sess-001/)).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1451,19 +1451,12 @@ describe('Session timelines — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<SessionTimelinesOverview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -1505,7 +1505,7 @@ describe('Traces — auth failure', () => {
 })
 
 describe('Traces — team switch to no-apps team', () => {
-    it('switching from team with apps to team with no apps must not router.replace with stale filters', async () => {
+    it('switching from team with apps to team with no apps shows NoApps after store reset', async () => {
         // Phase 1: render with team that has apps — fully load
         const { unmount } = renderWithProviders(<TracesOverview params={{ teamId: 'team-with-apps' }} />)
 
@@ -1513,10 +1513,10 @@ describe('Traces — team switch to no-apps team', () => {
             expect(screen.getByText('ID: trace-001')).toBeTruthy()
         }, { timeout: 5000 })
 
-        // Confirm router.replace was called for the first team
-        expect(mockRouterReplace).toHaveBeenCalled()
+        // Reset the filtersStore (simulating what onTeamChanged does in the layout)
+        filtersStore.getState().reset(true)
 
-        // Phase 2: switch to team with no apps (404 on /apps)
+        // Phase 2: override MSW to return 404 for apps, unmount, re-render with new teamId
         server.use(
             http.get('*/api/teams/:teamId/apps', () => {
                 return new HttpResponse(null, { status: 404 })
@@ -1524,19 +1524,12 @@ describe('Traces — team switch to no-apps team', () => {
         )
 
         unmount()
-        mockRouterReplace.mockClear()
 
         renderWithProviders(<TracesOverview params={{ teamId: 'team-no-apps' }} />)
 
-        // Should show NoApps message
+        // Wait for NoApps message to appear
         await waitFor(() => {
             expect(screen.getByText(/don.t have any apps/i)).toBeTruthy()
         }, { timeout: 5000 })
-
-        // router.replace must NOT have been called with stale filters
-        // from the previous team. With the real Next.js router, a stale
-        // router.replace during/after navigation corrupts the RSC flight
-        // response causing the "unparsable" crash in production builds.
-        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })

--- a/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
@@ -31,7 +31,6 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -31,7 +31,6 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/exception_details_test.tsx
+++ b/frontend/dashboard/__tests__/pages/exception_details_test.tsx
@@ -156,7 +156,6 @@ jest.mock('@/app/query/hooks', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return {

--- a/frontend/dashboard/__tests__/pages/exceptions_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/exceptions_overview_test.tsx
@@ -103,7 +103,6 @@ jest.mock('@/app/query/hooks', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/network_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/network_overview_test.tsx
@@ -26,7 +26,6 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/overview_test.tsx
@@ -23,7 +23,6 @@ jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
         filters: { ready: false, serialisedFilters: '' },
-        currentTeamId: '123',
     }))
     return {
         __esModule: true,

--- a/frontend/dashboard/__tests__/pages/session_timelines_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/session_timelines_overview_test.tsx
@@ -31,7 +31,6 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return { __esModule: true, useFiltersStore: filtersStore }

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -30,7 +30,6 @@ jest.mock('@/app/api/api_calls', () => ({
 jest.mock('@/app/stores/provider', () => {
     const { create } = jest.requireActual('zustand')
     const filtersStore = create(() => ({
-        currentTeamId: '123',
         filters: { ready: false, serialisedFilters: '' },
     }))
     return {

--- a/frontend/dashboard/app/[teamId]/alerts/page.tsx
+++ b/frontend/dashboard/app/[teamId]/alerts/page.tsx
@@ -19,7 +19,6 @@ export default function AlertsOverview({ params }: { params: { teamId: string } 
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -42,11 +41,8 @@ export default function AlertsOverview({ params }: { params: { teamId: string } 
         if (!filters.ready) {
             return
         }
-        if (currentTeamId !== params.teamId) {
-            return
-        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
     const { data: alertsOverview = emptyAlertsOverviewResponse, status, isFetching } = useAlertsOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -20,7 +20,6 @@ export default function BugReportsOverview({ params }: { params: { teamId: strin
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -43,11 +42,8 @@ export default function BugReportsOverview({ params }: { params: { teamId: strin
         if (!filters.ready) {
             return
         }
-        if (currentTeamId !== params.teamId) {
-            return
-        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
     const { data: bugReportsOverview = emptyBugReportsOverviewResponse, status, isFetching } = useBugReportsOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -175,6 +175,11 @@ export default function DashboardLayout({
   }
 
   const onTeamChanged = (item: Team) => {
+    // Reset the filters store before navigating so the new page doesn't
+    // mount with stale filters.ready=true from the previous team. Without
+    // this, Zustand's useSyncExternalStore triggers re-renders during the
+    // React transition, aborting the in-flight RSC fetch and crashing.
+    registry.filtersStore.getState().reset(true)
     const newPath = `/${item.id}/overview`
     router.push(newPath)
   }

--- a/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
@@ -21,7 +21,6 @@ export default function SessionTimelinesOverview({ params }: { params: { teamId:
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -44,11 +43,8 @@ export default function SessionTimelinesOverview({ params }: { params: { teamId:
         if (!filters.ready) {
             return
         }
-        if (currentTeamId !== params.teamId) {
-            return
-        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
     const { data: sessionTimelinesOverview = emptySessionTimelinesOverviewResponse, status, isFetching } = useSessionTimelinesOverviewQuery(paginationOffset)
 

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -20,7 +20,6 @@ export default function TracesOverview({ params }: { params: { teamId: string } 
     const searchParams = useSearchParams()
 
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     // Pagination is component-local state, initialized from URL
     const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -43,11 +42,8 @@ export default function TracesOverview({ params }: { params: { teamId: string } 
         if (!filters.ready) {
             return
         }
-        if (currentTeamId !== params.teamId) {
-            return
-        }
         router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-    }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, params.teamId])
+    }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
     const { data: spans = emptySpansResponse, status, isFetching } = useSpansQuery(paginationOffset)
 

--- a/frontend/dashboard/app/components/exceptions_details.tsx
+++ b/frontend/dashboard/app/components/exceptions_details.tsx
@@ -173,7 +173,6 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
   const searchParams = useSearchParams()
 
   const filters = useFiltersStore(state => state.filters)
-  const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
   // Pagination is component-local state, initialized from URL
   const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -201,12 +200,8 @@ export const ExceptionsDetails: React.FC<ExceptionsDetailsProps> = ({ exceptions
       return
     }
 
-    if (currentTeamId !== teamId) {
-      return
-    }
-
     router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-  }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, teamId])
+  }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
   // Both hooks must be called unconditionally (rules of hooks)
   const crashQuery = useCrashDetailsQuery(exceptionsGroupId!, paginationOffset)

--- a/frontend/dashboard/app/components/exceptions_overview.tsx
+++ b/frontend/dashboard/app/components/exceptions_overview.tsx
@@ -24,7 +24,6 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
   const searchParams = useSearchParams()
 
   const filters = useFiltersStore(state => state.filters)
-  const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
   // Pagination is component-local state, initialized from URL
   const [paginationOffset, setPaginationOffset] = useState(() => {
@@ -47,11 +46,8 @@ export const ExceptionsOverview: React.FC<ExceptionsOverviewProps> = ({ exceptio
     if (!filters.ready) {
       return
     }
-    if (currentTeamId !== teamId) {
-      return
-    }
     router.replace(`?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`, { scroll: false })
-  }, [paginationOffset, filters.ready, filters.serialisedFilters, currentTeamId, teamId])
+  }, [paginationOffset, filters.ready, filters.serialisedFilters])
 
   const { data: exceptionsOverview = emptyExceptionsOverviewResponse, status, isFetching } = useExceptionsOverviewQuery(exceptionsType, paginationOffset)
 

--- a/frontend/dashboard/app/components/network_overview.tsx
+++ b/frontend/dashboard/app/components/network_overview.tsx
@@ -89,7 +89,6 @@ const demoTimelineData = generateDemoTimelineData()
 export default function NetworkOverview({ params, demo = false, hideDemoTitle = false }: NetworkOverviewProps) {
     const router = useRouter()
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     const domainsQuery = useNetworkDomainsQuery()
 
@@ -141,9 +140,8 @@ export default function NetworkOverview({ params, demo = false, hideDemoTitle = 
     useEffect(() => {
         if (demo) return
         if (!filters.ready) return
-        if (currentTeamId !== params?.teamId) return
         router.replace(`?${filters.serialisedFilters!}`, { scroll: false })
-    }, [filters.ready, filters.serialisedFilters, currentTeamId, params?.teamId])
+    }, [filters.ready, filters.serialisedFilters])
 
     // Update recent paths when domain or pattern changes
     useEffect(() => {

--- a/frontend/dashboard/app/components/overview.tsx
+++ b/frontend/dashboard/app/components/overview.tsx
@@ -18,19 +18,15 @@ export default function Overview({ params = { teamId: 'demo-team-id' }, demo = f
     const router = useRouter()
     const teamId = params?.teamId ?? "demo-team"
     const filters = useFiltersStore(state => state.filters)
-    const currentTeamId = useFiltersStore(state => state.currentTeamId)
 
     useEffect(() => {
         if (!filters.ready) {
             return
         }
-        if (currentTeamId !== teamId) {
-            return
-        }
 
         // update url
         router.replace(`?${filters.serialisedFilters!}`, { scroll: false })
-    }, [filters.ready, filters.serialisedFilters, currentTeamId, teamId])
+    }, [filters.ready, filters.serialisedFilters])
 
     return (
         <div className="flex flex-col items-start">


### PR DESCRIPTION
# Description

The previous fix (c6ed19f1) added currentTeamId guards to every page's router.replace effect, but the real crash was the RSC fetch being  aborted by stale useSyncExternalStore updates during the router.push
transition — not the router.replace itself.

Replace the per-page guards with a single store reset in onTeamChanged before router.push. Also hide empty error messages in global-error.tsx.ounts with a clean state. Also hide the error message section in global-error.tsx when the message is empty.



