### PR TITLE
chore(frontend): unify "Data" line across plan cards

### DIFF
--- a/backend/api/measure/billing.go
+++ b/backend/api/measure/billing.go
@@ -58,6 +58,9 @@ type BillingInfo struct {
 	// BytesUnlimited is true when the customer's bytes feature is configured
 	// as unlimited in Autumn — typically only on bespoke Enterprise plans.
 	BytesUnlimited bool `json:"bytes_unlimited"`
+	// BytesOverageAllowed is true when the customer's plan permits going
+	// over BytesGranted (Pro: yes, Free: no, Enterprise: depends).
+	BytesOverageAllowed bool `json:"bytes_overage_allowed"`
 	// RetentionDays is the retention entitlement on the customer's current
 	// plan, read from the retention_days feature in Autumn. 0 when billing
 	// is disabled or the customer has no Autumn record yet.
@@ -294,6 +297,7 @@ func GetTeamBilling(c *gin.Context) {
 				result.BytesGranted = b.Granted
 				result.BytesUsed = b.Usage
 				result.BytesUnlimited = b.Unlimited
+				result.BytesOverageAllowed = b.OverageAllowed
 			}
 			if b, ok := cust.Balances[autumn.FeatureRetentionDays]; ok && b.Granted > 0 {
 				result.RetentionDays = int(b.Granted)

--- a/backend/api/measure/billing_test.go
+++ b/backend/api/measure/billing_test.go
@@ -678,6 +678,11 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 
 	t.Run("enterprise plan exposes retention_days and bytes_unlimited", func(t *testing.T) {
+		// A bespoke Enterprise plan typically has unlimited bytes and a
+		// custom retention entitlement (e.g. 365 days). Note that Autumn
+		// hardcodes balance.usage=0 for any feature marked unlimited, so
+		// even though the customer may be ingesting data, BytesUsed comes
+		// through as 0.
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
 		custID := uuid.New().String()
@@ -692,7 +697,7 @@ func TestGetTeamBilling(t *testing.T) {
 					Status: "active",
 				}},
 				Balances: map[string]autumn.Balance{
-					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Unlimited: true, Usage: 12_345},
+					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Unlimited: true, Usage: 0},
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 365},
 				},
 			}, nil
@@ -717,12 +722,9 @@ func TestGetTeamBilling(t *testing.T) {
 		if got["retention_days"] != float64(365) {
 			t.Errorf("retention_days = %v, want 365", got["retention_days"])
 		}
-		if got["bytes_used"] != float64(12_345) {
-			t.Errorf("bytes_used = %v, want 12345 (still surfaced under unlimited)", got["bytes_used"])
-		}
 	})
 
-	t.Run("non-unlimited bytes balance leaves bytes_unlimited=false and populates retention_days", func(t *testing.T) {
+	t.Run("non-unlimited bytes balance leaves bytes_unlimited=false and populates retention_days + bytes_overage_allowed", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
 		custID := uuid.New().String()
@@ -733,7 +735,7 @@ func TestGetTeamBilling(t *testing.T) {
 				ID:       custID,
 				Products: []autumn.CustomerProduct{{ID: autumnPlanPro}},
 				Balances: map[string]autumn.Balance{
-					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Granted: 25_000_000_000, Usage: 100, Unlimited: false},
+					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Granted: 25_000_000_000, Usage: 100, Unlimited: false, OverageAllowed: true},
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
 			}, nil
@@ -752,8 +754,98 @@ func TestGetTeamBilling(t *testing.T) {
 		if got["bytes_unlimited"] != false {
 			t.Errorf("bytes_unlimited = %v, want false", got["bytes_unlimited"])
 		}
+		if got["bytes_overage_allowed"] != true {
+			t.Errorf("bytes_overage_allowed = %v, want true (Pro allows overage)", got["bytes_overage_allowed"])
+		}
 		if got["retention_days"] != float64(90) {
 			t.Errorf("retention_days = %v, want 90", got["retention_days"])
+		}
+	})
+
+	t.Run("bespoke Enterprise plan with bounded quota + overage_allowed flows through correctly", func(t *testing.T) {
+		// Some Enterprise plans aren't unlimited — they have a
+		// quota with overage permitted (Autumn returns Granted > 0,
+		// Unlimited=false, OverageAllowed=true).
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: "measure_enterprise_acme"}},
+				Subscriptions: []autumn.Subscription{{
+					PlanID: "measure_enterprise_acme",
+					Status: "active",
+				}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Granted: 100_000_000_000, Usage: 110_000_000_000, Unlimited: false, OverageAllowed: true},
+					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 180},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["plan"] != planEnterprise {
+			t.Errorf("plan = %v, want %q", got["plan"], planEnterprise)
+		}
+		if got["bytes_unlimited"] != false {
+			t.Errorf("bytes_unlimited = %v, want false (bounded plan)", got["bytes_unlimited"])
+		}
+		if got["bytes_overage_allowed"] != true {
+			t.Errorf("bytes_overage_allowed = %v, want true", got["bytes_overage_allowed"])
+		}
+		if got["bytes_granted"] != float64(100_000_000_000) {
+			t.Errorf("bytes_granted = %v, want 100GB", got["bytes_granted"])
+		}
+		if got["bytes_used"] != float64(110_000_000_000) {
+			t.Errorf("bytes_used = %v, want 110GB", got["bytes_used"])
+		}
+		if got["retention_days"] != float64(180) {
+			t.Errorf("retention_days = %v, want 180", got["retention_days"])
+		}
+	})
+
+	t.Run("bytes_overage_allowed=false flows through (e.g. Free, hard-capped Enterprise)", func(t *testing.T) {
+		// The Free plan and any bespoke Enterprise plan with a hard byte
+		// cap configure bytes with overage_allowed=false.
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: autumnPlanFree}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {FeatureID: autumn.FeatureBytes, Granted: 5_000_000_000, Usage: 0, Unlimited: false, OverageAllowed: false},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["bytes_overage_allowed"] != false {
+			t.Errorf("bytes_overage_allowed = %v, want false (Free is hard-capped)", got["bytes_overage_allowed"])
 		}
 	})
 

