### PR TITLE
chore(frontend): show "Usage & Billing" label on cloud

### DIFF
--- a/frontend/dashboard/__tests__/components/app_breadcrumbs_test.tsx
+++ b/frontend/dashboard/__tests__/components/app_breadcrumbs_test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 
 let mockPathname = '/'
 let mockSearchParams = new URLSearchParams()
+let mockIsCloud = false
 
 jest.mock('next/navigation', () => ({
     __esModule: true,
@@ -16,11 +17,17 @@ jest.mock('next/link', () => ({
     default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
 }))
 
+jest.mock('@/app/utils/env_utils', () => ({
+    __esModule: true,
+    isCloud: () => mockIsCloud,
+}))
+
 import AppBreadcrumbs from '@/app/components/app_breadcrumbs'
 
 afterEach(() => {
     mockPathname = '/'
     mockSearchParams = new URLSearchParams()
+    mockIsCloud = false
 })
 
 describe('AppBreadcrumbs', () => {
@@ -67,6 +74,24 @@ describe('AppBreadcrumbs', () => {
             mockPathname = '/team-123/mystery_section'
             render(<AppBreadcrumbs />)
             expect(screen.getByText('mystery_section')).toBeInTheDocument()
+        })
+
+        it('renders "usage" slug as "Usage & Billing" in cloud mode', () => {
+            mockIsCloud = true
+            mockPathname = '/team-123/usage'
+            render(<AppBreadcrumbs />)
+            const el = screen.getByText('Usage & Billing')
+            expect(el).toBeInTheDocument()
+            expect(el).toHaveAttribute('aria-current', 'page')
+            expect(screen.queryByText('Usage')).toBeNull()
+        })
+
+        it('renders "usage" slug as "Usage" (not "Usage & Billing") in self-hosted mode', () => {
+            mockIsCloud = false
+            mockPathname = '/team-123/usage'
+            render(<AppBreadcrumbs />)
+            expect(screen.getByText('Usage')).toBeInTheDocument()
+            expect(screen.queryByText('Usage & Billing')).toBeNull()
         })
     })
 

--- a/frontend/dashboard/__tests__/integration/layout_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/layout_msw_test.tsx
@@ -73,6 +73,12 @@ jest.mock('next/image', () => ({
     default: (props: any) => <img {...props} />,
 }))
 
+let mockIsCloud = false
+jest.mock('@/app/utils/env_utils', () => ({
+    __esModule: true,
+    isCloud: () => mockIsCloud,
+}))
+
 // --- MSW ---
 import { makeTeamsFixture } from '../msw/fixtures'
 import { server } from '../msw/server'
@@ -86,6 +92,7 @@ afterEach(() => {
     mockRouterReplace.mockClear()
     mockRouterPush.mockClear()
     mockUsePathname.mockReturnValue('/team-001/overview')
+    mockIsCloud = false
 })
 afterAll(() => server.close())
 
@@ -206,8 +213,21 @@ describe('Dashboard Layout — navigation', () => {
             expect(screen.getByText('Notifications')).toBeTruthy()
             // "Usage" in self-hosted mode (not "Usage & Billing")
             expect(screen.getByText('Usage')).toBeTruthy()
+            expect(screen.queryByText('Usage & Billing')).toBeNull()
             expect(screen.getByText('Support')).toBeTruthy()
         })
+    })
+
+    it('renders Settings nav "Usage" item as "Usage & Billing" in cloud mode', async () => {
+        mockIsCloud = true
+        renderLayout()
+        await waitFor(() => {
+            expect(screen.getByText('Usage & Billing')).toBeTruthy()
+            expect(screen.queryByText('Usage')).toBeNull()
+        })
+        // Link still points to /usage — URL does not change based on env
+        const usageLink = screen.getByText('Usage & Billing').closest('a')
+        expect(usageLink?.getAttribute('href')).toBe('/team-001/usage')
     })
 
     it('nav links point to correct team-scoped URLs', async () => {

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -29,113 +29,115 @@ import UserAvatar from "../components/user_avatar"
 import { useMeasureStoreRegistry } from "../stores/provider"
 import { isCloud } from "../utils/env_utils"
 
-const initNavData = {
-  navMain: [
-    {
-      title: "Dashboard",
-      items: [
-        {
-          title: "Overview",
-          url: "overview",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Session Timelines",
-          url: "session_timelines",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Journeys",
-          url: "journeys",
-          isActive: false,
-          external: false,
-        },
-      ],
-    },
-    {
-      title: "Issues",
-      items: [
-        {
-          title: "Crashes",
-          url: "crashes",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "ANRs",
-          url: "anrs",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Bug Reports",
-          url: "bug_reports",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Alerts",
-          url: "alerts",
-          isActive: false,
-          external: false,
-        },
-      ],
-    },
-    {
-      title: "Performance",
-      items: [
-        {
-          title: "Traces",
-          url: "traces",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Network",
-          url: "network",
-          isActive: false,
-          external: false,
-        },
-      ],
-    },
-    {
-      title: "Settings",
-      items: [
-        {
-          title: "Apps",
-          url: "apps",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Team",
-          url: "team",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Notifications",
-          url: "notif_prefs",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: isCloud() ? "Usage & Billing" : "Usage",
-          url: "usage",
-          isActive: false,
-          external: false,
-        },
-        {
-          title: "Support",
-          url: "https://discord.gg/f6zGkBCt42",
-          isActive: false,
-          external: true,
-        },
-      ],
-    },
-  ],
+function buildInitNavData() {
+  return {
+    navMain: [
+      {
+        title: "Dashboard",
+        items: [
+          {
+            title: "Overview",
+            url: "overview",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Session Timelines",
+            url: "session_timelines",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Journeys",
+            url: "journeys",
+            isActive: false,
+            external: false,
+          },
+        ],
+      },
+      {
+        title: "Issues",
+        items: [
+          {
+            title: "Crashes",
+            url: "crashes",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "ANRs",
+            url: "anrs",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Bug Reports",
+            url: "bug_reports",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Alerts",
+            url: "alerts",
+            isActive: false,
+            external: false,
+          },
+        ],
+      },
+      {
+        title: "Performance",
+        items: [
+          {
+            title: "Traces",
+            url: "traces",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Network",
+            url: "network",
+            isActive: false,
+            external: false,
+          },
+        ],
+      },
+      {
+        title: "Settings",
+        items: [
+          {
+            title: "Apps",
+            url: "apps",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Team",
+            url: "team",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Notifications",
+            url: "notif_prefs",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: isCloud() ? "Usage & Billing" : "Usage",
+            url: "usage",
+            isActive: false,
+            external: false,
+          },
+          {
+            title: "Support",
+            url: "https://discord.gg/f6zGkBCt42",
+            isActive: false,
+            external: true,
+          },
+        ],
+      },
+    ],
+  }
 }
 
 export default function DashboardLayout({
@@ -145,7 +147,7 @@ export default function DashboardLayout({
 }) {
   const registry = useMeasureStoreRegistry()
   const { data: teams, status: teamsStatus } = useTeamsQuery()
-  const [navData, setNavData] = useState(initNavData)
+  const [navData, setNavData] = useState(buildInitNavData)
 
   const pathName = usePathname()
   const router = useRouter()
@@ -225,7 +227,7 @@ export default function DashboardLayout({
           <SidebarGroup>
             <SidebarMenu className="gap-2">
               {teamsStatus === 'pending' &&
-                initNavData.navMain.map((section) => (
+                navData.navMain.map((section) => (
                   <SidebarMenuItem key={section.title}>
                     <Skeleton className="h-7 w-24 mb-2" />
                     <SidebarMenuSub className="ml-0 border-l-0 px-1.5 gap-3">

--- a/frontend/dashboard/app/components/app_breadcrumbs.tsx
+++ b/frontend/dashboard/app/components/app_breadcrumbs.tsx
@@ -8,6 +8,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/app/components/breadcrumb"
+import { isCloud } from "@/app/utils/env_utils"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 
@@ -27,6 +28,13 @@ const sectionTitles: Record<string, string> = {
   usage: "Usage",
 }
 
+function resolveSectionTitle(slug: string): string {
+  if (slug === "usage" && isCloud()) {
+    return "Usage & Billing"
+  }
+  return sectionTitles[slug] ?? slug
+}
+
 const subrouteTitles: Record<string, string> = {
   details: "Details",
 }
@@ -43,7 +51,7 @@ export default function AppBreadcrumbs() {
     return null
   }
 
-  const sectionTitle = sectionTitles[sectionSlug] ?? sectionSlug
+  const sectionTitle = resolveSectionTitle(sectionSlug)
   const sectionHref = `/${teamId}/${sectionSlug}`
   const isSectionPage = rest.length === 0
 


### PR DESCRIPTION
# Description

Sidebar already used isCloud() for the Usage nav label; the breadcrumb on the /usage page still showed "Usage" in both environments. Extend the conditional to the breadcrumb so the page title matches the sidebar.

Moved isCloud() evaluation to render time (breadcrumb helper + lazy useState initializer in layout) so tests can toggle the env flag per case. Added cloud + self-hosted assertions to the breadcrumb unit test and the layout integration test. URL remains /[teamId]/usage in both modes.



