### PR TITLE
fix(ios): ignore http events with empty url

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/NetworkInterceptorProtocol.swift
@@ -100,7 +100,8 @@ extension NetworkInterceptorProtocol: URLSessionDataDelegate {
               let httpInterceptorCallbacks = NetworkInterceptorProtocol.httpInterceptorCallbacks,
               let configProvider = NetworkInterceptorProtocol.configProvider,
               let httpResponse = task.response as? HTTPURLResponse,
-              let urlString = request.url?.absoluteString else { return }
+              let urlString = request.url?.absoluteString,
+              !urlString.isEmpty else { return }
 
         guard configProvider.shouldTrackHttpUrl(url: urlString) else {
             return

--- a/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
@@ -77,6 +77,7 @@ final class URLSessionTaskInterceptor {
                                        startTime: UInt64?,
                                        endTime: UInt64) {
         guard let url = url,
+              !url.isEmpty,
               let httpInterceptorCallbacks = self.httpInterceptorCallbacks,
               let configProvider = self.configProvider,
               let signalSampler = self.signalSampler else { return }


### PR DESCRIPTION
# Description

Ignore http events with empty url

## Related issue
Fixes #3510 