### PR TITLE
fix(backend): preserve casing of app's unique id on onboard

### DIFF
--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -229,10 +229,10 @@ func (e eventreq) getOSVersion() (osVersion string) {
 // ingest batch.
 func (e eventreq) getAppUniqueID() (appUniqueID string) {
 	if len(e.events) > 0 {
-		return strings.ToLower(e.events[0].Attribute.AppUniqueID)
+		return e.events[0].Attribute.AppUniqueID
 	}
 
-	return strings.ToLower(e.spans[0].Attributes.AppUniqueID)
+	return e.spans[0].Attributes.AppUniqueID
 }
 
 // getUnhandledExceptions returns unhandled exceptions


### PR DESCRIPTION
## Summary

This PR fixes an issue where app's unique id would be stored in lowercase when onboarding. Both iOS/Android support mixed case, so we preserve the original case.

## See also

- fixes #3541

