### PR TITLE
chore(flutter): compress flutter screenshots using WebP

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -25,6 +25,7 @@ public final class sh/measure/android/Measure {
 	public static final fun init (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;)V
 	public static synthetic fun init$default (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;ILjava/lang/Object;)V
 	public final fun internalAddLog (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun internalEncodeWebP ([BIILkotlin/jvm/functions/Function1;)V
 	public final fun internalGetAttachmentDirectory ()Ljava/lang/String;
 	public final fun internalTrackEvent (Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun internalTrackEvent$default (Lsh/measure/android/Measure;Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -652,6 +652,26 @@ object Measure {
     }
 
     /**
+     * Encodes pixels to WebP asynchronously. The callback is invoked
+     * on the main thread.
+     *
+     * Internal API for Flutter only; not for public use. The `pixels`
+     * be encoded using Flutter's ImageByteFormat.rawRgba.
+     */
+    fun internalEncodeWebP(
+        pixels: ByteArray,
+        width: Int,
+        height: Int,
+        callback: (ByteArray?) -> Unit,
+    ) {
+        if (isInitialized.get()) {
+            measure.encodeWebP(pixels, width, height, callback)
+        } else {
+            callback(null)
+        }
+    }
+
+    /**
      * An internal method that adds logs Measure logger.
      * This method is not intended for public usage.
      */

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -13,6 +13,7 @@ import sh.measure.android.logger.SdkDebugLogWriter
 import sh.measure.android.tracing.Span
 import sh.measure.android.tracing.SpanBuilder
 import sh.measure.android.utils.AttachmentHelper
+import sh.measure.android.utils.WebPEncoder
 import sh.measure.android.utils.iso8601Timestamp
 
 /**
@@ -305,6 +306,19 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
     }
 
     fun getAttachmentDirectory(): String? = measure.fileStorage.getAttachmentDirectory()
+
+    fun encodeWebP(
+        pixels: ByteArray,
+        width: Int,
+        height: Int,
+        callback: (ByteArray?) -> Unit,
+    ) {
+        val quality = measure.configProvider.screenshotCompressionQuality
+        measure.executorServiceRegistry.defaultExecutor().submit {
+            val encoded = WebPEncoder.encode(pixels, width, height, quality, measure.logger)
+            mainHandler.post { callback(encoded) }
+        }
+    }
 
     fun internalAddLog(platform: String, message: String, throwable: Throwable?) {
         measure.logger.log(

--- a/android/measure/src/main/java/sh/measure/android/utils/WebPEncoder.kt
+++ b/android/measure/src/main/java/sh/measure/android/utils/WebPEncoder.kt
@@ -1,0 +1,35 @@
+package sh.measure.android.utils
+
+import android.graphics.Bitmap
+import androidx.core.graphics.createBitmap
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import java.nio.ByteBuffer
+
+/**
+ * Encodes an RGBA pixel buffer to WebP. This is built purposefully
+ * for Flutter which encodes the bytes using ImageByteFormat.rawRgba
+ */
+internal object WebPEncoder {
+    fun encode(
+        pixels: ByteArray,
+        width: Int,
+        height: Int,
+        quality: Int,
+        logger: Logger,
+    ): ByteArray? {
+        if (width <= 0 || height <= 0) return null
+        if (pixels.size != width * height * 4) return null
+        var bitmap: Bitmap? = null
+        return try {
+            bitmap = createBitmap(width, height)
+            bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(pixels))
+            BitmapHelper.compressBitmap(bitmap, quality, logger)?.second
+        } catch (_: Throwable) {
+            logger.log(LogLevel.Error, "WebPEncoder: failed to encode bitmap")
+            null
+        } finally {
+            bitmap?.recycle()
+        }
+    }
+}

--- a/android/measure/src/test/java/sh/measure/android/utils/WebPEncoderTest.kt
+++ b/android/measure/src/test/java/sh/measure/android/utils/WebPEncoderTest.kt
@@ -1,0 +1,37 @@
+package sh.measure.android.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import sh.measure.android.fakes.NoopLogger
+
+@RunWith(AndroidJUnit4::class)
+class WebPEncoderTest {
+    private val logger = NoopLogger()
+
+    @Test
+    fun `returns null for malformed input`() {
+        // pixel buffer too small for declared
+        // dimensions to force an error
+        val pixels = ByteArray(4)
+        val result =
+            WebPEncoder.encode(pixels, width = 2, height = 2, quality = 25, logger = logger)
+        assertNull(result)
+    }
+
+    @Test
+    fun `encodes a valid 2x2 RGBA buffer`() {
+        // We just verify the wiring produces
+        // non-empty bytes for a valid input.
+        val pixels = ByteArray(2 * 2 * 4)
+
+        val encoded =
+            WebPEncoder.encode(pixels, width = 2, height = 2, quality = 25, logger = logger)
+
+        assertNotNull(encoded)
+        assertTrue("expected non-empty encoded bytes", encoded!!.isNotEmpty())
+    }
+}

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
@@ -14,6 +14,7 @@ object MethodConstants {
     const val FUNCTION_ENABLE_SHAKE_DETECTOR = "enableShakeDetector"
     const val FUNCTION_DISABLE_SHAKE_DETECTOR = "disableShakeDetector"
     const val FUNCTION_GET_DYNAMIC_CONFIG_PATH = "getDynamicConfigPath"
+    const val FUNCTION_ENCODE_WEBP = "encodeWebP"
 
     // arguments
     const val ARG_EVENT_DATA = "event_data"
@@ -23,8 +24,6 @@ object MethodConstants {
     const val ARG_USER_TRIGGERED = "user_triggered"
     const val ARG_THREAD_NAME = "thread_name"
     const val ARG_ATTACHMENTS = "attachments"
-    const val ARG_CONFIG = "config"
-    const val ARG_CLIENT_INFO = "client_info"
     const val ARG_SPAN_NAME = "name";
     const val ARG_SPAN_TRACE_ID = "traceId";
     const val ARG_SPAN_SPAN_ID = "id";
@@ -39,6 +38,9 @@ object MethodConstants {
     const val ARG_SPAN_HAS_ENDED = "hasEnded";
     const val ARG_SPAN_IS_SAMPLED = "isSampled";
     const val ARG_USER_ID = "user_id";
+    const val ARG_ENCODE_WEBP_PIXELS = "pixels"
+    const val ARG_ENCODE_WEBP_WIDTH = "width"
+    const val ARG_ENCODE_WEBP_HEIGHT = "height"
 
     // Callbacks
     const val CALLBACK_ON_SHAKE_DETECTED = "onShakeDetected"

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
@@ -36,6 +36,7 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
                 MethodConstants.FUNCTION_ENABLE_SHAKE_DETECTOR -> enableShakeDetector()
                 MethodConstants.FUNCTION_DISABLE_SHAKE_DETECTOR -> disableShakeDetector()
                 MethodConstants.FUNCTION_GET_DYNAMIC_CONFIG_PATH -> getDynamicConfigPath(result)
+                MethodConstants.FUNCTION_ENCODE_WEBP -> encodeWebP(call, result)
                 else -> result.notImplemented()
             }
         } catch (e: MethodArgumentException) {
@@ -89,8 +90,8 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
         data: MutableMap<String, Any?>,
         type: String,
         timestamp: Long,
-        userDefinedAttrs: MutableMap<String, AttributeValue> = mutableMapOf<String, AttributeValue>(),
-        attachments: MutableList<MsrAttachment> = mutableListOf<MsrAttachment>(),
+        userDefinedAttrs: MutableMap<String, AttributeValue> = mutableMapOf(),
+        attachments: MutableList<MsrAttachment> = mutableListOf(),
         userTriggered: Boolean,
         sessionId: String? = null,
         threadName: String? = null,
@@ -184,6 +185,16 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
     private fun getDynamicConfigPath(result: MethodChannel.Result) {
         val path = Measure.getDynamicConfigPath()
         result.success(path)
+    }
+
+    private fun encodeWebP(call: MethodCall, result: MethodChannel.Result) {
+        val reader = MethodCallReader(call)
+        val pixels = reader.requireArg<ByteArray>(MethodConstants.ARG_ENCODE_WEBP_PIXELS)
+        val width = reader.requireArg<Int>(MethodConstants.ARG_ENCODE_WEBP_WIDTH)
+        val height = reader.requireArg<Int>(MethodConstants.ARG_ENCODE_WEBP_HEIGHT)
+        Measure.internalEncodeWebP(pixels, width, height) { encoded ->
+            result.success(encoded)
+        }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/flutter/packages/measure_flutter/ios/Classes/Constants.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/Constants.swift
@@ -21,6 +21,7 @@ enum MethodConstants {
     static let functionEnableShakeDetection = "enableShakeDetector"
     static let functionDisableShakeDetection = "disableShakeDetector"
     static let functionGetDynamicConfigPath = "getDynamicConfigPath"
+    static let functionEncodeWebP = "encodeWebP"
 
     // arguments
     static let argEventData = "event_data"
@@ -46,6 +47,9 @@ enum MethodConstants {
     static let argSpanHasEnded = "hasEnded"
     static let argSpanIsSampled = "isSampled"
     static let argUserId = "user_id"
+    static let argEncodeWebPPixels = "pixels"
+    static let argEncodeWebPWidth = "width"
+    static let argEncodeWebPHeight = "height"
 
     // Callbacks
     static let callbackOnShakeDetected = "onShakeDetected"

--- a/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
@@ -39,6 +39,8 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
                 try disableShakeDetector()
             case MethodConstants.functionGetDynamicConfigPath:
                 try getDynamicConfigPath(result: result)
+            case MethodConstants.functionEncodeWebP:
+                try encodeWebP(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -200,5 +202,20 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
     private func getDynamicConfigPath(result: @escaping FlutterResult) throws {
         let path = Measure.internalGetDynamicConfigPath()
         result(path)
+    }
+
+    private func encodeWebP(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        let reader = MethodCallReader(call)
+        let typed: FlutterStandardTypedData = try reader.requireArg(MethodConstants.argEncodeWebPPixels)
+        let width: Int = try reader.requireArg(MethodConstants.argEncodeWebPWidth)
+        let height: Int = try reader.requireArg(MethodConstants.argEncodeWebPHeight)
+        let pixels = typed.data
+        Measure.internalEncodeWebP(pixels: pixels, width: width, height: height) { encoded in
+            if let encoded = encoded {
+                result(FlutterStandardTypedData(bytes: encoded))
+            } else {
+                result(nil)
+            }
+        }
     }
 }

--- a/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
@@ -7,12 +7,12 @@ import 'package:measure_flutter/src/bug_report/ui/image_picker.dart';
 import 'package:measure_flutter/src/config/config_provider.dart';
 import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/logger/log_level.dart';
+import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 import 'package:measure_flutter/src/utils/id_provider.dart';
 
 import '../../measure_flutter.dart';
-import '../isolate/file_processor.dart';
 import '../logger/logger.dart';
 import '../storage/file_storage.dart';
 import 'bug_report_data.dart';
@@ -25,6 +25,7 @@ class BugReportCollector {
   final FileStorage _fileStorage;
   final ShakeDetector _shakeDetector;
   final TimeProvider _timeProvider;
+  final MsrMethodChannel _methodChannel;
   bool isEnabled = false;
 
   BugReportCollector({
@@ -35,13 +36,15 @@ class BugReportCollector {
     required FileStorage fileStorage,
     required ShakeDetector shakeDetector,
     required TimeProvider timeProvider,
+    required MsrMethodChannel methodChannel,
   })  : _logger = logger,
         _configProvider = configProvider,
         _signalProcessor = signalProcessor,
         _idProvider = idProvider,
         _fileStorage = fileStorage,
         _shakeDetector = shakeDetector,
-        _timeProvider = timeProvider;
+        _timeProvider = timeProvider,
+        _methodChannel = methodChannel;
 
   void register() {
     isEnabled = true;
@@ -59,14 +62,6 @@ class BugReportCollector {
     try {
       final storedAttachments = <MsrAttachment>[];
 
-      // Get root path once before processing
-      final rootPath = await _fileStorage.getRootPath();
-
-      if (rootPath == null) {
-        _logger.log(LogLevel.error, "Root path is null");
-        return;
-      }
-
       for (var attachment in attachments) {
         final path = attachment.path;
         var bytes = attachment.bytes;
@@ -79,36 +74,47 @@ class BugReportCollector {
         }
 
         final uuid = _idProvider.uuid();
-        final result = await compressAndSaveInIsolate(
-          CompressAndSaveParams(
-            originalBytes: bytes,
-            jpegQuality: _configProvider.screenshotCompressionQuality,
-            fileName: uuid,
-            rootPath: rootPath,
+        final width = attachment.width;
+        final height = attachment.height;
+
+        final File? file;
+        final int sizeBytes;
+        if (width != null && height != null) {
+          final webp = await _methodChannel.encodeWebP(
+            pixels: bytes,
+            width: width,
+            height: height,
+          );
+          if (webp == null) {
+            _logger.log(LogLevel.error, 'BugReportCollector: WebP encoding failed');
+            continue;
+          }
+          file = await _fileStorage.writeFile(webp, uuid);
+          sizeBytes = webp.length;
+        } else {
+          file = await _fileStorage.writeFile(bytes, uuid);
+          sizeBytes = bytes.length;
+        }
+
+        if (file == null) {
+          _logger.log(LogLevel.error, 'BugReportCollector: Failed to write attachment');
+          continue;
+        }
+
+        _logger.log(
+          LogLevel.debug,
+          'BugReportCollector: Successfully stored screenshot attachment (id: $uuid, size: $sizeBytes bytes, path: ${file.path})',
+        );
+        storedAttachments.add(
+          MsrAttachment(
+            name: uuid,
+            path: file.path,
+            type: attachment.type,
+            id: uuid,
+            size: sizeBytes,
+            bytes: null,
           ),
         );
-
-        final filePath = result.filePath;
-        final compressedSize = result.size;
-        if (filePath != null && compressedSize != null) {
-          _logger.log(
-            LogLevel.debug,
-            'BugReportCollector: Successfully stored screenshot attachment (id: $uuid, size: $compressedSize bytes, path: $filePath)',
-          );
-          storedAttachments.add(
-            MsrAttachment(
-              name: uuid,
-              path: filePath,
-              type: attachment.type,
-              id: uuid,
-              size: compressedSize,
-              bytes: null,
-            ),
-          );
-        } else {
-          _logger.log(LogLevel.error,
-              "BugReportCollector: Failed to process attachment: ${result.error}");
-        }
       }
 
       _logger.log(LogLevel.debug,

--- a/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
@@ -23,6 +23,16 @@ class MsrAttachment {
   @JsonKey(includeFromJson: false, includeToJson: false)
   final Uint8List? bytes;
 
+  /// Pixel width of [bytes] when [bytes] holds raw RGBA pixel data.
+  /// Null for encoded image bytes (PNG/JPEG/etc.) or path-based attachments.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final int? width;
+
+  /// Pixel height of [bytes] when [bytes] holds raw RGBA pixel data.
+  /// Null for encoded image bytes (PNG/JPEG/etc.) or path-based attachments.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final int? height;
+
   MsrAttachment({
     required this.name,
     required this.id,
@@ -30,6 +40,8 @@ class MsrAttachment {
     required this.size,
     this.path,
     this.bytes,
+    this.width,
+    this.height,
   });
 
   /// Creates an [MsrAttachment] from binary data.
@@ -45,6 +57,8 @@ class MsrAttachment {
     required Uint8List bytes,
     required AttachmentType type,
     required String uuid,
+    int? width,
+    int? height,
   }) {
     return MsrAttachment(
       name: uuid,
@@ -52,6 +66,8 @@ class MsrAttachment {
       type: type,
       size: bytes.length,
       bytes: bytes,
+      width: width,
+      height: height,
     );
   }
 

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
@@ -7,12 +7,12 @@ import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/exception/exception_factory.dart';
 import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
+import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/screenshot/screenshot_collector.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
 import '../events/event_type.dart';
-import '../isolate/file_processor.dart';
 import '../storage/file_storage.dart';
 
 final class ExceptionCollector {
@@ -21,8 +21,8 @@ final class ExceptionCollector {
   final ConfigProvider configProvider;
   final FileStorage fileStorage;
   final ScreenshotCollector screenshotCollector;
-  final Future<FileProcessingResult> Function(CompressAndSaveParams) compressAndSave;
   final TimeProvider timeProvider;
+  final MsrMethodChannel methodChannel;
   bool _enabled = false;
 
   ExceptionCollector({
@@ -32,7 +32,7 @@ final class ExceptionCollector {
     required this.fileStorage,
     required this.screenshotCollector,
     required this.timeProvider,
-    this.compressAndSave = compressAndSaveInIsolate,
+    required this.methodChannel,
   });
 
   void register() {
@@ -78,47 +78,38 @@ final class ExceptionCollector {
   }
 
   Future<void> _addScreenshot(List<MsrAttachment> attachments) async {
-    final rootPath = await fileStorage.getRootPath();
-
-    if (rootPath == null) {
+    final screenshot = await screenshotCollector.capture();
+    final width = screenshot?.width;
+    final height = screenshot?.height;
+    if (screenshot == null || screenshot.bytes == null || width == null || height == null) {
       return;
     }
 
-    final screenshot = await screenshotCollector.capture();
-
-    if (screenshot != null && screenshot.bytes != null) {
-      final result = await compressAndSave(
-        CompressAndSaveParams(
-          originalBytes: screenshot.bytes!,
-          jpegQuality: configProvider.screenshotCompressionQuality,
-          fileName: screenshot.id,
-          rootPath: rootPath,
-        ),
-      );
-
-      final filePath = result.filePath;
-      final compressedSize = result.size;
-      if (filePath != null && compressedSize != null) {
-        logger.log(
-          LogLevel.debug,
-          'ExceptionCollector: Successfully stored screenshot attachment (id: ${screenshot.id}, size: $compressedSize bytes, path: $filePath)',
-        );
-        attachments.add(
-          MsrAttachment(
-            name: screenshot.id,
-            path: filePath,
-            type: AttachmentType.screenshot,
-            id: screenshot.id,
-            size: compressedSize,
-            bytes: null,
-          ),
-        );
-      } else {
-        logger.log(
-          LogLevel.debug,
-          'ExceptionCollector: Failed to store screenshot attachment: ${result.error}',
-        );
-      }
+    final webp = await methodChannel.encodeWebP(
+      pixels: screenshot.bytes!,
+      width: width,
+      height: height,
+    );
+    if (webp == null) {
+      logger.log(LogLevel.debug, 'ExceptionCollector: WebP encoding failed');
+      return;
     }
+    final file = await fileStorage.writeFile(webp, screenshot.id);
+    if (file == null) return;
+
+    logger.log(
+      LogLevel.debug,
+      'ExceptionCollector: Successfully stored screenshot attachment (id: ${screenshot.id}, size: ${webp.length} bytes, path: ${file.path})',
+    );
+    attachments.add(
+      MsrAttachment(
+        name: screenshot.id,
+        path: file.path,
+        type: AttachmentType.screenshot,
+        id: screenshot.id,
+        size: webp.length,
+        bytes: null,
+      ),
+    );
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/isolate/file_processing_isolate.dart
+++ b/flutter/packages/measure_flutter/lib/src/isolate/file_processing_isolate.dart
@@ -21,17 +21,6 @@ sealed class FileProcessingRequest {
   });
 }
 
-/// Request to compress an image and save to file
-class ImageCompressionRequest extends FileProcessingRequest {
-  final CompressAndSaveParams params;
-
-  ImageCompressionRequest({
-    required super.requestId,
-    required super.responsePort,
-    required this.params,
-  });
-}
-
 /// Request to serialize JSON and save to file
 class LayoutSnapshotWriteRequest extends FileProcessingRequest {
   final SnapshotNode snapshot;
@@ -169,60 +158,6 @@ class FileProcessingIsolate {
     _isInitialized = false;
   }
 
-  /// Process image compression request
-  Future<FileProcessingResult> processImageCompression(
-    CompressAndSaveParams params,
-  ) async {
-    if (!_isInitialized || _sendPort == null) {
-      return const FileProcessingResult(
-        error: 'Isolate not initialized',
-      );
-    }
-
-    final requestId = params.fileName;
-    final completer = Completer<FileProcessingResult>();
-    _pendingRequests[requestId] = completer;
-
-    final sendPort = _sendPort;
-    final receivePort = _receivePort;
-
-    if (sendPort == null || receivePort == null) {
-      return const FileProcessingResult(
-        error: 'Isolate ports not available',
-      );
-    }
-
-    try {
-      sendPort.send(
-        ImageCompressionRequest(
-          requestId: requestId,
-          responsePort: receivePort.sendPort,
-          params: params,
-        ),
-      );
-
-      // Wait for response with timeout
-      return await completer.future.timeout(
-        _writeTimeout,
-        onTimeout: () {
-          return const FileProcessingResult(
-            error: 'Image compression timed out',
-          );
-        },
-      );
-    } catch (e, stackTrace) {
-      _logger.log(
-        LogLevel.error,
-        'FileProcessingIsolate: Error processing image: $e',
-        e,
-        stackTrace,
-      );
-      return FileProcessingResult(error: e.toString());
-    } finally {
-      _pendingRequests.remove(requestId);
-    }
-  }
-
   /// Process JSON write request
   Future<FileProcessingResult> processLayoutSnapshotWrite(
     SnapshotNode snapshot,
@@ -307,35 +242,10 @@ class FileProcessingIsolate {
 
     // Listen for requests
     receivePort.listen((message) async {
-      if (message is ImageCompressionRequest) {
-        await _handleImageCompression(message);
-      } else if (message is LayoutSnapshotWriteRequest) {
+      if (message is LayoutSnapshotWriteRequest) {
         await _handleJsonWrite(message);
       }
     });
-  }
-
-  /// Handle image compression in isolate
-  static Future<void> _handleImageCompression(
-    ImageCompressionRequest request,
-  ) async {
-    try {
-      final result = await compressAndSaveInIsolateWorker(request.params);
-
-      request.responsePort.send(
-        FileProcessingResponse(
-          requestId: request.requestId,
-          result: result,
-        ),
-      );
-    } catch (e) {
-      request.responsePort.send(
-        FileProcessingResponse(
-          requestId: request.requestId,
-          result: FileProcessingResult(error: e.toString()),
-        ),
-      );
-    }
   }
 
   /// Handle JSON write in isolate

--- a/flutter/packages/measure_flutter/lib/src/isolate/file_processor.dart
+++ b/flutter/packages/measure_flutter/lib/src/isolate/file_processor.dart
@@ -2,56 +2,15 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:image/image.dart' as img;
 import 'package:measure_flutter/src/isolate/file_processing_isolate.dart';
 
 import '../gestures/snapshot_node.dart';
 
-// Module-level reference to shared file processing isolate
 FileProcessingIsolate? _sharedWorker;
 
-/// Initialize the shared file processing isolate worker
+/// Initialize the shared file processing isolate worker for the JSON write path.
 void initializeFileProcessingIsolate(FileProcessingIsolate worker) {
   _sharedWorker = worker;
-}
-
-// Parameter classes
-class RgbaToJpegParams {
-  final Uint8List rgbaBytes;
-  final int width;
-  final int height;
-  final int jpegQuality;
-
-  const RgbaToJpegParams({
-    required this.rgbaBytes,
-    required this.width,
-    required this.height,
-    required this.jpegQuality,
-  });
-}
-
-class ImageToJpegParams {
-  final Uint8List originalBytes;
-  final int jpegQuality;
-
-  const ImageToJpegParams({
-    required this.originalBytes,
-    required this.jpegQuality,
-  });
-}
-
-class CompressAndSaveParams {
-  final Uint8List originalBytes;
-  final int jpegQuality;
-  final String fileName;
-  final String rootPath;
-
-  const CompressAndSaveParams({
-    required this.originalBytes,
-    required this.jpegQuality,
-    required this.fileName,
-    required this.rootPath,
-  });
 }
 
 class WriteLayoutSnapshotParams {
@@ -76,37 +35,6 @@ class FileProcessingResult {
   const FileProcessingResult({this.filePath, this.error, this.size});
 }
 
-// Core processing functions
-Future<Uint8List> convertRgbaToJpegInIsolate(RgbaToJpegParams params) async {
-  final rgbaImage = img.Image.fromBytes(
-    width: params.width,
-    height: params.height,
-    bytes: params.rgbaBytes.buffer,
-    order: img.ChannelOrder.rgba,
-  );
-
-  final encodedJpg = img.encodeJpg(rgbaImage, quality: params.jpegQuality);
-  return Uint8List.fromList(encodedJpg);
-}
-
-Future<Uint8List> convertImageToJpegInIsolate(ImageToJpegParams params) async {
-  final originalImage = img.decodeImage(params.originalBytes);
-  if (originalImage == null) {
-    throw Exception('Failed to decode image');
-  }
-
-  final encodedJpg = img.encodeJpg(originalImage, quality: params.jpegQuality);
-  return Uint8List.fromList(encodedJpg);
-}
-
-Future<FileProcessingResult> compressAndSaveInIsolate(CompressAndSaveParams params) async {
-  final worker = _sharedWorker;
-  if (worker == null) {
-    return const FileProcessingResult(error: 'File processing isolate not initialized');
-  }
-  return worker.processImageCompression(params);
-}
-
 Future<FileProcessingResult> writeJsonToFileInIsolate(WriteLayoutSnapshotParams params) async {
   final worker = _sharedWorker;
   if (worker == null) {
@@ -118,27 +46,6 @@ Future<FileProcessingResult> writeJsonToFileInIsolate(WriteLayoutSnapshotParams 
     params.rootPath,
     compress: params.compress,
   );
-}
-
-/// Compress image and write to file
-Future<FileProcessingResult> compressAndSaveInIsolateWorker(CompressAndSaveParams params) async {
-  try {
-    final compressedBytes = await convertImageToJpegInIsolate(
-      ImageToJpegParams(
-        originalBytes: params.originalBytes,
-        jpegQuality: params.jpegQuality,
-      ),
-    );
-
-    final filePath = await _writeFile(compressedBytes, params.fileName, params.rootPath);
-
-    return FileProcessingResult(
-      filePath: filePath,
-      size: compressedBytes.length,
-    );
-  } catch (e) {
-    return FileProcessingResult(error: e.toString());
-  }
 }
 
 Future<String> _writeFile(Uint8List data, String fileName, String rootPath) async {
@@ -166,11 +73,7 @@ Future<FileProcessingResult> writeJsonToFileInIsolateWorker(
       dataToWrite = Uint8List.fromList(jsonBytes);
     }
 
-    final filePath = await _writeFile(
-      dataToWrite,
-      fileName,
-      rootPath,
-    );
+    final filePath = await _writeFile(dataToWrite, fileName, rootPath);
 
     return FileProcessingResult(
       filePath: filePath,

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -133,6 +133,7 @@ final class MeasureInitializer {
       fileStorage: _fileStorage,
       screenshotCollector: _screenshotCollector,
       timeProvider: timeProvider,
+      methodChannel: _methodChannel,
     );
     _navigationCollector = NavigationCollector(
       signalProcessor: signalProcessor,
@@ -155,6 +156,7 @@ final class MeasureInitializer {
       idProvider: _idProvider,
       shakeDetector: _shakeDetector,
       timeProvider: _timeProvider,
+      methodChannel: _methodChannel,
     );
     _sampler = SamplerImpl(_configProvider);
     _spanProcessor = MsrSpanProcessor(

--- a/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
@@ -12,6 +12,7 @@ class MethodConstants {
   static const String functionEnableShakeDetector = 'enableShakeDetector';
   static const String functionDisableShakeDetector = 'disableShakeDetector';
   static const String functionGetDynamicConfigPath = 'getDynamicConfigPath';
+  static const String functionEncodeWebP = 'encodeWebP';
 
   // Argument keys
   static const String argEventData = 'event_data';
@@ -39,6 +40,9 @@ class MethodConstants {
   static const String argSpanHasEnded = "hasEnded";
   static const String argSpanIsSampled = "isSampled";
   static const String argUserId = 'user_id';
+  static const String argEncodeWebPPixels = 'pixels';
+  static const String argEncodeWebPWidth = 'width';
+  static const String argEncodeWebPHeight = 'height';
 
   // Error codes
   static const String errorInvalidArgument = 'invalid_argument';

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
@@ -112,6 +112,22 @@ class MsrMethodChannel extends MeasureFlutterPlatform {
         .invokeMethod(MethodConstants.functionGetDynamicConfigPath);
   }
 
+  @override
+  Future<Uint8List?> encodeWebP({
+    required Uint8List pixels,
+    required int width,
+    required int height,
+  }) {
+    return _methodChannel.invokeMethod<Uint8List>(
+      MethodConstants.functionEncodeWebP,
+      {
+        MethodConstants.argEncodeWebPPixels: pixels,
+        MethodConstants.argEncodeWebPWidth: width,
+        MethodConstants.argEncodeWebPHeight: height,
+      },
+    );
+  }
+
   void setMethodCallHandler(
       Future<void> Function(MethodCall call) handleMethodCall) {
     _methodChannel.setMethodCallHandler(handleMethodCall);

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -74,5 +76,13 @@ abstract class MeasureFlutterPlatform extends PlatformInterface {
 
   Future<String?> getDynamicConfigPath() {
     throw UnimplementedError('getDynamicConfigPath() has not been implemented.');
+  }
+
+  Future<Uint8List?> encodeWebP({
+    required Uint8List pixels,
+    required int width,
+    required int height,
+  }) {
+    throw UnimplementedError('encodeWebP() has not been implemented.');
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -42,20 +43,31 @@ class DefaultScreenshotCollector extends ScreenshotCollector {
       }
 
       final ui.Image image = await renderObject.toImage(pixelRatio: 1);
-      final png = await image.toByteData(format: ui.ImageByteFormat.png);
+      final ByteData? rgba;
+      final int width;
+      final int height;
+      try {
+        width = image.width;
+        height = image.height;
+        rgba = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      } finally {
+        image.dispose();
+      }
 
-      if (png == null) {
+      if (rgba == null) {
         logger.log(
           LogLevel.debug,
-          'ScreenshotService: Error reading image as PNG',
+          'ScreenshotService: Error reading image as raw RGBA',
         );
         return null;
       }
 
       return MsrAttachment.fromBytes(
-        bytes: png.buffer.asUint8List(),
+        bytes: rgba.buffer.asUint8List(),
         type: AttachmentType.screenshot,
         uuid: idProvider.uuid(),
+        width: width,
+        height: height,
       );
     } catch (e) {
       logger.log(

--- a/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
@@ -11,6 +11,7 @@ import 'package:measure_flutter/src/time/time_provider.dart';
 import '../utils/fake_config_provider.dart';
 import '../utils/fake_file_storage.dart';
 import '../utils/fake_id_provider.dart';
+import '../utils/fake_msr_method_channel.dart';
 import '../utils/fake_shake_detector.dart';
 import '../utils/fake_signal_processor.dart';
 import '../utils/noop_logger.dart';
@@ -44,6 +45,7 @@ void main() {
         fileStorage: fileStorage,
         shakeDetector: shakeDetector,
         timeProvider: timeProvider,
+        methodChannel: FakeMethodChannel(),
       );
       // Enable the collector for all tests
       collector.register();

--- a/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
@@ -5,24 +5,15 @@ import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/exception/exception_framework.dart';
-import 'package:measure_flutter/src/isolate/file_processor.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
 import '../utils/fake_config_provider.dart';
 import '../utils/fake_file_storage.dart';
+import '../utils/fake_msr_method_channel.dart';
 import '../utils/fake_screenshot_collector.dart';
 import '../utils/fake_signal_processor.dart';
 import '../utils/noop_logger.dart';
 import '../utils/test_clock.dart';
-
-// Mock the isolate function
-Future<FileProcessingResult> mockCompressAndSaveInIsolate(
-    CompressAndSaveParams params) async {
-  return FileProcessingResult(
-    filePath: '/mock/path/screenshot.jpg',
-    size: 1024,
-  );
-}
 
 void main() {
   group('ExceptionCollector', () {
@@ -46,7 +37,7 @@ void main() {
         fileStorage: fileStorage,
         screenshotCollector: screenshotCollector,
         timeProvider: FlutterTimeProvider(TestClock.create()),
-        compressAndSave: mockCompressAndSaveInIsolate,
+        methodChannel: FakeMethodChannel()..encodedWebPResult = Uint8List.fromList([1, 2, 3, 4]),
       );
     });
 

--- a/flutter/packages/measure_flutter/test/isolate/file_processing_isolate_test.dart
+++ b/flutter/packages/measure_flutter/test/isolate/file_processing_isolate_test.dart
@@ -3,10 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:measure_flutter/src/gestures/snapshot_node.dart';
 import 'package:measure_flutter/src/isolate/file_processing_isolate.dart';
-import 'package:measure_flutter/src/isolate/file_processor.dart';
 
 import '../utils/noop_logger.dart';
-import '../utils/test_png.dart';
 
 void main() {
   group('FileProcessingIsolate', () {
@@ -137,28 +135,6 @@ void main() {
       final content = await file.readAsString();
       expect(content, contains('Parent'));
       expect(content, contains('Child'));
-    });
-
-    test('processes image compression successfully', () async {
-      await isolate.init();
-
-      final imageBytes = createTestPngBytes();
-      final params = CompressAndSaveParams(
-        originalBytes: imageBytes,
-        jpegQuality: 85,
-        fileName: 'test-image.jpg',
-        rootPath: tempDir.path,
-      );
-
-      final result = await isolate.processImageCompression(params);
-
-      expect(result.error, isNull);
-      expect(result.filePath, contains('test-image.jpg'));
-      expect(result.size, greaterThan(0));
-
-      // Verify file was created
-      final file = File(result.filePath!);
-      expect(file.existsSync(), isTrue);
     });
 
     test('handles multiple concurrent requests', () async {

--- a/flutter/packages/measure_flutter/test/utils/fake_file_processing_isolate.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_file_processing_isolate.dart
@@ -42,14 +42,6 @@ class FakeFileProcessingIsolate implements FileProcessingIsolate {
     );
   }
 
-  @override
-  Future<FileProcessingResult> processImageCompression(
-    CompressAndSaveParams params,
-  ) async {
-    // Not used in layout snapshot collector tests
-    throw UnimplementedError();
-  }
-
   Future<void> shutdown() async {
     // No-op for testing
   }

--- a/flutter/packages/measure_flutter/test/utils/fake_file_storage.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_file_storage.dart
@@ -10,7 +10,10 @@ class FakeFileStorage implements FileStorage {
   int? shouldFailWriteAfterCount;
   int _writeCount = 0;
 
-  final String _rootPath = '/fake/root/path';
+  final Directory _tempDir =
+      Directory.systemTemp.createTempSync('fake_file_storage_');
+
+  String get _rootPath => _tempDir.path;
 
   @override
   Future<File?> writeFile(Uint8List data, String fileName) async {
@@ -26,7 +29,9 @@ class FakeFileStorage implements FileStorage {
     }
 
     _storedFiles[fileName] = data;
-    return File('$_rootPath/$fileName');
+    final file = File('$_rootPath/$fileName');
+    await file.writeAsBytes(data);
+    return file;
   }
 
   Uint8List? getStoredFile(String fileName) {

--- a/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
@@ -4,6 +4,7 @@ import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 
 class FakeMethodChannel extends MsrMethodChannel {
   Future<void> Function(MethodCall call)? handler;
+  Uint8List? encodedWebPResult;
 
   @override
   void setMethodCallHandler(
@@ -59,4 +60,12 @@ class FakeMethodChannel extends MsrMethodChannel {
 
   @override
   Future<void> disableShakeDetector() => throw UnimplementedError();
+
+  @override
+  Future<Uint8List?> encodeWebP({
+    required Uint8List pixels,
+    required int width,
+    required int height,
+  }) async =>
+      encodedWebPResult;
 }

--- a/flutter/packages/measure_flutter/test/utils/fake_screenshot_collector.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_screenshot_collector.dart
@@ -1,17 +1,21 @@
+import 'dart:typed_data';
+
 import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/screenshot/screenshot_collector.dart';
-
-import 'test_png.dart';
 
 class FakeScreenshotCollector extends ScreenshotCollector {
   @override
   Future<MsrAttachment?> capture() async {
+    // 1x1 raw RGBA pixel (red).
+    final rgba = Uint8List.fromList(<int>[255, 0, 0, 255]);
     return MsrAttachment(
       name: "screenshot",
       id: "test-id",
       type: AttachmentType.screenshot,
-      size: 100,
-      bytes: createTestPngBytes(),
+      size: rgba.length,
+      bytes: rgba,
+      width: 1,
+      height: 1,
     );
   }
 }

--- a/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/src/services/message_codec.dart';
 import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
@@ -93,6 +95,15 @@ class TestMethodChannel implements MsrMethodChannel {
 
   @override
   Future<String?> getDynamicConfigPath() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Uint8List?> encodeWebP({
+    required Uint8List pixels,
+    required int width,
+    required int height,
+  }) {
     throw UnimplementedError();
   }
 }

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -278,7 +278,15 @@ import UIKit
         guard let measureInternal = self.measureInternal else { return nil }
         return measureInternal.getDocumentDirectoryPath()
     }
-    
+
+    func internalEncodeWebP(pixels: Data, width: Int, height: Int, completion: @escaping (Data?) -> Void) {
+        guard let measureInternal = self.measureInternal else {
+            completion(nil)
+            return
+        }
+        measureInternal.encodeWebP(pixels: pixels, width: width, height: height, completion: completion)
+    }
+
     func internalGetDynamicConfigPath() -> String? {
         guard let measureInternal = self.measureInternal else { return nil }
         return measureInternal.getDynamicConfigPath()
@@ -809,7 +817,15 @@ extension Measure {
     public static func internalGetAttachmentDirectory() -> String? {
         return Measure.shared.internalGetAttachmentDirectory()
     }
-    
+
+    /// Encodes pixels to WebP asynchronously.
+    /// 
+    /// Internal API for Flutter only; not for public use. The `pixels`
+    /// be encoded using Flutter's ImageByteFormat.rawRgba.
+    public static func internalEncodeWebP(pixels: Data, width: Int, height: Int, completion: @escaping (Data?) -> Void) {
+        Measure.shared.internalEncodeWebP(pixels: pixels, width: width, height: height, completion: completion)
+    }
+
     public static func internalGetDynamicConfigPath() -> String? {
         return Measure.shared.internalGetDynamicConfigPath()
     }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -415,7 +415,15 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func getDocumentDirectoryPath() -> String? {
         return systemFileManager.getDirectoryPath(directory: FileManager.SearchPathDirectory.documentDirectory)
     }
-    
+
+    func encodeWebP(pixels: Data, width: Int, height: Int, completion: @escaping (Data?) -> Void) {
+        let quality = Int(configProvider.screenshotCompressionQuality)
+        measureDispatchQueue.submit {
+            let encoded = WebPEncoder.encode(pixels: pixels, width: width, height: height, quality: quality)
+            DispatchQueue.main.async { completion(encoded) }
+        }
+    }
+
     func getDynamicConfigPath() -> String? {
         return systemFileManager.getDynamicConfigPath()
     }

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/WebPEncoder.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/WebPEncoder.swift
@@ -11,6 +11,7 @@ import MeasureWebP
 #endif
 
 struct WebPEncoder {
+
     static func encode(_ image: UIImage, quality: CGFloat) -> Data? {
         guard let cgImage = image.cgImage else { return nil }
 
@@ -47,5 +48,24 @@ struct WebPEncoder {
         defer { WebPFree(outputPtr) }
 
         return Data(bytes: outputPtr, count: size)
+    }
+
+    
+    // Encodes an RGBA pixel buffer to WebP. This is built purposefully
+    // for Flutter which encodes the bytes using ImageByteFormat.rawRgba
+    static func encode(pixels: Data, width: Int, height: Int, quality: Int) -> Data? {
+        guard width > 0, height > 0 else { return nil }
+        let stride = width * 4
+        guard pixels.count == stride * height else { return nil }
+        let clamped = Float(max(0, min(100, quality)))
+
+        return pixels.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Data? in
+            guard let base = buf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return nil }
+            var output: UnsafeMutablePointer<UInt8>? = nil
+            let size = WebPEncodeRGBA(base, Int32(width), Int32(height), Int32(stride), clamped, &output)
+            guard size > 0, let outputPtr = output else { return nil }
+            defer { WebPFree(outputPtr) }
+            return Data(bytes: outputPtr, count: size)
+        }
     }
 }

--- a/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
+++ b/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
@@ -181,4 +181,29 @@ final class MeasureInternalTests: XCTestCase {
         measureInternal.trackError(NSError(domain: "Test", code: 1), attributes: [:], collectStackTraces: false)
         XCTAssertFalse(logger.logs.contains(where: { $0.contains("Event processed") }), "trackError should not proceed if not started")
     }
+
+    func testEncodeWebP_completesOnMainThreadWithEncodedBytes() {
+        // Use a synchronous dispatch queue + a config-provider with a known quality.
+        // Verifies the orchestrator (a) ran the codec, (b) hopped back to main
+        // before invoking the completion handler.
+        let initializer = MockMeasureInitializer(
+            configProvider: MockConfigProvider(autoStart: false),
+            measureDispatchQueue: MockMeasureDispatchQueue()
+        )
+        let internalUnderTest = MeasureInternal(initializer)
+        let pixels = Data(count: 2 * 2 * 4)
+        let completed = expectation(description: "completion")
+        var ranOnMainThread = false
+        var encoded: Data?
+
+        internalUnderTest.encodeWebP(pixels: pixels, width: 2, height: 2) { result in
+            ranOnMainThread = Thread.isMainThread
+            encoded = result
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1.0)
+        XCTAssertTrue(ranOnMainThread)
+        XCTAssertNotNil(encoded)
+    }
 }

--- a/ios/Tests/MeasureSDKTests/Screenshots/WebPEncoderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Screenshots/WebPEncoderTests.swift
@@ -1,0 +1,21 @@
+//
+//  WebPEncoderTests.swift
+//  MeasureSDKTests
+//
+
+import XCTest
+@testable import Measure
+
+final class WebPEncoderTests: XCTestCase {
+    func testEncode_returnsNilForMalformedInput() {
+        XCTAssertNil(WebPEncoder.encode(pixels: Data(count: 4), width: 2, height: 2, quality: 25))
+    }
+
+    func testEncode_returnsBytesForValidInput() {
+        let pixels = Data(count: 2 * 2 * 4)
+
+        let encoded = WebPEncoder.encode(pixels: pixels, width: 2, height: 2, quality: 25)
+
+        XCTAssertNotNil(encoded)
+    }
+}

--- a/samples/frank/ios/Podfile.lock
+++ b/samples/frank/ios/Podfile.lock
@@ -95,9 +95,12 @@ PODS:
     - KSCrash/Recording
   - measure-sh (0.10.0):
     - KSCrash (~> 2.5)
+    - measure-sh/WebP (= 0.10.0)
+  - measure-sh/WebP (0.10.0):
+    - KSCrash (~> 2.5)
   - measure_flutter (0.3.0):
     - Flutter
-    - measure-sh (= 0.10.0)
+    - measure-sh
   - MeasureReactNative (0.1.0):
     - measure-sh
     - React-Core
@@ -2175,11 +2178,11 @@ SPEC CHECKSUMS:
   FlutterPluginRegistrant: 72d81e4ec9cd63715219d3c18bfa6212ba2ce6f6
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 0d3f5af9c6b6e59a5e181d0472f0332b0185d247
+  hermes-engine: 83d3ad68b35a9b040db9975e1486b951c7b0ea34
   image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
   KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
-  measure-sh: 0c63eee92abea499f3b682afd63095008db5bd2b
-  measure_flutter: 6cfcf08c539d69e95023be25a188fc0a39ff89ff
+  measure-sh: cb4133b7169721eca11a96d473a1c904c94bf8e2
+  measure_flutter: 894ae80b6ca5869f9119f6537ef16d944b46dbb1
   MeasureReactNative: eb90f7cc5ce205436664b87a313a82274f4d57d0
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -2192,7 +2195,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: bdaa87b276ca31877632a982ecf7c36f8c826414
-  React-Core-prebuilt: bb05481052cb422306f8e5fdabc039b02b438a16
+  React-Core-prebuilt: f5b83ff01897b2e87f3a530a7970186c5ebf3f37
   React-CoreModules: b24989f62d56390ae08ca4f65e6f38fe6802de42
   React-cxxreact: 1a2dfcbc18a6b610664dba152adf327f063a0d12
   React-debug: d196e6df0599d78360b3211367e28c5583054133
@@ -2253,7 +2256,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 26bbf1e26768d08dd965a2b5e372e53f67b21fee
   ReactCodegen: d91185ae285197a0b1f97f432e936459494e71b1
   ReactCommon: 309419492d417c4cbb87af06f67735afa40ecb9d
-  ReactNativeDependencies: 2ae92dcff72f77096fdec77c230739694c7316bb
+  ReactNativeDependencies: a5e4a5958f2ee4def1a14e2777c7f56db3d34703
   Yoga: 846fbe6f595136be802ad81d05688ff748839764
 
 PODFILE CHECKSUM: c7c9bd3a3e54b1708e257a99c9a83abff487c638


### PR DESCRIPTION
# Description

Move screenshot encoding from JPEG to WebP via a new platform channel. Android uses `Bitmap.compress`; iOS uses libwebp's `WebPEncodeRGBA`. Compression runs off the main isolate so capture stays cheap. Both produce valid WebP files end-to-end.

## Related issue
References #3312