### PR TITLE
fix(frontend): hydrate teams cache on create to fix post-nav crash

### DIFF
--- a/frontend/dashboard/__tests__/integration/team_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/team_msw_test.tsx
@@ -11,7 +11,7 @@
  * control which actions are enabled.
  */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 
 // --- jsdom polyfills ---
@@ -77,6 +77,8 @@ afterAll(() => server.close())
 
 // --- Store/component imports ---
 import TeamOverview from '@/app/[teamId]/team/page'
+import { Team } from '@/app/api/api_calls'
+import { useCreateTeamMutation } from '@/app/query/hooks'
 import { queryClient } from '@/app/query/query_client'
 import { createSessionStore } from '@/app/stores/session_store'
 import { QueryClientProvider } from '@tanstack/react-query'
@@ -1603,6 +1605,99 @@ describe('Team Page — create team dialog', () => {
         })
 
         expect(apiCalled).toBe(false)
+    })
+})
+
+// ====================================================================
+// CACHE HYDRATION CONTRACT (regression guard)
+// ====================================================================
+//
+// After useCreateTeamMutation succeeds, the ["teams"] query cache must
+// contain the new team synchronously inside onSuccess — not after an
+// async refetch. That synchronous write is what lets the navigation
+// fired by CreateTeam (router.push to the new team's page) find the
+// team in the cache on mount instead of resolving to null, which
+// crashes the team page on the eagerly-evaluated `team!.name`
+// references in dialog bodies and the rename input's defaultValue.
+//
+// Tests below use renderHook so useTeamsQuery has no observers. With
+// no observers, invalidateQueries does not trigger a background
+// refetch, which would otherwise race the assertion and mask whether
+// the synchronous cache write actually happened.
+describe('useCreateTeamMutation — cache hydration contract', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    it('appends the new team to the existing ["teams"] cache on success', async () => {
+        server.use(
+            http.post('*/api/teams', async ({ request }) => {
+                const body = (await request.json()) as { name: string }
+                return HttpResponse.json({ id: 'team-new', name: body.name })
+            }),
+        )
+
+        queryClient.setQueryData<Team[]>(['teams'], [
+            { id: 'team-001', name: 'Test Team' },
+            { id: 'team-002', name: 'Other Team' },
+        ])
+
+        const { result } = renderHook(() => useCreateTeamMutation(), { wrapper })
+
+        await act(async () => {
+            await result.current.mutateAsync({ teamName: 'Brand New' })
+        })
+
+        expect(queryClient.getQueryData<Team[]>(['teams'])).toEqual([
+            { id: 'team-001', name: 'Test Team' },
+            { id: 'team-002', name: 'Other Team' },
+            { id: 'team-new', name: 'Brand New' },
+        ])
+    })
+
+    it('initializes the ["teams"] cache when no prior teams data exists', async () => {
+        server.use(
+            http.post('*/api/teams', async ({ request }) => {
+                const body = (await request.json()) as { name: string }
+                return HttpResponse.json({ id: 'team-new', name: body.name })
+            }),
+        )
+
+        expect(queryClient.getQueryData<Team[]>(['teams'])).toBeUndefined()
+
+        const { result } = renderHook(() => useCreateTeamMutation(), { wrapper })
+
+        await act(async () => {
+            await result.current.mutateAsync({ teamName: 'Solo' })
+        })
+
+        expect(queryClient.getQueryData<Team[]>(['teams'])).toEqual([
+            { id: 'team-new', name: 'Solo' },
+        ])
+    })
+
+    it('leaves the cache untouched when the mutation errors', async () => {
+        server.use(
+            http.post('*/api/teams', () => {
+                return HttpResponse.json({ error: 'duplicate' }, { status: 409 })
+            }),
+        )
+
+        const seed: Team[] = [
+            { id: 'team-001', name: 'Test Team' },
+            { id: 'team-002', name: 'Other Team' },
+        ]
+        queryClient.setQueryData<Team[]>(['teams'], seed)
+
+        const { result } = renderHook(() => useCreateTeamMutation(), { wrapper })
+
+        await act(async () => {
+            await expect(
+                result.current.mutateAsync({ teamName: 'Boom' }),
+            ).rejects.toThrow()
+        })
+
+        expect(queryClient.getQueryData<Team[]>(['teams'])).toEqual(seed)
     })
 })
 

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import {
   AlertsOverviewApiStatus,
@@ -52,6 +52,7 @@ import {
   SessionsVsExceptionsPlotApiStatus,
   SpanMetricsPlotApiStatus,
   SpansApiStatus,
+  Team,
   TeamNameChangeApiStatus,
   TeamsApiStatus,
   TestSlackAlertApiStatus,
@@ -125,25 +126,30 @@ import {
   updateNotifPrefsFromServer,
   updateSdkConfigFromServer,
   updateTeamSlackStatusFromServer,
-} from "@/app/api/api_calls"
-import { queryClient } from "@/app/query/query_client"
-import { useFiltersStore } from "@/app/stores/provider"
-import { Query, keepPreviousData, useMutation, useQuery } from "@tanstack/react-query"
+} from "@/app/api/api_calls";
+import { queryClient } from "@/app/query/query_client";
+import { useFiltersStore } from "@/app/stores/provider";
+import {
+  Query,
+  keepPreviousData,
+  useMutation,
+  useQuery,
+} from "@tanstack/react-query";
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
 export type ExceptionGroupCommonPath = {
-  sessions_analyzed: number
+  sessions_analyzed: number;
   steps: Array<{
-    description: string
-    thread_name: string
-    confidence_pct: number
-  }>
-}
+    description: string;
+    thread_name: string;
+    confidence_pct: number;
+  }>;
+};
 
 // ─── Constants re-exported for components ────────────────────────────────
 
-export const paginationOffsetUrlKey = "po"
+export const paginationOffsetUrlKey = "po";
 
 export enum TrendsTab {
   Latency = "Latency",
@@ -165,20 +171,30 @@ function mapPlotData(data: any[]) {
   return data.map((item: any) => ({
     id: item.id,
     data: item.data.map((d: any) => ({ x: d.datetime, y: d.instances })),
-  }))
+  }));
 }
 
 /** Span metrics: pick quantile value for y-axis */
