### PR TITLE
chore(ios): save measure related files in application support directory

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -301,6 +301,9 @@
 		CFEC97EE2D9A76A5000CFB68 /* MockMeasureInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BCF2362CB651C8003102DF /* MockMeasureInitializer.swift */; };
 		CFF2E6982F69246A003B5A66 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF2E6972F69246A003B5A66 /* Data+Extension.swift */; };
 		CFF5AE902ED5E912003BCA79 /* MeasureConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF5AE8F2ED5E912003BCA79 /* MeasureConfigTests.swift */; };
+		CFF77E672FB6CEE600564FDA /* AttachmentProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF77E662FB6CEE600564FDA /* AttachmentProcessorTests.swift */; };
+		CFF77E692FB6CEFF00564FDA /* SystemFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF77E682FB6CEFF00564FDA /* SystemFileManagerTests.swift */; };
+		CFF77E6C2FB6CFE500564FDA /* WebPEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF77E6A2FB6CFE500564FDA /* WebPEncoderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -672,6 +675,9 @@
 		CFEC97EC2D9A7642000CFB68 /* MeasureInternalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureInternalTests.swift; sourceTree = "<group>"; };
 		CFF2E6972F69246A003B5A66 /* Data+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extension.swift"; sourceTree = "<group>"; };
 		CFF5AE8F2ED5E912003BCA79 /* MeasureConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureConfigTests.swift; sourceTree = "<group>"; };
+		CFF77E662FB6CEE600564FDA /* AttachmentProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentProcessorTests.swift; sourceTree = "<group>"; };
+		CFF77E682FB6CEFF00564FDA /* SystemFileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemFileManagerTests.swift; sourceTree = "<group>"; };
+		CFF77E6A2FB6CFE500564FDA /* WebPEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPEncoderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -1130,10 +1136,11 @@
 		52B7F0F42D757F81001498BC /* Event */ = {
 			isa = PBXGroup;
 			children = (
+				CFF77E662FB6CEE600564FDA /* AttachmentProcessorTests.swift */,
 				6907519B2DC0F0B20085FDBA /* CrashReports */,
-				69C4496A2DACC7BE00E44CF4 /* InternalSignalCollectorTests.swift */,
 				52B7F0F22D757F81001498BC /* CustomEventCollectorTests.swift */,
 				52B7F0F32D757F81001498BC /* EventProcessorTests.swift */,
+				69C4496A2DACC7BE00E44CF4 /* InternalSignalCollectorTests.swift */,
 				CF4EA2D42EA243EB0020FC71 /* UserTriggeredEventCollectorTests.swift */,
 			);
 			path = Event;
@@ -1221,8 +1228,9 @@
 			isa = PBXGroup;
 			children = (
 				52B7F12A2D757F81001498BC /* LifecycleObserverTests.swift */,
-				52B7F12B2D757F81001498BC /* TimeProviderTests.swift */,
 				CFBF62702DB7B38100D5ADFB /* SwizzlingUtilityTests.swift */,
+				CFF77E682FB6CEFF00564FDA /* SystemFileManagerTests.swift */,
+				52B7F12B2D757F81001498BC /* TimeProviderTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1245,6 +1253,7 @@
 				CF1BB3B52DBA39CA00588506 /* Lifecycle */,
 				52B7F1222D757F81001498BC /* Mocks */,
 				52B7F1272D757F81001498BC /* Performance */,
+				CFF77E6B2FB6CFE500564FDA /* Screenshots */,
 				CFD88D2D2DAB80C30095115E /* Tracing */,
 				52B7F12C2D757F81001498BC /* Utils */,
 			);
@@ -1446,6 +1455,14 @@
 				CFE803B22F7A4E7600B15B47 /* SdkDebugLogWriter.swift */,
 			);
 			path = Logger;
