### PR TITLE
feat(frontend): make dashboard header sticky on scroll

### DIFF
--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -304,16 +304,18 @@ export default function DashboardLayout({
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2 px-4">
-          <SidebarTrigger className="-ml-1" />
-          <Separator
-            orientation="vertical"
-            className="data-[orientation=vertical]:h-4"
-          />
-          <ThemeToggle />
-        </header>
+        <div className="sticky top-0 z-30 bg-background">
+          <header className="flex h-16 shrink-0 items-center gap-2 px-4">
+            <SidebarTrigger className="-ml-1" />
+            <Separator
+              orientation="vertical"
+              className="data-[orientation=vertical]:h-4"
+            />
+            <ThemeToggle />
+          </header>
 
-        {selectedTeam && <UsageThresholdBanner teamId={selectedTeam.id} />}
+          {selectedTeam && <UsageThresholdBanner teamId={selectedTeam.id} />}
+        </div>
 
         <main className="flex justify-center">
           <div className="w-full max-w-[1100px] px-4 pb-24">{children}</div>


### PR DESCRIPTION
# Description

Wrap the top header (sidebar trigger + theme toggle) and usage threshold banner in a sticky container so they remain visible while scrolling long pages. Uses position: sticky (not fixed) so the header stays in normal flow and respects the sidebar layout. bg-background on the sticky wrapper prevents content from showing through the banner's mb-8 gap.



