### PR TITLE
fix(ios): send correct user defined attributes json

### DIFF
--- a/ios/DemoApp/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/ViewController.swift
@@ -67,6 +67,7 @@ import Measure
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
+        Measure.trackEvent(name: "custom_user_event", attributes: ["name": .string("Adwin"), "age": .int(34)])
         do {
             let path = "/path/that/does/not/exist.txt"
             _ = try String(contentsOfFile: path, encoding: .utf8)

--- a/ios/Sources/MeasureSDK/Swift/Events/Event.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/Event.swift
@@ -134,7 +134,7 @@ final class Event<T: Codable>: Codable {
         case attributes = "attribute"
         case userTriggered = "user_triggered"
         case timestampInMillis
-        case userDefinedAttributes = "user_defined_attributes"
+        case userDefinedAttributes = "user_defined_attribute"
         case exception
         case gestureClick = "gesture_click"
         case gestureLongClick = "gesture_long_click"

--- a/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
@@ -122,6 +122,11 @@ final class BaseNetworkClient: NetworkClient {
             }
 
             fullEventDict.removeValue(forKey: "timestampInMillis")
+            if let userDefinedAttributeString = fullEventDict["user_defined_attribute"] as? String,
+               let attributeData = userDefinedAttributeString.data(using: .utf8),
+               let attributeDict = try? JSONSerialization.jsonObject(with: attributeData, options: []) as? [String: Any] {
+                fullEventDict["user_defined_attribute"] = attributeDict
+            }
             if let attachments = fullEventDict["attachments"] as? [[String: Any]] {
                 let cleanedAttachments = attachments.map { attachment in
                     let requiredKeys: Set<String> = ["id", "name", "type", "size"]


### PR DESCRIPTION
# Description

This PR contains below changes:
- Use correct key `user_defined_attribute` instead of `user_defined_attributes`
- Send key value pair instead of json string

## Related issue
Fixes #3588