-function getYBasedOnQuantile(data: any, quantile: RootSpanMetricsQuantile): number {
+function getYBasedOnQuantile(
+  data: any,
+  quantile: RootSpanMetricsQuantile,
+): number {
   switch (quantile) {
-    case RootSpanMetricsQuantile.p50: return data.p50
-    case RootSpanMetricsQuantile.p90: return data.p90
-    case RootSpanMetricsQuantile.p95: return data.p95
-    case RootSpanMetricsQuantile.p99: return data.p99
+    case RootSpanMetricsQuantile.p50:
+      return data.p50;
+    case RootSpanMetricsQuantile.p90:
+      return data.p90;
+    case RootSpanMetricsQuantile.p95:
+      return data.p95;
+    case RootSpanMetricsQuantile.p99:
+      return data.p99;
   }
 }
 
-export function transformSpanMetricsPlotData(rawData: any, quantile: RootSpanMetricsQuantile) {
+export function transformSpanMetricsPlotData(
+  rawData: any,
+  quantile: RootSpanMetricsQuantile,
+) {
   return rawData.map((item: any) => ({
     id: item.id,
     data: item.data.map((data: any, index: number) => ({
@@ -186,84 +202,96 @@ export function transformSpanMetricsPlotData(rawData: any, quantile: RootSpanMet
       x: data.datetime,
       y: getYBasedOnQuantile(data, quantile),
     })),
-  }))
+  }));
 }
 
 /** Distribution plot: parse attribute/value pairs with OS version formatting */
 function formatAttribute(str: string, hasAndroidData: boolean = false): string {
   if (str === "os_version" && hasAndroidData) {
-    return "API Level"
+    return "API Level";
   }
   return str
     .split("_")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ")
+    .join(" ");
 }
 
 function formatOsVersionKey(key: string): string {
-  const parts = key.toLowerCase().split(" ")
+  const parts = key.toLowerCase().split(" ");
   if (parts.length >= 2) {
-    const osName = parts[0]
-    const version = parts[1]
+    const osName = parts[0];
+    const version = parts[1];
     const displayName =
-      osName === "android" ? "Android API Level"
-        : osName === "ios" ? "iOS"
-          : osName === "ipados" ? "iPadOS"
-            : osName
-    return `${displayName} ${version}`
+      osName === "android"
+        ? "Android API Level"
+        : osName === "ios"
+          ? "iOS"
+          : osName === "ipados"
+            ? "iPadOS"
+            : osName;
+    return `${displayName} ${version}`;
   }
-  return key
+  return key;
 }
 
 function parseDistributionPlot(resultData: any) {
-  const plotKeys: string[] = []
+  const plotKeys: string[] = [];
   const plot = Object.entries(resultData).map(([attribute, values]) => {
-    const transformedValues: { [key: string]: number } = {}
-    let hasAndroidData = false
-    Object.entries(values as { [key: string]: number }).forEach(([key, value]) => {
-      if (attribute === "os_version" && key.toLowerCase().startsWith("android")) {
-        hasAndroidData = true
-      }
-      const transformedKey = attribute === "os_version" ? formatOsVersionKey(key) : key
-      transformedValues[transformedKey] = value
-      if (!plotKeys.includes(transformedKey)) {
-        plotKeys.push(transformedKey)
-      }
-    })
-    return { attribute: formatAttribute(attribute, hasAndroidData), ...transformedValues }
-  })
-  return { plot, plotKeys }
+    const transformedValues: { [key: string]: number } = {};
+    let hasAndroidData = false;
+    Object.entries(values as { [key: string]: number }).forEach(
+      ([key, value]) => {
+        if (
+          attribute === "os_version" &&
+          key.toLowerCase().startsWith("android")
+        ) {
+          hasAndroidData = true;
+        }
+        const transformedKey =
+          attribute === "os_version" ? formatOsVersionKey(key) : key;
+        transformedValues[transformedKey] = value;
+        if (!plotKeys.includes(transformedKey)) {
+          plotKeys.push(transformedKey);
+        }
+      },
+    );
+    return {
+      attribute: formatAttribute(attribute, hasAndroidData),
+      ...transformedValues,
+    };
+  });
+  return { plot, plotKeys };
 }
 
 // ─── Metrics ─────────────────────────────────────────────────────────────
 
 export function useMetricsQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["metrics", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchMetricsFromServer(filters)
+      const result = await fetchMetricsFromServer(filters);
       if (result.status === MetricsApiStatus.Error) {
-        throw new Error("Failed to fetch metrics")
+        throw new Error("Failed to fetch metrics");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 export function useAppThresholdPrefsQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["appThresholdPrefs", appId] as const,
     queryFn: async () => {
-      const result = await fetchAppThresholdPrefsFromServer(appId!)
+      const result = await fetchAppThresholdPrefsFromServer(appId!);
       if (result.status === FetchAppThresholdPrefsApiStatus.Error) {
-        throw new Error("Failed to fetch threshold prefs")
+        throw new Error("Failed to fetch threshold prefs");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId,
-  })
+  });
 }
 
 // ─── Journey ─────────────────────────────────────────────────────────────
@@ -273,440 +301,596 @@ export function useJourneyQuery(
   exceptionsGroupId: string | null,
   bidirectional: boolean,
 ) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["journey", journeyType, exceptionsGroupId, bidirectional, filters.serialisedFilters] as const,
+    queryKey: [
+      "journey",
+      journeyType,
+      exceptionsGroupId,
+      bidirectional,
+      filters.serialisedFilters,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchJourneyFromServer(journeyType, exceptionsGroupId, bidirectional, filters)
+      const result = await fetchJourneyFromServer(
+        journeyType,
+        exceptionsGroupId,
+        bidirectional,
+        filters,
+      );
       if (result.status === JourneyApiStatus.Error) {
-        throw new Error("Failed to fetch journey")
+        throw new Error("Failed to fetch journey");
       }
       if (result.status === JourneyApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Network: Overview ───────────────────────────────────────────────────
 
 export function useNetworkDomainsQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkDomains", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchNetworkDomainsFromServer(filters.app!, filters)
+      const result = await fetchNetworkDomainsFromServer(filters.app!, filters);
       if (result.status === NetworkDomainsApiStatus.Error) {
-        throw new Error("Failed to fetch domains")
+        throw new Error("Failed to fetch domains");
       }
       if (result.status === NetworkDomainsApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data.results as string[]
+      return result.data.results as string[];
     },
     enabled: filters.ready && !!filters.app,
-  })
+  });
 }
 
 export function useNetworkPathsQuery(domain: string, searchPattern: string) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["networkPaths", filters.serialisedFilters, domain, searchPattern] as const,
+    queryKey: [
+      "networkPaths",
+      filters.serialisedFilters,
+      domain,
+      searchPattern,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchNetworkPathsFromServer(filters.app!, domain, searchPattern, filters)
+      const result = await fetchNetworkPathsFromServer(
+        filters.app!,
+        domain,
+        searchPattern,
+        filters,
+      );
       if (result.status === NetworkPathsApiStatus.Error) {
-        throw new Error("Failed to fetch paths")
+        throw new Error("Failed to fetch paths");
       }
       if (result.status === NetworkPathsApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data.results as string[]
+      return result.data.results as string[];
     },
     enabled: filters.ready && !!filters.app && domain !== "",
-  })
+  });
 }
 
 export function useNetworkStatusPlotQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkStatusPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchNetworkOverviewStatusCodesPlotFromServer(filters)
