### PR TITLE
fix(backend): preserve role name encoding under pgx simple protocol

### DIFF
--- a/backend/api/measure/authz.go
+++ b/backend/api/measure/authz.go
@@ -1,6 +1,7 @@
 package measure
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,6 +61,15 @@ func (r rank) Valid() bool {
 	default:
 		return false
 	}
+}
+
+// Value implements driver.Valuer so rank is encoded as its role name
+// (e.g. "owner") rather than the underlying int when used as a SQL
+// parameter. pgx v5.9.2 stopped wrapping fmt.Stringer types ahead of
+// the underlying int codec, which would otherwise insert "4" into
+// varchar role columns and break the team_membership FK.
+func (r rank) Value() (driver.Value, error) {
+	return r.String(), nil
 }
 
 func (r rank) String() string {


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced by the `github.com/jackc/pgx/v5` bump from 5.9.1 to 5.9.2 in `backend/testinfra` (#3520) that caused `TestMCPCallbackExchange` and any other code path inserting into `measure.team_membership.role` to fail with `team_membership_role_fkey` foreign key violations.

## Tasks

- [x] Add driver.Valuer to rank so role columns receive 'owner' instead of role integer