### PR TITLE
chore(ios): add github action to prepare ios release

### DIFF
--- a/.github/workflows/ios-prepare-release.yml
+++ b/.github/workflows/ios-prepare-release.yml
@@ -1,0 +1,118 @@
+name: Prepare iOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 0.9.0)'
+        required: true
+        type: string
+
+env:
+  XCODE_VERSION: '16.4'
+
+jobs:
+  prepare-release:
+    name: Prepare iOS SDK Release
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: .
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.SDK_RELEASE }}
+
+      - name: Setup Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Switch to Xcode ${{ env.XCODE_VERSION }}
+        run: sudo xcode-select -switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+
+      - name: Validate input version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
+            echo "Error: Version must match semantic versioning pattern:"
+            echo "  - x.y.z (e.g. 1.2.3)"
+            echo "  - x.y.z-alpha.N or x.y.z-beta.N"
+            echo "Got: ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Build Measure SDK
+        run: |
+          xcodebuild build \
+            -project ios/MeasureSDK.xcodeproj \
+            -scheme Measure \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
+            ONLY_ACTIVE_ARCH=YES \
+            SKIP_TESTING=YES
+
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -project ios/MeasureSDK.xcodeproj \
+            -scheme MeasureSDKTests \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
+            ONLY_ACTIVE_ARCH=YES \
+            -parallel-testing-enabled NO
+
+      - name: Update version in FrameworkInfo.swift
+        run: |
+          sed -i '' 's/static let version = ".*"/static let version = "${{ inputs.version }}"/' \
+            ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
+
+      - name: Update version in measure-sh.podspec
+        run: |
+          sed -E -i '' 's/(spec\.version[[:space:]]*=[[:space:]]*")[^"]*/\1${{ inputs.version }}/' \
+            measure-sh.podspec
+
+      - name: Update version in MeasureReactNative.podspec
+        run: |
+          sed -E -i '' 's/(s\.version[[:space:]]*=[[:space:]]*")[^"]*/\1${{ inputs.version }}/' \
+            react-native/MeasureReactNative.podspec
+
+      - name: Update version in docs
+        run: |
+          sed -E -i '' 's|(\.package\(url: "https://github\.com/measure-sh/measure\.git", branch: "ios-v)[^"]*|\1${{ inputs.version }}|g' \
+            docs/sdk-integration-guide.md
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: ios/cliff.toml
+          args: --output ios/CHANGELOG.md --tag ios-v${{ inputs.version }}
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.SDK_RELEASE }}
+          commit-message: "chore(ios): prepare sdk release ${{ inputs.version }}"
+          branch: ios-v${{ inputs.version }}
+          delete-branch: false
+          title: "chore(ios): prepare sdk release ${{ inputs.version }}"
+          body: |
+            This PR prepares the iOS SDK for release version ${{ inputs.version }}.
+
+            Changes:
+            - Updated version to ${{ inputs.version }} in FrameworkInfo.swift
+            - Updated version to ${{ inputs.version }} in measure-sh.podspec
+            - Updated version to ${{ inputs.version }} in MeasureReactNative.podspec
+            - Updated version in docs/sdk-integration-guide.md
+            - Generated changelog for version ${{ inputs.version }}
+          base: main
+          labels: ios

--- a/.github/workflows/ios-prepare-release.yml
+++ b/.github/workflows/ios-prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 'main'
           fetch-depth: 0
@@ -79,15 +79,10 @@ jobs:
           sed -E -i '' 's/(spec\.version[[:space:]]*=[[:space:]]*")[^"]*/\1${{ inputs.version }}/' \
             measure-sh.podspec
 
-      - name: Update version in MeasureReactNative.podspec
-        run: |
-          sed -E -i '' 's/(s\.version[[:space:]]*=[[:space:]]*")[^"]*/\1${{ inputs.version }}/' \
-            react-native/MeasureReactNative.podspec
-
       - name: Update version in docs
         run: |
           sed -E -i '' 's|(\.package\(url: "https://github\.com/measure-sh/measure\.git", branch: "ios-v)[^"]*|\1${{ inputs.version }}|g' \