+      const result =
+        await fetchNetworkOverviewStatusCodesPlotFromServer(filters);
       if (result.status === NetworkOverviewStatusCodesPlotApiStatus.Error) {
-        throw new Error("Failed to fetch status plot")
+        throw new Error("Failed to fetch status plot");
       }
       if (result.status === NetworkOverviewStatusCodesPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && !!filters.app,
-  })
+  });
 }
 
 export function useNetworkTimelineQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkTimeline", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchNetworkTimelinePlotFromServer(filters, 10)
+      const result = await fetchNetworkTimelinePlotFromServer(filters, 10);
       if (result.status === NetworkTimelinePlotApiStatus.Error) {
-        throw new Error("Failed to fetch timeline")
+        throw new Error("Failed to fetch timeline");
       }
       if (result.status === NetworkTimelinePlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && !!filters.app,
-  })
+  });
 }
 
 // ─── Network: Details ────────────────────────────────────────────────────
 
 export function useNetworkEndpointLatencyQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["networkEndpointLatency", filters.serialisedFilters, domain, path] as const,
+    queryKey: [
+      "networkEndpointLatency",
+      filters.serialisedFilters,
+      domain,
+      path,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchNetworkEndpointLatencyPlotFromServer(filters, domain, path)
+      const result = await fetchNetworkEndpointLatencyPlotFromServer(
+        filters,
+        domain,
+        path,
+      );
       if (result.status === NetworkEndpointLatencyPlotApiStatus.Error) {
-        throw new Error("Failed to fetch latency")
+        throw new Error("Failed to fetch latency");
       }
       if (result.status === NetworkEndpointLatencyPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && domain !== "" && path !== "",
-  })
+  });
 }
 
-export function useNetworkEndpointStatusCodesQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useNetworkEndpointStatusCodesQuery(
+  domain: string,
+  path: string,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["networkEndpointStatusCodes", filters.serialisedFilters, domain, path] as const,
+    queryKey: [
+      "networkEndpointStatusCodes",
+      filters.serialisedFilters,
+      domain,
+      path,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchNetworkEndpointStatusCodesPlotFromServer(filters, domain, path)
+      const result = await fetchNetworkEndpointStatusCodesPlotFromServer(
+        filters,
+        domain,
+        path,
+      );
       if (result.status === NetworkEndpointStatusCodesPlotApiStatus.Error) {
-        throw new Error("Failed to fetch status codes")
+        throw new Error("Failed to fetch status codes");
       }
       if (result.status === NetworkEndpointStatusCodesPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && domain !== "" && path !== "",
-  })
+  });
 }
 
 export function useNetworkEndpointTimelineQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["networkEndpointTimeline", filters.serialisedFilters, domain, path] as const,
+    queryKey: [
+      "networkEndpointTimeline",
+      filters.serialisedFilters,
+      domain,
+      path,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchNetworkEndpointTimelinePlotFromServer(filters, domain, path)
+      const result = await fetchNetworkEndpointTimelinePlotFromServer(
+        filters,
+        domain,
+        path,
+      );
       if (result.status === NetworkEndpointTimelinePlotApiStatus.Error) {
-        throw new Error("Failed to fetch endpoint timeline")
+        throw new Error("Failed to fetch endpoint timeline");
       }
       if (result.status === NetworkEndpointTimelinePlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && domain !== "" && path !== "",
-  })
+  });
 }
 
 // ─── Network: Trends ─────────────────────────────────────────────────────
 
 export function useNetworkTrendsQuery(active: boolean) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkTrends", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchNetworkTrendsFromServer(filters, 15)
+      const result = await fetchNetworkTrendsFromServer(filters, 15);
       if (result.status === NetworkTrendsApiStatus.Error) {
-        throw new Error("Failed to fetch trends")
+        throw new Error("Failed to fetch trends");
       }
       if (result.status === NetworkTrendsApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && active,
-  })
+  });
 }
 
 // ─── Plot: Overview ──────────────────────────────────────────────────────
 
 export function useExceptionsOverviewPlotQuery(exceptionsType: ExceptionsType) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["exceptionsOverviewPlot", exceptionsType, filters.serialisedFilters] as const,
