### PR TITLE
feat(frontend): serve markdown for marketing & docs pages to agents

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ---
 title: "Contribute to Measure"
-description: "Contribute to Measure. Project workflow, local development setup, tests, commit messages, and release process."
+description: "Contribute to Measure. Project workflow, local development setup, tests, commit messages and release process."
 ---
 
 # Measure Contribution Guidelines
@@ -422,4 +422,4 @@ set VERSION $(git cliff --bumped-version) && git tag -s $VERSION -m $VERSION && 
 - Public facing docs should be in [docs](../README.md) folder - API requests & responses, self host guide, SDK guides and so on
 - Main folder of subproject should link to main guide. ex: [frontend README](../frontend/dashboard/README.md) has link to self hosting and local dev guide
 - Non public facing docs can stay in sub folder. ex: [backend benchmarking README](../backend/benchmarking/README.md) which describes its purpose
-- Docs pages, sidebar nav, search index, and sitemap are all auto-generated at build time from the markdown files. The sidebar nav is derived from the link structure in [docs/README.md](../README.md) — ordering and grouping come from the links there, and titles come from each page's `# H1` heading. To add a new doc page, create the `.md` file and add a link to it in the README
+- Docs pages, sidebar nav, search index and sitemap are all auto-generated at build time from the markdown files. The sidebar nav is derived from the link structure in [docs/README.md](../README.md) — ordering and grouping come from the links there, and titles come from each page's `# H1` heading. To add a new doc page, create the `.md` file and add a link to it in the README

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Measure SDK Documentation"
-description: "Measure documentation. SDK integration, features, self-hosting, and REST API reference for monitoring mobile apps."
+description: "Measure documentation. SDK integration, features, self-hosting and REST API reference for monitoring mobile apps."
 ---
 
 # Documentation

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Dashboard REST API Reference"
-description: "Reference for Measure's Dashboard REST API. Every endpoint, request body, response format, and status code."
+description: "Reference for Measure's Dashboard REST API. Every endpoint, request body, response format and status code."
 ---
 
 # Dashboard REST API Documentation <!-- omit in toc -->
