### PR TITLE
feat(ios): add performance tracing apis for objc

### DIFF
--- a/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
+++ b/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
@@ -62,9 +62,9 @@
 
 - (UIView *)createTableHeaderView {
     // Create the header view
-    UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 100)];
-    
-    NSArray *buttonTitles = @[@"SwiftUI Controller", @"Collection Controller"];
+    UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 150)];
+
+    NSArray *buttonTitles = @[@"SwiftUI Controller", @"Collection Controller", @"Track Spans"];
     
     // Create two vertical stack views
     UIStackView *verticalStackView1 = [[UIStackView alloc] init];
@@ -124,9 +124,36 @@
         case 1:
             [self transitionToCollectionViewController];
             break;
+        case 2:
+            [self trackSpans];
+            break;
         default:
             break;
     }
+}
+
+- (void)trackSpans {
+    MsrObjCSpan *parentSpan = [Measure startSpanWithName:@"parent_span"];
+
+    MsrObjCSpanBuilder *childBuilder1 = [Measure createSpanBuilderWithName:@"child_span_1"];
+    [childBuilder1 setParent:parentSpan];
+    MsrObjCSpan *childSpan1 = [childBuilder1 startSpan];
+
+    MsrObjCSpanBuilder *childBuilder2 = [Measure createSpanBuilderWithName:@"child_span_2"];
+    [childBuilder2 setParent:parentSpan];
+    MsrObjCSpan *childSpan2 = [childBuilder2 startSpan];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [childSpan1 setStatus:MsrSpanStatusOk];
+        [childSpan1 end];
+        [childSpan2 setStatus:MsrSpanStatusOk];
+        [childSpan2 end];
+    });
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [parentSpan setStatus:MsrSpanStatusOk];
+        [parentSpan end];
+    });
 }
 
 -(void)transitionToCollectionViewController {

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -184,6 +184,10 @@
 		CF0F95782F5834450018D95D /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = CF0F95772F5834450018D95D /* Recording */; };
 		CF11CCD82F1B996B00EF68E9 /* MockSignalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF11CCD72F1B996B00EF68E9 /* MockSignalStore.swift */; };
 		CF1200002D9BF5A000A3FCF7 /* AtomicBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12FFFF2D9BF5A000A3FCF7 /* AtomicBool.swift */; };
+		CF123F862FAA11E40053856F /* MockAttributeTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF123F852FAA11E40053856F /* MockAttributeTransformer.swift */; };
+		CF123F882FAA11FE0053856F /* BaseAttributeTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF123F872FAA11FE0053856F /* BaseAttributeTransformerTests.swift */; };
+		CF123F8B2FAA121C0053856F /* MsrObjCSpanBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF123F892FAA121C0053856F /* MsrObjCSpanBuilderTests.swift */; };
+		CF123F8C2FAA121C0053856F /* MsrObjCSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF123F8A2FAA121C0053856F /* MsrObjCSpanTests.swift */; };
 		CF12A68E2E97A761001C8112 /* AttributeValueValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12A68D2E97A761001C8112 /* AttributeValueValidator.swift */; };
 		CF12A6902E97B0A9001C8112 /* AttributeValueValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12A68F2E97B0A9001C8112 /* AttributeValueValidatorTests.swift */; };
 		CF12A6F42E97D220001C8112 /* AttachmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12A6F32E97D220001C8112 /* AttachmentStore.swift */; };
@@ -217,6 +221,10 @@
 		CF3095422E9D4D0B002CAC1C /* MockAttachmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3095412E9D4D0B002CAC1C /* MockAttachmentStore.swift */; };
 		CF35CE092F559E4D006D7A0D /* SessionAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF35CE082F559E4D006D7A0D /* SessionAttributeProcessor.swift */; };
 		CF3C913B2F6B17FA00AE7378 /* LayoutSnapshotGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3C913A2F6B17FA00AE7378 /* LayoutSnapshotGeneratorTests.swift */; };
+		CF44B05D2FA8D7E500A03D17 /* MsrObjCSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF44B05A2FA8D7E500A03D17 /* MsrObjCSpan.swift */; };
+		CF44B05E2FA8D7E500A03D17 /* MsrObjCSpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF44B05B2FA8D7E500A03D17 /* MsrObjCSpanBuilder.swift */; };
+		CF44B05F2FA8D7E500A03D17 /* MsrSpanStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF44B05C2FA8D7E500A03D17 /* MsrSpanStatus.swift */; };
+		CF44B0612FA8D80C00A03D17 /* AttributeTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF44B0602FA8D80C00A03D17 /* AttributeTransformer.swift */; };
 		CF48773F2DEEB26B00311F57 /* UIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48773E2DEEB26B00311F57 /* UIApplication+Extension.swift */; };
 		CF4877412DEEB2C000311F57 /* UIWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4877402DEEB2C000311F57 /* UIWindow+Extension.swift */; };
 		CF48E3562DF95E8100FCD26D /* ExceptionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48E3552DF95E8100FCD26D /* ExceptionGenerator.swift */; };
@@ -544,6 +552,10 @@
 		CF041C422ED437F6004B4D28 /* SignalSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalSampler.swift; sourceTree = "<group>"; };
 		CF041C442ED46E7F004B4D28 /* MockSignalSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignalSampler.swift; sourceTree = "<group>"; };
 		CF11CCD72F1B996B00EF68E9 /* MockSignalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignalStore.swift; sourceTree = "<group>"; };
+		CF123F852FAA11E40053856F /* MockAttributeTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAttributeTransformer.swift; sourceTree = "<group>"; };
+		CF123F872FAA11FE0053856F /* BaseAttributeTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAttributeTransformerTests.swift; sourceTree = "<group>"; };
+		CF123F892FAA121C0053856F /* MsrObjCSpanBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrObjCSpanBuilderTests.swift; sourceTree = "<group>"; };
+		CF123F8A2FAA121C0053856F /* MsrObjCSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrObjCSpanTests.swift; sourceTree = "<group>"; };
 		CF12A68D2E97A761001C8112 /* AttributeValueValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeValueValidator.swift; sourceTree = "<group>"; };
 		CF12A68F2E97B0A9001C8112 /* AttributeValueValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeValueValidatorTests.swift; sourceTree = "<group>"; };
 		CF12A6F32E97D220001C8112 /* AttachmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentStore.swift; sourceTree = "<group>"; };
@@ -578,6 +590,10 @@
 		CF3095412E9D4D0B002CAC1C /* MockAttachmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAttachmentStore.swift; sourceTree = "<group>"; };
 		CF35CE082F559E4D006D7A0D /* SessionAttributeProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAttributeProcessor.swift; sourceTree = "<group>"; };
 		CF3C913A2F6B17FA00AE7378 /* LayoutSnapshotGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutSnapshotGeneratorTests.swift; sourceTree = "<group>"; };
+		CF44B05A2FA8D7E500A03D17 /* MsrObjCSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrObjCSpan.swift; sourceTree = "<group>"; };
+		CF44B05B2FA8D7E500A03D17 /* MsrObjCSpanBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrObjCSpanBuilder.swift; sourceTree = "<group>"; };
+		CF44B05C2FA8D7E500A03D17 /* MsrSpanStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrSpanStatus.swift; sourceTree = "<group>"; };
+		CF44B0602FA8D80C00A03D17 /* AttributeTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeTransformer.swift; sourceTree = "<group>"; };
 		CF48773E2DEEB26B00311F57 /* UIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extension.swift"; sourceTree = "<group>"; };
 		CF4877402DEEB2C000311F57 /* UIWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Extension.swift"; sourceTree = "<group>"; };
 		CF48E3552DF95E8100FCD26D /* ExceptionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionGenerator.swift; sourceTree = "<group>"; };
@@ -753,6 +769,7 @@
 				526D179B2D5A1913009A2E90 /* AppAttributeProcessor.swift */,
 				526D179C2D5A1913009A2E90 /* Attribute.swift */,
 				526D179D2D5A1913009A2E90 /* AttributeProcessor.swift */,
