### PR TITLE
chore(frontend): use consent provider to manage cookie consent

### DIFF
--- a/frontend/dashboard/__tests__/components/conditional_google_tag_manager_test.tsx
+++ b/frontend/dashboard/__tests__/components/conditional_google_tag_manager_test.tsx
@@ -1,0 +1,71 @@
+import { ConditionalGoogleTagManager } from '@/app/components/conditional_google_tag_manager'
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@next/third-parties/google', () => ({
+    GoogleTagManager: ({ gtmId }: { gtmId: string }) => (
+        <div data-testid="gtm" data-gtm-id={gtmId} />
+    ),
+}))
+
+jest.mock('@/app/context/cookie_consent', () => ({
+    useCookieConsent: jest.fn(),
+}))
+
+import { useCookieConsent } from '@/app/context/cookie_consent'
+
+beforeEach(() => {
+    process.env.NEXT_PUBLIC_GTM_ID = 'GTM-TEST'
+    ; (useCookieConsent as jest.Mock).mockReturnValue({
+        consent: 'granted',
+        setConsent: jest.fn(),
+        hydrated: true,
+    })
+})
+
+afterEach(() => {
+    delete process.env.NEXT_PUBLIC_GTM_ID
+})
+
+describe('ConditionalGoogleTagManager', () => {
+    it('renders GoogleTagManager when consent is granted and GTM ID is set', () => {
+        render(<ConditionalGoogleTagManager />)
+
+        const gtm = screen.getByTestId('gtm')
+        expect(gtm).toBeInTheDocument()
+        expect(gtm).toHaveAttribute('data-gtm-id', 'GTM-TEST')
+    })
+
+    it('does not render when consent is pending', () => {
+        ; (useCookieConsent as jest.Mock).mockReturnValue({
+            consent: 'pending',
+            setConsent: jest.fn(),
+            hydrated: true,
+        })
+
+        render(<ConditionalGoogleTagManager />)
+
+        expect(screen.queryByTestId('gtm')).not.toBeInTheDocument()
+    })
+
+    it('does not render when consent is denied', () => {
+        ; (useCookieConsent as jest.Mock).mockReturnValue({
+            consent: 'denied',
+            setConsent: jest.fn(),
+            hydrated: true,
+        })
+
+        render(<ConditionalGoogleTagManager />)
+
+        expect(screen.queryByTestId('gtm')).not.toBeInTheDocument()
+    })
+
+    it('does not render when GTM ID is not set, even if consent is granted', () => {
+        delete process.env.NEXT_PUBLIC_GTM_ID
+
+        render(<ConditionalGoogleTagManager />)
+
+        expect(screen.queryByTestId('gtm')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/dashboard/__tests__/components/cookie_banner_test.tsx
+++ b/frontend/dashboard/__tests__/components/cookie_banner_test.tsx
@@ -2,41 +2,31 @@ import { CookieBanner } from '@/app/components/cookie_banner'
 import { beforeEach, describe, expect, it } from '@jest/globals'
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { usePostHog } from 'posthog-js/react'
 
-jest.mock('posthog-js/react', () => ({
-    usePostHog: jest.fn(),
+jest.mock('@/app/context/cookie_consent', () => ({
+    useCookieConsent: jest.fn(),
 }))
 
-jest.mock('@/app/context/posthog', () => ({
-    usePostHogLoaded: jest.fn().mockReturnValue(true),
-}))
+import { useCookieConsent } from '@/app/context/cookie_consent'
 
-import { usePostHogLoaded } from '@/app/context/posthog'
-
-const mockPostHog = {
-    get_explicit_consent_status: jest.fn(),
-    opt_in_capturing: jest.fn(),
-    opt_out_capturing: jest.fn(),
-}
+const setConsent = jest.fn()
 
 beforeEach(() => {
-    ; (usePostHog as jest.Mock).mockReturnValue(mockPostHog)
-        ; (usePostHogLoaded as jest.Mock).mockReturnValue(true)
+    setConsent.mockClear()
+    ; (useCookieConsent as jest.Mock).mockReturnValue({
+        consent: 'pending',
+        setConsent,
+        hydrated: true,
+    })
 })
 
 describe('CookieBanner', () => {
-    it('does not render banner when posthog is not available', () => {
-        ; (usePostHog as jest.Mock).mockReturnValue(null)
-
-        render(<CookieBanner />)
-
-        expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument()
-    })
-
-    it('does not render banner before posthog has loaded, even when consent would be pending', () => {
-        ; (usePostHogLoaded as jest.Mock).mockReturnValue(false)
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
+    it('does not render banner before hydration', () => {
+        ; (useCookieConsent as jest.Mock).mockReturnValue({
+            consent: 'pending',
+            setConsent,
+            hydrated: false,
+        })
 
         render(<CookieBanner />)
 
@@ -44,16 +34,11 @@ describe('CookieBanner', () => {
     })
 
     it('does not render banner when consent is denied', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('denied')
-
-        render(<CookieBanner />)
-
-        expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument()
-    })
-
-    it('does not render banner when PostHog is blocked and noop returns denied', () => {
-        // Simulates the canary-fetch blocked case: createNoopPostHog returns 'denied'
-        mockPostHog.get_explicit_consent_status.mockReturnValue('denied')
+        ; (useCookieConsent as jest.Mock).mockReturnValue({
+            consent: 'denied',
+            setConsent,
+            hydrated: true,
+        })
 
         render(<CookieBanner />)
 
@@ -61,16 +46,18 @@ describe('CookieBanner', () => {
     })
 
     it('does not render banner when consent is granted', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('granted')
+        ; (useCookieConsent as jest.Mock).mockReturnValue({
+            consent: 'granted',
+            setConsent,
+            hydrated: true,
+        })
 
         render(<CookieBanner />)
 
         expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument()
     })
 
-    it('renders banner when consent is pending', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
+    it('renders banner when consent is pending and hydrated', () => {
         render(<CookieBanner />)
 
         expect(screen.getByText(/we use cookies/i)).toBeInTheDocument()
@@ -79,16 +66,12 @@ describe('CookieBanner', () => {
     })
 
     it('renders the full descriptive text', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
         render(<CookieBanner />)
 
         expect(screen.getByText(/we use cookies to understand how you use the product and help us improve it/i)).toBeInTheDocument()
     })
 
     it('renders privacy policy link with correct href and target', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
         render(<CookieBanner />)
 
         const link = screen.getByRole('link', { name: /privacy policy/i })
@@ -98,34 +81,25 @@ describe('CookieBanner', () => {
     })
 
     it('renders both Accept All and Accept Essential buttons', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
         render(<CookieBanner />)
 
-        const acceptAllButton = screen.getByRole('button', { name: /accept all/i })
-        const acceptEssentialButton = screen.getByRole('button', { name: /accept essential/i })
-
-        expect(acceptAllButton).toBeInTheDocument()
-        expect(acceptEssentialButton).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /accept all/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /accept essential/i })).toBeInTheDocument()
     })
 
-    it('calls opt_in_capturing and hides banner when Accept All is clicked', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
+    it('calls setConsent("granted") when Accept All is clicked', () => {
         render(<CookieBanner />)
         fireEvent.click(screen.getByRole('button', { name: /accept all/i }))
 
-        expect(mockPostHog.opt_in_capturing).toHaveBeenCalledTimes(1)
-        expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument()
+        expect(setConsent).toHaveBeenCalledTimes(1)
+        expect(setConsent).toHaveBeenCalledWith('granted')
     })
 
-    it('calls opt_out_capturing and hides banner when Accept Essential is clicked', () => {
-        mockPostHog.get_explicit_consent_status.mockReturnValue('pending')
-
+    it('calls setConsent("denied") when Accept Essential is clicked', () => {
         render(<CookieBanner />)
         fireEvent.click(screen.getByRole('button', { name: /accept essential/i }))
 
-        expect(mockPostHog.opt_out_capturing).toHaveBeenCalledTimes(1)
-        expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument()
+        expect(setConsent).toHaveBeenCalledTimes(1)
+        expect(setConsent).toHaveBeenCalledWith('denied')
     })
 })

--- a/frontend/dashboard/__tests__/providers/cookie_consent_test.tsx
+++ b/frontend/dashboard/__tests__/providers/cookie_consent_test.tsx
@@ -1,0 +1,158 @@
+import { CookieConsentProvider, useCookieConsent } from "@/app/context/cookie_consent";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@/app/utils/env_utils", () => ({
+  isCloud: jest.fn(),
+}));
+
+import { isCloud } from "@/app/utils/env_utils";
+
+const STORAGE_KEY = "msr_cookie_consent";
+
+function ConsentProbe() {
+  const { consent, hydrated, setConsent } = useCookieConsent();
+  return (
+    <>
+      <div data-testid="consent">{consent}</div>
+      <div data-testid="hydrated">{String(hydrated)}</div>
+      <button data-testid="grant" onClick={() => setConsent("granted")}>grant</button>
+      <button data-testid="deny" onClick={() => setConsent("denied")}>deny</button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("CookieConsentProvider in cloud mode", () => {
+  beforeEach(() => {
+    (isCloud as jest.Mock).mockReturnValue(true);
+  });
+
+  it("starts pending and hydrates from empty storage", async () => {
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hydrated")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("consent")).toHaveTextContent("pending");
+  });
+
+  it("hydrates 'granted' from localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "granted");
+
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toHaveTextContent("granted");
+    });
+  });
+
+  it("hydrates 'denied' from localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "denied");
+
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toHaveTextContent("denied");
+    });
+  });
+
+  it("ignores unknown stored values", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "garbage");
+
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hydrated")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("consent")).toHaveTextContent("pending");
+  });
+
+  it("setConsent('granted') writes to localStorage and updates state", async () => {
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("grant"));
+    });
+
+    expect(screen.getByTestId("consent")).toHaveTextContent("granted");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("granted");
+  });
+
+  it("setConsent('denied') writes to localStorage and updates state", async () => {
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("deny"));
+    });
+
+    expect(screen.getByTestId("consent")).toHaveTextContent("denied");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("denied");
+  });
+});
+
+describe("CookieConsentProvider in self-hosted mode", () => {
+  beforeEach(() => {
+    (isCloud as jest.Mock).mockReturnValue(false);
+  });
+
+  it("forces consent to 'denied' regardless of localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "granted");
+
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    expect(screen.getByTestId("consent")).toHaveTextContent("denied");
+    expect(screen.getByTestId("hydrated")).toHaveTextContent("true");
+  });
+
+  it("setConsent is a noop and does not write to localStorage", async () => {
+    render(
+      <CookieConsentProvider>
+        <ConsentProbe />
+      </CookieConsentProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("grant"));
+    });
+
+    expect(screen.getByTestId("consent")).toHaveTextContent("denied");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/dashboard/__tests__/providers/posthog_provider_test.tsx
+++ b/frontend/dashboard/__tests__/providers/posthog_provider_test.tsx
@@ -1,28 +1,39 @@
 import { PostHogProvider } from "@/app/context/posthog";
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
-import { usePostHog } from "posthog-js/react";
+import { render, waitFor } from "@testing-library/react";
 
 jest.mock("posthog-js", () => ({
   __esModule: true,
   default: {
-    init: jest.fn().mockImplementation((_key: string, opts?: { loaded?: () => void }) => {
-      opts?.loaded?.();
-    }),
-    get_explicit_consent_status: jest.fn().mockReturnValue("pending"),
+    init: jest.fn(),
+    opt_in_capturing: jest.fn(),
+    opt_out_capturing: jest.fn(),
   },
 }));
 
+jest.mock("@/app/utils/env_utils", () => ({
+  isCloud: jest.fn(),
+}));
+
+jest.mock("@/app/context/cookie_consent", () => ({
+  useCookieConsent: jest.fn(),
+}));
+
+import { useCookieConsent } from "@/app/context/cookie_consent";
+import { isCloud } from "@/app/utils/env_utils";
 import posthog from "posthog-js";
 
-function ConsentStatusChild() {
-  const ph = usePostHog();
-  return <div data-testid="status">{ph?.get_explicit_consent_status?.() ?? ""}</div>;
-}
-
 beforeEach(() => {
-  (posthog.get_explicit_consent_status as jest.Mock).mockReturnValue("pending");
+  (posthog.init as jest.Mock).mockClear();
+  (posthog.opt_in_capturing as jest.Mock).mockClear();
+  (posthog.opt_out_capturing as jest.Mock).mockClear();
+  (isCloud as jest.Mock).mockReturnValue(true);
+  (useCookieConsent as jest.Mock).mockReturnValue({
+    consent: "pending",
+    setConsent: jest.fn(),
+    hydrated: true,
+  });
   process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key";
 });
 
@@ -32,23 +43,36 @@ afterEach(() => {
 });
 
 describe("PostHogProvider", () => {
-  it("does not call posthog.init and uses noop client when no API key", () => {
+  it("does not call posthog.init when no API key", () => {
     delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY;
 
     render(
       <PostHogProvider>
-        <ConsentStatusChild />
+        <div />
       </PostHogProvider>,
     );
 
     expect(posthog.init).not.toHaveBeenCalled();
-    expect(screen.getByTestId("status")).toHaveTextContent("denied");
   });
 
-  it("calls posthog.init with correct params when API key is set", async () => {
+  it("does not call posthog.init in self-hosted mode", async () => {
+    (isCloud as jest.Mock).mockReturnValue(false);
+
     render(
       <PostHogProvider>
-        <ConsentStatusChild />
+        <div />
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthog.init).not.toHaveBeenCalled();
+    });
+  });
+
+  it("calls posthog.init with correct params when cloud + API key", async () => {
+    render(
+      <PostHogProvider>
+        <div />
       </PostHogProvider>,
     );
 
@@ -63,8 +87,6 @@ describe("PostHogProvider", () => {
         }),
       );
     });
-
-    expect(screen.getByTestId("status")).toHaveTextContent("pending");
   });
 
   it("uses custom host from NEXT_PUBLIC_POSTHOG_HOST env var", async () => {
@@ -127,5 +149,102 @@ describe("PostHogProvider", () => {
 
     const initCall = (posthog.init as jest.Mock).mock.calls[0][1];
     expect(initCall).not.toHaveProperty("ui_host");
+  });
+});
+
+describe("PostHogProvider consent sync", () => {
+  it("calls opt_in_capturing when consent is 'granted'", async () => {
+    (useCookieConsent as jest.Mock).mockReturnValue({
+      consent: "granted",
+      setConsent: jest.fn(),
+      hydrated: true,
+    });
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1);
+    });
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled();
+  });
+
+  it("calls opt_out_capturing when consent is 'denied'", async () => {
+    (useCookieConsent as jest.Mock).mockReturnValue({
+      consent: "denied",
+      setConsent: jest.fn(),
+      hydrated: true,
+    });
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1);
+    });
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+  });
+
+  it("calls opt_out_capturing when consent is 'pending' so PostHog stays cookieless until user chooses", async () => {
+    (useCookieConsent as jest.Mock).mockReturnValue({
+      consent: "pending",
+      setConsent: jest.fn(),
+      hydrated: true,
+    });
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1);
+    });
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+  });
+
+  it("does not sync consent before hydration", async () => {
+    (useCookieConsent as jest.Mock).mockReturnValue({
+      consent: "granted",
+      setConsent: jest.fn(),
+      hydrated: false,
+    });
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(posthog.init).toHaveBeenCalled();
+    });
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled();
+  });
+
+  it("does not sync consent in self-hosted mode", async () => {
+    (isCloud as jest.Mock).mockReturnValue(false);
+    (useCookieConsent as jest.Mock).mockReturnValue({
+      consent: "denied",
+      setConsent: jest.fn(),
+      hydrated: true,
+    });
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>,
+    );
+
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled();
   });
 });

