### PR TITLE
fix(frontend): restore social preview image on landing pages

### DIFF
--- a/frontend/dashboard/app/about/page.tsx
+++ b/frontend/dashboard/app/about/page.tsx
@@ -5,6 +5,7 @@ import LandingHeader from "../components/landing_header";
 
 import { buttonVariants } from "../components/button_variants";
 import LandingFooter from "../components/landing_footer";
+import { sharedOpenGraph } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 
 export const metadata: Metadata = {
@@ -13,6 +14,7 @@ export const metadata: Metadata = {
     "Mobile apps break, get to the root cause faster. Built by and for mobile developers.",
   alternates: { canonical: "/about" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "About Measure",
     description:
       "Mobile apps break, get to the root cause faster. Built by and for mobile developers.",

--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "./components/toaster";
 import { CookieConsentProvider } from "./context/cookie_consent";
 import { PostHogProvider } from "./context/posthog";
 import "./globals.css";
+import { previewImage, sharedOpenGraph } from "./utils/metadata";
 
 const josefin_sans = Josefin_Sans({
   subsets: ["latin"],
@@ -35,8 +36,6 @@ const fira_code = Fira_Code({
 const title = "Measure";
 const description =
   "Open source mobile app monitoring for crashes, ANRs, performance, bug reports, user journeys, and more.";
-const siteName = "measure.sh";
-const previewImage = "/images/social_preview.png";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://measure.sh"),
@@ -49,20 +48,10 @@ export const metadata: Metadata = {
   description: description,
 
   openGraph: {
+    ...sharedOpenGraph,
     title: title,
     description: description,
     url: "/",
-    siteName: siteName,
-    images: [
-      {
-        url: previewImage,
-        width: 1200,
-        height: 630,
-        alt: "Measure preview image",
-      },
-    ],
-    locale: "en_US",
-    type: "website",
   },
 
   twitter: {

--- a/frontend/dashboard/app/page.tsx
+++ b/frontend/dashboard/app/page.tsx
@@ -11,6 +11,7 @@ import LandingFooter from "./components/landing_footer";
 import LandingHeader from "./components/landing_header";
 import LandingHeroAnimation from "./components/landing_hero_animation";
 import MCPDemo from "./components/mcp_demo";
+import { sharedOpenGraph } from "./utils/metadata";
 import { cn } from "./utils/shadcn_utils";
 import { underlineLinkStyle } from "./utils/shared_styles";
 
@@ -22,6 +23,7 @@ export const metadata: Metadata = {
     "Complete Mobile App Monitoring platform — Crash Reporting, ANR Tracking, Bug Reporting, Performance Tracing, Logging and more! 100% Open Source alternative to Firebase Crashlytics.",
   alternates: { canonical: "/" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Open Source Mobile App Monitoring & Crash Reporting | Measure",
     description:
       "Complete Mobile App Monitoring platform — Crash Reporting, ANR Tracking, Bug Reporting, Performance Tracing, Logging and more. 100% Open Source alternative to Firebase Crashlytics.",

--- a/frontend/dashboard/app/pricing/page.tsx
+++ b/frontend/dashboard/app/pricing/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Card } from "../components/card";
 import LandingFooter from "../components/landing_footer";
 import LandingHeader from "../components/landing_header";
+import { sharedOpenGraph } from "../utils/metadata";
 import {
   FREE_GB,
   FREE_RETENTION_DAYS,
@@ -21,6 +22,7 @@ export const metadata: Metadata = {
     "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits, no feature restrictions. 100% Open Source.",
   alternates: { canonical: "/pricing" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Plans and Pricing",
     description:
       "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits, no feature restrictions. 100% Open Source.",

--- a/frontend/dashboard/app/privacy-policy/page.tsx
+++ b/frontend/dashboard/app/privacy-policy/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { buttonVariants } from "../components/button_variants";
 import LandingFooter from "../components/landing_footer";
 import LandingHeader from "../components/landing_header";
+import { sharedOpenGraph } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "What Measure does with your data. Open source so you can audit it yourself.",
   alternates: { canonical: "/privacy-policy" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Privacy Policy",
     description:
       "What Measure does with your data. Open source so you can audit it yourself.",

--- a/frontend/dashboard/app/product/adaptive-capture/page.tsx
+++ b/frontend/dashboard/app/product/adaptive-capture/page.tsx
@@ -1,5 +1,6 @@
 import AdaptiveCaptureDemo from "@/app/components/adaptive_capture_demo";
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you will never read.",
   alternates: { canonical: "/product/adaptive-capture" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Adaptive Capture — Control Mobile Monitoring Costs",
     description:
       "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you will never read.",

--- a/frontend/dashboard/app/product/app-health/page.tsx
+++ b/frontend/dashboard/app/product/app-health/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Stay on top of your mobile app's health by tracking the metrics that matter: crash-free sessions, app launch times, release adoption and more.",
   alternates: { canonical: "/product/app-health" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Mobile App Health",
     description:
       "Stay on top of your mobile app's health by tracking the metrics that matter: crash-free sessions, app launch times, release adoption and more.",

--- a/frontend/dashboard/app/product/bug-reports/page.tsx
+++ b/frontend/dashboard/app/product/bug-reports/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Capture bug reports with a device shake or SDK call. Get the full session context, device state, and network info so you can get to the root cause.",
   alternates: { canonical: "/product/bug-reports" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "In-App Bug Reporting for Mobile Apps",
     description:
       "Capture bug reports with a device shake or SDK call. Get the full session context, device state, and network info so you can get to the root cause.",

--- a/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
+++ b/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Mobile Crash Reporting and ANR Tracking - Open Source Firebase Crashlytics alternative. Get full stack traces, likely reproduction steps and complete session context to fix crashes faster.",
   alternates: { canonical: "/product/crashes-and-anrs" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Mobile Crash Reporting & ANR Tracking",
     description:
       "Mobile Crash Reporting and ANR Tracking - Open Source Firebase Crashlytics alternative. Get full stack traces, likely reproduction steps and complete session context to fix crashes faster.",

--- a/frontend/dashboard/app/product/mcp/page.tsx
+++ b/frontend/dashboard/app/product/mcp/page.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from "@/app/components/button_variants";
 import MCPDemo from "@/app/components/mcp_demo";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Connect Measure to Claude, Codex, Cursor and other coding agents. Query crashes, traces and sessions to fix issues faster than ever with AI.",
   alternates: { canonical: "/product/mcp" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Measure MCP Server",
     description:
       "Connect Measure to Claude, Codex, Cursor and other coding agents. Query crashes, traces and sessions to fix issues faster than ever with AI.",

--- a/frontend/dashboard/app/product/network-performance/page.tsx
+++ b/frontend/dashboard/app/product/network-performance/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Monitor the API call latency that your users actually feel. Investigate HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",
   alternates: { canonical: "/product/network-performance" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Mobile Network Performance Monitoring",
     description:
       "Monitor the API call latency that your users actually feel. Investigate HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",

--- a/frontend/dashboard/app/product/performance-traces/page.tsx
+++ b/frontend/dashboard/app/product/performance-traces/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues harming your app experience.",
   alternates: { canonical: "/product/performance-traces" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Mobile App Performance Tracing & Monitoring",
     description:
       "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues harming your app experience.",

--- a/frontend/dashboard/app/product/session-timelines/page.tsx
+++ b/frontend/dashboard/app/product/session-timelines/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "No more guessing what the user was doing - see every click, navigation, network call, log, error and CPU/memory signal stitched into a single timeline to diagnose issues faster.",
   alternates: { canonical: "/product/session-timelines" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Mobile Session Timelines",
     description:
       "No more guessing what the user was doing - see every click, navigation, network call, log, error and CPU/memory signal stitched into a single timeline to diagnose issues faster.",

--- a/frontend/dashboard/app/product/user-journeys/page.tsx
+++ b/frontend/dashboard/app/product/user-journeys/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Understand how users actually move through your mobile app. Track popular paths, find friction, and prioritize the flows that matter most.",
   alternates: { canonical: "/product/user-journeys" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "User Journey Tracking for Mobile Apps",
     description:
       "Understand how users actually move through your mobile app. Track popular paths, find friction, and prioritize the flows that matter most.",

--- a/frontend/dashboard/app/security/page.tsx
+++ b/frontend/dashboard/app/security/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { buttonVariants } from "../components/button_variants";
 import LandingFooter from "../components/landing_footer";
 import LandingHeader from "../components/landing_header";
+import { sharedOpenGraph } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Measure is committed to security and protection of your app's data. Completely open source so you can audit it yourself.",
   alternates: { canonical: "/security" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Security at Measure",
     description:
       "Measure is committed to security and protection of your app's data. Completely open source so you can audit it yourself.",

--- a/frontend/dashboard/app/terms-of-service/page.tsx
+++ b/frontend/dashboard/app/terms-of-service/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { buttonVariants } from "../components/button_variants";
 import LandingFooter from "../components/landing_footer";
 import LandingHeader from "../components/landing_header";
+import { sharedOpenGraph } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     "Terms of Service for Measure Cloud and the open source Measure project.",
   alternates: { canonical: "/terms-of-service" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Terms of Service",
     description:
       "Terms of Service for Measure Cloud and the open source Measure project.",

--- a/frontend/dashboard/app/utils/metadata.ts
+++ b/frontend/dashboard/app/utils/metadata.ts
@@ -1,0 +1,17 @@
+const siteName = "measure.sh";
+
+export const previewImage = "/images/social_preview.png";
+
+export const sharedOpenGraph = {
+  siteName,
+  images: [
+    {
+      url: previewImage,
+      width: 1200,
+      height: 630,
+      alt: "Measure preview image",
+    },
+  ],
+  locale: "en_US",
+  type: "website" as const,
+};

--- a/frontend/dashboard/app/why-measure/page.tsx
+++ b/frontend/dashboard/app/why-measure/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "@/app/components/button_variants";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import {
   LucideBug,
@@ -18,6 +19,7 @@ export const metadata: Metadata = {
     "At Measure, Mobile is not an add-on to an observability product. Mobile is the product.",
   alternates: { canonical: "/why-measure" },
   openGraph: {
+    ...sharedOpenGraph,
     title: "Why Measure",
     description:
       "At Measure, Mobile is not an add-on to an observability product. Mobile is the product.",


### PR DESCRIPTION
# Description

The recent SEO update added page-level openGraph metadata (title, description, url) to 16 landing pages. Next.js does not deep-merge openGraph between layout and page — a page-level object replaces the layout's entirely — so the social_preview.png set in app/layout.tsx was wiped from every page that overrode openGraph. Social scrapers fell back to scraping the DOM and picked the first sizable image on the page instead.

- extract shared openGraph fields (siteName, images, locale, type) into app/utils/metadata.ts
- spread the shared object into the layout and all 16 page-level openGraph blocks so each route keeps its custom title/description while inheriting the social preview image