+    queryKey: [
+      "exceptionsOverviewPlot",
+      exceptionsType,
+      filters.serialisedFilters,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchExceptionsOverviewPlotFromServer(exceptionsType, filters)
+      const result = await fetchExceptionsOverviewPlotFromServer(
+        exceptionsType,
+        filters,
+      );
       if (result.status === ExceptionsOverviewPlotApiStatus.Error) {
-        throw new Error("Failed to fetch exceptions plot")
+        throw new Error("Failed to fetch exceptions plot");
       }
       if (result.status === ExceptionsOverviewPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return mapPlotData(result.data)
+      return mapPlotData(result.data);
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 export function useBugReportsOverviewPlotQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["bugReportsOverviewPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchBugReportsOverviewPlotFromServer(filters)
+      const result = await fetchBugReportsOverviewPlotFromServer(filters);
       if (result.status === BugReportsOverviewPlotApiStatus.Error) {
-        throw new Error("Failed to fetch bug reports plot")
+        throw new Error("Failed to fetch bug reports plot");
       }
       if (result.status === BugReportsOverviewPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return mapPlotData(result.data)
+      return mapPlotData(result.data);
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 export function useSessionTimelinesOverviewPlotQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["sessionTimelinesOverviewPlot", filters.serialisedFilters] as const,
+    queryKey: [
+      "sessionTimelinesOverviewPlot",
+      filters.serialisedFilters,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchSessionTimelinesOverviewPlotFromServer(filters)
+      const result = await fetchSessionTimelinesOverviewPlotFromServer(filters);
       if (result.status === SessionTimelinesOverviewPlotApiStatus.Error) {
-        throw new Error("Failed to fetch session timelines plot")
+        throw new Error("Failed to fetch session timelines plot");
       }
       if (result.status === SessionTimelinesOverviewPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return mapPlotData(result.data)
+      return mapPlotData(result.data);
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 export function useSessionsVsExceptionsPlotQuery() {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["sessionsVsExceptionsPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchSessionsVsExceptionsPlotFromServer(filters)
+      const result = await fetchSessionsVsExceptionsPlotFromServer(filters);
       if (result.status === SessionsVsExceptionsPlotApiStatus.Error) {
-        throw new Error("Failed to fetch sessions vs exceptions plot")
+        throw new Error("Failed to fetch sessions vs exceptions plot");
       }
       if (result.status === SessionsVsExceptionsPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Plot: Exception Details ─────────────────────────────────────────────
 
-export function useExceptionsDetailsPlotQuery(exceptionsType: ExceptionsType, exceptionsGroupId: string) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useExceptionsDetailsPlotQuery(
+  exceptionsType: ExceptionsType,
+  exceptionsGroupId: string,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["exceptionsDetailsPlot", exceptionsType, exceptionsGroupId, filters.serialisedFilters] as const,
+    queryKey: [
+      "exceptionsDetailsPlot",
+      exceptionsType,
+      exceptionsGroupId,
+      filters.serialisedFilters,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchExceptionsDetailsPlotFromServer(exceptionsType, exceptionsGroupId, filters)
+      const result = await fetchExceptionsDetailsPlotFromServer(
+        exceptionsType,
+        exceptionsGroupId,
+        filters,
+      );
       if (result.status === ExceptionsDetailsPlotApiStatus.Error) {
-        throw new Error("Failed to fetch exceptions details plot")
+        throw new Error("Failed to fetch exceptions details plot");
       }
       if (result.status === ExceptionsDetailsPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return mapPlotData(result.data)
+      return mapPlotData(result.data);
     },
     enabled: filters.ready && exceptionsGroupId !== "",
-  })
+  });
 }
 
-export function useExceptionsDistributionPlotQuery(exceptionsType: ExceptionsType, exceptionsGroupId: string) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useExceptionsDistributionPlotQuery(
+  exceptionsType: ExceptionsType,
+  exceptionsGroupId: string,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["exceptionsDistributionPlot", exceptionsType, exceptionsGroupId, filters.serialisedFilters] as const,
+    queryKey: [
+      "exceptionsDistributionPlot",
+      exceptionsType,
+      exceptionsGroupId,
+      filters.serialisedFilters,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchExceptionsDistributionPlotFromServer(exceptionsType, exceptionsGroupId, filters)
+      const result = await fetchExceptionsDistributionPlotFromServer(
+        exceptionsType,
+        exceptionsGroupId,
+        filters,
+      );
       if (result.status === ExceptionsDistributionPlotApiStatus.Error) {
-        throw new Error("Failed to fetch distribution plot")
+        throw new Error("Failed to fetch distribution plot");
       }
       if (result.status === ExceptionsDistributionPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return parseDistributionPlot(result.data)
+      return parseDistributionPlot(result.data);
     },
     enabled: filters.ready && exceptionsGroupId !== "",
-  })
+  });
 }
 
 // ─── Plot: Span Metrics ──────────────────────────────────────────────────
 
 export function useSpanMetricsPlotQuery(quantile: RootSpanMetricsQuantile) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["spanMetricsPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchSpanMetricsPlotFromServer(filters)
+      const result = await fetchSpanMetricsPlotFromServer(filters);
       if (result.status === SpanMetricsPlotApiStatus.Error) {
-        throw new Error("Failed to fetch span metrics plot")
+        throw new Error("Failed to fetch span metrics plot");
       }
       if (result.status === SpanMetricsPlotApiStatus.NoData) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
-    select: (rawData) => (rawData ? transformSpanMetricsPlotData(rawData, quantile) : null),
+    select: (rawData) =>
+      rawData ? transformSpanMetricsPlotData(rawData, quantile) : null,
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Alerts ───────────────────────────────────────────────────
 
-const ALERTS_LIMIT = 5
+const ALERTS_LIMIT = 5;
 
 export function useAlertsOverviewQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["alertsOverview", filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "alertsOverview",
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchAlertsOverviewFromServer(filters, ALERTS_LIMIT, paginationOffset)
+      const result = await fetchAlertsOverviewFromServer(
+        filters,
+        ALERTS_LIMIT,
+        paginationOffset,
+      );
       if (result.status === AlertsOverviewApiStatus.Error) {
-        throw new Error("Failed to fetch alerts")
+        throw new Error("Failed to fetch alerts");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Bug Reports ──────────────────────────────────────────────
 
-const BUG_REPORTS_LIMIT = 5
+const BUG_REPORTS_LIMIT = 5;
 
 export function useBugReportsOverviewQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["bugReportsOverview", filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "bugReportsOverview",
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchBugReportsOverviewFromServer(filters, BUG_REPORTS_LIMIT, paginationOffset)
+      const result = await fetchBugReportsOverviewFromServer(
+        filters,
+        BUG_REPORTS_LIMIT,
+        paginationOffset,
+      );
       if (result.status === BugReportsOverviewApiStatus.Error) {
-        throw new Error("Failed to fetch bug reports")
+        throw new Error("Failed to fetch bug reports");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Exceptions Overview ──────────────────────────────────────
 
-const EXCEPTIONS_OVERVIEW_LIMIT = 5
+const EXCEPTIONS_OVERVIEW_LIMIT = 5;
 
-export function useExceptionsOverviewQuery(exceptionsType: ExceptionsType, paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useExceptionsOverviewQuery(
+  exceptionsType: ExceptionsType,
+  paginationOffset: number,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["exceptionsOverview", exceptionsType, filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "exceptionsOverview",
+      exceptionsType,
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchExceptionsOverviewFromServer(exceptionsType, filters, EXCEPTIONS_OVERVIEW_LIMIT, paginationOffset)
+      const result = await fetchExceptionsOverviewFromServer(
+        exceptionsType,
+        filters,
+        EXCEPTIONS_OVERVIEW_LIMIT,
+        paginationOffset,
+      );
       if (result.status === ExceptionsOverviewApiStatus.Error) {
-        throw new Error("Failed to fetch exceptions overview")
+        throw new Error("Failed to fetch exceptions overview");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Traces ───────────────────────────────────────────────────
 
-const TRACES_LIMIT = 5
+const TRACES_LIMIT = 5;
 
 export function useSpansQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["spans", filters.serialisedFilters, paginationOffset] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchSpansFromServer(filters, TRACES_LIMIT, paginationOffset)
+      const result = await fetchSpansFromServer(
+        filters,
+        TRACES_LIMIT,
+        paginationOffset,
+      );
       if (result.status === SpansApiStatus.Error) {
-        throw new Error("Failed to fetch spans")
+        throw new Error("Failed to fetch spans");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Session Timelines ────────────────────────────────────────
 
-const SESSION_TIMELINES_LIMIT = 5
+const SESSION_TIMELINES_LIMIT = 5;
 
 export function useSessionTimelinesOverviewQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["sessionTimelinesOverview", filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "sessionTimelinesOverview",
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchSessionTimelinesOverviewFromServer(filters, SESSION_TIMELINES_LIMIT, paginationOffset)
+      const result = await fetchSessionTimelinesOverviewFromServer(
+        filters,
+        SESSION_TIMELINES_LIMIT,
+        paginationOffset,
+      );
       if (result.status === SessionTimelinesOverviewApiStatus.Error) {
-        throw new Error("Failed to fetch session timelines")
+        throw new Error("Failed to fetch session timelines");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready,
-  })
+  });
 }
 
 // ─── Paginated: Crash/ANR Details ────────────────────────────────────────
 
-const EXCEPTIONS_DETAILS_LIMIT = 1
+const EXCEPTIONS_DETAILS_LIMIT = 1;
 
-export function useCrashDetailsQuery(exceptionsGroupId: string, paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useCrashDetailsQuery(
+  exceptionsGroupId: string,
+  paginationOffset: number,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["crashDetails", exceptionsGroupId, filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "crashDetails",
+      exceptionsGroupId,
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchExceptionsDetailsFromServer(ExceptionsType.Crash, exceptionsGroupId, filters, EXCEPTIONS_DETAILS_LIMIT, paginationOffset)
+      const result = await fetchExceptionsDetailsFromServer(
+        ExceptionsType.Crash,
+        exceptionsGroupId,
+        filters,
+        EXCEPTIONS_DETAILS_LIMIT,
+        paginationOffset,
+      );
       if (result.status === ExceptionsDetailsApiStatus.Error) {
-        throw new Error("Failed to fetch crash details")
+        throw new Error("Failed to fetch crash details");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && exceptionsGroupId !== "",
-  })
+  });
 }
 
-export function useAnrDetailsQuery(exceptionsGroupId: string, paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters)
+export function useAnrDetailsQuery(
+  exceptionsGroupId: string,
+  paginationOffset: number,
+) {
+  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["anrDetails", exceptionsGroupId, filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "anrDetails",
+      exceptionsGroupId,
+      filters.serialisedFilters,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      const result = await fetchExceptionsDetailsFromServer(ExceptionsType.Anr, exceptionsGroupId, filters, EXCEPTIONS_DETAILS_LIMIT, paginationOffset)
+      const result = await fetchExceptionsDetailsFromServer(
+        ExceptionsType.Anr,
+        exceptionsGroupId,
+        filters,
+        EXCEPTIONS_DETAILS_LIMIT,
+        paginationOffset,
+      );
       if (result.status === ExceptionsDetailsApiStatus.Error) {
-        throw new Error("Failed to fetch ANR details")
+        throw new Error("Failed to fetch ANR details");
       }
-      return result.data
+      return result.data;
     },
     enabled: filters.ready && exceptionsGroupId !== "",
-  })
+  });
 }
 
 // ─── Teams ──────────────────────────────────────────────────────────────
@@ -715,13 +899,13 @@ export function useTeamsQuery() {
   return useQuery({
     queryKey: ["teams"] as const,
     queryFn: async () => {
-      const result = await fetchTeamsFromServer()
+      const result = await fetchTeamsFromServer();
       if (result.status === TeamsApiStatus.Error) {
-        throw new Error("Failed to fetch teams")
+        throw new Error("Failed to fetch teams");
       }
-      return result.data
+      return result.data;
     },
-  })
+  });
 }
 
 // ─── Trace Details ──────────────────────────────────────────────────────
@@ -730,14 +914,14 @@ export function useTraceQuery(appId: string, traceId: string) {
   return useQuery({
     queryKey: ["trace", appId, traceId] as const,
     queryFn: async () => {
-      const result = await fetchTraceFromServer(appId, traceId)
+      const result = await fetchTraceFromServer(appId, traceId);
       if (result.status === TraceApiStatus.Error) {
-        throw new Error("Failed to fetch trace")
+        throw new Error("Failed to fetch trace");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId && !!traceId,
-  })
+  });
 }
 
 // ─── Session Timeline ───────────────────────────────────────────────────
@@ -746,30 +930,38 @@ export function useSessionTimelineQuery(appId: string, sessionId: string) {
   return useQuery({
     queryKey: ["sessionTimeline", appId, sessionId] as const,
     queryFn: async () => {
-      const result = await fetchSessionTimelineFromServer(appId, sessionId)
+      const result = await fetchSessionTimelineFromServer(appId, sessionId);
       if (result.status === SessionTimelineApiStatus.Error) {
-        throw new Error("Failed to fetch session timeline")
+        throw new Error("Failed to fetch session timeline");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId && !!sessionId,
-  })
+  });
 }
 
 // ─── Exception Group Common Path ────────────────────────────────────────
 
-export function useExceptionGroupCommonPathQuery(type: ExceptionsType, appId: string, groupId: string) {
+export function useExceptionGroupCommonPathQuery(
+  type: ExceptionsType,
+  appId: string,
+  groupId: string,
+) {
   return useQuery<ExceptionGroupCommonPath>({
     queryKey: ["exceptionGroupCommonPath", type, appId, groupId] as const,
     queryFn: async () => {
-      const result = await fetchExceptionGroupCommonPathFromServer(type, appId, groupId)
+      const result = await fetchExceptionGroupCommonPathFromServer(
+        type,
+        appId,
+        groupId,
+      );
       if (result.status === ExceptionGroupCommonPathApiStatus.Error) {
-        throw new Error("Failed to fetch common path")
+        throw new Error("Failed to fetch common path");
       }
-      return result.data as ExceptionGroupCommonPath
+      return result.data as ExceptionGroupCommonPath;
     },
     enabled: !!appId && !!groupId,
-  })
+  });
 }
 
 // ─── Bug Report ─────────────────────────────────────────────────────────
@@ -778,29 +970,39 @@ export function useBugReportQuery(appId: string, bugReportId: string) {
   return useQuery({
     queryKey: ["bugReport", appId, bugReportId] as const,
     queryFn: async () => {
-      const result = await fetchBugReportFromServer(appId, bugReportId)
+      const result = await fetchBugReportFromServer(appId, bugReportId);
       if (result.status === BugReportApiStatus.Error) {
-        throw new Error("Failed to fetch bug report")
+        throw new Error("Failed to fetch bug report");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId && !!bugReportId,
-  })
+  });
 }
 
 export function useToggleBugReportStatusMutation() {
   return useMutation({
-    mutationFn: async (params: { appId: string; bugReportId: string; newStatus: number }) => {
-      const result = await updateBugReportStatusFromServer(params.appId, params.bugReportId, params.newStatus)
+    mutationFn: async (params: {
+      appId: string;
+      bugReportId: string;
+      newStatus: number;
+    }) => {
+      const result = await updateBugReportStatusFromServer(
+        params.appId,
+        params.bugReportId,
+        params.newStatus,
+      );
       if (result.status === UpdateBugReportStatusApiStatus.Error) {
-        throw new Error("Failed to update bug report status")
+        throw new Error("Failed to update bug report status");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["bugReport", variables.appId, variables.bugReportId] })
-      queryClient.invalidateQueries({ queryKey: ["bugReportsOverview"] })
+      queryClient.invalidateQueries({
+        queryKey: ["bugReport", variables.appId, variables.bugReportId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["bugReportsOverview"] });
     },
-  })
+  });
 }
 
 // ─── Notification Preferences ───────────────────────────────────────────
@@ -809,27 +1011,27 @@ export function useNotifPrefsQuery() {
   return useQuery({
     queryKey: ["notifPrefs"] as const,
     queryFn: async () => {
-      const result = await fetchNotifPrefsFromServer()
+      const result = await fetchNotifPrefsFromServer();
       if (result.status === FetchNotifPrefsApiStatus.Error) {
-        throw new Error("Failed to fetch notification preferences")
+        throw new Error("Failed to fetch notification preferences");
       }
-      return result.data
+      return result.data;
     },
-  })
+  });
 }
 
 export function useSaveNotifPrefsMutation() {
   return useMutation({
     mutationFn: async (params: { notifPrefs: typeof emptyNotifPrefs }) => {
-      const result = await updateNotifPrefsFromServer(params.notifPrefs)
+      const result = await updateNotifPrefsFromServer(params.notifPrefs);
       if (result.status === UpdateNotifPrefsApiStatus.Error) {
-        throw new Error("Failed to save notification preferences")
+        throw new Error("Failed to save notification preferences");
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["notifPrefs"] })
+      queryClient.invalidateQueries({ queryKey: ["notifPrefs"] });
     },
-  })
+  });
 }
 
 // ─── Create App ─────────────────────────────────────────────────────────