+				CF44B0602FA8D80C00A03D17 /* AttributeTransformer.swift */,
 				526D179E2D5A1913009A2E90 /* AttributeValue.swift */,
 				CF12A68D2E97A761001C8112 /* AttributeValueValidator.swift */,
 				526D179F2D5A1913009A2E90 /* ComputeOnceAttributeProcessor.swift */,
@@ -1067,10 +1084,11 @@
 			isa = PBXGroup;
 			children = (
 				52B7F0DE2D757F81001498BC /* AttributeProcessorTests.swift */,
+				CF12A68F2E97B0A9001C8112 /* AttributeValueValidatorTests.swift */,
+				CF123F872FAA11FE0053856F /* BaseAttributeTransformerTests.swift */,
 				52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */,
 				52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */,
 				52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */,
-				CF12A68F2E97B0A9001C8112 /* AttributeValueValidatorTests.swift */,
 			);
 			path = Attribute;
 			sourceTree = "<group>";
@@ -1149,6 +1167,7 @@
 				CF90E9E42F6B16DB00D3351B /* MockAttachmentProcessor.swift */,
 				CF3095412E9D4D0B002CAC1C /* MockAttachmentStore.swift */,
 				52B7F1082D757F81001498BC /* MockAttributeProcessor.swift */,
+				CF123F852FAA11E40053856F /* MockAttributeTransformer.swift */,
 				52B7F10A2D757F81001498BC /* MockBatchStore.swift */,
 				CF1BB4F92DDEFD9F00588506 /* MockBugReportManager.swift */,
 				52B7F10B2D757F81001498BC /* MockConfigLoader.swift */,
@@ -1380,8 +1399,11 @@
 				CFD88D022DA4D4AB0095115E /* Checkpoint.swift */,
 				CFD88CFE2DA4D4760095115E /* InternalSpan.swift */,
 				CFD88D062DA4D4C50095115E /* InvalidSpan.swift */,
+				CF44B05A2FA8D7E500A03D17 /* MsrObjCSpan.swift */,
+				CF44B05B2FA8D7E500A03D17 /* MsrObjCSpanBuilder.swift */,
 				CFD88C692D9E94B40095115E /* MsrSpan.swift */,
 				CFD88D0E2DA796A60095115E /* MsrSpanBuilder.swift */,
+				CF44B05C2FA8D7E500A03D17 /* MsrSpanStatus.swift */,
 				CFD88D122DA798330095115E /* MsrTracer.swift */,
 				526D180D2D5A1913009A2E90 /* SignPost.swift */,
 				CFD88C6A2D9E94B40095115E /* Span.swift */,
