### PR TITLE
chore(backend): reduce iggy consumer poll interval

### DIFF
--- a/backend/ingest-worker/server/server.go
+++ b/backend/ingest-worker/server/server.go
@@ -405,7 +405,7 @@ func Init(config *ServerConfig) {
 		}
 		log.Println("iggy batch size:", batchSize)
 
-		pollInterval := 30 * time.Second
+		pollInterval := 1 * time.Second
 		ingestPollInterval := os.Getenv("INGEST_POLL_INTERVAL")
 		if ingestPollInterval != "" {
 			pollInterval, err = time.ParseDuration(ingestPollInterval)


### PR DESCRIPTION
## Summary

This PR reduces the iggy consumer poll interval to 1 sec.

## See also

- fixes #3619