### PR TITLE
chore(flutter): add diagnostic mode for SDK logging

### DIFF
--- a/android/measure/api/measure.api
+++ b/android/measure/api/measure.api
@@ -24,7 +24,7 @@ public final class sh/measure/android/Measure {
 	public static final fun init (Landroid/content/Context;)V
 	public static final fun init (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;)V
 	public static synthetic fun init$default (Landroid/content/Context;Lsh/measure/android/config/MeasureConfig;ILjava/lang/Object;)V
-	public final fun internalAddLog (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun internalAddLog (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun internalEncodeWebP ([BIILkotlin/jvm/functions/Function1;)V
 	public final fun internalGetAttachmentDirectory ()Ljava/lang/String;
 	public final fun internalTrackEvent (Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V

--- a/android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -676,9 +676,9 @@ object Measure {
      * An internal method that adds logs Measure logger.
      * This method is not intended for public usage.
      */
-    fun internalAddLog(platform: String, message: String, throwable: Throwable?) {
+    fun internalAddLog(platform: String, message: String) {
         if (isInitialized.get()) {
-            measure.internalAddLog(platform, message, throwable)
+            measure.internalAddLog(platform, message)
         }
     }
 

--- a/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -321,11 +321,10 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         }
     }
 
-    fun internalAddLog(platform: String, message: String, throwable: Throwable?) {
+    fun internalAddLog(platform: String, message: String) {
         measure.logger.log(
             LogLevel.Debug,
             "[$platform] $message",
-            throwable,
         )
     }
 

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -254,7 +254,7 @@ Defaults to `false`.
 To pull all log files to your local machine:
 
 ```shell
-adb shell "run-as <your.package.name> tar czf - measure/sdk_debug_logs/" > sdk_debug_logs.tar.gz
+adb shell "run-as <your.package.name> tar czf - files/measure/sdk_debug_logs/" > sdk_debug_logs.tar.gz
 ```
 
 To delete all diagnostic log files:

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -665,6 +665,22 @@ Measure.initialize(with: clientInfo, config: config)
 
 </details>
 
+<details>
+    <summary>Flutter</summary>
+
+Enable diagnostic mode during SDK initialization.
+
+```dart
+await Measure.instance.init(
+  () => runApp(MeasureWidget(child: MyApp())),
+  config: const MeasureConfig(enableDiagnosticMode: true),
+);
+```
+
+On iOS, the `enableDiagnosticModeGesture` flag is set on the native `BaseMeasureConfig` in your `AppDelegate` (see the iOS section above), not on the Dart `MeasureConfig`.
+
+</details>
+
 #### Step 2: Reproduce the issue
 
 Run the app and reproduce the issue you're facing. The SDK will write logs to files in the

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
@@ -42,9 +42,8 @@ object MethodConstants {
     const val ARG_ENCODE_WEBP_PIXELS = "pixels"
     const val ARG_ENCODE_WEBP_WIDTH = "width"
     const val ARG_ENCODE_WEBP_HEIGHT = "height"
-    const val ARG_PLATFORM = "platform"
-    const val ARG_MESSAGE = "message"
-    const val ARG_ERROR_MESSAGE = "error_message"
+    const val ARG_DIAGNOSTIC_MODE_PLATFORM = "platform"
+    const val ARG_DIAGNOSTIC_MODE_MESSAGE = "message"
 
     // Callbacks
     const val CALLBACK_ON_SHAKE_DETECTED = "onShakeDetected"

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/Constants.kt
@@ -15,6 +15,7 @@ object MethodConstants {
     const val FUNCTION_DISABLE_SHAKE_DETECTOR = "disableShakeDetector"
     const val FUNCTION_GET_DYNAMIC_CONFIG_PATH = "getDynamicConfigPath"
     const val FUNCTION_ENCODE_WEBP = "encodeWebP"
+    const val FUNCTION_INTERNAL_ADD_LOG = "internalAddLog"
 
     // arguments
     const val ARG_EVENT_DATA = "event_data"
@@ -41,6 +42,9 @@ object MethodConstants {
     const val ARG_ENCODE_WEBP_PIXELS = "pixels"
     const val ARG_ENCODE_WEBP_WIDTH = "width"
     const val ARG_ENCODE_WEBP_HEIGHT = "height"
+    const val ARG_PLATFORM = "platform"
+    const val ARG_MESSAGE = "message"
+    const val ARG_ERROR_MESSAGE = "error_message"
 
     // Callbacks
     const val CALLBACK_ON_SHAKE_DETECTED = "onShakeDetected"

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
@@ -37,6 +37,7 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
                 MethodConstants.FUNCTION_DISABLE_SHAKE_DETECTOR -> disableShakeDetector()
                 MethodConstants.FUNCTION_GET_DYNAMIC_CONFIG_PATH -> getDynamicConfigPath(result)
                 MethodConstants.FUNCTION_ENCODE_WEBP -> encodeWebP(call, result)
+                MethodConstants.FUNCTION_INTERNAL_ADD_LOG -> internalAddLog(call, result)
                 else -> result.notImplemented()
             }
         } catch (e: MethodArgumentException) {
@@ -185,6 +186,16 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
     private fun getDynamicConfigPath(result: MethodChannel.Result) {
         val path = Measure.getDynamicConfigPath()
         result.success(path)
+    }
+
+    private fun internalAddLog(call: MethodCall, result: MethodChannel.Result) {
+        val reader = MethodCallReader(call)
+        val platform = reader.requireArg<String>(MethodConstants.ARG_PLATFORM)
+        val message = reader.requireArg<String>(MethodConstants.ARG_MESSAGE)
+        val errorMessage = reader.optionalArg<String>(MethodConstants.ARG_ERROR_MESSAGE)
+        val throwable = errorMessage?.let { Exception(it) }
+        Measure.internalAddLog(platform = platform, message = message, throwable = throwable)
+        result.success(null)
     }
 
     private fun encodeWebP(call: MethodCall, result: MethodChannel.Result) {

--- a/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
+++ b/flutter/packages/measure_flutter/android/src/main/kotlin/sh/measure/flutter/MeasurePlugin.kt
@@ -190,11 +190,9 @@ class MeasurePlugin : FlutterPlugin, MethodCallHandler {
 
     private fun internalAddLog(call: MethodCall, result: MethodChannel.Result) {
         val reader = MethodCallReader(call)
-        val platform = reader.requireArg<String>(MethodConstants.ARG_PLATFORM)
-        val message = reader.requireArg<String>(MethodConstants.ARG_MESSAGE)
-        val errorMessage = reader.optionalArg<String>(MethodConstants.ARG_ERROR_MESSAGE)
-        val throwable = errorMessage?.let { Exception(it) }
-        Measure.internalAddLog(platform = platform, message = message, throwable = throwable)
+        val platform = reader.requireArg<String>(MethodConstants.ARG_DIAGNOSTIC_MODE_PLATFORM)
+        val message = reader.requireArg<String>(MethodConstants.ARG_DIAGNOSTIC_MODE_MESSAGE)
+        Measure.internalAddLog(platform = platform, message = message)
         result.success(null)
     }
 

--- a/flutter/packages/measure_flutter/example/pubspec.lock
+++ b/flutter/packages/measure_flutter/example/pubspec.lock
@@ -29,26 +29,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cross_file:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -283,26 +283,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -323,33 +323,33 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   measure_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.6.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -362,10 +362,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
@@ -410,7 +410,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -431,18 +431,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -532,5 +532,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/flutter/packages/measure_flutter/ios/Classes/Constants.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/Constants.swift
@@ -22,6 +22,7 @@ enum MethodConstants {
     static let functionDisableShakeDetection = "disableShakeDetector"
     static let functionGetDynamicConfigPath = "getDynamicConfigPath"
     static let functionEncodeWebP = "encodeWebP"
+    static let functionInternalAddLog = "internalAddLog"
 
     // arguments
     static let argEventData = "event_data"
@@ -50,6 +51,9 @@ enum MethodConstants {
     static let argEncodeWebPPixels = "pixels"
     static let argEncodeWebPWidth = "width"
     static let argEncodeWebPHeight = "height"
+    static let argPlatform = "platform"
+    static let argMessage = "message"
+    static let argErrorMessage = "error_message"
 
     // Callbacks
     static let callbackOnShakeDetected = "onShakeDetected"

--- a/flutter/packages/measure_flutter/ios/Classes/Constants.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/Constants.swift
@@ -51,9 +51,8 @@ enum MethodConstants {
     static let argEncodeWebPPixels = "pixels"
     static let argEncodeWebPWidth = "width"
     static let argEncodeWebPHeight = "height"
-    static let argPlatform = "platform"
-    static let argMessage = "message"
-    static let argErrorMessage = "error_message"
+    static let argDiagnosticModePlatform = "platform"
+    static let argDiagnosticModeMessage = "message"
 
     // Callbacks
     static let callbackOnShakeDetected = "onShakeDetected"

--- a/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
@@ -41,6 +41,8 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
                 try getDynamicConfigPath(result: result)
             case MethodConstants.functionEncodeWebP:
                 try encodeWebP(call, result: result)
+            case MethodConstants.functionInternalAddLog:
+                try internalAddLog(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -202,6 +204,18 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
     private func getDynamicConfigPath(result: @escaping FlutterResult) throws {
         let path = Measure.internalGetDynamicConfigPath()
         result(path)
+    }
+
+    private func internalAddLog(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        let reader = MethodCallReader(call)
+        let platform: String = try reader.requireArg(MethodConstants.argPlatform)
+        let message: String = try reader.requireArg(MethodConstants.argMessage)
+        let errorMessage: String? = reader.optionalArg(MethodConstants.argErrorMessage)
+        let nsError: NSError? = errorMessage.map {
+            NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: $0])
+        }
+        Measure.internalAddLog(platform: platform, message: message, error: nsError)
+        result(nil)
     }
 
     private func encodeWebP(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {

--- a/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
+++ b/flutter/packages/measure_flutter/ios/Classes/MeasurePlugin.swift
@@ -208,13 +208,9 @@ public class MeasurePlugin: NSObject, FlutterPlugin {
 
     private func internalAddLog(_ call: FlutterMethodCall, result: @escaping FlutterResult) throws {
         let reader = MethodCallReader(call)
-        let platform: String = try reader.requireArg(MethodConstants.argPlatform)
-        let message: String = try reader.requireArg(MethodConstants.argMessage)
-        let errorMessage: String? = reader.optionalArg(MethodConstants.argErrorMessage)
-        let nsError: NSError? = errorMessage.map {
-            NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: $0])
-        }
-        Measure.internalAddLog(platform: platform, message: message, error: nsError)
+        let platform: String = try reader.requireArg(MethodConstants.argDiagnosticModePlatform)
+        let message: String = try reader.requireArg(MethodConstants.argDiagnosticModeMessage)
+        Measure.internalAddLog(platform: platform, message: message)
         result(nil)
     }
 

--- a/flutter/packages/measure_flutter/lib/src/config/config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config.dart
@@ -6,6 +6,7 @@ class Config implements InternalConfig, IMeasureConfig {
   const Config({
     this.enableLogging = DefaultConfig.enableLogging,
     this.autoStart = DefaultConfig.autoStart,
+    this.enableDiagnosticMode = DefaultConfig.enableDiagnosticMode,
     this.maxCheckpointNameLength = DefaultConfig.maxCheckpointNameLength,
     this.maxSpanNameLength = DefaultConfig.maxSpanNameLength,
     this.maxCheckpointsPerSpan = DefaultConfig.maxCheckpointsPerSpan,
@@ -24,6 +25,8 @@ class Config implements InternalConfig, IMeasureConfig {
   final bool enableLogging;
   @override
   final bool autoStart;
+  @override
+  final bool enableDiagnosticMode;
   @override
   final int maxCheckpointNameLength;
   @override

--- a/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/config_provider.dart
@@ -95,6 +95,9 @@ class ConfigProviderImpl implements ConfigProvider {
   bool get autoStart => _defaultConfig.autoStart;
 
   @override
+  bool get enableDiagnosticMode => _defaultConfig.enableDiagnosticMode;
+
+  @override
   List<String> get defaultHttpContentTypeAllowlist => _defaultConfig.defaultHttpContentTypeAllowlist;
 
   @override

--- a/flutter/packages/measure_flutter/lib/src/config/default_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/default_config.dart
@@ -1,5 +1,6 @@
 class DefaultConfig {
   static const bool enableLogging = false;
+  static const bool enableDiagnosticMode = false;
   static const bool trackScreenshotOnCrash = false;
   static const bool autoInitializeNativeSDK = true;
   static const bool autoStart = true;

--- a/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
@@ -32,7 +32,7 @@ class MeasureConfig implements IMeasureConfig {
   ///
   /// To pull all log files from an Android device:
   /// ```
-  /// adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+  /// adb shell "run-as <your.package.name> tar czf - files/measure/sdk_debug_logs/" > sdk_debug_logs.tar.gz
   /// ```
   /// On iOS, set `enableDiagnosticModeGesture` on the native `MeasureConfig` (in your AppDelegate)
   /// to trigger the share sheet via the double finger double tap gesture.

--- a/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
+++ b/flutter/packages/measure_flutter/lib/src/config/measure_config.dart
@@ -7,6 +7,8 @@ abstract class IMeasureConfig {
 
   bool get autoStart;
 
+  bool get enableDiagnosticMode;
+
   Map<Type, String> get widgetFilter;
 }
 
@@ -23,6 +25,20 @@ class MeasureConfig implements IMeasureConfig {
   @override
   final bool autoStart;
 
+  /// Enables diagnostic mode which writes all SDK logs to a file. The log file can be attached
+  /// when reporting a bug to help with debugging SDK issues.
+  ///
+  /// Defaults to `false`.
+  ///
+  /// To pull all log files from an Android device:
+  /// ```
+  /// adb shell "run-as <your.package.name> tar cf - files/measure/sdk_debug_logs/" | tar xf - -C /tmp/
+  /// ```
+  /// On iOS, set `enableDiagnosticModeGesture` on the native `MeasureConfig` (in your AppDelegate)
+  /// to trigger the share sheet via the double finger double tap gesture.
+  @override
+  final bool enableDiagnosticMode;
+
   @override
   final Map<Type, String> widgetFilter;
 
@@ -30,6 +46,7 @@ class MeasureConfig implements IMeasureConfig {
   const MeasureConfig({
     this.enableLogging = DefaultConfig.enableLogging,
     this.autoStart = DefaultConfig.autoStart,
+    this.enableDiagnosticMode = DefaultConfig.enableDiagnosticMode,
     this.widgetFilter = DefaultConfig.widgetFilter,
   });
 }

--- a/flutter/packages/measure_flutter/lib/src/logger/flutter_logger.dart
+++ b/flutter/packages/measure_flutter/lib/src/logger/flutter_logger.dart
@@ -30,12 +30,20 @@ final class FlutterLogger implements Logger {
       );
     }
     if (enableDiagnosticMode) {
+      final composed = StringBuffer(message);
+      if (error != null) {
+        composed.write('\n');
+        composed.write(error.toString());
+      }
+      if (stackTrace != null) {
+        composed.write('\n');
+        composed.write(stackTrace.toString());
+      }
       unawaited(
         MeasureFlutterPlatform.instance
             .internalAddLog(
               platform: _platformFlutter,
-              message: message,
-              errorMessage: error?.toString(),
+              message: composed.toString(),
             )
             .catchError((_) {}),
       );

--- a/flutter/packages/measure_flutter/lib/src/logger/flutter_logger.dart
+++ b/flutter/packages/measure_flutter/lib/src/logger/flutter_logger.dart
@@ -1,24 +1,44 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
+import 'package:measure_flutter/src/method_channel/msr_platform_interface.dart';
+
+const String _platformFlutter = 'flutter';
 
 final class FlutterLogger implements Logger {
   @override
   final bool enabled;
+  final bool enableDiagnosticMode;
 
-  const FlutterLogger({required this.enabled});
+  const FlutterLogger({
+    required this.enabled,
+    this.enableDiagnosticMode = false,
+  });
 
   @override
   void log(LogLevel level, String message,
       [dynamic error, StackTrace? stackTrace]) {
-    if (!enabled) return;
-    developer.log(
-      message,
-      level: level.level,
-      error: error,
-      stackTrace: stackTrace,
-      name: "Measure",
-    );
+    if (enabled) {
+      developer.log(
+        message,
+        level: level.level,
+        error: error,
+        stackTrace: stackTrace,
+        name: "Measure",
+      );
+    }
+    if (enableDiagnosticMode) {
+      unawaited(
+        MeasureFlutterPlatform.instance
+            .internalAddLog(
+              platform: _platformFlutter,
+              message: message,
+              errorMessage: error?.toString(),
+            )
+            .catchError((_) {}),
+      );
+    }
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -95,7 +95,10 @@ final class MeasureInitializer {
   }
 
   void _initializeDependencies(MeasureConfig inputConfig) {
-    _logger = FlutterLogger(enabled: inputConfig.enableLogging);
+    _logger = FlutterLogger(
+      enabled: inputConfig.enableLogging,
+      enableDiagnosticMode: inputConfig.enableDiagnosticMode,
+    );
     final clock = DateTimeClock();
     _timeProvider = FlutterTimeProvider(clock);
     _methodChannel = MsrMethodChannel();
@@ -112,6 +115,7 @@ final class MeasureInitializer {
       defaultConfig: Config(
         enableLogging: inputConfig.enableLogging,
         autoStart: inputConfig.autoStart,
+        enableDiagnosticMode: inputConfig.enableDiagnosticMode,
       ),
     );
     _signalProcessor = DefaultSignalProcessor(logger: logger, channel: _methodChannel, configProvider: _configProvider);

--- a/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
@@ -13,6 +13,7 @@ class MethodConstants {
   static const String functionDisableShakeDetector = 'disableShakeDetector';
   static const String functionGetDynamicConfigPath = 'getDynamicConfigPath';
   static const String functionEncodeWebP = 'encodeWebP';
+  static const String functionInternalAddLog = 'internalAddLog';
 
   // Argument keys
   static const String argEventData = 'event_data';
@@ -43,6 +44,9 @@ class MethodConstants {
   static const String argEncodeWebPPixels = 'pixels';
   static const String argEncodeWebPWidth = 'width';
   static const String argEncodeWebPHeight = 'height';
+  static const String argPlatform = 'platform';
+  static const String argMessage = 'message';
+  static const String argErrorMessage = 'error_message';
 
   // Error codes
   static const String errorInvalidArgument = 'invalid_argument';

--- a/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/method_constants.dart
@@ -44,9 +44,8 @@ class MethodConstants {
   static const String argEncodeWebPPixels = 'pixels';
   static const String argEncodeWebPWidth = 'width';
   static const String argEncodeWebPHeight = 'height';
-  static const String argPlatform = 'platform';
-  static const String argMessage = 'message';
-  static const String argErrorMessage = 'error_message';
+  static const String argDiagnosticModePlatform = 'platform';
+  static const String argDiagnosticModeMessage = 'message';
 
   // Error codes
   static const String errorInvalidArgument = 'invalid_argument';

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
@@ -128,6 +128,22 @@ class MsrMethodChannel extends MeasureFlutterPlatform {
     );
   }
 
+  @override
+  Future<void> internalAddLog({
+    required String platform,
+    required String message,
+    String? errorMessage,
+  }) {
+    return _methodChannel.invokeMethod(
+      MethodConstants.functionInternalAddLog,
+      {
+        MethodConstants.argPlatform: platform,
+        MethodConstants.argMessage: message,
+        MethodConstants.argErrorMessage: errorMessage,
+      },
+    );
+  }
+
   void setMethodCallHandler(
       Future<void> Function(MethodCall call) handleMethodCall) {
     _methodChannel.setMethodCallHandler(handleMethodCall);

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_method_channel.dart
@@ -132,14 +132,12 @@ class MsrMethodChannel extends MeasureFlutterPlatform {
   Future<void> internalAddLog({
     required String platform,
     required String message,
-    String? errorMessage,
   }) {
     return _methodChannel.invokeMethod(
       MethodConstants.functionInternalAddLog,
       {
-        MethodConstants.argPlatform: platform,
-        MethodConstants.argMessage: message,
-        MethodConstants.argErrorMessage: errorMessage,
+        MethodConstants.argDiagnosticModePlatform: platform,
+        MethodConstants.argDiagnosticModeMessage: message,
       },
     );
   }

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
@@ -85,4 +85,12 @@ abstract class MeasureFlutterPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('encodeWebP() has not been implemented.');
   }
+
+  Future<void> internalAddLog({
+    required String platform,
+    required String message,
+    String? errorMessage,
+  }) {
+    throw UnimplementedError('internalAddLog() has not been implemented.');
+  }
 }

--- a/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
+++ b/flutter/packages/measure_flutter/lib/src/method_channel/msr_platform_interface.dart
@@ -89,7 +89,6 @@ abstract class MeasureFlutterPlatform extends PlatformInterface {
   Future<void> internalAddLog({
     required String platform,
     required String message,
-    String? errorMessage,
   }) {
     throw UnimplementedError('internalAddLog() has not been implemented.');
   }

--- a/flutter/packages/measure_flutter/test/config/config_provider_test.dart
+++ b/flutter/packages/measure_flutter/test/config/config_provider_test.dart
@@ -18,6 +18,19 @@ void main() {
     );
   });
 
+  group('enableDiagnosticMode', () {
+    test('defaults to false when not set', () {
+      expect(provider.enableDiagnosticMode, isFalse);
+    });
+
+    test('reflects value from default config', () {
+      final p = ConfigProviderImpl(
+        defaultConfig: Config(enableDiagnosticMode: true),
+      );
+      expect(p.enableDiagnosticMode, isTrue);
+    });
+  });
+
   group('shouldTrackHttpEvent', () {
     test('returns true when no URLs are blocked', () {
       expect(provider.shouldTrackHttpEvent('https://api.example.com/data'), isTrue);

--- a/flutter/packages/measure_flutter/test/logger/flutter_logger_test.dart
+++ b/flutter/packages/measure_flutter/test/logger/flutter_logger_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(fakeChannel.internalAddLogCalls, isEmpty);
     });
 
-    test('calls internalAddLog with platform=flutter when diagnostic mode is on',
+    test('forwards just the message when no error or stack is provided',
         () async {
       final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
 
@@ -40,10 +40,9 @@ void main() {
       final call = fakeChannel.internalAddLogCalls.single;
       expect(call.platform, 'flutter');
       expect(call.message, 'a message');
-      expect(call.errorMessage, isNull);
     });
 
-    test('forwards stringified error when diagnostic mode is on', () async {
+    test('appends error.toString() when error is provided', () async {
       final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
       final error = Exception('boom');
 
@@ -51,8 +50,33 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(fakeChannel.internalAddLogCalls, hasLength(1));
-      expect(fakeChannel.internalAddLogCalls.single.errorMessage,
-          error.toString());
+      expect(fakeChannel.internalAddLogCalls.single.message,
+          'failed\n${error.toString()}');
+    });
+
+    test('appends stack trace when stackTrace is provided', () async {
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+      final stack = StackTrace.fromString('#0 fakeFrame (file.dart:1:1)');
+
+      logger.log(LogLevel.error, 'failed', null, stack);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+      expect(fakeChannel.internalAddLogCalls.single.message,
+          'failed\n${stack.toString()}');
+    });
+
+    test('appends both error and stack when both are provided', () async {
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+      final error = Exception('boom');
+      final stack = StackTrace.fromString('#0 fakeFrame (file.dart:1:1)');
+
+      logger.log(LogLevel.error, 'failed', error, stack);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+      expect(fakeChannel.internalAddLogCalls.single.message,
+          'failed\n${error.toString()}\n${stack.toString()}');
     });
 
     test('swallows errors thrown by internalAddLog', () async {

--- a/flutter/packages/measure_flutter/test/logger/flutter_logger_test.dart
+++ b/flutter/packages/measure_flutter/test/logger/flutter_logger_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/logger/flutter_logger.dart';
+import 'package:measure_flutter/src/logger/log_level.dart';
+import 'package:measure_flutter/src/method_channel/msr_platform_interface.dart';
+
+import '../utils/fake_msr_method_channel.dart';
+
+void main() {
+  group('FlutterLogger diagnostic mode', () {
+    late FakeMethodChannel fakeChannel;
+    late MeasureFlutterPlatform originalInstance;
+
+    setUp(() {
+      originalInstance = MeasureFlutterPlatform.instance;
+      fakeChannel = FakeMethodChannel();
+      MeasureFlutterPlatform.instance = fakeChannel;
+    });
+
+    tearDown(() {
+      MeasureFlutterPlatform.instance = originalInstance;
+    });
+
+    test('does not call internalAddLog when diagnostic mode is off', () async {
+      final logger = FlutterLogger(enabled: true, enableDiagnosticMode: false);
+
+      logger.log(LogLevel.info, 'hello');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, isEmpty);
+    });
+
+    test('calls internalAddLog with platform=flutter when diagnostic mode is on',
+        () async {
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+
+      logger.log(LogLevel.info, 'a message');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+      final call = fakeChannel.internalAddLogCalls.single;
+      expect(call.platform, 'flutter');
+      expect(call.message, 'a message');
+      expect(call.errorMessage, isNull);
+    });
+
+    test('forwards stringified error when diagnostic mode is on', () async {
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+      final error = Exception('boom');
+
+      logger.log(LogLevel.error, 'failed', error);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+      expect(fakeChannel.internalAddLogCalls.single.errorMessage,
+          error.toString());
+    });
+
+    test('swallows errors thrown by internalAddLog', () async {
+      fakeChannel.internalAddLogShouldThrow = true;
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+
+      expect(() => logger.log(LogLevel.info, 'x'), returnsNormally);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+    });
+
+    test('forwards even when developer logging is disabled', () async {
+      final logger = FlutterLogger(enabled: false, enableDiagnosticMode: true);
+
+      logger.log(LogLevel.debug, 'still forwarded');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeChannel.internalAddLogCalls, hasLength(1));
+    });
+  });
+
+  group('FlutterLogger constructor defaults', () {
+    test('enableDiagnosticMode defaults to false', () {
+      const logger = FlutterLogger(enabled: true);
+      expect(logger.enableDiagnosticMode, isFalse);
+    });
+  });
+}

--- a/flutter/packages/measure_flutter/test/method_channel/msr_method_channel_internal_add_log_test.dart
+++ b/flutter/packages/measure_flutter/test/method_channel/msr_method_channel_internal_add_log_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/method_channel/method_constants.dart';
+import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MsrMethodChannel.internalAddLog', () {
+    const channel = MethodChannel('measure_flutter');
+    final messenger = TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger;
+
+    tearDown(() {
+      messenger.setMockMethodCallHandler(channel, null);
+    });
+
+    test('invokes functionInternalAddLog with all three args', () async {
+      MethodCall? receivedCall;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        receivedCall = call;
+        return null;
+      });
+
+      await MsrMethodChannel().internalAddLog(
+        platform: 'flutter',
+        message: 'a message',
+        errorMessage: 'boom',
+      );
+
+      expect(receivedCall, isNotNull);
+      expect(receivedCall!.method, MethodConstants.functionInternalAddLog);
+      expect(receivedCall!.arguments, {
+        MethodConstants.argPlatform: 'flutter',
+        MethodConstants.argMessage: 'a message',
+        MethodConstants.argErrorMessage: 'boom',
+      });
+    });
+
+    test('forwards null errorMessage when not provided', () async {
+      MethodCall? receivedCall;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        receivedCall = call;
+        return null;
+      });
+
+      await MsrMethodChannel().internalAddLog(
+        platform: 'flutter',
+        message: 'no error',
+      );
+
+      expect(receivedCall!.arguments[MethodConstants.argErrorMessage], isNull);
+    });
+  });
+}

--- a/flutter/packages/measure_flutter/test/method_channel/msr_method_channel_internal_add_log_test.dart
+++ b/flutter/packages/measure_flutter/test/method_channel/msr_method_channel_internal_add_log_test.dart
@@ -15,7 +15,7 @@ void main() {
       messenger.setMockMethodCallHandler(channel, null);
     });
 
-    test('invokes functionInternalAddLog with all three args', () async {
+    test('invokes functionInternalAddLog with platform and message', () async {
       MethodCall? receivedCall;
       messenger.setMockMethodCallHandler(channel, (call) async {
         receivedCall = call;
@@ -25,31 +25,14 @@ void main() {
       await MsrMethodChannel().internalAddLog(
         platform: 'flutter',
         message: 'a message',
-        errorMessage: 'boom',
       );
 
       expect(receivedCall, isNotNull);
       expect(receivedCall!.method, MethodConstants.functionInternalAddLog);
       expect(receivedCall!.arguments, {
-        MethodConstants.argPlatform: 'flutter',
-        MethodConstants.argMessage: 'a message',
-        MethodConstants.argErrorMessage: 'boom',
+        MethodConstants.argDiagnosticModePlatform: 'flutter',
+        MethodConstants.argDiagnosticModeMessage: 'a message',
       });
-    });
-
-    test('forwards null errorMessage when not provided', () async {
-      MethodCall? receivedCall;
-      messenger.setMockMethodCallHandler(channel, (call) async {
-        receivedCall = call;
-        return null;
-      });
-
-      await MsrMethodChannel().internalAddLog(
-        platform: 'flutter',
-        message: 'no error',
-      );
-
-      expect(receivedCall!.arguments[MethodConstants.argErrorMessage], isNull);
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_config_provider.dart
@@ -6,6 +6,7 @@ class FakeConfigProvider implements ConfigProvider {
   List<String> _defaultHttpContentTypeAllowlist = [];
   List<String> _defaultHttpHeadersBlocklist = [];
   bool _enableLogging = false;
+  bool _enableDiagnosticMode = false;
   int _maxCheckpointNameLength = 64;
   int _maxCheckpointsPerSpan = 100;
   int _maxSpanNameLength = 64;
@@ -41,6 +42,9 @@ class FakeConfigProvider implements ConfigProvider {
 
   @override
   bool get enableLogging => _enableLogging;
+
+  @override
+  bool get enableDiagnosticMode => _enableDiagnosticMode;
 
   @override
   int get maxCheckpointNameLength => _maxCheckpointNameLength;
@@ -138,6 +142,8 @@ class FakeConfigProvider implements ConfigProvider {
   set defaultHttpHeadersBlocklist(List<String> value) => _defaultHttpHeadersBlocklist = value;
 
   set enableLogging(bool value) => _enableLogging = value;
+
+  set enableDiagnosticMode(bool value) => _enableDiagnosticMode = value;
 
   @override
   bool get autoStart => _autoStart;

--- a/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
@@ -5,8 +5,7 @@ import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 class FakeMethodChannel extends MsrMethodChannel {
   Future<void> Function(MethodCall call)? handler;
   Uint8List? encodedWebPResult;
-  final List<({String platform, String message, String? errorMessage})>
-      internalAddLogCalls = [];
+  final List<({String platform, String message})> internalAddLogCalls = [];
   bool internalAddLogShouldThrow = false;
 
   @override
@@ -76,10 +75,8 @@ class FakeMethodChannel extends MsrMethodChannel {
   Future<void> internalAddLog({
     required String platform,
     required String message,
-    String? errorMessage,
   }) async {
-    internalAddLogCalls
-        .add((platform: platform, message: message, errorMessage: errorMessage));
+    internalAddLogCalls.add((platform: platform, message: message));
     if (internalAddLogShouldThrow) {
       throw Exception('forced error');
     }

--- a/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_msr_method_channel.dart
@@ -5,6 +5,9 @@ import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 class FakeMethodChannel extends MsrMethodChannel {
   Future<void> Function(MethodCall call)? handler;
   Uint8List? encodedWebPResult;
+  final List<({String platform, String message, String? errorMessage})>
+      internalAddLogCalls = [];
+  bool internalAddLogShouldThrow = false;
 
   @override
   void setMethodCallHandler(
@@ -68,4 +71,17 @@ class FakeMethodChannel extends MsrMethodChannel {
     required int height,
   }) async =>
       encodedWebPResult;
+
+  @override
+  Future<void> internalAddLog({
+    required String platform,
+    required String message,
+    String? errorMessage,
+  }) async {
+    internalAddLogCalls
+        .add((platform: platform, message: message, errorMessage: errorMessage));
+    if (internalAddLogShouldThrow) {
+      throw Exception('forced error');
+    }
+  }
 }

--- a/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
+++ b/flutter/packages/measure_flutter/test/utils/test_method_channel.dart
@@ -106,4 +106,11 @@ class TestMethodChannel implements MsrMethodChannel {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> internalAddLog({
+    required String platform,
+    required String message,
+    String? errorMessage,
+  }) async {}
 }

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -107,10 +107,10 @@ import UIKit
                                           attachments: attachments)
     }
 
-    func internalAddLog(platform: String, message: String, error: Error?) {
+    func internalAddLog(platform: String, message: String) {
         guard let measureInternal = measureInternal else { return }
 
-        measureInternal.internalAddLog(platform: platform, message: message, error: error)
+        measureInternal.internalAddLog(platform: platform, message: message)
     }
 
     func internalTrackSpan(name: String, // swiftlint:disable:this function_parameter_count
@@ -472,9 +472,8 @@ extension Measure {
     /// - Parameters:
     ///   - platform: The platform sending the log. `react-native` for React native project or `flutter` for Flutter project.
     ///   - message: Message to log
-    ///   - error: Error object to log
-    public static func internalAddLog(platform: String, message: String, error: Error?) {
-        Measure.shared.internalAddLog(platform: platform, message: message, error: error)
+    public static func internalAddLog(platform: String, message: String) {
+        Measure.shared.internalAddLog(platform: platform, message: message)
     }
 
     /// An internal method to track spans from cross-platform frameworks

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -472,8 +472,8 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
                                                           responseBody: responseBody)
     }
 
-    func internalAddLog(platform: String, message: String, error: Error?) {
-        logger.log(level: .info, message: "[\(platform)] \(message)", error: error, data: nil)
+    func internalAddLog(platform: String, message: String) {
+        logger.log(level: .info, message: "[\(platform)] \(message)", error: nil, data: nil)
     }
 
     private func applicationDidEnterBackground() {

--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -357,12 +357,10 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun internalAddLog(platform: String, message: String, errorMessage: String?, promise: Promise) {
-        val throwable = errorMessage?.let { Exception(it) }
+    fun internalAddLog(platform: String, message: String, promise: Promise) {
         Measure.internalAddLog(
             platform = platform,
             message = message,
-            throwable = throwable
         )
         promise.resolve(null)
     }

--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -266,16 +266,11 @@ class MeasureModule: NSObject, RCTBridgeModule {
     @objc
     func internalAddLog(_ platform: NSString,
                         message: NSString,
-                        errorMessage: NSString?,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) {
-        let nsError: NSError? = errorMessage.map {
-            NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: $0 as String])
-        }
         Measure.internalAddLog(
             platform: platform as String,
-            message: message as String,
-            error: nsError
+            message: message as String
         )
         resolve(nil)
     }

--- a/react-native/ios/MeasureModuleBridge.m
+++ b/react-native/ios/MeasureModuleBridge.m
@@ -65,7 +65,6 @@ RCT_EXTERN_METHOD(trackBugReport:(NSString *)description
                   rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(internalAddLog:(NSString *)platform
                   message:(NSString *)message
-                  errorMessage:(nullable NSString *)errorMessage
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve

--- a/react-native/src/__tests__/utils/logger.test.ts
+++ b/react-native/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,83 @@
+import { MeasureLogger } from '../../utils/logger';
+
+jest.mock('../../native/measureBridge', () => ({
+  internalAddLog: jest.fn(() => Promise.resolve()),
+}));
+
+const { internalAddLog } = jest.requireMock('../../native/measureBridge');
+
+describe('MeasureLogger diagnostic mode', () => {
+  beforeEach(() => {
+    (internalAddLog as jest.Mock).mockClear();
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not call internalAddLog when diagnostic mode is off', () => {
+    const logger = new MeasureLogger('test', true, false, false);
+
+    logger.log('info', 'hello');
+
+    expect(internalAddLog).not.toHaveBeenCalled();
+  });
+
+  it('forwards just the message when no error is provided', () => {
+    const logger = new MeasureLogger('test', true, false, true);
+
+    logger.log('info', 'a message');
+
+    expect(internalAddLog).toHaveBeenCalledWith('react-native', 'a message');
+  });
+
+  it('appends error.stack (already containing message) without duplicating the message', () => {
+    const logger = new MeasureLogger('test', true, false, true);
+    const err = new Error('boom');
+    err.stack = 'Error: boom\n    at thing (file.js:1:1)';
+
+    logger.log('error', 'failed', err);
+
+    expect(internalAddLog).toHaveBeenCalledWith(
+      'react-native',
+      `failed\n${err.stack}`
+    );
+    const composed = (internalAddLog as jest.Mock).mock.calls[0][1] as string;
+    expect(composed.match(/boom/g)).toHaveLength(1);
+  });
+
+  it('falls back to error.message when error.stack is undefined', () => {
+    const logger = new MeasureLogger('test', true, false, true);
+    const err = new Error('boom');
+    err.stack = undefined;
+
+    logger.log('error', 'failed', err);
+
+    expect(internalAddLog).toHaveBeenCalledWith(
+      'react-native',
+      'failed\nboom'
+    );
+  });
+
+  it('uses String(error) for non-Error values', () => {
+    const logger = new MeasureLogger('test', true, false, true);
+
+    logger.log('error', 'failed', { code: 42, toString: () => '<obj>' });
+
+    expect(internalAddLog).toHaveBeenCalledWith(
+      'react-native',
+      'failed\n<obj>'
+    );
+  });
+
+  it('swallows errors thrown by internalAddLog', () => {
+    (internalAddLog as jest.Mock).mockReturnValueOnce(
+      Promise.reject(new Error('forced'))
+    );
+    const logger = new MeasureLogger('test', true, false, true);
+
+    expect(() => logger.log('info', 'x')).not.toThrow();
+  });
+});

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -239,8 +239,7 @@ export function trackBugReport(
 
 export function internalAddLog(
   platform: string,
-  message: string,
-  errorMessage?: string | null
+  message: string
 ): Promise<void> {
   if (!MeasureModule.internalAddLog || isDisabled()) {
     return Promise.reject(
@@ -248,7 +247,7 @@ export function internalAddLog(
     );
   }
 
-  return MeasureModule.internalAddLog(platform, message, errorMessage ?? null);
+  return MeasureModule.internalAddLog(platform, message);
 }
 
 export function getSessionId(): Promise<string | null> {

--- a/react-native/src/utils/logger.ts
+++ b/react-native/src/utils/logger.ts
@@ -49,12 +49,13 @@ export class MeasureLogger implements Logger {
     const output = `${prefix} ${message} ${dataStr} ${errorStr}`.trim();
 
     if (this.enableDiagnosticMode) {
-      const errorStr = error
-        ? error instanceof Error
-          ? error.message
-          : String(error)
-        : null;
-      internalAddLog('react-native', message, errorStr).catch(() => {});
+      let composed = message;
+      if (error instanceof Error) {
+        composed += '\n' + (error.stack ?? error.message);
+      } else if (error != null) {
+        composed += '\n' + String(error);
+      }
+      internalAddLog('react-native', composed).catch(() => {});
     }
 
     switch (level) {

--- a/samples/frank/android/app/src/main/java/sh/frankenstein/android/MainApplication.kt
+++ b/samples/frank/android/app/src/main/java/sh/frankenstein/android/MainApplication.kt
@@ -38,6 +38,7 @@ class MainApplication : Application(), ReactApplication {
             this, MeasureConfig(
                 enableLogging = true,
                 enableFullCollectionMode = true,
+                enableDiagnosticMode = true,
             )
         )
         SoLoader.init(this, OpenSourceMergedSoMapping)

--- a/samples/frank/flutter/lib/main.dart
+++ b/samples/frank/flutter/lib/main.dart
@@ -17,7 +17,10 @@ Future<void> main() async {
   };
   await Measure.instance.init(
     () => runApp(const MeasureWidget(child: FlutterApp())),
-    config: const MeasureConfig(enableLogging: true),
+    config: const MeasureConfig(
+      enableLogging: true,
+      enableDiagnosticMode: true,
+    ),
   );
 }
 

--- a/samples/frank/flutter/pubspec.lock
+++ b/samples/frank/flutter/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -566,10 +566,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/samples/frank/ios/FrankensteinApp/AppDelegate.swift
+++ b/samples/frank/ios/FrankensteinApp/AppDelegate.swift
@@ -13,7 +13,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let apiKey = Bundle.main.object(forInfoDictionaryKey: "MeasureApiKey") as? String ?? ""
         let apiUrl = Bundle.main.object(forInfoDictionaryKey: "MeasureApiUrl") as? String ?? ""
         let clientInfo = ClientInfo(apiKey: apiKey, apiUrl: apiUrl)
-        let config = BaseMeasureConfig(enableLogging: true, enableFullCollectionMode: true)
+        let config = BaseMeasureConfig(
+            enableLogging: true,
+            enableFullCollectionMode: true,
+            enableDiagnosticMode: true,
+            enableDiagnosticModeGesture: true
+        )
         Measure.initialize(with: clientInfo, config: config)
 
         FirebaseApp.configure()

--- a/samples/frank/react_native/index.js
+++ b/samples/frank/react_native/index.js
@@ -468,6 +468,7 @@ const measureReady = Measure.init(
   new MeasureConfig({
     enableLogging: true,
     enableFullCollectionMode: true,
+    enableDiagnosticMode: true,
   }),
 );
 


### PR DESCRIPTION
# Description

 - Add `enableDiagnosticMode` config to the Flutter SDK
 - Diagnostic logs from Flutter and React Native now carry the real Dart / JS stack trace instead.
 - Drop the now-unused `Throwable` / `Error` parameter from `Measure.internalAddLog` (Android + iOS core SDKs)
 - React Native frank sample turns on `enableDiagnosticMode` to match the Flutter and iOS frank apps.

#### Sample logs

**RN**

```
Debug [react-native] Fatal exception
Error: Simulated JavaScript exception
    at c (index.android.bundle:5:922)
    at value (index.android.bundle:320:8166)
    at value (index.android.bundle:320:7458)
    at onResponderRelease (index.android.bundle:320:5435)
    at O (index.android.bundle:120:4052)
    at Ye (index.android.bundle:120:16779)
    at forEach (native)
    at pe (index.android.bundle:120:8696)
    at anonymous (index.android.bundle:120:114857)
    at We (index.android.bundle:120:117282)
    at $e (index.android.bundle:120:16589)
    at anonymous (index.android.bundle:120:114589)
Debug [react-native] [SignalProcessor] Tracking event: exception
```

**Flutter**

```
Debug [flutter] Successfully initialized Measure Flutter SDK
Debug [flutter] verify-formatting test
FormatException: verify-formatting test error
#0      Measure._logInitializationSuccess (package:measure_flutter/measure_flutter.dart:1072:7)
#1      Measure.init (package:measure_flutter/measure_flutter.dart:191:7)
<asynchronous suspension>
#2      main (package:flutter_module/main.dart:18:3)
<asynchronous suspension>

Debug [flutter] screen_view: {name: /}
```

## Related issue
Closes #3435 


