### PR TITLE
chore(flutter): fix screenshot rendering in bug reports

### DIFF
--- a/flutter/packages/measure_flutter/example/pubspec.lock
+++ b/flutter/packages/measure_flutter/example/pubspec.lock
@@ -29,26 +29,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cross_file:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -283,26 +283,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -323,33 +323,33 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   measure_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.6.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -362,10 +362,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
@@ -410,7 +410,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -431,18 +431,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -532,5 +532,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
@@ -74,16 +74,14 @@ class BugReportCollector {
         }
 
         final uuid = _idProvider.uuid();
-        final width = attachment.width;
-        final height = attachment.height;
 
         final File? file;
         final int sizeBytes;
-        if (width != null && height != null) {
+        if (attachment.hasRawPixels) {
           final webp = await _methodChannel.encodeWebP(
             pixels: bytes,
-            width: width,
-            height: height,
+            width: attachment.width!,
+            height: attachment.height!,
           );
           if (webp == null) {
             _logger.log(LogLevel.error, 'BugReportCollector: WebP encoding failed');

--- a/flutter/packages/measure_flutter/lib/src/bug_report/ui/raw_rgba_image_provider.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/ui/raw_rgba_image_provider.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+/// An [ImageProvider] for raw RGBA8888 pixel buffers.
+///
+/// [MemoryImage] cannot be used for raw pixels because it runs the bytes
+/// through the platform image codec, which expects an encoded format
+/// (PNG/JPEG/WebP/etc.) and fails on a bare pixel buffer.
+class RawRgbaImageProvider extends ImageProvider<RawRgbaImageProvider> {
+  RawRgbaImageProvider({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    this.scale = 1.0,
+  });
+
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final double scale;
+
+  @override
+  Future<RawRgbaImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<RawRgbaImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+      RawRgbaImageProvider key, ImageDecoderCallback decode) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadCodec(),
+      scale: key.scale,
+      debugLabel: 'RawRgbaImageProvider(${width}x$height)',
+    );
+  }
+
+  Future<ui.Codec> _loadCodec() async {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+    final descriptor = ui.ImageDescriptor.raw(
+      buffer,
+      width: width,
+      height: height,
+      pixelFormat: ui.PixelFormat.rgba8888,
+    );
+    return descriptor.instantiateCodec();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RawRgbaImageProvider &&
+        identical(other.bytes, bytes) &&
+        other.width == width &&
+        other.height == height &&
+        other.scale == scale;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(identityHashCode(bytes), width, height, scale);
+}

--- a/flutter/packages/measure_flutter/lib/src/bug_report/ui/screenshot_list_item.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/ui/screenshot_list_item.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:measure_flutter/src/bug_report/ui/delete_screenshot_button.dart';
+import 'package:measure_flutter/src/bug_report/ui/raw_rgba_image_provider.dart';
 import 'package:measure_flutter/src/events/msr_attachment.dart';
 
 class ScreenshotListItem extends StatefulWidget {
@@ -77,8 +78,15 @@ class _ScreenshotListItemState extends State<ScreenshotListItem> {
         frameBuilder: _buildFrameBuilder,
       );
     } else if (widget.screenshot.bytes != null) {
-      image = Image.memory(
-        widget.screenshot.bytes!,
+      final ImageProvider provider = widget.screenshot.hasRawPixels
+          ? RawRgbaImageProvider(
+              bytes: widget.screenshot.bytes!,
+              width: widget.screenshot.width!,
+              height: widget.screenshot.height!,
+            )
+          : MemoryImage(widget.screenshot.bytes!);
+      image = Image(
+        image: provider,
         fit: BoxFit.cover,
         frameBuilder: _buildFrameBuilder,
       );

--- a/flutter/packages/measure_flutter/lib/src/events/attachment_bytes_format.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/attachment_bytes_format.dart
@@ -1,0 +1,8 @@
+/// Internal: describes how `MsrAttachment.bytes` is laid out.
+enum AttachmentBytesFormat {
+  /// Raw RGBA8888 pixel data. The buffer length equals `width * height * 4`.
+  rawRgba8888,
+
+  /// Bytes already in an encoded image container (PNG/JPEG/WebP/etc.).
+  encoded,
+}

--- a/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/events/attachment_bytes_format.dart';
 
 part 'msr_attachment.g.dart';
 
@@ -23,13 +24,16 @@ class MsrAttachment {
   @JsonKey(includeFromJson: false, includeToJson: false)
   final Uint8List? bytes;
 
-  /// Pixel width of [bytes] when [bytes] holds raw RGBA pixel data.
-  /// Null for encoded image bytes (PNG/JPEG/etc.) or path-based attachments.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final AttachmentBytesFormat? bytesFormat;
+
+  /// Pixel width of [bytes]. Set only for raw-pixel attachments produced
+  /// internally by the screenshot collector.
   @JsonKey(includeFromJson: false, includeToJson: false)
   final int? width;
 
-  /// Pixel height of [bytes] when [bytes] holds raw RGBA pixel data.
-  /// Null for encoded image bytes (PNG/JPEG/etc.) or path-based attachments.
+  /// Pixel height of [bytes]. Set only for raw-pixel attachments produced
+  /// internally by the screenshot collector.
   @JsonKey(includeFromJson: false, includeToJson: false)
   final int? height;
 
@@ -40,25 +44,32 @@ class MsrAttachment {
     required this.size,
     this.path,
     this.bytes,
+    this.bytesFormat,
     this.width,
     this.height,
-  });
+  })  : assert(bytes == null || bytesFormat != null,
+            'bytesFormat is required whenever bytes is non-null'),
+        assert(
+            bytesFormat != AttachmentBytesFormat.rawRgba8888 ||
+                (width != null && height != null),
+            'rawRgba8888 attachments require width and height');
 
-  /// Creates an [MsrAttachment] from binary data.
+  bool get hasRawPixels =>
+      bytes != null && bytesFormat == AttachmentBytesFormat.rawRgba8888;
+
+  /// Creates an [MsrAttachment] from encoded image bytes (PNG/JPEG/WebP/etc.).
   ///
-  /// Use this factory when you have file content as bytes, such as
-  /// from a screenshot capture or downloaded file.
+  /// Use this factory when you have file content as bytes, such as a
+  /// downloaded file. For screenshots, prefer [Measure.captureScreenshot].
   ///
   /// **Parameters:**
-  /// - [bytes]: The binary file content
+  /// - [bytes]: The encoded image bytes
   /// - [type]: The type of attachment (screenshot, image, etc.)
   /// - [uuid]: A unique identifier for this attachment
   factory MsrAttachment.fromBytes({
     required Uint8List bytes,
     required AttachmentType type,
     required String uuid,
-    int? width,
-    int? height,
   }) {
     return MsrAttachment(
       name: uuid,
@@ -66,6 +77,28 @@ class MsrAttachment {
       type: type,
       size: bytes.length,
       bytes: bytes,
+      bytesFormat: AttachmentBytesFormat.encoded,
+    );
+  }
+
+  /// Creates an [MsrAttachment] holding raw RGBA8888 pixels.
+  ///
+  /// Internal: used by the screenshot collector to defer WebP encoding to
+  /// the native side. Not part of the public SDK surface.
+  factory MsrAttachment.fromRawPixels({
+    required Uint8List bytes,
+    required int width,
+    required int height,
+    required AttachmentType type,
+    required String uuid,
+  }) {
+    return MsrAttachment(
+      name: uuid,
+      id: uuid,
+      type: type,
+      size: bytes.length,
+      bytes: bytes,
+      bytesFormat: AttachmentBytesFormat.rawRgba8888,
       width: width,
       height: height,
     );
@@ -105,3 +138,4 @@ class MsrAttachment {
     return 'MsrAttachment{id: $id, type: $type, name: $name, size: $size, path: $path, bytes: $bytes}';
   }
 }
+

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
@@ -79,16 +79,14 @@ final class ExceptionCollector {
 
   Future<void> _addScreenshot(List<MsrAttachment> attachments) async {
     final screenshot = await screenshotCollector.capture();
-    final width = screenshot?.width;
-    final height = screenshot?.height;
-    if (screenshot == null || screenshot.bytes == null || width == null || height == null) {
+    if (screenshot == null || !screenshot.hasRawPixels) {
       return;
     }
 
     final webp = await methodChannel.encodeWebP(
       pixels: screenshot.bytes!,
-      width: width,
-      height: height,
+      width: screenshot.width!,
+      height: screenshot.height!,
     );
     if (webp == null) {
       logger.log(LogLevel.debug, 'ExceptionCollector: WebP encoding failed');

--- a/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
@@ -62,12 +62,12 @@ class DefaultScreenshotCollector extends ScreenshotCollector {
         return null;
       }
 
-      return MsrAttachment.fromBytes(
+      return MsrAttachment.fromRawPixels(
         bytes: rgba.buffer.asUint8List(),
-        type: AttachmentType.screenshot,
-        uuid: idProvider.uuid(),
         width: width,
         height: height,
+        type: AttachmentType.screenshot,
+        uuid: idProvider.uuid(),
       );
     } catch (e) {
       logger.log(

--- a/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
@@ -71,12 +71,10 @@ void main() {
       const description = 'Test bug with attachments';
       final attachmentBytes = createTestPngBytes();
       final attachments = <MsrAttachment>[
-        MsrAttachment(
-          name: 'test.png',
-          id: 'test-id',
-          size: attachmentBytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachmentBytes,
           type: AttachmentType.screenshot,
+          uuid: 'test-id',
         ),
       ];
 
@@ -127,12 +125,10 @@ void main() {
       const description = 'Test bug with storage failure';
       final attachmentBytes = createTestPngBytes();
       final attachments = <MsrAttachment>[
-        MsrAttachment(
-          name: 'test.png',
-          id: 'test-id',
-          size: attachmentBytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachmentBytes,
           type: AttachmentType.screenshot,
+          uuid: 'test-id',
         ),
       ];
       fileStorage.shouldFailWrite = true;
@@ -149,19 +145,15 @@ void main() {
       final attachment1Bytes = createTestPngBytes();
       final attachment2Bytes = createTestPngBytes();
       final attachments = <MsrAttachment>[
-        MsrAttachment(
-          name: 'test1.png',
-          id: 'test1-id',
-          size: attachment1Bytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachment1Bytes,
           type: AttachmentType.screenshot,
+          uuid: 'test1-id',
         ),
-        MsrAttachment(
-          name: 'test2.png',
-          id: 'test2-id',
-          size: attachment2Bytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachment2Bytes,
           type: AttachmentType.screenshot,
+          uuid: 'test2-id',
         ),
       ];
 
@@ -197,19 +189,15 @@ void main() {
       final attachment1Bytes = createTestPngBytes();
       final attachment2Bytes = createTestPngBytes();
       final attachments = <MsrAttachment>[
-        MsrAttachment(
-          name: 'test1.png',
-          id: 'test1-id',
-          size: attachment1Bytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachment1Bytes,
           type: AttachmentType.screenshot,
+          uuid: 'test1-id',
         ),
-        MsrAttachment(
-          name: 'test2.png',
-          id: 'test2-id',
-          size: attachment2Bytes.length,
+        MsrAttachment.fromBytes(
           bytes: attachment2Bytes,
           type: AttachmentType.screenshot,
+          uuid: 'test2-id',
         ),
       ];
 

--- a/flutter/packages/measure_flutter/test/bug_report/screenshot_list_item_test.dart
+++ b/flutter/packages/measure_flutter/test/bug_report/screenshot_list_item_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/bug_report/ui/raw_rgba_image_provider.dart';
+import 'package:measure_flutter/src/bug_report/ui/screenshot_list_item.dart';
+
+void main() {
+  group('ScreenshotListItem', () {
+    Widget wrap(Widget child) => MaterialApp(
+          home: Scaffold(
+            body: SizedBox(width: 200, height: 200, child: child),
+          ),
+        );
+
+    testWidgets(
+        'renders raw RGBA bytes via RawRgbaImageProvider without codec error',
+        (tester) async {
+      const width = 4;
+      const height = 4;
+      final pixels = Uint8List(width * height * 4);
+      for (var i = 0; i < pixels.length; i += 4) {
+        pixels[i] = 255; // R
+        pixels[i + 1] = 0; // G
+        pixels[i + 2] = 0; // B
+        pixels[i + 3] = 255; // A
+      }
+
+      final attachment = MsrAttachment.fromRawPixels(
+        bytes: pixels,
+        width: width,
+        height: height,
+        type: AttachmentType.screenshot,
+        uuid: 'raw-rgba',
+      );
+
+      await tester.pumpWidget(wrap(
+        ScreenshotListItem(screenshot: attachment, onDelete: () {}),
+      ));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.image, isA<RawRgbaImageProvider>());
+    });
+
+    testWidgets('selects MemoryImage for encoded bytes', (tester) async {
+      final attachment = MsrAttachment.fromBytes(
+        bytes: _onePixelPng,
+        type: AttachmentType.screenshot,
+        uuid: 'encoded-png',
+      );
+
+      await tester.pumpWidget(wrap(
+        ScreenshotListItem(screenshot: attachment, onDelete: () {}),
+      ));
+      // Avoid pumpAndSettle: image decoding completes via flutter_tester's
+      // fake async, but the framework also schedules a 500ms AnimatedOpacity
+      // that we don't care about here.
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.image, isA<MemoryImage>());
+    });
+  });
+}
+
+/// 1x1 transparent PNG (smallest valid PNG, 67 bytes).
+final Uint8List _onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+);

--- a/flutter/packages/measure_flutter/test/utils/fake_screenshot_collector.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_screenshot_collector.dart
@@ -8,14 +8,12 @@ class FakeScreenshotCollector extends ScreenshotCollector {
   Future<MsrAttachment?> capture() async {
     // 1x1 raw RGBA pixel (red).
     final rgba = Uint8List.fromList(<int>[255, 0, 0, 255]);
-    return MsrAttachment(
-      name: "screenshot",
-      id: "test-id",
-      type: AttachmentType.screenshot,
-      size: rgba.length,
+    return MsrAttachment.fromRawPixels(
       bytes: rgba,
       width: 1,
       height: 1,
+      type: AttachmentType.screenshot,
+      uuid: "test-id",
     );
   }
 }


### PR DESCRIPTION
# Description

- The bug report sheet crashed whenever it tried to show a screenshot, because the preview widget assumed the bytes were an encoded image and ran them through Flutter's image codec, but captured screenshots are raw RGBA pixels, which the codec can't decode. 
- The attachment object now carries an explicit format flag (raw pixels vs. encoded image) to tell the difference.
- The preview widget picks the right decoder based on that flag.

## Related issue
Closes #3614 
