### PR TITLE
fix(frontend): make journeys panel open only on nodes with issues

### DIFF
--- a/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
@@ -139,7 +139,8 @@ describe('Alerts Overview (MSW integration)', () => {
             // First alert: '2026-04-10T14:30:00Z' → "10 Apr, 2026"
             expect(screen.getByText(/10 Apr, 2026/)).toBeTruthy()
             // Second alert: '2026-04-09T09:15:00Z' → "9 Apr, 2026"
-            expect(screen.getByText(/9 Apr, 2026/)).toBeTruthy()
+            // \b prevents matching "19 Apr, 2026" from the date-range filter.
+            expect(screen.getByText(/\b9 Apr, 2026/)).toBeTruthy()
         })
 
         it('renders formatted time in time column', async () => {

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -876,7 +876,8 @@ describe('Bug Reports Overview (MSW integration)', () => {
         it('renders date for second row as well', async () => {
             await renderAndWaitForData()
             // Second fixture: '2026-04-09T09:15:00Z' → "9 Apr, 2026"
-            expect(screen.getByText(/9 Apr, 2026/)).toBeTruthy()
+            // \b prevents matching "19 Apr, 2026" from the date-range filter.
+            expect(screen.getByText(/\b9 Apr, 2026/)).toBeTruthy()
         })
     })
 

--- a/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
@@ -51,7 +51,15 @@ jest.mock('@nivo/sankey', () => ({
                 </span>
             ))}
             {data?.links?.map((link: any, i: number) => (
-                <span key={i} data-testid={`sankey-link-${i}`}>
+                <span
+                    key={i}
+                    data-testid={`sankey-link-${i}`}
+                    onClick={() => onClick?.({
+                        ...link,
+                        source: { id: link.source },
+                        target: { id: link.target },
+                    })}
+                >
                     {link.source}→{link.target}: {link.value}
                 </span>
             ))}
@@ -375,7 +383,7 @@ describe('Journeys page — exceptions panel', () => {
         expect(screen.queryByText('Close')).toBeNull()
     })
 
-    it('clicking a node with NO issues opens panel but shows no crash/ANR content', async () => {
+    it('clicking a node with NO issues does NOT open the panel', async () => {
         renderWithProviders(<UserJourneys params={{ teamId: 'test-team' }} />)
         await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
 
@@ -387,11 +395,89 @@ describe('Journeys page — exceptions panel', () => {
             fireEvent.click(screen.getByTestId('sankey-node-MainActivity'))
         })
 
-        // Panel opens but has no crash/ANR titles
+        // Panel should not open — no Close button visible
+        expect(screen.queryByText('Close')).toBeNull()
+    })
+
+    it('clicking a link does NOT open the panel', async () => {
+        renderWithProviders(<UserJourneys params={{ teamId: 'test-team' }} />)
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        await act(async () => { fireEvent.click(screen.getByText('Exceptions')) })
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-link-0'))
+        })
+
+        expect(screen.queryByText('Close')).toBeNull()
+    })
+
+    it('open panel closes when clicking a node with no issues', async () => {
+        renderWithProviders(<UserJourneys params={{ teamId: 'test-team' }} />)
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        await act(async () => { fireEvent.click(screen.getByText('Exceptions')) })
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        // Open panel via an exception node
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-node-ProductListActivity'))
+        })
+        await waitFor(() => expect(screen.getByText('Close')).toBeTruthy(), { timeout: 5000 })
+
+        // Click a node without issues — should close the panel
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-node-MainActivity'))
+        })
+
+        expect(screen.queryByText('Close')).toBeNull()
+    })
+
+    it('open panel closes when clicking a link', async () => {
+        renderWithProviders(<UserJourneys params={{ teamId: 'test-team' }} />)
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        await act(async () => { fireEvent.click(screen.getByText('Exceptions')) })
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        // Open panel via an exception node
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-node-CartActivity'))
+        })
+        await waitFor(() => expect(screen.getByText('Close')).toBeTruthy(), { timeout: 5000 })
+
+        // Click a link — should close the panel
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-link-0'))
+        })
+
+        expect(screen.queryByText('Close')).toBeNull()
+    })
+
+    it('open panel stays open when clicking another node with issues (switches to new node)', async () => {
+        renderWithProviders(<UserJourneys params={{ teamId: 'test-team' }} />)
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        await act(async () => { fireEvent.click(screen.getByText('Exceptions')) })
+        await waitFor(() => expect(screen.getByTestId('nivo-sankey')).toBeTruthy(), { timeout: 5000 })
+
+        // Open panel via a node with crashes
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-node-ProductListActivity'))
+        })
+        await waitFor(() => expect(screen.getByText(/NullPointerException at ProductList/)).toBeTruthy(), { timeout: 5000 })
+
+        // Click another node that also has issues — panel should stay open and switch
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('sankey-node-CartActivity'))
+        })
+
         await waitFor(() => {
-            expect(screen.getByText('Close')).toBeTruthy()
-        }, { timeout: 5000 })
-        expect(screen.queryByText(/NullPointerException/)).toBeNull()
+            expect(screen.getByText(/ANR in CartActivity/)).toBeTruthy()
+        })
+        // Previous node's content should no longer be visible
+        expect(screen.queryByText(/NullPointerException at ProductList/)).toBeNull()
     })
 
     it('crash links point to crash detail page', async () => {

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -238,7 +238,8 @@ describe('Traces Overview (MSW integration)', () => {
         it('renders formatted date in start time column', async () => {
             await renderAndWaitForData()
             expect(screen.getByText(/10 Apr, 2026/)).toBeTruthy()
-            expect(screen.getByText(/9 Apr, 2026/)).toBeTruthy()
+            // \b prevents matching "19 Apr, 2026" from the date-range filter.
+            expect(screen.getByText(/\b9 Apr, 2026/)).toBeTruthy()
         })
 
         it('renders formatted time in start time column', async () => {

--- a/frontend/dashboard/app/components/journey.tsx
+++ b/frontend/dashboard/app/components/journey.tsx
@@ -402,144 +402,147 @@ const Journey: React.FC<JourneyProps> = ({ teamId, bidirectional: bidirectionalP
   }
 
   return (
-    <div className="flex flex-col items-center justify-center font-body text-sm w-full h-full overflow-hidden">
-      <div className="flex-1 flex items-center justify-center w-full h-full">
-        {effectiveStatus === 'pending' && <SkeletonPlot showAxes={false} />}
-        {effectiveStatus === 'error' && <p className="text-lg font-display text-center p-4">Error fetching journey. Please refresh page or change filters to try again.</p>}
-        {effectiveStatus === 'nodata' && <p className="text-lg font-display text-center p-4">No journey data</p>}
-        {effectiveStatus === 'success' &&
-          <div className='relative w-full h-full'>
-            <ResponsiveSankey
-              data={getSearchFilteredJourney()}
-              align="justify"
-              sort="input"
-              margin={{ top: 10, right: 10, bottom: 40, left: 10 }}
-              linkContract={30}
-              colors={journeyType === JourneyType.Exceptions ? node => node.nodeColor : theme === 'dark' ? { scheme: 'tableau10' } : { scheme: 'nivo' }}
-              nodeBorderColor={
-                {
+    <div className="w-full h-full overflow-hidden">
+      {effectiveStatus === 'pending' && <SkeletonPlot showAxes={false} />}
+      {effectiveStatus === 'error' && <p className="text-lg font-display text-center p-4">Error fetching journey. Please refresh page or change filters to try again.</p>}
+      {effectiveStatus === 'nodata' && <p className="text-lg font-display text-center p-4">No journey data</p>}
+      {effectiveStatus === 'success' &&
+        <div className='relative w-full h-full'>
+          <ResponsiveSankey
+            data={getSearchFilteredJourney()}
+            align="justify"
+            sort="input"
+            margin={{ top: 10, right: 10, bottom: 40, left: 10 }}
+            linkContract={30}
+            colors={journeyType === JourneyType.Exceptions ? node => node.nodeColor : theme === 'dark' ? { scheme: 'tableau10' } : { scheme: 'nivo' }}
+            nodeBorderColor={
+              {
+                from: 'color',
+                modifiers: [theme === "dark" ? ['brighter', 0.5] : ['darker', 0.3]]
+              }
+            }
+            nodeBorderRadius={3}
+            enableLinkGradient={true}
+            label={node => `${node.id.split(".").pop()?.substring(0, 4)}...`}
+            labelPosition="inside"
+            labelOrientation="horizontal"
+            labelPadding={8}
+            labelTextColor={
+              journeyType === JourneyType.Exceptions
+                ? (theme === 'dark' ? exceptionNodeLabelColourDark : exceptionNodeLabelColour)
+                : {
                   from: 'color',
-                  modifiers: [theme === "dark" ? ['brighter', 0.5] : ['darker', 0.3]]
+                  modifiers: [theme === 'dark' ? ['brighter', 0.5] : ['darker', 0.7]]
                 }
-              }
-              nodeBorderRadius={3}
-              enableLinkGradient={true}
-              label={node => `${node.id.split(".").pop()?.substring(0, 4)}...`}
-              labelPosition="inside"
-              labelOrientation="horizontal"
-              labelPadding={8}
-              labelTextColor={
-                journeyType === JourneyType.Exceptions
-                  ? (theme === 'dark' ? exceptionNodeLabelColourDark : exceptionNodeLabelColour)
-                  : {
-                    from: 'color',
-                    modifiers: [theme === 'dark' ? ['brighter', 0.5] : ['darker', 0.7]]
-                  }
-              }
-              linkBlendMode={theme === 'dark' ? 'lighten' : 'multiply'}
-              onClick={journeyType === JourneyType.Exceptions ? (nodeOrLink) => setSelectedNode(nodeOrLink as JourneyNode) : undefined}
-              linkTooltip={({
-                link
-              }) =>
-                <div className={`flex flex-col p-2 text-xs font-body rounded-md bg-accent text-accent-foreground break-words`}>
-                  <p className='p-2'>{link.source.id.split(".").pop()} → {link.target.id.split(".").pop()}: {link.value > 1 ? link.value + ' sessions' : link.value + ' session'}</p>
-                </div>}
-              nodeTooltip={({
-                node
-              }) =>
-                <div className={`flex flex-col p-2 text-xs font-body rounded-md bg-accent text-accent-foreground break-words`}>
-                  <p className='p-2'>{node.id}</p>
+            }
+            linkBlendMode={theme === 'dark' ? 'lighten' : 'multiply'}
+            onClick={journeyType === JourneyType.Exceptions ? (nodeOrLink) => {
+              const maybeNode = nodeOrLink as Partial<JourneyNode>
+              const hasIssues = (maybeNode.issues?.crashes?.length ?? 0) > 0 || (maybeNode.issues?.anrs?.length ?? 0) > 0
+              setSelectedNode(hasIssues ? (nodeOrLink as JourneyNode) : undefined)
+            } : undefined}
+            linkTooltip={({
+              link
+            }) =>
+              <div className={`flex flex-col p-2 text-xs font-body rounded-md bg-accent text-accent-foreground break-words`}>
+                <p className='p-2'>{link.source.id.split(".").pop()} → {link.target.id.split(".").pop()}: {link.value > 1 ? link.value + ' sessions' : link.value + ' session'}</p>
+              </div>}
+            nodeTooltip={({
+              node
+            }) =>
+              <div className={`flex flex-col p-2 text-xs font-body rounded-md bg-accent text-accent-foreground break-words`}>
+                <p className='p-2'>{node.id}</p>
 
-                  {journeyType === JourneyType.Exceptions && node.issues?.crashes?.length! > 0 &&
-                    <p className='px-2 py-1 text-red-400'>Crashes: {node.issues?.crashes?.reduce((sum, issue) => sum + issue.count, 0)}</p>
-                  }
+                {journeyType === JourneyType.Exceptions && node.issues?.crashes?.length! > 0 &&
+                  <p className='px-2 py-1 text-red-400'>Crashes: {node.issues?.crashes?.reduce((sum, issue) => sum + issue.count, 0)}</p>
+                }
 
-                  {journeyType === JourneyType.Exceptions && node.issues?.anrs?.length! > 0 &&
-                    <p className='px-2 py-1 text-yellow-400'>ANRs: {node.issues?.anrs?.reduce((sum, issue) => sum + issue.count, 0)}</p>
-                  }
+                {journeyType === JourneyType.Exceptions && node.issues?.anrs?.length! > 0 &&
+                  <p className='px-2 py-1 text-yellow-400'>ANRs: {node.issues?.anrs?.reduce((sum, issue) => sum + issue.count, 0)}</p>
+                }
 
-                  {journeyType === JourneyType.Exceptions && (node.issues?.crashes?.length! > 0 || node.issues?.anrs?.length! > 0) &&
-                    <p className='px-2 pt-4 pb-2'>Click for details</p>
-                  }
+                {journeyType === JourneyType.Exceptions && (node.issues?.crashes?.length! > 0 || node.issues?.anrs?.length! > 0) &&
+                  <p className='px-2 pt-4 pb-2'>Click for details</p>
+                }
 
-                </div>
-              }
-            />
-            {/* Panel */}
-            <div
-              className={`absolute overflow-auto top-0 right-0 h-full w-3/4 bg-accent p-4 text-accent-foreground break-words transform transition-transform duration-300 ease-in-out ${showPanel ? 'translate-x-0' : 'translate-x-full'
-                }`}
-            >
-              {selectedNode !== undefined &&
-                <div>
-                  <Button variant="secondary" className="py-2 px-4"
-                    onClick={() => setSelectedNode(undefined)}>Close
-                  </Button>
-                  <p className='mt-6 text-lg'>{selectedNode!.id}</p>
-                  {selectedNode.issues?.crashes?.length! > 0 && (
-                    <div>
-                      <p className="font-body mt-4">Crashes:</p>
-                      <ul className="list-disc list-inside pt-2 pb-4 pl-2 pr-2">
-                        {selectedNode.issues?.crashes?.map(({ id, title, count }) => (
-                          <li key={title}>
-                            {/* Show clickable link if Exceptions journey type */}
-                            {journeyType === JourneyType.Exceptions &&
-                              <span className="font-body text-xs">
-                                {demo ? (
-                                  <div className={underlineLinkStyle}>{title} - {numberToKMB(count)}</div>
-                                ) : (
-                                  <Link href={`/${teamId}/crashes/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`} className={underlineLinkStyle}>
-                                    {title} - {numberToKMB(count)}
-                                  </Link>
-                                )}
-                              </span>
-                            }
-                            {/* Show only title and count if crash or anr journey type */}
-                            {(journeyType === JourneyType.CrashDetails || journeyType === JourneyType.AnrDetails) &&
-                              <span className="font-body text-xs">
-                                {title} - {numberToKMB(count)}
-                              </span>
-                            }
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {selectedNode.issues?.anrs?.length! > 0 && (
-                    <div>
-                      <p className="font-body pt-2">ANRs:</p>
-                      <ul className="list-disc list-inside pt-2 pb-4 pl-2 pr-2">
-                        {selectedNode.issues?.anrs?.map(({ id, title, count }) => (
-                          <li key={title}>
-                            {/* Show clickable link if Exceptions journey type */}
-                            {journeyType === JourneyType.Exceptions &&
-                              <span className="font-body text-xs">
-                                {demo ? (
-                                  <div className={underlineLinkStyle}>{title} - {numberToKMB(count)}</div>
-                                ) : (
-                                  <Link href={`/${teamId}/anrs/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`} className={underlineLinkStyle}>
-                                    {title} - {numberToKMB(count)}
-                                  </Link>
-                                )}
-                              </span>
-                            }
-                            {/* Show only title and count if crash or anr journey type */}
-                            {(journeyType === JourneyType.CrashDetails || journeyType === JourneyType.AnrDetails) &&
-                              <span className="font-body text-xs">
-                                {title} - {numberToKMB(count)}
-                              </span>
-                            }
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                </div>
-              }
-            </div>
-          </div>}
-      </div>
-    </div >
+              </div>
+            }
+          />
+          {/* Panel */}
+          <div
+            className={`absolute overflow-auto top-0 right-0 h-full w-3/4 bg-accent p-4 text-accent-foreground break-words transform transition-transform duration-300 ease-in-out ${showPanel ? 'translate-x-0' : 'translate-x-full'
+              }`}
+          >
+            {selectedNode !== undefined &&
+              <div>
+                <Button variant="secondary" className="py-2 px-4"
+                  onClick={() => setSelectedNode(undefined)}>
+                  Close
+                </Button>
+                <p className='mt-6 text-lg'>{selectedNode!.id}</p>
+                {selectedNode.issues?.crashes?.length! > 0 && (
+                  <div>
+                    <p className="font-body mt-4">Crashes:</p>
+                    <ul className="list-disc list-inside pt-2 pb-4 pl-2 pr-2">
+                      {selectedNode.issues?.crashes?.map(({ id, title, count }) => (
+                        <li key={title}>
+                          {/* Show clickable link if Exceptions journey type */}
+                          {journeyType === JourneyType.Exceptions &&
+                            <span className="font-body text-xs">
+                              {demo ? (
+                                <div className={underlineLinkStyle}>{title} - {numberToKMB(count)}</div>
+                              ) : (
+                                <Link href={`/${teamId}/crashes/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`} className={underlineLinkStyle}>
+                                  {title} - {numberToKMB(count)}
+                                </Link>
+                              )}
+                            </span>
+                          }
+                          {/* Show only title and count if crash or anr journey type */}
+                          {(journeyType === JourneyType.CrashDetails || journeyType === JourneyType.AnrDetails) &&
+                            <span className="font-body text-xs">
+                              {title} - {numberToKMB(count)}
+                            </span>
+                          }
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {selectedNode.issues?.anrs?.length! > 0 && (
+                  <div>
+                    <p className="font-body pt-2">ANRs:</p>
+                    <ul className="list-disc list-inside pt-2 pb-4 pl-2 pr-2">
+                      {selectedNode.issues?.anrs?.map(({ id, title, count }) => (
+                        <li key={title}>
+                          {/* Show clickable link if Exceptions journey type */}
+                          {journeyType === JourneyType.Exceptions &&
+                            <span className="font-body text-xs">
+                              {demo ? (
+                                <div className={underlineLinkStyle}>{title} - {numberToKMB(count)}</div>
+                              ) : (
+                                <Link href={`/${teamId}/anrs/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`} className={underlineLinkStyle}>
+                                  {title} - {numberToKMB(count)}
+                                </Link>
+                              )}
+                            </span>
+                          }
+                          {/* Show only title and count if crash or anr journey type */}
+                          {(journeyType === JourneyType.CrashDetails || journeyType === JourneyType.AnrDetails) &&
+                            <span className="font-body text-xs">
+                              {title} - {numberToKMB(count)}
+                            </span>
+                          }
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            }
+          </div>
+        </div>}
+    </div>
   )
 }
 


### PR DESCRIPTION
# Description

Journey panel was opening on any node or link click. This commit ensures that it opens only in exceptions mode and only if node has issues. If a node or label is clicked while it's open, panel will close unless new node also has issues.



