### PR TITLE
fix(backend): some jvm stacktraces were not fully symbolicated

### DIFF
--- a/backend/ingest-worker/symbolicator/payload.go
+++ b/backend/ingest-worker/symbolicator/payload.go
@@ -112,7 +112,8 @@ type frameJVM struct {
 // stacktraceJVM represents a stacktrace
 // for JVM symbolication.
 type stacktraceJVM struct {
-	Frames []frameJVM `json:"frames"`
+	Exception *exceptionJVM `json:"exception,omitempty"`
+	Frames    []frameJVM    `json:"frames"`
 }
 
 // moduleJVM represents a module

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -344,12 +344,12 @@ func (js *jvmSymbolicator) symbolicate(events []event.EventField, spans []span.S
 		}
 
 		if logResponse {
-			// bytes, err := json.MarshalIndent(js.response, "", "  ")
 			bytes, err := json.Marshal(js.response)
 			if err != nil {
 				return err
 			}
-			fmt.Println("response:", string(bytes))
+			fmt.Println("response")
+			fmt.Println(string(bytes))
 		}
 
 		js.rewriteException(events, spans, lambdaWorkaround)
@@ -385,15 +385,29 @@ func (js *jvmSymbolicator) configureModule(mappings map[string]symbol.MappingTyp
 	return
 }
 
+// splitClassName splits a fully qualified JVM class name into
+// its package (module) and simple class name components.
+// e.g. "java.lang.RuntimeException" → ("java.lang", "RuntimeException")
+func splitClassName(fqn string) (module, typeName string) {
+	idx := strings.LastIndex(fqn, ".")
+	if idx < 0 {
+		return "", fqn
+	}
+	return fqn[:idx], fqn[idx+1:]
+}
+
 // parseExceptions parses the exceptions
 // and threads from the event request
 // and prepares the JVM symbolicator
 // request.
 func (s *jvmSymbolicator) parseExceptions(exceptions event.ExceptionUnits, threads event.Threads, index int) {
 	for j, excep := range exceptions {
-		s.request.Exceptions = append(s.request.Exceptions, exceptionJVM{
-			Type: excep.Type,
-		})
+		module, typeName := splitClassName(excep.Type)
+		exc := exceptionJVM{
+			Type:   typeName,
+			Module: module,
+		}
+		s.request.Exceptions = append(s.request.Exceptions, exc)
 
 		// symbolicate each exception unit's type
 		// by matching classes
@@ -417,7 +431,8 @@ func (s *jvmSymbolicator) parseExceptions(exceptions event.ExceptionUnits, threa
 			s.stacktraceLUT = append(s.stacktraceLUT, stacktraceEntry{index, j, k, -1, -1, len(s.request.Stacktraces)})
 		}
 		s.request.Stacktraces = append(s.request.Stacktraces, stacktraceJVM{
-			Frames: frameJVMs,
+			Exception: &exc,
+			Frames:    frameJVMs,
 		})
 	}
 

--- a/backend/ingest-worker/symbolicator/symbolicator_test.go
+++ b/backend/ingest-worker/symbolicator/symbolicator_test.go
@@ -41,9 +41,10 @@ var (
 	minioEndpoint           string
 	s3Client                *s3.Client
 	symbolsBucket           = "test-symbols"
-	basicProguardMappingKey string // unified layout key for the basic proguard mapping
-	basicProguardDebugID    string // UUID-formatted debug ID for the basic proguard mapping
-	realProguardMappingKey  string // unified layout key for the real proguard mapping
+	basicProguardMappingKey  string // unified layout key for the basic proguard mapping
+	basicProguardDebugID     string // UUID-formatted debug ID for the basic proguard mapping
+	realProguardMappingKey   string // unified layout key for the real proguard mapping
+	sqliteProguardMappingKey string // unified layout key for the sqlite proguard mapping
 	elfDebugMappingKey      string // unified layout key for the ELF debug symbols
 	symbolicatorContainer   testcontainers.Container
 	minioContainer          testcontainers.Container
@@ -161,6 +162,26 @@ func TestMain(m *testing.M) {
 	})
 	if err != nil {
 		fmt.Printf("failed to upload real mapping to minio: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Upload sqlite proguard mapping (mapping_sqlite.txt) to MinIO
+	sqliteMappingBytes, err := os.ReadFile(filepath.Join(testdataDir, "mapping_sqlite.txt"))
+	if err != nil {
+		fmt.Printf("failed to read mapping_sqlite.txt: %v\n", err)
+		os.Exit(1)
+	}
+
+	sqliteDebugUUID := uuid.NewSHA1(ns, sqliteMappingBytes)
+	sqliteProguardMappingKey = symbol.BuildUnifiedLayout(sqliteDebugUUID.String()) + "/proguard"
+
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(symbolsBucket),
+		Key:    aws.String(sqliteProguardMappingKey),
+		Body:   bytes.NewReader(sqliteMappingBytes),
+	})
+	if err != nil {
+		fmt.Printf("failed to upload sqlite mapping to minio: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -1096,4 +1117,26 @@ func TestJVMNestedExceptionReal(t *testing.T) {
 
 	stacktrace := events[0].Exception.Stacktrace()
 	assertStacktraceMatchesGolden(t, "jvm_nested_exception_stacktrace_golden.txt", stacktrace)
+}
+
+func TestJVMSQLiteExceptionReal(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	versionName := "2.0.0"
+	versionCode := "200"
+
+	seedApp(ctx, t, appID)
+	seedBuildMapping(ctx, t, appID, versionName, versionCode, "proguard", sqliteProguardMappingKey)
+
+	events := makeJVMRealEvents(t, "jvm_sqlite_input.json", versionName, versionCode)
+	sources := []Source{newS3Source()}
+
+	symb := New(symbolicatorOrigin, "android", sources, []SentrySource{newSentrySource()})
+	err := symb.Symbolicate(ctx, pgPool, appID, events, nil)
+	if err != nil {
+		t.Fatalf("Symbolicate failed: %v", err)
+	}
+
+	results := extractResult(events)
+	assertMatchesGolden(t, "jvm_sqlite_exception_golden.json", results)
 }

--- a/backend/ingest-worker/symbolicator/testdata/jvm_sqlite_exception_golden.json
+++ b/backend/ingest-worker/symbolicator/testdata/jvm_sqlite_exception_golden.json
@@ -1,0 +1,424 @@
+[
+  {
+    "type": "exception",
+    "exception_types": [
+      "java.lang.IllegalStateException",
+      "android.database.sqlite.SQLiteCantOpenDatabaseException",
+      "android.database.sqlite.SQLiteCantOpenDatabaseException"
+    ],
+    "exception_frames": [
+      [
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "run",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 120
+        },
+        {
+          "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+          "method_name": "run",
+          "file_name": "SerialExecutorImpl.java",
+          "line_num": 96
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor",
+          "method_name": "runWorker",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 1154
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+          "method_name": "run",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 652
+        },
+        {
+          "class_name": "java.lang.Thread",
+          "method_name": "run",
+          "file_name": "Thread.java",
+          "line_num": 1564
+        }
+      ],
+      [
+        {
+          "class_name": "android.database.sqlite.SQLiteConnection",
+          "method_name": "open",
+          "file_name": "SQLiteConnection.java",
+          "line_num": 276
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnection",
+          "method_name": "open",
+          "file_name": "SQLiteConnection.java",
+          "line_num": 219
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "openConnectionLocked",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 528
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "open",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 215
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "open",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 207
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openInner",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 1087
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "open",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 1067
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openDatabase",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 931
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openDatabase",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 920
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteOpenHelper",
+          "method_name": "getDatabaseLocked",
+          "file_name": "SQLiteOpenHelper.java",
+          "line_num": 373
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteOpenHelper",
+          "method_name": "getWritableDatabase",
+          "file_name": "SQLiteOpenHelper.java",
+          "line_num": 316
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.f",
+          "method_name": "j",
+          "file_name": "SourceFile",
+          "line_num": 140
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.f",
+          "method_name": "c",
+          "file_name": "SourceFile",
+          "line_num": 24
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.g",
+          "method_name": "d0",
+          "file_name": "SourceFile",
+          "line_num": 10
+        },
+        {
+          "class_name": "androidx.room.RoomDatabase",
+          "method_name": "inTransaction",
+          "file_name": "RoomDatabase.kt",
+          "line_num": 632
+        },
+        {
+          "class_name": "androidx.room.RoomDatabase",
+          "method_name": "assertNotSuspendingTransaction",
+          "file_name": "RoomDatabase.kt",
+          "line_num": 451
+        },
+        {
+          "class_name": "androidx.work.impl.model.SystemIdInfoDao_Impl",
+          "method_name": "getWorkSpecIds",
+          "file_name": "SystemIdInfoDao_Impl.java",
+          "line_num": 156
+        },
+        {
+          "class_name": "androidx.work.impl.background.systemjob.SystemJobScheduler",
+          "method_name": "reconcileJobs",
+          "file_name": "SystemJobScheduler.java",
+          "line_num": 313
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "cleanUp",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 291
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "forceStopRunnable",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 254
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "run",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 180
+        },
+        {
+          "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+          "method_name": "run",
+          "file_name": "SerialExecutorImpl.java",
+          "line_num": 96
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor",
+          "method_name": "runWorker",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 1154
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+          "method_name": "run",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 652
+        },
+        {
+          "class_name": "java.lang.Thread",
+          "method_name": "run",
+          "file_name": "Thread.java",
+          "line_num": 1564
+        }
+      ],
+      [
+        {
+          "class_name": "android.database.sqlite.SQLiteConnection",
+          "method_name": "nativeOpen",
+          "file_name": "SQLiteConnection.java",
+          "line_num": 0
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnection",
+          "method_name": "open",
+          "file_name": "SQLiteConnection.java",
+          "line_num": 238
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnection",
+          "method_name": "open",
+          "file_name": "SQLiteConnection.java",
+          "line_num": 219
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "openConnectionLocked",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 528
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "open",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 215
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteConnectionPool",
+          "method_name": "open",
+          "file_name": "SQLiteConnectionPool.java",
+          "line_num": 207
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openInner",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 1087
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "open",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 1067
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openDatabase",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 931
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteDatabase",
+          "method_name": "openDatabase",
+          "file_name": "SQLiteDatabase.java",
+          "line_num": 920
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteOpenHelper",
+          "method_name": "getDatabaseLocked",
+          "file_name": "SQLiteOpenHelper.java",
+          "line_num": 373
+        },
+        {
+          "class_name": "android.database.sqlite.SQLiteOpenHelper",
+          "method_name": "getWritableDatabase",
+          "file_name": "SQLiteOpenHelper.java",
+          "line_num": 316
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.f",
+          "method_name": "j",
+          "file_name": "SourceFile",
+          "line_num": 140
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.f",
+          "method_name": "c",
+          "file_name": "SourceFile",
+          "line_num": 24
+        },
+        {
+          "class_name": "androidx.sqlite.db.framework.g",
+          "method_name": "d0",
+          "file_name": "SourceFile",
+          "line_num": 10
+        },
+        {
+          "class_name": "androidx.room.RoomDatabase",
+          "method_name": "inTransaction",
+          "file_name": "RoomDatabase.kt",
+          "line_num": 632
+        },
+        {
+          "class_name": "androidx.room.RoomDatabase",
+          "method_name": "assertNotSuspendingTransaction",
+          "file_name": "RoomDatabase.kt",
+          "line_num": 451
+        },
+        {
+          "class_name": "androidx.work.impl.model.SystemIdInfoDao_Impl",
+          "method_name": "getWorkSpecIds",
+          "file_name": "SystemIdInfoDao_Impl.java",
+          "line_num": 156
+        },
+        {
+          "class_name": "androidx.work.impl.background.systemjob.SystemJobScheduler",
+          "method_name": "reconcileJobs",
+          "file_name": "SystemJobScheduler.java",
+          "line_num": 313
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "cleanUp",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 291
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "forceStopRunnable",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 254
+        },
+        {
+          "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+          "method_name": "run",
+          "file_name": "ForceStopRunnable.java",
+          "line_num": 180
+        },
+        {
+          "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+          "method_name": "run",
+          "file_name": "SerialExecutorImpl.java",
+          "line_num": 96
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor",
+          "method_name": "runWorker",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 1154
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+          "method_name": "run",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 652
+        },
+        {
+          "class_name": "java.lang.Thread",
+          "method_name": "run",
+          "file_name": "Thread.java",
+          "line_num": 1564
+        }
+      ]
+    ],
+    "thread_frames": [
+      [
+        {
+          "class_name": "jdk.internal.misc.Unsafe",
+          "method_name": "park",
+          "file_name": "Unsafe.java",
+          "line_num": 0
+        },
+        {
+          "class_name": "java.util.concurrent.locks.LockSupport",
+          "method_name": "park",
+          "file_name": "LockSupport.java",
+          "line_num": 371
+        },
+        {
+          "class_name": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode",
+          "method_name": "block",
+          "file_name": "AbstractQueuedSynchronizer.java",
+          "line_num": 519
+        },
+        {
+          "class_name": "java.util.concurrent.ForkJoinPool",
+          "method_name": "unmanagedBlock",
+          "file_name": "ForkJoinPool.java",
+          "line_num": 3797
+        },
+        {
+          "class_name": "java.util.concurrent.ForkJoinPool",
+          "method_name": "managedBlock",
+          "file_name": "ForkJoinPool.java",
+          "line_num": 3738
+        },
+        {
+          "class_name": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+          "method_name": "await",
+          "file_name": "AbstractQueuedSynchronizer.java",
+          "line_num": 1712
+        },
+        {
+          "class_name": "java.util.concurrent.LinkedBlockingQueue",
+          "method_name": "take",
+          "file_name": "LinkedBlockingQueue.java",
+          "line_num": 435
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor",
+          "method_name": "getTask",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 1080
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor",
+          "method_name": "runWorker",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 1140
+        },
+        {
+          "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+          "method_name": "run",
+          "file_name": "ThreadPoolExecutor.java",
+          "line_num": 652
+        },
+        {
+          "class_name": "java.lang.Thread",
+          "method_name": "run",
+          "file_name": "Thread.java",
+          "line_num": 1564
+        }
+      ]
+    ]
+  }
+]

--- a/backend/ingest-worker/symbolicator/testdata/jvm_sqlite_input.json
+++ b/backend/ingest-worker/symbolicator/testdata/jvm_sqlite_input.json
@@ -1,0 +1,431 @@
+{
+    "exception": {
+        "exceptions": [
+            {
+                "type": "java.lang.IllegalStateException",
+                "frames": [
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "run",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 165
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+                        "method_name": "run",
+                        "file_name": "SerialExecutorImpl.java",
+                        "line_num": 96
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor",
+                        "method_name": "runWorker",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 1154
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+                        "method_name": "run",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 652
+                    },
+                    {
+                        "class_name": "java.lang.Thread",
+                        "method_name": "run",
+                        "file_name": "Thread.java",
+                        "line_num": 1564
+                    }
+                ]
+            },
+            {
+                "type": "android.database.sqlite.SQLiteCantOpenDatabaseException",
+                "frames": [
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnection",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnection.java",
+                        "line_num": 276
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnection",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnection.java",
+                        "line_num": 219
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "openConnectionLocked",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 528
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 215
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 207
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openInner",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 1087
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "open",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 1067
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openDatabase",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 931
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openDatabase",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 920
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteOpenHelper",
+                        "method_name": "getDatabaseLocked",
+                        "file_name": "SQLiteOpenHelper.java",
+                        "line_num": 373
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteOpenHelper",
+                        "method_name": "getWritableDatabase",
+                        "file_name": "SQLiteOpenHelper.java",
+                        "line_num": 316
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.f",
+                        "method_name": "j",
+                        "file_name": "SourceFile",
+                        "line_num": 140
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.f",
+                        "method_name": "c",
+                        "file_name": "SourceFile",
+                        "line_num": 24
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.g",
+                        "method_name": "d0",
+                        "file_name": "SourceFile",
+                        "line_num": 10
+                    },
+                    {
+                        "class_name": "androidx.room.RoomDatabase",
+                        "method_name": "inTransaction",
+                        "file_name": "RoomDatabase.kt",
+                        "line_num": 632
+                    },
+                    {
+                        "class_name": "androidx.room.RoomDatabase",
+                        "method_name": "assertNotSuspendingTransaction",
+                        "file_name": "RoomDatabase.kt",
+                        "line_num": 451
+                    },
+                    {
+                        "class_name": "androidx.work.impl.model.SystemIdInfoDao_Impl",
+                        "method_name": "getWorkSpecIds",
+                        "file_name": "SystemIdInfoDao_Impl.java",
+                        "line_num": 156
+                    },
+                    {
+                        "class_name": "androidx.work.impl.background.systemjob.SystemJobScheduler",
+                        "method_name": "reconcileJobs",
+                        "file_name": "SystemJobScheduler.java",
+                        "line_num": 313
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "cleanUp",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 291
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "forceStopRunnable",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 254
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "run",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 136
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+                        "method_name": "run",
+                        "file_name": "SerialExecutorImpl.java",
+                        "line_num": 96
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor",
+                        "method_name": "runWorker",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 1154
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+                        "method_name": "run",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 652
+                    },
+                    {
+                        "class_name": "java.lang.Thread",
+                        "method_name": "run",
+                        "file_name": "Thread.java",
+                        "line_num": 1564
+                    }
+                ]
+            },
+            {
+                "type": "android.database.sqlite.SQLiteCantOpenDatabaseException",
+                "frames": [
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnection",
+                        "method_name": "nativeOpen",
+                        "file_name": "SQLiteConnection.java",
+                        "line_num": 0
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnection",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnection.java",
+                        "line_num": 238
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnection",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnection.java",
+                        "line_num": 219
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "openConnectionLocked",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 528
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 215
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteConnectionPool",
+                        "method_name": "open",
+                        "file_name": "SQLiteConnectionPool.java",
+                        "line_num": 207
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openInner",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 1087
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "open",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 1067
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openDatabase",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 931
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteDatabase",
+                        "method_name": "openDatabase",
+                        "file_name": "SQLiteDatabase.java",
+                        "line_num": 920
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteOpenHelper",
+                        "method_name": "getDatabaseLocked",
+                        "file_name": "SQLiteOpenHelper.java",
+                        "line_num": 373
+                    },
+                    {
+                        "class_name": "android.database.sqlite.SQLiteOpenHelper",
+                        "method_name": "getWritableDatabase",
+                        "file_name": "SQLiteOpenHelper.java",
+                        "line_num": 316
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.f",
+                        "method_name": "j",
+                        "file_name": "SourceFile",
+                        "line_num": 140
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.f",
+                        "method_name": "c",
+                        "file_name": "SourceFile",
+                        "line_num": 24
+                    },
+                    {
+                        "class_name": "androidx.sqlite.db.framework.g",
+                        "method_name": "d0",
+                        "file_name": "SourceFile",
+                        "line_num": 10
+                    },
+                    {
+                        "class_name": "androidx.room.RoomDatabase",
+                        "method_name": "inTransaction",
+                        "file_name": "RoomDatabase.kt",
+                        "line_num": 632
+                    },
+                    {
+                        "class_name": "androidx.room.RoomDatabase",
+                        "method_name": "assertNotSuspendingTransaction",
+                        "file_name": "RoomDatabase.kt",
+                        "line_num": 451
+                    },
+                    {
+                        "class_name": "androidx.work.impl.model.SystemIdInfoDao_Impl",
+                        "method_name": "getWorkSpecIds",
+                        "file_name": "SystemIdInfoDao_Impl.java",
+                        "line_num": 156
+                    },
+                    {
+                        "class_name": "androidx.work.impl.background.systemjob.SystemJobScheduler",
+                        "method_name": "reconcileJobs",
+                        "file_name": "SystemJobScheduler.java",
+                        "line_num": 313
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "cleanUp",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 291
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "forceStopRunnable",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 254
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.ForceStopRunnable",
+                        "method_name": "run",
+                        "file_name": "ForceStopRunnable.java",
+                        "line_num": 136
+                    },
+                    {
+                        "class_name": "androidx.work.impl.utils.SerialExecutorImpl$Task",
+                        "method_name": "run",
+                        "file_name": "SerialExecutorImpl.java",
+                        "line_num": 96
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor",
+                        "method_name": "runWorker",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 1154
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+                        "method_name": "run",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 652
+                    },
+                    {
+                        "class_name": "java.lang.Thread",
+                        "method_name": "run",
+                        "file_name": "Thread.java",
+                        "line_num": 1564
+                    }
+                ]
+            }
+        ],
+        "threads": [
+            {
+                "name": "wm_work_pool-thread-1",
+                "frames": [
+                    {
+                        "class_name": "jdk.internal.misc.Unsafe",
+                        "method_name": "park",
+                        "file_name": "Unsafe.java",
+                        "line_num": 0
+                    },
+                    {
+                        "class_name": "java.util.concurrent.locks.LockSupport",
+                        "method_name": "park",
+                        "file_name": "LockSupport.java",
+                        "line_num": 371
+                    },
+                    {
+                        "class_name": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode",
+                        "method_name": "block",
+                        "file_name": "AbstractQueuedSynchronizer.java",
+                        "line_num": 519
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ForkJoinPool",
+                        "method_name": "unmanagedBlock",
+                        "file_name": "ForkJoinPool.java",
+                        "line_num": 3797
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ForkJoinPool",
+                        "method_name": "managedBlock",
+                        "file_name": "ForkJoinPool.java",
+                        "line_num": 3738
+                    },
+                    {
+                        "class_name": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+                        "method_name": "await",
+                        "file_name": "AbstractQueuedSynchronizer.java",
+                        "line_num": 1712
+                    },
+                    {
+                        "class_name": "java.util.concurrent.LinkedBlockingQueue",
+                        "method_name": "take",
+                        "file_name": "LinkedBlockingQueue.java",
+                        "line_num": 435
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor",
+                        "method_name": "getTask",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 1080
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor",
+                        "method_name": "runWorker",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 1140
+                    },
+                    {
+                        "class_name": "java.util.concurrent.ThreadPoolExecutor$Worker",
+                        "method_name": "run",
+                        "file_name": "ThreadPoolExecutor.java",
+                        "line_num": 652
+                    },
+                    {
+                        "class_name": "java.lang.Thread",
+                        "method_name": "run",
+                        "file_name": "Thread.java",
+                        "line_num": 1564
+                    }
+                ]
+            }
+        ],
+        "handled": false
+    }
+}

--- a/backend/ingest-worker/symbolicator/testdata/mapping_sqlite.txt
+++ b/backend/ingest-worker/symbolicator/testdata/mapping_sqlite.txt
@@ -1,0 +1,9 @@
+# compiler: R8
+# compiler_version: 8.9.27
+# min_api: 21
+# common_typos_disable
+# {"id":"com.android.tools.r8.mapping","version":"2.2"}
+androidx.work.impl.utils.ForceStopRunnable -> androidx.work.impl.utils.ForceStopRunnable:
+# {"id":"sourceFile","fileName":"ForceStopRunnable.java"}
+    165:165:void run():120:120 -> run
+    136:136:void run():180:180 -> run


### PR DESCRIPTION
## Summary

This PR addresses an issue where crash exception types were not being symbolicated for some JVM stacktraces.

## Tasks

- [x] Populate the module field by splitting the FQN in the JVM symbolication request
- [x] Always send `stacktraces[].exception` to ensure R8 `@RewriteFrames` are enabled
- [x] Update symbolication tests
- [x] Improve symbolication debug logging

## See also

- fixes #3506
