### PR TITLE
fix(frontend): remove overflow-auto from inner main to fix scroll hitch

### DIFF
--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -315,7 +315,7 @@ export default function DashboardLayout({
 
         {selectedTeam && <UsageThresholdBanner teamId={selectedTeam.id} />}
 
-        <main className="md:overflow-auto flex justify-center">
+        <main className="flex justify-center">
           <div className="w-full max-w-[1100px] px-4 pb-24">{children}</div>
         </main>
       </SidebarInset>


### PR DESCRIPTION
# Description

The journeys page had a trackpad scroll hitch requiring two swipes to register a scroll. Root cause: the journey page contains an h-[800px] fixed-height chart container. In flexbox, a definite-height child combined with an overflow-auto ancestor activates that ancestor as a scroll container — where indefinite content (lists, tables on other pages) does not.

As a result, journeys scrolled the inner <main> while every other page scrolled the document. On macOS Chrome, the inner main's overflow-auto absorbed the first wheel event of each gesture before chaining to the actual scroller, producing the hitch.

Removing md:overflow-auto unifies scroll behavior across all pages — the document is the scroll root everywhere, matching the behavior that was already implicit on every other page. The header now scrolls with content on journeys too; we can bring back a fixed header as a dedicated layout change later.

## Related issue
Fixes #3486 