--- a/frontend/dashboard/__tests__/integration/usage_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/usage_msw_test.tsx
@@ -732,13 +732,19 @@ describe("Usage — billing enabled", () => {
         { timeout: 5000 },
       );
 
-      expect(screen.getByText(/Data included:/)).toBeTruthy();
+      expect(screen.getByText(/^Data:/)).toBeTruthy();
       expect(screen.getByText("Unlimited")).toBeTruthy();
       expect(screen.getByText(/Retention:/)).toBeTruthy();
       expect(screen.getByText("365 days")).toBeTruthy();
       expect(screen.getByText(/Plan period:/)).toBeTruthy();
-      expect(screen.getByText(/Data used this cycle:/)).toBeTruthy();
       expect(screen.getByText("Manage Billing")).toBeTruthy();
+
+      // The Pro-style "this cycle" framing and the prior split
+      // "Data included" / "Data used" wording must not leak onto the
+      // unified enterprise Data line.
+      expect(screen.queryByText(/Data included:/)).toBeNull();
+      expect(screen.queryByText(/Data used:/)).toBeNull();
+      expect(screen.queryByText(/Data used this cycle:/)).toBeNull();
 
       // Pro/Free affordances must not appear on the enterprise screen.
       expect(screen.queryByText("FREE")).toBeNull();
@@ -746,6 +752,39 @@ describe("Usage — billing enabled", () => {
       expect(screen.queryByText("Upgrade to Pro")).toBeNull();
       expect(screen.queryByText("Downgrade to Free")).toBeNull();
       expect(screen.queryByText(/personalised plans/)).toBeNull();
+    });
+
+    it("Enterprise Data line shows 'X of Y used, Z overage' when overage is allowed and used > granted", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/billing/info", () => {
+          return HttpResponse.json(
+            makeBillingInfoFixture({
+              plan: "enterprise",
+              bytes_unlimited: false,
+              bytes_overage_allowed: true,
+              bytes_granted: 100_000_000_000, // 100 GB
+              bytes_used: 110_000_000_000, // 110 GB
+              retention_days: 90,
+              status: "active",
+              current_period_start: 1700000000,
+              current_period_end: 1702678400,
+            }),
+          );
+        }),
+      );
+
+      renderWithProviders(<Usage params={{ teamId: "test-team" }} />);
+      await waitFor(
+        () => {
+          expect(screen.getByText("ENTERPRISE")).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      expect(
+        screen.getByText(/110\.00 GB of 100\.00 GB used, 10\.00 GB overage/),
+      ).toBeTruthy();
+      expect(screen.queryByText("Unlimited")).toBeNull();
     });
 
     it("clicking Manage Billing on enterprise opens the customer portal", async () => {
@@ -804,6 +843,50 @@ describe("Usage — billing enabled", () => {
         writable: true,
         value: originalLocation,
       });
+    });
+  });
+
+  describe("free plan", () => {
+    it("Free card shows the unified Data line driven by Autumn values; Pro pitch keeps marketing copy", async () => {
+      // End-to-end: API returns plan=free with the user's actual byte
+      // figures. The Free card should render "Data: X of Y used" sourced
+      // from the response, and the Pro upgrade pitch alongside it should
+      // keep the marketing bullets (we don't have Pro's Autumn balance
+      // for an unattached user).
+      server.use(
+        http.get("*/api/teams/:teamId/billing/info", () => {
+          return HttpResponse.json(
+            makeBillingInfoFixture({
+              plan: "free",
+              bytes_granted: 5_000_000_000,
+              bytes_used: 1_500_000_000,
+              bytes_unlimited: false,
+              bytes_overage_allowed: false,
+            }),
+          );
+        }),
+      );
+
+      renderWithProviders(<Usage params={{ teamId: "test-team" }} />);
+      await waitFor(
+        () => {
+          expect(screen.getByText("FREE")).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      // Free card: Autumn-driven Data line, no overage suffix.
+      expect(
+        screen.getByText(/1\.50 GB of 5\.00 GB used/),
+      ).toBeTruthy();
+      expect(screen.queryByText(/overage/)).toBeNull();
+      // Removed bullet must not regress.
+      expect(screen.queryByText(/No credit card needed/)).toBeNull();
+
+      // Pro pitch card: marketing constants must still render.
+      expect(screen.getByText(/GB per month included/)).toBeTruthy();
+      expect(screen.getByText(/Extra data charged at \$/)).toBeTruthy();
+      expect(screen.getByText("Upgrade to Pro")).toBeTruthy();
     });
   });
 });

