### PR TITLE
fix(backend): app versions may not appear properly sorted

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -871,7 +871,7 @@ func (af AppFilter) getAppVersions(ctx context.Context) (versions, versionCodes 
 		Where("app_id = toUUID(?)", af.AppID).
 		GroupBy("version").
 		GroupBy("code").
-		OrderBy("code desc, version")
+		OrderBy("code::UInt32 desc, version")
 
 	defer stmt.Close()
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where app versions would not be sorted using version codes in natural descending order when 2 or more version names are same.

## Tasks

- [x] Always sort using app's build number in natural descending order

## See also

- fixes #3539