### PR TITLE
fix(rn): fix bugs in public API and native bridge layer

### DIFF
--- a/react-native/src/config/configLoader.ts
+++ b/react-native/src/config/configLoader.ts
@@ -31,7 +31,6 @@ export class ConfigLoader {
         'info',
         'ConfigLoader: Dynamic config loaded successfully'
       );
-      console.log('Loaded dynamic config:', json);
 
       return DynamicConfig.fromNative(json);
   }

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -78,6 +78,7 @@ export const Measure = {
   start(): void {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
+      return;
     }
     return _measureInternal.start();
   },
@@ -88,6 +89,7 @@ export const Measure = {
   stop(): void {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
+      return;
     }
     return _measureInternal.stop();
   },

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -99,9 +99,6 @@ export const Measure = {
    *
    * Event names should be clear and consistent to aid in dashboard searches.
    *
-   * For now, this simply logs the event and its attributes to the console.
-   * A future version will send the event to the Measure SDK for full tracking.
-   *
    * @param name - The name of the event (max 64 characters).
    * @param attributes - Optional key-value pairs providing additional context.
    * @param timestamp - Optional timestamp in milliseconds (defaults to current time).
@@ -204,7 +201,6 @@ export const Measure = {
     if (!_measureInternal) {
       return new InvalidSpan();
     }
-    // Assuming MeasureInternal has a method to call the Tracer/Collector with a timestamp
     return _measureInternal.startSpan(name, timestampMs);
   },
 

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -53,20 +53,16 @@ export const Measure = {
       return _initializationPromise;
     }
 
-    _initializationPromise = new Promise(async (resolve, reject) => {
-      try {
-        console.info('Initializing Measure SDK ...');
+    _initializationPromise = (async () => {
+      console.info('Initializing Measure SDK ...');
 
-        _measureInitializer = new MeasureInitializer(config);
-        _measureInternal = new MeasureInternal(_measureInitializer);
+      _measureInitializer = new MeasureInitializer(config);
+      _measureInternal = new MeasureInternal(_measureInitializer);
 
-        await _measureInternal.init(config);
-
-        resolve();
-      } catch (error) {
-        _initializationPromise = null;
-        reject(error);
-      }
+      await _measureInternal.init(config);
+    })().catch((error) => {
+      _initializationPromise = null;
+      throw error;
     });
 
     return _initializationPromise;

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -258,6 +258,8 @@ export const Measure = {
       console.warn('Measure.setUserId requires a non-empty string.');
       return;
     }
+
+    _measureInternal.setUserId(userId);
   },
 
   /**

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -228,6 +228,9 @@ export const Measure = {
    * @returns A W3C trace context compliant header value (e.g., '00-traceId-spanId-01').
    */
   getTraceParentHeaderValue(span: Span): string {
+    if (!_measureInternal) {
+      return '';
+    }
     return _measureInternal.getTraceParentHeaderValue(span);
   },
 
@@ -237,6 +240,9 @@ export const Measure = {
    * @returns The standardized header key 'traceparent'.
    */
   getTraceParentHeaderKey(): string {
+    if (!_measureInternal) {
+      return '';
+    }
     return _measureInternal.getTraceParentHeaderKey();
   },
 
@@ -333,6 +339,11 @@ export const Measure = {
     bugReportConfig: Record<string, any> = {},
     attributes: Record<string, ValidAttributeValue> = {}
   ): Promise<void> {
+    if (!_measureInternal) {
+      return Promise.reject(
+        new Error('Measure is not initialized. Call init() first.')
+      );
+    }
     return _measureInternal.launchBugReport(
       takeScreenshot,
       bugReportConfig,

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -63,6 +63,7 @@ export class MeasureInternal {
       })
       .catch((error) => {
         console.error('Failed to load dynamic config', error);
+        this.measureInitializer.spanProcessor.onConfigLoaded();
       });
 
     if (config?.autoStart) {

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -69,6 +69,7 @@ export class MeasureInternal {
     if (config?.autoStart) {
       this.started = true;
       this.registerCollectors();
+      enableNativeModule();
     }
   }
 

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -52,7 +52,7 @@ export function trackEvent(
   sessionId?: string,
   threadName?: string,
   attachments: any[] = []
-): Promise<any> {
+): Promise<void> {
   if (!MeasureModule.trackEvent || isDisabled()) {
     return Promise.reject(new Error('trackEvent native method not available.'));
   }
@@ -84,7 +84,7 @@ export function trackSpan(
   checkpoints: Record<string, number> = {},
   hasEnded: boolean,
   isSampled: boolean
-): Promise<any> {
+): Promise<void> {
   if (!MeasureModule.trackSpan || isDisabled()) {
     return Promise.reject(new Error('trackSpan native method not available.'));
   }
@@ -176,7 +176,7 @@ export function launchBugReport(
 
 export function setShakeListener(enable: boolean, handler?: () => void): void {
   if (!MeasureModule.setShakeListener || isDisabled()) {
-    throw new Error('setShakeListener native method not available.');
+    return;
   }
 
   const emitter = getShakeEmitter();


### PR DESCRIPTION
# Description

This PR fixes below issues:

- Call _measureInternal.setUserId() after validation
- Return start/stop function early after uninitialised warning
- Add missing init guards
- Flush spans on config load failure
- Fix warnings