--- a/frontend/dashboard/__tests__/pages/usage_test.tsx
+++ b/frontend/dashboard/__tests__/pages/usage_test.tsx
@@ -1,4 +1,9 @@
 import Usage from "@/app/[teamId]/usage/page";
+import {
+  INCLUDED_PRO_GB,
+  PRICE_PER_GB_MONTH,
+  PRO_RETENTION_DAYS,
+} from "@/app/utils/pricing_constants";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -1186,7 +1191,7 @@ describe("Usage Page", () => {
     expect(screen.getByText(/active/i)).toBeInTheDocument();
     expect(screen.getByText(/Current billing cycle:/)).toBeInTheDocument();
     expect(screen.getByText(/Next invoice:/)).toBeInTheDocument();
-    expect(screen.getByText(/Data used this cycle:/)).toBeInTheDocument();
+    expect(screen.getByText(/^Data:/)).toBeInTheDocument();
   });
 
   it("does not show subscription info when on free plan", async () => {
@@ -1240,59 +1245,34 @@ describe("Usage Page", () => {
     expect(screen.getByText("PRO")).toBeInTheDocument();
   });
 
-  it("shows bytes used in pro plan card", async () => {
+  it("Free plan card shows 'Data: X of Y used' from Autumn values", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
-      billingInfo: { ...proBillingInfo, bytes_used: 1_000_000_000 }, // 1 GB
-      currentUserCanChangePlan: true,
+      fetchBillingInfoApiStatus: 1,
+      billingInfo: {
+        ...freeBillingInfo,
+        bytes_used: 1_000_000_000,
+        bytes_granted: 5_000_000_000,
+      },
     });
 
     await act(async () => {
       render(<Usage params={{ teamId: "team1" }} />);
     });
 
-    const unitsItem = screen.getByText(/Data used this cycle/);
-    expect(unitsItem).toBeInTheDocument();
-    expect(unitsItem.textContent).toMatch(/GB/);
+    expect(screen.getByText(/^Data:/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.00 GB of 5\.00 GB used/)).toBeInTheDocument();
+    // Free has no overage — must not append the overage suffix even if
+    // used > granted (which can't happen on Free in practice).
+    expect(screen.queryByText(/overage/)).not.toBeInTheDocument();
   });
 
-  it("shows bytes used in pro plan card with high usage", async () => {
+  it("Pro upgrade-pitch card shown to free users keeps the marketing copy", async () => {
+    // The Pro card on a Free user's view is purely marketing (we don't have
+    // Pro's Autumn balance for an unattached user). Lock the contract so a
+    // future "use Autumn for everything" attempt doesn't silently delete the
+    // pitch bullets.
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
-      billingInfo: { ...proBillingInfo, bytes_used: 30_000_000_000 }, // 30 GB
-      currentUserCanChangePlan: true,
-    });
-
-    await act(async () => {
-      render(<Usage params={{ teamId: "team1" }} />);
-    });
-
-    const unitsItem = screen.getByText(/Data used this cycle/);
-    expect(unitsItem).toBeInTheDocument();
-    expect(unitsItem.textContent).toMatch(/GB/);
-  });
-
-  it("formats small byte counts with a sub-GB unit", async () => {
-    useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
-      billingInfo: { ...proBillingInfo, bytes_used: 5_000_000 }, // 5 MB
-      currentUserCanChangePlan: true,
-    });
-
-    await act(async () => {
-      render(<Usage params={{ teamId: "team1" }} />);
-    });
-
-    const unitsItem = screen.getByText(/Data used this cycle/);
-    // Must render a human-readable unit — don't assert the exact formatter,
-    // just that it's not a raw byte count or 0 GB.
-    expect(unitsItem.textContent).not.toContain("5000000");
-    expect(unitsItem.textContent).not.toContain("0 GB");
-  });
-
-  it("does not show data used on free plan", async () => {
-    useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      fetchBillingInfoApiStatus: 1,
       billingInfo: freeBillingInfo,
     });
 