-            docs/sdk-integration-guide.md
+            frontend/dashboard/content/docs/sdk-integration-guide.mdx
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -111,8 +106,7 @@ jobs:
             Changes:
             - Updated version to ${{ inputs.version }} in FrameworkInfo.swift
             - Updated version to ${{ inputs.version }} in measure-sh.podspec
-            - Updated version to ${{ inputs.version }} in MeasureReactNative.podspec
-            - Updated version in docs/sdk-integration-guide.md
+            - Updated version in frontend/dashboard/content/docs/sdk-integration-guide.mdx
             - Generated changelog for version ${{ inputs.version }}
           base: main
           labels: ios

--- a/ios/RELEASE.md
+++ b/ios/RELEASE.md
@@ -4,18 +4,15 @@
 
 To release the iOS SDK, follow the below steps.
 
-1. Checkout a new branch named `origin/ios-release-vx.x.x` based on the latest commit from the main branch.
-2. Build and run tests before releasing.
-3. Run `./ios/Scripts/release.sh <major/minor/patch>`. This script is executed in below 2 steps:
-   1. Update local versions
-        - First the script will get the current SDK version from `FrameworkInfo.swift` and increment it.
-        - It will then update the SDK versions in `measure-sh.podspec`, `FrameworkInfo.swift` and `README.md`.
-        - Verify these before moving forward.
-   2. Update CHANGELOG.md
-        - We use git-cliff to generate change logs. This step might require you to add github-token with `public_repo` permission if the changes are too long.
-4. Commit the changes with the message `chore(ios): prepare sdk release x.x.x`
-5. Create a PR and merge.
-6. Go to the releases tab and create a new release.
-7. Run `pod trunk register <email> 'measure.sh' --description='<description>'` to authenticate to the cocoapod server.
-8. Run `pod spec lint measure-sh.podspec` which will check if the current configuration of podspec is correct.
-9. Run `pod trunk push measure-sh.podspec` to push the pod to cocoapods.
+1. Go to **Actions → Prepare iOS Release → Run workflow** and enter the version number (e.g. `0.9.0`).
+   - The workflow will run the test suite, bump versions in all relevant files, generate the changelog, and open a PR.
+2. Review and merge the PR.
+3. Push the release tag:
+   ```
+   git tag ios-v<version>
+   git push origin ios-v<version>
+   ```
+4. Run `pod trunk register <email> 'measure.sh' --description='<description>'` to authenticate to the CocoaPods server.
+5. Run `pod spec lint measure-sh.podspec` to check the podspec configuration is correct.
+6. Run `pod trunk push measure-sh.podspec` to push the pod to CocoaPods.
+7. Go to the releases tab and create a new release using the pushed tag.

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -715,7 +715,7 @@ extension Measure {
     }
 
     /// Returns the W3C traceparent header value for the given span. For use from Objective-C.
-    /// - Parameter span: The `MsrObjCSpan` to extract the traceparent header value from.
+    /// - Parameter objcSpan: The `MsrObjCSpan` to extract the traceparent header value from.
     /// - Returns: A W3C trace context compliant header value in the format: `{version}-{traceId}-{spanId}-{traceFlags}`
     ///
     /// In Swift, use `getTraceParentHeaderValue(span:)` which accepts the `Span` protocol directly.

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -704,7 +704,7 @@ extension Measure {
     }
 
     /// Returns the W3C traceparent header value for the given span. For use from Objective-C.
-    /// - Parameter span: The `MsrObjCSpan` to extract the traceparent header value from.
+    /// - Parameter objcSpan: The `MsrObjCSpan` to extract the traceparent header value from.
     /// - Returns: A W3C trace context compliant header value in the format: `{version}-{traceId}-{spanId}-{traceFlags}`
     ///
     /// In Swift, use `getTraceParentHeaderValue(span:)` which accepts the `Span` protocol directly.


### PR DESCRIPTION
# Description

 - Adds `ios-prepare-release` GitHub Actions workflow to automate the iOS SDK release preparation
- Workflow runs tests, bumps versions across all relevant files, generates the changelog and opens a PR.
- Updates `ios/release.md` to reflect the new release process

## What remains manual

- Pushing the release tag
- CocoaPods publish
- Creating the GitHub Release

## Related issue
Closes #3611