### PR TITLE
chore(backend): switch to bearer token auth for reading gcs symbols

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -1345,10 +1345,6 @@ func (e EventField) HasAttachments() bool {
 // GetFramework returns the exception framework
 // in a backwards compatible way.
 func (e Exception) GetFramework() (f string) {
-	fmt.Println("len", len(e.Exceptions))
-	jsonBytes, _ := json.Marshal(e.Exceptions)
-	fmt.Println("ios exceptions")
-	fmt.Println(string(jsonBytes))
 	// if we have the framework, just use it
 	// no need to infer
 	// could be "dart"

--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -1345,6 +1345,10 @@ func (e EventField) HasAttachments() bool {
 // GetFramework returns the exception framework
 // in a backwards compatible way.
 func (e Exception) GetFramework() (f string) {
+	fmt.Println("len", len(e.Exceptions))
+	jsonBytes, _ := json.Marshal(e.Exceptions)
+	fmt.Println("ios exceptions")
+	fmt.Println(string(jsonBytes))
 	// if we have the framework, just use it
 	// no need to infer
 	// could be "dart"
@@ -1354,10 +1358,6 @@ func (e Exception) GetFramework() (f string) {
 
 	// Apple exception or error or error with exception
 	if e.HasExceptions() {
-		fmt.Println("len", len(e.Exceptions))
-		jsonBytes, _ := json.Marshal(e.Exceptions)
-		fmt.Println("ios exceptions")
-		fmt.Println(string(jsonBytes))
 		if e.Exceptions[0].ExceptionUnitiOS != nil && e.Exceptions[0].Signal != "" {
 			return FrameworkApple
 		}

--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -1354,6 +1354,10 @@ func (e Exception) GetFramework() (f string) {
 
 	// Apple exception or error or error with exception
 	if e.HasExceptions() {
+		fmt.Println("len", len(e.Exceptions))
+		jsonBytes, _ := json.Marshal(e.Exceptions)
+		fmt.Println("ios exceptions")
+		fmt.Println(string(jsonBytes))
 		if e.Exceptions[0].ExceptionUnitiOS != nil && e.Exceptions[0].Signal != "" {
 			return FrameworkApple
 		}

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -17,10 +17,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
+	"sync"
 	"time"
 
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/auth/credentials"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -1028,6 +1030,28 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 	return server.Server.ChPool.Exec(asyncCtx, stmt.String(), stmt.Args()...)
 }
 
+var gcsCreds struct {
+	sync.Once
+	creds *auth.Credentials
+}
+
+func getGCSCreds() (*auth.Credentials, error) {
+	gcsCreds.Do(func() {
+		creds, err := credentials.DetectDefault(&credentials.DetectOptions{
+			Scopes: []string{"https://www.googleapis.com/auth/devstorage.read_only"},
+		})
+		if err != nil {
+			fmt.Printf("failed to detect GCS credentials: %v\n", err)
+			return
+		}
+		gcsCreds.creds = creds
+	})
+	if gcsCreds.creds == nil {
+		return nil, fmt.Errorf("GCS credentials unavailable")
+	}
+	return gcsCreds.creds, nil
+}
+
 // PushHandler handles incoming Pub/Sub push messages containing
 // ingest batches published by the ingest service.
 func PushHandler(c *gin.Context) {
@@ -1199,9 +1223,14 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 			switch opsys.ToFamily(osName) {
 			case opsys.Android:
 				if config.IsCloud() {
-					privateKey := os.Getenv("SYMBOLS_READER_SA_KEY")
-					clientEmail := os.Getenv("SYMBOLS_READER_SA_EMAIL")
-					sources = append(sources, symbolicator.NewGCSSourceAndroid("msr-symbols", config.SymbolsBucket, privateKey, clientEmail))
+					creds, err := getGCSCreds()
+					if err != nil {
+						fmt.Printf("failed to obtain credentials for GCS Android source: %v\n", err)
+					} else if tok, err := creds.Token(ingestCtx); err != nil {
+						fmt.Printf("failed to generate token for GCS Android source: %v\n", err)
+					} else {
+						sources = append(sources, symbolicator.NewGCSSourceAndroid("msr-symbols", config.SymbolsBucket, tok.Value))
+					}
 				} else {
 					sources = append(sources, symbolicator.NewS3SourceAndroid("msr-symbols", config.SymbolsBucket, config.SymbolsBucketRegion, config.AWSEndpoint, config.SymbolsAccessKey, config.SymbolsSecretAccessKey))
 				}
@@ -1221,9 +1250,14 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 				}
 			case opsys.AppleFamily:
 				if config.IsCloud() {
-					privateKey := os.Getenv("SYMBOLS_READER_SA_KEY")
-					clientEmail := os.Getenv("SYMBOLS_READER_SA_EMAIL")
-					sources = append(sources, symbolicator.NewGCSSourceApple("msr-symbols", config.SymbolsBucket, privateKey, clientEmail))
+					creds, err := getGCSCreds()
+					if err != nil {
+						fmt.Printf("failed to obtain credentials for GCS Apple source: %v\n", err)
+					} else if tok, err := creds.Token(ingestCtx); err != nil {
+						fmt.Printf("failed to generate token for GCS Apple source: %v\n", err)
+					} else {
+						sources = append(sources, symbolicator.NewGCSSourceApple("msr-symbols", config.SymbolsBucket, tok.Value))
+					}
 				} else {
 					sources = append(sources, symbolicator.NewS3SourceApple("msr-symbols", config.SymbolsBucket, config.SymbolsBucketRegion, config.AWSEndpoint, config.SymbolsAccessKey, config.SymbolsSecretAccessKey))
 				}

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -1037,9 +1037,7 @@ var gcsCreds struct {
 
 func getGCSCreds() (*auth.Credentials, error) {
 	gcsCreds.Do(func() {
-		creds, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes: []string{"https://www.googleapis.com/auth/cloud-platform.read_only"},
-		})
+		creds, err := credentials.DetectDefault(&credentials.DetectOptions{})
 		if err != nil {
 			fmt.Printf("failed to detect GCS credentials: %v\n", err)
 			return

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -1038,7 +1038,7 @@ var gcsCreds struct {
 func getGCSCreds() (*auth.Credentials, error) {
 	gcsCreds.Do(func() {
 		creds, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes: []string{"https://www.googleapis.com/auth/devstorage.read_only"},
+			Scopes: []string{"https://www.googleapis.com/auth/cloud-platform.read_only"},
 		})
 		if err != nil {
 			fmt.Printf("failed to detect GCS credentials: %v\n", err)

--- a/backend/ingest-worker/symbolicator/source.go
+++ b/backend/ingest-worker/symbolicator/source.go
@@ -38,6 +38,9 @@ type Source struct {
 	// ClientEmail is the Google Cloud Storage email
 	// for authentication.
 	ClientEmail string `json:"client_email,omitempty"`
+	// BearerToken is the authorization token that can be
+	// used instead of `private_key` & `client_email`.
+	BearerToken string `json:"bearer_token,omitempty"`
 	// Filters are a set of filters to reduce the
 	// number of unnecessary hits on a symbol server.
 	Filters struct {
@@ -98,13 +101,12 @@ func NewS3SourceAndroid(id, bucket, region, origin, accessKey, secretKey string)
 
 // NewGCSSourceApple creates a GCS source
 // for Apple platform.
-func NewGCSSourceApple(id, bucket, privateKey, clientEmail string) (source Source) {
+func NewGCSSourceApple(id, bucket, bearerToken string) (source Source) {
 	source.ID = id
 	source.Type = "gcs"
 	source.Bucket = bucket
 	source.Prefix = ""
-	source.PrivateKey = privateKey
-	source.ClientEmail = clientEmail
+	source.BearerToken = bearerToken
 	source.Filters.FileTypes = []string{"mach_debug"}
 	source.Filters.PathPatterns = []string{}
 	source.Layout.Type = "unified"
@@ -115,13 +117,12 @@ func NewGCSSourceApple(id, bucket, privateKey, clientEmail string) (source Sourc
 
 // NewGCSSourceAndroid creates a GCS source for
 // Android platform.
-func NewGCSSourceAndroid(id, bucket, privateKey, clientEmail string) (source Source) {
+func NewGCSSourceAndroid(id, bucket, bearerToken string) (source Source) {
 	source.ID = id
 	source.Type = "gcs"
 	source.Bucket = bucket
 	source.Prefix = ""
-	source.PrivateKey = privateKey
-	source.ClientEmail = clientEmail
+	source.BearerToken = bearerToken
 	source.Filters.FileTypes = []string{"proguard", "elf_debug"}
 	source.Filters.PathPatterns = []string{}
 	source.Layout.Type = "unified"

--- a/backend/ingest-worker/symbolicator/source_test.go
+++ b/backend/ingest-worker/symbolicator/source_test.go
@@ -36,12 +36,12 @@ func TestNewS3SourceAndroid(t *testing.T) {
 }
 
 func TestNewGCSSourceApple(t *testing.T) {
-	source := NewGCSSourceApple("my-id", "my-bucket", "my-private-key", "my-client-email")
+	source := NewGCSSourceApple("my-id", "my-bucket", "my-bearer-token")
 
 	{
 		bytes, _ := json.Marshal(source)
 
-		expected := `{"id":"my-id","type":"gcs","bucket":"my-bucket","prefix":"","private_key":"my-private-key","client_email":"my-client-email","filters":{"filetypes":["mach_debug"],"path_patterns":[]},"layout":{"type":"unified","casing":"lowercase"}}`
+		expected := `{"id":"my-id","type":"gcs","bucket":"my-bucket","prefix":"","bearer_token":"my-bearer-token","filters":{"filetypes":["mach_debug"],"path_patterns":[]},"layout":{"type":"unified","casing":"lowercase"}}`
 		got := string(bytes)
 
 		if expected != got {


### PR DESCRIPTION
## Summary

This PR switches the authentication mechanism used for reading GCS symbol sources for symbolication from service account keys to a more safer & efficient bearer tokens based mechanism.

## Tasks

- [x] `SYMBOLS_READER_SA_KEY/EMAIL` environment variables are no longer read by ingest-worker service
- [x] Implement new bearer token based auth mechanism for GCS symbol sources for symbolication
- [x] Update tests