@@ -837,16 +1039,16 @@ export function useSaveNotifPrefsMutation() {
 export function useCreateAppMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; appName: string }) => {
-      const result = await createAppFromServer(params.teamId, params.appName)
+      const result = await createAppFromServer(params.teamId, params.appName);
       if (result.status === CreateAppApiStatus.Error) {
-        throw new Error(result.error ?? "Failed to create app")
+        throw new Error(result.error ?? "Failed to create app");
       }
-      return result.data
+      return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
-  })
+  });
 }
 
 // ─── Create Team ────────────────────────────────────────────────────────
@@ -854,16 +1056,19 @@ export function useCreateAppMutation() {
 export function useCreateTeamMutation() {
   return useMutation({
     mutationFn: async (params: { teamName: string }) => {
-      const result = await createTeamFromServer(params.teamName)
+      const result = await createTeamFromServer(params.teamName);
       if (result.status === CreateTeamApiStatus.Error) {
-        throw new Error(result.error ?? "Failed to create team")
+        throw new Error(result.error ?? "Failed to create team");
       }
-      return result.data
+      return result.data as Team;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] })
+    onSuccess: (newTeam) => {
+      queryClient.setQueryData<Team[]>(["teams"], (old) =>
+        old ? [...old, newTeam] : [newTeam],
+      );
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
-  })
+  });
 }
 
 // ─── Apps Store: Reads ──────────────────────────────────────────────────