--- a/frontend/dashboard/app/components/conditional_google_tag_manager.tsx
+++ b/frontend/dashboard/app/components/conditional_google_tag_manager.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { GoogleTagManager } from "@next/third-parties/google";
+import { useCookieConsent } from "../context/cookie_consent";
+
+export function ConditionalGoogleTagManager() {
+  const { consent } = useCookieConsent();
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+
+  if (!gtmId || consent !== "granted") {
+    return null;
+  }
+
+  return <GoogleTagManager gtmId={gtmId} />;
+}

--- a/frontend/dashboard/app/components/cookie_banner.tsx
+++ b/frontend/dashboard/app/components/cookie_banner.tsx
@@ -1,61 +1,45 @@
 "use client";
 
 import Link from "next/link";
-import { usePostHog } from "posthog-js/react";
-import { useEffect, useState } from "react";
-import { usePostHogLoaded } from "../context/posthog";
+import { useCookieConsent } from "../context/cookie_consent";
 import { underlineLinkStyle } from "../utils/shared_styles";
 import { Button } from "./button";
 
 export function CookieBanner() {
-  const posthog = usePostHog();
-  const phLoaded = usePostHogLoaded();
-  const [consentGiven, setConsentGiven] = useState("");
+  const { consent, setConsent, hydrated } = useCookieConsent();
 
-  useEffect(() => {
-    if (phLoaded && posthog) {
-      setConsentGiven(posthog.get_explicit_consent_status());
-    }
-  }, [posthog, phLoaded]);
-
-  const handleAcceptCookies = () => {
-    posthog.opt_in_capturing();
-    setConsentGiven("granted");
-  };
-
-  const handleDeclineCookies = () => {
-    posthog.opt_out_capturing();
-    setConsentGiven("denied");
-  };
+  if (!hydrated || consent !== "pending") {
+    return null;
+  }
 
   return (
-    <>
-      {consentGiven === "pending" && (
-        <div className="fixed bottom-6 left-0 right-0 z-50 flex justify-start">
-          <div className="mx-4 w-full max-w-xl flex flex-col border border-border items-start bg-accent text-accent-foreground font-display rounded-md p-4 shadow-lg">
-            <p>
-              We use cookies to understand how you use the product and help us improve it. To learn
-              more, please see our{" "}
-              <Link target="_blank" className={underlineLinkStyle} href="/privacy-policy">
-                privacy policy
-              </Link>
-              .
-            </p>
-            <div className="flex flex-row gap-2 mt-4">
-              <Button variant="default" onClick={handleAcceptCookies}>
-                Accept All
-              </Button>
-              <Button
-                variant="ghost"
-                className={"text-accent-foreground/50"}
-                onClick={handleDeclineCookies}
-              >
-                Accept Essential
-              </Button>
-            </div>
-          </div>
+    <div className="fixed bottom-6 left-0 right-0 z-50 flex justify-start">
+      <div className="mx-4 w-full max-w-xl flex flex-col border border-border items-start bg-accent text-accent-foreground font-display rounded-md p-4 shadow-lg">
+        <p>
+          We use cookies to understand how you use the product and help us
+          improve it. To learn more, please see our{" "}
+          <Link
+            target="_blank"
+            className={underlineLinkStyle}
+            href="/privacy-policy"
+          >
+            privacy policy
+          </Link>
+          .
+        </p>
+        <div className="flex flex-row gap-2 mt-4">
+          <Button variant="default" onClick={() => setConsent("granted")}>
+            Accept All
+          </Button>
+          <Button
+            variant="ghost"
+            className={"text-accent-foreground/50"}
+            onClick={() => setConsent("denied")}
+          >
+            Accept Essential
+          </Button>
         </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 }

--- a/frontend/dashboard/app/context/cookie_consent.tsx
+++ b/frontend/dashboard/app/context/cookie_consent.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { isCloud } from "../utils/env_utils";
+
+const STORAGE_KEY = "msr_cookie_consent";
+
+export type ConsentStatus = "pending" | "granted" | "denied";
+
+type CookieConsentValue = {
+  consent: ConsentStatus;
+  setConsent: (status: "granted" | "denied") => void;
+  /**
+   * False until the persisted consent value has been read from storage.
+   * Consumers should wait for `hydrated` before reacting to the default
+   * "pending" state, otherwise they may briefly act on it during the first
+   * render before the stored choice is applied. (ex: cookie banner flashing
+   * briefly when initial state is pending and then it's dismissed becuase
+   * storage read completes and state is denied or granted.)
+   */
+  hydrated: boolean;
+};
+
+const CookieConsentContext = createContext<CookieConsentValue>({
+  consent: "denied",
+  setConsent: () => {},
+  hydrated: false,
+});
+
+export function useCookieConsent() {
+  return useContext(CookieConsentContext);
+}
+
+export function CookieConsentProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const cloud = isCloud();
+  const [consent, setConsentState] = useState<ConsentStatus>("pending");
+  const [hydrated, setHydrated] = useState(!cloud);
+
+  useEffect(() => {
+    if (!cloud) {
+      return;
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === "granted" || stored === "denied") {
+        setConsentState(stored);
+      }
+    } catch {
+      // localStorage unavailable (private browsing, blocked storage); leave at "pending"
+    }
+    setHydrated(true);
+  }, [cloud]);
+
+  const setConsent = useCallback(
+    (status: "granted" | "denied") => {
+      if (!cloud) {
+        return;
+      }
+      try {
+        window.localStorage.setItem(STORAGE_KEY, status);
+      } catch {
+        // best-effort persistence; still update in-memory state below
+      }
+      setConsentState(status);
+    },
+    [cloud],
+  );
+
+  const value = useMemo<CookieConsentValue>(
+    () => ({
+      consent: cloud ? consent : "denied",
+      setConsent,
+      hydrated,
+    }),
+    [cloud, consent, setConsent, hydrated],
+  );
+
+  return (
+    <CookieConsentContext.Provider value={value}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+}

--- a/frontend/dashboard/app/context/posthog.tsx
+++ b/frontend/dashboard/app/context/posthog.tsx
@@ -1,24 +1,18 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { isCloud } from "../utils/env_utils";
+import { useCookieConsent } from "./cookie_consent";
 
-const PostHogLoadedContext = createContext(false);
-
-export function usePostHogLoaded() {
-  return useContext(PostHogLoadedContext);
-}
-
-// Returns 'denied' so the cookie banner doesn't show when PostHog is unavailable
 const createNoopPostHog = () =>
   ({
-    get_explicit_consent_status: () => "denied",
-    opt_in_capturing: () => { },
-    opt_out_capturing: () => { },
-    init: () => { },
-    capture: () => { },
+    opt_in_capturing: () => {},
+    opt_out_capturing: () => {},
+    init: () => {},
+    capture: () => {},
   }) as unknown as typeof posthog;
 
 export function PostHogProvider({
@@ -36,35 +30,41 @@ export function PostHogProvider({
   proxyPath?: string;
 }) {
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY;
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+  const host =
+    process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+  const { consent, hydrated } = useCookieConsent();
 
-  const [phLoaded, setPhLoaded] = useState(false);
-
-  const shouldInit = !!apiKey;
+  const shouldInit = isCloud() && !!apiKey;
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
-    if (shouldInit) {
+    if (shouldInit && !initialized) {
       posthog.init(apiKey as string, {
         api_host: proxyPath ?? host,
         ...(proxyPath && { ui_host: "https://us.posthog.com" }),
         person_profiles: "identified_only",
         defaults: "2025-05-24",
         cookieless_mode: "on_reject",
-        loaded: () => setPhLoaded(true),
       });
+      setInitialized(true);
     }
-  }, [shouldInit, apiKey, host, proxyPath]);
+  }, [shouldInit, initialized, apiKey, host, proxyPath]);
 
-  const client = useMemo(() => (shouldInit ? posthog : createNoopPostHog()), [shouldInit]);
+  useEffect(() => {
+    if (!shouldInit || !initialized || !hydrated) {
+      return;
+    }
+    if (consent === "granted") {
+      posthog.opt_in_capturing();
+    } else {
+      posthog.opt_out_capturing();
+    }
+  }, [shouldInit, initialized, hydrated, consent]);
 
-  // When there's no API key the noop client is used immediately — treat as loaded.
-  const phLoadedValue = phLoaded || !shouldInit;
-
-  return (
-    <PHProvider client={client}>
-      <PostHogLoadedContext.Provider value={phLoadedValue}>
-        {children}
-      </PostHogLoadedContext.Provider>
-    </PHProvider>
+  const client = useMemo(
+    () => (shouldInit ? posthog : createNoopPostHog()),
+    [shouldInit],
   );
+
+  return <PHProvider client={client}>{children}</PHProvider>;
 }

--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -1,10 +1,11 @@
-import { GoogleTagManager } from "@next/third-parties/google";
 import type { Metadata, Viewport } from "next";
 import { Fira_Code, Josefin_Sans, Work_Sans } from "next/font/google";
 import { ClientProviders } from "./components/client_providers";
+import { ConditionalGoogleTagManager } from "./components/conditional_google_tag_manager";
 import { CookieBanner } from "./components/cookie_banner";
 import { ThemeProvider } from "./components/theme_provider";
 import { Toaster } from "./components/toaster";
+import { CookieConsentProvider } from "./context/cookie_consent";
 import { PostHogProvider } from "./context/posthog";
 import "./globals.css";
 
@@ -73,13 +74,16 @@ export const viewport: Viewport = {
   minimumScale: 1,
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${josefin_sans.variable} ${work_sans.variable} ${fira_code.variable}`}>
-        {process.env.NEXT_PUBLIC_GTM_ID && (
-          <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
-        )}
+      <body
+        className={`${josefin_sans.variable} ${work_sans.variable} ${fira_code.variable}`}
+      >
         <ClientProviders>
           <ThemeProvider
             attribute="class"
@@ -87,10 +91,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             enableSystem
             disableTransitionOnChange
           >
-            <PostHogProvider proxyPath="/yrtmlt">
+            <CookieConsentProvider>
+              <ConditionalGoogleTagManager />
               <CookieBanner />
-              <div className="bg-background text-foreground">{children}</div>
-            </PostHogProvider>
+              <PostHogProvider proxyPath="/yrtmlt">
+                <div className="bg-background text-foreground">{children}</div>
+              </PostHogProvider>
+            </CookieConsentProvider>
             <Toaster />
           </ThemeProvider>
         </ClientProviders>

--- a/frontend/dashboard/app/utils/env_utils.ts
+++ b/frontend/dashboard/app/utils/env_utils.ts
@@ -1,3 +1,3 @@
 export function isCloud(): boolean {
-    return process.env.NEXT_PUBLIC_IS_CLOUD === 'true';
+  return process.env.NEXT_PUBLIC_IS_CLOUD === "true";
 }


### PR DESCRIPTION
# Description

 Move cookie consent ownership out of the PostHog provider into a standalone CookieConsentProvider backed by localStorage. PostHog and the new ConditionalGoogleTagManager now both read from the same context, which makes it easy to gate any future analytics tool on the same consent.

Also gates the banner, PostHog initialization, and GTM on the NEXT_PUBLIC_IS_CLOUD env var so self-hosted instances don't show the banner or load any third-party scripts.

Note: existing users will see the cookie banner once more on next visit, since the persisted consent moved from PostHog's storage to a new "msr_cookie_consent" key.



