### PR TITLE
chore(frontend): update titles & descriptions for docs + website pages

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+---
+title: "Contribute to Measure"
+description: "Contribute to Measure. Project workflow, local development setup, tests, commit messages, and release process."
+---
+
 # Measure Contribution Guidelines
 
 ## General workflow
@@ -415,6 +420,6 @@ set VERSION $(git cliff --bumped-version) && git tag -s $VERSION -m $VERSION && 
 
 ## Documentation
 - Public facing docs should be in [docs](../README.md) folder - API requests & responses, self host guide, SDK guides and so on
-- Main folder of subproject should link to main guide. ex: [frontend README](../../frontend/dashboard/README.md) has link to self hosting and local dev guide
-- Non public facing docs can stay in sub folder. ex: [backend benchmarking README](../../backend/benchmarking/README.md) which describes its purpose
+- Main folder of subproject should link to main guide. ex: [frontend README](../frontend/dashboard/README.md) has link to self hosting and local dev guide
+- Non public facing docs can stay in sub folder. ex: [backend benchmarking README](../backend/benchmarking/README.md) which describes its purpose
 - Docs pages, sidebar nav, search index, and sitemap are all auto-generated at build time from the markdown files. The sidebar nav is derived from the link structure in [docs/README.md](../README.md) — ordering and grouping come from the links there, and titles come from each page's `# H1` heading. To add a new doc page, create the `.md` file and add a link to it in the README

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+---
+title: "Measure SDK Documentation"
+description: "Measure documentation. SDK integration, features, self-hosting, and REST API reference for monitoring mobile apps."
+---
+
 # Documentation
 
 ### Table of Contents