@@ -872,47 +1077,52 @@ export function useAuthzAndMembersQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["authzAndMembers", teamId] as const,
     queryFn: async () => {
-      const result = await fetchAuthzAndMembersFromServer(teamId!)
+      const result = await fetchAuthzAndMembersFromServer(teamId!);
       if (result.status === AuthzAndMembersApiStatus.Error) {
-        throw new Error("Failed to fetch authz and members")
+        throw new Error("Failed to fetch authz and members");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!teamId,
-  })
+  });
 }
 
 export function useAppRetentionQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["appRetention", appId] as const,
     queryFn: async () => {
-      const result = await fetchAppRetentionFromServer(appId!)
+      const result = await fetchAppRetentionFromServer(appId!);
       if (result.status === FetchAppRetentionApiStatus.Error) {
-        throw new Error("Failed to fetch app retention")
+        throw new Error("Failed to fetch app retention");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId,
-  })
+  });
 }
 
 export function useSdkConfigQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["sdkConfig", appId] as const,
     queryFn: async () => {
-      const result = await fetchSdkConfigFromServer(appId!)
+      const result = await fetchSdkConfigFromServer(appId!);
       if (result.status === SdkConfigApiStatus.Error) {
-        throw new Error("Failed to fetch SDK config")
+        throw new Error("Failed to fetch SDK config");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!appId,
-  })
+  });
 }
 
-type BillingInfoData = Awaited<ReturnType<typeof fetchBillingInfoFromServer>>["data"]
+type BillingInfoData = Awaited<
+  ReturnType<typeof fetchBillingInfoFromServer>
+>["data"];
 