+			sourceTree = "<group>";
+		};
+		CFF77E6B2FB6CFE500564FDA /* Screenshots */ = {
+			isa = PBXGroup;
+			children = (
+				CFF77E6A2FB6CFE500564FDA /* WebPEncoderTests.swift */,
+			);
+			path = Screenshots;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1886,6 +1903,7 @@
 				CF1BB4F52DDEFCCB00588506 /* ShakeBugReportCollectorTests.swift in Sources */,
 				CFD88D792DAFDA530095115E /* MockSpanStore.swift in Sources */,
 				52B7F1372D757F81001498BC /* UserAttributeProcessorTests.swift in Sources */,
+				CFF77E672FB6CEE600564FDA /* AttachmentProcessorTests.swift in Sources */,
 				CF123F8B2FAA121C0053856F /* MsrObjCSpanBuilderTests.swift in Sources */,
 				CF123F8C2FAA121C0053856F /* MsrObjCSpanTests.swift in Sources */,
 				52B7F16A2D757F81001498BC /* MockSystemFileManager.swift in Sources */,
@@ -1902,6 +1920,7 @@
 				52B7F1562D757F81001498BC /* MockBatchStore.swift in Sources */,
 				52B7F1642D757F81001498BC /* MockRandomizer.swift in Sources */,
 				52B7F16C2D757F81001498BC /* MockUserDefaultStorage.swift in Sources */,
+				CFF77E692FB6CEFF00564FDA /* SystemFileManagerTests.swift in Sources */,
 				CFD88D772DAFD0A70095115E /* MsrSpanBuilderTests.swift in Sources */,
 				52B7F1542D757F81001498BC /* MockAttributeProcessor.swift in Sources */,
 				CF7CABB92F278BF900A9DC30 /* MockHttpClient.swift in Sources */,
@@ -1960,6 +1979,7 @@
 				52B7F1752D757F81001498BC /* SessionManagerTests.swift in Sources */,
 				52B7F13A2D757F81001498BC /* DataCleanupServiceTests.swift in Sources */,
 				52B7F15B2D757F81001498BC /* MockCrashDataPersistence.swift in Sources */,
+				CFF77E6C2FB6CFE500564FDA /* WebPEncoderTests.swift in Sources */,
 				CF12A6902E97B0A9001C8112 /* AttributeValueValidatorTests.swift in Sources */,
 				52B7F14D2D757F81001498BC /* Attributes+Extension.swift in Sources */,
 				CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -387,9 +387,7 @@ extension Measure.Measure {
   #if compiler(>=5.3) && $NonescapableTypes
   public static func internalTrackEvent(data: inout [Swift.String : Any?], type: Swift.String, timestamp: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], userTriggered: Swift.Bool, sessionId: Swift.String?, threadName: Swift.String?, attachments: [Measure.MsrAttachment])
   #endif
-  #if compiler(>=5.3) && $NonescapableTypes
-  public static func internalAddLog(platform: Swift.String, message: Swift.String, error: (any Swift.Error)?)
-  #endif
+  public static func internalAddLog(platform: Swift.String, message: Swift.String)
   #if compiler(>=5.3) && $NonescapableTypes
   public static func internalTrackSpan(name: Swift.String, traceId: Swift.String, spanId: Swift.String, parentId: Swift.String?, startTime: Swift.Int64, endTime: Swift.Int64, duration: Swift.Int64, status: Swift.Int64, attributes: [Swift.String : Any?], userDefinedAttrs: [Swift.String : Measure.AttributeValue], checkpoints: [Swift.String : Swift.Int64], hasEnded: Swift.Bool, isSampled: Swift.Bool)
   #endif

--- a/ios/Sources/MeasureSDK/Swift/BugReport/AccelerometerShakeDetector.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/AccelerometerShakeDetector.swift
@@ -39,8 +39,10 @@ final class AccelerometerShakeDetector: ShakeDetector {
             if gForce > Double(self.configProvider.shakeAccelerationThreshold),
                Date().timeIntervalSince(self.lastShakeTime) > Double(self.configProvider.shakeMinTimeIntervalMs) / 1000 {
                 self.lastShakeTime = Date()
-                DispatchQueue.main.async {
-                    self.listener?.onShake()
+                if let listener = listener {
+                    DispatchQueue.main.async {
+                        listener.onShake()
+                    }
                 }
             }
         }

--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
@@ -95,10 +95,12 @@ final class BaseBugReportManager: BugReportManager {
         }
     }
 
-    private func clearState() {
-        self.localAttachments.forEach { attachment in
-            if let path = attachment.path {
-                systemFileManager.deleteFile(atPath: path)
+    private func clearState(_ shouldClearAttachments: Bool = true) {
+        if shouldClearAttachments {
+            self.localAttachments.forEach { attachment in
+                if let path = attachment.path {
+                    systemFileManager.deleteFile(atPath: path)
+                }
             }
         }
         self.localAttachments.removeAll()
@@ -111,17 +113,20 @@ extension BaseBugReportManager: BugReportingViewControllerDelegate {
     func bugReportingViewControllerDidDismiss(_ description: String?, attachments: [MsrAttachment]?) {
         self.bugReportingViewController = nil
         self.isBugReporterOpen = false
-        if let description = description, let attachments = attachments, let bugReportCollector = bugReportCollector {
-            bugReportCollector.trackBugReport(description: description, attachments: attachments, attributes: nil)
+        guard let description, let attachments, let bugReportCollector else {
+            clearState()
+            return
         }
-        clearState()
+
+        bugReportCollector.trackBugReport(description: description, attachments: attachments, attributes: nil)
+        clearState(false)
     }
 
     func bugReportingViewControllerDidRequestScreenshot(_ description: String?, attachments: [MsrAttachment]) {
         self.bugReportingViewController = nil
         self.isBugReporterOpen = false
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, let floatingButtonViewController = self.floatingButtonViewController else { return }
+            guard let self = self else { return }
             self.localAttachments = attachments
             self.description = description
 
@@ -130,11 +135,11 @@ extension BaseBugReportManager: BugReportingViewControllerDelegate {
                                                                              attachments: self.localAttachments,
                                                                              configProvider: configProvider,
                                                                              systemFileManager: systemFileManager)
-            floatingButtonViewController.delegate = self
+            self.floatingButtonViewController?.delegate = self
 
-            if let window = UIWindow.keyWindow() {
-                floatingButtonViewController.view.frame = window.bounds
-                window.addSubview(floatingButtonViewController.view)
+            if let window = UIWindow.keyWindow(), let view = self.floatingButtonViewController?.view {
+                self.floatingButtonViewController?.view.frame = window.bounds
+                window.addSubview(view)
             }
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
@@ -22,15 +22,20 @@ final class BaseBugReportManager: BugReportManager {
     private var isBugReporterOpen: Bool = false
     private let configProvider: ConfigProvider
     private let idProvider: IdProvider
+    private let systemFileManager: SystemFileManager
     private var bugReportConfig: BugReportConfig?
     private weak var bugReportCollector: BaseBugReportCollector?
     private var hasBugReportFlowStarted = false
     private var description: String?
 
-    init(screenshotGenerator: ScreenshotGenerator, configProvider: ConfigProvider, idProvider: IdProvider) {
+    init(screenshotGenerator: ScreenshotGenerator,
+         configProvider: ConfigProvider,
+         idProvider: IdProvider,
+         systemFileManager: SystemFileManager) {
         self.screenshotGenerator = screenshotGenerator
         self.configProvider = configProvider
         self.idProvider = idProvider
+        self.systemFileManager = systemFileManager
     }
 
     func setBugReportCollector(_ collector: BaseBugReportCollector) {
@@ -74,7 +79,8 @@ final class BaseBugReportManager: BugReportManager {
                                                attachments: self.localAttachments,
                                                configProvider: configProvider,
                                                bugReportConfig: bugReportConfig ?? BugReportConfig.default,
-                                               idProvider: idProvider)
+                                               idProvider: idProvider,
+                                               systemFileManager: systemFileManager)
         bugVC.modalPresentationStyle = .fullScreen
         bugVC.delegate = self
         self.bugReportingViewController = bugVC
@@ -90,6 +96,11 @@ final class BaseBugReportManager: BugReportManager {
     }
 
     private func clearState() {
+        self.localAttachments.forEach { attachment in
+            if let path = attachment.path {
+                systemFileManager.deleteFile(atPath: path)
+            }
+        }
         self.localAttachments.removeAll()
         self.description = nil
         self.hasBugReportFlowStarted = false
@@ -100,8 +111,8 @@ extension BaseBugReportManager: BugReportingViewControllerDelegate {
     func bugReportingViewControllerDidDismiss(_ description: String?, attachments: [MsrAttachment]?) {
         self.bugReportingViewController = nil
         self.isBugReporterOpen = false
-        if let description = description, let attachments = attachments {
-            bugReportCollector?.trackBugReport(description: description, attachments: attachments, attributes: nil)
+        if let description = description, let attachments = attachments, let bugReportCollector = bugReportCollector {
+            bugReportCollector.trackBugReport(description: description, attachments: attachments, attributes: nil)
         }
         clearState()
     }
@@ -110,19 +121,20 @@ extension BaseBugReportManager: BugReportingViewControllerDelegate {
         self.bugReportingViewController = nil
         self.isBugReporterOpen = false
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, let floatingButtonViewController = self.floatingButtonViewController else { return }
             self.localAttachments = attachments
             self.description = description
 
             self.floatingButtonViewController = FloatingButtonViewController(screenshotGenerator: self.screenshotGenerator,
                                                                              bugReportConfig: bugReportConfig ?? BugReportConfig.default,
                                                                              attachments: self.localAttachments,
-                                                                             configProvider: configProvider)
-            self.floatingButtonViewController?.delegate = self
+                                                                             configProvider: configProvider,
+                                                                             systemFileManager: systemFileManager)
+            floatingButtonViewController.delegate = self
 
             if let window = UIWindow.keyWindow() {
-                self.floatingButtonViewController?.view.frame = window.bounds
-                window.addSubview(self.floatingButtonViewController!.view)
+                floatingButtonViewController.view.frame = window.bounds
+                window.addSubview(floatingButtonViewController.view)
             }
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
@@ -23,6 +23,7 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
     private let configProvider: ConfigProvider
     private let bugReportConfig: BugReportConfig
     private let idProvider: IdProvider
+    private let systemFileManager: SystemFileManager
 
     private let imagesCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -47,13 +48,19 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
     private var screenshotButtonTopToLabelConstraint: NSLayoutConstraint?
     private var galleryButtonTopToLabelConstraint: NSLayoutConstraint?
 
-    init(description: String?, attachments: [MsrAttachment] = [], configProvider: ConfigProvider, bugReportConfig: BugReportConfig, idProvider: IdProvider) {
+    init(description: String?,
+         attachments: [MsrAttachment] = [],
+         configProvider: ConfigProvider,
+         bugReportConfig: BugReportConfig,
+         idProvider: IdProvider,
+         systemFileManager: SystemFileManager) {
         self.textView.text = description
         placeholderLabel.isHidden = !textView.text.isEmpty
         self.attachments = attachments
         self.configProvider = configProvider
         self.bugReportConfig = bugReportConfig
         self.idProvider = idProvider
+        self.systemFileManager = systemFileManager
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -120,12 +127,12 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
     @objc private func sentTapped() {
         guard !textView.text.isEmpty && !attachments.isEmpty else { return }
         self.dismiss(animated: true) { [weak self] in
-            guard let delegate = self?.delegate,
-                  let text = self?.textView.text,
+            guard let self,
+                  let delegate = self.delegate,
+                  let text = self.textView.text,
                   !text.isEmpty,
-                  let attachment = self?.attachments,
-                  !attachment.isEmpty else { return }
-            delegate.bugReportingViewControllerDidDismiss(text, attachments: attachment)
+                  !self.attachments.isEmpty else { return }
+            delegate.bugReportingViewControllerDidDismiss(text, attachments: self.attachments)
         }
     }
 
@@ -206,8 +213,8 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
     @objc private func screenshotButtonTapped() {
         // Dismiss and notify delegate
         self.dismiss(animated: true) { [weak self] in
-            guard let self = self else { return }
-            self.delegate?.bugReportingViewControllerDidRequestScreenshot(textView.text, attachments: self.attachments)
+            guard let self = self, let delegate = delegate else { return }
+            delegate.bugReportingViewControllerDidRequestScreenshot(textView.text, attachments: self.attachments)
         }
     }
 
@@ -370,12 +377,20 @@ extension BugReportingViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ImageCell", for: indexPath) as? BugReportImageCell else {
             return UICollectionViewCell()
         }
-        if let data = attachments[indexPath.item].bytes, let image = UIImage(data: data) {
+        var imageData = attachments[indexPath.item].bytes
+        if imageData == nil, let path = attachments[indexPath.item].path {
+            imageData = systemFileManager.retrieveFile(atPath: path)
+        }
+        if let data = imageData, let image = UIImage(data: data) {
             cell.configure(with: image, isDarkModeEnabled: false)
             cell.onDelete = { [weak self] in
-                self?.attachments.remove(at: indexPath.item)
+                guard let self = self else { return }
+                if let path = self.attachments[indexPath.item].path {
+                    self.systemFileManager.deleteFile(atPath: path)
+                }
+                self.attachments.remove(at: indexPath.item)
                 collectionView.reloadData()
-                self?.updateActionButtonsState()
+                self.updateActionButtonsState()
             }
         }
         return cell

--- a/ios/Sources/MeasureSDK/Swift/BugReport/FloatingButtonViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/FloatingButtonViewController.swift
@@ -21,6 +21,7 @@ final class FloatingButtonViewController: UIViewController {
     private let topSafeArea: CGFloat = 60
     private var attachments = [MsrAttachment]()
     private let configProvider: ConfigProvider
+    private let systemFileManager: SystemFileManager
     weak var delegate: FloatingButtonViewControllerDelegate?
     private var lastKnownBounds: CGRect = .zero
 
@@ -28,11 +29,16 @@ final class FloatingButtonViewController: UIViewController {
         self.view = FloatingButtonContainerView(cancelButton: cancelButton, floatingButton: button)
     }
 
-    init(screenshotGenerator: ScreenshotGenerator, bugReportConfig: BugReportConfig, attachments: [MsrAttachment], configProvider: ConfigProvider) {
+    init(screenshotGenerator: ScreenshotGenerator,
+         bugReportConfig: BugReportConfig,
+         attachments: [MsrAttachment],
+         configProvider: ConfigProvider,
+         systemFileManager: SystemFileManager) {
         self.screenshotGenerator = screenshotGenerator
         self.bugReportConfig = bugReportConfig
         self.attachments = attachments
         self.configProvider = configProvider
+        self.systemFileManager = systemFileManager
 
         if #available(iOS 13.0, *) {
             button.setImage(UIImage(systemName: "camera.fill"), for: .normal)
@@ -143,7 +149,11 @@ final class FloatingButtonViewController: UIViewController {
     }
 
     private func animateScreenshotToButton(_ attachment: MsrAttachment) {
-        guard let window = view.window, let imageData = attachment.bytes, let screenshot = UIImage(data: imageData) else { return }
+        var imageData = attachment.bytes
+        if imageData == nil, let path = attachment.path {
+            imageData = systemFileManager.retrieveFile(atPath: path)
+        }
+        guard let window = view.window, let imageData = imageData, let screenshot = UIImage(data: imageData) else { return }
         let startFrame = CGRect(x: 0, y: 0 - 80, width: window.bounds.width, height: window.bounds.height)
         let imageView = UIImageView(image: screenshot)
         imageView.frame = startFrame

--- a/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
@@ -53,7 +53,7 @@ struct BaseConfigLoader: ConfigLoader {
     private func loadConfigFromDisk() -> BaseDynamicConfig? {
         guard let data = fileManager.retrieveFile(
             name: ConfigFileConstants.fileName,
-            folderName: ConfigFileConstants.folderName,
+            folderName: "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)",
             directory: ConfigFileConstants.directory
         ) else {
             return nil
@@ -71,7 +71,7 @@ struct BaseConfigLoader: ConfigLoader {
             let data = try encoder.encode(config)
             _ = fileManager.saveFile(data: data,
                                      name: ConfigFileConstants.fileName,
-                                     folderName: ConfigFileConstants.folderName,
+                                     folderName: "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)",
                                      directory: ConfigFileConstants.directory)
         } catch {
             logger.internalLog(level: .error, message: "ConfigLoader: Failed to save Dynamic config to disk.", error: error, data: nil)

--- a/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
@@ -44,7 +44,7 @@ final class BaseAttachmentProcessor: AttachmentProcessor {
         case .data:
             return MsrAttachment(name: attachmentName, type: attachmentType, size: Int64(image.count), id: uuid, bytes: image, path: nil)
         case .fileStorage:
-            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: "measure", directory: .applicationSupportDirectory) else {
+            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.attachmentsFolderName)", directory: .applicationSupportDirectory) else {
                 logger.internalLog(level: .error, message: "AttachmentProcessor: Failed to save compressed image to file storage.", error: nil, data: nil)
                 return nil
             }

--- a/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
@@ -44,7 +44,7 @@ final class BaseAttachmentProcessor: AttachmentProcessor {
         case .data:
             return MsrAttachment(name: attachmentName, type: attachmentType, size: Int64(image.count), id: uuid, bytes: image, path: nil)
         case .fileStorage:
-            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: "measure", directory: .documentDirectory) else {
+            guard let fileURL = fileManager.saveFile(data: image, name: attachmentName, folderName: "measure", directory: .applicationSupportDirectory) else {
                 logger.internalLog(level: .error, message: "AttachmentProcessor: Failed to save compressed image to file storage.", error: nil, data: nil)
                 return nil
             }

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -296,7 +296,7 @@ import UIKit
 
     func internalGetAttachmentDirectory() -> String? {
         guard let measureInternal = self.measureInternal else { return nil }
-        return measureInternal.getDocumentDirectoryPath()
+        return measureInternal.getAttachmentDirectoryPath()
     }
 
     func internalEncodeWebP(pixels: Data, width: Int, height: Int, completion: @escaping (Data?) -> Void) {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -447,7 +447,8 @@ final class BaseMeasureInitializer: MeasureInitializer {
                                                            userPermissionManager: userPermissionManager)
         self.bugReportManager = BaseBugReportManager(screenshotGenerator: screenshotGenerator,
                                                      configProvider: configProvider,
-                                                     idProvider: idProvider)
+                                                     idProvider: idProvider,
+                                                     systemFileManager: systemFileManager)
         self.bugReportCollector = BaseBugReportCollector(bugReportManager: bugReportManager,
                                                          signalProcessor: signalProcessor,
                                                          timeProvider: timeProvider,

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -432,8 +432,8 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
     }
 
-    func getDocumentDirectoryPath() -> String? {
-        return systemFileManager.getDirectoryPath(directory: FileManager.SearchPathDirectory.documentDirectory)
+    func getAttachmentDirectoryPath() -> String? {
+        return systemFileManager.getAttachmentDirectoryPath()
     }
 
     func encodeWebP(pixels: Data, width: Int, height: Int, completion: @escaping (Data?) -> Void) {

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -58,15 +58,7 @@ final class BaseSystemFileManager: SystemFileManager {
             logger.internalLog(level: .error, message: "SystemFileManager: Failed to create crash report directory.", error: error, data: nil)
             return nil
         }
-        let newCrashPath = crashDir.appendingPathComponent(crashDataFileName)
-        if !fileManager.fileExists(atPath: newCrashPath.path),
-           let oldCrashPath = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
-               .appendingPathComponent(cacheDirectoryName)
-               .appendingPathComponent(crashDataFileName),
-           fileManager.fileExists(atPath: oldCrashPath.path) {
-            try? fileManager.moveItem(at: oldCrashPath, to: newCrashPath)
-        }
-        return newCrashPath
+        return crashDir.appendingPathComponent(crashDataFileName)
     }
 
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL? {

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -12,6 +12,9 @@ enum ConfigFileConstants {
     static let folderName = "measure"
     static let directory: FileManager.SearchPathDirectory = .applicationSupportDirectory
     static let sdkDebugLogsFolderName = "sdk_debug_logs"
+    static let crashDataFolderName = "crash_data"
+    static let dynamicConfigFolderName = "dynamic_config"
+    static let attachmentsFolderName = "attachments"
 }
 
 /// A protocol that defines file system related operations.
@@ -46,15 +49,16 @@ final class BaseSystemFileManager: SystemFileManager {
 
     func getCrashFilePath() -> URL? {
         guard let measureDir = measureDirectory else { return nil }
+        let crashDir = measureDir.appendingPathComponent(ConfigFileConstants.crashDataFolderName)
         do {
-            if !fileManager.fileExists(atPath: measureDir.path) {
-                try fileManager.createDirectory(at: measureDir, withIntermediateDirectories: true, attributes: nil)
+            if !fileManager.fileExists(atPath: crashDir.path) {
+                try fileManager.createDirectory(at: crashDir, withIntermediateDirectories: true, attributes: nil)
             }
         } catch {
             logger.internalLog(level: .error, message: "SystemFileManager: Failed to create crash report directory.", error: error, data: nil)
             return nil
         }
-        let newCrashPath = measureDir.appendingPathComponent(crashDataFileName)
+        let newCrashPath = crashDir.appendingPathComponent(crashDataFileName)
         if !fileManager.fileExists(atPath: newCrashPath.path),
            let oldCrashPath = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
                .appendingPathComponent(cacheDirectoryName)
@@ -131,19 +135,23 @@ final class BaseSystemFileManager: SystemFileManager {
     }
 
     func getAttachmentDirectoryPath() -> String? {
-        return measureDirectory?.path
+        guard let attachmentsDir = measureDirectory?.appendingPathComponent(ConfigFileConstants.attachmentsFolderName) else { return nil }
+        if !fileManager.fileExists(atPath: attachmentsDir.path) {
+            do {
+                try fileManager.createDirectory(at: attachmentsDir, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                logger.internalLog(level: .error, message: "SystemFileManager: Failed to create attachments directory", error: error, data: nil)
+                return nil
+            }
+        }
+        return attachmentsDir.path
     }
 
     func getDynamicConfigPath() -> String? {
-        guard let directoryURL = fileManager.urls(for: ConfigFileConstants.directory, in: .userDomainMask).first else {
-            logger.internalLog(level: .error, message: "SystemFileManager: Unable to access directory \(ConfigFileConstants.directory)", error: nil, data: nil)
-            return nil
-        }
-
-        let folderURL = directoryURL.appendingPathComponent(ConfigFileConstants.folderName)
-        let fileURL = folderURL.appendingPathComponent(ConfigFileConstants.fileName)
-
-        return fileURL.path
+        return measureDirectory?
+            .appendingPathComponent(ConfigFileConstants.dynamicConfigFolderName)
+            .appendingPathComponent(ConfigFileConstants.fileName)
+            .path
     }
     
     func retrieveFile(atPath path: String) -> Data? {

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -10,13 +10,14 @@ import Foundation
 enum ConfigFileConstants {
     static let fileName = "dynamic_config.json"
     static let folderName = "measure"
-    static let directory: FileManager.SearchPathDirectory = .cachesDirectory
+    static let directory: FileManager.SearchPathDirectory = .applicationSupportDirectory
     static let sdkDebugLogsFolderName = "sdk_debug_logs"
 }
 
 /// A protocol that defines file system related operations.
 protocol SystemFileManager {
     func getDirectoryPath(directory: FileManager.SearchPathDirectory) -> String?
+    func getAttachmentDirectoryPath() -> String?
     func getCrashFilePath() -> URL?
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL?
     func retrieveFile(name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> Data?
@@ -31,12 +32,12 @@ protocol SystemFileManager {
 final class BaseSystemFileManager: SystemFileManager {
     private let logger: Logger
     private let fileManager: FileManager
-    private var cacheDirectory: URL? {
-        guard let cacheDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            logger.internalLog(level: .error, message: "SystemFileManager: Unable to access cache directory", error: nil, data: nil)
+    private var measureDirectory: URL? {
+        guard let appSupportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            logger.internalLog(level: .error, message: "SystemFileManager: Unable to access application support directory", error: nil, data: nil)
             return nil
         }
-        return cacheDirectory.appendingPathComponent(cacheDirectoryName)
+        return appSupportDirectory.appendingPathComponent(ConfigFileConstants.folderName)
     }
     init(logger: Logger) {
         self.logger = logger
@@ -44,16 +45,24 @@ final class BaseSystemFileManager: SystemFileManager {
     }
 
     func getCrashFilePath() -> URL? {
-        guard let crashReportDirectory = cacheDirectory else { return nil }
+        guard let measureDir = measureDirectory else { return nil }
         do {
-            if !fileManager.fileExists(atPath: crashReportDirectory.path) {
-                try fileManager.createDirectory(at: crashReportDirectory, withIntermediateDirectories: true, attributes: nil)
+            if !fileManager.fileExists(atPath: measureDir.path) {
+                try fileManager.createDirectory(at: measureDir, withIntermediateDirectories: true, attributes: nil)
             }
         } catch {
             logger.internalLog(level: .error, message: "SystemFileManager: Failed to create crash report directory.", error: error, data: nil)
             return nil
         }
-        return crashReportDirectory.appendingPathComponent(crashDataFileName)
+        let newCrashPath = measureDir.appendingPathComponent(crashDataFileName)
+        if !fileManager.fileExists(atPath: newCrashPath.path),
+           let oldCrashPath = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+               .appendingPathComponent(cacheDirectoryName)
+               .appendingPathComponent(crashDataFileName),
+           fileManager.fileExists(atPath: oldCrashPath.path) {
+            try? fileManager.moveItem(at: oldCrashPath, to: newCrashPath)
+        }
+        return newCrashPath
     }
 
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL? {
@@ -121,6 +130,10 @@ final class BaseSystemFileManager: SystemFileManager {
         return directoryURL.path
     }
 
+    func getAttachmentDirectoryPath() -> String? {
+        return measureDirectory?.path
+    }
+
     func getDynamicConfigPath() -> String? {
         guard let directoryURL = fileManager.urls(for: ConfigFileConstants.directory, in: .userDomainMask).first else {
             logger.internalLog(level: .error, message: "SystemFileManager: Unable to access directory \(ConfigFileConstants.directory)", error: nil, data: nil)
@@ -176,12 +189,9 @@ final class BaseSystemFileManager: SystemFileManager {
     }
 
     func getSdkDebugLogsDirectory() -> URL? {
-        guard let appSupportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            logger.internalLog(level: .error, message: "SystemFileManager: Unable to access application support directory", error: nil, data: nil)
-            return nil
-        }
+        guard let measureDir = measureDirectory else { return nil }
 
-        let debugLogsDirectory = appSupportDirectory.appendingPathComponent(ConfigFileConstants.sdkDebugLogsFolderName)
+        let debugLogsDirectory = measureDir.appendingPathComponent(ConfigFileConstants.sdkDebugLogsFolderName)
 
         if !fileManager.fileExists(atPath: debugLogsDirectory.path) {
             do {

--- a/ios/Tests/MeasureSDKTests/Config/ConfigLoaderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/ConfigLoaderTests.swift
@@ -59,7 +59,8 @@ final class ConfigLoaderTests: XCTestCase {
     }
 
     func testLoadDynamicConfig_returnsDefault_whenInvalidJSON() {
-        mockFileManager.savedFiles["config/config.json"] = Data("{ invalid".utf8)
+        let configKey = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)/\(ConfigFileConstants.fileName)"
+        mockFileManager.savedFiles[configKey] = Data("{ invalid".utf8)
 
         let exp = expectation(description: "loaded")
 
@@ -75,7 +76,8 @@ final class ConfigLoaderTests: XCTestCase {
         let expected = BaseDynamicConfig()
         let data = try JSONEncoder().encode(expected)
 
-        mockFileManager.savedFiles["config/config.json"] = data
+        let configKey = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)/\(ConfigFileConstants.fileName)"
+        mockFileManager.savedFiles[configKey] = data
 
         // Cache NOT expired
         mockUserDefaults.configFetchTimestamp = 1000
@@ -116,7 +118,7 @@ final class ConfigLoaderTests: XCTestCase {
 
         configLoader.loadDynamicConfig { _ in }
 
-        let key = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.fileName)"
+        let key = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)/\(ConfigFileConstants.fileName)"
         let saved = try XCTUnwrap(mockFileManager.savedFiles[key])
         let decoded = try JSONDecoder().decode(BaseDynamicConfig.self, from: saved)
 
@@ -180,6 +182,37 @@ final class ConfigLoaderTests: XCTestCase {
         configLoader.loadDynamicConfig { _ in }
 
         XCTAssertNil(mockNetworkClient.lastETag)
+    }
+
+    // MARK: - Folder structure
+
+    func test_saveConfigToDisk_savesUnderDynamicConfigSubfolder() {
+        setupCacheExpired()
+        mockNetworkClient.stubConfig(.success(config: BaseDynamicConfig(), eTag: "etag", cacheControl: 3600))
+
+        configLoader.loadDynamicConfig { _ in }
+
+        let expectedKey = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)/\(ConfigFileConstants.fileName)"
+        XCTAssertNotNil(mockFileManager.savedFiles[expectedKey])
+    }
+
+    func test_loadConfigFromDisk_readsFromDynamicConfigSubfolder() throws {
+        let expected = BaseDynamicConfig()
+        let data = try JSONEncoder().encode(expected)
+        let configKey = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.dynamicConfigFolderName)/\(ConfigFileConstants.fileName)"
+        mockFileManager.savedFiles[configKey] = data
+        mockUserDefaults.configFetchTimestamp = 1000
+        mockUserDefaults.configCacheControl = 10_000
+        mockTimeProvider.current = 2000
+
+        let exp = expectation(description: "loaded")
+        configLoader.loadDynamicConfig { loaded in
+            let result = loaded as? BaseDynamicConfig
+            self.assertConfigsEqual(result, expected)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1)
     }
 
     // MARK: - Helpers

--- a/ios/Tests/MeasureSDKTests/Event/AttachmentProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Event/AttachmentProcessorTests.swift
@@ -1,0 +1,71 @@
+//
+//  AttachmentProcessorTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 14/05/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class AttachmentProcessorTests: XCTestCase {
+    private var sut: BaseAttachmentProcessor!
+    private var mockFileManager: MockSystemFileManager!
+    private var mockIdProvider: MockIdProvider!
+
+    override func setUp() {
+        super.setUp()
+        mockFileManager = MockSystemFileManager()
+        mockIdProvider = MockIdProvider()
+        mockIdProvider.uuId = "test-uuid"
+        sut = BaseAttachmentProcessor(
+            logger: MockLogger(),
+            fileManager: mockFileManager,
+            idProvider: mockIdProvider
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockFileManager = nil
+        mockIdProvider = nil
+        super.tearDown()
+    }
+
+    func test_data_returnsBytesAndNilPath() {
+        let attachment = sut.getAttachmentObject(for: Data("image".utf8),
+                                                  storageType: .data,
+                                                  attachmentType: .screenshot)
+
+        XCTAssertNotNil(attachment?.bytes)
+        XCTAssertNil(attachment?.path)
+    }
+
+    func test_fileStorage_savesToMeasureAttachmentsFolder() {
+        let expectedFolder = "\(ConfigFileConstants.folderName)/\(ConfigFileConstants.attachmentsFolderName)"
+
+        _ = sut.getAttachmentObject(for: Data("image".utf8),
+                                     storageType: .fileStorage,
+                                     attachmentType: .screenshot)
+
+        XCTAssertTrue(mockFileManager.savedFiles.keys.contains { $0.hasPrefix(expectedFolder) })
+    }
+
+    func test_fileStorage_returnsPathAndNilBytes() {
+        let attachment = sut.getAttachmentObject(for: Data("image".utf8),
+                                                  storageType: .fileStorage,
+                                                  attachmentType: .screenshot)
+
+        XCTAssertNotNil(attachment?.path)
+        XCTAssertNil(attachment?.bytes)
+    }
+
+    func test_gzip_returnsBytesAndNilPath() {
+        let attachment = sut.getAttachmentObject(for: Data("snapshot".utf8),
+                                                  storageType: .gzip,
+                                                  attachmentType: .layoutSnapshotJson)
+
+        XCTAssertNotNil(attachment?.bytes)
+        XCTAssertNil(attachment?.path)
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -351,7 +351,8 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                            userPermissionManager: self.userPermissionManager)
         self.bugReportManager = bugReportManager ?? BaseBugReportManager(screenshotGenerator: self.screenshotGenerator,
                                                      configProvider: self.configProvider,
-                                                     idProvider: self.idProvider)
+                                                                         idProvider: self.idProvider,
+                                                                         systemFileManager: self.systemFileManager)
 
         self.bugReportCollector = bugReportCollector ?? BaseBugReportCollector(bugReportManager: self.bugReportManager,
                                                          signalProcessor: self.signalProcessor,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
@@ -11,6 +11,7 @@ import Foundation
 final class MockSystemFileManager: SystemFileManager {
     var crashFilePath: URL?
     var directoryPath: String?
+    var attachmentDirectoryPath: String?
     var dynamicConfigPath: String?
     var savedFiles: [String: Data] = [:]
     var sdkDebugLogsDirectory: URL?
@@ -35,6 +36,10 @@ final class MockSystemFileManager: SystemFileManager {
 
     func getDirectoryPath(directory: FileManager.SearchPathDirectory) -> String? {
         return directoryPath
+    }
+
+    func getAttachmentDirectoryPath() -> String? {
+        return attachmentDirectoryPath
     }
 
     func getDynamicConfigPath() -> String? {

--- a/ios/Tests/MeasureSDKTests/Utils/SystemFileManagerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Utils/SystemFileManagerTests.swift
@@ -1,0 +1,98 @@
+//
+//  SystemFileManagerTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 14/05/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class SystemFileManagerTests: XCTestCase {
+    private var sut: BaseSystemFileManager!
+    private var measureURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        sut = BaseSystemFileManager(logger: MockLogger())
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        measureURL = appSupportURL.appendingPathComponent(ConfigFileConstants.folderName)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: measureURL)
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_getCrashFilePath_returnsPathUnderMeasureCrashDataFolder() {
+        let expected = measureURL
+            .appendingPathComponent(ConfigFileConstants.crashDataFolderName)
+            .appendingPathComponent(crashDataFileName)
+
+        XCTAssertEqual(sut.getCrashFilePath(), expected)
+    }
+
+    func test_getCrashFilePath_createsCrashDataDirectory() {
+        _ = sut.getCrashFilePath()
+
+        let crashDir = measureURL.appendingPathComponent(ConfigFileConstants.crashDataFolderName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: crashDir.path))
+    }
+
+    func test_getDynamicConfigPath_returnsPathUnderMeasureDynamicConfigFolder() {
+        let expected = measureURL
+            .appendingPathComponent(ConfigFileConstants.dynamicConfigFolderName)
+            .appendingPathComponent(ConfigFileConstants.fileName)
+            .path
+
+        XCTAssertEqual(sut.getDynamicConfigPath(), expected)
+    }
+
+    func test_getAttachmentDirectoryPath_returnsPathUnderMeasureAttachmentsFolder() {
+        let expected = measureURL
+            .appendingPathComponent(ConfigFileConstants.attachmentsFolderName)
+            .path
+
+        XCTAssertEqual(sut.getAttachmentDirectoryPath(), expected)
+    }
+
+    func test_getAttachmentDirectoryPath_createsDirectoryIfAbsent() {
+        _ = sut.getAttachmentDirectoryPath()
+
+        let attachmentsDir = measureURL.appendingPathComponent(ConfigFileConstants.attachmentsFolderName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: attachmentsDir.path))
+    }
+
+    func test_getAttachmentDirectoryPath_returnsNil_whenDirectoryCreationFails() throws {
+        // Place a file at measureURL so createDirectory for the attachments subfolder fails
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        try FileManager.default.createDirectory(at: appSupportURL, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: measureURL.path, contents: nil)
+
+        XCTAssertNil(sut.getAttachmentDirectoryPath())
+    }
+
+    func test_getAttachmentDirectoryPath_isIdempotent() {
+        let first = sut.getAttachmentDirectoryPath()
+        let second = sut.getAttachmentDirectoryPath()
+
+        XCTAssertNotNil(first)
+        XCTAssertEqual(first, second)
+    }
+
+    func test_getSdkDebugLogsDirectory_returnsPathUnderMeasureSdkDebugLogsFolder() {
+        let expected = measureURL.appendingPathComponent(ConfigFileConstants.sdkDebugLogsFolderName)
+
+        XCTAssertEqual(sut.getSdkDebugLogsDirectory(), expected)
+    }
+
+    func test_allPaths_areRootedUnderApplicationSupportMeasure() {
+        let expectedRoot = measureURL.path
+
+        XCTAssertTrue(sut.getCrashFilePath()!.path.hasPrefix(expectedRoot))
+        XCTAssertTrue(sut.getDynamicConfigPath()!.hasPrefix(expectedRoot))
+        XCTAssertTrue(sut.getAttachmentDirectoryPath()!.hasPrefix(expectedRoot))
+        XCTAssertTrue(sut.getSdkDebugLogsDirectory()!.path.hasPrefix(expectedRoot))
+    }
+}


### PR DESCRIPTION
# Description

 This PR contains below changes:

  - Consolidated all SDK-managed files under a single `ApplicationSupport/measure/` root directory, replacing the previous
  scattered layout across Documents/, Caches/, and ApplicationSupport/.
  - Organised files into dedicated subfolders: crash_data/ for crash reports, dynamic_config/ for remote config, attachments/
  for screenshots and layout snapshots, and sdk_debug_logs/ for diagnostic logs.
  - Updated internalGetAttachmentDirectory and internalGetDynamicConfigPath to return paths from the new
  unified location.
  - Updated AttachmentProcessor and ConfigLoader to use updated paths.
  - Added BugReportManager support for file-system-backed attachments
  - Update tests

## Related issue
Closes #3601