@@ -1399,8 +1421,10 @@
 		CFD88D2D2DAB80C30095115E /* Tracing */ = {
 			isa = PBXGroup;
 			children = (
-				CFD88D2E2DAB80EA0095115E /* MsrSpanTests.swift */,
+				CF123F892FAA121C0053856F /* MsrObjCSpanBuilderTests.swift */,
+				CF123F8A2FAA121C0053856F /* MsrObjCSpanTests.swift */,
 				CFD88D762DAFD0A70095115E /* MsrSpanBuilderTests.swift */,
+				CFD88D2E2DAB80EA0095115E /* MsrSpanTests.swift */,
 				CFB838202DAFEF780023592B /* SpanProcessorTests.swift */,
 			);
 			path = Tracing;
@@ -1541,7 +1565,6 @@
 			mainGroup = 524CC5B02C6A4B11001AB506;
 			packageReferences = (
 				CF0F95762F5834450018D95D /* XCRemoteSwiftPackageReference "KSCrash" */,
-				CF79C7642F977453007196E0 /* XCLocalSwiftPackageReference "../../measure" */,
 			);
 			productRefGroup = 524CC5BB2C6A4B11001AB506 /* Products */;
 			projectDirPath = "";
@@ -1689,6 +1712,7 @@
 				CF893DD22E950A7E00D99D45 /* MeasureModelV1ToV2.xcmappingmodel in Sources */,
 				CF1BB3BF2DC0BCA300588506 /* CGFloat+Extension.swift in Sources */,
 				CFD88C6E2D9E94B40095115E /* SpanProcessor.swift in Sources */,
+				CF44B0612FA8D80C00A03D17 /* AttributeTransformer.swift in Sources */,
 				CFD88C6F2D9E94B40095115E /* MsrSpan.swift in Sources */,
 				CFD88C702D9E94B40095115E /* Span.swift in Sources */,
 				526D184F2D5A1913009A2E90 /* Exception.swift in Sources */,
@@ -1787,6 +1811,9 @@
 				CF1BB54F2DE436F300588506 /* MsrColors.swift in Sources */,
 				526D18252D5A1913009A2E90 /* LaunchCallbacks.swift in Sources */,
 				CF12A6F42E97D220001C8112 /* AttachmentStore.swift in Sources */,
+				CF44B05D2FA8D7E500A03D17 /* MsrObjCSpan.swift in Sources */,
+				CF44B05E2FA8D7E500A03D17 /* MsrObjCSpanBuilder.swift in Sources */,
+				CF44B05F2FA8D7E500A03D17 /* MsrSpanStatus.swift in Sources */,
 				526D18592D5A1913009A2E90 /* NetworkClient.swift in Sources */,
 				CF48E3562DF95E8100FCD26D /* ExceptionGenerator.swift in Sources */,
 				526D184E2D5A1913009A2E90 /* UserTriggeredEventCollector.swift in Sources */,
@@ -1859,6 +1886,8 @@
 				CF1BB4F52DDEFCCB00588506 /* ShakeBugReportCollectorTests.swift in Sources */,
 				CFD88D792DAFDA530095115E /* MockSpanStore.swift in Sources */,
 				52B7F1372D757F81001498BC /* UserAttributeProcessorTests.swift in Sources */,
+				CF123F8B2FAA121C0053856F /* MsrObjCSpanBuilderTests.swift in Sources */,
+				CF123F8C2FAA121C0053856F /* MsrObjCSpanTests.swift in Sources */,
 				52B7F16A2D757F81001498BC /* MockSystemFileManager.swift in Sources */,
 				52B7F1502D757F81001498BC /* TestDataGenerator.swift in Sources */,
 				CFD88D312DAB8CA60095115E /* MockSpanProcessor.swift in Sources */,
@@ -1876,6 +1905,7 @@
 				CFD88D772DAFD0A70095115E /* MsrSpanBuilderTests.swift in Sources */,
 				52B7F1542D757F81001498BC /* MockAttributeProcessor.swift in Sources */,
 				CF7CABB92F278BF900A9DC30 /* MockHttpClient.swift in Sources */,
+				CF123F882FAA11FE0053856F /* BaseAttributeTransformerTests.swift in Sources */,
 				52B7F16D2D757F81001498BC /* MockUserPermissionManager.swift in Sources */,
 				52B7F1632D757F81001498BC /* MockNetworkClient.swift in Sources */,
 				CF83E2E52E0DA3AE00FE7041 /* MockMeasureDispatchQueue.swift in Sources */,
@@ -1887,6 +1917,7 @@
 				CFE1DD542F62EC6C003BD29B /* CrashReportManagerTests.swift in Sources */,
 				52B7F15E2D757F81001498BC /* MockEventStore.swift in Sources */,
 				52B7F1592D757F81001498BC /* MockCoreDataManager.swift in Sources */,
+				CF123F862FAA11E40053856F /* MockAttributeTransformer.swift in Sources */,
 				CFD88D2F2DAB80EA0095115E /* MsrSpanTests.swift in Sources */,
 				CF4EA2D72EA246700020FC71 /* MockExceptionGenerator.swift in Sources */,
 				CF7CABBB2F27BE4000A9DC30 /* SignalStoreTests.swift in Sources */,
@@ -2461,13 +2492,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		CF79C7642F977453007196E0 /* XCLocalSwiftPackageReference "../../measure" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../measure;
-		};
-/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		CF0F95762F5834450018D95D /* XCRemoteSwiftPackageReference "KSCrash" */ = {

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -260,6 +260,56 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   #endif
   @objc deinit
 }
+@_hasMissingDesignatedInitializers @objc final public class MsrObjCSpan : ObjectiveC.NSObject {
+  @objc final public var traceId: Swift.String {
+    @objc get
+  }
+  @objc final public var spanId: Swift.String {
+    @objc get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc final public var parentId: Swift.String? {
+    @objc get
+  }
+  #endif
+  @objc final public var isSampled: Swift.Bool {
+    @objc get
+  }
+  @objc final public func setStatus(_ status: Measure.MsrSpanStatus)
+  @objc final public func setParent(_ parentSpan: Measure.MsrObjCSpan)
+  @objc final public func setCheckpoint(_ name: Swift.String)
+  @objc final public func setName(_ name: Swift.String)
+  @objc final public func setAttributeString(_ key: Swift.String, value: Swift.String)
+  @objc final public func setAttributeInt(_ key: Swift.String, value: Swift.Int)
+  @objc final public func setAttributeDouble(_ key: Swift.String, value: Swift.Double)
+  @objc final public func setAttributeBool(_ key: Swift.String, value: Swift.Bool)
+  @objc final public func setAttributes(_ attributes: [Swift.String : Any])
+  @objc final public func removeAttribute(_ key: Swift.String)
+  @objc final public func end()
+  @objc(endWithTimestamp:) final public func end(timestamp: Swift.Int64)
+  @objc final public func hasEnded() -> Swift.Bool
+  @objc final public func getDuration() -> Swift.Int64
+  @objc deinit
+}
+@_hasMissingDesignatedInitializers @objc final public class MsrObjCSpanBuilder : ObjectiveC.NSObject {
+  @discardableResult
+  @objc final public func setParent(_ span: Measure.MsrObjCSpan) -> Measure.MsrObjCSpanBuilder
+  @objc final public func startSpan() -> Measure.MsrObjCSpan
+  @objc(startSpanWithTimestamp:) final public func startSpan(timestamp: Swift.Int64) -> Measure.MsrObjCSpan
+  @objc deinit
+}
+@objc public enum MsrSpanStatus : Swift.Int {
+  case unset = 0
+  case ok = 1
+  case error = 2
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init?(rawValue: Swift.Int)
+  #endif
+  public typealias RawValue = Swift.Int
+  public var rawValue: Swift.Int {
+    get
+  }
+}
 @objc public protocol MsrRequestHeadersProvider : ObjectiveC.NSObjectProtocol {
   @objc func getRequestHeaders() -> Foundation.NSDictionary
 }
@@ -364,7 +414,13 @@ extension Measure.Measure {
   public static func createSpanBuilder(name: Swift.String) -> (any Measure.SpanBuilder)?
   #endif
   public static func getTraceParentHeaderValue(span: any Measure.Span) -> Swift.String
-  public static func getTraceParentHeaderKey() -> Swift.String
+  @objc public static func getTraceParentHeaderKey() -> Swift.String
+  @objc(startSpanWithName:) public static func startSpanObjC(name: Swift.String) -> Measure.MsrObjCSpan
+  @objc(startSpanWithName:timestamp:) public static func startSpanObjC(name: Swift.String, timestamp: Swift.Int64) -> Measure.MsrObjCSpan
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(createSpanBuilderWithName:) public static func createSpanBuilderObjC(name: Swift.String) -> Measure.MsrObjCSpanBuilder?
+  #endif
+  @objc(getTraceParentHeaderValueForSpan:) public static func getTraceParentHeaderValue(objcSpan: Measure.MsrObjCSpan) -> Swift.String
   #if compiler(>=5.3) && $NonescapableTypes
   public static func launchBugReport(takeScreenshot: Swift.Bool = true, bugReportConfig: Measure.BugReportConfig = .default, attributes: [Swift.String : Measure.AttributeValue]? = nil)
   #endif
@@ -447,6 +503,9 @@ extension Measure.ScreenshotMaskLevel : Swift.RawRepresentable {}
 extension Measure.ScreenshotMaskLevelObjc : Swift.Equatable {}
 extension Measure.ScreenshotMaskLevelObjc : Swift.Hashable {}
 extension Measure.ScreenshotMaskLevelObjc : Swift.RawRepresentable {}
+extension Measure.MsrSpanStatus : Swift.Equatable {}
+extension Measure.MsrSpanStatus : Swift.Hashable {}
+extension Measure.MsrSpanStatus : Swift.RawRepresentable {}
 extension Measure.VCLifecycleEventType : Swift.Equatable {}
 extension Measure.VCLifecycleEventType : Swift.Hashable {}
 extension Measure.VCLifecycleEventType : Swift.RawRepresentable {}

--- a/ios/Sources/MeasureSDK/Swift/Attribute/AttributeTransformer.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/AttributeTransformer.swift
@@ -1,0 +1,48 @@
+//
+//  AttributeTransformer.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 04/05/26.
+//
+
+import Foundation
+
+protocol AttributeTransformer {
+    func transformAttributes(_ attributes: [String: Any]?) -> [String: AttributeValue]
+}
+
+final class BaseAttributeTransformer: AttributeTransformer {
+    private let logger: Logger?
+
+    init(logger: Logger? = nil) {
+        self.logger = logger
+    }
+
+    func transformAttributes(_ attributes: [String: Any]?) -> [String: AttributeValue] {
+        guard let attributes = attributes else {
+            return [:]
+        }
+
+        var transformedAttributes: [String: AttributeValue] = [:]
+
+        for (key, value) in attributes {
+            if let boolVal = value as? Bool {
+                transformedAttributes[key] = .boolean(boolVal)
+            } else if let stringVal = value as? String {
+                transformedAttributes[key] = .string(stringVal)
+            } else if let intVal = value as? Int {
+                transformedAttributes[key] = .int(intVal)
+            } else if let longVal = value as? Int64 {
+                transformedAttributes[key] = .long(longVal)
+            } else if let floatVal = value as? Float {
+                transformedAttributes[key] = .float(floatVal)
+            } else if let doubleVal = value as? Double {
+                transformedAttributes[key] = .double(doubleVal)
+            } else {
+                logger?.log(level: .fatal, message: "Attribute value can only be a string, boolean, integer, or double.", error: nil, data: nil)
+            }
+        }
+
+        return transformedAttributes
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -200,6 +200,26 @@ import UIKit
         return measureInternal.getTraceParentHeaderKey()
     }
 
+    func startSpanObjC(name: String) -> MsrObjCSpan {
+        guard let measureInternal = self.measureInternal else { return .invalid }
+        return measureInternal.startSpanObjC(name: name)
+    }
+
+    func startSpanObjC(name: String, timestamp: Int64) -> MsrObjCSpan {
+        guard let measureInternal = self.measureInternal else { return .invalid }
+        return measureInternal.startSpanObjC(name: name, timestamp: timestamp)
+    }
+
+    func createSpanBuilderObjC(name: String) -> MsrObjCSpanBuilder? {
+        guard let measureInternal = self.measureInternal else { return nil }
+        return measureInternal.createSpanBuilderObjC(name: name)
+    }
+
+    func getTraceParentHeaderValue(objcSpan: MsrObjCSpan) -> String {
+        guard let measureInternal = self.measureInternal else { return "" }
+        return measureInternal.getTraceParentHeaderValue(for: objcSpan)
+    }
+
     func launchBugReport(takeScreenshot: Bool = true,
                          bugReportConfig: BugReportConfig = .default,
                          attributes: [String: AttributeValue]? = nil) {
@@ -659,8 +679,50 @@ extension Measure {
     /// Returns the W3C traceparent header key/name.
     /// - Returns: The standardized header key 'traceparent' that should be used when adding
     /// distributed tracing context to HTTP requests
-    public static func getTraceParentHeaderKey() -> String {
+    @objc public static func getTraceParentHeaderKey() -> String {
         Measure.shared.getTraceParentHeaderKey()
+    }
+
+    /// Starts a new performance tracing span with the specified name. For use from Objective-C.
+    /// - Parameter name: The name to identify this span.
+    /// - Returns: A new span if the SDK is initialized, or a no-op span if not initialized.
+    ///
+    /// In Swift, use `startSpan(name:)` which returns the `Span` protocol directly.
+    @objc(startSpanWithName:)
+    public static func startSpanObjC(name: String) -> MsrObjCSpan {
+        Measure.shared.startSpanObjC(name: name)
+    }
+
+    /// Starts a new performance tracing span with the specified name and start timestamp. For use from Objective-C.
+    /// - Parameters:
+    ///   - name: The name to identify this span.
+    ///   - timestamp: The milliseconds since epoch when the span started. Obtain via `getCurrentTime()`.
+    /// - Returns: A new span if the SDK is initialized, or a no-op span if not initialized.
+    ///
+    /// In Swift, use `startSpan(name:timestamp:)` which returns the `Span` protocol directly.
+    @objc(startSpanWithName:timestamp:)
+    public static func startSpanObjC(name: String, timestamp: Int64) -> MsrObjCSpan {
+        Measure.shared.startSpanObjC(name: name, timestamp: timestamp)
+    }
+
+    /// Creates a configurable span builder for deferred span creation. For use from Objective-C.
+    /// - Parameter name: The name to identify this span.
+    /// - Returns: A builder instance if the SDK is initialized, or nil if not initialized.
+    ///
+    /// In Swift, use `createSpanBuilder(name:)` which returns the `SpanBuilder` protocol directly.
+    @objc(createSpanBuilderWithName:)
+    public static func createSpanBuilderObjC(name: String) -> MsrObjCSpanBuilder? {
+        Measure.shared.createSpanBuilderObjC(name: name)
+    }
+
+    /// Returns the W3C traceparent header value for the given span. For use from Objective-C.
+    /// - Parameter span: The `MsrObjCSpan` to extract the traceparent header value from.
+    /// - Returns: A W3C trace context compliant header value in the format: `{version}-{traceId}-{spanId}-{traceFlags}`
+    ///
+    /// In Swift, use `getTraceParentHeaderValue(span:)` which accepts the `Span` protocol directly.
+    @objc(getTraceParentHeaderValueForSpan:)
+    public static func getTraceParentHeaderValue(objcSpan: MsrObjCSpan) -> String {
+        Measure.shared.getTraceParentHeaderValue(objcSpan: objcSpan)
     }
 
     /// Takes a screenshot and launches the bug report flow.

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -75,6 +75,7 @@ protocol MeasureInitializer {
     var measureDispatchQueue: MeasureDispatchQueue { get }
     var attributeValueValidator: AttributeValueValidator { get }
     var signalSampler: SignalSampler { get }
+    var attributeTransformer: AttributeTransformer { get }
 }
 
 /// `BaseMeasureInitializer` is responsible for setting up the internal configuration
@@ -211,6 +212,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
     let attributeValueValidator: AttributeValueValidator
     let attachmentStore: AttachmentStore
     let signalSampler: SignalSampler
+    let attributeTransformer: AttributeTransformer
 
     init(config: MeasureConfig, // swiftlint:disable:this function_body_length
          client: Client) {
@@ -225,6 +227,7 @@ final class BaseMeasureInitializer: MeasureInitializer {
         self.configProvider.setMeasureUrl(url: client.apiUrl.absoluteString)
         self.userDefaultStorage = BaseUserDefaultStorage()
         self.logger = MeasureLogger(enabled: config.enableLogging)
+        self.attributeTransformer = BaseAttributeTransformer(logger: logger)
         self.systemFileManager = BaseSystemFileManager(logger: logger)
         self.httpClient = BaseHttpClient(logger: logger, configProvider: configProvider)
         self.networkClient = BaseNetworkClient(client: client,

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -162,6 +162,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     private var launchTracker: LaunchTracker {
         return measureInitializer.launchTracker
     }
+    var attributeTransformer: AttributeTransformer {
+        return measureInitializer.attributeTransformer
+    }
     private let lifecycleObserver: LifecycleObserver
     var isStarted: Bool = false
     var previousSessionCrashed = false
@@ -291,7 +294,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func trackEvent(_ name: String, attributes: [String: Any], timestamp: NSNumber?) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
 
         customEventCollector.trackEvent(name: name, attributes: transformedAttributes, timestamp: timestamp?.int64Value)
     }
@@ -305,7 +308,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func trackScreenView(_ screenName: String, attributes: [String: Any]?) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
 
         userTriggeredEventCollector.trackScreenView(screenName, attributes: transformedAttributes)
     }
@@ -332,6 +335,23 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
 
     func getTraceParentHeaderKey() -> String {
         return spanCollector.getTraceParentHeaderKey()
+    }
+
+    func startSpanObjC(name: String) -> MsrObjCSpan {
+        MsrObjCSpan(startSpan(name: name), attributeTransformer: attributeTransformer)
+    }
+
+    func startSpanObjC(name: String, timestamp: Int64) -> MsrObjCSpan {
+        MsrObjCSpan(startSpan(name: name, timestamp: timestamp), attributeTransformer: attributeTransformer)
+    }
+
+    func createSpanBuilderObjC(name: String) -> MsrObjCSpanBuilder? {
+        guard let builder = createSpan(name: name) else { return nil }
+        return MsrObjCSpanBuilder(builder, attributeTransformer: attributeTransformer)
+    }
+
+    func getTraceParentHeaderValue(for objcSpan: MsrObjCSpan) -> String {
+        getTraceParentHeaderValue(for: objcSpan.span)
     }
 
     func startBugReportFlow(takeScreenshot: Bool = true,
@@ -373,7 +393,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
                             attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
         startBugReportFlow(takeScreenshot: takeScreenshot, bugReportConfig: bugReportConfig, attributes: transformedAttributes)
     }
 
@@ -382,7 +402,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
                         attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
         trackBugReport(description: description, attachments: attachments, attributes: transformedAttributes)
     }
 
@@ -395,7 +415,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func trackError(_ error: NSError, attributes: [String: Any]? = nil, collectStackTraces: Bool) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
         userTriggeredEventCollector.trackError(error, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
     }
 
@@ -408,7 +428,7 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func trackException(_ exception: NSException, attributes: [String: Any]? = nil, collectStackTraces: Bool) {
         guard isStarted else { return }
 
-        let transformedAttributes = transformAttributes(attributes)
+        let transformedAttributes = attributeTransformer.transformAttributes(attributes)
         userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
     }
 
@@ -522,33 +542,6 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.appLaunchCollector.enable()
     }
 
-    private func transformAttributes(_ attributes: [String: Any]?) -> [String: AttributeValue] {
-        guard let attributes = attributes else {
-            return [:]
-        }
-
-        var transformedAttributes: [String: AttributeValue] = [:]
-
-        for (key, value) in attributes {
-            if let stringVal = value as? String {
-                transformedAttributes[key] = .string(stringVal)
-            } else if let boolVal = value as? Bool {
-                transformedAttributes[key] = .boolean(boolVal)
-            } else if let intVal = value as? Int {
-                transformedAttributes[key] = .int(intVal)
-            } else if let longVal = value as? Int64 {
-                transformedAttributes[key] = .long(longVal)
-            } else if let floatVal = value as? Float {
-                transformedAttributes[key] = .float(floatVal)
-            } else if let doubleVal = value as? Double {
-                transformedAttributes[key] = .double(doubleVal)
-            } else {
-                logger.log(level: .fatal, message: "MeasureInternal: Attribute value can only be a string, boolean, integer, or double.", error: nil, data: nil)
-            }
-        }
-
-        return transformedAttributes
-    }
 
     private func trackSessionStart(_ sessionId: String, timestamp: Number) {
         self.signalProcessor.track(data: SessionStartData(),

--- a/ios/Sources/MeasureSDK/Swift/Tracing/MsrObjCSpan.swift
+++ b/ios/Sources/MeasureSDK/Swift/Tracing/MsrObjCSpan.swift
@@ -1,0 +1,117 @@
+//
+//  MsrObjCSpan.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 04/05/26.
+//
+
+import Foundation
+
+/// Objective-C compatible wrapper for a tracing span.
+///
+/// Obtain instances via `Measure.startSpan(name:)` or `MsrObjCSpanBuilder.startSpan()`.
+/// In Swift, use the `Span` protocol directly instead.
+///
+/// Example:
+/// ```objc
+/// MsrObjCSpan *span = [Measure startSpanWithName:@"load_data"];
+/// // perform work
+/// [span setCheckpoint:@"data_fetched"];
+/// [span setStatus:MsrSpanStatusOk];
+/// [span end];
+/// ```
+@objc public final class MsrObjCSpan: NSObject {
+    static let invalid = MsrObjCSpan(InvalidSpan(), attributeTransformer: BaseAttributeTransformer())
+
+    let span: Span
+    private let attributeTransformer: AttributeTransformer
+
+    init(_ span: Span, attributeTransformer: AttributeTransformer) {
+        self.span = span
+        self.attributeTransformer = attributeTransformer
+    }
+
+    /// The unique identifier for the trace this span belongs to.
+    @objc public var traceId: String { span.traceId }
+
+    /// The unique identifier for this span.
+    @objc public var spanId: String { span.spanId }
+
+    /// The span ID of this span's parent, or nil if this is a root span.
+    @objc public var parentId: String? { span.parentId }
+
+    /// Whether this span has been selected for collection and export.
+    @objc public var isSampled: Bool { span.isSampled }
+
+    /// Updates the status of this span. No-op if called after the span has ended.
+    @objc public func setStatus(_ status: MsrSpanStatus) {
+        _ = span.setStatus(status.spanStatus)
+    }
+
+    /// Sets the parent span, establishing a hierarchical relationship. No-op if called after the span has ended.
+    @objc public func setParent(_ parentSpan: MsrObjCSpan) {
+        _ = span.setParent(parentSpan.span)
+    }
+
+    /// Adds a checkpoint marking a significant moment during the span's lifetime. No-op if called after the span has ended.
+    @objc public func setCheckpoint(_ name: String) {
+        _ = span.setCheckpoint(name)
+    }
+
+    /// Updates the name of the span. No-op if called after the span has ended.
+    @objc public func setName(_ name: String) {
+        _ = span.setName(name)
+    }
+
+    /// Adds a string attribute to this span.
+    @objc public func setAttributeString(_ key: String, value: String) {
+        _ = span.setAttribute(key, value: value)
+    }
+
+    /// Adds an integer attribute to this span.
+    @objc public func setAttributeInt(_ key: String, value: Int) {
+        _ = span.setAttribute(key, value: value)
+    }
+
+    /// Adds a double attribute to this span.
+    @objc public func setAttributeDouble(_ key: String, value: Double) {
+        _ = span.setAttribute(key, value: value)
+    }
+
+    /// Adds a boolean attribute to this span.
+    @objc public func setAttributeBool(_ key: String, value: Bool) {
+        _ = span.setAttribute(key, value: value)
+    }
+
+    /// Adds multiple attributes to this span. Supported value types: String, Bool, Int, Int64, Float, Double.
+    /// Unsupported types are silently ignored.
+    @objc public func setAttributes(_ attributes: [String: Any]) {
+        _ = span.setAttributes(attributeTransformer.transformAttributes(attributes))
+    }
+
+    /// Removes an attribute from this span. No-op if the attribute does not exist.
+    @objc public func removeAttribute(_ key: String) {
+        _ = span.removeAttribute(key)
+    }
+
+    /// Marks this span as completed, recording its end time.
+    @objc public func end() {
+        _ = span.end()
+    }
+
+    /// Marks this span as completed using the specified end time.
+    /// - Parameter timestamp: The end time in milliseconds since epoch, obtained via `Measure.getCurrentTime()`.
+    @objc(endWithTimestamp:) public func end(timestamp: Int64) {
+        _ = span.end(timestamp: timestamp)
+    }
+
+    /// Returns true if `end()` has been called on this span.
+    @objc public func hasEnded() -> Bool {
+        span.hasEnded()
+    }
+
+    /// Returns the duration of this span in milliseconds, or 0 if the span has not ended yet.
+    @objc public func getDuration() -> Int64 {
+        span.getDuration()
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Tracing/MsrObjCSpanBuilder.swift
+++ b/ios/Sources/MeasureSDK/Swift/Tracing/MsrObjCSpanBuilder.swift
@@ -1,0 +1,47 @@
+//
+//  MsrObjCSpanBuilder.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 04/05/26.
+//
+
+import Foundation
+
+/// Objective-C compatible wrapper for configuring and creating a new span.
+///
+/// Obtain instances via `Measure.createSpanBuilder(name:)`.
+/// In Swift, use the `SpanBuilder` protocol directly instead.
+///
+/// Example:
+/// ```objc
+/// MsrObjCSpanBuilder *builder = [Measure createSpanBuilderWithName:@"load_data"];
+/// [builder setParent:parentSpan];
+/// MsrObjCSpan *span = [builder startSpan];
+/// ```
+@objc public final class MsrObjCSpanBuilder: NSObject {
+    private let builder: SpanBuilder
+    private let attributeTransformer: AttributeTransformer
+
+    init(_ builder: SpanBuilder, attributeTransformer: AttributeTransformer) {
+        self.builder = builder
+        self.attributeTransformer = attributeTransformer
+    }
+
+    /// Sets the parent span for the span being built. Returns the builder for method chaining.
+    @discardableResult
+    @objc public func setParent(_ span: MsrObjCSpan) -> MsrObjCSpanBuilder {
+        _ = builder.setParent(span.span)
+        return self
+    }
+
+    /// Creates and starts a new span with the current time.
+    @objc public func startSpan() -> MsrObjCSpan {
+        MsrObjCSpan(builder.startSpan(), attributeTransformer: attributeTransformer)
+    }
+
+    /// Creates and starts a new span with the specified start time.
+    /// - Parameter timestamp: The start time in milliseconds since epoch, obtained via `Measure.getCurrentTime()`.
+    @objc(startSpanWithTimestamp:) public func startSpan(timestamp: Int64) -> MsrObjCSpan {
+        MsrObjCSpan(builder.startSpan(timestamp), attributeTransformer: attributeTransformer)
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Tracing/MsrSpanStatus.swift
+++ b/ios/Sources/MeasureSDK/Swift/Tracing/MsrSpanStatus.swift
@@ -1,0 +1,32 @@
+//
+//  MsrSpanStatus.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 04/05/26.
+//
+
+import Foundation
+
+/// Objective-C compatible span status. Use this type when calling span APIs from Objective-C.
+///
+/// In Swift, use `SpanStatus` directly instead.
+@objc public enum MsrSpanStatus: Int {
+    /// Default value. The operation's outcome is unset.
+    case unset = 0
+
+    /// The operation completed successfully.
+    case ok = 1 // swiftlint:disable:this identifier_name
+
+    /// The operation ended in a failure.
+    case error = 2
+}
+
+extension MsrSpanStatus {
+    var spanStatus: SpanStatus {
+        switch self {
+        case .unset: return .unset
+        case .ok: return .ok
+        case .error: return .error
+        }
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Attribute/BaseAttributeTransformerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/BaseAttributeTransformerTests.swift
@@ -1,0 +1,103 @@
+//
+//  BaseAttributeTransformerTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 05/05/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class BaseAttributeTransformerTests: XCTestCase {
+    private var logger: MockLogger!
+    private var transformer: BaseAttributeTransformer!
+
+    override func setUp() {
+        super.setUp()
+        logger = MockLogger()
+        transformer = BaseAttributeTransformer(logger: logger)
+    }
+
+    override func tearDown() {
+        logger = nil
+        transformer = nil
+        super.tearDown()
+    }
+
+    func test_returnsEmptyDict_whenInputIsNil() {
+        let result = transformer.transformAttributes(nil)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_convertsStringValue() {
+        let result = transformer.transformAttributes(["key": "hello"])
+        guard case .string(let value) = result["key"] else {
+            return XCTFail("Expected .string, got \(String(describing: result["key"]))")
+        }
+        XCTAssertEqual(value, "hello")
+    }
+
+    func test_convertsBoolValue() {
+        let result = transformer.transformAttributes(["key": true])
+        guard case .boolean(let value) = result["key"] else {
+            return XCTFail("Expected .boolean, got \(String(describing: result["key"]))")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func test_convertsIntValue() {
+        let result = transformer.transformAttributes(["key": 42])
+        guard case .int(let value) = result["key"] else {
+            return XCTFail("Expected .int, got \(String(describing: result["key"]))")
+        }
+        XCTAssertEqual(value, 42)
+    }
+
+    func test_convertsInt64Value() {
+        let result = transformer.transformAttributes(["key": Int64(9_000_000_000)])
+        guard case .long(let value) = result["key"] else {
+            return XCTFail("Expected .long, got \(String(describing: result["key"]))")
+        }
+        XCTAssertEqual(value, 9_000_000_000)
+    }
+
+    func test_convertsFloatValue() {
+        let result = transformer.transformAttributes(["key": Float(1.5)])
+        guard case .float(let value) = result["key"] else {
+            return XCTFail("Expected .float, got \(String(describing: result["key"]))")
+        }
+        XCTAssertEqual(value, Float(1.5))
+    }
+
+    func test_convertsDoubleValue() {
+        let result = transformer.transformAttributes(["key": Double(2.5)])
+        guard case .double(let value) = result["key"] else {
+            return XCTFail("Expected .double, got \(String(describing: result["key"]))")
+        }
+        XCTAssertEqual(value, 2.5)
+    }
+
+    func test_skipsUnsupportedTypes() {
+        let result = transformer.transformAttributes(["key": NSArray()])
+        XCTAssertNil(result["key"])
+    }
+
+    func test_prefersBoolOverInt_forNSNumberBoolValues() {
+        // NSNumber(value: true) satisfies both `as? Bool` and `as? Int` when bridged from ObjC.
+        // The transformer must resolve to .boolean, not .int.
+        let result = transformer.transformAttributes(["flag": NSNumber(value: true)])
+        guard case .boolean(let value) = result["flag"] else {
+            return XCTFail("Expected .boolean, got \(String(describing: result["flag"]))")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func test_logsError_whenValueTypeIsUnsupported() {
+        var capturedLevel: LogLevel?
+        logger.onLog = { level, _, _, _ in capturedLevel = level }
+
+        _ = transformer.transformAttributes(["key": NSArray()])
+
+        XCTAssertEqual(capturedLevel, .fatal)
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockAttributeTransformer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockAttributeTransformer.swift
@@ -1,0 +1,21 @@
+//
+//  MockAttributeTransformer.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 05/05/26.
+//
+
+import Foundation
+@testable import Measure
+
+final class MockAttributeTransformer: AttributeTransformer {
+    private(set) var transformCallCount = 0
+    private(set) var lastInput: [String: Any]?
+    var returnValue: [String: AttributeValue] = [:]
+
+    func transformAttributes(_ attributes: [String: Any]?) -> [String: AttributeValue] {
+        transformCallCount += 1
+        lastInput = attributes
+        return returnValue
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -8,7 +8,8 @@
 import Foundation
 @testable import Measure
 
-final class MockMeasureInitializer: MeasureInitializer { // swiftlint:disable:this type_body_length
+final class MockMeasureInitializer: MeasureInitializer {
+    // swiftlint:disable:this type_body_length
     let configLoader: ConfigLoader
     let signalSampler: SignalSampler
     let configProvider: ConfigProvider
@@ -74,6 +75,7 @@ final class MockMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
     let measureDispatchQueue: MeasureDispatchQueue
     let attributeValueValidator: AttributeValueValidator
     let attachmentStore: AttachmentStore
+    let attributeTransformer: AttributeTransformer
 
     init(client: Client? = nil, // swiftlint:disable:this function_body_length
          configLoader: ConfigLoader? = nil,
@@ -138,10 +140,12 @@ final class MockMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
          bugReportManager: BugReportManager? = nil,
          bugReportCollector: BugReportCollector? = nil,
          shakeDetector: ShakeDetector? = nil,
-         shakeBugReportCollector: ShakeBugReportCollector? = nil) {
+         shakeBugReportCollector: ShakeBugReportCollector? = nil,
+         attributeTransformer: AttributeTransformer? = nil) {
         self.client = client ?? ClientInfo(apiKey: "test", apiUrl: "https://test.com")
         self.configProvider = configProvider ?? BaseConfigProvider(defaultConfig: Config())
         self.logger = logger ?? MockLogger()
+        self.attributeTransformer = attributeTransformer ?? BaseAttributeTransformer()
         self.userDefaultStorage = userDefaultStorage ?? BaseUserDefaultStorage()
         self.systemFileManager = systemFileManager ?? BaseSystemFileManager(logger: self.logger)
         self.httpClient = httpClient ?? BaseHttpClient(logger: self.logger, configProvider: self.configProvider)

--- a/ios/Tests/MeasureSDKTests/Tracing/MsrObjCSpanBuilderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Tracing/MsrObjCSpanBuilderTests.swift
@@ -1,0 +1,90 @@
+//
+//  MsrObjCSpanBuilderTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 05/05/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class MsrObjCSpanBuilderTests: XCTestCase {
+    private var logger: MockLogger!
+    private var timeProvider: MockTimeProvider!
+    private var idProvider: MockIdProvider!
+    private var spanProcessor: MockSpanProcessor!
+    private var sessionManager: MockSessionManager!
+    private var signalSampler: MockSignalSampler!
+    private var attributeTransformer: MockAttributeTransformer!
+
+    override func setUp() {
+        super.setUp()
+        logger = MockLogger()
+        timeProvider = MockTimeProvider()
+        idProvider = MockIdProvider()
+        spanProcessor = MockSpanProcessor()
+        sessionManager = MockSessionManager(sessionId: "session-id")
+        signalSampler = MockSignalSampler()
+        attributeTransformer = MockAttributeTransformer()
+    }
+
+    override func tearDown() {
+        logger = nil
+        timeProvider = nil
+        idProvider = nil
+        spanProcessor = nil
+        sessionManager = nil
+        signalSampler = nil
+        attributeTransformer = nil
+        super.tearDown()
+    }
+
+    private func makeObjCBuilder(name: String = "test-span") -> MsrObjCSpanBuilder {
+        let builder = MsrSpanBuilder(name: name,
+                                     idProvider: idProvider,
+                                     timeProvider: timeProvider,
+                                     spanProcessor: spanProcessor,
+                                     sessionManager: sessionManager,
+                                     signalSampler: signalSampler,
+                                     logger: logger)
+        return MsrObjCSpanBuilder(builder, attributeTransformer: attributeTransformer)
+    }
+
+    private func makeObjCParentSpan() -> MsrObjCSpan {
+        let span = MsrSpan.startSpan(name: "parent",
+                                     logger: logger,
+                                     timeProvider: timeProvider,
+                                     sessionManager: sessionManager,
+                                     idProvider: idProvider,
+                                     signalSampler: signalSampler,
+                                     parentSpan: nil,
+                                     spanProcessor: spanProcessor)
+        return MsrObjCSpan(span, attributeTransformer: attributeTransformer)
+    }
+
+    func test_setParent_setsParentIdOnStartedSpan() {
+        let parent = makeObjCParentSpan()
+        let child = makeObjCBuilder().setParent(parent).startSpan()
+
+        XCTAssertEqual(child.parentId, parent.spanId)
+    }
+
+    func test_startSpan_returnsWrappedMsrObjCSpan() {
+        let result = makeObjCBuilder().startSpan()
+
+        XCTAssertNotNil(result.span as? MsrSpan)
+    }
+
+    func test_startSpanWithTimestamp_passesTimestampToUnderlyingSpan() {
+        let result = makeObjCBuilder().startSpan(timestamp: 99999)
+
+        XCTAssertEqual((result.span as? InternalSpan)?.startTime, 99999)
+    }
+
+    func test_startSpan_propagatesTransformerToResultingSpan() {
+        let span = makeObjCBuilder().startSpan()
+        span.setAttributes(["key": "value"])
+
+        XCTAssertEqual(attributeTransformer.transformCallCount, 1)
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Tracing/MsrObjCSpanTests.swift
+++ b/ios/Tests/MeasureSDKTests/Tracing/MsrObjCSpanTests.swift
@@ -1,0 +1,111 @@
+//
+//  MsrObjCSpanTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 05/05/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class MsrObjCSpanTests: XCTestCase {
+    private var logger: MockLogger!
+    private var timeProvider: MockTimeProvider!
+    private var idProvider: MockIdProvider!
+    private var spanProcessor: MockSpanProcessor!
+    private var sessionManager: MockSessionManager!
+    private var signalSampler: MockSignalSampler!
+    private var attributeTransformer: MockAttributeTransformer!
+
+    override func setUp() {
+        super.setUp()
+        logger = MockLogger()
+        timeProvider = MockTimeProvider()
+        idProvider = MockIdProvider()
+        spanProcessor = MockSpanProcessor()
+        sessionManager = MockSessionManager(sessionId: "session-id")
+        signalSampler = MockSignalSampler()
+        attributeTransformer = MockAttributeTransformer()
+    }
+
+    override func tearDown() {
+        logger = nil
+        timeProvider = nil
+        idProvider = nil
+        spanProcessor = nil
+        sessionManager = nil
+        signalSampler = nil
+        attributeTransformer = nil
+        super.tearDown()
+    }
+
+    private func makeSpan(name: String = "test-span") -> MsrSpan {
+        MsrSpan.startSpan(name: name,
+                          logger: logger,
+                          timeProvider: timeProvider,
+                          sessionManager: sessionManager,
+                          idProvider: idProvider,
+                          signalSampler: signalSampler,
+                          parentSpan: nil,
+                          spanProcessor: spanProcessor) as! MsrSpan
+    }
+
+    private func makeObjCSpan(name: String = "test-span") -> MsrObjCSpan {
+        MsrObjCSpan(makeSpan(name: name), attributeTransformer: attributeTransformer)
+    }
+
+    func test_properties_delegateToUnderlyingSpan() {
+        idProvider.spanid = "span-123"
+        idProvider.traceid = "trace-456"
+        let span = makeObjCSpan()
+
+        XCTAssertEqual(span.spanId, "span-123")
+        XCTAssertEqual(span.traceId, "trace-456")
+        XCTAssertNil(span.parentId)
+        XCTAssertEqual(span.isSampled, signalSampler.shouldTrackTrace())
+    }
+
+    func test_setStatus_unset_mapsCorrectly() {
+        let span = makeObjCSpan()
+        span.setStatus(.unset)
+
+        XCTAssertEqual((span.span as? InternalSpan)?.getStatus(), .unset)
+    }
+
+    func test_setStatus_ok_mapsCorrectly() {
+        let span = makeObjCSpan()
+        span.setStatus(.ok)
+
+        XCTAssertEqual((span.span as? InternalSpan)?.getStatus(), .ok)
+    }
+
+    func test_setStatus_error_mapsCorrectly() {
+        let span = makeObjCSpan()
+        span.setStatus(.error)
+
+        XCTAssertEqual((span.span as? InternalSpan)?.getStatus(), .error)
+    }
+
+    func test_setParent_setsParentIdOnChildSpan() {
+        let parent = makeObjCSpan(name: "parent")
+        let child = makeObjCSpan(name: "child")
+
+        child.setParent(parent)
+
+        XCTAssertEqual(child.parentId, parent.spanId)
+    }
+
+    func test_setAttributes_usesTransformer() {
+        let span = makeObjCSpan()
+        span.setAttributes(["count": 1])
+
+        XCTAssertEqual(attributeTransformer.transformCallCount, 1)
+        XCTAssertEqual(attributeTransformer.lastInput?["count"] as? Int, 1)
+    }
+
+    func test_invalid_hasInvalidSpanValues() {
+        XCTAssertEqual(MsrObjCSpan.invalid.spanId, "invalid-span-id")
+        XCTAssertEqual(MsrObjCSpan.invalid.traceId, "invalid-trace-id")
+        XCTAssertFalse(MsrObjCSpan.invalid.isSampled)
+    }
+}


### PR DESCRIPTION
# Description

This PR adds below changes:

  - Created an ObjC wrapper around existing span APIs to expose spans to ObjC via `MsrObjCSpan` and `MsrObjCSpanBuilder`
  - APIs added:
      - `[Measure startSpanWithName:]` → `MsrObjCSpan`
      - `[Measure startSpanWithName:timestamp:]` → `MsrObjCSpan`
      - `[Measure createSpanBuilderWithName:]` → `MsrObjCSpanBuilder`
      - `[Measure getTraceParentHeaderValueForSpan:]` → `NSString`
      - `[Measure getTraceParentHeaderKey]` → `NSString`
  - Tests updated.

## Related issue
Closes #3552 