### PR TITLE
Ios swiftui screenshot bug

### DIFF
--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -423,6 +423,13 @@ By default, the following headers are never collected, even if not specified in 
 Change the masking level of screenshots collected with Crashes and ANRs. It helps prevent sensitive
 information from leaking.
 
+> [!NOTE]
+> _Applies to iOS UIKit screens only._ The mask level configuration does not apply to SwiftUI screens.
+> Because of the way SwiftUI renders its views, all SwiftUI content is masked by default regardless of
+> the mask level setting. See [Screenshot Masking for SwiftUI](feature_screenshot_masking_swiftui.md)
+> for details on how to control masking for SwiftUI views using the `.msrMask()` and `.msrUnmask()`
+> modifiers.
+
 The following levels of masking can be applied to the screenshots:
 
 #### Mask all text and media

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -424,7 +424,7 @@ Change the masking level of screenshots collected with Crashes and ANRs. It help
 information from leaking.
 
 > [!NOTE]
-> _Applies to iOS UIKit screens only._ The mask level configuration does not apply to SwiftUI screens.
+> _The mask level configuration does not apply to SwiftUI screens._
 > Because of the way SwiftUI renders its views, all SwiftUI content is masked by default regardless of
 > the mask level setting. See [Screenshot Masking for SwiftUI](feature_screenshot_masking_swiftui.md)
 > for details on how to control masking for SwiftUI views using the `.msrMask()` and `.msrUnmask()`