-type RefetchInterval = number | false | ((q: Query<BillingInfoData>) => number | false)
+type RefetchInterval =
+  | number
+  | false
+  | ((q: Query<BillingInfoData>) => number | false);
 
 export function useBillingInfoQuery(
   teamId: string | undefined,
@@ -921,90 +1131,117 @@ export function useBillingInfoQuery(
   return useQuery({
     queryKey: ["billingInfo", teamId] as const,
     queryFn: async () => {
-      const result = await fetchBillingInfoFromServer(teamId!)
+      const result = await fetchBillingInfoFromServer(teamId!);
       if (result.status === FetchBillingInfoApiStatus.Error) {
-        throw new Error("Failed to fetch billing info")
+        throw new Error("Failed to fetch billing info");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!teamId,
     refetchInterval: opts?.refetchInterval,
-  })
+  });
 }
 
 // ─── Apps Store: Mutations ──────────────────────────────────────────────
 
 export function useUpdateAppRetentionMutation() {
   return useMutation({
-    mutationFn: async (params: { appId: string; retention: typeof emptyAppRetention }) => {
-      const result = await updateAppRetentionFromServer(params.appId, params.retention)
+    mutationFn: async (params: {
+      appId: string;
+      retention: typeof emptyAppRetention;
+    }) => {
+      const result = await updateAppRetentionFromServer(
+        params.appId,
+        params.retention,
+      );
       if (result.status === UpdateAppRetentionApiStatus.Error) {
-        throw new Error("Failed to update app retention")
+        throw new Error("Failed to update app retention");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["appRetention", variables.appId] })
+      queryClient.invalidateQueries({
+        queryKey: ["appRetention", variables.appId],
+      });
     },
-  })
+  });
 }
 
 export function useChangeAppNameMutation() {
   return useMutation({
     mutationFn: async (params: { appId: string; appName: string }) => {
-      const result = await changeAppNameFromServer(params.appId, params.appName)
+      const result = await changeAppNameFromServer(
+        params.appId,
+        params.appName,
+      );
       if (result.status === AppNameChangeApiStatus.Error) {
-        throw new Error("Failed to change app name")
+        throw new Error("Failed to change app name");
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
-  })
+  });
 }
 
 export function useChangeAppApiKeyMutation() {
   return useMutation({
     mutationFn: async (params: { appId: string }) => {
-      const result = await changeAppApiKeyFromServer(params.appId)
+      const result = await changeAppApiKeyFromServer(params.appId);
       if (result.status === AppApiKeyChangeApiStatus.Error) {
-        throw new Error("Failed to change app API key")
+        throw new Error("Failed to change app API key");
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
-  })
+  });
 }
 
 export function useUpdateAppThresholdPrefsMutation() {
   return useMutation({
-    mutationFn: async (params: { appId: string; prefs: typeof defaultAppThresholdPrefs }) => {
-      const result = await updateAppThresholdPrefsFromServer(params.appId, params.prefs)
+    mutationFn: async (params: {
+      appId: string;
+      prefs: typeof defaultAppThresholdPrefs;
+    }) => {
+      const result = await updateAppThresholdPrefsFromServer(
+        params.appId,
+        params.prefs,
+      );
       if (result.status === UpdateAppThresholdPrefsApiStatus.Error) {
-        throw new Error("Failed to update threshold prefs")
+        throw new Error("Failed to update threshold prefs");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["appThresholdPrefs", variables.appId] })
+      queryClient.invalidateQueries({
+        queryKey: ["appThresholdPrefs", variables.appId],
+      });
     },
-  })
+  });
 }
 
 // ─── SDK Configurator ───────────────────────────────────────────────────
 
 export function useSaveSdkConfigMutation() {
   return useMutation({
-    mutationFn: async (params: { appId: string; config: Partial<SdkConfig> }) => {
-      const result = await updateSdkConfigFromServer(params.appId, params.config)
+    mutationFn: async (params: {
+      appId: string;
+      config: Partial<SdkConfig>;
+    }) => {
+      const result = await updateSdkConfigFromServer(
+        params.appId,
+        params.config,
+      );
       if (result.status === UpdateSdkConfigApiStatus.Error) {
-        throw new Error("Failed to save SDK config")
+        throw new Error("Failed to save SDK config");
       }
-      return result.data
+      return result.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["sdkConfig", variables.appId] })
+      queryClient.invalidateQueries({
+        queryKey: ["sdkConfig", variables.appId],
+      });
     },
-  })
+  });
 }
 
 // ─── Team Page: Reads ───────────────────────────────────────────────────
@@ -1013,42 +1250,50 @@ export function usePendingInvitesQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["pendingInvites", teamId] as const,
     queryFn: async () => {
-      const result = await fetchPendingInvitesFromServer(teamId!)
+      const result = await fetchPendingInvitesFromServer(teamId!);
       if (result.status === PendingInvitesApiStatus.Error) {
-        throw new Error("Failed to fetch pending invites")
+        throw new Error("Failed to fetch pending invites");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!teamId,
-  })
+  });
 }
 
-export function useTeamSlackConnectUrlQuery(userId: string | undefined, teamId: string | undefined, redirectUrl: string) {
+export function useTeamSlackConnectUrlQuery(
+  userId: string | undefined,
+  teamId: string | undefined,
+  redirectUrl: string,
+) {
   return useQuery({
     queryKey: ["teamSlackConnectUrl", teamId] as const,
     queryFn: async () => {
-      const result = await fetchTeamSlackConnectUrlFromServer(userId!, teamId!, redirectUrl)
+      const result = await fetchTeamSlackConnectUrlFromServer(
+        userId!,
+        teamId!,
+        redirectUrl,
+      );
       if (result.status === FetchTeamSlackConnectUrlApiStatus.Error) {
-        throw new Error("Failed to fetch Slack connect URL")
+        throw new Error("Failed to fetch Slack connect URL");
       }
-      return result.data.url as string
+      return result.data.url as string;
     },
     enabled: !!userId && !!teamId,
-  })
+  });
 }
 
 export function useTeamSlackStatusQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["teamSlackStatus", teamId] as const,
     queryFn: async () => {
-      const result = await fetchTeamSlackStatusFromServer(teamId!)
+      const result = await fetchTeamSlackStatusFromServer(teamId!);
       if (result.status === FetchTeamSlackStatusApiStatus.Error) {
-        throw new Error("Failed to fetch Slack status")
+        throw new Error("Failed to fetch Slack status");
       }
-      return result.data
+      return result.data;
     },
     enabled: !!teamId,
-  })
+  });
 }
 
 // ─── Team Page: Mutations ───────────────────────────────────────────────
