### PR TITLE
fix(frontend): block framing to prevent clickjacking

### DIFF
--- a/frontend/dashboard/next.config.js
+++ b/frontend/dashboard/next.config.js
@@ -31,8 +31,22 @@ const nextConfig = {
     ],
   },
   async headers() {
-    // allow loading assets for PostHog session replays
     return [
+      // deny framing on every route to prevent clickjacking
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'none'",
+          },
+        ],
+      },
+      // allow loading assets for PostHog session replays
       {
         source: "/_next/static/:path*",
         headers: [


### PR DESCRIPTION
# Description

Set X-Frame-Options: DENY and Content-Security-Policy: frame-ancestors 'none' on all dashboard routes via next.config.js, so the site cannot be embedded in an iframe by a third party.

Reported externally against /auth/login; the dashboard has no legitimate iframe embeds, so a strict deny is safe.