@@ -1300,12 +1280,66 @@ describe("Usage Page", () => {
       render(<Usage params={{ teamId: "team1" }} />);
     });
 
-    expect(screen.queryByText(/Data used this cycle/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(`${INCLUDED_PRO_GB} GB per month included`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${PRO_RETENTION_DAYS} days retention`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Extra data charged at $${PRICE_PER_GB_MONTH.toFixed(2)} per GB/month`,
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("does not show subscription details when status is missing on billingInfo", async () => {
+  it("Pro plan Data line shows 'X of Y used' when under quota", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      fetchBillingInfoApiStatus: 1,
+      billingInfo: {
+        ...proBillingInfo,
+        bytes_used: 1_000_000_000, // 1 GB
+        bytes_granted: 25_000_000_000, // 25 GB
+        bytes_overage_allowed: true,
+      },
+      currentUserCanChangePlan: true,
+    });
+
+    await act(async () => {
+      render(<Usage params={{ teamId: "team1" }} />);
+    });
+
+    expect(screen.getByText(/1\.00 GB of 25\.00 GB used/)).toBeInTheDocument();
+    expect(screen.queryByText(/overage/)).not.toBeInTheDocument();
+  });
+
+  it("Pro plan Data line appends ', Z overage' when used > granted and overage is allowed", async () => {
+    useUsageStore.setState({
+      fetchBillingInfoApiStatus: 1,
+      billingInfo: {
+        ...proBillingInfo,
+        bytes_used: 30_000_000_000, // 30 GB
+        bytes_granted: 25_000_000_000, // 25 GB
+        bytes_overage_allowed: true,
+      },
+      currentUserCanChangePlan: true,
+    });
+
+    await act(async () => {
+      render(<Usage params={{ teamId: "team1" }} />);
+    });
+
+    expect(
+      screen.getByText(/30\.00 GB of 25\.00 GB used, 5\.00 GB overage/),
+    ).toBeInTheDocument();
+  });
+
+  it("Subscription block (Status/Cycle/Data) is hidden on pro when status is missing", async () => {
+    // The Data line on Pro lives inside the subscription block; if status
+    // isn't populated yet the whole block is omitted, so "Data:" must not
+    // appear on the Pro card.
+    useUsageStore.setState({
+      fetchBillingInfoApiStatus: 1,
       billingInfo: { ...proBillingInfo, status: undefined },
       currentUserCanChangePlan: true,
     });
@@ -1314,7 +1348,11 @@ describe("Usage Page", () => {
       render(<Usage params={{ teamId: "team1" }} />);
     });
 
-    expect(screen.queryByText(/Data used this cycle/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Status:/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Current billing cycle:/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Data:/)).not.toBeInTheDocument();
   });
 
   // ---- Manage Billing button ----
@@ -1362,11 +1400,9 @@ describe("Usage Page", () => {
   });
 
   it("clicking Manage Billing calls portal API and redirects", async () => {
-    const handleManageBilling = jest
-      .fn()
-      .mockResolvedValue({
-        redirect: "https://billing.stripe.com/session/test",
-      });
+    const handleManageBilling = jest.fn().mockResolvedValue({
+      redirect: "https://billing.stripe.com/session/test",
+    });
     useUsageStore.setState({
       fetchBillingInfoApiStatus: 1, // Success
       billingInfo: proBillingInfo,
@@ -1596,7 +1632,7 @@ describe("Usage Page", () => {
     expect(screen.getByText("ENTERPRISE")).toBeInTheDocument();
   });
 
-  it('shows "Unlimited" data label when bytes_unlimited is true on enterprise', async () => {
+  it("Enterprise Data line reads 'Unlimited' when bytes_unlimited is true", async () => {
     useUsageStore.setState({
       fetchBillingInfoApiStatus: 1,
       billingInfo: enterpriseBillingInfo,
@@ -1606,17 +1642,21 @@ describe("Usage Page", () => {
       render(<Usage params={{ teamId: "team1" }} />);
     });
 
-    expect(screen.getByText(/Data included:/)).toBeInTheDocument();
+    expect(screen.getByText(/^Data:/)).toBeInTheDocument();
     expect(screen.getByText("Unlimited")).toBeInTheDocument();
+    expect(screen.queryByText(/used/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/overage/)).not.toBeInTheDocument();
   });
 
-  it("shows formatted byte allotment when bytes_unlimited is false on enterprise", async () => {
+  it("Enterprise Data line reads 'X of Y used' for bounded plans without overage", async () => {
     useUsageStore.setState({
       fetchBillingInfoApiStatus: 1,
       billingInfo: {
         ...enterpriseBillingInfo,
         bytes_unlimited: false,
         bytes_granted: 100_000_000_000,
+        bytes_used: 5_000_000_000,
+        bytes_overage_allowed: false,
       },
     });
 
@@ -1625,7 +1665,51 @@ describe("Usage Page", () => {
     });
 
     expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
-    expect(screen.getByText(/100\.00 GB/)).toBeInTheDocument();
+    expect(screen.getByText(/5\.00 GB of 100\.00 GB used/)).toBeInTheDocument();
+    expect(screen.queryByText(/overage/)).not.toBeInTheDocument();
+  });
+
+  it("Enterprise Data line appends ', Z overage' when overage allowed and used > granted", async () => {
+    useUsageStore.setState({
+      fetchBillingInfoApiStatus: 1,
+      billingInfo: {
+        ...enterpriseBillingInfo,
+        bytes_unlimited: false,
+        bytes_granted: 100_000_000_000,
+        bytes_used: 110_000_000_000,
+        bytes_overage_allowed: true,
+      },
+    });
+
+    await act(async () => {
+      render(<Usage params={{ teamId: "team1" }} />);
+    });
+
+    expect(
+      screen.getByText(/110\.00 GB of 100\.00 GB used, 10\.00 GB overage/),
+    ).toBeInTheDocument();
+  });
+
+  it("Enterprise Data line omits overage even when used > granted if overage is not allowed", async () => {
+    useUsageStore.setState({
+      fetchBillingInfoApiStatus: 1,
+      billingInfo: {
+        ...enterpriseBillingInfo,
+        bytes_unlimited: false,
+        bytes_granted: 100_000_000_000,
+        bytes_used: 110_000_000_000,
+        bytes_overage_allowed: false,
+      },
+    });
+
+    await act(async () => {
+      render(<Usage params={{ teamId: "team1" }} />);
+    });
+
+    expect(
+      screen.getByText(/110\.00 GB of 100\.00 GB used/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/overage/)).not.toBeInTheDocument();
   });
 
   it("shows retention line when retention_days is set on enterprise", async () => {
@@ -1685,7 +1769,10 @@ describe("Usage Page", () => {
     expect(screen.queryByText(/Plan period:/)).not.toBeInTheDocument();
   });
 
-  it("shows data used this cycle on enterprise", async () => {
+  it("Enterprise card never uses the Pro 'Data used this cycle' wording", async () => {
+    // The Pro framing implies a recurring cycle; Enterprise plans often
+    // aren't recurring. Whatever variant the Data line takes, it's just
+    // "Data:".
     useUsageStore.setState({
       fetchBillingInfoApiStatus: 1,
       billingInfo: enterpriseBillingInfo,
@@ -1695,8 +1782,9 @@ describe("Usage Page", () => {
       render(<Usage params={{ teamId: "team1" }} />);
     });
 
-    expect(screen.getByText(/Data used this cycle:/)).toBeInTheDocument();
-    expect(screen.getByText(/5\.00 GB/)).toBeInTheDocument();
+    expect(screen.queryByText(/Data used this cycle:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Data used:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Data included:/)).not.toBeInTheDocument();
   });
 
   it("hides Free and Pro cards on enterprise plan", async () => {

--- a/frontend/dashboard/app/[teamId]/usage/page.tsx
+++ b/frontend/dashboard/app/[teamId]/usage/page.tsx
@@ -45,6 +45,31 @@ type AppMonthlyUsage = {
   bytes_in: number;
 };
 
+// formatDataLine renders the unified "Data" line shown on the user's
+// current plan card. All inputs come from BillingInfo (i.e. Autumn) so the
+// caller doesn't need plan-specific constants.
+//
+//   - bytes_unlimited           → "Unlimited"
+//   - else, with overage usage  → "X of Y used, Z overage"
+//   - else                      → "X of Y used"
+function formatDataLine(billingInfo: {
+  bytes_used?: number;
+  bytes_granted?: number;
+  bytes_unlimited?: boolean;
+  bytes_overage_allowed?: boolean;
+}): string {
+  if (billingInfo?.bytes_unlimited) {
+    return "Unlimited";
+  }
+  const used = billingInfo?.bytes_used ?? 0;
+  const granted = billingInfo?.bytes_granted ?? 0;
+  const base = `${formatBytesSI(used)} of ${formatBytesSI(granted)} used`;
+  if (billingInfo?.bytes_overage_allowed && used > granted) {
+    return `${base}, ${formatBytesSI(used - granted)} overage`;
+  }
+  return base;
+}
+
 function parseMonths(data: any[]): string[] {
   const monthYearSet: Set<string> = new Set();
   data.forEach((app) => {
@@ -472,11 +497,12 @@ export default function Usage({ params }: { params: { teamId: string } }) {
                       <p className="text-xl font-display">FREE</p>
                       <p className="text-4xl font-display py-2">$0 per month</p>
                       <ul className="list-disc space-y-2 mt-6">
-                        <li className="font-body">{FREE_GB} GB per month</li>
+                        <li className="font-body">
+                          Data: {formatDataLine(billingInfo)}
+                        </li>
                         <li className="font-body">
                           {FREE_RETENTION_DAYS} days retention
                         </li>
-                        <li className="font-body">No credit card needed</li>
                       </ul>
                     </div>
                   </Card>
@@ -544,9 +570,9 @@ export default function Usage({ params }: { params: { teamId: string } }) {
                                 </li>
                               )}
                               <li className="text-green-900 dark:text-foreground">
-                                Data used this cycle:{" "}
+                                Data:{" "}
                                 <span className="font-semibold">
-                                  {formatBytesSI(bytesUsed)}
+                                  {formatDataLine(billingInfo)}
                                 </span>
                               </li>
                             </ul>
@@ -641,11 +667,9 @@ export default function Usage({ params }: { params: { teamId: string } }) {
                       <div className="mt-4 font-body text-start space-y-1">
                         <ul className="list-disc list-inside">
                           <li className="text-green-900 dark:text-foreground">
-                            Data included:{" "}
+                            Data:{" "}
                             <span className="font-semibold">
-                              {billingInfo?.bytes_unlimited
-                                ? "Unlimited"
-                                : formatBytesSI(bytesGranted)}
+                              {formatDataLine(billingInfo)}
                             </span>
                           </li>
                           {billingInfo?.retention_days ? (
@@ -671,12 +695,6 @@ export default function Usage({ params }: { params: { teamId: string } }) {
                               </span>
                             </li>
                           ) : null}
-                          <li className="text-green-900 dark:text-foreground">
-                            Data used this cycle:{" "}
-                            <span className="font-semibold">
-                              {formatBytesSI(bytesUsed)}
-                            </span>
-                          </li>
                         </ul>
                       </div>
                       <div className="pt-12">


### PR DESCRIPTION
# Description

Each plan card now renders one "Data:" line driven by Autumn values:

```
Free   →  Data: X of Y used
Pro    →  Data: X of Y used [, Z overage]
Ent.   →  Data: Unlimited
               Data: X of Y used                       (bounded, no overage)
               Data: X of Y used, Z overage    (bounded, overage allowed)
```               

Backend exposes the new `bytes_overage_allowed` flag on GET /teams/{id}/billing/info, sourced from Autumn's bytes balance. The frontend's shared formatDataLine() helper consumes it, plus the existing `bytes_unlimited` / `bytes_used` / `bytes_granted` fields, to pick the right variant.

Side cleanups on the Free card: drop the hardcoded "{FREE_GB} GB per month" bullet (now redundant with the Data line) and the "No credit card needed" bullet (irrelevant once the user is in the dashboard).



