### PR TITLE
chore(gradle): upload react native source maps for symbolication

### DIFF
--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -29,8 +29,14 @@ import java.net.URI
 import java.net.URL
 
 internal const val HEADER_AUTHORIZATION = "Authorization"
+
+// Ignore unknown keys so new fields in the builds API response do not break
+// older plugin versions.
+private val json = Json { ignoreUnknownKeys = true }
+
 private const val TYPE_PROGUARD = "proguard"
 private const val TYPE_FLUTTER_SYMBOLS = "elf_debug"
+private const val TYPE_JS_BUNDLE = "jsbundle"
 private const val BUILDS_PATH = "builds"
 
 private const val ERROR_MSG_401 =
@@ -96,6 +102,9 @@ abstract class BuildUploadTask : DefaultTask() {
     @get:InputFiles
     abstract val flutterSymbolsFiles: ConfigurableFileCollection
 
+    @get:InputFiles
+    abstract val reactNativeBundleArchives: ConfigurableFileCollection
+
     @get:InputFile
     abstract val manifestFileProperty: RegularFileProperty
 
@@ -114,12 +123,13 @@ abstract class BuildUploadTask : DefaultTask() {
         val mappingFile = mappingFileProperty.getOrNull()?.asFile
         val buildMetadataFile = buildMetadataFileProperty.get().asFile
         val flutterSymbols = flutterSymbolsFiles.files
+        val rnBundleArchives = reactNativeBundleArchives.files
 
         val manifestData = readManifestData(manifestFile)
         val (buildSize, buildType) = readBuildMetadata(buildMetadataFile)
 
         val client = httpClientProvider.get().client
-        val mappings = collectMappingInfo(mappingFile, flutterSymbols)
+        val mappings = collectMappingInfo(mappingFile, flutterSymbols, rnBundleArchives)
         val buildsRequest = createBuildsRequest(manifestData, buildSize, buildType, mappings)
 
         sendBuildsRequest(
@@ -129,12 +139,14 @@ abstract class BuildUploadTask : DefaultTask() {
             mappings,
             mappingFile,
             flutterSymbols,
+            rnBundleArchives,
         )
     }
 
     private fun collectMappingInfo(
         mappingFile: File?,
         flutterSymbols: Set<File>,
+        rnBundleArchives: Set<File>,
     ): List<MappingInfo> {
         val mappings = mutableListOf<MappingInfo>()
 
@@ -149,6 +161,13 @@ abstract class BuildUploadTask : DefaultTask() {
             logger.info("measure: ${flutterSymbols.size} flutter symbol files found")
             flutterSymbols.forEach { symbolsFile ->
                 mappings.add(MappingInfo(type = TYPE_FLUTTER_SYMBOLS, filename = symbolsFile.name))
+            }
+        }
+
+        rnBundleArchives.forEach { archive ->
+            if (archive.exists()) {
+                logger.info("measure: react native bundle archive found at ${archive.absolutePath}")
+                mappings.add(MappingInfo(type = TYPE_JS_BUNDLE, filename = archive.name))
             }
         }
 
@@ -177,10 +196,11 @@ abstract class BuildUploadTask : DefaultTask() {
         mappings: List<MappingInfo>,
         mappingFile: File?,
         flutterSymbols: Set<File>,
+        rnBundleArchives: Set<File>,
     ) {
         val buildsResponse = callBuildsApi(client, manifestData, buildsRequest)
         if (buildsResponse != null && mappings.isNotEmpty()) {
-            uploadMappingFiles(client, buildsResponse, mappingFile, flutterSymbols)
+            uploadMappingFiles(client, buildsResponse, mappingFile, flutterSymbols, rnBundleArchives)
         }
     }
 
@@ -194,7 +214,7 @@ abstract class BuildUploadTask : DefaultTask() {
 
         return executeHttpRequestWithRetry(client, request, "Builds API request") { response ->
             if (response.isSuccessful) {
-                Json.decodeFromString(BuildsApiResponse.serializer(), response.body!!.string())
+                json.decodeFromString(BuildsApiResponse.serializer(), response.body!!.string())
             } else {
                 logError(response)
                 null
@@ -207,7 +227,7 @@ abstract class BuildUploadTask : DefaultTask() {
         manifestData: ManifestData,
         buildsRequest: BuildsApiRequest,
     ): Request {
-        val jsonBody = Json.encodeToString(BuildsApiRequest.serializer(), buildsRequest)
+        val jsonBody = json.encodeToString(BuildsApiRequest.serializer(), buildsRequest)
             .toRequestBody("application/json".toMediaType())
         return createJsonRequest(url, manifestData, jsonBody)
     }
@@ -227,11 +247,13 @@ abstract class BuildUploadTask : DefaultTask() {
         buildsResponse: BuildsApiResponse,
         mappingFile: File?,
         flutterSymbols: Set<File>,
+        rnBundleArchives: Set<File>,
     ) {
         buildsResponse.mappings.forEach { mapping ->
             val file = when (mapping.type) {
                 TYPE_PROGUARD -> mappingFile
                 TYPE_FLUTTER_SYMBOLS -> flutterSymbols.firstOrNull { it.name == mapping.filename }
+                TYPE_JS_BUNDLE -> rnBundleArchives.firstOrNull { it.name == mapping.filename }
                 else -> null
             }
 

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -6,9 +6,18 @@ import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Compression
+import org.gradle.api.tasks.bundling.Tar
 import sh.measure.asm.BytecodeTransformationPipelineBuilder
 import sh.measure.asm.BytecodeTransformer
 import sh.measure.asm.HttpUrlConnectionTransformer
@@ -103,6 +112,8 @@ class MeasurePlugin : Plugin<Project> {
                 it.appSizeOutputFileProperty.set(appSizeFileProvider(project, variant))
             }
 
+        val rnBundleArchives = project.objects.fileCollection()
+
         val uploadBuildProvider =
             project.tasks
                 .register(
@@ -116,6 +127,7 @@ class MeasurePlugin : Plugin<Project> {
                             project.fileTree(dir) { tree -> tree.include("**/*.symbols") },
                         )
                     }
+                    it.reactNativeBundleArchives.setFrom(rnBundleArchives)
                     it.buildMetadataFileProperty.set(appSizeFileProvider(project, variant))
                     it.retriesProperty.set(DEFAULT_RETRIES)
                     it.usesService(httpClientProvider)
@@ -144,6 +156,7 @@ class MeasurePlugin : Plugin<Project> {
                 task.finalizedBy(aabSizeProvider, uploadBuildProvider)
             }
         }
+        wireReactNativeBundle(project, variant, rnBundleArchives)
     }
 
     private fun getFlutterExtension(project: Project): Any? = project.extensions.findByName("flutter")
@@ -170,6 +183,114 @@ class MeasurePlugin : Plugin<Project> {
     private fun buildUploadTaskName(variant: Variant) = "upload${variant.name.capitalize()}BuildToMeasure"
 
     private fun extractManifestDataTaskName(variant: Variant) = "extract${variant.name.capitalize()}ManifestData"
+
+    private fun packageReactNativeBundleTaskName(variant: Variant) = "packageReactNativeBundle${variant.name.capitalize()}"
+
+    private fun packageReactNativeSourceMapTaskName(variant: Variant) = "packageReactNativeSourceMap${variant.name.capitalize()}"
+
+    // The builds API expects the JS bundle and its source map as two separate
+    // jsbundle mappings, each a .tgz wrapping a single file. Symbolication pairs
+    // them server-side via the inner filename's .map suffix.
+    private fun wireReactNativeBundle(
+        project: Project,
+        variant: Variant,
+        rnBundleArchives: ConfigurableFileCollection,
+    ) {
+        if (!project.plugins.hasPlugin("com.facebook.react")) return
+
+        val capName = variant.name.capitalize()
+        val candidateNames = setOf(
+            "createBundle${capName}JsAndAssets",
+            "bundle${capName}JsAndAssets",
+        )
+
+        val bundleFile = project.objects.fileProperty()
+        val sourceMapFile = project.objects.fileProperty()
+
+        val packageBundleTask = registerPackageArchiveTask(
+            project,
+            variant,
+            packageReactNativeBundleTaskName(variant),
+            bundleFile,
+        )
+        val packageSourceMapTask = registerPackageArchiveTask(
+            project,
+            variant,
+            packageReactNativeSourceMapTaskName(variant),
+            sourceMapFile,
+        )
+
+        project.tasks.matching { it.name in candidateNames }.configureEach { bundleTask ->
+            val paths = readReactNativeBundlePaths(project, bundleTask) ?: return@configureEach
+            bundleFile.set(paths.bundle)
+            sourceMapFile.set(paths.sourceMap)
+            rnBundleArchives.from(
+                packageBundleTask.flatMap { it.archiveFile },
+                packageSourceMapTask.flatMap { it.archiveFile },
+            )
+        }
+    }
+
+    private fun registerPackageArchiveTask(
+        project: Project,
+        variant: Variant,
+        taskName: String,
+        file: RegularFileProperty,
+    ): TaskProvider<Tar> = project.tasks.register(taskName, Tar::class.java) {
+        it.compression = Compression.GZIP
+        it.archiveFileName.set(file.map { f -> "${f.asFile.name}.tgz" })
+        it.destinationDirectory.set(
+            project.layout.buildDirectory.dir("intermediates/measure/${variant.name}"),
+        )
+        it.from(file)
+    }
+
+    private data class ReactNativeBundlePaths(
+        val bundle: Provider<RegularFile>,
+        val sourceMap: Provider<RegularFile>,
+    )
+
+    private fun readReactNativeBundlePaths(
+        project: Project,
+        bundleTask: Task,
+    ): ReactNativeBundlePaths? = try {
+        val jsBundleDir = bundleTask::class.java.getMethod("getJsBundleDir")
+            .invoke(bundleTask) as DirectoryProperty
+        val jsSourceMapsDir = bundleTask::class.java.getMethod("getJsSourceMapsDir")
+            .invoke(bundleTask) as DirectoryProperty
+
+        @Suppress("UNCHECKED_CAST")
+        val bundleAssetName = bundleTask::class.java.getMethod("getBundleAssetName")
+            .invoke(bundleTask) as Property<String>
+
+        @Suppress("UNCHECKED_CAST")
+        val hermesEnabled = bundleTask::class.java.getMethod("getHermesEnabled")
+            .invoke(bundleTask) as Property<Boolean>
+
+        @Suppress("UNCHECKED_CAST")
+        val hermesFlags = bundleTask::class.java.getMethod("getHermesFlags")
+            .invoke(bundleTask) as ListProperty<String>
+
+        if (hermesEnabled.get() && "-output-source-map" !in hermesFlags.get()) {
+            project.logger.warn(
+                "measure: Hermes is enabled but -output-source-map is missing from " +
+                    "hermesFlags; no React Native source map will be uploaded. Add " +
+                    "-output-source-map back to hermesFlags to enable symbolication.",
+            )
+            null
+        } else {
+            ReactNativeBundlePaths(
+                bundle = jsBundleDir.file(bundleAssetName),
+                sourceMap = jsSourceMapsDir.file(bundleAssetName.map { "$it.map" }),
+            )
+        }
+    } catch (e: Exception) {
+        project.logger.warn(
+            "measure: could not read React Native bundle config from $bundleTask, " +
+                "bundle will not be uploaded: ${e.message}",
+        )
+        null
+    }
 
     // Returns the path to the flutter symbols directory if it exists.
     // This function uses the flutter extension to get the source directory and then uses the

--- a/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
+++ b/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
@@ -152,6 +152,139 @@ class BuildUploadTaskTest {
     }
 
     @Test
+    fun `sends request with React Native bundle and source map archives when available`() {
+        val bundleArchive = temporaryFolder.newFile("index.android.bundle.tgz").apply {
+            writeText("bundle tarball")
+        }
+        val sourceMapArchive = temporaryFolder.newFile("index.android.bundle.map.tgz").apply {
+            writeText("source map tarball")
+        }
+        task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
+        )
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val buildsRequest =
+            Json.decodeFromString(BuildsApiRequest.serializer(), recordedRequest.body.readUtf8())
+
+        assertEquals(3, buildsRequest.mappings.size)
+        assertTrue(buildsRequest.mappings.any { it.type == "proguard" && it.filename == "mapping.txt" })
+        assertTrue(buildsRequest.mappings.any { it.type == "jsbundle" && it.filename == "index.android.bundle.tgz" })
+        assertTrue(buildsRequest.mappings.any { it.type == "jsbundle" && it.filename == "index.android.bundle.map.tgz" })
+    }
+
+    @Test
+    fun `sends request with proguard, flutter, and RN mappings together`() {
+        val flutterSymbolsDir = temporaryFolder.root.resolve("flutter_symbols")
+        File(flutterSymbolsDir, "app.android-arm64.symbols").writeText("flutter symbols data")
+        val bundleArchive = temporaryFolder.newFile("index.android.bundle.tgz").apply {
+            writeText("bundle tarball")
+        }
+        val sourceMapArchive = temporaryFolder.newFile("index.android.bundle.map.tgz").apply {
+            writeText("source map tarball")
+        }
+        task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
+        )
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val buildsRequest =
+            Json.decodeFromString(BuildsApiRequest.serializer(), recordedRequest.body.readUtf8())
+
+        assertEquals(4, buildsRequest.mappings.size)
+        assertTrue(buildsRequest.mappings.any { it.type == "proguard" })
+        assertTrue(buildsRequest.mappings.any { it.type == "elf_debug" })
+        assertEquals(2, buildsRequest.mappings.count { it.type == "jsbundle" })
+    }
+
+    @Test
+    fun `sends only RN bundle archives when proguard mapping is absent`() {
+        val bundleArchive = temporaryFolder.newFile("index.android.bundle.tgz").apply {
+            writeText("bundle tarball")
+        }
+        val sourceMapArchive = temporaryFolder.newFile("index.android.bundle.map.tgz").apply {
+            writeText("source map tarball")
+        }
+        task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
+        task.mappingFileProperty.set(null as File?)
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
+        )
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val buildsRequest =
+            Json.decodeFromString(BuildsApiRequest.serializer(), recordedRequest.body.readUtf8())
+
+        assertEquals(2, buildsRequest.mappings.size)
+        assertTrue(buildsRequest.mappings.all { it.type == "jsbundle" })
+        assertTrue(buildsRequest.mappings.any { it.filename == "index.android.bundle.tgz" })
+        assertTrue(buildsRequest.mappings.any { it.filename == "index.android.bundle.map.tgz" })
+    }
+
+    @Test
+    fun `uploads RN bundle and source map archive contents to presigned URLs`() {
+        val bundleContent = "react-native-bundle-tarball"
+        val sourceMapContent = "react-native-source-map-tarball"
+        val bundleArchive = temporaryFolder.newFile("index.android.bundle.tgz").apply {
+            writeText(bundleContent)
+        }
+        val sourceMapArchive = temporaryFolder.newFile("index.android.bundle.map.tgz").apply {
+            writeText(sourceMapContent)
+        }
+        task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
+        task.mappingFileProperty.set(null as File?)
+
+        val bundleUploadUrl = mockWebServer.url("/upload-rn-bundle").toString()
+        val sourceMapUploadUrl = mockWebServer.url("/upload-rn-source-map").toString()
+        val buildsResponse = """
+            {
+                "mappings": [
+                    {
+                        "id": "rn-bundle-id",
+                        "type": "jsbundle",
+                        "filename": "index.android.bundle.tgz",
+                        "upload_url": "$bundleUploadUrl",
+                        "expires_at": "2025-08-13T01:59:45.577889184Z",
+                        "headers": {
+                            "x-amz-meta-mapping_id": "rn-bundle-id"
+                        },
+                        "patch_id": null
+                    },
+                    {
+                        "id": "rn-source-map-id",
+                        "type": "jsbundle",
+                        "filename": "index.android.bundle.map.tgz",
+                        "upload_url": "$sourceMapUploadUrl",
+                        "expires_at": "2025-08-13T01:59:45.577889184Z",
+                        "headers": {
+                            "x-amz-meta-mapping_id": "rn-source-map-id"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(buildsResponse))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+        task.upload()
+
+        mockWebServer.takeRequest()
+        val uploadsByPath = (1..2).associate {
+            val request = mockWebServer.takeRequest()
+            assertEquals("PUT", request.method)
+            request.path to request.body.readUtf8()
+        }
+        assertEquals(bundleContent, uploadsByPath["/upload-rn-bundle"])
+        assertEquals(sourceMapContent, uploadsByPath["/upload-rn-source-map"])
+    }
+
+    @Test
     fun `sends request with API_KEY in the header`() {
         mockWebServer.enqueue(
             MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,6 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
 // swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
 import AVKit
 import CoreData

--- a/samples/frank/ios/FrankensteinApp/Info.plist
+++ b/samples/frank/ios/FrankensteinApp/Info.plist
@@ -43,5 +43,10 @@
 	<string>$(MEASURE_API_KEY)</string>
 	<key>MeasureApiUrl</key>
 	<string>$(MEASURE_API_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/samples/frank/ios/Podfile.lock
+++ b/samples/frank/ios/Podfile.lock
@@ -2165,8 +2165,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
   Firebase: 065f2bb395062046623036d8e6dc857bc2521d56
-  firebase_core: 98bcc1bd1a097bcb8b1ed6e091de3039802527c4
-  firebase_crashlytics: 2fd6c030ca2f91e8d3b13d2e6e9a08a282c9d259
+  firebase_core: 8e6f58412ca227827c366b92e7cee047a2148c60
+  firebase_crashlytics: c399f9682c474beb06a89c11dfab04db537f3cd2
   FirebaseCore: 428912f751178b06bef0a1793effeb4a5e09a9b8
   FirebaseCoreExtension: e911052d59cd0da237a45d706fc0f81654f035c1
   FirebaseCoreInternal: b321eafae5362113bc182956fafc9922cfc77b72
@@ -2175,88 +2175,88 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 765ee19cd2bfa8e54937c8dae901eb634ad6787d
   FirebaseSessions: a2d06fd980431fda934c7a543901aca05fc4edcc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  FlutterPluginRegistrant: 72d81e4ec9cd63715219d3c18bfa6212ba2ce6f6
+  FlutterPluginRegistrant: 01160e8af7df47e77a86aca8b735d0a3054aa2cd
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 0d3f5af9c6b6e59a5e181d0472f0332b0185d247
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  hermes-engine: ce38c28daa8435132d7f1094beeec522068c32f5
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
   measure-sh: cb4133b7169721eca11a96d473a1c904c94bf8e2
-  measure_flutter: 894ae80b6ca5869f9119f6537ef16d944b46dbb1
-  MeasureReactNative: eb90f7cc5ce205436664b87a313a82274f4d57d0
+  measure_flutter: a0499a08f607a1c0eb922400a5a20cb92e7e601f
+  MeasureReactNative: 21a8711d223d1f4bf8ec456a1239589fcd7caae8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
   RCTSwiftUI: afc0a0a635860da1040a0b894bfd529da06d7810
-  RCTSwiftUIWrapper: cbb32eb90f09bd42ea9ed1eecd51fef3294da673
+  RCTSwiftUIWrapper: 3197c020094f3b2151bb2d1223f7276787be8166
   RCTTypeSafety: d13e192a37f151ce354641184bf4239844a3be17
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
-  React-Core: bdaa87b276ca31877632a982ecf7c36f8c826414
-  React-Core-prebuilt: bb05481052cb422306f8e5fdabc039b02b438a16
-  React-CoreModules: b24989f62d56390ae08ca4f65e6f38fe6802de42
-  React-cxxreact: 1a2dfcbc18a6b610664dba152adf327f063a0d12
+  React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
+  React-Core-prebuilt: 6ccf907425addfe8e8166dc56a057ed93c939c07
+  React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
+  React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: d196e6df0599d78360b3211367e28c5583054133
-  React-defaultsnativemodule: 373d46623421362fb7bd90137a1406e2818105a6
-  React-domnativemodule: 20cf626bfb83a413b84c4e488c097d3f004885ee
-  React-Fabric: 50dba3b9a73243ccd9228cca556d7d92b15ef00b
-  React-FabricComponents: 1a54e44e157244ceed980050324b9a13605b5d15
-  React-FabricImage: 3a691e5f66e7c5dcc5d8a6e5fc37c5351f75e9a3
-  React-featureflags: 86fb29088c6451cc8a633ecaf3e9f0b9c9411134
-  React-featureflagsnativemodule: 2b735d3d035a23ec571a8678ace7e7b9c2c8deff
-  React-graphics: 32f0b3d81256f38959d6564ec9a69b75b4fc937a
-  React-hermes: c2bde95033e6df1599b5c1b6d7e45736a8aa5cba
-  React-idlecallbacksnativemodule: 2c5f68fad7eec1b39c49b2c6967a98a9c1c47edd
-  React-ImageManager: b5a66937ab9034acaf22c599ed0b203fb36985c2
-  React-intersectionobservernativemodule: fba8173758f6017ec602cf346e8d01cd2dfa4080
-  React-jserrorhandler: 3fa5c4e304863432b2c6e2ac98a57ef5f1fb217f
-  React-jsi: 382de7964299bbf878458006a14f52cb66a36cfc
-  React-jsiexecutor: b781400a9becfb24e36ac063dccb42a52dcb44ca
-  React-jsinspector: 5263c3977d2a81aee6740dd733c8e705f8aeed7f
-  React-jsinspectorcdp: 9fee8119af7e14811db89b2107ef76c5412a053a
-  React-jsinspectornetwork: b4107cf233a8d9036e00557d6acf20a7f29a093e
-  React-jsinspectortracing: 2ba89f6790ce54f1ad3ea8de3b525abb1a952368
-  React-jsitooling: 95cb7e233d090eb4f28abc53c5ae98a85397ef7e
-  React-jsitracing: ce5760997e21716cad27ea631140976d573dc585
-  React-logger: 517377b1d2ba7ac722d47fb2183b98de86632063
-  React-Mapbuffer: 7d792cb0f9deffefa85c1c366025a694e3f0bafa
-  React-microtasksnativemodule: ed07f2f9ff4a848db25eb608306afffc45a7f5e4
-  React-NativeModulesApple: b94faa2dce6d8c0a9d722ed7ee27b996d28b62d1
-  React-networking: 82a21cd4ab792254f6bde0090fb2e086c0b3e5ad
+  React-defaultsnativemodule: fb293625c6bb890a9a546edcf80f946f67908aaf
+  React-domnativemodule: 16e331f3bef280db2da6a3d1ce23c67a094e6a2e
+  React-Fabric: d3634fbca73bf4f0be4b3e871b4eb1550297e657
+  React-FabricComponents: a718c092b5cdd75c0cd85dae479f74277a66653c
+  React-FabricImage: 4277dba3b575ba7d215fa3683676c644f090ce87
+  React-featureflags: d2f82cf0f0e711e6a4175541534144b89cbbd2f3
+  React-featureflagsnativemodule: 7fd86a2320e38cdbbdcd66af50497fcc215f1dd3
+  React-graphics: dc425d5fef7f7d989b3265dac8c461caa79b6abd
+  React-hermes: 666c66bbc856b46dfa4b132f1c9efaa37ad419a1
+  React-idlecallbacksnativemodule: ea2287291065049ca055b4cb4f10a2570ddaa28c
+  React-ImageManager: e187eb7a2a7ca0a9b39699cecc9c8df427695613
+  React-intersectionobservernativemodule: 000f27429f2c8806a75bfb1c59855f1a647fb0d4
+  React-jserrorhandler: ea7af8d511c4016fff7618c6cb71c304b60e479c
+  React-jsi: 33db13b95bb53827b03d9fb0f567d12b63dfc8ef
+  React-jsiexecutor: 49de4d48a7c4f283eaa865f7a4f3919f2c39be1c
+  React-jsinspector: 3ca9fe04f09c16dc8d3a5b8839b43404c36ea6b7
+  React-jsinspectorcdp: 53a9f8d9d03509469493c4ef910fec81a4b8de58
+  React-jsinspectornetwork: dc5ee29afca54564ee6c6470872aaebe0b672309
+  React-jsinspectortracing: c1fa5b8b1e3c7faef3c2816b032023d5e065dd6d
+  React-jsitooling: 0995909d465f0942f921d39563816ca31a1820a6
+  React-jsitracing: 2bf43db3d78775cf35ffc5c3a622cdb2f8ddbcb7
+  React-logger: b5521614afb8690420146dfc61a1447bb5d65419
+  React-Mapbuffer: 0db00b587a6a6f0f6813e9fb2655e337261f513e
+  React-microtasksnativemodule: 7ccd4c74006eec09a2df88ca31ba8b0c22c50a4d
+  React-NativeModulesApple: 5ba0903927f6b8d335a091700e9fda143980f819
+  React-networking: ad2727500e93943a43da70d3b162454af151469c
   React-oscompat: ff26abf0ae3e3fdbe47b44224571e3fc7226a573
-  React-perflogger: 757c8c725cc20e94eba406885047f03cf83044fb
-  React-performancecdpmetrics: 0b6cacda843c6e193eacb7acda2358eb095cd502
-  React-performancetimeline: 452e9104e9095c63a59ece194641a30cb361b6b7
+  React-perflogger: a86b2146936f2ffa80188425c6e8892729e2ad01
+  React-performancecdpmetrics: 85976f9321ae685d1cbc3b842308f046ad4968d8
+  React-performancetimeline: 521f72baddea6d8ff259d5d7dc5d7b31bf1a6a69
   React-RCTActionSheet: fc1d5d419856868e7f8c13c14591ed63dadef43a
-  React-RCTAnimation: 1ce166ec15ab1f8eca8ebaae7f8f709d9be6958c
-  React-RCTAppDelegate: c752d93f597168a9a4d5678e9354bbb8d84df6d1
-  React-RCTBlob: 147d41ee9f80cf27fe9b2f7adc1d6d24f68ec3fc
-  React-RCTFabric: 6cdc832f1a8cf77b15da5f45b21f915408cec160
-  React-RCTFBReactNativeSpec: 077bf3d69dde2d06513aa927ae252126acf18388
-  React-RCTImage: fd39f1c478f1e43357bc72c2dbdc2454aafe4035
-  React-RCTLinking: 02ca1c83536dab08130f5db4852f293c53885dd6
-  React-RCTNetwork: 85dc64c530e4b0be7436f9a15b03caba24e9a3a1
-  React-RCTRuntime: c9cadb3d552eca49d5011ee4e9b1b2988d00accd
-  React-RCTSettings: df5da31865cc1bab7ef5314e65ca18f6b538d71d
-  React-RCTText: 41587e426883c9a83fd8eb0c57fe328aad4ed57a
-  React-RCTVibration: 8ca2f9839c53416dffb584adb94501431ba7f96e
+  React-RCTAnimation: 2a1e7eeb55b71e8524db296fa31e46eeaa2d0da4
+  React-RCTAppDelegate: 317c1102a2d0bcc07567d8de58d9147102080b0e
+  React-RCTBlob: c82bbf96b2d1389550c05fb9739d4e85d471052e
+  React-RCTFabric: 01f5cd463bd82260358b8667328a8e0f73cfc1d3
+  React-RCTFBReactNativeSpec: 2db8b42782377838f4b3a8c51ab5d6f1c487c942
+  React-RCTImage: f959463e53ea731ab267e371eea1b92fccf27634
+  React-RCTLinking: 2a857113b8059ac4f0a8ae89f8aa312837b955d0
+  React-RCTNetwork: dc026bf25f6457249349be8cf8bd5fdf84cdfb14
+  React-RCTRuntime: 205340a02f49c8937a372e4e9eaa296987d8445d
+  React-RCTSettings: e159e19475df2e92fd3b4ddcfe29f6cc12cf0ee4
+  React-RCTText: 7356cc84c2ed79635931891c176f72e0289dc75d
+  React-RCTVibration: 77621175b67b22e655ce4b29d1cda8498f2033e7
   React-rendererconsistency: fba8b761416e5321021366efce596d530e0c558b
-  React-renderercss: b34fe0b46d8f9130bf048407ec6d5f08ee64d4ca
-  React-rendererdebug: d671c61d6bdd080210768ab344d368ff21860fb1
-  React-RuntimeApple: 7a4b89178d0fa3e3856bf260dd7631aaa6d027f1
-  React-RuntimeCore: 9df30a5e6c2b610560510becae93ada730217636
-  React-runtimeexecutor: c42d96d0193a9b54dfad829284bea0ae2d8c3877
-  React-RuntimeHermes: a715852b1a87e0bcb30c12de7045340fb966f041
-  React-runtimescheduler: d23494fabab085958cc264cb8fc5aed3568fa6e3
-  React-timing: 9166d213454bbfe595b327d7e6137d7a2967a4fe
-  React-utils: 53fa76153a7fee030db7104923b59e8658b68ee3
-  React-webperformancenativemodule: 6fa0ca4dc4616e130317c81dc81a275ba9a26d7d
-  ReactAppDependencyProvider: 26bbf1e26768d08dd965a2b5e372e53f67b21fee
-  ReactCodegen: d91185ae285197a0b1f97f432e936459494e71b1
-  ReactCommon: 309419492d417c4cbb87af06f67735afa40ecb9d
-  ReactNativeDependencies: 2ae92dcff72f77096fdec77c230739694c7316bb
+  React-renderercss: 8d9876f64a5ee6fea6d91617f4909e1bd153cc78
+  React-rendererdebug: 5d63ef4df4712687ccef8a4bf6b15ef018a974bb
+  React-RuntimeApple: 1cf8a27ae270d27bf6e819ab448d0155e4ac210a
+  React-RuntimeCore: 2ae912c0af9a1898560c69c1e4b6daca2e63342c
+  React-runtimeexecutor: 8d9a79a97e2826e5017bc4aadb00a1d7d69d252b
+  React-RuntimeHermes: 83eecb1fb796090a4b57f9a5a0cef62114885708
+  React-runtimescheduler: c45208e3506c717c0700023aede07c1ca271763f
+  React-timing: 2f65f30369ed4cd7c5356135dd160d0710a95257
+  React-utils: 7ace4a70a287291541c646e3f02688ba439ed743
+  React-webperformancenativemodule: 4b56d01c3a3f403231c3756ac7031db8ab64f504
+  ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
+  ReactCodegen: 9b5b6e3e47bc11814c207cdc06210e69627660fb
+  ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
+  ReactNativeDependencies: 47cd2dc6edd5cdf5d270f32919c7633e5afa208b
   Yoga: 846fbe6f595136be802ad81d05688ff748839764
 
 PODFILE CHECKSUM: d306df5979fef4e71dcf5d81c2d71ccaeaa916d5


### PR DESCRIPTION
# Description

The gradle plugin now detects projects with the React Native gradle plugin applied and uploads the composed JS source map alongside any ProGuard or Flutter mappings. Works for both pure-RN and hybrid apps where RN coexists with native, Flutter, or KMP modules.

## Related issue
Depends on #2666 



