### PR TITLE
fix(backend): prevent occasional panic in apple symbolication

### DIFF
--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -688,7 +688,9 @@ func (as *appleSymbolicator) makeAppleCrashReport(event event.EventField) {
 		b.WriteString(fmt.Sprintf("Exception Type: %s\n", exception.Signal))
 
 		// write exception codes
-		b.WriteString(fmt.Sprintf("Exception Codes: #%d at 0x%s\n", exception.ThreadSequence, exception.Frames[exception.ThreadSequence].SymbolAddress))
+		if len(exception.Frames) > 0 {
+			b.WriteString(fmt.Sprintf("Exception Codes: #%d at 0x%s\n", exception.ThreadSequence, exception.Frames[0].SymbolAddress))
+		}
 
 		// write crashed thread
 		b.WriteString(fmt.Sprintf("Crashed Thread: %d\n", exception.ThreadSequence))


### PR DESCRIPTION
## Summary

This PR fixes an occasional panic in Apple symbolication due to incorrectly reading exception unit's thread sequence instead of its first frame.

## Tasks

- [x] Add bounds check before accessing exception unit's frames
- [x] Use exception unit's first frame instead of incorrectly using its thread sequence

## See also

- fixes #3624