--- a/docs/features/feature_screenshot_masking_swiftui.md
+++ b/docs/features/feature_screenshot_masking_swiftui.md
@@ -1,0 +1,136 @@
+# Screenshot Masking for SwiftUI
+
+Measure's screenshot masking works by traversing the UIKit view hierarchy to identify and redact
+sensitive views. Because SwiftUI renders its views differently from UIKit, the standard masking
+configuration options behave differently in SwiftUI contexts.
+
+To manage masking in SwiftUI, Measure provides the `.msrMask()` and `.msrUnmask()` view modifiers.
+
+# Table of Contents
+
+* [**How SwiftUI Masking Works**](#how-swiftui-masking-works)
+* [**Manual Masking**](#manual-masking)
+    * [**`.msrMask()`**](#msrmask)
+    * [**`.msrUnmask()`**](#msrunmask)
+* [**Examples**](#examples)
+    * [**Masking a standalone Text view**](#masking-a-standalone-text-view)
+    * [**Unmasking content inside a SwiftUI screen**](#unmasking-content-inside-a-swiftui-screen)
+    * [**Mixed masking in a form**](#mixed-masking-in-a-form)
+
+# How SwiftUI Masking Works
+
+In UIKit, every visible element on screen corresponds to a `UIView` instance in the view hierarchy.
+Measure's masking traverses this hierarchy and redacts views that match known sensitive types such
+as `UILabel`, `UITextField`, and `UITextView`.
+
+SwiftUI does not follow this pattern. Most SwiftUI views do not produce individual `UIView` instances.
+Instead, the entire SwiftUI view tree is hosted inside a `_UIHostingView`, which renders its content
+directly without creating UIKit counterparts for each view.
+
+As a result, **Measure masks the entire `_UIHostingView` frame by default** when a SwiftUI screen
+is present. This is the safest default — it ensures no SwiftUI content leaks into screenshots —
+but it means all SwiftUI content is masked, including content that may not be sensitive.
+
+Use `.msrUnmask()` to selectively expose content that is safe to show, and `.msrMask()` to
+explicitly mask content that needs to be hidden.
+
+# Manual Masking
+
+## `.msrMask()`
+
+Marks a SwiftUI view as sensitive. The view's frame will be redacted in screenshots regardless of
+whether it would be detected automatically.
+
+Use this for:
+
+- Standalone `Text` views containing sensitive data outside of `List` contexts
+- Any custom SwiftUI view containing sensitive content that is not automatically detected
+
+```swift
+Text(userEmail)
+    .msrMask()
+```
+
+## `.msrUnmask()`
+
+Exempts a SwiftUI view from masking. Use this to opt specific views out of the blanket
+`_UIHostingView` masking that is applied by default.
+
+When `.msrUnmask()` is applied to a view, its frame is subtracted from the masked region. This
+means content behind the unmasked view will also become visible in the screenshot.
+
+Use this for:
+
+- Non-sensitive SwiftUI content you want to remain visible in screenshots
+- Structural views like navigation titles, icons, or static labels that contain no user data
+
+```swift
+Text("Welcome back")
+    .msrUnmask()
+```
+
+> [!NOTE]
+> `.msrUnmask()` takes precedence over automatic masking for the specific view it is applied to.
+> It does not affect sibling or parent views.
+
+# Examples
+
+## Masking a standalone Text view
+
+By default, `Text` views outside a `List` are not automatically detected. Use `.msrMask()` to
+ensure they are redacted.
+
+```swift
+var body: some View {
+    VStack {
+        Text("Account balance")       // not sensitive, no modifier needed
+        Text("\(user.balance)")        // sensitive — mask explicitly
+            .msrMask()
+    }
+}
+```
+
+## Unmasking content inside a SwiftUI screen
+
+Because all SwiftUI content is masked by default via `_UIHostingView`, use `.msrUnmask()` to
+expose non-sensitive content.
+
+```swift
+var body: some View {
+    VStack {
+        Text("Hello, \(user.name)")   // sensitive — remains masked by default
+        Image(systemName: "star")     // not sensitive — unmask explicitly
+            .msrUnmask()
+    }
+}
+```
+
+## Mixed masking in a form
+
+In a form with both sensitive and non-sensitive fields, use both modifiers together.
+
+```swift
+var body: some View {
+    Form {
+        Section("Profile") {
+            Text("Username")          // label — unmask
+                .msrUnmask()
+            TextField("Username", text: $username)
+                                      // UITextField — masked automatically
+        }
+        Section("Security") {
+            Text("Password")          // label — unmask
+                .msrUnmask()
+            SecureField("Password", text: $password)
+                                      // UITextField — masked automatically
+            Text(sensitiveHint)       // sensitive Text — mask explicitly
+                .msrMask()
+        }
+    }
+}
+```
+
+> [!WARNING]
+> Do not use `.msrUnmask()` on views that contain or overlap sensitive content. The unmasked
+> frame is subtracted from the masked region, which means any sensitive content behind it will
+> also become visible in the screenshot.

--- a/ios/DemoApp/DemoApp/Controller/SwiftUIDetailViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/SwiftUIDetailViewController.swift
@@ -36,7 +36,6 @@ struct SwiftUIDetailViewController: View {
             NavigationView {
                 VStack(spacing: 0) {
 
-                    // MARK: - UILabel (bridges as UILabel in hierarchy)
                     VStack(alignment: .leading, spacing: 8) {
                         Text("UILabel equivalent (Text)")
                             .font(.headline)
@@ -51,7 +50,6 @@ struct SwiftUIDetailViewController: View {
 
                     Divider()
 
-                    // MARK: - UITextField (bridges as UITextField in hierarchy)
                     VStack(alignment: .leading, spacing: 8) {
                         Text("UITextField equivalent (TextField)")
                             .font(.headline)
@@ -67,7 +65,6 @@ struct SwiftUIDetailViewController: View {
 
                     Divider()
 
-                    // MARK: - UITextView (bridges as UITextView in hierarchy)
                     VStack(alignment: .leading, spacing: 8) {
                         Text("UITextView equivalent (TextEditor)")
                             .font(.headline)

--- a/ios/DemoApp/DemoApp/Controller/SwiftUIDetailViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/SwiftUIDetailViewController.swift
@@ -10,6 +10,9 @@ import SwiftUI
 import UIKit
 
 struct SwiftUIDetailViewController: View {
+    @State private var textFieldValue: String = "Sensitive text field input"
+    @State private var textEditorValue: String = "Sensitive text editor content.\nThis spans multiple lines."
+
     let crashTypes = [
         "Trigger Http Event",
         "Abort",
@@ -31,13 +34,63 @@ struct SwiftUIDetailViewController: View {
     var body: some View {
         MsrMoniterView("DetailListView") {
             NavigationView {
-                VStack {
+                VStack(spacing: 0) {
+
+                    // MARK: - UILabel (bridges as UILabel in hierarchy)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("UILabel equivalent (Text)")
+                            .font(.headline)
+                            .padding(.horizontal)
+                        Text("Sensitive label content")
+                            .padding(.horizontal)
+                    }
+                    .msrMask()
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemBackground))
+
+                    Divider()
+
+                    // MARK: - UITextField (bridges as UITextField in hierarchy)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("UITextField equivalent (TextField)")
+                            .font(.headline)
+                            .padding(.horizontal)
+                        TextField("Enter sensitive data", text: $textFieldValue)
+                            .textFieldStyle(.roundedBorder)
+                            .padding(.horizontal)
+                    }
+                    .msrMask()
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemBackground))
+
+                    Divider()
+
+                    // MARK: - UITextView (bridges as UITextView in hierarchy)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("UITextView equivalent (TextEditor)")
+                            .font(.headline)
+                            .padding(.horizontal)
+                        TextEditor(text: $textEditorValue)
+                            .frame(height: 80)
+                            .padding(.horizontal)
+                    }
+                    .msrMask()
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemBackground))
+
+                    Divider()
+
+                    // MARK: - All three inside a List (the hard case)
+
                     List(crashTypes, id: \.self) { crashType in
                         Text(crashType)
                             .onTapGesture {
                                 triggerCrash(type: crashType)
                             }
-                    }
+                    }.msrUnmask()
                     .navigationBarTitle("SwiftUI View Controller", displayMode: .inline)
                 }
             }

--- a/ios/DemoAppSwiftUI/DemoAppSwiftUI/ContentView.swift
+++ b/ios/DemoAppSwiftUI/DemoAppSwiftUI/ContentView.swift
@@ -41,6 +41,9 @@ struct ContentView: View {
                         ContentView()
                     }
 
+                    Button("bug report") {
+                        Measure.launchBugReport(takeScreenshot: true)
+                    }
                     // Button 3: Modal Navigation using .sheet
                     Button("Present Modal with .sheet") {
                         isSheetPresented = true

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -177,6 +177,8 @@
 		69C4496B2DACC7C700E44CF4 /* InternalSignalCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C4496A2DACC7BE00E44CF4 /* InternalSignalCollectorTests.swift */; };
 		69E4B4D32DA7581A00361E25 /* MeasureInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E4B4D22DA7581A00361E25 /* MeasureInitializer.swift */; };
 		69F6D44B2DFAA2DA000367EA /* ClientInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F6D44A2DFAA2D4000367EA /* ClientInfoTests.swift */; };
+		CF03BF232F9CC218001F5CE3 /* MsrRedactViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF03BF222F9CC218001F5CE3 /* MsrRedactViewHelper.swift */; };
+		CF03BF252F9CC22B001F5CE3 /* MsrMaskModifier.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = CF03BF242F9CC22B001F5CE3 /* MsrMaskModifier.swift .swift */; };
 		CF041C432ED437F6004B4D28 /* SignalSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF041C422ED437F6004B4D28 /* SignalSampler.swift */; };
 		CF041C452ED46E7F004B4D28 /* MockSignalSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF041C442ED46E7F004B4D28 /* MockSignalSampler.swift */; };
 		CF0F95782F5834450018D95D /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = CF0F95772F5834450018D95D /* Recording */; };
@@ -537,6 +539,8 @@
 		69C4496A2DACC7BE00E44CF4 /* InternalSignalCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalSignalCollectorTests.swift; sourceTree = "<group>"; };
 		69E4B4D22DA7581A00361E25 /* MeasureInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureInitializer.swift; sourceTree = "<group>"; };
 		69F6D44A2DFAA2D4000367EA /* ClientInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInfoTests.swift; sourceTree = "<group>"; };
+		CF03BF222F9CC218001F5CE3 /* MsrRedactViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrRedactViewHelper.swift; sourceTree = "<group>"; };
+		CF03BF242F9CC22B001F5CE3 /* MsrMaskModifier.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MsrMaskModifier.swift .swift"; sourceTree = "<group>"; };
 		CF041C422ED437F6004B4D28 /* SignalSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalSampler.swift; sourceTree = "<group>"; };
 		CF041C442ED46E7F004B4D28 /* MockSignalSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignalSampler.swift; sourceTree = "<group>"; };
 		CF11CCD72F1B996B00EF68E9 /* MockSignalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignalStore.swift; sourceTree = "<group>"; };
@@ -950,6 +954,8 @@
 			isa = PBXGroup;
 			children = (
 				CFD9D88B2F97513600EE8E21 /* WebPEncoder.swift */,
+				CF03BF242F9CC22B001F5CE3 /* MsrMaskModifier.swift .swift */,
+				CF03BF222F9CC218001F5CE3 /* MsrRedactViewHelper.swift */,
 				526D17FB2D5A1913009A2E90 /* ScreenshotGenerator.swift */,
 			);
 			path = Screenshots;
@@ -1678,6 +1684,7 @@
 				CF041C432ED437F6004B4D28 /* SignalSampler.swift in Sources */,
 				69C449692DA9266400E44CF4 /* InternalSignalCollector.swift in Sources */,
 				CFBF626F2DB7ADA200D5ADFB /* SwizzlingUtility.swift in Sources */,
+				CF03BF252F9CC22B001F5CE3 /* MsrMaskModifier.swift .swift in Sources */,
 				526D18222D5A1913009A2E90 /* MSRViewController.m in Sources */,
 				CF893DD22E950A7E00D99D45 /* MeasureModelV1ToV2.xcmappingmodel in Sources */,
 				CF1BB3BF2DC0BCA300588506 /* CGFloat+Extension.swift in Sources */,
@@ -1730,6 +1737,7 @@
 				CF1BB4A02DD2039000588506 /* BugReportImageCell.swift in Sources */,
 				526D18352D5A1913009A2E90 /* InternalConfig.swift in Sources */,
 				526D18442D5A1913009A2E90 /* SystemCrashReporter.swift in Sources */,
+				CF03BF232F9CC218001F5CE3 /* MsrRedactViewHelper.swift in Sources */,
 				CF86818F2DB6541F00C62DA5 /* SpanId.swift in Sources */,
 				CF9D74C52E6169F3007D6D30 /* LifecycleManagerInternal.swift in Sources */,
 				CF8681902DB6541F00C62DA5 /* TraceId.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -10,6 +10,7 @@ import Foundation
 import KSCrashRecording
 import MachO
 import MeasureWebP
+import ObjectiveC.NSObjCRuntime
 import Network
 import ObjectiveC
 import Photos
@@ -81,6 +82,13 @@ extension Measure.SessionOb {
   required public init(from decoder: any Swift.Decoder) throws
   final public func encode(to encoder: any Swift.Encoder) throws
   @objc deinit
+}
+@available(iOS 13.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func msrMask() -> some SwiftUICore.View
+  
+  @_Concurrency.MainActor @preconcurrency public func msrUnmask() -> some SwiftUICore.View
+  
 }
 public protocol Span {
   var traceId: Swift.String { get }

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/MsrMaskModifier.swift .swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/MsrMaskModifier.swift .swift
@@ -24,7 +24,7 @@ private struct MsrRedactUIView: UIViewRepresentable {
 
     func updateUIView(_ uiView: MsrOverlayView, context: Context) {
         switch behavior {
-        case .mask:   MsrRedactViewHelper.maskView(uiView)
+        case .mask: MsrRedactViewHelper.maskView(uiView)
         case .unmask: MsrRedactViewHelper.unmaskView(uiView)
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/MsrMaskModifier.swift .swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/MsrMaskModifier.swift .swift
@@ -1,0 +1,62 @@
+//
+//  MsrMaskModifier.swift .swift
+//  Measure
+//
+//  Created by Adwin Ross on 25/04/26.
+//
+
+import SwiftUI
+import UIKit
+
+private enum MsrMaskBehavior {
+    case mask
+    case unmask
+}
+
+private struct MsrRedactUIView: UIViewRepresentable {
+    let behavior: MsrMaskBehavior
+
+    class MsrOverlayView: UIView {}
+
+    func makeUIView(context: Context) -> MsrOverlayView {
+        MsrOverlayView()
+    }
+
+    func updateUIView(_ uiView: MsrOverlayView, context: Context) {
+        switch behavior {
+        case .mask:   MsrRedactViewHelper.maskView(uiView)
+        case .unmask: MsrRedactViewHelper.unmaskView(uiView)
+        }
+    }
+}
+
+private struct MsrMaskModifier: ViewModifier {
+    @available(iOS 13.0, *)
+    func body(content: Content) -> some View {
+        content.overlay(MsrRedactUIView(behavior: .mask).disabled(true))
+    }
+}
+
+private struct MsrUnmaskModifier: ViewModifier {
+    @available(iOS 13.0, *)
+    func body(content: Content) -> some View {
+        content.overlay(MsrRedactUIView(behavior: .unmask).disabled(true))
+    }
+}
+
+@available(iOS 13.0, *)
+public extension View {
+    /// Explicitly marks this SwiftUI view as sensitive so it gets masked
+    /// in screenshots. Use this for views that cannot be automatically
+    /// detected by the UIKit hierarchy walker, such as standalone Text
+    /// views outside of List contexts.
+    func msrMask() -> some View {
+        modifier(MsrMaskModifier())
+    }
+
+    /// Exempts this SwiftUI view from masking. Use this to opt specific
+    /// views out of the blanket _UIHostingView masking applied by default.
+    func msrUnmask() -> some View {
+        modifier(MsrUnmaskModifier())
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/MsrRedactViewHelper.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/MsrRedactViewHelper.swift
@@ -1,0 +1,32 @@
+//
+//  MsrRedactViewHelper.swift
+//  Measure
+//
+//  Created by Adwin Ross on 25/04/26.
+//
+
+import UIKit
+import ObjectiveC.NSObjCRuntime
+
+final class MsrRedactViewHelper: NSObject {
+    private static var maskedHandle: UInt8 = 0
+    private static var unmaskedHandle: UInt8 = 0
+
+    private override init() {}
+
+    static func maskView(_ view: UIView) {
+        objc_setAssociatedObject(view, &maskedHandle, true, .OBJC_ASSOCIATION_ASSIGN)
+    }
+
+    static func unmaskView(_ view: UIView) {
+        objc_setAssociatedObject(view, &unmaskedHandle, true, .OBJC_ASSOCIATION_ASSIGN)
+    }
+
+    static func shouldMask(_ view: UIView) -> Bool {
+        (objc_getAssociatedObject(view, &maskedHandle) as? NSNumber)?.boolValue ?? false
+    }
+
+    static func shouldUnmask(_ view: UIView) -> Bool {
+        (objc_getAssociatedObject(view, &unmaskedHandle) as? NSNumber)?.boolValue ?? false
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
@@ -25,7 +25,25 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
     private let logger: Logger
     private let attachmentProcessor: AttachmentProcessor
     private let userPermissionManager: UserPermissionManager
-    private let maskedClassNameFragments: [String] = ["RCTParagraphTextView"]
+
+    /// Class name fragments that trigger masking via name matching.
+    /// Used for SwiftUI backing views that don't appear as known UIView
+    /// subclasses. _UIHostingView blanket-masks all SwiftUI content by
+    /// default — use .msrUnmask() to opt specific views out.
+    private let maskedClassNameFragments: [String] = [
+        "RCTParagraphTextView",
+        "_UIHostingView"
+    ]
+
+    /// Class name fragments whose subtrees are skipped during traversal
+    /// to prevent crashes from accessing problematic private layers.
+    private let traversalBlocklist: [String] = {
+        var blocklist: [String] = []
+        if #available(iOS 26.0, *) {
+            blocklist.append("CameraUI.ChromeSwiftUIView")
+        }
+        return blocklist
+    }()
 
     init(configProvider: ConfigProvider,
          logger: Logger,
@@ -50,14 +68,26 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
 
             SignPost.trace(subcategory: "Attachment", label: "generateScreenshot") {
                 let typesToMask = self.typesToMask(for: self.configProvider.screenshotMaskLevel)
-                let sensitiveFrames = self.findSensitiveFrames(in: window, rootView: window, types: typesToMask)
+                let result = self.findSensitiveFrames(in: window, rootView: window, types: typesToMask)
+
+                // Subtract exempt frames from sensitive frames
+                var sensitiveFrames = result.sensitive
+                if !result.exempt.isEmpty {
+                    sensitiveFrames = sensitiveFrames.filter { frame in
+                        !result.exempt.contains { $0.intersects(frame) }
+                    }
+                }
 
                 let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
                 let screenshot = renderer.image { _ in
                     window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
                 }
 
-                guard let redactedImage = self.redactScreenshot(screenshot, sensitiveFrames: sensitiveFrames, maskColor: self.maskColor) else {
+                guard let redactedImage = self.redactScreenshot(
+                    screenshot,
+                    sensitiveFrames: sensitiveFrames,
+                    maskColor: self.maskColor
+                ) else {
                     completion(nil)
                     return
                 }
@@ -96,28 +126,43 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
         }
     }
 
-    private func findSensitiveFrames(in view: UIView, rootView: UIView, types: [UIView.Type]) -> [CGRect] {
-        var sensitiveFrames: [CGRect] = []
+    private func findSensitiveFrames(in view: UIView, rootView: UIView, types: [UIView.Type]) -> (sensitive: [CGRect], exempt: [CGRect]) {
+        var sensitive: [CGRect] = []
+        var exempt: [CGRect] = []
 
-        for type in types {
-            if view.isKind(of: type) {
-                let frameInRootView = view.convert(view.bounds, to: rootView)
-                sensitiveFrames.append(frameInRootView)
-                break
+        // Per-instance override from .msrMask() takes highest priority
+        if MsrRedactViewHelper.shouldMask(view) {
+            sensitive.append(view.convert(view.bounds, to: rootView))
+        } else if MsrRedactViewHelper.shouldUnmask(view) {
+            // Per-instance unmask — record frame for subtraction
+            exempt.append(view.convert(view.bounds, to: rootView))
+        } else {
+            // Fall through to class-based and fragment-based checks
+            let className = String(describing: type(of: view))
+            let matchesType = types.contains { view.isKind(of: $0) }
+            let matchesFragment = maskedClassNameFragments.contains { className.contains($0) }
+
+            if matchesType || matchesFragment {
+                sensitive.append(view.convert(view.bounds, to: rootView))
             }
-            let className = String(describing: view)
-            if maskedClassNameFragments.contains(where: { className.contains($0) }) {
-                let frameInRootView = view.convert(view.bounds, to: rootView)
-                sensitiveFrames.append(frameInRootView)
-                break
-            }
+        }
+
+        // Skip subtree traversal for known crash-prone view types.
+        // The view itself is still masked above if it matched — only
+        // traversal into its children is skipped.
+        let className = String(describing: type(of: view))
+        let isBlocked = traversalBlocklist.contains { className.contains($0) }
+        guard !isBlocked else {
+            return (sensitive, exempt)
         }
 
         for subview in view.subviews {
-            sensitiveFrames.append(contentsOf: findSensitiveFrames(in: subview, rootView: rootView, types: types))
+            let result = findSensitiveFrames(in: subview, rootView: rootView, types: types)
+            sensitive.append(contentsOf: result.sensitive)
+            exempt.append(contentsOf: result.exempt)
         }
 
-        return sensitiveFrames
+        return (sensitive, exempt)
     }
 
     private func redactScreenshot(_ screenshot: UIImage, sensitiveFrames: [CGRect], maskColor: UIColor) -> UIImage? {


### PR DESCRIPTION
# Description

This PR contains below changes:

- Fix screenshot masking for SwiftUI screens by blanket-masking all _UIHostingView content by default, since SwiftUI does not produce individual UIKit view instances for its components.
- Add .msrMask() and .msrUnmask() SwiftUI view modifiers to allow consumers to explicitly control masking for individual views.
- Fix a crash during view hierarchy traversal caused by accessing subtrees of certain private system views such as CameraUI.ChromeSwiftUIView on iOS 26+, affected views are now skipped during traversal while still being masked
- Update docs.

## Related issue
Fixes #3514 