@@ -5,7 +10,7 @@
 * [**Integrate the SDK**](#integrate-the-sdk) — Set up the measure-sh SDK in your mobile app
 * [**Explore Features**](#explore-features) — Discover all available features
 * [**Configuration Options**](#configuration-options) — Customize SDK behavior
-* [**Data Control**](#data-control) — Techniques to manage data collection and storage costs
+* [**Data Retention**](#data-retention) — Techniques to manage data collection and storage costs
 * [**Performance Impact**](#performance-impact) — Assess the SDK's impact on app performance
 * [**SDK Upgrade Guides**](sdk-upgrade-guides/README.md) — Upgrade to the latest SDK versions for Android and iOS
 
@@ -39,6 +44,7 @@ feature's documentation to understand its underlying mechanism and enhance your 
     * [**Android**](features/feature-bug-report-android.md)
     * [**iOS**](features/feature-bug-report-ios.md)
     * [**Flutter**](features/feature-bug-report-flutter.md)
+* [**Screenshot Masking for SwiftUI**](features/feature-screenshot-masking-swiftui.md) — Mask sensitive content in SwiftUI views when capturing screenshots
 * [**App Launch Metrics**](features/feature-app-launch-metrics.md) — Measure app launch performance
 * [**Network Monitoring**](features/feature-network-monitoring.md) — Monitor HTTP requests and responses
 * [**Network Connectivity Changes**](features/feature-network-connectivity-changes.md) — Track when network connectivity changes

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,7 @@
+---
+description: "Measure's REST APIs for SDK ingestion and the Dashboard, designed around standard REST principles."
+---
+
 # Measure REST API Documentation <!-- omit in toc -->
 
 Measure APIs are built following sound REST API design principles. At the moment, Measure offers APIs for the following channels.

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -1,3 +1,8 @@
+---
+title: "Dashboard REST API Reference"
+description: "Reference for Measure's Dashboard REST API. Every endpoint, request body, response format, and status code."
+---
+
 # Dashboard REST API Documentation <!-- omit in toc -->
 
 Find all the endpoints, resources and detailed documentation for Measure Dashboard REST APIs.
@@ -379,7 +384,7 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
 
 - [**POST `/auth/github`**](#post-authgithub) - Sign in with Github.
 - [**POST `/auth/google`**](#post-authgoogle) - Sign in with Google.
-- [**POST `/auth/validateInvite`**](#post-validateInvite) - Validate invite.
+- [**POST `/auth/validateInvite`**](#post-authvalidateinvite) - Validate invite.
 - [**POST `/auth/refresh`**](#post-authrefresh) - Refresh session.
 - [**GET `/auth/session`**](#get-authsession) - Fetch session.
 - [**DELETE `/auth/signout`**](#delete-authsignout) - Sign out.
@@ -6708,12 +6713,12 @@ List of HTTP status codes for success and failures.
 - [**PATCH `/teams/:id/rename`**](#patch-teamsidrename) -  Rename a team.
 - [**GET `/teams/:id/members`**](#get-teamsidmembers) -  Fetch list of team members for a team.
 - [**DELETE `/teams/:id/members/:id`**](#delete-teamsidmembersid) -  Remove a member from a team.
-- [**PATCH `/teams/:id/members/:id/role`**](#patch-teamsidmembersid) -  Change role of a member of a team.
+- [**PATCH `/teams/:id/members/:id/role`**](#patch-teamsidmembersidrole) -  Change role of a member of a team.
 - [**GET `/teams/:id/authz`**](#get-teamsidauthz) -  Fetch authorization details of access token holder for a team.
 - [**GET `/teams/:id/usage`**](#get-teamsidusage) -  Fetch data usage details for a team.
 - [**GET `/teams/:id/slack`**](#get-teamsidslack) -  Fetch Slack details for a team.
 - [**PATCH `/teams/:id/slack/status`**](#patch-teamsidslackstatus) -  Update a team's Slack integration status to active or inactive.
-- [**POST `/teams/:id/slack/test`**](#patch-teamsidslacktest) -  Send test alerts to all registered Slack channels.
+- [**POST `/teams/:id/slack/test`**](#post-teamsidslacktest) -  Send test alerts to all registered Slack channels.
 
 ### POST `/teams`
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -1,3 +1,8 @@
+---
+title: "SDK Ingestion REST API Reference"
+description: "Reference for the Measure SDK ingestion REST API. Events, builds, config, attachments, traces, and authentication."
+---
+
 # SDK REST API Documentation <!-- omit in toc -->
 
 Find all the endpoints, resources and detailed documentation for Measure SDK REST APIs.
@@ -55,7 +60,7 @@ Find all the endpoints, resources and detailed documentation for Measure SDK RES
     - [**`navigation`**](#navigation)
     - [**`screen_view`**](#screen_view)
     - [**`custom`**](#custom)
-    - [**`session_start`**](#session-start)
+    - [**`session_start`**](#session_start)
 
   - [Traces](#traces)
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,3 +1,7 @@
+---
+description: "Common issues with Measure integration and how to troubleshoot them.."
+---
+
 # Frequently Asked Questions
 
 A few product questions that you may have.

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -1,3 +1,8 @@
+---
+title: "SDK Configuration Options"
+description: "Every Measure SDK configuration option. Tune data collection, masking, sampling, and disk usage at init or remotely from the dashboard."
+---
+
 # Configuration Options
 
 Measure provides a number of configuration options to customize data collection and SDK behavior. These options are
@@ -15,13 +20,13 @@ available in two ways:
         * [**Android**](#android)
         * [**iOS**](#ios)
         * [**Flutter**](#flutter)
-    * [**trackActivityIntentData**](#trackActivityIntentData)
-    * [**enableLogging**](#enableLogging)
-    * [**autoStart**](#autoStart)
-    * [**requestHeadersProvider**](#requestHeadersProvider)
-    * [**maxDiskUsageInMb**](#maxDiskUsageInMb)
-    * [**enableFullCollectionMode**](#enableFullCollectionMode)
-    * [**enableDiagnosticMode**](#enableDiagnosticMode)
+    * [**trackActivityIntentData**](#trackactivityintentdata)
+    * [**enableLogging**](#enablelogging)
+    * [**autoStart**](#autostart)
+    * [**requestHeadersProvider**](#requestheadersprovider)
+    * [**maxDiskUsageInMb**](#maxdiskusageinmb)
+    * [**enableFullCollectionMode**](#enablefullcollectionmode)
+    * [**enableDiagnosticMode**](#enablediagnosticmode)
 * [**Remote Configuration Options**](#remote-configuration-options)
     * [**Crash Reporting**](#crash-reporting)
     * [**ANR Reporting**](#anr-reporting)
@@ -426,7 +431,7 @@ information from leaking.
 > [!NOTE]
 > _The mask level configuration does not apply to SwiftUI screens._
 > Because of the way SwiftUI renders its views, all SwiftUI content is masked by default regardless of
-> the mask level setting. See [Screenshot Masking for SwiftUI](feature_screenshot_masking_swiftui.md)
+> the mask level setting. See [Screenshot Masking for SwiftUI](feature-screenshot-masking-swiftui.md)
 > for details on how to control masking for SwiftUI views using the `.msrMask()` and `.msrUnmask()`
 > modifiers.
 

--- a/docs/features/feature-alerts.md
+++ b/docs/features/feature-alerts.md
@@ -1,6 +1,11 @@
+---
+title: "Crash, ANR, Bug Report and Daily Summary Alert Notifications"
+description: "Receive crash spike, ANR spike, bug report alerts and daily summaries of core app metrics over email and Slack."
+---
+
 # Alerts
 
-Measure sends out alert notifications via email and slack on Crash & ANR spikes along with Daily Summaries of core app metrics.
+Measure sends out alert notifications via email and slack on Crash spikes, ANR spikes and on receiving Bug Reports. Measure also sends out daily dummaries of core app metrics.
 
 * [**Email Integration**](#email-integration)
   * [**Setting Up Email**](#setting-up-email)
@@ -14,7 +19,7 @@ Measure sends out alert notifications via email and slack on Crash & ANR spikes 
 Email integration allows you to receive alert notifications and daily summaries in your inbox.
 
 ### Setting up email
-If you are a self hosted user, please set up your email integration if you haven't done so using this [guide](/docs/hosting/smtp-email.md).
+If you are a self hosted user, please set up your email integration if you haven't done so using this [guide](../hosting/smtp-email.md).
 
 Once completed, all members in your team will receive emails for apps belonging to the same team.
 
@@ -27,7 +32,7 @@ Slack integration allows you to receive alert notifications and daily summaries 
 >
 > #### Self Hosted User
 >
-> If you are a self hosted user, please set up your slack integration if you haven't done so using this [guide](/docs/hosting/slack.md).
+> If you are a self hosted user, please set up your slack integration if you haven't done so using this [guide](../hosting/slack.md).
 
 Click `Add to Slack` button and authorize Measure Slack App for your workspace.
 

--- a/docs/features/feature-anr-reporting.md
+++ b/docs/features/feature-anr-reporting.md
@@ -1,3 +1,8 @@
+---
+title: "Android ANR Reporting"
+description: "Capture ANRs (Application Not Responding errors) in Android apps with stack traces and optional UI screenshots."
+---
+
 # ANR Reporting
 
 * [**Debugging ANRs**](#debugging-anrs)
@@ -64,7 +69,7 @@ Where:
 - **Total Sessions**: The total number of sessions recorded.
 - **ANR Sessions**: The number of sessions that experienced an ANR.
 
-## Get a UI Snapshot
+## Get a UI Screenshot
 
 A screenshot of the app is captured when an app crashes. This feature is enabled by default and can be
 remotely configured on the dashboard under the "Apps" section. The following configuration options are available:
@@ -75,7 +80,7 @@ remotely configured on the dashboard under the "Apps" section. The following con
 
 ## Data Collected
 
-Check out all the data collected for App Exit in the [App Exit Event](../../api/sdk/README.md#appexit) section.
+Check out all the data collected for App Exit in the [App Exit Event](../api/sdk/README.md#app_exit) section.
 
 ## How It Works
 

--- a/docs/features/feature-app-launch-metrics.md
+++ b/docs/features/feature-app-launch-metrics.md
@@ -1,3 +1,8 @@
+---
+title: "Mobile App Launch Metrics"
+description: "Track cold, warm, and hot launch times for Android and iOS apps with full sampling control.."
+---
+
 # App Launch Metrics
 
 * [**Introduction**](#introduction)
@@ -26,7 +31,7 @@ metrics.
 
 ## Data Collected
 
-Check out the data collected by Measure for [Cold Launch](../api/sdk/README.md#coldlaunch), [Warm Launch](../api/sdk/README.md#warmlaunch), and [Hot Launch](../api/sdk/README.md#hotlaunch) respectively.
+Check out the data collected by Measure for [Cold Launch](../api/sdk/README.md#cold_launch), [Warm Launch](../api/sdk/README.md#warm_launch), and [Hot Launch](../api/sdk/README.md#hot_launch) respectively.
 
 ## How It Works
 

--- a/docs/features/feature-app-size-monitoring.md
+++ b/docs/features/feature-app-size-monitoring.md
@@ -1,3 +1,8 @@
+---
+title: "App Size Monitoring (APK, AAB, IPA)"
+description: "Track your Android APK/AAB and iOS IPA size for every release to spot regressions before they ship."
+---
+
 # App Size Monitoring
 
 * [**Android**](#android)
@@ -27,7 +32,7 @@ Read more about AAB format [here](https://developer.android.com/guide/app-bundle
 
 ## iOS
 
-Measure automatically tracks size of the IPA file for each version when you upload dSYMs via the [upload_dsyms.sh](../../ios/Scripts/upload_dsyms.sh) script.
+Measure automatically tracks size of the IPA file for each version when you upload dSYMs using the [upload_dsym_xcarchive.sh](../../ios/Scripts/upload_dsym_xcarchive.sh) or [upload_dsym_manual.sh](../../ios/Scripts/upload_dsym_manual.sh) script.
 
 > [!NOTE]
 > This represents the size of the generated .ipa, not the actual App Store download size.

--- a/docs/features/feature-bug-report-android.md
+++ b/docs/features/feature-bug-report-android.md
@@ -1,3 +1,8 @@
+---
+title: "In-App Bug Reports — Android SDK"
+description: "Let users report bugs from inside your Android app. Built-in or custom UI, screenshots, layout snapshots, and shake to report."
+---
+
 # Bug Reports — Android
 
 Bug reports enable users to report issues directly from the app. Measure SDK provides two approaches to implement bug reporting.
@@ -103,11 +108,11 @@ Measure.trackBugReport(
 ```
 
 > [!IMPORTANT]
-> For privacy, screenshots can be masked with the same configuration provided during SDK initialization. See all the configuration options [here](configuration-options.md#screenshotmasklevel).
+> For privacy, screenshots can be masked with the same configuration provided during SDK initialization. See all the configuration options [here](configuration-options.md#screenshot-mask-level).
 
 #### Capture Layout Snapshot
 
-Capture a layout snapshot using `captureLayoutSnapshot`. This function must be called from the main thread. Read more about layout snapshots [here](../feature_layout_snapshots.md).
+Capture a layout snapshot using `captureLayoutSnapshot`. This function must be called from the main thread.
 
 ```kotlin
 private val attachments = mutableListOf<Attachment>()

--- a/docs/features/feature-bug-report-flutter.md
+++ b/docs/features/feature-bug-report-flutter.md
@@ -1,3 +1,8 @@
+---
+title: "In-App Bug Reports — Flutter SDK"
+description: "Let users report bugs from inside your Flutter app. Built-in or custom UI, screenshots, attachments, i18n, and shake to report."
+---
+
 # Bug Reports — Flutter
 
 Bug reports enable users to report issues directly from the app. Measure SDK provides two approaches to implement bug reporting.

--- a/docs/features/feature-bug-report-ios.md
+++ b/docs/features/feature-bug-report-ios.md
@@ -1,3 +1,8 @@
+---
+title: "In-App Bug Reports — iOS SDK"
+description: "et users report bugs from inside your iOS app. Built-in or custom UI, screenshots, attachments, theming, and shake to report"
+---
+
 # Bug Reports — iOS
 
 Bug reports enable users to report issues directly from the app. There are two ways to use the bug reporting feature:

--- a/docs/features/feature-cpu-monitoring.md
+++ b/docs/features/feature-cpu-monitoring.md
@@ -1,6 +1,10 @@
+---
+title: "Mobile App CPU Monitoring"
+description: "Periodically capture CPU usage of Android, iOS, and Flutter apps while they're in the foreground."
+---
+
 # CPU Monitoring
 
-- [**Introduction**](#introduction)
 - [**Android**](#android)
 - [**iOS**](#ios)
 - [**Flutter**](#flutter)
@@ -70,4 +74,4 @@ same methods as described above for Android and iOS.
 
 ## Data collected
 
-Checkout the data collected by Measure in [CPU Usage Event](../api/sdk/README.md#cpuusage) section.
+Checkout the data collected by Measure in [CPU Usage Event](../api/sdk/README.md#cpu_usage) section.

--- a/docs/features/feature-crash-reporting.md
+++ b/docs/features/feature-crash-reporting.md
@@ -1,3 +1,8 @@
+---
+title: "Mobile Crash Reporting (Android, iOS, Flutter)"
+description: "Track crashes in Android, iOS, and Flutter apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping, and symbolicated stack traces."
+---
+
 # Crash Reporting
 
 Crashes are automatically tracked, optionally with a snapshot of the app's UI at the time of the crash.

--- a/docs/features/feature-custom-events.md
+++ b/docs/features/feature-custom-events.md
@@ -1,3 +1,7 @@
+---
+description: "Track app-specific events like user actions with custom attributes and view them on the Session Timeline."
+---
+
 # Track Custom Events
 
 * [**Introduction**](#introduction)
@@ -17,7 +21,7 @@ Custom events let you add your own context on top of the automatically collected
 
 ## Custom Events in Session Timeline
 
-Custom events are included in the [Session Timeline](feature-session-monitoring.md#session-timeline) along with other automatically collected events. The event and its attributes can be viewed in the timeline, making it easy to get context on what happened during a session.
+Custom events are included in the [Session Timeline](feature-session-timelines.md) along with other automatically collected events. The event and its attributes can be viewed in the timeline, making it easy to get context on what happened during a session.
 
 ## API Reference
 

--- a/docs/features/feature-data-retention.md
+++ b/docs/features/feature-data-retention.md
@@ -1,3 +1,8 @@
+---
+title: "Data Retention Settings"
+description: "Configure how long Measure retains mobile app monitoring data per app."
+---
+
 # Data retention
 
 To control the amount of data stored on the server, measure-sh provides options to limit the time for which data is

--- a/docs/features/feature-error-tracking.md
+++ b/docs/features/feature-error-tracking.md
@@ -1,3 +1,8 @@
+---
+title: "Error Tracking (Handled Exceptions)"
+description: "Track handled exceptions in your mobile app — issues that don't crash but still affect users. Android, iOS, and Flutter APIs."
+---
+
 # Track errors
 
 Measure automatically captures crashes and ANRs (Application Not Responding) in your app, but you can also track handled

--- a/docs/features/feature-gesture-tracking.md
+++ b/docs/features/feature-gesture-tracking.md
@@ -1,3 +1,8 @@
+---
+title: "Gesture Tracking with Layout Snapshots"
+description: "Automatically capture user gestures like taps, scrolls and long-presses alongside layout snapshots showing the UI that was acted on."
+---
+
 # Gesture Tracking
 
 * [**Overview**](#overview)
@@ -254,8 +259,6 @@ TLDR;
 
 - On average, it takes **4 ms** to identify the clicked view in a view hierarchy with a depth of **1,500**.
 - For more common scenarios, a view hierarchy with a depth of **20** takes approximately **0.2 ms**.
-- You can find the benchmark tests
-  in [GestureTargetFinderTests](../../ios/Tests/MeasureSDKTests//GestureTargetFinderTests.swift).
 
 ### Flutter
 

--- a/docs/features/feature-identify-users.md
+++ b/docs/features/feature-identify-users.md
@@ -1,3 +1,8 @@
+---
+title: "Identify Users with User ID"
+description: "Set a user ID to correlate sessions with users for debugging. Persisted across app launches. Recommended to avoid PII."
+---
+
 # Identify users
 
 Correlating sessions with users is critical for debugging certain issues. You can set a user ID which can then be used

--- a/docs/features/feature-manually-start-stop-sdk.md
+++ b/docs/features/feature-manually-start-stop-sdk.md
@@ -1,3 +1,7 @@
+---
+description: "Manually start and stop the Measure mobile app monitoring SDK to control when data collection happens."
+---
+
 # Manually Start and Stop the SDK
 
 By default, initializing the SDK starts collection of events. To delay start to a different point in your app

--- a/docs/features/feature-mcp.md
+++ b/docs/features/feature-mcp.md
@@ -1,3 +1,8 @@
+---
+title: "MCP Server for Mobile App Monitoring"
+description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows."
+---
+
 # MCP Server
 
 Measure exposes a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI-powered coding tools query your app's crash and error data directly.
@@ -27,8 +32,6 @@ Measure exposes a [Model Context Protocol](https://modelcontextprotocol.io) (MCP
   * [`get_alerts`](#get_alerts)
   * [`get_journey`](#get_journey)
   * [`update_bug_report_status`](#update_bug_report_status)
-* [**Authentication**](#authentication)
-* [**Self Hosted Setup**](#self-hosted-setup)
 
 ## What is MCP?
 

--- a/docs/features/feature-memory-monitoring.md
+++ b/docs/features/feature-memory-monitoring.md
@@ -1,3 +1,8 @@
+---
+title: "Mobile App Memory Monitoring"
+description: "Periodically capture memory usage of Android, iOS, and Flutter apps to spot leaks and memory pressure."
+---
+
 # Memory Monitoring
 
 - [Introduction](#introduction)
@@ -36,7 +41,7 @@ A worker thread reads the following properties every 2 seconds and reports them 
 #### Data collected
 
 Checkout all the data collected for memory usage in
-the [Memory Usage Event](../api/sdk/README.md#memoryusage) section.
+the [Memory Usage Event](../api/sdk/README.md#memory_usage) section.
 
 ## iOS
 

--- a/docs/features/feature-navigation-lifecycle-tracking.md
+++ b/docs/features/feature-navigation-lifecycle-tracking.md
@@ -1,3 +1,7 @@
+---
+description: "Automatic capture of Activity, Fragment, View Controller, SwiftUI, and Flutter lifecycle events plus screen views for navigation."
+---
+
 # Navigation & Lifecycle Tracking
 
 - [**Introduction**](#introduction)
@@ -205,12 +209,12 @@ Measure.instance.trackScreenView("Home");
 
 Check the following sections for the data collected by Measure for each lifecycle event:
 
-- [App Lifecycle Event](../api/sdk/README.md#lifecycleapp) — for application foregrounded and backgrounded.
-- [Activity Lifecycle Event](../api/sdk/README.md#lifecycleactivity) — for `Activity` lifecycle events.
-- [Fragment Lifecycle Event](../api/sdk/README.md#lifecyclefragment) — for `Fragment` lifecycle events.
+- [App Lifecycle Event](../api/sdk/README.md#lifecycle_app) — for application foregrounded and backgrounded.
+- [Activity Lifecycle Event](../api/sdk/README.md#lifecycle_activity) — for `Activity` lifecycle events.
+- [Fragment Lifecycle Event](../api/sdk/README.md#lifecycle_fragment) — for `Fragment` lifecycle events.
 - [View Controller Lifecycle Event](https://github.com/measure-sh/measure/blob/main/docs/api/sdk/README.md#lifecycle_view_controller) —
   for `UIViewController` lifecycle events.
 - [SwiftUI Lifecycle Event](https://github.com/measure-sh/measure/blob/main/docs/api/sdk/README.md#lifecycle_swift_ui) —
   for
   `SwiftUI` lifecycle events.
-- [Screen View Event](../api/sdk/README.md#screenview) — for screen view events.
+- [Screen View Event](../api/sdk/README.md#screen_view) — for screen view events.

--- a/docs/features/feature-network-connectivity-changes.md
+++ b/docs/features/feature-network-connectivity-changes.md
@@ -1,3 +1,8 @@
+---
+title: "Network Connectivity Change Tracking"
+description: "Track when your app gains or loses network connectivity, switches between WiFi and cellular, or changes carrier."
+---
+
 # Network Connectivity Changes
 
 * [**Android**](#android)
@@ -42,5 +47,5 @@ same methods as described above for Android and iOS.
 
 ## Data collected
 
-Checkout the data collected by Measure for each network change in the [Network Event](../../api/sdk/README.md#networkchange) section.
+Checkout the data collected by Measure for each network change in the [Network Event](../api/sdk/README.md#network_change) section.
 

--- a/docs/features/feature-network-monitoring.md
+++ b/docs/features/feature-network-monitoring.md
@@ -1,3 +1,8 @@
+---
+title: "HTTP Network Monitoring"
+description: "Monitor HTTP requests and responses from your mobile app. Status codes, latency, payload sizes and per-endpoint metrics."
+---
+
 # Network Monitoring
 
 * [**Overview**](#overview)

--- a/docs/features/feature-performance-tracing.md
+++ b/docs/features/feature-performance-tracing.md
@@ -1,3 +1,8 @@
+---
+title: "Mobile Performance Tracing"
+description: "Trace any operation in your mobile app — API calls, DB queries, custom user flows — with nested spans, attributes, and automatic screen load traces."
+---
+
 # Performance Tracing
 
 * [**Introduction**](#introduction)
@@ -32,7 +37,7 @@ You can easily track the performance of any part of your application, such as AP
 
 > [!NOTE]
 >
-> measure-sh can automatically track traces for screen load times in Android and iOS apps for _Activities_, _Fragments_, and _UIViewControllers_. See [Screen Load Time](feature-screen-load-time.md) for more details.
+> measure-sh can automatically track traces for screen load times in Android and iOS apps for _Activities_, _Fragments_, and _UIViewControllers_. See [Screen Load Time](#screen-load-time) for more details.
 
 Here's a simple example of how to use the performance tracing APIs:
 

--- a/docs/features/feature-screenshot-masking-swiftui.md
+++ b/docs/features/feature-screenshot-masking-swiftui.md
@@ -1,3 +1,7 @@
+---
+description: "Mask sensitive content in SwiftUI views when Measure captures screenshots."
+---
+
 # Screenshot Masking for SwiftUI
 
 Measure's screenshot masking works by traversing the UIKit view hierarchy to identify and redact

--- a/docs/features/feature-session-timelines.md
+++ b/docs/features/feature-session-timelines.md
@@ -1,3 +1,8 @@
+---
+title: "Session Timelines"
+description: "View every session as a chronological timeline of events, errors, screens, and gestures, with CPU and memory usage graphs."
+---
+
 # Session Timeline
 
 * [**What Is a Session?**](#what-is-a-session)

--- a/docs/features/feature-slack-integration.md
+++ b/docs/features/feature-slack-integration.md
@@ -1,3 +1,8 @@
+---
+title: "Slack Integration — Crash, ANR, Bug Report Alerts and Daily Summaries"
+description: "Receive Measure crash spike, ANR spike, bug report alerts and daily summaries in Slack. Manage subscriptions, list channels, and stop alerts via slash commands."
+---
+
 # Slack Integration
 
 Measure's Slack integration lets you receive alert notifications and daily summaries directly in your Slack workspace.
@@ -9,7 +14,7 @@ Measure's Slack integration lets you receive alert notifications and daily summa
   * [`/list-alert-channels`](#list-alert-channels)
 * [**Sending a Test Alert**](#sending-a-test-alert)
 * [**Disabling Slack Integration**](#disabling-slack-integration)
-* [**Self Hosted Setup**](#self-hosted-setup)
+* [**Self Hosted Setup**](../hosting/slack.md)
 
 ## Connecting Your Slack Workspace
 

--- a/docs/features/performance-impact.md
+++ b/docs/features/performance-impact.md
@@ -1,3 +1,8 @@
+---
+title: "Measure SDK Performance Impact & Benchmarks"
+description: "Benchmarks for the Measure SDK's impact on app startup and per-event overhead, plus comparison to Firebase initialization."
+---
+
 # Performance Impact
 
 See the platform-specific sections below for details on the performance impact of the Measure SDK on your app.

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosting Guide"
+description: "Self-host Measure to monitor crashes, ANRs, and performance for your mobile apps. Deploy on a Linux VM and configure OAuth, SMTP, and Slack."
+---
+
 # Self Hosting Guide <!-- omit in toc -->
 
 measure.sh is designed from the ground up for easy self-hosting. Follow along to run measure.sh on your own infrastructure.

--- a/docs/hosting/github-oauth.md
+++ b/docs/hosting/github-oauth.md
@@ -1,3 +1,8 @@
+---
+title: "Set Up GitHub OAuth for Self-Hosted Measure"
+description: "Set up a GitHub OAuth application for your self-hosted Measure instance. Register, configure credentials, and connect to Measure."
+---
+
 # Setup a GitHub OAuth Application
 
 1. Visit your GitHub organization's settings page, located at https://github.com/organizations/YOUR-ORGANIZATION/settings/profile. Replace `YOUR-ORGANIZATION` with the name of your organization.

--- a/docs/hosting/google-oauth.md
+++ b/docs/hosting/google-oauth.md
@@ -1,3 +1,8 @@
+---
+title: "Set Up Google OAuth for Self-Hosted Measure"
+description: "Set up a Google OAuth application for your self-hosted Measure instance. Configure the consent screen, scopes, and redirect URIs."
+---
+
 # Setup a Google OAuth Application
 
 In this guide, we'll help you setup a Google OAuth app so that your users can login using their Google accounts on your Measure Web dashboard.

--- a/docs/hosting/migration-guides/README.md
+++ b/docs/hosting/migration-guides/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosting Migration Guides"
+description: "Migration guides for upgrading self-hosted Measure across versions that need extra configuration or data migration."
+---
+
 # Migration Guides
 
 Use these guides when upgrading to newer versions of Measure that requires some additional configurations, like one time data maintenance operations. For the usual upgrade process, [follow this guide](../../hosting/README.md#upgrade-a-self-hosted-installation).

--- a/docs/hosting/migration-guides/v0.10.x/README.md
+++ b/docs/hosting/migration-guides/v0.10.x/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosted Measure v0.10.x Migration Guide"
+description: "Migration guide for self-hosted Measure v0.10.x. Adds a Google OAuth client secret, a dedicated ingest endpoint and configuration migration."
+---
+
 # Migration Guide for `v0.10.x`
 
 Use this guide only when you are on less than `v0.10.0` and upgrading to `v0.10.x`.

--- a/docs/hosting/migration-guides/v0.4.x/README.md
+++ b/docs/hosting/migration-guides/v0.4.x/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosted Measure v0.4.x Migration Guide"
+description: "Migration guide for self-hosted Measure v0.4.x. Optional drop of old data and required data backfills."
+---
+
 # Migration Guide for `v0.4.x`
 
 Use this guide only when you are on less than `v0.4.0` and upgrading to `v0.4.x`.

--- a/docs/hosting/migration-guides/v0.6.x/README.md
+++ b/docs/hosting/migration-guides/v0.6.x/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosted Measure v0.6.x Migration Guide"
+description: "Migration guide for self-hosted Measure v0.6.x. Required data backfills for user-defined attributes."
+---
+
 # Migration Guide for `v0.6.x`
 
 Use this guide only when you are on less than `v0.6.0` and upgrading to `v0.6.x`.

--- a/docs/hosting/migration-guides/v0.8.x/README.md
+++ b/docs/hosting/migration-guides/v0.8.x/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosted Measure v0.8.x Migration Guide"
+description: "Migration guide for self-hosted Measure v0.8.x. Required data backfills for crashes and ANRs."
+---
+
 # Migration Guide for `v0.8.x`
 
 Use this guide only when you are on less than `v0.8.0` and upgrading to `v0.8.x`.

--- a/docs/hosting/migration-guides/v0.9.x/README.md
+++ b/docs/hosting/migration-guides/v0.9.x/README.md
@@ -1,3 +1,8 @@
+---
+title: "Self-Hosted Measure v0.9.x Migration Guide"
+description: "Migration guide for self-hosted Measure v0.9.x. Configuration migration and database synchronization."
+---
+
 # Migration Guide for `v0.9.x`
 
 Use this guide only when you are on less than `v0.9.0` and upgrading to `v0.9.x`.

--- a/docs/hosting/slack.md
+++ b/docs/hosting/slack.md
@@ -1,3 +1,8 @@
+---
+title: "Set Up Slack for Self-Hosted Measure"
+description: "Set up Slack integration for your self-hosted Measure instance. Configure the Slack app with OAuth and slash commands for crash alerts."
+---
+
 # Set up Slack integration <!-- omit in toc -->
 
 Use this guide to setup Slack integration to receive Measure alert notifications on Slack.

--- a/docs/hosting/smtp-email.md
+++ b/docs/hosting/smtp-email.md
@@ -1,3 +1,8 @@
+---
+title: "Set Up SMTP Email for Self-Hosted Measure"
+description: "Configure an SMTP email provider for your self-hosted Measure instance to send invites, alerts, and daily summary emails."
+---
+
 # Set up an SMTP email provider
 
 Set up an email provider to get SMTP credentials. We recommend [Ethereal Mail](https://ethereal.email) for local development/testing and [Resend](https://resend.com), [SendGrid](https://sendgrid.com) or [AWS SES](https://aws.amazon.com/ses) for production.

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -1,3 +1,8 @@
+---
+title: "Measure SDK Integration Guide"
+description: "Integrate the Measure SDK on Android, iOS, or Flutter to track your app. Create an app in the dashboard, add the SDK, and verify installation."
+---
+
 # Getting Started
 
 * [1. Create an App](#1-create-an-app)

--- a/docs/sdk-upgrade-guides/README.md
+++ b/docs/sdk-upgrade-guides/README.md
@@ -1,3 +1,8 @@
+---
+title: "SDK Upgrade Guides (Android, iOS, Flutter)"
+description: "Upgrade guides for major Measure SDK versions across Android, iOS, and Flutter. Breaking changes and migration steps."
+---
+
 # SDK Upgrade Guides
 
 This directory contains upgrade guides for the SDKs. This contains detailed information about any breaking changes or
@@ -7,3 +12,4 @@ any breaking changes or behavior changes, we recommend checking the release note
 
 - [Android SDK v0.16.0](android-v0.16.0.md)
 - [iOS SDK v0.9.0](ios-v0.9.0.md)
+- [Measure Flutter SDK v0.4.0](measre_flutter-v0.4.0.md)

--- a/docs/sdk-upgrade-guides/android-v0.16.0.md
+++ b/docs/sdk-upgrade-guides/android-v0.16.0.md
@@ -1,3 +1,8 @@
+---
+title: "Upgrade Measure Android SDK to v0.16.0"
+description: "Upgrade the Measure Android SDK to v0.16.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines."
+---
+
 # Upgrading to Android SDK v0.16.0
 
 ## Breaking Changes

--- a/docs/sdk-upgrade-guides/ios-v0.9.0.md
+++ b/docs/sdk-upgrade-guides/ios-v0.9.0.md
@@ -1,3 +1,8 @@
+---
+title: "Upgrade Measure iOS SDK to v0.9.0"
+description: "Upgrade the Measure iOS SDK to v0.9.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines."
+---
+
 # Upgrading to iOS SDK v0.9.0
 
 ## Breaking Changes

--- a/docs/sdk-upgrade-guides/measre_flutter-v0.4.0.md
+++ b/docs/sdk-upgrade-guides/measre_flutter-v0.4.0.md
@@ -1,3 +1,8 @@
+---
+title: "Upgrade Measure Flutter SDK to v0.4.0"
+description: "Upgrade the Measure Flutter SDK to v0.4.0. Adds Layout Snapshots, requires manual native SDK init, and moves MeasureConfig options to the dashboard."
+---
+
 # Upgrading to Measure Flutter SDK v0.4.0
 
 ## Breaking Changes

--- a/docs/versioning/README.md
+++ b/docs/versioning/README.md
@@ -1,3 +1,8 @@
+---
+title: "Measure SDK and project Versioning"
+description: "How Measure versions its SDKs, backend, and dashboard with semver and platform-prefixed git tags."
+---
+
 # Versioning
 
 We use git tags and [semver](https://semver.org/) for versioning. 

--- a/docs_description.txt
+++ b/docs_description.txt
@@ -1,0 +1,251 @@
+# Docs page meta tags
+
+Title appears as `<title>X | Measure</title>` (the `| Measure` suffix is appended by the root layout).
+Source: frontmatter `description:` > first plain paragraph fallback.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+URL:         https://measure.sh/docs
+Title:       Documentation
+Description: Measure documentation. SDK integration, features, self-hosting, and REST API reference for monitoring mobile apps.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/CONTRIBUTING
+Title:       Measure Contribution Guidelines
+Description: Contribute to Measure. Project workflow, local development setup, tests, commit messages, and release process.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/api
+Title:       Measure REST API Documentation
+Description: Measure's REST APIs for SDK ingestion and the Dashboard, designed around standard REST principles.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/api/dashboard
+Title:       Dashboard REST API Documentation
+Description: Reference for Measure's Dashboard REST API. Every endpoint, request body, response format, and status code.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/api/sdk
+Title:       SDK REST API Documentation
+Description: Reference for the Measure SDK ingestion REST API. Events, builds, config, attachments, traces, and authentication.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/faqs
+Title:       Frequently Asked Questions
+Description: Common gotchas with Measure — like why app launch metrics may show "No data".
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/configuration-options
+Title:       Configuration Options
+Description: Every Measure SDK configuration option. Tune data collection, masking, sampling, and disk usage at init or remotely from the dashboard.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-alerts
+Title:       Alerts
+Description: Receive crash and ANR spike alerts plus daily summaries of core app metrics over email and Slack.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-anr-reporting
+Title:       ANR Reporting
+Description: Capture ANRs (Application Not Responding errors) in Android apps with stack traces and optional UI snapshots.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-app-launch-metrics
+Title:       App Launch Metrics
+Description: Track cold, warm, and hot launch times for Android and iOS apps. Time to Initial Display and Time to Full Display.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-app-size-monitoring
+Title:       App Size Monitoring
+Description: Track your Android APK/AAB and iOS IPA size for every release to spot regressions before they ship.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-bug-report-android
+Title:       Bug Reports — Android
+Description: Let users report bugs from inside your Android app. Built-in or custom UI, screenshots, layout snapshots, and shake to report.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-bug-report-flutter
+Title:       Bug Reports — Flutter
+Description: Let users report bugs from inside your Flutter app. Built-in or custom UI, screenshots, attachments, i18n, and shake to report.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-bug-report-ios
+Title:       Bug Reports — iOS
+Description: Let users report bugs from inside your iOS app. Built-in or custom UI, screenshots, attachments, theming, and shake to report.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-cpu-monitoring
+Title:       CPU Monitoring
+Description: Periodically capture CPU usage of Android, iOS, and Flutter apps while they're in the foreground.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-crash-reporting
+Title:       Crash Reporting
+Description: Track crashes in Android, iOS, and Flutter apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping, and symbolicated stack traces.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-custom-events
+Title:       Track Custom Events
+Description: Track app-specific events with attributes — feature usage, flags, user actions — and view them on the session timeline.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-data-retention
+Title:       Data retention
+Description: Configure how long Measure retains data per app. 7–365 day window set when creating an app or changed in settings later.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-error-tracking
+Title:       Track errors
+Description: Track handled exceptions in your mobile app — issues that don't crash but still affect users. Android, iOS, and Flutter APIs.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-gesture-tracking
+Title:       Gesture Tracking
+Description: Automatically capture user gestures — taps, scrolls, long-presses — alongside SVG layout snapshots showing what was tapped.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-identify-users
+Title:       Identify users
+Description: Set a user ID to correlate sessions with users for debugging. Persisted across app launches; recommended to avoid PII.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-manually-start-stop-sdk
+Title:       Manually Start and Stop the SDK
+Description: Manually start and stop the Measure SDK to control when data collection happens. Defer with autoStart=false, then call start() and stop().
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-mcp
+Title:       MCP Server
+Description: Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions, and bug reports from your editor.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-memory-monitoring
+Title:       Memory Monitoring
+Description: Periodically capture memory usage of Android, iOS, and Flutter apps to spot leaks and pressure across releases.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-navigation-lifecycle-tracking
+Title:       Navigation & Lifecycle Tracking
+Description: Automatic capture of Activity, Fragment, View Controller, SwiftUI, and Flutter lifecycle events plus screen views for navigation.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-network-connectivity-changes
+Title:       Network Connectivity Changes
+Description: Track when your app gains or loses network connectivity, switches between WiFi and cellular, or changes carrier.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-network-monitoring
+Title:       Network Monitoring
+Description: Monitor HTTP requests and responses from your mobile app. Status codes, latency, payload sizes, and per-endpoint metrics.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-performance-tracing
+Title:       Performance Tracing
+Description: Trace any operation in your mobile app — API calls, DB queries, custom user flows — with nested spans, attributes, and automatic screen load traces.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-screenshot-masking-swiftui
+Title:       Screenshot Masking for SwiftUI
+Description: Mask sensitive content in SwiftUI views when Measure captures screenshots. Per-view control with .msrMask() and .msrUnmask().
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-session-timelines
+Title:       Session Timeline
+Description: View every session as a chronological timeline of events, errors, screens, and gestures, with CPU and memory usage graphs.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/feature-slack-integration
+Title:       Slack Integration
+Description: Receive Measure crash alerts and daily summaries in Slack. Manage subscriptions, list channels, and stop alerts via slash commands.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/features/performance-impact
+Title:       Performance Impact
+Description: Benchmarks for the Measure SDK's impact on app startup and per-event overhead, plus comparison to Firebase initialization.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting
+Title:       Self Hosting Guide
+Description: Self-host Measure to monitor crashes, ANRs, and performance for your mobile apps. Deploy on a Linux VM and configure OAuth, SMTP, and Slack.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/github-oauth
+Title:       Setup a GitHub OAuth Application
+Description: Set up a GitHub OAuth application for your self-hosted Measure instance. Register, configure credentials, and connect to Measure.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/google-oauth
+Title:       Setup a Google OAuth Application
+Description: Set up a Google OAuth application for your self-hosted Measure instance. Configure the consent screen, scopes, and redirect URIs.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides
+Title:       Migration Guides
+Description: Migration guides for upgrading self-hosted Measure across versions that need extra configuration or data migration.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides/v0.10.x
+Title:       Migration Guide for `v0.10.x`
+Description: Migration guide for self-hosted Measure v0.10.x. Adds a Google OAuth client secret, a dedicated ingest endpoint, and configuration migration.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides/v0.4.x
+Title:       Migration Guide for `v0.4.x`
+Description: Migration guide for self-hosted Measure v0.4.x. Optional drop of old data and required data backfills.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides/v0.6.x
+Title:       Migration Guide for `v0.6.x`
+Description: Migration guide for self-hosted Measure v0.6.x. Required data backfills for user-defined attributes.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides/v0.8.x
+Title:       Migration Guide for `v0.8.x`
+Description: Migration guide for self-hosted Measure v0.8.x. Required data backfills for crashes and ANRs.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/migration-guides/v0.9.x
+Title:       Migration Guide for `v0.9.x`
+Description: Migration guide for self-hosted Measure v0.9.x. Configuration migration and database synchronization.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/slack
+Title:       Set up Slack integration
+Description: Set up Slack integration for your self-hosted Measure instance. Configure the Slack app with OAuth and slash commands for crash alerts.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/hosting/smtp-email
+Title:       Set up an SMTP email provider
+Description: Configure an SMTP email provider for your self-hosted Measure instance to send invites, alerts, and daily summary emails.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/sdk-integration-guide
+Title:       Getting Started
+Description: Integrate the Measure SDK on Android, iOS, or Flutter to track your app. Create an app in the dashboard, add the SDK, and verify installation.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/sdk-upgrade-guides
+Title:       SDK Upgrade Guides
+Description: Upgrade guides for major Measure SDK versions across Android, iOS, and Flutter. Breaking changes and migration steps.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/sdk-upgrade-guides/android-v0.16.0
+Title:       Upgrading to Android SDK v0.16.0
+Description: Upgrade the Measure Android SDK to v0.16.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/sdk-upgrade-guides/ios-v0.9.0
+Title:       Upgrading to iOS SDK v0.9.0
+Description: Upgrade the Measure iOS SDK to v0.9.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/sdk-upgrade-guides/measre_flutter-v0.4.0
+Title:       Upgrading to Measure Flutter SDK v0.4.0
+Description: Upgrade the Measure Flutter SDK to v0.4.0. Adds Layout Snapshots, requires manual native SDK init, and moves MeasureConfig options to the dashboard.
+Source:      frontmatter
+
+URL:         https://measure.sh/docs/versioning
+Title:       Versioning
+Description: How Measure versions its SDKs, backend, and dashboard with semver and platform-prefixed git tags.
+Source:      frontmatter

--- a/frontend/dashboard/__tests__/docs/docs_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_test.ts
@@ -1,4 +1,4 @@
-import { cleanContent, extractTitle, extractTocEntries } from '@/app/docs/docs'
+import { cleanContent, extractDescription, extractTitle, extractTocEntries, parseFrontmatter } from '@/app/docs/docs'
 import { describe, expect, it } from '@jest/globals'
 
 describe('extractTocEntries', () => {
@@ -209,5 +209,167 @@ describe('extractTitle', () => {
 
   it('ignores h2 and h3 headings', () => {
     expect(extractTitle('## Not a title\n### Also not')).toBe('Documentation')
+  })
+})
+
+describe('extractDescription', () => {
+  it('returns the first paragraph after the title', () => {
+    const content = [
+      '# Crash Reporting',
+      '',
+      'Crashes are automatically tracked, optionally with a snapshot of the app UI.',
+      '',
+      '## Metrics',
+    ].join('\n')
+
+    expect(extractDescription(content)).toBe(
+      'Crashes are automatically tracked, optionally with a snapshot of the app UI.',
+    )
+  })
+
+  it('skips a TOC bullet list that immediately follows the title', () => {
+    const content = [
+      '# Getting Started',
+      '',
+      '* [Step 1](#step-1)',
+      '* [Step 2](#step-2)',
+      '',
+      'Welcome to the integration guide for measure-sh.',
+    ].join('\n')
+
+    expect(extractDescription(content)).toBe(
+      'Welcome to the integration guide for measure-sh.',
+    )
+  })
+
+  it('skips admonitions and headings before finding a paragraph', () => {
+    const content = [
+      '# Feature',
+      '',
+      '> [!NOTE]',
+      '> This is in beta.',
+      '',
+      '## Overview',
+      '',
+      'This feature lets you do things.',
+    ].join('\n')
+
+    expect(extractDescription(content)).toBe('This feature lets you do things.')
+  })
+
+  it('strips markdown links and emphasis', () => {
+    const content = [
+      '# Title',
+      '',
+      'See the [docs](https://example.com) for **details** and `code`.',
+    ].join('\n')
+
+    expect(extractDescription(content)).toBe(
+      'See the docs for details and code.',
+    )
+  })
+
+  it('truncates long paragraphs at a word boundary with an ellipsis', () => {
+    const paragraph =
+      'This is a long paragraph that goes on and on and on, packed with words that will need to be truncated because we only allow a limited number of characters in the description tag, which is a constraint imposed by search engines.'
+    const content = ['# Title', '', paragraph].join('\n')
+
+    const result = extractDescription(content)
+    expect(result.length).toBeLessThan(paragraph.length)
+    expect(result.length).toBeLessThanOrEqual(161)
+    expect(result.endsWith('…')).toBe(true)
+    expect(result.slice(0, -1)).not.toMatch(/\s$/)
+    expect(paragraph).toContain(result.slice(0, -1))
+  })
+
+  it('returns empty string when no plain paragraph is present', () => {
+    const content = [
+      '# Title',
+      '',
+      '* only a list',
+      '* of bullet items',
+    ].join('\n')
+
+    expect(extractDescription(content)).toBe('')
+  })
+
+  it('returns empty string for content with only a title', () => {
+    expect(extractDescription('# Just a title')).toBe('')
+  })
+})
+
+describe('parseFrontmatter', () => {
+  it('returns empty frontmatter when content has none', () => {
+    expect(parseFrontmatter('# Title\n\nbody')).toEqual({
+      frontmatter: {},
+      body: '# Title\n\nbody',
+    })
+  })
+
+  it('parses a single description field', () => {
+    const out = parseFrontmatter(
+      '---\ndescription: A short summary.\n---\n\n# Title',
+    )
+    expect(out.frontmatter).toEqual({ description: 'A short summary.' })
+    expect(out.body).toBe('# Title')
+  })
+
+  it('strips surrounding double quotes from values', () => {
+    const out = parseFrontmatter(
+      '---\ndescription: "Quoted summary with : a colon"\n---\n\n# Title',
+    )
+    expect(out.frontmatter.description).toBe('Quoted summary with : a colon')
+  })
+
+  it('strips surrounding single quotes from values', () => {
+    const out = parseFrontmatter(
+      "---\ntitle: 'Single quoted'\n---\n\n# X",
+    )
+    expect(out.frontmatter.title).toBe('Single quoted')
+  })
+
+  it('parses multiple fields', () => {
+    const out = parseFrontmatter(
+      '---\ntitle: T\ndescription: D\n---\n\n# X',
+    )
+    expect(out.frontmatter).toEqual({ title: 'T', description: 'D' })
+  })
+
+  it('returns original content if frontmatter has no closing delimiter', () => {
+    const input = '---\ndescription: no closing\n# Title'
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: input,
+    })
+  })
+
+  it('ignores frontmatter that does not start the file', () => {
+    const input = 'lead text\n---\ndescription: nope\n---\n# Title'
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: input,
+    })
+  })
+
+  it('preserves the body verbatim after the closing delimiter', () => {
+    const out = parseFrontmatter(
+      '---\ndescription: x\n---\n\n# Title\n\nFirst paragraph.\n',
+    )
+    expect(out.body).toBe('# Title\n\nFirst paragraph.\n')
+  })
+
+  it('handles CRLF line endings', () => {
+    const out = parseFrontmatter(
+      '---\r\ndescription: D\r\n---\r\n\r\n# X',
+    )
+    expect(out.frontmatter).toEqual({ description: 'D' })
+    expect(out.body).toBe('# X')
+  })
+
+  it('skips lines that are not key: value pairs', () => {
+    const out = parseFrontmatter(
+      '---\n# a comment\ndescription: D\n---\n# X',
+    )
+    expect(out.frontmatter).toEqual({ description: 'D' })
   })
 })

--- a/frontend/dashboard/__tests__/docs/md_components_test.tsx
+++ b/frontend/dashboard/__tests__/docs/md_components_test.tsx
@@ -89,6 +89,66 @@ describe('rewriteHref', () => {
       expect(result).toBe('https://github.com/measure-sh/measure/blob/main/self-host/session-data/config.toml.example')
     })
   })
+
+  describe('README/index page links (isIndex=true)', () => {
+    it('resolves a sibling .md link relative to the directory itself', () => {
+      // sdk-upgrade-guides/README.md → [Android v0.16.0](android-v0.16.0.md)
+      expect(rewriteHref('android-v0.16.0.md', ['sdk-upgrade-guides'], true)).toBe(
+        '/docs/sdk-upgrade-guides/android-v0.16.0',
+      )
+    })
+
+    it('resolves a ./sibling.md link relative to the directory itself', () => {
+      // hosting/README.md → [Set up Slack Integration](./slack.md)
+      expect(rewriteHref('./slack.md', ['hosting'], true)).toBe(
+        '/docs/hosting/slack',
+      )
+    })
+
+    it('resolves a subdirectory README.md from a directory README', () => {
+      // api/README.md → [Browse API documentation](./dashboard/README.md)
+      expect(rewriteHref('./dashboard/README.md', ['api'], true)).toBe(
+        '/docs/api/dashboard',
+      )
+    })
+
+    it('resolves nested README.md from a nested directory README', () => {
+      // hosting/migration-guides/README.md → [v0.4.x](./v0.4.x/README.md)
+      expect(
+        rewriteHref('./v0.4.x/README.md', ['hosting', 'migration-guides'], true),
+      ).toBe('/docs/hosting/migration-guides/v0.4.x')
+    })
+
+    it('resolves ../sibling .md link from a directory README', () => {
+      // hosting/README.md → [Migration Guides](../hosting/migration-guides/README.md)
+      expect(
+        rewriteHref('../hosting/migration-guides/README.md', ['hosting'], true),
+      ).toBe('/docs/hosting/migration-guides')
+    })
+
+    it('resolves an anchor link from a directory README to a sibling page', () => {
+      // hosting/migration-guides/README.md → ../../hosting/README.md#upgrade-...
+      expect(
+        rewriteHref(
+          '../../hosting/README.md#upgrade-a-self-hosted-installation',
+          ['hosting', 'migration-guides'],
+          true,
+        ),
+      ).toBe('/docs/hosting#upgrade-a-self-hosted-installation')
+    })
+
+    it('escapes to GitHub when traversal exceeds docs tree from a README', () => {
+      // hosting/README.md → [symboloader](../../backend/symboloader/README.md)
+      const result = rewriteHref(
+        '../../backend/symboloader/README.md',
+        ['hosting'],
+        true,
+      )
+      expect(result).toBe(
+        'https://github.com/measure-sh/measure/blob/main/backend/symboloader/README.md',
+      )
+    })
+  })
 })
 
 // ─── rewriteImgSrc ──────────────────────────────────────────────────────────

--- a/frontend/dashboard/app/about/page.tsx
+++ b/frontend/dashboard/app/about/page.tsx
@@ -9,15 +9,13 @@ import { sharedOpenGraph } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 
 export const metadata: Metadata = {
-  title: "About",
-  description:
-    "Mobile apps break, get to the root cause faster. Built by and for mobile developers.",
+  title: "About Measure — Built by and for Mobile Developers",
+  description: "Meet the team behind Measure. Open source mobile app monitoring built by mobile developers, for mobile developers.",
   alternates: { canonical: "/about" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "About Measure",
-    description:
-      "Mobile apps break, get to the root cause faster. Built by and for mobile developers.",
+    title: "About Measure — Built by and for Mobile Developers | Measure",
+    description: "Meet the team behind Measure. Open source mobile app monitoring built by mobile developers, for mobile developers.",
     url: "/about",
   },
 };

--- a/frontend/dashboard/app/crashlytics-alternatives/page.tsx
+++ b/frontend/dashboard/app/crashlytics-alternatives/page.tsx
@@ -15,17 +15,13 @@ import LandingHeader from "../components/landing_header";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
 export const metadata: Metadata = {
-  title: {
-    absolute: "Measure vs Firebase Crashlytics",
-  },
-  description:
-    "Measure is an open-source Firebase Crashlytics alternative built for mobile teams. Measure unifies Crashes, ANRs, Performance, Network and full Session Timelines into a single platform so you can stop stitching context and get to the root cause faster.",
+  title: "Open Source Firebase Crashlytics Alternative",
+  description: "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
   alternates: { canonical: "/crashlytics-alternatives" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Measure vs Firebase Crashlytics",
-    description:
-      "Measure is an open-source Firebase Crashlytics alternative built for mobile teams. Measure unifies Crashes, ANRs, Performance, Network and full Session Timelines into a single platform so you can stop stitching context and get to the root cause faster.",
+    title: "Open Source Firebase Crashlytics Alternative | Measure",
+    description: "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
     url: "/crashlytics-alternatives",
   },
 };

--- a/frontend/dashboard/app/docs/[...slug]/page.tsx
+++ b/frontend/dashboard/app/docs/[...slug]/page.tsx
@@ -1,4 +1,9 @@
-import { extractTocEntries, getAllDocSlugs, getDocBySlug } from "@/app/docs/docs";
+import {
+  extractTocEntries,
+  getAllDocSlugs,
+  getDocBySlug,
+} from "@/app/docs/docs";
+import { sharedOpenGraph } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Markdown from "react-markdown";
@@ -25,8 +30,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
+  const path = `/docs/${params.slug.join("/")}`;
+
   return {
     title: doc.title,
+    ...(doc.description && { description: doc.description }),
+    alternates: { canonical: path },
+    openGraph: {
+      ...sharedOpenGraph,
+      title: doc.title,
+      ...(doc.description && { description: doc.description }),
+      url: path,
+    },
   };
 }
 
@@ -46,7 +61,7 @@ export default function DocPage({ params }: PageProps) {
           <Markdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeRaw, rehypeSlug]}
-            components={createMarkdownComponents(params.slug)}
+            components={createMarkdownComponents(params.slug, doc.isIndex)}
           >
             {doc.content}
           </Markdown>

--- a/frontend/dashboard/app/docs/components/md_components.tsx
+++ b/frontend/dashboard/app/docs/components/md_components.tsx
@@ -5,16 +5,26 @@ import type { Components } from "react-markdown";
 
 /**
  * Rewrite relative markdown links to /docs/... routes.
+ *
+ * `isIndex` indicates whether the current page is rendered from a README.md.
+ * For README pages, currentSlug already represents the directory the page lives
+ * in, so we resolve siblings relative to currentSlug directly. For file pages
+ * (e.g. /docs/features/feature-X) the directory is one level up.
  */
-export function rewriteHref(href: string, currentSlug: string[]): string {
+export function rewriteHref(href: string, currentSlug: string[], isIndex = false): string {
   if (!href || href.startsWith("#") || href.startsWith("http://") || href.startsWith("https://") || href.startsWith("mailto:")) {
     return href;
   }
 
+  const currentDir = isIndex
+    ? [...currentSlug]
+    : currentSlug.length > 0
+      ? currentSlug.slice(0, -1)
+      : [];
+
   // Relative .md link
   if (href.includes(".md")) {
     const [pathPart, anchor] = href.split("#");
-    const currentDir = currentSlug.length > 0 ? currentSlug.slice(0, -1) : [];
     const segments = pathPart.split("/");
     const resolved: string[] = [...currentDir];
 
@@ -25,7 +35,7 @@ export function rewriteHref(href: string, currentSlug: string[]): string {
       if (seg === "..") {
         if (resolved.length === 0) {
           const remainingSegments = segments.slice(segments.indexOf(seg));
-          const githubPath = resolveGitHubPath(currentSlug, remainingSegments);
+          const githubPath = resolveGitHubPath(currentDir, remainingSegments);
           return `https://github.com/measure-sh/measure/blob/main/${githubPath}`;
         }
         resolved.pop();
@@ -48,7 +58,7 @@ export function rewriteHref(href: string, currentSlug: string[]): string {
   // Relative path with ../ that escapes the docs tree — link to GitHub
   if (href.includes("..")) {
     const segments = href.replace(/^\.\//, "").split("/");
-    const resolved = [...(currentSlug.length > 0 ? currentSlug.slice(0, -1) : [])];
+    const resolved = [...currentDir];
     for (const seg of segments) {
       if (seg === "." || seg === "") {
         continue;
@@ -56,7 +66,7 @@ export function rewriteHref(href: string, currentSlug: string[]): string {
       if (seg === "..") {
         if (resolved.length === 0) {
           const remainingSegments = segments.slice(segments.indexOf(seg));
-          const githubPath = resolveGitHubPath(currentSlug, remainingSegments);
+          const githubPath = resolveGitHubPath(currentDir, remainingSegments);
           return `https://github.com/measure-sh/measure/blob/main/${githubPath}`;
         }
         resolved.pop();
@@ -69,8 +79,8 @@ export function rewriteHref(href: string, currentSlug: string[]): string {
   return href;
 }
 
-function resolveGitHubPath(currentSlug: string[], segments: string[]): string {
-  const repoPath = ["docs", ...currentSlug.slice(0, -1)];
+function resolveGitHubPath(currentDir: string[], segments: string[]): string {
+  const repoPath = ["docs", ...currentDir];
   for (const seg of segments) {
     if (seg === "..") {
       repoPath.pop();
@@ -95,7 +105,7 @@ export function rewriteImgSrc(src: string): string {
   return src;
 }
 
-export function createMarkdownComponents(currentSlug: string[]): Components {
+export function createMarkdownComponents(currentSlug: string[], isIndex = false): Components {
   return {
     h1: ({ children, id }) => (
       <h1 id={id} className="font-display text-3xl font-bold mt-12 mb-6 scroll-mt-24">
@@ -133,7 +143,7 @@ export function createMarkdownComponents(currentSlug: string[]): Components {
       </p>
     ),
     a: ({ href, children, node, ...props }) => {
-      const rewritten = rewriteHref(href || "", currentSlug);
+      const rewritten = rewriteHref(href || "", currentSlug, isIndex);
       const isExternal = rewritten.startsWith("http://") || rewritten.startsWith("https://") || rewritten.startsWith("mailto:");
 
       if (isExternal) {

--- a/frontend/dashboard/app/docs/docs.ts
+++ b/frontend/dashboard/app/docs/docs.ts
@@ -15,6 +15,39 @@ export interface DocPage {
   slug: string[];
   content: string;
   title: string;
+  description: string;
+  isIndex: boolean;
+}
+
+/**
+ * Parse YAML frontmatter at the start of a markdown file. Only supports flat
+ * `key: value` lines (with optional surrounding "single" or "double" quotes) —
+ * enough for `title` and `description` fields, no nested structures.
+ */
+export function parseFrontmatter(content: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  const match = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/);
+  if (!match) {
+    return { frontmatter: {}, body: content };
+  }
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
+    if (!kv) {
+      continue;
+    }
+    let value = kv[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\'/g, "'");
+    }
+    frontmatter[kv[1]] = value;
+  }
+  return { frontmatter, body: content.slice(match[0].length) };
 }
 
 /**
@@ -56,6 +89,57 @@ export function extractTitle(content: string): string {
   return match ? match[1].trim() : "Documentation";
 }
 
+/**
+ * Extract the first plain paragraph from markdown content, skipping
+ * the title, TOC lists, admonitions, headings, tables, and code blocks.
+ * Returns an empty string when no suitable paragraph is found.
+ */
+export function extractDescription(content: string): string {
+  const afterTitle = content.replace(/^#\s+.+$/m, "");
+  const blocks = afterTitle.split(/\n\s*\n/);
+
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const firstChar = trimmed[0];
+    if (
+      firstChar === "#" ||
+      firstChar === "*" ||
+      firstChar === "-" ||
+      firstChar === "+" ||
+      firstChar === ">" ||
+      firstChar === "|" ||
+      firstChar === "<" ||
+      trimmed.startsWith("```")
+    ) {
+      continue;
+    }
+
+    const plain = trimmed
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/[*_`~]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (!plain) {
+      continue;
+    }
+
+    if (plain.length > 160) {
+      const truncated = plain.slice(0, 157);
+      const lastSpace = truncated.lastIndexOf(" ");
+      const cut = lastSpace > 100 ? truncated.slice(0, lastSpace) : truncated;
+      return `${cut}…`;
+    }
+    return plain;
+  }
+
+  return "";
+}
+
 export function getDocBySlug(slug: string[]): DocPage | null {
   const docsDir = getDocsDirectory();
   const filePath = slugToFilePath(docsDir, slug);
@@ -64,13 +148,16 @@ export function getDocBySlug(slug: string[]): DocPage | null {
     return null;
   }
 
-  const content = fs.readFileSync(filePath, "utf-8");
-  const cleaned = cleanContent(content);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { frontmatter, body } = parseFrontmatter(raw);
+  const cleaned = cleanContent(body);
 
   return {
     slug,
     content: cleaned,
-    title: extractTitle(cleaned),
+    title: frontmatter.title || extractTitle(cleaned),
+    description: frontmatter.description || extractDescription(cleaned),
+    isIndex: filePath.endsWith(`${path.sep}README.md`),
   };
 }
 
@@ -82,13 +169,16 @@ export function getDocIndex(): DocPage | null {
     return null;
   }
 
-  const content = fs.readFileSync(filePath, "utf-8");
-  const cleaned = cleanContent(content);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { frontmatter, body } = parseFrontmatter(raw);
+  const cleaned = cleanContent(body);
 
   return {
     slug: [],
     content: cleaned,
-    title: extractTitle(cleaned),
+    title: frontmatter.title || extractTitle(cleaned),
+    description: frontmatter.description || extractDescription(cleaned),
+    isIndex: true,
   };
 }
 
@@ -188,9 +278,10 @@ export function generateSearchIndex(): SearchIndexEntry[] {
   const entries: SearchIndexEntry[] = [];
 
   function processFile(filePath: string, slug: string[]) {
-    const content = fs.readFileSync(filePath, "utf-8");
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const { frontmatter, body: content } = parseFrontmatter(raw);
 
-    const title = extractTitle(content);
+    const title = frontmatter.title || extractTitle(content);
     const headings: string[] = [];
     const headingRegex = /^#{2,3}\s+(.+)$/gm;
     let match;

--- a/frontend/dashboard/app/docs/page.tsx
+++ b/frontend/dashboard/app/docs/page.tsx
@@ -1,4 +1,6 @@
 import { extractTocEntries, getDocIndex } from "@/app/docs/docs";
+import { sharedOpenGraph } from "@/app/utils/metadata";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Markdown from "react-markdown";
 import rehypeSlug from "rehype-slug";
@@ -6,6 +8,24 @@ import remarkGfm from "remark-gfm";
 import DocsNavLinks from "./components/docs_nav_links";
 import DocsToc from "./components/docs_toc";
 import { createMarkdownComponents } from "./components/md_components";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const doc = getDocIndex();
+  if (!doc) {
+    return {};
+  }
+  return {
+    title: doc.title,
+    ...(doc.description && { description: doc.description }),
+    alternates: { canonical: "/docs" },
+    openGraph: {
+      ...sharedOpenGraph,
+      title: doc.title,
+      ...(doc.description && { description: doc.description }),
+      url: "/docs",
+    },
+  };
+}
 
 export default function DocsIndexPage() {
   const doc = getDocIndex();
@@ -23,7 +43,7 @@ export default function DocsIndexPage() {
           <Markdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeSlug]}
-            components={createMarkdownComponents([])}
+            components={createMarkdownComponents([], true)}
           >
             {doc.content}
           </Markdown>

--- a/frontend/dashboard/app/page.tsx
+++ b/frontend/dashboard/app/page.tsx
@@ -16,17 +16,13 @@ import { cn } from "./utils/shadcn_utils";
 import { underlineLinkStyle } from "./utils/shared_styles";
 
 export const metadata: Metadata = {
-  title: {
-    absolute: "Open Source Mobile App Monitoring & Crash Reporting | Measure",
-  },
-  description:
-    "Complete Mobile App Monitoring platform — Crash Reporting, ANR Tracking, Bug Reporting, Performance Tracing, Logging and more! 100% Open Source alternative to Firebase Crashlytics.",
+  title: "Open Source Mobile App Monitoring & Crash Reporting",
+  description: "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
   alternates: { canonical: "/" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Open Source Mobile App Monitoring & Crash Reporting | Measure",
-    description:
-      "Complete Mobile App Monitoring platform — Crash Reporting, ANR Tracking, Bug Reporting, Performance Tracing, Logging and more. 100% Open Source alternative to Firebase Crashlytics.",
+    description: "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
     url: "/",
   },
 };

--- a/frontend/dashboard/app/pricing/page.tsx
+++ b/frontend/dashboard/app/pricing/page.tsx
@@ -17,15 +17,13 @@ import { underlineLinkStyle } from "../utils/shared_styles";
 import PricingCalculator from "./pricing_calculator";
 
 export const metadata: Metadata = {
-  title: "Plans and Pricing",
-  description:
-    "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits, no feature restrictions. 100% Open Source.",
+  title: "Pricing & Plans",
+  description: "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. 100% open source.",
   alternates: { canonical: "/pricing" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Plans and Pricing",
-    description:
-      "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits, no feature restrictions. 100% Open Source.",
+    title: "Pricing & Plans | Measure",
+    description: "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. 100% open source.",
     url: "/pricing",
   },
 };

--- a/frontend/dashboard/app/privacy-policy/page.tsx
+++ b/frontend/dashboard/app/privacy-policy/page.tsx
@@ -9,14 +9,12 @@ import { underlineLinkStyle } from "../utils/shared_styles";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description:
-    "What Measure does with your data. Open source so you can audit it yourself.",
+  description: "What Measure does with your data, how we collect it and how we store it. Open source so you can audit it yourself.",
   alternates: { canonical: "/privacy-policy" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Privacy Policy",
-    description:
-      "What Measure does with your data. Open source so you can audit it yourself.",
+    description: "What Measure does with your data, how we collect it and how we store it. Open source so you can audit it yourself.",
     url: "/privacy-policy",
   },
 };

--- a/frontend/dashboard/app/product/adaptive-capture/page.tsx
+++ b/frontend/dashboard/app/product/adaptive-capture/page.tsx
@@ -9,14 +9,12 @@ import LandingHeader from "../../components/landing_header";
 
 export const metadata: Metadata = {
   title: "Adaptive Capture — Control Mobile Monitoring Costs",
-  description:
-    "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you will never read.",
+  description: "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you'll never use.",
   alternates: { canonical: "/product/adaptive-capture" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Adaptive Capture — Control Mobile Monitoring Costs",
-    description:
-      "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you will never read.",
+    description: "Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you'll never use.",
     url: "/product/adaptive-capture",
   },
 };

--- a/frontend/dashboard/app/product/app-health/page.tsx
+++ b/frontend/dashboard/app/product/app-health/page.tsx
@@ -8,15 +8,13 @@ import LandingHeader from "../../components/landing_header";
 import OverviewDemo from "./overview_demo";
 
 export const metadata: Metadata = {
-  title: "Mobile App Health",
-  description:
-    "Stay on top of your mobile app's health by tracking the metrics that matter: crash-free sessions, app launch times, release adoption and more.",
+  title: "Mobile App Health Metrics & Dashboards",
+  description: "Track mobile app health metrics that matter: crash-free sessions, ANR-free sessions, app launch times, release adoption and more.",
   alternates: { canonical: "/product/app-health" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Mobile App Health",
-    description:
-      "Stay on top of your mobile app's health by tracking the metrics that matter: crash-free sessions, app launch times, release adoption and more.",
+    title: "Mobile App Health Metrics & Dashboards | Measure",
+    description: "Track mobile app health metrics that matter: crash-free sessions, ANR-free sessions, app launch times, release adoption and more.",
     url: "/product/app-health",
   },
 };

--- a/frontend/dashboard/app/product/bug-reports/page.tsx
+++ b/frontend/dashboard/app/product/bug-reports/page.tsx
@@ -9,14 +9,12 @@ import BugReportDemo from "./bug_report_demo";
 
 export const metadata: Metadata = {
   title: "In-App Bug Reporting for Mobile Apps",
-  description:
-    "Capture bug reports with a device shake or SDK call. Get the full session context, device state, and network info so you can get to the root cause.",
+  description: "Capture bug reports with a device shake or SDK call. Get the full session context, device state and network info so you can get to the root cause.",
   alternates: { canonical: "/product/bug-reports" },
   openGraph: {
     ...sharedOpenGraph,
     title: "In-App Bug Reporting for Mobile Apps",
-    description:
-      "Capture bug reports with a device shake or SDK call. Get the full session context, device state, and network info so you can get to the root cause.",
+    description: "Capture bug reports with a device shake or SDK call. Get the full session context, device state and network info so you can get to the root cause.",
     url: "/product/bug-reports",
   },
 };

--- a/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
+++ b/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
@@ -9,14 +9,12 @@ import ExceptionsDemo from "./exceptions_demo";
 
 export const metadata: Metadata = {
   title: "Mobile Crash Reporting & ANR Tracking",
-  description:
-    "Mobile Crash Reporting and ANR Tracking - Open Source Firebase Crashlytics alternative. Get full stack traces, likely reproduction steps and complete session context to fix crashes faster.",
+  description: "Open source mobile Crash Reporting and ANR Tracking. Full stack traces, reproduction steps and session timelines — a Firebase Crashlytics alternative.",
   alternates: { canonical: "/product/crashes-and-anrs" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Mobile Crash Reporting & ANR Tracking",
-    description:
-      "Mobile Crash Reporting and ANR Tracking - Open Source Firebase Crashlytics alternative. Get full stack traces, likely reproduction steps and complete session context to fix crashes faster.",
+    description: "Open source mobile Crash Reporting and ANR Tracking. Full stack traces, reproduction steps and session timelines — a Firebase Crashlytics alternative.",
     url: "/product/crashes-and-anrs",
   },
 };

--- a/frontend/dashboard/app/product/mcp/page.tsx
+++ b/frontend/dashboard/app/product/mcp/page.tsx
@@ -8,15 +8,13 @@ import LandingFooter from "../../components/landing_footer";
 import LandingHeader from "../../components/landing_header";
 
 export const metadata: Metadata = {
-  title: "MCP Server",
-  description:
-    "Connect Measure to Claude, Codex, Cursor and other coding agents. Query crashes, traces and sessions to fix issues faster than ever with AI.",
+  title: "MCP Server — Connect AI Agents to Measure",
+  description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
   alternates: { canonical: "/product/mcp" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Measure MCP Server",
-    description:
-      "Connect Measure to Claude, Codex, Cursor and other coding agents. Query crashes, traces and sessions to fix issues faster than ever with AI.",
+    title: "MCP Server — Connect AI Agents to Measure | Measure",
+    description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
     url: "/product/mcp",
   },
 };

--- a/frontend/dashboard/app/product/network-performance/page.tsx
+++ b/frontend/dashboard/app/product/network-performance/page.tsx
@@ -9,14 +9,12 @@ import NetworkDemo from "./network_demo";
 
 export const metadata: Metadata = {
   title: "Mobile Network Performance Monitoring",
-  description:
-    "Monitor the API call latency that your users actually feel. Investigate HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",
+  description: "Monitor mobile API call latency, HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",
   alternates: { canonical: "/product/network-performance" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Mobile Network Performance Monitoring",
-    description:
-      "Monitor the API call latency that your users actually feel. Investigate HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",
+    description: "Monitor mobile API call latency, HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.",
     url: "/product/network-performance",
   },
 };

--- a/frontend/dashboard/app/product/performance-traces/page.tsx
+++ b/frontend/dashboard/app/product/performance-traces/page.tsx
@@ -9,14 +9,12 @@ import TraceDemo from "./trace_demo";
 
 export const metadata: Metadata = {
   title: "Mobile App Performance Tracing & Monitoring",
-  description:
-    "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues harming your app experience.",
+  description: "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks, and fix performance issues hurting your app.",
   alternates: { canonical: "/product/performance-traces" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Mobile App Performance Tracing & Monitoring",
-    description:
-      "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues harming your app experience.",
+    description: "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks, and fix performance issues hurting your app.",
     url: "/product/performance-traces",
   },
 };

--- a/frontend/dashboard/app/product/session-timelines/page.tsx
+++ b/frontend/dashboard/app/product/session-timelines/page.tsx
@@ -8,15 +8,13 @@ import LandingHeader from "../../components/landing_header";
 import SessionTimelineDemo from "./session_timeline_demo";
 
 export const metadata: Metadata = {
-  title: "Mobile Session Timelines",
-  description:
-    "No more guessing what the user was doing - see every click, navigation, network call, log, error and CPU/memory signal stitched into a single timeline to diagnose issues faster.",
+  title: "Mobile Session Timelines & Replay",
+  description: "See every click, navigation, network call, log, error and CPU/memory signal stitched into a single mobile session timeline to diagnose issues faster.",
   alternates: { canonical: "/product/session-timelines" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Mobile Session Timelines",
-    description:
-      "No more guessing what the user was doing - see every click, navigation, network call, log, error and CPU/memory signal stitched into a single timeline to diagnose issues faster.",
+    title: "Mobile Session Timelines & Replay | Measure",
+    description: "See every click, navigation, network call, log, error and CPU/memory signal stitched into a single mobile session timeline to diagnose issues faster.",
     url: "/product/session-timelines",
   },
 };

--- a/frontend/dashboard/app/product/user-journeys/page.tsx
+++ b/frontend/dashboard/app/product/user-journeys/page.tsx
@@ -9,14 +9,12 @@ import UserJourneysDemo from "./user_journeys_demo";
 
 export const metadata: Metadata = {
   title: "User Journey Tracking for Mobile Apps",
-  description:
-    "Understand how users actually move through your mobile app. Track popular paths, find friction, and prioritize the flows that matter most.",
+  description: "Understand how users actually move through your mobile app. Track popular paths, find friction and prioritize the flows that matter most.",
   alternates: { canonical: "/product/user-journeys" },
   openGraph: {
     ...sharedOpenGraph,
     title: "User Journey Tracking for Mobile Apps",
-    description:
-      "Understand how users actually move through your mobile app. Track popular paths, find friction, and prioritize the flows that matter most.",
+    description: "Understand how users actually move through your mobile app. Track popular paths, find friction and prioritize the flows that matter most.",
     url: "/product/user-journeys",
   },
 };

--- a/frontend/dashboard/app/security/page.tsx
+++ b/frontend/dashboard/app/security/page.tsx
@@ -8,15 +8,13 @@ import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
 export const metadata: Metadata = {
-  title: "Security",
-  description:
-    "Measure is committed to security and protection of your app's data. Completely open source so you can audit it yourself.",
+  title: "Security & Data Protection",
+  description: "How Measure protects your app's data — encryption, infrastructure and access controls. Open source so you can audit it yourself.",
   alternates: { canonical: "/security" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Security at Measure",
-    description:
-      "Measure is committed to security and protection of your app's data. Completely open source so you can audit it yourself.",
+    title: "Security & Data Protection | Measure",
+    description: "How Measure protects your app's data — encryption, infrastructure and access controls. Open source so you can audit it yourself.",
     url: "/security",
   },
 };

--- a/frontend/dashboard/app/why-measure/page.tsx
+++ b/frontend/dashboard/app/why-measure/page.tsx
@@ -14,15 +14,13 @@ import LandingHeader from "../components/landing_header";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
 export const metadata: Metadata = {
-  title: { absolute: "Why Measure" },
-  description:
-    "At Measure, Mobile is not an add-on to an observability product. Mobile is the product.",
+  title: "Mobile-First App Monitoring",
+  description: "Mobile is the product, not an add-on to a backend observability tool. Why we built Measure for mobile engineering teams.",
   alternates: { canonical: "/why-measure" },
   openGraph: {
     ...sharedOpenGraph,
-    title: "Why Measure",
-    description:
-      "At Measure, Mobile is not an add-on to an observability product. Mobile is the product.",
+    title: "Mobile-First App Monitoring | Measure",
+    description: "Mobile is the product, not an add-on to a backend observability tool. Why we built Measure for mobile engineering teams.",
     url: "/why-measure",
   },
 };

--- a/frontend/dashboard/scripts/copy_docs.js
+++ b/frontend/dashboard/scripts/copy_docs.js
@@ -45,8 +45,16 @@ function stripHtmlComments(text) {
   return result.trim();
 }
 
+/**
+ * Strip leading YAML frontmatter (--- ... --- block at start of file).
+ */
+function stripFrontmatter(text) {
+  const match = text.match(/^---\s*\r?\n[\s\S]*?\r?\n---\s*(?:\r?\n|$)/);
+  return match ? text.slice(match[0].length) : text;
+}
+
 function extractTitle(content) {
-  const match = content.match(/^#\s+(.+)$/m);
+  const match = stripFrontmatter(content).match(/^#\s+(.+)$/m);
   return match ? stripHtmlComments(match[1]).trim() : "Documentation";
 }
 
@@ -63,15 +71,7 @@ function generateSearchIndex(docsDir) {
       } else if (entry.isFile() && entry.name.endsWith(".md")) {
         const filePath = path.join(dir, entry.name);
         const content = fs.readFileSync(filePath, "utf-8");
-
-        // Strip frontmatter
-        let body = content;
-        if (body.startsWith("---")) {
-          const end = body.indexOf("---", 3);
-          if (end !== -1) {
-            body = body.slice(end + 3).trim();
-          }
-        }
+        const body = stripFrontmatter(content);
 
         const title = extractTitle(body);
         const headings = [];
@@ -134,7 +134,7 @@ function getTitleFromFile(docsDir, mdPath) {
   if (!fs.existsSync(filePath)) {
     return null;
   }
-  const content = fs.readFileSync(filePath, "utf-8");
+  const content = stripFrontmatter(fs.readFileSync(filePath, "utf-8"));
   const match = content.match(/^#\s+(.+)$/m);
   return match ? stripHtmlComments(match[1]).trim() : null;
 }
@@ -149,7 +149,7 @@ function parseDirectoryNav(docsDir, subDir) {
     return [];
   }
 
-  const readme = fs.readFileSync(readmePath, "utf-8");
+  const readme = stripFrontmatter(fs.readFileSync(readmePath, "utf-8"));
   const children = [];
   const seen = new Set();
 
@@ -253,7 +253,9 @@ function parseDirectoryNav(docsDir, subDir) {
  * - "Further Reading" section for directory-based groups
  */
 function generateDocsNav(docsDir) {
-  const readme = fs.readFileSync(path.join(docsDir, "README.md"), "utf-8");
+  const readme = stripFrontmatter(
+    fs.readFileSync(path.join(docsDir, "README.md"), "utf-8"),
+  );
   const lines = readme.split("\n");
   const nav = [];
   const preambleLinks = []; // .md links from before the first content section
@@ -398,6 +400,7 @@ function generateDocsNav(docsDir) {
 // Exports for testing
 module.exports = {
   stripHtmlComments,
+  stripFrontmatter,
   extractTitle,
   mdPathToSlug,
   getTitleFromFile,

--- a/frontend/dashboard/scripts/generate_llms_txts.js
+++ b/frontend/dashboard/scripts/generate_llms_txts.js
@@ -12,7 +12,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const { stripHtmlComments, mdPathToSlug } = require("./copy_docs");
+const { stripHtmlComments, stripFrontmatter, mdPathToSlug } = require("./copy_docs");
 
 const rootDir = path.resolve(__dirname, "..");
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://measure.sh";
@@ -167,7 +167,7 @@ function generateLlmsFullTxt(docsDir, navData) {
     }
 
     const raw = fs.readFileSync(filePath, "utf-8");
-    const cleaned = stripHtmlComments(raw);
+    const cleaned = stripHtmlComments(stripFrontmatter(raw));
     const rewritten = rewriteRelativeLinks(cleaned);
     const sourceUrl =
       slug === "/docs" ? `${SITE_URL}/docs` : `${SITE_URL}${slug}`;


### PR DESCRIPTION
# Description

- adds yaml frontmatter for readme pages which are used to generate title and description for docs pages for SEO and social media
- updates titles and descriptions for website pages for consistency