@@ -856,7 +856,7 @@ List of HTTP status codes for success and failures.
 - [**PATCH `/apps/:id/config`**](#patch-appsidconfig) - Update an app's config.
 - [**GET `/apps/:id/networkRequests/domains`**](#get-appsidnetworkrequestsdomains) - Fetch an app's unique network request domains.
 - [**GET `/apps/:id/networkRequests/paths`**](#get-appsidnetworkrequestspaths) - Fetch an app's network request paths for a domain.
-- [**GET `/apps/:id/networkRequests/trends`**](#get-appsidnetworkrequeststrends) - Fetch an app's network request trends by latency, error rate, and frequency.
+- [**GET `/apps/:id/networkRequests/trends`**](#get-appsidnetworkrequeststrends) - Fetch an app's network request trends by latency, error rate and frequency.
 - [**GET `/apps/:id/networkRequests/plots/overviewStatusCodes`**](#get-appsidnetworkrequestsplotsoverviewstatuscodes) - Fetch an app's overall network status distribution plot.
 - [**GET `/apps/:id/networkRequests/plots/endpointLatency`**](#get-appsidnetworkrequestsplotsendpointlatency) - Fetch a network endpoint's latency percentiles plot.
 - [**GET `/apps/:id/networkRequests/plots/endpointStatusCodes`**](#get-appsidnetworkrequestsplotsendpointstatuscodes) - Fetch a network endpoint's status distribution plot.
@@ -6077,7 +6077,7 @@ List of HTTP status codes for success and failures.
 
 ### GET `/apps/:id/networkRequests/trends`
 
-Fetch an app's network request trends showing top endpoints by latency, error rate, and frequency.
+Fetch an app's network request trends showing top endpoints by latency, error rate and frequency.
 
 #### Usage Notes
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -1,6 +1,6 @@
 ---
 title: "SDK Ingestion REST API Reference"
-description: "Reference for the Measure SDK ingestion REST API. Events, builds, config, attachments, traces, and authentication."
+description: "Reference for the Measure SDK ingestion REST API. Events, builds, config, attachments, traces and authentication."
 ---
 
 # SDK REST API Documentation <!-- omit in toc -->

--- a/docs/features/configuration-options.md
+++ b/docs/features/configuration-options.md
@@ -1,6 +1,6 @@
 ---
 title: "SDK Configuration Options"
-description: "Every Measure SDK configuration option. Tune data collection, masking, sampling, and disk usage at init or remotely from the dashboard."
+description: "Every Measure SDK configuration option. Tune data collection, masking, sampling and disk usage at init or remotely from the dashboard."
 ---
 
 # Configuration Options
@@ -217,7 +217,7 @@ ClientInfo *clientInfo = [[ClientInfo alloc] initWithApiKey:@"api-key" apiUrl:@"
 ## `maxDiskUsageInMb`
 
 Allows setting the maximum disk usage for Measure SDK. This is useful to control the amount of disk space
-used by the SDK for storing session data, crash reports, and other collected information.
+used by the SDK for storing session data, crash reports and other collected information.
 
 All Measure SDKs store data to disk and upload it to the server in batches. While the app is in foreground, the data
 is synced periodically and usually the disk space used by the SDK is low. However, if the device is offline
@@ -345,7 +345,7 @@ the amount of data collected.
 
 ## Launch Metrics Sampling
 
-Launch metrics include Cold Launch, Warm Launch, and Hot Launch metrics shown on the Overview page on the dashboard. A
+Launch metrics include Cold Launch, Warm Launch and Hot Launch metrics shown on the Overview page on the dashboard. A
 sampling rate can be configured to control the number of sessions for whom these launch metrics are collected.
 
 By default, 0.01% (1 in 10000) of sessions will have launch metrics collected. You can adjust this percentage
@@ -354,7 +354,7 @@ from 0.001% to 100% to control the amount of data collected.
 ## Journey Sampling
 
 Journey events are used to construct the Journey view in the Measure dashboard. Journey events include Activity
-Lifecycle events, Fragment Lifecycle events, and Screen View events. A sampling rate can be configured to control
+Lifecycle events, Fragment Lifecycle events and Screen View events. A sampling rate can be configured to control
 the number of sessions for whom these Journey events are collected.
 
 By default, 0.01% (1 in 10000) of sessions will have Journey events collected. You can adjust this percentage from

--- a/docs/features/feature-app-launch-metrics.md
+++ b/docs/features/feature-app-launch-metrics.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile App Launch Metrics"
-description: "Track cold, warm, and hot launch times for Android and iOS apps with full sampling control.."
+description: "Track cold, warm and hot launch times for Android and iOS apps with full sampling control.."
 ---
 
 # App Launch Metrics
@@ -14,7 +14,7 @@ description: "Track cold, warm, and hot launch times for Android and iOS apps wi
 
 ## Introduction
 
-Measure automatically tracks cold, warm, and hot app launches along with the time taken for each. No sampling is done, ensuring that the data is accurate and represents the real-world performance of your app.
+Measure automatically tracks cold, warm and hot app launches along with the time taken for each. No sampling is done, ensuring that the data is accurate and represents the real-world performance of your app.
 
 - **Cold Launch**: The time taken to launch the app from scratch.
 - **Warm Launch**: The time taken to launch the app from a previously cached state.
@@ -31,7 +31,7 @@ metrics.
 
 ## Data Collected
 
-Check out the data collected by Measure for [Cold Launch](../api/sdk/README.md#cold_launch), [Warm Launch](../api/sdk/README.md#warm_launch), and [Hot Launch](../api/sdk/README.md#hot_launch) respectively.
+Check out the data collected by Measure for [Cold Launch](../api/sdk/README.md#cold_launch), [Warm Launch](../api/sdk/README.md#warm_launch) and [Hot Launch](../api/sdk/README.md#hot_launch) respectively.
 
 ## How It Works
 
@@ -96,7 +96,7 @@ certain resources being released, the system might need to recreate those resour
 
 #### Cold Launch
 
-A cold launch refers to an app starting up from scratch. Cold launches occur when the app is launched after a reboot or when the app is updated. When an app is launched from scratch, the app is brought from the disk to the memory, iOS loads startup system-side services that support the app, frameworks, and daemons that the app depends on to launch might also require re-launching and paging in from disk. Once this is done, the process is spanned.
+A cold launch refers to an app starting up from scratch. Cold launches occur when the app is launched after a reboot or when the app is updated. When an app is launched from scratch, the app is brought from the disk to the memory, iOS loads startup system-side services that support the app, frameworks and daemons that the app depends on to launch might also require re-launching and paging in from disk. Once this is done, the process is spanned.
 
 #### Warm Launch
 

--- a/docs/features/feature-bug-report-android.md
+++ b/docs/features/feature-bug-report-android.md
@@ -1,6 +1,6 @@
 ---
 title: "In-App Bug Reports — Android SDK"
-description: "Let users report bugs from inside your Android app. Built-in or custom UI, screenshots, layout snapshots, and shake to report."
+description: "Let users report bugs from inside your Android app. Built-in or custom UI, screenshots, layout snapshots and shake to report."
 ---
 
 # Bug Reports — Android
@@ -168,10 +168,10 @@ Measure.trackBugReport(
 
 ## Add Attributes
 
-Attributes allow attaching additional contextual data to bug reports. This helps in adding relevant information about the user's state, app configuration, or other metadata that can help with debugging.
+Attributes allow attaching additional contextual data to bug reports. This helps in adding relevant information about the user's state, app configuration or other metadata that can help with debugging.
 
 - Attribute keys must be strings with a maximum length of 256 characters.
-- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 - String attribute values can have a maximum length of 256 characters.
 
 Add attributes when the Bug Report Activity is launched:

--- a/docs/features/feature-bug-report-flutter.md
+++ b/docs/features/feature-bug-report-flutter.md
@@ -1,6 +1,6 @@
 ---
 title: "In-App Bug Reports — Flutter SDK"
-description: "Let users report bugs from inside your Flutter app. Built-in or custom UI, screenshots, attachments, i18n, and shake to report."
+description: "Let users report bugs from inside your Flutter app. Built-in or custom UI, screenshots, attachments, i18n and shake to report."
 ---
 
 # Bug Reports — Flutter
@@ -137,10 +137,10 @@ Measure.trackBugReport(
 
 ## Add Attributes
 
-Attributes allow attaching additional contextual data to bug reports. This helps in adding relevant information about the user's state, app configuration, or other metadata that can help with debugging.
+Attributes allow attaching additional contextual data to bug reports. This helps in adding relevant information about the user's state, app configuration or other metadata that can help with debugging.
 
 - Attribute keys must be strings with a maximum length of 256 characters.
-- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 - String attribute values can have a maximum length of 256 characters.
 
 To add attributes, use the optinal `attributes` property in `createBugReportWidget`:

--- a/docs/features/feature-bug-report-ios.md
+++ b/docs/features/feature-bug-report-ios.md
@@ -1,6 +1,6 @@
 ---
 title: "In-App Bug Reports — iOS SDK"
-description: "et users report bugs from inside your iOS app. Built-in or custom UI, screenshots, attachments, theming, and shake to report"
+description: "et users report bugs from inside your iOS app. Built-in or custom UI, screenshots, attachments, theming and shake to report"
 ---
 
 # Bug Reports — iOS

--- a/docs/features/feature-cpu-monitoring.md
+++ b/docs/features/feature-cpu-monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile App CPU Monitoring"
-description: "Periodically capture CPU usage of Android, iOS, and Flutter apps while they're in the foreground."
+description: "Periodically capture CPU usage of Android, iOS and Flutter apps while they're in the foreground."
 ---
 
 # CPU Monitoring
@@ -48,7 +48,7 @@ Measure SDK calculates CPU usage by retrieving task and thread information using
 
 - Retrieve Task-Level CPU Usage:
     - Uses task_info with `TASK_BASIC_INFO` to get overall CPU time for the process.
-    - This provides details such as total user time, system time, and memory usage.
+    - This provides details such as total user time, system time and memory usage.
 
 - Retrieve Thread-Level CPU Usage:
     - Uses task_threads to obtain a list of active threads within the process.

--- a/docs/features/feature-crash-reporting.md
+++ b/docs/features/feature-crash-reporting.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile Crash Reporting (Android, iOS, Flutter)"
-description: "Track crashes in Android, iOS, and Flutter apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping, and symbolicated stack traces."
+description: "Track crashes in Android, iOS and Flutter apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping and symbolicated stack traces."
 ---
 
 # Crash Reporting
@@ -74,7 +74,7 @@ Crashes are grouped to help you identify the most common issues in your app. Eac
 
 Exceptions in Android (JVM) are grouped based on the exception type and the stack trace. Crashes with the same type and the same method name and file name from the _first frame_ of the stack trace are grouped together.
 
-For example, for the following crash, the exception type is `java.lang.NullPointerException`, the method name of the first frame is `onCreate`, and the file name is `MainActivity.kt`:
+For example, for the following crash, the exception type is `java.lang.NullPointerException`, the method name of the first frame is `onCreate` and the file name is `MainActivity.kt`:
 
 ```
 java.lang.NullPointerException: Attempt to invoke virtual method 'void com.example.app.MainActivity.onCreate(android.os.Bundle)' on a null object reference
@@ -87,7 +87,7 @@ java.lang.NullPointerException: Attempt to invoke virtual method 'void com.examp
 
 Exceptions in iOS (Objective-C/Swift) are grouped based on the exception signal and the stack trace. Crashes with the same signal, for example, `SIGABRT`, the same method name and file name from the _first frame belonging to the application binary_ are grouped together.
 
-For example, for the following crash, the signal is `SIGABRT`, the method name of the first relevant frame is `-viewDidLoad`, and the file name is `MainViewController.m`:
+For example, for the following crash, the signal is `SIGABRT`, the method name of the first relevant frame is `-viewDidLoad` and the file name is `MainViewController.m`:
 
 ```
 Exception Type: EXC_CRASH (SIGABRT)
@@ -112,7 +112,7 @@ In Flutter, crashes are grouped based on the exception type and the stack trace.
 and the same method name and file name from the _first frame_ of the stack trace are grouped together.
 
 For example, for the following crash, the exception type is `FlutterError`, the method name of the first frame
-is `_incrementCounter`, and the file name is `main.dart`:
+is `_incrementCounter` and the file name is `main.dart`:
 
 ```
 FlutterError (setState() called after dispose(): _MyHomePageState#12345(ticker: _TickerModeEnabled))

--- a/docs/features/feature-custom-events.md
+++ b/docs/features/feature-custom-events.md
@@ -13,7 +13,7 @@ description: "Track app-specific events like user actions with custom attributes
 
 ## Introduction
 
-Custom events let you add your own context on top of the automatically collected events. They’re great for tracking things that matter to your app, like user actions, feature usage, feature flags, or any other domain-specific data. This helps you debug issues more effectively and analyze the real-world impact of your features.
+Custom events let you add your own context on top of the automatically collected events. They’re great for tracking things that matter to your app, like user actions, feature usage, feature flags or any other domain-specific data. This helps you debug issues more effectively and analyze the real-world impact of your features.
 
 > [!TIP]
 >
@@ -62,7 +62,7 @@ A custom event can also contain attributes, which are key-value pairs.
 > [!NOTE]
 > - Attribute keys must be strings with a maximum length of `256` characters.
 > - Attribute keys must only contain alphabets, numbers, hyphens and underscores.
-> - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+> - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 > - String attribute values can have a maximum length of `256` characters.
 
 #### Android

--- a/docs/features/feature-error-tracking.md
+++ b/docs/features/feature-error-tracking.md
@@ -1,6 +1,6 @@
 ---
 title: "Error Tracking (Handled Exceptions)"
-description: "Track handled exceptions in your mobile app — issues that don't crash but still affect users. Android, iOS, and Flutter APIs."
+description: "Track handled exceptions in your mobile app — issues that don't crash but still affect users. Android, iOS and Flutter APIs."
 ---
 
 # Track errors
@@ -32,7 +32,7 @@ From version `0.12.0` onwards you can also add attributes to the tracked excepti
 providing additional context about the error.
 
 - Attribute keys must be strings with a maximum length of 256 characters.
-- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 - String attribute values can have a maximum length of 256 characters.
 
 ```kotlin
@@ -61,7 +61,7 @@ do {
 You can optionally include attributes and enable stack trace collection.
 
 - Attribute keys must be strings with a maximum length of 256 characters.
-- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 - String attribute values can have a maximum length of 256 characters.
 
 ```swift

--- a/docs/features/feature-gesture-tracking.md
+++ b/docs/features/feature-gesture-tracking.md
@@ -162,7 +162,7 @@ them into different gesture types:
 
 Gesture target detection identifies the UI element interacted with during a gesture. It first determines the view at the
 touch location and then searches its subviews to find the most relevant target. For scroll detection, it checks if the
-interacted element is a scrollable view like `UIScrollView`, `UIDatePicker`, or `UIPickerView`.
+interacted element is a scrollable view like `UIScrollView`, `UIDatePicker` or `UIPickerView`.
 
 ### Flutter
 
@@ -233,7 +233,7 @@ widgets, while for scrolls, it looks for scrollable widgets.
 ### Layout snapshots
 
 Layout snapshots capture your app's UI structure by traversing the widget tree from the root widget. The SDK collects
-key information about each widget—including its type, position, size, and hierarchy—to build a lightweight
+key information about each widget—including its type, position, size and hierarchy—to build a lightweight
 representation of your UI.
 
 The entire layout snapshot is generated in a single pass through the widget tree using the `visitChildElements` method.

--- a/docs/features/feature-mcp.md
+++ b/docs/features/feature-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server for Mobile App Monitoring"
-description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows."
+description: "Connect Measure to Claude Code, Codex, Cursor, Gemini and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows."
 ---
 
 # MCP Server
@@ -35,7 +35,7 @@ Measure exposes a [Model Context Protocol](https://modelcontextprotocol.io) (MCP
 
 ## What is MCP?
 
-The [Model Context Protocol](https://modelcontextprotocol.io) is an open standard that allows AI tools to interact with external data sources through a consistent interface. With Measure's MCP server, you can ask AI assistants to look up crashes, analyze error trends, and inspect stack traces without leaving your editor.
+The [Model Context Protocol](https://modelcontextprotocol.io) is an open standard that allows AI tools to interact with external data sources through a consistent interface. With Measure's MCP server, you can ask AI assistants to look up crashes, analyze error trends and inspect stack traces without leaving your editor.
 
 ## Connecting to MCP via Coding Agents
 
@@ -72,7 +72,7 @@ Get available filter options (versions, OS, countries, devices, etc.) for an app
 
 ### `get_metrics`
 
-Get app metrics including adoption, crash-free/ANR-free sessions, and launch performance (cold/warm/hot p95).
+Get app metrics including adoption, crash-free/ANR-free sessions and launch performance (cold/warm/hot p95).
 
 ### `get_errors`
 

--- a/docs/features/feature-memory-monitoring.md
+++ b/docs/features/feature-memory-monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile App Memory Monitoring"
-description: "Periodically capture memory usage of Android, iOS, and Flutter apps to spot leaks and memory pressure."
+description: "Periodically capture memory usage of Android, iOS and Flutter apps to spot leaks and memory pressure."
 ---
 
 # Memory Monitoring

--- a/docs/features/feature-navigation-lifecycle-tracking.md
+++ b/docs/features/feature-navigation-lifecycle-tracking.md
@@ -1,5 +1,5 @@
 ---
-description: "Automatic capture of Activity, Fragment, View Controller, SwiftUI, and Flutter lifecycle events plus screen views for navigation."
+description: "Automatic capture of Activity, Fragment, View Controller, SwiftUI and Flutter lifecycle events plus screen views for navigation."
 ---
 
 # Navigation & Lifecycle Tracking
@@ -155,7 +155,7 @@ From version `0.12.0` onwards, you can also add attributes to the tracked screen
 providing additional context about the screen.
 
 - Attribute keys must be strings with a maximum length of 256 characters.
-- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+- Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 - String attribute values can have a maximum length of 256 characters.
 
 

--- a/docs/features/feature-network-connectivity-changes.md
+++ b/docs/features/feature-network-connectivity-changes.md
@@ -1,6 +1,6 @@
 ---
 title: "Network Connectivity Change Tracking"
-description: "Track when your app gains or loses network connectivity, switches between WiFi and cellular, or changes carrier."
+description: "Track when your app gains or loses network connectivity, switches between WiFi and cellular or changes carrier."
 ---
 
 # Network Connectivity Changes
@@ -11,7 +11,7 @@ description: "Track when your app gains or loses network connectivity, switches 
 * [**Data collected**](#data-collected)
 
 Measure SDK captures changes to network connection state of the device. This includes changes to the type of network
-connection (WiFi, Mobile, etc.), the network provider (Airtel, T-Mobile, etc.), and the network generation (2G, 3G, 4G,
+connection (WiFi, Mobile, etc.), the network provider (Airtel, T-Mobile, etc.) and the network generation (2G, 3G, 4G,
 etc.).
 
 ## Android

--- a/docs/features/feature-performance-tracing.md
+++ b/docs/features/feature-performance-tracing.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile Performance Tracing"
-description: "Trace any operation in your mobile app — API calls, DB queries, custom user flows — with nested spans, attributes, and automatic screen load traces."
+description: "Trace any operation in your mobile app — API calls, DB queries, custom user flows — with nested spans, attributes and automatic screen load traces."
 ---
 
 # Performance Tracing
@@ -33,11 +33,11 @@ description: "Trace any operation in your mobile app — API calls, DB queries, 
 
 ## Introduction
 
-You can easily track the performance of any part of your application, such as API calls, DB queries, any function, or a user journey, using the performance tracing APIs. The SDK supports nested spans to track hierarchical operations.
+You can easily track the performance of any part of your application, such as API calls, DB queries, any function or a user journey, using the performance tracing APIs. The SDK supports nested spans to track hierarchical operations.
 
 > [!NOTE]
 >
-> measure-sh can automatically track traces for screen load times in Android and iOS apps for _Activities_, _Fragments_, and _UIViewControllers_. See [Screen Load Time](#screen-load-time) for more details.
+> measure-sh can automatically track traces for screen load times in Android and iOS apps for _Activities_, _Fragments_ and _UIViewControllers_. See [Screen Load Time](#screen-load-time) for more details.
 
 Here's a simple example of how to use the performance tracing APIs:
 
@@ -121,11 +121,11 @@ onboarding-flow ━━━━━━━━━━━━━━━━━━━━━�
 
 ## Concepts
 
-Tracing helps you understand how long certain operations take to complete, from the moment they begin until they finish, including all the intermediate steps, dependencies, and parallel activities that occur during execution.
+Tracing helps you understand how long certain operations take to complete, from the moment they begin until they finish, including all the intermediate steps, dependencies and parallel activities that occur during execution.
 
 A **trace** represents the entire operation, which could be a complete user journey like onboarding, further divided into multiple steps like login, create profile, etc. A trace is represented by a `trace_id`.
 
-A **span** is the fundamental building block of a trace. A span represents a single unit of work. This could be an HTTP request, a database query, a function call, etc. Each span contains information about the operation — when it started, how long it took, and whether it completed successfully or not. A span is identified using a `span_id` and a user-defined `name`.
+A **span** is the fundamental building block of a trace. A span represents a single unit of work. This could be an HTTP request, a database query, a function call, etc. Each span contains information about the operation — when it started, how long it took and whether it completed successfully or not. A span is identified using a `span_id` and a user-defined `name`.
 
 Each span can optionally have a **parent span**, which allows you to create a hierarchy of spans. This is useful for tracking nested operations. For example, if a user journey involves multiple steps, each step can be represented as a child span of the main user journey span.
 
@@ -326,7 +326,7 @@ Attributes are key-value pairs that can be attached to a span. Attributes are us
 > [!NOTE]
 > - Attribute keys must be strings with a maximum length of `256` characters.
 > - Attribute keys must only contain alphabets, numbers, hyphens and underscores.
-> - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float`, or `boolean`.
+> - Attribute values must be one of the primitive types: `int`, `long`, `double`, `float` or `boolean`.
 > - String attribute values can have a maximum length of `256` characters.
 
 To add attributes to a span, use `setAttribute`.
@@ -538,7 +538,7 @@ final span = spanBuilder.startSpan();
 ## Distributed Tracing
 
 Distributed tracing is a monitoring method that helps tracking requests as they travel through
-different services in a distributed system (like microservices, serverless functions, and mobile
+different services in a distributed system (like microservices, serverless functions and mobile
 apps).
 
 The `traceparent` header is a key component of distributed tracing that helps track requests as they

--- a/docs/features/feature-screenshot-masking-swiftui.md
+++ b/docs/features/feature-screenshot-masking-swiftui.md
@@ -25,7 +25,7 @@ To manage masking in SwiftUI, Measure provides the `.msrMask()` and `.msrUnmask(
 
 In UIKit, every visible element on screen corresponds to a `UIView` instance in the view hierarchy.
 Measure's masking traverses this hierarchy and redacts views that match known sensitive types such
-as `UILabel`, `UITextField`, and `UITextView`.
+as `UILabel`, `UITextField` and `UITextView`.
 
 SwiftUI does not follow this pattern. Most SwiftUI views do not produce individual `UIView` instances.
 Instead, the entire SwiftUI view tree is hosted inside a `_UIHostingView`, which renders its content
@@ -66,7 +66,7 @@ means content behind the unmasked view will also become visible in the screensho
 Use this for:
 
 - Non-sensitive SwiftUI content you want to remain visible in screenshots
-- Structural views like navigation titles, icons, or static labels that contain no user data
+- Structural views like navigation titles, icons or static labels that contain no user data
 
 ```swift
 Text("Welcome back")

--- a/docs/features/feature-session-timelines.md
+++ b/docs/features/feature-session-timelines.md
@@ -1,6 +1,6 @@
 ---
 title: "Session Timelines"
-description: "View every session as a chronological timeline of events, errors, screens, and gestures, with CPU and memory usage graphs."
+description: "View every session as a chronological timeline of events, errors, screens and gestures, with CPU and memory usage graphs."
 ---
 
 # Session Timeline
@@ -19,7 +19,7 @@ A session is a continuous period of activity within the app. A new session is cr
 
 The session timeline provides a detailed, chronological view of all events during a session. You can see the exact order of actions leading up to an issue, making it easier to spot problems. The timeline also includes memory and CPU usage graphs to help you understand how the app was performing at different moments.
 
-Additionally, screenshots and layout snapshots give you a window into what the user saw at the time. This visual context helps you catch UI issues, performance bottlenecks, or anything else that might not be obvious just from logs.
+Additionally, screenshots and layout snapshots give you a window into what the user saw at the time. This visual context helps you catch UI issues, performance bottlenecks or anything else that might not be obvious just from logs.
 
 Session timelines are automatically collected for sessions with Crashes and Bug Reports. Each session timeline includes all events that occurred 5 minutes before the issue, giving you deep context on what led to the problem.
 
@@ -27,7 +27,7 @@ See [Configuration Options](configuration-options.md) for details on how to conf
 
 ## Session Search
 
-You can easily find session timelines using attributes like user ID, session ID, device model, app version, OS version, country, and more. You can also search based on specific events, such as when a view was clicked or a screen was visited. This is particularly useful for investigating user- or device-specific issues.
+You can easily find session timelines using attributes like user ID, session ID, device model, app version, OS version, country and more. You can also search based on specific events, such as when a view was clicked or a screen was visited. This is particularly useful for investigating user- or device-specific issues.
 
 The session search supports all custom events and attributes defined in your app, allowing you to filter sessions based on custom data like feature flags or user actions.
 

--- a/docs/features/feature-slack-integration.md
+++ b/docs/features/feature-slack-integration.md
@@ -1,6 +1,6 @@
 ---
 title: "Slack Integration — Crash, ANR, Bug Report Alerts and Daily Summaries"
-description: "Receive Measure crash spike, ANR spike, bug report alerts and daily summaries in Slack. Manage subscriptions, list channels, and stop alerts via slash commands."
+description: "Receive Measure crash spike, ANR spike, bug report alerts and daily summaries in Slack. Manage subscriptions, list channels and stop alerts via slash commands."
 ---
 
 # Slack Integration

--- a/docs/features/performance-impact.md
+++ b/docs/features/performance-impact.md
@@ -88,9 +88,9 @@ key operations performed by the SDK can be found below:
 
 | Operation                 | p95       | Description                                                   |
 |---------------------------|-----------|---------------------------------------------------------------|
-| `trackEvent`              | 195 µs    | Includes event collection, attribute enrichment, and queueing |
+| `trackEvent`              | 195 µs    | Includes event collection, attribute enrichment and queueing |
 | `appendAttributes`        | 360 µs    | Dynamic attribute gathering (e.g., network, device state)     |
-| `trackBugReport`          | 120 µs    | Complete flow including screenshot, layout, and metadata      |
+| `trackBugReport`          | 120 µs    | Complete flow including screenshot, layout and metadata      |
 | `trackEventUserTriggered` | 32 µs     | User-triggered event tracking                                 |
 | `trackSpanTriggered`      | 96 µs     | When a trace event is emitted                                 |
 | `spanProcessorOnStart`    | 105 µs    | Span construction                                             |

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Self-Hosting Guide"
-description: "Self-host Measure to monitor crashes, ANRs, and performance for your mobile apps. Deploy on a Linux VM and configure OAuth, SMTP, and Slack."
+description: "Self-host Measure to monitor crashes, ANRs and performance for your mobile apps. Deploy on a Linux VM and configure OAuth, SMTP and Slack."
 ---
 
 # Self Hosting Guide <!-- omit in toc -->

--- a/docs/hosting/github-oauth.md
+++ b/docs/hosting/github-oauth.md
@@ -1,6 +1,6 @@
 ---
 title: "Set Up GitHub OAuth for Self-Hosted Measure"
-description: "Set up a GitHub OAuth application for your self-hosted Measure instance. Register, configure credentials, and connect to Measure."
+description: "Set up a GitHub OAuth application for your self-hosted Measure instance. Register, configure credentials and connect to Measure."
 ---
 
 # Setup a GitHub OAuth Application

--- a/docs/hosting/google-oauth.md
+++ b/docs/hosting/google-oauth.md
@@ -1,6 +1,6 @@
 ---
 title: "Set Up Google OAuth for Self-Hosted Measure"
-description: "Set up a Google OAuth application for your self-hosted Measure instance. Configure the consent screen, scopes, and redirect URIs."
+description: "Set up a Google OAuth application for your self-hosted Measure instance. Configure the consent screen, scopes and redirect URIs."
 ---
 
 # Setup a Google OAuth Application

--- a/docs/hosting/smtp-email.md
+++ b/docs/hosting/smtp-email.md
@@ -1,6 +1,6 @@
 ---
 title: "Set Up SMTP Email for Self-Hosted Measure"
-description: "Configure an SMTP email provider for your self-hosted Measure instance to send invites, alerts, and daily summary emails."
+description: "Configure an SMTP email provider for your self-hosted Measure instance to send invites, alerts and daily summary emails."
 ---
 
 # Set up an SMTP email provider

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -1,6 +1,6 @@
 ---
 title: "Measure SDK Integration Guide"
-description: "Integrate the Measure SDK on Android, iOS, or Flutter to track your app. Create an app in the dashboard, add the SDK, and verify installation."
+description: "Integrate the Measure SDK on Android, iOS or Flutter to track your app. Create an app in the dashboard, add the SDK and verify installation."
 ---
 
 # Getting Started

--- a/docs/sdk-upgrade-guides/README.md
+++ b/docs/sdk-upgrade-guides/README.md
@@ -1,6 +1,6 @@
 ---
 title: "SDK Upgrade Guides (Android, iOS, Flutter)"
-description: "Upgrade guides for major Measure SDK versions across Android, iOS, and Flutter. Breaking changes and migration steps."
+description: "Upgrade guides for major Measure SDK versions across Android, iOS and Flutter. Breaking changes and migration steps."
 ---
 
 # SDK Upgrade Guides
@@ -12,4 +12,4 @@ any breaking changes or behavior changes, we recommend checking the release note
 
 - [Android SDK v0.16.0](android-v0.16.0.md)
 - [iOS SDK v0.9.0](ios-v0.9.0.md)
-- [Measure Flutter SDK v0.4.0](measre_flutter-v0.4.0.md)
+- [Measure Flutter SDK v0.4.0](measure_flutter-v0.4.0.md)

--- a/docs/sdk-upgrade-guides/android-v0.16.0.md
+++ b/docs/sdk-upgrade-guides/android-v0.16.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrade Measure Android SDK to v0.16.0"
-description: "Upgrade the Measure Android SDK to v0.16.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines."
+description: "Upgrade the Measure Android SDK to v0.16.0. MeasureConfig moved to the dashboard, stricter span validation and configurable session timelines."
 ---
 
 # Upgrading to Android SDK v0.16.0

--- a/docs/sdk-upgrade-guides/ios-v0.9.0.md
+++ b/docs/sdk-upgrade-guides/ios-v0.9.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrade Measure iOS SDK to v0.9.0"
-description: "Upgrade the Measure iOS SDK to v0.9.0. MeasureConfig moved to the dashboard, stricter span validation, and configurable session timelines."
+description: "Upgrade the Measure iOS SDK to v0.9.0. MeasureConfig moved to the dashboard, stricter span validation and configurable session timelines."
 ---
 
 # Upgrading to iOS SDK v0.9.0

--- a/docs/sdk-upgrade-guides/measure_flutter-v0.4.0.md
+++ b/docs/sdk-upgrade-guides/measure_flutter-v0.4.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrade Measure Flutter SDK to v0.4.0"
-description: "Upgrade the Measure Flutter SDK to v0.4.0. Adds Layout Snapshots, requires manual native SDK init, and moves MeasureConfig options to the dashboard."
+description: "Upgrade the Measure Flutter SDK to v0.4.0. Adds Layout Snapshots, requires manual native SDK init and moves MeasureConfig options to the dashboard."
 ---
 
 # Upgrading to Measure Flutter SDK v0.4.0

--- a/docs/versioning/README.md
+++ b/docs/versioning/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Measure SDK and project Versioning"
-description: "How Measure versions its SDKs, backend, and dashboard with semver and platform-prefixed git tags."
+description: "How Measure versions its SDKs, backend and dashboard with semver and platform-prefixed git tags."
 ---
 
 # Versioning

--- a/frontend/dashboard/__tests__/integration/page_md_route_msw_test.ts
+++ b/frontend/dashboard/__tests__/integration/page_md_route_msw_test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests for the markdown content-negotiation route handler at
+ * `app/page-md/[...path]/route.ts`.
+ *
+ * The middleware unit tests cover the *rewrite decision* — given a
+ * pathname + matcher, what URL does the function emit? They can't cover
+ * what actually happens after the rewrite hits the route handler, which
+ * is where the markdown source is resolved, the response is built, and
+ * status codes are decided.
+ *
+ * These tests run in the integration jest config so we get real Fetch
+ * API globals (Request/Response/Headers from undici), which NextResponse
+ * needs to instantiate. They invoke the exported `GET` handler directly
+ * with constructed params — no Next.js server boot required.
+ */
+import {
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+import { GET } from "@/app/page-md/[...path]/route";
+
+function call(segments: string[] | undefined) {
+  // The handler ignores the request object — only params.path is read.
+  return GET({} as any, { params: { path: segments } });
+}
+
+async function expectMarkdown(res: Response, expectedSubstring: string) {
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+  expect(res.headers.get("Vary")).toBe("Accept");
+  expect(res.headers.get("Cache-Control")).toBe(
+    "public, max-age=300, s-maxage=600",
+  );
+  const body = await res.text();
+  expect(body).toContain(expectedSubstring);
+  return body;
+}
+
+async function expect406(res: Response) {
+  expect(res.status).toBe(406);
+  expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+  expect(res.headers.get("Vary")).toBe("Accept");
+  const body = await res.text();
+  expect(body).toContain("No markdown representation available");
+}
+
+describe("/page-md/[...path] route handler", () => {
+  describe("marketing pages (colocated app/<route>/page.md)", () => {
+    it("serves the homepage from app/page.md when segments=['index']", async () => {
+      const res = await call(["index"]);
+      const body = await expectMarkdown(res, "Mobile apps break, get to the root cause faster.");
+      // Frontmatter must be stripped before serving
+      expect(body.startsWith("---")).toBe(false);
+      expect(body).not.toContain("canonical: /");
+    });
+
+    it("serves /about from app/about/page.md", async () => {
+      const res = await call(["about"]);
+      await expectMarkdown(res, "# For mobile engineers, by mobile engineers");
+    });
+
+    it("serves /pricing from app/pricing/page.md", async () => {
+      const res = await call(["pricing"]);
+      await expectMarkdown(res, "# Pricing");
+    });
+
+    it("serves nested product pages from app/product/<slug>/page.md", async () => {
+      const res = await call(["product", "mcp"]);
+      await expectMarkdown(res, "# MCP");
+    });
+
+    it("serves every product page that exists on disk", async () => {
+      const productDir = path.join(process.cwd(), "app", "product");
+      const slugs = fs
+        .readdirSync(productDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .filter((name) =>
+          fs.existsSync(path.join(productDir, name, "page.md")),
+        );
+
+      expect(slugs.length).toBeGreaterThan(0);
+
+      for (const slug of slugs) {
+        const res = await call(["product", slug]);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("Content-Type")).toBe(
+          "text/markdown; charset=utf-8",
+        );
+      }
+    });
+
+    it("returns 406 for marketing paths that have no .md twin (privacy-policy)", async () => {
+      const res = await call(["privacy-policy"]);
+      await expect406(res);
+    });
+
+    it("returns 406 for marketing paths that have no .md twin (terms-of-service)", async () => {
+      const res = await call(["terms-of-service"]);
+      await expect406(res);
+    });
+
+    it("returns 406 for an unknown top-level path", async () => {
+      const res = await call(["this-page-does-not-exist"]);
+      await expect406(res);
+    });
+
+    it("returns 406 for an unknown product subpath", async () => {
+      const res = await call(["product", "made-up-feature"]);
+      await expect406(res);
+    });
+
+    it("returns 406 for routes that have page.tsx but no page.md (e.g. /auth)", async () => {
+      // app/auth/page.tsx exists but auth flows aren't marketing — no twin
+      const res = await call(["auth"]);
+      await expect406(res);
+    });
+  });
+
+  describe("docs pages", () => {
+    it("serves /docs (root) using getDocIndex when segments=['docs']", async () => {
+      const res = await call(["docs"]);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe(
+        "text/markdown; charset=utf-8",
+      );
+      const body = await res.text();
+      // Root docs README is hand-authored; just confirm it's non-empty markdown
+      expect(body.length).toBeGreaterThan(0);
+    });
+
+    it("serves a specific doc via getDocBySlug", async () => {
+      const res = await call(["docs", "sdk-integration-guide"]);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body.length).toBeGreaterThan(0);
+    });
+
+    it("returns 406 for a docs path that doesn't exist", async () => {
+      const res = await call(["docs", "this-doc-does-not-exist"]);
+      await expect406(res);
+    });
+  });
+
+  describe("security and edge cases", () => {
+    it("returns 406 when params.path is undefined (catch-all matched with no segments)", async () => {
+      const res = await call(undefined);
+      await expect406(res);
+    });
+
+    it("returns 406 when params.path is an empty array", async () => {
+      const res = await call([]);
+      await expect406(res);
+    });
+
+    it("rejects path-traversal attempts via .. segments", async () => {
+      // path.join collapses "..", so `app/../etc/passwd` would
+      // become `etc/passwd`. The startsWith(APP_DIR) guard catches
+      // the escape and returns 406.
+      const res = await call(["..", "etc", "passwd"]);
+      await expect406(res);
+    });
+
+    it("returns 406 for an attempted escape via mixed segments", async () => {
+      const res = await call(["product", "..", "..", "package.json"]);
+      await expect406(res);
+    });
+
+    it("strips frontmatter from the served body", async () => {
+      const res = await call(["about"]);
+      const body = await res.text();
+      // The on-disk file starts with `---\ntitle: ...\n---`, but the
+      // response body must not include that block.
+      expect(body).not.toMatch(/^---\s*\n/);
+      expect(body).not.toContain("canonical: /about");
+    });
+
+    it("served homepage body matches app/page.md after frontmatter strip", async () => {
+      const res = await call(["index"]);
+      const body = await res.text();
+      const raw = fs.readFileSync(
+        path.join(process.cwd(), "app", "page.md"),
+        "utf-8",
+      );
+      // After stripping frontmatter, what's left should be exactly what
+      // the route returns.
+      const afterFm = raw.replace(/^---[\s\S]*?---\s*\n?/, "");
+      expect(body).toBe(afterFm);
+    });
+  });
+
+  describe("response shape consistency", () => {
+    it("all 200 responses use the same set of headers", async () => {
+      const fixtures = [
+        ["about"],
+        ["pricing"],
+        ["product", "mcp"],
+      ] as string[][];
+
+      for (const segs of fixtures) {
+        const res = await call(segs);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("Content-Type")).toBe(
+          "text/markdown; charset=utf-8",
+        );
+        expect(res.headers.get("Vary")).toBe("Accept");
+        expect(res.headers.get("Cache-Control")).toBe(
+          "public, max-age=300, s-maxage=600",
+        );
+      }
+    });
+
+    it("all 406 responses use the same set of headers", async () => {
+      const fixtures = [
+        [],
+        ["privacy-policy"],
+        ["this-does-not-exist"],
+        ["docs", "missing-doc"],
+      ] as string[][];
+
+      for (const segs of fixtures) {
+        const res = await call(segs);
+        expect(res.status).toBe(406);
+        expect(res.headers.get("Content-Type")).toBe(
+          "text/plain; charset=utf-8",
+        );
+        expect(res.headers.get("Vary")).toBe("Accept");
+      }
+    });
+  });
+});

--- a/frontend/dashboard/__tests__/middleware_test.ts
+++ b/frontend/dashboard/__tests__/middleware_test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+// Mock next/server before importing the middleware so the import picks up
+// the mock. NextResponse.rewrite captures the destination URL as a string.
+jest.mock("next/server", () => ({
+  NextResponse: {
+    rewrite: (url: URL) => ({ type: "rewrite", url: url.toString() }),
+    next: () => ({ type: "next" }),
+  },
+}));
+
+import { config, middleware } from "@/middleware";
+
+// Build a minimal stub of NextRequest. The middleware only touches
+// `request.nextUrl.pathname`, `request.nextUrl.search`, and the cloned
+// URL returned by `request.nextUrl.clone()`. Headers are not inspected
+// by the function — they're filtered upstream by `config.matcher`.
+function makeRequest(pathname: string, search = "", origin = "https://measure.sh") {
+  return {
+    nextUrl: {
+      pathname,
+      search,
+      clone() {
+        return new URL(`${origin}${pathname}${search}`);
+      },
+    },
+  } as any;
+}
+
+describe("middleware", () => {
+  const originalApi = process.env.API_BASE_URL;
+  const originalPosthog = process.env.POSTHOG_HOST;
+
+  beforeEach(() => {
+    delete process.env.API_BASE_URL;
+    delete process.env.POSTHOG_HOST;
+  });
+
+  afterEach(() => {
+    if (originalApi === undefined) {
+      delete process.env.API_BASE_URL;
+    } else {
+      process.env.API_BASE_URL = originalApi;
+    }
+    if (originalPosthog === undefined) {
+      delete process.env.POSTHOG_HOST;
+    } else {
+      process.env.POSTHOG_HOST = originalPosthog;
+    }
+  });
+
+  describe("/api proxy", () => {
+    it("rewrites /api/foo to the default API origin", () => {
+      const result: any = middleware(makeRequest("/api/foo"));
+      expect(result.type).toBe("rewrite");
+      expect(result.url).toBe("http://api:8080/foo");
+    });
+
+    it("preserves query string", () => {
+      const result: any = middleware(makeRequest("/api/users", "?limit=10&offset=20"));
+      expect(result.url).toBe("http://api:8080/users?limit=10&offset=20");
+    });
+
+    it("uses API_BASE_URL env var when set", () => {
+      process.env.API_BASE_URL = "https://api.example.com:9000";
+      const result: any = middleware(makeRequest("/api/foo"));
+      expect(result.url).toBe("https://api.example.com:9000/foo");
+    });
+
+    it("replaces only the first /api occurrence", () => {
+      // /api/api-keys → after replace("/api", "") → /api-keys (not //-keys)
+      const result: any = middleware(makeRequest("/api/api-keys"));
+      expect(result.url).toBe("http://api:8080/api-keys");
+    });
+
+    it("handles a bare /api with no trailing path", () => {
+      // After replacement pathname becomes "" — URL normalizes to "/"
+      const result: any = middleware(makeRequest("/api"));
+      expect(result.url).toBe("http://api:8080/");
+    });
+
+    it("handles a deeply nested path", () => {
+      const result: any = middleware(makeRequest("/api/teams/abc/apps/xyz/sessions"));
+      expect(result.url).toBe("http://api:8080/teams/abc/apps/xyz/sessions");
+    });
+
+    it("falls back to http://api:8080 when API_BASE_URL is empty string", () => {
+      process.env.API_BASE_URL = "";
+      const result: any = middleware(makeRequest("/api/foo"));
+      expect(result.url).toBe("http://api:8080/foo");
+    });
+  });
+
+  describe("/yrtmlt/static proxy", () => {
+    it("rewrites /yrtmlt/static/array.js to PostHog assets CDN", () => {
+      const result: any = middleware(makeRequest("/yrtmlt/static/array.js"));
+      expect(result.url).toBe("https://us-assets.i.posthog.com/static/array.js");
+    });
+
+    it("preserves nested static paths", () => {
+      const result: any = middleware(makeRequest("/yrtmlt/static/recorder/recorder.js"));
+      expect(result.url).toBe("https://us-assets.i.posthog.com/static/recorder/recorder.js");
+    });
+
+    it("static branch takes precedence over generic /yrtmlt branch", () => {
+      // Path starts with /yrtmlt/static/ so it must hit the assets CDN,
+      // not the POSTHOG_HOST branch (which doesn't need to be set).
+      const result: any = middleware(makeRequest("/yrtmlt/static/foo.js"));
+      expect(result.url).toContain("us-assets.i.posthog.com");
+    });
+  });
+
+  describe("/yrtmlt non-static proxy", () => {
+    it("rewrites /yrtmlt/decide to POSTHOG_HOST", () => {
+      process.env.POSTHOG_HOST = "https://us.posthog.com";
+      const result: any = middleware(makeRequest("/yrtmlt/decide"));
+      expect(result.url).toBe("https://us.posthog.com/decide");
+    });
+
+    it("handles POSTHOG_HOST with a custom port", () => {
+      process.env.POSTHOG_HOST = "http://posthog.local:8000";
+      const result: any = middleware(makeRequest("/yrtmlt/e"));
+      expect(result.url).toBe("http://posthog.local:8000/e");
+    });
+
+    it("does not match the /static/ branch when path is /yrtmlt/static (no trailing slash)", () => {
+      // "/yrtmlt/static".startsWith("/yrtmlt/static/") is false, so this
+      // falls through to the generic /yrtmlt branch.
+      process.env.POSTHOG_HOST = "https://us.posthog.com";
+      const result: any = middleware(makeRequest("/yrtmlt/static"));
+      expect(result.url).toBe("https://us.posthog.com/static");
+    });
+
+    it("throws when POSTHOG_HOST is unset (documented behavior)", () => {
+      // The middleware constructs `new URL(process.env.POSTHOG_HOST || "")`.
+      // Empty string is not a valid URL, so this throws — the runtime
+      // contract assumes POSTHOG_HOST is set whenever /yrtmlt routes are live.
+      expect(() => middleware(makeRequest("/yrtmlt/foo"))).toThrow();
+    });
+  });
+
+  describe("markdown content negotiation (fall-through)", () => {
+    it("rewrites / to /page-md/index (homepage sentinel)", () => {
+      const result: any = middleware(makeRequest("/"));
+      expect(result.url).toBe("https://measure.sh/page-md/index");
+    });
+
+    it("rewrites /about to /page-md/about", () => {
+      const result: any = middleware(makeRequest("/about"));
+      expect(result.url).toBe("https://measure.sh/page-md/about");
+    });
+
+    it("rewrites nested product paths", () => {
+      const result: any = middleware(makeRequest("/product/mcp"));
+      expect(result.url).toBe("https://measure.sh/page-md/product/mcp");
+    });
+
+    it("rewrites docs paths so /page-md/[...path]/route.ts can serve them", () => {
+      const result: any = middleware(makeRequest("/docs/sdk-integration-guide"));
+      expect(result.url).toBe("https://measure.sh/page-md/docs/sdk-integration-guide");
+    });
+
+    it("rewrites pages with query strings (search params preserved on the URL)", () => {
+      const result: any = middleware(makeRequest("/about", "?utm=email"));
+      expect(result.url).toBe("https://measure.sh/page-md/about?utm=email");
+    });
+
+    it("preserves the original origin", () => {
+      const result: any = middleware(makeRequest("/pricing", "", "http://localhost:3000"));
+      expect(result.url).toBe("http://localhost:3000/page-md/pricing");
+    });
+  });
+
+  describe("config.matcher", () => {
+    it("exports three matcher entries", () => {
+      expect(Array.isArray(config.matcher)).toBe(true);
+      expect(config.matcher).toHaveLength(3);
+    });
+
+    it("first entry routes /api/:path*", () => {
+      expect(config.matcher[0]).toBe("/api/:path*");
+    });
+
+    it("second entry routes /yrtmlt/:path*", () => {
+      expect(config.matcher[1]).toBe("/yrtmlt/:path*");
+    });
+
+    it("third entry is an object with source + has filter", () => {
+      const m: any = config.matcher[2];
+      expect(typeof m).toBe("object");
+      expect(m.source).toBe("/((?!_next|page-md|api|yrtmlt|favicon\\.ico).*)");
+      expect(m.has).toEqual([
+        { type: "header", key: "accept", value: ".*text/markdown.*" },
+      ]);
+    });
+
+    it("third entry's source excludes Next internals, the markdown route itself, API and PostHog proxies, and favicon", () => {
+      const m: any = config.matcher[2];
+      const sourceRegex = new RegExp(
+        m.source
+          .replace("/((?!", "^/(?!")
+          .replace(").*)", ").*$"),
+      );
+      // Should NOT match (filtered by negative lookahead)
+      expect(sourceRegex.test("/_next/static/foo.js")).toBe(false);
+      expect(sourceRegex.test("/page-md/about")).toBe(false);
+      expect(sourceRegex.test("/api/teams")).toBe(false);
+      expect(sourceRegex.test("/yrtmlt/decide")).toBe(false);
+      expect(sourceRegex.test("/favicon.ico")).toBe(false);
+      // Should match (paths the markdown rewrite handles)
+      expect(sourceRegex.test("/about")).toBe(true);
+      expect(sourceRegex.test("/docs/foo")).toBe(true);
+      expect(sourceRegex.test("/product/mcp")).toBe(true);
+    });
+
+    it("`has.value` regex matches text/markdown in common Accept formats", () => {
+      const m: any = config.matcher[2];
+      const re = new RegExp(m.has[0].value);
+      expect(re.test("text/markdown")).toBe(true);
+      expect(re.test("text/markdown;q=0.9")).toBe(true);
+      expect(re.test("text/html, text/markdown")).toBe(true);
+      expect(re.test("application/json")).toBe(false);
+      expect(re.test("text/html")).toBe(false);
+    });
+
+    it("`has.value` regex is intentionally loose — matches text/markdownx too", () => {
+      // The pattern `.*text/markdown.*` has no word boundary, so subtypes
+      // like `text/markdownx` would also satisfy the matcher. No real
+      // client sends that, but flagging here so future tightening is
+      // explicit.
+      const m: any = config.matcher[2];
+      const re = new RegExp(m.has[0].value);
+      expect(re.test("text/markdownx")).toBe(true);
+    });
+  });
+
+  describe("path edge cases", () => {
+    it("/api/ with trailing slash rewrites to API origin root", () => {
+      // pathname.replace("/api", "") → "/", URL keeps it
+      const result: any = middleware(makeRequest("/api/"));
+      expect(result.url).toBe("http://api:8080/");
+    });
+
+    it("/api/foo/ preserves trailing slash on the rewritten path", () => {
+      const result: any = middleware(makeRequest("/api/foo/"));
+      expect(result.url).toBe("http://api:8080/foo/");
+    });
+
+    it("preserves percent-encoded segments through the API rewrite", () => {
+      const result: any = middleware(makeRequest("/api/teams/team%20one"));
+      expect(result.url).toBe("http://api:8080/teams/team%20one");
+    });
+
+    it("preserves a leading double slash after /api stripping", () => {
+      // /api//foo → pathname.replace("/api", "") → "//foo"
+      // URL does not collapse the double slash; documents existing behavior.
+      const result: any = middleware(makeRequest("/api//foo"));
+      expect(result.url).toBe("http://api:8080//foo");
+    });
+
+    it("markdown rewrite preserves a trailing slash on marketing paths", () => {
+      const result: any = middleware(makeRequest("/about/"));
+      expect(result.url).toBe("https://measure.sh/page-md/about/");
+    });
+  });
+
+  describe("header behavior", () => {
+    it("API branch does not consult Accept header — /api routes to API origin regardless", () => {
+      // Even if the markdown matcher fires alongside the /api matcher,
+      // the function's if-chain checks pathname first and routes the
+      // request to the API origin. Agents requesting /api/foo with
+      // Accept: text/markdown still hit the API.
+      const req = makeRequest("/api/foo");
+      // Provide a headers object to make the test's intent explicit;
+      // the function should not read it.
+      req.headers = {
+        get: (name: string) =>
+          name.toLowerCase() === "accept" ? "text/markdown" : null,
+      };
+      const result: any = middleware(req);
+      expect(result.url).toBe("http://api:8080/foo");
+    });
+  });
+
+  describe("POSTHOG_HOST configuration edge cases", () => {
+    it("throws when POSTHOG_HOST is a non-URL string", () => {
+      process.env.POSTHOG_HOST = "not-a-url";
+      expect(() => middleware(makeRequest("/yrtmlt/foo"))).toThrow();
+    });
+
+    it("silently drops the path component of POSTHOG_HOST", () => {
+      // The middleware reads only protocol/hostname/port off POSTHOG_HOST
+      // and overwrites pathname with the rewritten /yrtmlt/* path. Any
+      // path in POSTHOG_HOST (e.g. /proxy) is therefore discarded.
+      process.env.POSTHOG_HOST = "https://us.posthog.com/proxy";
+      const result: any = middleware(makeRequest("/yrtmlt/decide"));
+      expect(result.url).toBe("https://us.posthog.com/decide");
+    });
+  });
+});

--- a/frontend/dashboard/app/about/page.md
+++ b/frontend/dashboard/app/about/page.md
@@ -1,0 +1,44 @@
+---
+title: About Measure — Built by and for Mobile Developers
+description: Meet the team behind Measure. Open source mobile app monitoring built by mobile developers, for mobile developers.
+canonical: /about
+---
+
+# For mobile engineers, by mobile engineers
+
+We built Measure to solve the unique challenges mobile developers face in monitoring production apps.
+
+After spending years in the trenches building mobile apps at scale, we understood that existing tools that are often web and backend centric don't address mobile-specific needs.
+
+For us, mobile is not an add-on to an observability product. Mobile **is** the product.
+
+We strongly believe that tools for mobile developers can and should be better and that's what drives us everyday.
+
+## Team
+
+- **[Gandharva Kumar](https://www.linkedin.com/in/gandharvakr/)** — CEO
+- **[Anup Cowkur](https://www.linkedin.com/in/anupcowkur/)** — CTO
+- **[Abhay Sood](https://www.linkedin.com/in/abhaysood/)** — Head of Mobile
+- **[Debjeet Biswas](https://www.linkedin.com/in/debjeet-biswas-9b4337281/)** — Head of Infra
+- **[Adwin Ross](https://www.linkedin.com/in/adwin-ronald-ross/)** — Mobile Engineer
+
+## Investors
+
+Picus Capital · DeVC · Astir Ventures
+
+## Angels
+
+- Mustafa Ali — Head of Mobile, Shopify
+- Kunal Shah — Founder, CRED
+- Misbah Ashraf — Co-Founder, Jar
+- Vatsal Singhal — Co-Founder, Ultrahuman
+- Anshuman Bajoria — Strategy and Operations, Revolut
+- Anuj Bhagat — Product, Google
+- Sudhanshu Raheja — President, GoTo Financial
+- Sidu Ponnappa — CEO, realfast
+- Abhinit Tiwari — Head of Design, Gojek
+- Ranjan Sakalley — Co-Founder, base14
+- Gaurav Batra — Co-Founder, Semaai
+- Paul Meinshausen — CEO, Aampe
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/api/api_client.ts
+++ b/frontend/dashboard/app/api/api_client.ts
@@ -8,7 +8,7 @@ import posthog from "posthog-js"
  * - Posthog metrics for API calls
  *
  * It does not manage auth state — that lives in useSessionStore.
- * It does not deduplicate, cache, or track in-flight requests — those concerns
+ * It does not deduplicate, cache or track in-flight requests — those concerns
  * are owned by the store layer (see app/stores/utils/in_flight.ts).
  */
 export class ApiClient {

--- a/frontend/dashboard/app/auth/slack/url/route.ts
+++ b/frontend/dashboard/app/auth/slack/url/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     const { userId, teamId, redirectUrl } = await req.json()
 
     if (!userId || !teamId || !redirectUrl) {
-      err = `Slack OAuth URL generation failure: userId, teamId, and redirectUrl are required`
+      err = `Slack OAuth URL generation failure: userId, teamId and redirectUrl are required`
       posthog.captureException(err, {
         source: 'slack_oauth_url_generation',
         user_id: userId,

--- a/frontend/dashboard/app/crashlytics-alternatives/page.md
+++ b/frontend/dashboard/app/crashlytics-alternatives/page.md
@@ -1,0 +1,49 @@
+---
+title: Open Source Firebase Crashlytics Alternative
+description: Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.
+canonical: /crashlytics-alternatives
+---
+
+# Looking for Crashlytics alternatives?
+
+Firebase Crashlytics is a great beginner crash reporting solution. Mobile teams need more than crashes and often end up looking for complete mobile app monitoring solutions.
+
+Measure is an open-source Crashlytics alternative built for mobile.
+
+## Beyond Crashes
+
+Crashlytics handles basic crash reporting but requires more tooling to complete the mobile app monitoring picture.
+
+Want performance traces? You need the Firebase Performance Monitoring add-on. Want to understand what the user was doing when the crash happened? You'll need to enable Google Analytics and manually instrument breadcrumb logs for every kind of error you care about. Want users to report bugs? Buy a third party tool or hack your own. Want to analyse your data? Export it to BigQuery and pay per query. The number of SDKs in your app and the tools you need to look at keep expanding.
+
+Measure unifies [Crashes & ANRs](/product/crashes-and-anrs), [Network Performance](/product/network-performance), [Performance Traces](/product/performance-traces), [App Health](/product/app-health), [Bug Reports](/product/bug-reports) and [User Journeys](/product/user-journeys) in one product. Every issue comes with a full Session Timeline which is auto collected for you without having to manually instrument every user interaction in your app.
+
+One SDK, one dashboard, one place to look so you can stop stitching context and get to the root cause faster.
+
+## Full session context, not just stack traces
+
+When a crash hits in Crashlytics you get the stack trace plus breadcrumb logs. Those logs are powered by Google Analytics, so screen views are captured automatically but anything richer, like taps, navigation timing, network calls or lifecycle events, requires error-prone, manual instrumentation.
+
+Measure auto-captures gestures, navigation, lifecycle events, network calls and custom spans, and replays them as a [Session Timeline](/product/session-timelines) attached to every crash, ANR or error.
+
+You see exactly what the user did, what the app did and where things went wrong, without instrumenting every screen by hand.
+
+## Open source
+
+The Crashlytics SDKs are open source on GitHub, but the backend and dashboard are closed and run only on Google's infrastructure. Your users' stack traces, device info and any breadcrumbs you log all flow through Firebase, and you can't see or change what happens once the data leaves the SDK.
+
+Measure is [fully open source](https://github.com/measure-sh/measure). Read the SDK, read the backend, file issues, contribute fixes. Your data is yours, the pipeline is auditable and you can be part of the community and help make it better.
+
+## Predictable, transparent pricing
+
+Crashlytics itself is free, and if free crash reporting is all you need, that's a fair choice. The catch is that going further usually means stepping into the rest of the Firebase and GCP price list: BigQuery exports for analysis, Cloud Functions for alerting and other paid GCP services for anything you want to do with the data.
+
+Measure has a single, transparent [price](/pricing) based on data volume and retention. No per-seat charges, no hidden product bundles. With [Adaptive Capture](/product/adaptive-capture) you can dial collection up or down without rolling out app updates.
+
+## Built for mobile, by mobile devs
+
+Crashlytics sits inside the larger Firebase suite where mobile is one product line among many. The roadmap is opaque, and feature requests compete with the priorities of a much bigger platform.
+
+Measure is built by a mobile-first team. Every feature, every default and every trade-off is shaped by mobile devs solving real production issues. The roadmap and issue tracker are public on [GitHub](https://github.com/measure-sh/measure). If something is missing, you can file it, see where it sits or send a pull request.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/crashlytics-alternatives/page.tsx
+++ b/frontend/dashboard/app/crashlytics-alternatives/page.tsx
@@ -16,12 +16,14 @@ import { underlineLinkStyle } from "../utils/shared_styles";
 
 export const metadata: Metadata = {
   title: "Open Source Firebase Crashlytics Alternative",
-  description: "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
+  description:
+    "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
   alternates: { canonical: "/crashlytics-alternatives" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Open Source Firebase Crashlytics Alternative | Measure",
-    description: "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
+    description:
+      "Open source alternative to Firebase Crashlytics. Unifies crashes, ANRs, performance, network and full session timelines for mobile engineering teams.",
     url: "/crashlytics-alternatives",
   },
 };
@@ -56,7 +58,7 @@ export default function CrashlyticsAlternatives() {
                 tooling to complete the mobile app monitoring picture.
                 <br />
                 <br />
-                Want performance traces? You need the Firebase Peformance
+                Want performance traces? You need the Firebase Performance
                 Monitoring add-on. Want to understand what the user was doing
                 when the crash happened? You&apos;ll need to enable Google
                 Analytics and manually instrument breadcrumb logs for every kind
@@ -144,7 +146,7 @@ export default function CrashlyticsAlternatives() {
                 attached to every crash, ANR or error.
                 <br />
                 <br />
-                You see exactly what the user did, what the app did, and where
+                You see exactly what the user did, what the app did and where
                 things went wrong, without instrumenting every screen by hand.
               </p>
             </div>
@@ -175,7 +177,7 @@ export default function CrashlyticsAlternatives() {
                   fully open source
                 </Link>
                 . Read the SDK, read the backend, file issues, contribute fixes.
-                Your data is yours, the pipeline is auditable, and you can be
+                Your data is yours, the pipeline is auditable and you can be
                 part of the community and help make it better.
               </p>
             </div>
@@ -195,7 +197,7 @@ export default function CrashlyticsAlternatives() {
                 you need, that&apos;s a fair choice. The catch is that going
                 further usually means stepping into the rest of the Firebase and
                 GCP price list: BigQuery exports for analysis, Cloud Functions
-                for alerting, and other paid GCP services for anything you want
+                for alerting and other paid GCP services for anything you want
                 to do with the data.
                 <br />
                 <br />
@@ -244,7 +246,7 @@ export default function CrashlyticsAlternatives() {
                 >
                   GitHub
                 </Link>
-                . If something is missing, you can file it, see where it sits,
+                . If something is missing, you can file it, see where it sits
                 or send a pull request.
               </p>
             </div>

--- a/frontend/dashboard/app/docs/docs.ts
+++ b/frontend/dashboard/app/docs/docs.ts
@@ -103,7 +103,7 @@ function stripHtmlTags(input: string): string {
 /**
  * Reduce a markdown body to plain text suitable for full-text search.
  * Strips fences, headings, raw HTML, images/links, emphasis markers,
- * list/blockquote prefixes, table pipes, and GFM callout markers
+ * list/blockquote prefixes, table pipes and GFM callout markers
  * (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`).
  */
 export function stripSearchContent(content: string): string {
@@ -134,7 +134,7 @@ export function extractTitle(content: string): string {
 
 /**
  * Extract the first plain paragraph from markdown content, skipping
- * the title, TOC lists, admonitions, headings, tables, and code blocks.
+ * the title, TOC lists, admonitions, headings, tables and code blocks.
  * Returns an empty string when no suitable paragraph is found.
  */
 export function extractDescription(content: string): string {

--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -35,7 +35,7 @@ const fira_code = Fira_Code({
 
 const title = "Measure";
 const description =
-  "Open source mobile app monitoring for crashes, ANRs, performance, bug reports, user journeys, and more.";
+  "Open source mobile app monitoring for crashes, ANRs, performance, bug reports, user journeys and more.";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://measure.sh"),

--- a/frontend/dashboard/app/page-md/[...path]/route.ts
+++ b/frontend/dashboard/app/page-md/[...path]/route.ts
@@ -1,0 +1,82 @@
+// Folder is named `page-md`, not `_md`: Next.js App Router treats
+// underscore-prefixed folders as private and excludes them from routing.
+// Don't rename to anything starting with `_` or this handler silently 404s.
+import { getDocBySlug, getDocIndex, parseFrontmatter } from "@/app/docs/docs";
+import fs from "fs";
+import { type NextRequest, NextResponse } from "next/server";
+import path from "path";
+
+const APP_DIR = path.join(process.cwd(), "app");
+
+function notAcceptable() {
+  return new NextResponse(
+    "No markdown representation available for this resource.\n",
+    {
+      status: 406,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        Vary: "Accept",
+      },
+    },
+  );
+}
+
+function markdownResponse(body: string) {
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Vary: "Accept",
+      "Cache-Control": "public, max-age=300, s-maxage=600",
+    },
+  });
+}
+
+/**
+ * Resolve URL segments to a colocated `page.md` next to the route's
+ * `page.tsx`. The middleware rewrites `/` to `/_md/index` so the homepage
+ * lands here as ["index"] — translate that back to `app/page.md`.
+ */
+function resolvePageMd(segments: string[]): string | null {
+  const rel = segments.length === 1 && segments[0] === "index"
+    ? "page.md"
+    : path.join(...segments, "page.md");
+
+  const candidate = path.join(APP_DIR, rel);
+  // path.join collapses any "..", and the startsWith guard catches escapes
+  if (!candidate.startsWith(`${APP_DIR}${path.sep}`)) {
+    return null;
+  }
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { path?: string[] } },
+) {
+  const segments = params.path ?? [];
+
+  if (segments.length === 0) {
+    return notAcceptable();
+  }
+
+  if (segments[0] === "docs") {
+    const slug = segments.slice(1);
+    const doc = slug.length === 0 ? getDocIndex() : getDocBySlug(slug);
+    if (!doc) {
+      return notAcceptable();
+    }
+    // getDocBySlug strips HTML comments from the body but leaves frontmatter
+    // already removed; doc.content is the cleaned markdown body.
+    return markdownResponse(doc.content);
+  }
+
+  const file = resolvePageMd(segments);
+  if (!file) {
+    return notAcceptable();
+  }
+
+  const raw = fs.readFileSync(file, "utf-8");
+  const { body } = parseFrontmatter(raw);
+  return markdownResponse(body);
+}

--- a/frontend/dashboard/app/page.md
+++ b/frontend/dashboard/app/page.md
@@ -1,0 +1,61 @@
+---
+title: Open Source Mobile App Monitoring & Crash Reporting
+description: Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.
+canonical: /
+---
+
+# Mobile apps break, get to the root cause faster.
+
+Complete Mobile App Monitoring platform with Crash Reporting, ANR Tracking, Bug Reporting, Performance Tracing, Logging and more!
+
+100% Open Source alternative to **Firebase Crashlytics**.
+
+## Trusted by high growth mobile teams
+
+Kuku FM, Hoichoi, Country Delight, Dashreels, Turtlemint, Astro, Allofresh, SMC India, Even, Karya.
+
+## One dashboard, Complete context
+
+## Collect what you need, Only when you need it
+
+Most monitoring data rots away in a warehouse and runs up your costs 💰. Our [Adaptive Capture](/product/adaptive-capture) feature lets you control and dynamically change what data to collect without needing to roll out app updates.
+
+## Intelligent debugging, Seamless integration
+
+Connect Measure with your favorite coding agents through our [MCP](/product/mcp) server. Let your coding agent query errors, traces and session timelines directly in your development workflow.
+
+## Tried it, Loved it ❤️
+
+> I've been using measure.sh lately to monitor my mobile apps and host it myself and it has been a delight. Definitely recommend it to anyone looking for an open source mobile app monitoring tool.
+>
+> — Hussain Mustafa ([source](https://x.com/husslingaround/status/1855983892294983980))
+
+> I'm surprised this hasn't gained more attention yet — it's incredibly exciting for the mobile space, where we definitely lack observability and measure addresses so many of those gaps.
+>
+> — Aditya Pahilwani ([source](https://x.com/AdityaPahilwani/status/1843561672188821520))
+
+> When I stumbled upon measure.sh, I was blown away! Crash-free sessions improved dramatically — now hitting a mythical 99.99% consistently. Logs, metrics, traces — finally stitched together in one view. Our hot & warm app startup times? Looking great!
+>
+> — Sutirth Chakravarty ([source](https://www.linkedin.com/posts/sutirthchakravarty_circa-early-2024-i-had-the-chance-to-attend-activity-7317570327520124928-yo1s))
+
+> The good folks at measure.sh have been working on a mobile app monitoring platform for several months now and have open-sourced it. Do check it out and show it some love! This is quite a strong team that led several mobile platform initiatives at Gojek.
+>
+> — Ragunath Jawahar ([source](https://x.com/ragunathjawahar/status/1825490936857522290))
+
+> I'm personally a fan. Not just of the product, but of the minds behind it. It's built by some of the sharpest mobile engineers I've admired for years. Folks who live and breathe performance, scaling, and observability. This isn't just another tool. It's crafted with intent, care, and deep expertise.
+>
+> — Iniyan Murugavel ([source](https://www.linkedin.com/posts/iniyanarul_crashes-were-observed-first-on-measure-activity-7316853914589413377-gFd_/))
+
+> Looking for a way to keep tabs on your mobile apps? How about using a free and open-source solution? Consider exploring measure.sh!
+>
+> — Tuist ([source](https://www.linkedin.com/posts/tuistio_github-measure-shmeasure-measure-is-an-activity-7312413362292719616-DUlU))
+
+## Built For Mobile Devs
+
+For us, Mobile is not an add-on to an observability product. It **is** the product. Measure is built by mobile engineers, for mobile engineers.
+
+- **Open Source** — [Star us on GitHub](https://github.com/measure-sh/measure).
+- **Simple Pricing** — Pay only for the [data you use](/pricing). No seat limits or feature restrictions.
+- **Every mobile platform** — Android, iOS, Flutter, React Native (soon).
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/page.tsx
+++ b/frontend/dashboard/app/page.tsx
@@ -17,12 +17,14 @@ import { underlineLinkStyle } from "./utils/shared_styles";
 
 export const metadata: Metadata = {
   title: "Open Source Mobile App Monitoring & Crash Reporting",
-  description: "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
+  description:
+    "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
   alternates: { canonical: "/" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Open Source Mobile App Monitoring & Crash Reporting | Measure",
-    description: "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
+    description:
+      "Open source mobile app monitoring — crashes, ANRs, bug reports, performance traces, network and session timelines. A Firebase Crashlytics alternative.",
     url: "/",
   },
 };
@@ -296,7 +298,7 @@ export default function Home() {
             <Link href="/product/mcp" className={underlineLinkStyle}>
               MCP
             </Link>{" "}
-            server. Let your coding agent query errors, traces, and session
+            server. Let your coding agent query errors, traces and session
             timelines directly in your development workflow.
           </p>
           <div className="py-8" />

--- a/frontend/dashboard/app/pricing/page.md
+++ b/frontend/dashboard/app/pricing/page.md
@@ -1,0 +1,25 @@
+---
+title: Pricing & Plans
+description: Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. No artificial bundles. 100% open source.
+canonical: /pricing
+---
+
+# Pricing
+
+Simple pricing based on the data used. No stressing over seat limits. No need to buy artificial bundles of crashes and spans - just track what you need to get to the root cause faster.
+
+## Free — $0 per month
+
+- 5 GB per month
+- 30 days retention
+- No credit card needed
+
+## Pro — $50 per month
+
+- 25 GB per month included
+- 90 days retention
+- Extra data charged at $2.00 per GB/month
+
+Control costs with [Adaptive Capture](/product/adaptive-capture) · No Seat Limits · No Artificial Bundles
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/pricing/page.tsx
+++ b/frontend/dashboard/app/pricing/page.tsx
@@ -18,12 +18,14 @@ import PricingCalculator from "./pricing_calculator";
 
 export const metadata: Metadata = {
   title: "Pricing & Plans",
-  description: "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. 100% open source.",
+  description:
+    "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. No artificial bundles. 100% open source.",
   alternates: { canonical: "/pricing" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Pricing & Plans | Measure",
-    description: "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. 100% open source.",
+    description:
+      "Free tier for solo devs and small teams. Usage-based Pro plan for scale. No seat limits. No artificial bundles. 100% open source.",
     url: "/pricing",
   },
 };
@@ -40,7 +42,7 @@ export default function Pricing() {
         <div className="py-8" />
         <p className="text-lg leading-relaxed font-body md:w-6xl text-justify px-4">
           Simple pricing based on the data used. No stressing over seat limits.
-          No need to buy artifical bundles of crashes and spans - just track
+          No need to buy artificial bundles of crashes and spans - just track
           what you need to get to the root cause faster.
         </p>
 

--- a/frontend/dashboard/app/privacy-policy/page.tsx
+++ b/frontend/dashboard/app/privacy-policy/page.tsx
@@ -139,7 +139,7 @@ export default function PrivacyPolicy() {
                 is any information that relates to an identified or identifiable
                 individual in connection with your account and use of our
                 Service. This includes information such as your name, email
-                address, and payment information.
+                address and payment information.
               </dd>
             </div>
 
@@ -191,7 +191,7 @@ export default function PrivacyPolicy() {
               <dd className="mt-1 text-justify">
                 (referred to as &quot;You&quot;, &quot;you&quot;,
                 &quot;Your&quot; or &quot;your&quot; in this Agreement) is the
-                individual accessing or using the Service, or the company, or
+                individual accessing or using the Service, or the company or
                 other legal entity on behalf of which such individual is
                 accessing or using the Service, as applicable.
               </dd>
@@ -206,7 +206,7 @@ export default function PrivacyPolicy() {
             We collect and process two distinct categories of data when you use
             our Service: Personal Data about you as a user, and Monitoring Data
             that you send to our platform for monitoring purposes. These are
-            separate categories with different purposes, uses, and retention
+            separate categories with different purposes, uses and retention
             policies.
           </p>
 
@@ -260,7 +260,7 @@ export default function PrivacyPolicy() {
           <p className="mb-4 text-justify text-lg">
             We use Cookies and similar tracking technologies to track the
             activity on our Service and store certain information. Tracking
-            technologies used are beacons, tags, and scripts to collect and
+            technologies used are beacons, tags and scripts to collect and
             track information and to improve and analyze our Service. The
             technologies we use may include:
           </p>
@@ -278,7 +278,7 @@ export default function PrivacyPolicy() {
             <li className="text-justify">
               <strong>Web Beacons.</strong> Certain sections of our Service and
               our emails may contain small electronic files known as web beacons
-              (also referred to as clear gifs, pixel tags, and single-pixel
+              (also referred to as clear gifs, pixel tags and single-pixel
               gifs) that permit the Company, for example, to count users who
               have visited those pages or opened an email and for other related
               website statistics (for example, recording the popularity of a
@@ -366,7 +366,7 @@ export default function PrivacyPolicy() {
             </li>
             <li className="text-justify">
               <strong>To contact you:</strong> To contact you by email,
-              telephone calls, SMS, or other equivalent forms of electronic
+              telephone calls, SMS or other equivalent forms of electronic
               communication, such as a mobile application&apos;s push
               notifications regarding updates or informative communications
               related to the functionalities, products or contracted services,
@@ -387,9 +387,9 @@ export default function PrivacyPolicy() {
             <li className="text-justify">
               <strong>For business transfers:</strong> We may use your
               information to evaluate or conduct a merger, divestiture,
-              restructuring, reorganization, dissolution, or other sale or
+              restructuring, reorganization, dissolution or other sale or
               transfer of some or all of our assets, whether as a going concern
-              or as part of bankruptcy, liquidation, or similar proceeding, in
+              or as part of bankruptcy, liquidation or similar proceeding, in
               which Personal Data held by us about our Service users is among
               the assets transferred.
             </li>
@@ -410,7 +410,7 @@ export default function PrivacyPolicy() {
             <li className="text-justify">
               <strong>With Service Providers:</strong> We may share your
               personal account information with Service Providers to monitor and
-              analyze the use of our Service, to contact you, and to process
+              analyze the use of our Service, to contact you and to process
               payments.
             </li>
             <li className="text-justify">
@@ -451,7 +451,7 @@ export default function PrivacyPolicy() {
           </h2>
           <p className="mb-4 text-justify text-lg">
             The Company will retain your Personal Data (such as your name, email
-            address, account information, and payment details—but NOT your
+            address, account information and payment details—but NOT your
             Monitoring Data) only for as long as is necessary for the purposes
             set out in this Privacy Policy. Specifically:
           </p>
@@ -466,7 +466,7 @@ export default function PrivacyPolicy() {
               legal obligations (for example, if we are required to retain your
               data to comply with applicable laws, tax regulations, or
               accounting requirements), resolve disputes, enforce our legal
-              agreements and policies, and prevent fraud.
+              agreements and policies and prevent fraud.
             </li>
             <li className="text-justify">
               We will also retain Usage Data for internal analysis purposes.
@@ -516,10 +516,10 @@ export default function PrivacyPolicy() {
             about you from within the Service.
           </p>
           <p className="mb-4 text-justify text-lg">
-            You may update, amend, or delete your Personal Data at any time by
+            You may update, amend or delete your Personal Data at any time by
             signing in to your Account, if you have one, and visiting the
             account settings section that allows you to manage your personal
-            information. You may also contact us to request access to, correct,
+            information. You may also contact us to request access to, correct
             or delete any Personal Data that you have provided to us.
           </p>
           <p className="mb-6 text-justify text-lg">

--- a/frontend/dashboard/app/product/adaptive-capture/page.md
+++ b/frontend/dashboard/app/product/adaptive-capture/page.md
@@ -1,0 +1,17 @@
+---
+title: Adaptive Capture — Control Mobile Monitoring Costs
+description: Dynamically control what monitoring data your mobile app collects without shipping new builds. Stop paying for data you'll never use.
+canonical: /product/adaptive-capture
+---
+
+# Adaptive Capture
+
+Most monitoring data is never read but ends up inflating your costs 💰. Adaptive Capture lets you capture what matters based on changing needs.
+
+Need more data during a product launch or incident? Simply tweak your collection parameters to capture additional context when it matters most and collect only the essentials when things are running smoothly.
+
+The best part? No need to roll out app updates! When you change your captures settings, our servers propagate the changes to our SDK seamlessly.
+
+No more worrying about bloated costs or wasted data, Adaptive Capture lets you get the data you need, when you need it.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/app-health/page.md
+++ b/frontend/dashboard/app/product/app-health/page.md
@@ -1,0 +1,15 @@
+---
+title: Mobile App Health Metrics & Dashboards
+description: Track mobile app health metrics that matter: crash-free sessions, ANR-free sessions, app launch times, release adoption and more.
+canonical: /product/app-health
+---
+
+# App Health
+
+Keep your finger on the pulse of your app's performance with comprehensive health monitoring that goes beyond the basics.
+
+App Health gives you fast insights into the metrics that matter most - from error rates, error rates as perceived by users, app adoption and app size to precise launch time measurements across cold, warm and hot starts.
+
+With App Health, you can proactively identify and address performance issues before they impact your users leading to a smooth rollout every time.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/bug-reports/page.md
+++ b/frontend/dashboard/app/product/bug-reports/page.md
@@ -1,0 +1,17 @@
+---
+title: In-App Bug Reporting for Mobile Apps
+description: Capture bug reports with a device shake or SDK call. Get the full session context, device state and network info so you can get to the root cause.
+canonical: /product/bug-reports
+---
+
+# Bug Reports
+
+Empower your users to report issues directly from your app with a device shake or using your own custom button.
+
+Bug Reports automatically capture everything that matters - device information, app version, network conditions and the exact timestamp alongside the user's description and screenshots.
+
+Every bug report links directly to the complete session timeline, so you can see exactly what the user experienced, review the sequence of events and identify the root cause without stumbling around in the dark.
+
+Bug Reports allows you to skip the email threads, support tickets and the back-and-forth asking users to remember what they were doing - your users describe the problem in their own words and you get all the technical data you need to solve it.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/bug-reports/page.tsx
+++ b/frontend/dashboard/app/product/bug-reports/page.tsx
@@ -41,7 +41,7 @@ export default function ProductBugReports() {
           <br />
           Every bug report links directly to the complete session timeline, so
           you can see exactly what the user experienced, review the sequence of
-          events, and identify the root cause without stumbling around in the
+          events and identify the root cause without stumbling around in the
           dark.
           <br />
           <br />

--- a/frontend/dashboard/app/product/crashes-and-anrs/page.md
+++ b/frontend/dashboard/app/product/crashes-and-anrs/page.md
@@ -1,0 +1,15 @@
+---
+title: Mobile Crash Reporting & ANR Tracking
+description: Open source mobile Crash Reporting and ANR Tracking. Full stack traces, reproduction steps and session timelines — a Firebase Crashlytics alternative.
+canonical: /product/crashes-and-anrs
+---
+
+# Crashes and ANRs
+
+Get instant visibility into every exception with detailed crash reports that include full stack traces, device information, OS versions and intelligent analysis of the sequence of user actions that led to the failure.
+
+Our Common Path feature reconstructs the user journey before each crash, showing you what screens they visited, which actions they took, what API calls were and several other important signals.
+
+Path analysis combined with comprehensive stack traces and thread-level details, gives you everything you need to reproduce issues effectively and ship fixes with confidence.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
+++ b/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
@@ -32,7 +32,7 @@ export default function ProductCrashesAndANRs() {
         <p className="text-lg leading-relaxed font-body md:w-6xl text-justify px-4">
           Get instant visibility into every exception with detailed crash
           reports that include full stack traces, device information, OS
-          versions, and intelligent analysis of the sequence of user actions
+          versions and intelligent analysis of the sequence of user actions
           that led to the failure.
           <br />
           <br />

--- a/frontend/dashboard/app/product/mcp/page.md
+++ b/frontend/dashboard/app/product/mcp/page.md
@@ -1,0 +1,15 @@
+---
+title: MCP Server — Connect AI Agents to Measure
+description: Connect Measure to Claude Code, Codex, Cursor, Gemini and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.
+canonical: /product/mcp
+---
+
+# MCP
+
+Connect Measure with your favorite coding agents through the Model Context Protocol.
+
+MCP lets AI coding assistants like Claude, Codex and Gemini access your errors, performance traces, session timelines and bug reports directly in your development workflow.
+
+With MCP, you can simply ask your AI assistant to look up an error, get the full context including stack traces and session timelines leading to the issue and harness the power of AI to ship fixes faster than ever before.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/mcp/page.tsx
+++ b/frontend/dashboard/app/product/mcp/page.tsx
@@ -9,12 +9,12 @@ import LandingHeader from "../../components/landing_header";
 
 export const metadata: Metadata = {
   title: "MCP Server — Connect AI Agents to Measure",
-  description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
+  description: "Connect Measure to Claude Code, Codex, Cursor, Gemini and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
   alternates: { canonical: "/product/mcp" },
   openGraph: {
     ...sharedOpenGraph,
     title: "MCP Server — Connect AI Agents to Measure | Measure",
-    description: "Connect Measure to Claude Code, Codex, Cursor, Gemini, and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
+    description: "Connect Measure to Claude Code, Codex, Cursor, Gemini and other AI coding agents. Query crashes, traces, sessions and bug reports from your editor or AI agent workflows.",
     url: "/product/mcp",
   },
 };
@@ -32,8 +32,8 @@ export default function ProductMCP() {
           Context Protocol.
           <br />
           <br />
-          MCP lets AI coding assistants like Claude, Codex, and Gemini access
-          your errors, performance traces, session timelines, and bug reports
+          MCP lets AI coding assistants like Claude, Codex and Gemini access
+          your errors, performance traces, session timelines and bug reports
           directly in your development workflow.
           <br />
           <br />

--- a/frontend/dashboard/app/product/network-performance/page.md
+++ b/frontend/dashboard/app/product/network-performance/page.md
@@ -1,0 +1,15 @@
+---
+title: Mobile Network Performance Monitoring
+description: Monitor mobile API call latency, HTTP status codes and slow endpoints. Find and fix the network calls killing your app's performance.
+canonical: /product/network-performance
+---
+
+# Network Performance
+
+Monitor the health and performance of every network request your app makes. Instantly see HTTP status code distributions over time, giving you a clear picture of how your API layer is performing at a glance.
+
+Drill into your top endpoints ranked by latency, error rate and request frequency to pinpoint exactly which calls are slowing down your app or failing silently. Visualize when specific endpoints are called during a session to understand request patterns and timing.
+
+With Network Performance, you can proactively catch degraded endpoints, reduce error rates and optimize the API calls that matter most to your users.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/network-performance/page.tsx
+++ b/frontend/dashboard/app/product/network-performance/page.tsx
@@ -35,14 +35,14 @@ export default function ProductNetworkPerformance() {
           you a clear picture of how your API layer is performing at a glance.
           <br />
           <br />
-          Drill into your top endpoints ranked by latency, error rate, and
+          Drill into your top endpoints ranked by latency, error rate and
           request frequency to pinpoint exactly which calls are slowing down
           your app or failing silently. Visualize when specific endpoints are
           called during a session to understand request patterns and timing.
           <br />
           <br />
           With Network Performance, you can proactively catch degraded
-          endpoints, reduce error rates, and optimize the API calls that matter
+          endpoints, reduce error rates and optimize the API calls that matter
           most to your users.
         </p>
 

--- a/frontend/dashboard/app/product/performance-traces/page.md
+++ b/frontend/dashboard/app/product/performance-traces/page.md
@@ -1,0 +1,17 @@
+---
+title: Mobile App Performance Tracing & Monitoring
+description: Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues hurting your app.
+canonical: /product/performance-traces
+---
+
+# Performance Traces
+
+Measure exactly what matters for your app's user experience by instrumenting critical operations in your codebase.
+
+Performance traces let you understand how API fetches, complex code operations and UI rendering stack up within a single user flow or aggregate across millions of sessions, with waterfall charts that make bottlenecks immediately obvious.
+
+Every trace includes rich context such as device type and network conditions and links to a full session timeline so you can spot patterns and correlate slowdowns within specific environments.
+
+Whether you're reducing checkout time, speeding up content loading or improving screen transitions, Performance Traces give you the quantitative data you need to make precise improvements.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/performance-traces/page.tsx
+++ b/frontend/dashboard/app/product/performance-traces/page.tsx
@@ -9,12 +9,14 @@ import TraceDemo from "./trace_demo";
 
 export const metadata: Metadata = {
   title: "Mobile App Performance Tracing & Monitoring",
-  description: "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks, and fix performance issues hurting your app.",
+  description:
+    "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues hurting your app.",
   alternates: { canonical: "/product/performance-traces" },
   openGraph: {
     ...sharedOpenGraph,
     title: "Mobile App Performance Tracing & Monitoring",
-    description: "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks, and fix performance issues hurting your app.",
+    description:
+      "Improve mobile app performance with traces and spans. Find slow code, isolate bottlenecks and fix performance issues hurting your app.",
     url: "/product/performance-traces",
   },
 };
@@ -36,8 +38,8 @@ export default function ProductPerformanceTraces() {
           <br />
           Performance traces let you understand how API fetches, complex code
           operations and UI rendering stack up within a single user flow or
-          aggregrate across millions of sessions, with waterfall charts that
-          make bottlenecks immediately obvious.
+          aggregate across millions of sessions, with waterfall charts that make
+          bottlenecks immediately obvious.
           <br />
           <br />
           Every trace includes rich context such as device type and network
@@ -46,7 +48,7 @@ export default function ProductPerformanceTraces() {
           <br />
           <br />
           Whether you&apos;re reducing checkout time, speeding up content
-          loading, or improving screen transitions, Performance Traces give you
+          loading or improving screen transitions, Performance Traces give you
           the quantitative data you need to make precise improvements.
         </p>
 

--- a/frontend/dashboard/app/product/session-timelines/page.md
+++ b/frontend/dashboard/app/product/session-timelines/page.md
@@ -1,0 +1,15 @@
+---
+title: Mobile Session Timelines & Replay
+description: See every click, navigation, network call, log, error and CPU/memory signal stitched into a single mobile session timeline to diagnose issues faster.
+canonical: /product/session-timelines
+---
+
+# Session Timelines
+
+Debug issues faster by replaying the exact sequence of events that led to a crash or performance problem.
+
+Session Timeline captures the complete story - see which API call failed, what the user clicked right before an error occurred and how your app's resources were behaving at that precise moment.
+
+With Session Timelines, you can stop guessing and have the full context you need to identify and fix root causes in an easy-to-navigate timeline.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/session-timelines/page.tsx
+++ b/frontend/dashboard/app/product/session-timelines/page.tsx
@@ -35,7 +35,7 @@ export default function ProductSessionTimelines() {
           <br />
           <br />
           Session Timeline captures the complete story - see which API call
-          failed, what the user clicked right before an error occurred, and how
+          failed, what the user clicked right before an error occurred and how
           your app&apos;s resources were behaving at that precise moment.
           <br />
           <br />

--- a/frontend/dashboard/app/product/user-journeys/page.md
+++ b/frontend/dashboard/app/product/user-journeys/page.md
@@ -1,0 +1,17 @@
+---
+title: User Journey Tracking for Mobile Apps
+description: Understand how users actually move through your mobile app. Track popular paths, find friction and prioritize the flows that matter most.
+canonical: /product/user-journeys
+---
+
+# User Journeys
+
+See the full picture of user behavior with beautiful flow diagrams that reveal the actual paths users take through your app.
+
+User Journeys automatically map every screen transition, showing you which flows are most popular, where users drop off and which navigation patterns you never anticipated. Easily add your own screens and views to enrich them further.
+
+Toggle between normal path analysis and exception view to see exactly where crashes and ANRs interrupt user flows. If users consistently crash when navigating from Product List to Product Detail screens, you'll see it highlighted with crash counts and session volumes. Click any path or exception to drill into the details and investigate further.
+
+Whether you're redesigning navigation, prioritizing feature work or debugging issues in conversion funnels, User Journeys transforms complex behavioral data into clear, actionable visualizations that help you build better experiences.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/product/user-journeys/page.tsx
+++ b/frontend/dashboard/app/product/user-journeys/page.tsx
@@ -35,7 +35,7 @@ export default function ProductUserJourneys() {
           <br />
           <br />
           User Journeys automatically map every screen transition, showing you
-          which flows are most popular, where users drop off, and which
+          which flows are most popular, where users drop off and which
           navigation patterns you never anticipated. Easily add your own screens
           and views to enrich them further.
           <br />

--- a/frontend/dashboard/app/security/page.md
+++ b/frontend/dashboard/app/security/page.md
@@ -1,0 +1,49 @@
+---
+title: Security & Data Protection
+description: How Measure protects your app's data — encryption, infrastructure and access controls. Open source so you can audit it yourself.
+canonical: /security
+---
+
+# Security
+
+At Measure, we recognize that security is fundamental to the trust placed in our open-source software and Measure Cloud (our managed SaaS offering).
+
+Security is a core priority throughout the development, deployment and maintenance of our systems, and we adhere to established industry best practices to safeguard code, data and operations.
+
+This policy outlines the principles, standards and controls that guide our commitment to maintaining the confidentiality, integrity and availability of our software, infrastructure and services.
+
+## Open Source Transparency
+
+Measure is fully open-source, and its source code is publicly available on [GitHub](https://github.com/measure-sh/measure). This transparency allows continuous review by the open-source community, fostering early identification and remediation of potential security issues.
+
+## Supply Chain Security
+
+Dependencies are regularly audited through GitHub [Dependabot](https://github.com/measure-sh/measure/security/dependabot) and code scanning tools, including [secret scanning](https://github.com/measure-sh/measure/security/secret-scanning), to detect and address vulnerabilities promptly. We ensure timely updates to dependencies to mitigate risks. An up-to-date [Software Bill of Materials](https://github.com/measure-sh/measure/network/dependencies) (SBOM) is maintained, and users are encouraged to inspect or export it for their own assessments.
+
+## Authentication & Authorization
+
+**Open Source (Self Hosted)**: Authentication and authorization are provided via Google and GitHub OAuth 2.0 protocols, strictly following the latest version of the [OAuth](https://oauth.net/specs/) standards. We use JSON Web Tokens (JWT) with a short expiry to minimize potential exploitation. We do not ask for or store user passwords, eliminating password-based vulnerabilities. Database credentials for Postgres and ClickHouse are generated using cryptographically secure algorithms via OpenSSL, unique to each installation. All communications with the software should be conducted over secure channels (TLS 1.2 or higher) when exposing APIs externally.
+
+**Measure Cloud**: Authentication is managed centrally, with the same OAuth 2.0 and JWT standards applied. Infrastructure and secret management follow cloud security best practices, including encryption at rest and in transit. All Measure APIs use TLS 1.2 or higher for encryption in transit to protect data integrity and confidentiality. Private keys and sensitive credentials are securely stored and managed using [Google Secret Manager](https://cloud.google.com/security/products/secret-manager). Role-based access controls and centralized key management are enforced.
+
+## Data Security
+
+**Open Source (Self Hosted)**: Measure does not process or store sensitive customer data by design. All data is stored within the user's infrastructure. Users are responsible for performing security assessments and implementing safeguards appropriate to their environment.
+
+**Measure Cloud**: Customer data is processed and stored within Measure Cloud infrastructure, hosted on Google Cloud Platform. All Google Cloud Storage (GCS) buckets are encrypted at rest using Google-managed encryption keys with the **AES-256** algorithm. Data in transit, including API requests and responses, is encrypted using **TLS 1.2** or higher. We apply strict access controls, monitoring and regular security reviews to ensure data security. Our architecture follows the principle of least privilege and enforces separation between customer environments. Measure Cloud adheres to Google's security best practices, as outlined in the [Google Cloud Security Best Practices Center](https://cloud.google.com/security/best-practices).
+
+## Data Retention
+
+**Session Data**: All session-related data is retained only according to the user-configured application data retention settings in the Measure Dashboard. Users have full control over retention periods for their applications.
+
+**Crash and ANR Metadata**: We retain minimal crash and ANR (Application Not Responding) metadata solely to facilitate the identification and resolution of recurring issues in future application sessions. This data is anonymized and does not contain personally identifiable information (PII) by design.
+
+## Monitoring for Performance & Reliability
+
+We continuously monitor the health, availability and performance of our software using industry-standard observability tools to ensure operational reliability. Monitoring is designed to detect and address potential security issues proactively. Collected data does not include customer application data or personally identifiable information (PII) by design and is used solely to maintain performance, stability and security.
+
+## Vulnerability Reporting
+
+We encourage responsible disclosure of security vulnerabilities via [GitHub's Security Advisory](https://github.com/measure-sh/measure?tab=security-ov-file) process. Potential security issues may also be reported by emailing <security@measure.sh> for prompt investigation and remediation.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/app/security/page.tsx
+++ b/frontend/dashboard/app/security/page.tsx
@@ -34,13 +34,13 @@ export default function Security() {
             SaaS offering).
             <br />
             <br /> Security is a core priority throughout the development,
-            deployment, and maintenance of our systems, and we adhere to
-            established industry best practices to safeguard code, data, and
+            deployment and maintenance of our systems, and we adhere to
+            established industry best practices to safeguard code, data and
             operations.
             <br />
-            <br /> This policy outlines the principles, standards, and controls
+            <br /> This policy outlines the principles, standards and controls
             that guide our commitment to maintaining the confidentiality,
-            integrity, and availability of our software, infrastructure, and
+            integrity and availability of our software, infrastructure and
             services.
           </p>
 
@@ -155,7 +155,7 @@ export default function Security() {
             Google-managed encryption keys with the <b>AES-256</b> algorithm.
             Data in transit, including API requests and responses, is encrypted
             using <b>TLS 1.2</b> or higher. We apply strict access controls,
-            monitoring, and regular security reviews to ensure data security.
+            monitoring and regular security reviews to ensure data security.
             Our architecture follows the principle of least privilege and
             enforces separation between customer environments. Measure Cloud
             adheres to Google&apos;s security best practices, as outlined in the{" "}

--- a/frontend/dashboard/app/stores/ARCHITECTURE.md
+++ b/frontend/dashboard/app/stores/ARCHITECTURE.md
@@ -86,7 +86,7 @@ In `app/query/query_client.ts`:
 2. Import and use it in the component
 3. For mutations, add `onSuccess` invalidation for affected query keys
 
-No store files, registry, or provider changes needed.
+No store files, registry or provider changes needed.
 
 ## Zustand — shared client state (3 stores)
 

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -470,7 +470,7 @@ interface FiltersStoreState {
   selectedVersions: AppVersion[];
 
   // Filter selections — reset to defaults on page navigation, persisted
-  // within a page. App, versions, and dates above are persisted across pages.
+  // within a page. App, versions and dates above are persisted across pages.
   selectedRootSpanName: string;
   selectedSessionTypes: SessionType[];
   selectedSpanStatuses: SpanStatus[];
@@ -800,7 +800,7 @@ function clearSelections(): Partial<FiltersStoreState> {
 
 // Resolve filter selections for the current app and filter data.
 // Priority: URL params > existing selections > defaults.
-// App, versions, and dates are handled by the caller.
+// App, versions and dates are handled by the caller.
 function applyFilterOptions(
   data: FilterOptionsData,
   app: App,
@@ -1345,7 +1345,7 @@ export function createFiltersStore() {
         }
 
         // Source changed — clear per-page selections so applyFilterOptions
-        // applies fresh defaults. App, versions, and dates are preserved.
+        // applies fresh defaults. App, versions and dates are preserved.
         set({
           config,
           selectedOsVersions: [],

--- a/frontend/dashboard/app/terms-of-service/page.tsx
+++ b/frontend/dashboard/app/terms-of-service/page.tsx
@@ -169,7 +169,7 @@ export default function TermsOfService() {
               <dd className="mt-1 text-justify">
                 (referred to as &quot;You&quot;, &quot;you&quot;,
                 &quot;Your&quot; or &quot;your&quot; in this Agreement) is the
-                individual accessing or using the Service, or the company, or
+                individual accessing or using the Service, or the company or
                 other legal entity on behalf of which such individual is
                 accessing or using the Service, as applicable.
               </dd>
@@ -247,7 +247,7 @@ export default function TermsOfService() {
           <p className="mb-4 text-justify text-lg">
             You shall provide the Company with accurate and complete billing
             information including full name, address, state, zip code, telephone
-            number, and a valid payment method information. You authorize the
+            number and a valid payment method information. You authorize the
             Company to charge your payment method for both recurring
             subscription fees and any applicable usage or overage fees.
           </p>
@@ -316,7 +316,7 @@ export default function TermsOfService() {
           <h3 className="text-2xl font-display mt-12 mb-4">User Accounts</h3>
           <p className="mb-4 text-justify text-lg">
             When you create an account with us, you must provide us information
-            that is accurate, complete, and current at all times. Failure to do
+            that is accurate, complete and current at all times. Failure to do
             so constitutes a breach of the Terms, which may result in immediate
             termination of your account on our Service.
           </p>
@@ -335,7 +335,7 @@ export default function TermsOfService() {
             You may not use as a username the name of another person or entity
             or that is not lawfully available for use, a name or trademark that
             is subject to any rights of another person or entity other than you
-            without appropriate authorization, or a name that is otherwise
+            without appropriate authorization or a name that is otherwise
             offensive, vulgar or obscene.
           </p>
 
@@ -362,7 +362,7 @@ export default function TermsOfService() {
           </p>
           <p className="mb-4 text-justify text-lg">
             The Company has no control over, and assumes no responsibility for,
-            the content, privacy policies, or practices of any third party web
+            the content, privacy policies or practices of any third party web
             sites or services. You further acknowledge and agree that the
             Company shall not be responsible or liable, directly or indirectly,
             for any damage or loss caused or alleged to be caused by or in
@@ -402,12 +402,12 @@ export default function TermsOfService() {
           <p className="mb-4 text-justify text-lg">
             To the maximum extent permitted by applicable law, in no event shall
             the Company or its suppliers be liable for any special, incidental,
-            indirect, or consequential damages whatsoever (including, but not
+            indirect or consequential damages whatsoever (including, but not
             limited to, damages for loss of profits, loss of data or other
             information, for business interruption, for personal injury, loss of
             privacy arising out of or in any way related to the use of or
             inability to use the Service, third-party software and/or
-            third-party hardware used with the Service, or otherwise in
+            third-party hardware used with the Service or otherwise in
             connection with any provision of this Terms), even if the Company or
             any supplier has been advised of the possibility of such damages and
             even if the remedy fails of its essential purpose.
@@ -433,7 +433,7 @@ export default function TermsOfService() {
             disclaims all warranties, whether express, implied, statutory or
             otherwise, with respect to the Service, including all implied
             warranties of merchantability, fitness for a particular purpose,
-            title and non-infringement, and warranties that may arise out of
+            title and non-infringement and warranties that may arise out of
             course of dealing, course of performance, usage or trade practice.
             Without limitation to the foregoing, the Company provides no
             warranty or undertaking, and makes no representation of any kind
@@ -447,11 +447,11 @@ export default function TermsOfService() {
             Without limiting the foregoing, neither the Company nor any of the
             company&apos;s provider makes any representation or warranty of any
             kind, express or implied: (i) as to the operation or availability of
-            the Service, or the information, content, and materials or products
+            the Service, or the information, content and materials or products
             included thereon; (ii) that the Service will be uninterrupted or
-            error-free; (iii) as to the accuracy, reliability, or currency of
+            error-free; (iii) as to the accuracy, reliability or currency of
             any information or content provided through the Service; or (iv)
-            that the Service, its servers, the content, or e-mails sent from or
+            that the Service, its servers, the content or e-mails sent from or
             on behalf of the Company are free of viruses, scripts, trojan
             horses, worms, malware, timebombs or other harmful components.
           </p>

--- a/frontend/dashboard/app/why-measure/page.md
+++ b/frontend/dashboard/app/why-measure/page.md
@@ -1,0 +1,41 @@
+---
+title: Mobile-First App Monitoring
+description: Mobile is the product, not an add-on to a backend observability tool. Why we built Measure for mobile engineering teams.
+canonical: /why-measure
+---
+
+# Why Measure?
+
+There are several mobile app monitoring tools in the market. What is different between these tools is the core philosophy of the teams building them which affects the products in small and large ways.
+
+## Beyond Crashes
+
+Measure is focused on giving the full picture of apps in production to mobile developers and is not just limited to basic error tracking.
+
+With advanced automated capture techniques and full [Session Timelines](/product/session-timelines), Measure allows you to get the full context of errors and performance issues as they happen in the wild.
+
+If you're looking to truly understand what issues occur in your app, how they impact users and how to debug them quickly, Measure is the right tool for you.
+
+## Mobile Focus
+
+Measure is built by mobile developers for mobile developers. Every feature, every design decision and every trade-off is made with mobile app production monitoring in mind.
+
+Mobile is not an add-on or afterthought to an observability product, it **is** the product.
+
+If you care about your app being treated with the respect and focus it deserves, Measure is the perfect match for you.
+
+## Open Source
+
+Measure is [fully open source](https://github.com/measure-sh/measure). This means our code is open to scrutiny and community contributions which we strongly believe leads to a better product.
+
+If you value transparency, flexibility and open development, Measure is the right community for you.
+
+## Simple Pricing
+
+Measure offers clear and transparent [pricing](/pricing) based on data and retention. There are no bundles, hidden charges, seats or tiers (although we do offer discounts for high volume apps). You can send any combination of errors, metrics, spans etc without worrying about exceeding artificial limits.
+
+Further, with [Adaptive Capture](/product/adaptive-capture), you can optimize your data collection to only capture what you need and adjust it dynamically without rolling out app updates, reducing costs and data bloat.
+
+If you hate playing with excel sheets and pricing calculators to figure out your monthly bill and would like to adjust your data collection based on changing needs, Measure is the right choice for you.
+
+Get started: <https://measure.sh/auth/login>

--- a/frontend/dashboard/middleware.ts
+++ b/frontend/dashboard/middleware.ts
@@ -1,53 +1,95 @@
+/**
+ * Reverse proxies (`/api`, `/yrtmlt`) and markdown content negotiation
+ * for marketing/docs pages.
+ *
+ * Marketing page markdown twins:
+ *   Each public marketing route (homepage, /about, /pricing, /why-measure,
+ *   /security, /crashlytics-alternatives, /product/*) has a hand-authored
+ *   `page.md` colocated with its `page.tsx`:
+ *
+ *     app/about/page.tsx        ← React component (HTML)
+ *     app/about/page.md         ← markdown twin for agents
+ *
+ *   When a request arrives with `Accept: text/markdown`, the matcher
+ *   below fires and the function rewrites to `/page-md/<path>` (or
+ *   `/page-md/index` for the homepage). The route handler at
+ *   `app/page-md/[...path]/route.ts` reads `app/<segments>/page.md` and
+ *   returns it with `Content-Type: text/markdown`.
+ *
+ *   `/privacy-policy` and `/terms-of-service` deliberately have no
+ *   markdown twin — agents requesting them get 406.
+ *
+ *   **Sync rule:** if you change a marketing `page.tsx`, update the
+ *   sibling `page.md` in the same change. Visual-only components
+ *   (calculators, demos, icons, CTA buttons, layout chrome) are
+ *   intentionally omitted from the markdown — keep copy, prices, links,
+ *   and definitions aligned; drop the chrome.
+ *
+ *   `scripts/generate_llms_txts.js` walks `app/` for folders containing
+ *   both `page.tsx` and `page.md` (no skip list — the dual-file check is
+ *   the filter) and emits the `## Pages` section in `llms.txt` plus the
+ *   marketing portion of `llms-full.txt`.
+ */
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  switch (true) {
-    case pathname.startsWith("/api"): {
-      // reverse proxy all API requests
-      const apiOrigin = process.env.API_BASE_URL || "http://api:8080";
-      const apiOriginUrl = new URL(apiOrigin);
+  if (pathname.startsWith("/api")) {
+    // reverse proxy all API requests
+    const apiOrigin = process.env.API_BASE_URL || "http://api:8080";
+    const apiOriginUrl = new URL(apiOrigin);
 
-      const url = request.nextUrl.clone();
-      url.protocol = apiOriginUrl.protocol;
-      url.pathname = request.nextUrl.pathname.replace("/api", "");
-      url.search = request.nextUrl.search;
-      url.hostname = apiOriginUrl.hostname;
-      url.port = apiOriginUrl.port;
+    const url = request.nextUrl.clone();
+    url.protocol = apiOriginUrl.protocol;
+    url.pathname = pathname.replace("/api", "");
+    url.search = request.nextUrl.search;
+    url.hostname = apiOriginUrl.hostname;
+    url.port = apiOriginUrl.port;
 
-      return NextResponse.rewrite(url);
-    }
-
-    case pathname.startsWith("/yrtmlt/static/"): {
-      const url = request.nextUrl.clone();
-      url.protocol = "https:";
-      url.hostname = "us-assets.i.posthog.com";
-      url.port = "";
-      url.pathname = pathname.replace("/yrtmlt/static", "/static");
-
-      return NextResponse.rewrite(url);
-    }
-
-    case pathname.startsWith("/yrtmlt/"): {
-      const phHost = new URL(process.env.POSTHOG_HOST || "");
-
-      const url = request.nextUrl.clone();
-      url.protocol = phHost.protocol;
-      url.hostname = phHost.hostname;
-      url.port = phHost.port;
-      url.pathname = pathname.replace("/yrtmlt", "");
-
-      return NextResponse.rewrite(url);
-    }
-
-    default:
-      // handle non-matching requests as usual
-      return NextResponse.next();
+    return NextResponse.rewrite(url);
   }
+
+  if (pathname.startsWith("/yrtmlt/static/")) {
+    const url = request.nextUrl.clone();
+    url.protocol = "https:";
+    url.hostname = "us-assets.i.posthog.com";
+    url.port = "";
+    url.pathname = pathname.replace("/yrtmlt/static", "/static");
+
+    return NextResponse.rewrite(url);
+  }
+
+  if (pathname.startsWith("/yrtmlt/")) {
+    const phHost = new URL(process.env.POSTHOG_HOST || "");
+
+    const url = request.nextUrl.clone();
+    url.protocol = phHost.protocol;
+    url.hostname = phHost.hostname;
+    url.port = phHost.port;
+    url.pathname = pathname.replace("/yrtmlt", "");
+
+    return NextResponse.rewrite(url);
+  }
+
+  // Content negotiation: the third matcher entry below (with `has`)
+  // only fires when Accept asks for text/markdown, so reaching this
+  // point means the agent wants markdown for a non-/api, non-/yrtmlt
+  // path. Rewrite to the internal /page-md/* route which resolves the
+  // markdown source on disk.
+  const url = request.nextUrl.clone();
+  url.pathname = `/page-md${pathname === "/" ? "/index" : pathname}`;
+  return NextResponse.rewrite(url);
 }
 
 export const config = {
-  matcher: ["/api/:path*", "/yrtmlt/:path*"],
+  matcher: [
+    "/api/:path*",
+    "/yrtmlt/:path*",
+    {
+      source: "/((?!_next|page-md|api|yrtmlt|favicon\\.ico).*)",
+      has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+    },
+  ],
 };

--- a/frontend/dashboard/next.config.js
+++ b/frontend/dashboard/next.config.js
@@ -4,6 +4,13 @@ const nextConfig = {
   poweredByHeader: false,
   experimental: {
     proxyTimeout: 90000,
+    // The /_md/[...path] route handler reads markdown source files at runtime.
+    // Next's tracer can't infer these dynamic reads, so include them explicitly
+    // in the standalone output. Without this, agents requesting Accept:text/markdown
+    // would get 406 in production.
+    outputFileTracingIncludes: {
+      "/page-md/[...path]": ["./app/**/page.md", "./content/docs/**/*"],
+    },
   },
   images: {
     remotePatterns: [

--- a/frontend/dashboard/scripts/copy_docs.js
+++ b/frontend/dashboard/scripts/copy_docs.js
@@ -80,7 +80,7 @@ function stripHtmlTags(input) {
 /**
  * Reduce a markdown body to plain text suitable for full-text search.
  * Strips fences, headings, raw HTML, images/links, emphasis markers,
- * list/blockquote prefixes, table pipes, and GFM callout markers
+ * list/blockquote prefixes, table pipes and GFM callout markers
  * (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`).
  */
 function stripSearchContent(body) {

--- a/frontend/dashboard/scripts/generate_llms_txts.js
+++ b/frontend/dashboard/scripts/generate_llms_txts.js
@@ -12,7 +12,11 @@
 const fs = require("fs");
 const path = require("path");
 
-const { stripHtmlComments, stripFrontmatter, mdPathToSlug } = require("./copy_docs");
+const {
+  stripHtmlComments,
+  stripFrontmatter,
+  mdPathToSlug,
+} = require("./copy_docs");
 
 const rootDir = path.resolve(__dirname, "..");
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://measure.sh";
@@ -24,6 +28,92 @@ function getDocsDirectory() {
   }
   // Local dev fallback
   return path.resolve(rootDir, "..", "..", "docs");
+}
+
+function getAppDirectory() {
+  return path.join(rootDir, "app");
+}
+
+/**
+ * Parse flat key:value YAML frontmatter from a markdown file. Mirrors the
+ * parser in app/docs/docs.ts — kept duplicated here because this script
+ * runs at build time before Next.js compiles TS.
+ */
+function parseFrontmatterKV(text) {
+  const match = text.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/);
+  if (!match) {
+    return {};
+  }
+  const kv = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
+    if (!m) {
+      continue;
+    }
+    let v = m[2].trim();
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    kv[m[1]] = v;
+  }
+  return kv;
+}
+
+/**
+ * Walk app/ and return [{ slug, title, filePath }] for every route folder
+ * that has both `page.tsx` (a real Next.js route) and `page.md` (a
+ * hand-authored markdown twin).
+ *
+ * The dual-file check is the filter: folders like app/components/ have no
+ * page.tsx so they're skipped; dynamic routes like app/[teamId]/ have
+ * page.tsx but no page.md so they're also skipped. No hardcoded skip list.
+ *
+ * Slug mapping:
+ *   app/page.md                       -> "/"
+ *   app/about/page.md                 -> "/about"
+ *   app/product/mcp/page.md           -> "/product/mcp"
+ */
+function walkPagesWithMd(appDir) {
+  if (!fs.existsSync(appDir)) {
+    return [];
+  }
+  const pages = [];
+
+  function walk(dir, prefix) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    const hasPageMd = entries.some((e) => e.isFile() && e.name === "page.md");
+    const hasPageTsx = entries.some((e) => e.isFile() && e.name === "page.tsx");
+
+    if (hasPageMd && hasPageTsx) {
+      const slug = prefix.length === 0 ? "/" : `/${prefix.join("/")}`;
+      const filePath = path.join(dir, "page.md");
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const fm = parseFrontmatterKV(raw);
+      pages.push({
+        slug,
+        title: fm.title || prefix[prefix.length - 1] || "index",
+        filePath,
+      });
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name), [...prefix, entry.name]);
+      }
+    }
+  }
+
+  walk(appDir, []);
+  // Homepage first, then alphabetical by slug
+  return pages.sort((a, b) => {
+    if (a.slug === "/") return -1;
+    if (b.slug === "/") return 1;
+    return a.slug.localeCompare(b.slug);
+  });
 }
 
 /**
@@ -71,13 +161,11 @@ function flattenNavSlugs(navData) {
  * Produces a markdown file with H1 title, blockquote description,
  * and organized links to all doc pages.
  */
-function generateLlmsTxt(navData) {
+function generateLlmsTxt(navData, pages = []) {
   const lines = [];
   lines.push("# measure.sh");
   lines.push("");
-  lines.push(
-    "> Open source tool to monitor mobile apps"
-  );
+  lines.push("> Open source tool to monitor mobile apps");
   lines.push("");
 
   const standaloneItems = [];
@@ -92,7 +180,7 @@ function generateLlmsTxt(navData) {
           for (const grandchild of child.children) {
             if (grandchild.slug) {
               lines.push(
-                `- [${grandchild.title}](${SITE_URL}${grandchild.slug})`
+                `- [${grandchild.title}](${SITE_URL}${grandchild.slug})`,
               );
             }
           }
@@ -115,10 +203,20 @@ function generateLlmsTxt(navData) {
     lines.push("");
   }
 
+  if (pages.length > 0) {
+    lines.push("## Pages");
+    lines.push("");
+    for (const p of pages) {
+      const url = p.slug === "/" ? SITE_URL : `${SITE_URL}${p.slug}`;
+      lines.push(`- [${p.title}](${url})`);
+    }
+    lines.push("");
+  }
+
   lines.push("## Optional");
   lines.push("");
   lines.push(
-    `- [llms-full.txt](${SITE_URL}/llms-full.txt): Complete documentation in a single file`
+    `- [llms-full.txt](${SITE_URL}/llms-full.txt): Complete documentation in a single file`,
   );
   lines.push("");
 
@@ -135,22 +233,22 @@ function rewriteRelativeLinks(content) {
       (match, text, href) => {
         const slug = mdPathToSlug(href);
         return `[${text}](${SITE_URL}${slug})`;
-      }
+      },
     )
     .replace(
       /!\[([^\]]*)\]\((?:\.\/)?assets\/([^)]+)\)/g,
       (match, alt, assetPath) => {
         return `![${alt}](${SITE_URL}/docs/assets/${assetPath})`;
-      }
+      },
     );
 }
 
 /**
  * Generate llms-full.txt with all documentation concatenated.
- * Follows the nav ordering, strips HTML comments, and rewrites
+ * Follows the nav ordering, strips HTML comments and rewrites
  * relative links to absolute URLs.
  */
-function generateLlmsFullTxt(docsDir, navData) {
+function generateLlmsFullTxt(docsDir, navData, pages = []) {
   const slugs = flattenNavSlugs(navData);
   const seen = new Set();
   const sections = [];
@@ -175,6 +273,13 @@ function generateLlmsFullTxt(docsDir, navData) {
     sections.push(`---\nSource: ${sourceUrl}\n---\n\n${rewritten}`);
   }
 
+  for (const p of pages) {
+    const raw = fs.readFileSync(p.filePath, "utf-8");
+    const cleaned = stripHtmlComments(stripFrontmatter(raw));
+    const sourceUrl = p.slug === "/" ? SITE_URL : `${SITE_URL}${p.slug}`;
+    sections.push(`---\nSource: ${sourceUrl}\n---\n\n${cleaned}`);
+  }
+
   return sections.join("\n\n");
 }
 
@@ -185,26 +290,29 @@ module.exports = {
   generateLlmsTxt,
   generateLlmsFullTxt,
   rewriteRelativeLinks,
+  walkPagesWithMd,
+  parseFrontmatterKV,
   SITE_URL,
 };
 
 // Main — only runs when executed directly, not when required by tests
 if (require.main === module) {
   const docsDir = getDocsDirectory();
+  const appDir = getAppDirectory();
   const navPath = path.join(rootDir, "content", "docs_nav.json");
 
   if (!fs.existsSync(navPath)) {
-    console.error(
-      "Error: docs_nav.json not found. Run copy_docs.js first."
-    );
+    console.error("Error: docs_nav.json not found. Run copy_docs.js first.");
     process.exit(1);
   }
 
   const navData = JSON.parse(fs.readFileSync(navPath, "utf-8"));
+  const pages = walkPagesWithMd(appDir);
+  console.log(`Found ${pages.length} pages with a markdown twin.`);
 
   // Generate llms.txt
   console.log("Generating llms.txt...");
-  const llmsTxt = generateLlmsTxt(navData);
+  const llmsTxt = generateLlmsTxt(navData, pages);
   const llmsTxtDest = path.join(rootDir, "public", "llms.txt");
   fs.mkdirSync(path.dirname(llmsTxtDest), { recursive: true });
   fs.writeFileSync(llmsTxtDest, llmsTxt);
@@ -212,7 +320,7 @@ if (require.main === module) {
 
   // Generate llms-full.txt
   console.log("Generating llms-full.txt...");
-  const llmsFullTxt = generateLlmsFullTxt(docsDir, navData);
+  const llmsFullTxt = generateLlmsFullTxt(docsDir, navData, pages);
   const llmsFullTxtDest = path.join(rootDir, "public", "llms-full.txt");
   fs.writeFileSync(llmsFullTxtDest, llmsFullTxt);
   console.log("llms-full.txt generated.");

--- a/frontend/dashboard/scripts/smoke_test_pages.js
+++ b/frontend/dashboard/scripts/smoke_test_pages.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * End-to-end smoke test for content negotiation across every marketing,
+ * docs, and non-public route. For each URL we make two requests:
+ *
+ *   1. With no Accept header — expect HTML (page.tsx rendering).
+ *   2. With Accept: text/markdown — expect a 200 markdown response for
+ *      routes that have a page.md or a docs/*.md source, and 406 for
+ *      routes that intentionally have no markdown twin (legal pages,
+ *      auth, dashboard).
+ *
+ * Runs against a live dashboard (defaults to http://localhost:3000).
+ * Exits non-zero if any check fails and prints a failure summary.
+ *
+ * Usage:
+ *   node scripts/smoke_test_pages.js
+ *   BASE=https://measure.sh node scripts/smoke_test_pages.js
+ */
+
+const BASE = process.env.BASE || "http://localhost:3000";
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+async function check(url, mode, expectStatus, expectCtype, expectBodyRe) {
+  const headers = {};
+  if (mode !== "html") {
+    headers.Accept = "text/markdown";
+  }
+
+  let status;
+  let ctype = "";
+  let body = "";
+  try {
+    const res = await fetch(`${BASE}${url}`, { headers, redirect: "manual" });
+    status = res.status;
+    ctype = res.headers.get("content-type") || "";
+    body = await res.text();
+  } catch (err) {
+    status = "ERR";
+    ctype = err.message;
+  }
+
+  let ok = true;
+  let why = "";
+  if (String(status) !== String(expectStatus)) {
+    ok = false;
+    why = `status=${status} (want ${expectStatus})`;
+  } else if (!ctype.includes(expectCtype)) {
+    ok = false;
+    why = `content-type=${ctype} (want ${expectCtype})`;
+  } else if (
+    expectBodyRe &&
+    !new RegExp(expectBodyRe).test(body.slice(0, 4096))
+  ) {
+    ok = false;
+    why = `body did not match /${expectBodyRe}/`;
+  }
+
+  const label = `  ${ok ? "PASS" : "FAIL"} ${url.padEnd(58)} [${mode}] `;
+  if (ok) {
+    pass++;
+    console.log(label + status);
+  } else {
+    fail++;
+    failures.push(`${url} [${mode}] — ${why}`);
+    console.log(label + why);
+  }
+}
+
+// Marketing pages: have a colocated page.md, expect markdown in both modes
+const MARKETING_URLS = [
+  "/",
+  "/about",
+  "/why-measure",
+  "/pricing",
+  "/security",
+  "/crashlytics-alternatives",
+  "/product/adaptive-capture",
+  "/product/app-health",
+  "/product/bug-reports",
+  "/product/crashes-and-anrs",
+  "/product/mcp",
+  "/product/network-performance",
+  "/product/performance-traces",
+  "/product/session-timelines",
+  "/product/user-journeys",
+];
+
+// Legal pages: intentionally no page.md, markdown mode must 406
+const LEGAL_URLS = ["/privacy-policy", "/terms-of-service"];
+
+// Docs: every slug Next.js can resolve from content/docs/ — kept exhaustive
+// so removing a doc fails the test and forces a list update.
+const DOCS_URLS = [
+  "/docs",
+  "/docs/sdk-integration-guide",
+  "/docs/faqs",
+  "/docs/versioning",
+  "/docs/CONTRIBUTING",
+  "/docs/features/configuration-options",
+  "/docs/features/feature-data-retention",
+  "/docs/features/performance-impact",
+  "/docs/features/feature-session-timelines",
+  "/docs/features/feature-crash-reporting",
+  "/docs/features/feature-anr-reporting",
+  "/docs/features/feature-error-tracking",
+  "/docs/features/feature-gesture-tracking",
+  "/docs/features/feature-performance-tracing",
+  "/docs/features/feature-custom-events",
+  "/docs/features/feature-bug-report-android",
+  "/docs/features/feature-bug-report-ios",
+  "/docs/features/feature-bug-report-flutter",
+  "/docs/features/feature-screenshot-masking-swiftui",
+  "/docs/features/feature-app-launch-metrics",
+  "/docs/features/feature-network-monitoring",
+  "/docs/features/feature-network-connectivity-changes",
+  "/docs/features/feature-navigation-lifecycle-tracking",
+  "/docs/features/feature-cpu-monitoring",
+  "/docs/features/feature-memory-monitoring",
+  "/docs/features/feature-identify-users",
+  "/docs/features/feature-manually-start-stop-sdk",
+  "/docs/features/feature-app-size-monitoring",
+  "/docs/features/feature-alerts",
+  "/docs/features/feature-slack-integration",
+  "/docs/features/feature-mcp",
+  "/docs/sdk-upgrade-guides",
+  "/docs/sdk-upgrade-guides/android-v0.16.0",
+  "/docs/sdk-upgrade-guides/ios-v0.9.0",
+  "/docs/sdk-upgrade-guides/measure_flutter-v0.4.0",
+  "/docs/hosting",
+  "/docs/hosting/google-oauth",
+  "/docs/hosting/github-oauth",
+  "/docs/hosting/smtp-email",
+  "/docs/hosting/slack",
+  "/docs/hosting/migration-guides",
+  "/docs/hosting/migration-guides/v0.4.x",
+  "/docs/hosting/migration-guides/v0.6.x",
+  "/docs/hosting/migration-guides/v0.8.x",
+  "/docs/hosting/migration-guides/v0.9.x",
+  "/docs/hosting/migration-guides/v0.10.x",
+  "/docs/api",
+  "/docs/api/sdk",
+  "/docs/api/dashboard",
+];
+
+// Non-marketing routes: page.tsx exists but no page.md is authored.
+// Markdown mode must 406; HTML mode must still serve the page. The
+// dashboard route uses an arbitrary teamId — the page is reachable
+// (auth is checked client-side after the initial render).
+const NON_PUBLIC_URLS = ["/auth/login", "/some-team/overview"];
+
+async function main() {
+  console.log(`Smoke testing ${BASE}\n`);
+
+  console.log("=== Marketing pages — HTML mode ===");
+  for (const u of MARKETING_URLS) {
+    await check(u, "html", 200, "text/html", "(<!DOCTYPE|<html)");
+  }
+
+  console.log("\n=== Marketing pages — markdown mode ===");
+  for (const u of MARKETING_URLS) {
+    await check(u, "md", 200, "text/markdown", "^#");
+  }
+
+  console.log("\n=== Legal pages — HTML mode (should be 200) ===");
+  for (const u of LEGAL_URLS) {
+    await check(u, "html", 200, "text/html", "(<!DOCTYPE|<html)");
+  }
+
+  console.log("\n=== Legal pages — markdown mode (should be 406) ===");
+  for (const u of LEGAL_URLS) {
+    await check(u, "md-406", 406, "text/plain", "No markdown representation");
+  }
+
+  console.log("\n=== Docs pages — HTML mode ===");
+  for (const u of DOCS_URLS) {
+    await check(u, "html", 200, "text/html", "(<!DOCTYPE|<html)");
+  }
+
+  console.log("\n=== Docs pages — markdown mode ===");
+  for (const u of DOCS_URLS) {
+    await check(u, "md", 200, "text/markdown", "^#");
+  }
+
+  console.log("\n=== Non-public routes — HTML mode (page.tsx renders) ===");
+  for (const u of NON_PUBLIC_URLS) {
+    await check(u, "html", 200, "text/html", "(<!DOCTYPE|<html)");
+  }
+
+  console.log("\n=== Non-public routes — markdown mode (no page.md → 406) ===");
+  for (const u of NON_PUBLIC_URLS) {
+    await check(u, "md-406", 406, "text/plain", "No markdown representation");
+  }
+
+  console.log("\n=============================================");
+  console.log(`Summary: PASS=${pass}  FAIL=${fail}`);
+  if (fail > 0) {
+    console.log("\nFailures:");
+    for (const f of failures) {
+      console.log(`  - ${f}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/samples/frank/README.md
+++ b/samples/frank/README.md
@@ -196,7 +196,7 @@ SDK are picked up on the next Xcode build without needing to `pod update`.
 
 ## CI/CD
 
-CI is handled by `.github/workflows/frank.yml`. It triggers on PRs and pushes to `main` when changes are made to `samples/frank/`, `android/`, `ios/`, `flutter/`, or `react-native/`. Each run builds both debug and release for Android and a release archive for iOS. On merge to `main`, it also publishes to Firebase App Distribution (`measure-devs` group). Android uses the `wzieba/Firebase-Distribution-Github-Action` while iOS uses the Firebase CLI directly (since the GitHub Action requires a Linux runner).
+CI is handled by `.github/workflows/frank.yml`. It triggers on PRs and pushes to `main` when changes are made to `samples/frank/`, `android/`, `ios/`, `flutter/` or `react-native/`. Each run builds both debug and release for Android and a release archive for iOS. On merge to `main`, it also publishes to Firebase App Distribution (`measure-devs` group). Android uses the `wzieba/Firebase-Distribution-Github-Action` while iOS uses the Firebase CLI directly (since the GitHub Action requires a Linux runner).
 
 ### CI Secrets
 

--- a/self-host/k6/README.md
+++ b/self-host/k6/README.md
@@ -19,7 +19,7 @@ This is the main load testing script. It simulates traffic from Measure SDKs by 
 #### Key Features:
 
 *   **Realistic Simulation**: The script virtualizes `session_id` and `event_id` on each run, ensuring that the backend processes them as unique entities. It also applies a random "clock skew" to event timestamps to simulate data coming from different devices with slightly out-of-sync clocks.
-*   **Staged Load Ramping**: The test is configured with stages to gradually ramp up the number of virtual users, sustain the load, and then ramp down. This helps in understanding how the system behaves under increasing stress.
+*   **Staged Load Ramping**: The test is configured with stages to gradually ramp up the number of virtual users, sustain the load and then ramp down. This helps in understanding how the system behaves under increasing stress.
 *   **Data Fixtures**: The script uses sample data from `fixtures/sample-app.ts` to simulate different payloads.
 *   **Batching**: Requests are sent in parallel batches to generate a higher load.
 


### PR DESCRIPTION
# Description

Agents fetching a marketing or docs URL with `Accept: text/markdown` now get a clean markdown response instead of React-rendered HTML. The same sources feed `llms.txt` / `llms-full.txt` so agent indexes stay in sync.

- Middleware detects `Accept: text/markdown` and rewrites to `/page-md/<path>`.
- New route handler at `app/page-md/[...path]/route.ts` resolves the markdown source.
- Marketing pages have a colocated `page.md` next to each `page.tsx`; docs reuse the existing `content/docs/` files.
- Routes with no markdown twin (legal pages, auth, dashboard) return 406.
- `scripts/generate_llms_txts.js` picks up any folder containing both `page.tsx` and `page.md` — no skip list to maintain.
- `next.config.js` declares `outputFileTracingIncludes` so the standalone build ships the `.md` files.
- Tested with unit tests, integration tests, and a live smoke test script at `scripts/smoke_test_pages.js`.