@@ -1056,111 +1301,156 @@ export function useTeamSlackStatusQuery(teamId: string | undefined) {
 export function useChangeTeamNameMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; newName: string }) => {
-      const result = await changeTeamNameFromServer(params.teamId, params.newName)
+      const result = await changeTeamNameFromServer(
+        params.teamId,
+        params.newName,
+      );
       if (result.status === TeamNameChangeApiStatus.Error) {
-        throw new Error("Failed to change team name")
+        throw new Error("Failed to change team name");
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
-  })
+  });
 }
 
 export function useInviteMemberMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string; email: string; role: string }) => {
-      const result = await inviteMemberFromServer(params.teamId, params.email, params.role)
+    mutationFn: async (params: {
+      teamId: string;
+      email: string;
+      role: string;
+    }) => {
+      const result = await inviteMemberFromServer(
+        params.teamId,
+        params.email,
+        params.role,
+      );
       if (result.status === InviteMemberApiStatus.Error) {
-        throw new Error("Failed to invite member")
+        throw new Error("Failed to invite member");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["authzAndMembers", variables.teamId] })
-      queryClient.invalidateQueries({ queryKey: ["pendingInvites", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["authzAndMembers", variables.teamId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["pendingInvites", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useRemoveMemberMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; memberId: string }) => {
-      const result = await removeMemberFromServer(params.teamId, params.memberId)
+      const result = await removeMemberFromServer(
+        params.teamId,
+        params.memberId,
+      );
       if (result.status === RemoveMemberApiStatus.Error) {
-        throw new Error("Failed to remove member")
+        throw new Error("Failed to remove member");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["authzAndMembers", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["authzAndMembers", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useResendPendingInviteMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; inviteId: string }) => {
-      const result = await resendPendingInviteFromServer(params.teamId, params.inviteId)
+      const result = await resendPendingInviteFromServer(
+        params.teamId,
+        params.inviteId,
+      );
       if (result.status === ResendPendingInviteApiStatus.Error) {
-        throw new Error("Failed to resend invite")
+        throw new Error("Failed to resend invite");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["pendingInvites", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["pendingInvites", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useRemovePendingInviteMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; inviteId: string }) => {
-      const result = await removePendingInviteFromServer(params.teamId, params.inviteId)
+      const result = await removePendingInviteFromServer(
+        params.teamId,
+        params.inviteId,
+      );
       if (result.status === RemovePendingInviteApiStatus.Error) {
-        throw new Error("Failed to remove invite")
+        throw new Error("Failed to remove invite");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["pendingInvites", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["pendingInvites", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useChangeRoleMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string; newRole: string; memberId: string }) => {
-      const result = await changeRoleFromServer(params.teamId, params.newRole, params.memberId)
+    mutationFn: async (params: {
+      teamId: string;
+      newRole: string;
+      memberId: string;
+    }) => {
+      const result = await changeRoleFromServer(
+        params.teamId,
+        params.newRole,
+        params.memberId,
+      );
       if (result.status === RoleChangeApiStatus.Error) {
-        throw new Error("Failed to change role")
+        throw new Error("Failed to change role");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["authzAndMembers", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["authzAndMembers", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useUpdateSlackStatusMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; status: boolean }) => {
-      const result = await updateTeamSlackStatusFromServer(params.teamId, params.status)
+      const result = await updateTeamSlackStatusFromServer(
+        params.teamId,
+        params.status,
+      );
       if (result.status === UpdateTeamSlackStatusApiStatus.Error) {
-        throw new Error("Failed to update Slack status")
+        throw new Error("Failed to update Slack status");
       }
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["teamSlackStatus", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["teamSlackStatus", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useTestSlackAlertMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
-      const result = await sendTestSlackAlertFromServer(params.teamId)
+      const result = await sendTestSlackAlertFromServer(params.teamId);
       if (result.status === TestSlackAlertApiStatus.Error) {
-        throw new Error("Failed to send test Slack alert")
+        throw new Error("Failed to send test Slack alert");
       }
     },
-  })
+  });
 }
 
 // ─── Usage Store: Reads ─────────────────────────────────────────────────
@@ -1169,31 +1459,31 @@ export function useUsageQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["usage", teamId] as const,
     queryFn: async () => {
-      const result = await fetchUsageFromServer(teamId!)
+      const result = await fetchUsageFromServer(teamId!);
       if (result.status === FetchUsageApiStatus.Error) {
-        throw new Error("Failed to fetch usage")
+        throw new Error("Failed to fetch usage");
       }
       if (result.status === FetchUsageApiStatus.NoApps) {
-        return null
+        return null;
       }
-      return result.data
+      return result.data;
     },
     enabled: !!teamId,
-  })
+  });
 }
 
 export function useUsagePermissionsQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["usagePermissions", teamId] as const,
     queryFn: async () => {
-      const result = await fetchAuthzAndMembersFromServer(teamId!)
+      const result = await fetchAuthzAndMembersFromServer(teamId!);
       if (result.status === AuthzAndMembersApiStatus.Error) {
-        throw new Error("Failed to fetch usage permissions")
+        throw new Error("Failed to fetch usage permissions");
       }
-      return { canChangePlan: result.data.can_change_billing === true }
+      return { canChangePlan: result.data.can_change_billing === true };
     },
     enabled: !!teamId,
-  })
+  });
 }
 
 // ─── Usage Store: Mutations ─────────────────────────────────────────────
@@ -1201,60 +1491,72 @@ export function useUsagePermissionsQuery(teamId: string | undefined) {
 export function useHandleUpgradeMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; successUrl: string }) => {
-      const result = await fetchCheckoutSessionFromServer(params.teamId, params.successUrl)
+      const result = await fetchCheckoutSessionFromServer(
+        params.teamId,
+        params.successUrl,
+      );
       if (result.status === FetchCheckoutSessionApiStatus.Error) {
-        throw new Error("Failed to create checkout session")
+        throw new Error("Failed to create checkout session");
       }
-      return result.data
+      return result.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["billingInfo", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["billingInfo", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useDowngradeToFreeMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
-      const result = await downgradeToFreeFromServer(params.teamId)
+      const result = await downgradeToFreeFromServer(params.teamId);
       if (result.status === DowngradeToFreeApiStatus.Error) {
-        throw new Error("Failed to downgrade to free")
+        throw new Error("Failed to downgrade to free");
       }
-      return result.data
+      return result.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["billingInfo", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["billingInfo", variables.teamId],
+      });
     },
-  })
+  });
 }
 
 export function useUndoDowngradeMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
-      const result = await undoDowngradeFromServer(params.teamId)
+      const result = await undoDowngradeFromServer(params.teamId);
       if (result.status === UndoDowngradeApiStatus.Error) {
-        throw new Error("Failed to undo cancellation")
+        throw new Error("Failed to undo cancellation");
       }
-      return result.data
+      return result.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["billingInfo", variables.teamId] })
+      queryClient.invalidateQueries({
+        queryKey: ["billingInfo", variables.teamId],
+      });
     },
-  })
+  });
 }
 
-export async function fetchCustomerPortalUrl(teamId: string, returnUrl: string): Promise<{ redirect?: string; error?: string }> {
-  const result = await fetchCustomerPortalUrlFromServer(teamId, returnUrl)
+export async function fetchCustomerPortalUrl(
+  teamId: string,
+  returnUrl: string,
+): Promise<{ redirect?: string; error?: string }> {
+  const result = await fetchCustomerPortalUrlFromServer(teamId, returnUrl);
 
   switch (result.status) {
     case FetchCustomerPortalUrlApiStatus.Success:
       if (result.data?.url) {
-        return { redirect: result.data.url }
+        return { redirect: result.data.url };
       }
-      return { error: "No portal URL returned." }
+      return { error: "No portal URL returned." };
     case FetchCustomerPortalUrlApiStatus.Error:
-      return { error: "Please try again." }
+      return { error: "Please try again." };
     default:
-      return { error: "Request was cancelled." }
+      return { error: "Request was cancelled." };
   }
 }


### PR DESCRIPTION
# Description

useCreateTeamMutation only called invalidateQueries(["teams"]) on success — an async refetch. CreateTeam.handleCreateTeam then immediately router.pushed to the new team's page, which mounted before the refetch completed. teams.find() returned undefined, `team` resolved to null, and the eagerly-evaluated `team!.name` references in dialog bodies and the rename input's defaultValue threw "Cannot read properties of null (reading 'name')". Happened in staging and not localhost due to lower latency in local.

onSuccess now writes the new team into the ["teams"] cache via setQueryData before invalidate, populating the cache synchronously so the new page sees fresh data on mount. The invalidate still runs to reconcile with the server.

Added three regression tests for the cache-hydration contract: appends to an existing cache, initializes when the cache is empty, and leaves the cache untouched on error.



