### PR TITLE
fix(ios): remove orphaned attachment cleanup logic

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/DataCleanupService.swift
@@ -45,7 +45,6 @@ final class BaseDataCleanupService: DataCleanupService {
 
     func clearStaleData() {
         trimIfDiskLimitExceeded(currentSessionId: sessionManager.sessionId)
-        cleanupOrphanedAttachments()
         attachmentStore.deleteExpiredAttachments()
         trimSdkDebugLogs()
 
@@ -151,16 +150,6 @@ final class BaseDataCleanupService: DataCleanupService {
         eventStore.deleteEvents(sessionIds: sessionIds)
         spanStore.deleteSpans(sessionIds: sessionIds)
         attachmentStore.deleteAttachments(forSessionIds: sessionIds)
-    }
-
-    private func cleanupOrphanedAttachments() {
-        guard !userDefaultsStorage.hasRunOrphanAttachmentCleanup() else { return }
-
-        let validPaths = attachmentStore.getAllAttachmentPaths()
-
-        systemFileManager.cleanupOrphanedAttachmentFiles(validPaths: validPaths)
-
-        userDefaultsStorage.setHasRunOrphanAttachmentCleanup(true)
     }
 
     private func trimSdkDebugLogs() {

--- a/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
@@ -44,7 +44,7 @@ final class BaseAttachmentProcessor: AttachmentProcessor {
         case .data:
             return MsrAttachment(name: attachmentName, type: attachmentType, size: Int64(image.count), id: uuid, bytes: image, path: nil)
         case .fileStorage:
-            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: nil, directory: .documentDirectory) else {
+            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: "measure", directory: .documentDirectory) else {
                 logger.internalLog(level: .error, message: "AttachmentProcessor: Failed to save compressed image to file storage.", error: nil, data: nil)
                 return nil
             }

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -23,7 +23,6 @@ protocol SystemFileManager {
     func getDynamicConfigPath() -> String?
     func retrieveFile(atPath path: String) -> Data?
     func deleteFile(atPath path: String)
-    func cleanupOrphanedAttachmentFiles(validPaths: Set<String>)
     func getSdkDebugLogsDirectory() -> URL?
     func getLogFile(_ fileId: String) -> URL?
     func getContentsOfDebugLogsDirectory() -> [URL]
@@ -173,35 +172,6 @@ final class BaseSystemFileManager: SystemFileManager {
                 error: error,
                 data: nil
             )
-        }
-    }
-
-    func cleanupOrphanedAttachmentFiles(validPaths: Set<String>) {
-        guard let attachmentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            logger.internalLog(level: .error, message: "SystemFileManager: Unable to access directory documents directory.", error: nil, data: nil)
-            return
-        }
-
-        guard let enumerator = fileManager.enumerator(
-            at: attachmentsDirectory,
-            includingPropertiesForKeys: nil
-        ) else { return }
-
-        for case let fileURL as URL in enumerator {
-            let path = fileURL.path
-
-            if !validPaths.contains(path) {
-                do {
-                    try fileManager.removeItem(at: fileURL)
-                } catch {
-                    logger.internalLog(
-                        level: .error,
-                        message: "SystemFileManager: Failed to delete orphaned attachment at path \(path)",
-                        error: error,
-                        data: nil
-                    )
-                }
-            }
         }
     }
 

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
@@ -51,15 +51,6 @@ final class MockSystemFileManager: SystemFileManager {
         sdkDebugLogFiles.removeAll { $0.path == path }
     }
 
-    func cleanupOrphanedAttachmentFiles(validPaths: Set<String>) {
-        let allPaths = Array(savedFiles.keys)
-        for path in allPaths {
-            if !validPaths.contains(path) {
-                savedFiles.removeValue(forKey: path)
-            }
-        }
-    }
-
     func getSdkDebugLogsDirectory() -> URL? {
         return sdkDebugLogsDirectory
     }


### PR DESCRIPTION
# Description

In the initial flutter versions, the attachments were not getting uploaded on iOS side because the file upload was not implemented for files stored in the documents directory.

This lead to a bunch of stale attachments getting accumulated in the documents directory. To fix this issue, a cleanup logic was added to clear orphaned attachments in this [PR](https://github.com/measure-sh/measure/pull/3135) to run one time in the lifecycle of the app. This cleanup logic cleared not only the measure attachments but also other files present in the documents directory.

This cleanup logic is not needed and is now removed in this PR.

## Related issue
Fixes #3599 