### PR TITLE
ci: optimize frank app build times

### DIFF
--- a/.github/workflows/frank.yml
+++ b/.github/workflows/frank.yml
@@ -54,14 +54,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
-          cache-dependency-path: |
-            react-native/yarn.lock
-            samples/frank/react_native/yarn.lock
       - name: Setup Yarn
         run: |
           corepack enable
           corepack prepare yarn@${{ env.YARN_VERSION }} --activate
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ hashFiles('react-native/yarn.lock', 'samples/frank/react_native/yarn.lock') }}
+          restore-keys: yarn-
       - name: Build Measure React Native SDK
         run: |
           yarn install
@@ -131,14 +136,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
-          cache-dependency-path: |
-            react-native/yarn.lock
-            samples/frank/react_native/yarn.lock
       - name: Setup Yarn
         run: |
           corepack enable
           corepack prepare yarn@${{ env.YARN_VERSION }} --activate
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ hashFiles('react-native/yarn.lock', 'samples/frank/react_native/yarn.lock') }}
+          restore-keys: yarn-
       - name: Build Measure React Native SDK
         run: |
           yarn install

--- a/.github/workflows/frank.yml
+++ b/.github/workflows/frank.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
+          cache: 'gradle'
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
           channel: stable
@@ -149,6 +150,15 @@ jobs:
         run: |
           echo '${{ secrets.FRANK_APP_ENV }}' > samples/frank/.env
           cd samples/frank && ./setup-secrets.sh
+      - name: Restore Measure xcframework cache
+        id: xcframework-cache
+        uses: actions/cache@v4
+        with:
+          path: kmp/measure-kmp/build/xcframework/Measure.xcframework
+          key: xcframework-${{ hashFiles('ios/Sources/**', 'ios/MeasureSDK.xcodeproj/**', 'ios/Measure.xcworkspace/**', 'ios/Package.resolved') }}
+      - name: Build Measure xcframework
+        if: steps.xcframework-cache.outputs.cache-hit != 'true'
+        run: bash kmp/measure-kmp/Scripts/build-xcframework.sh
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:

--- a/.github/workflows/frank.yml
+++ b/.github/workflows/frank.yml
@@ -54,6 +54,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: |
+            react-native/yarn.lock
+            samples/frank/react_native/yarn.lock
       - name: Setup Yarn
         run: |
           corepack enable
@@ -127,6 +131,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: |
+            react-native/yarn.lock
+            samples/frank/react_native/yarn.lock
       - name: Setup Yarn
         run: |
           corepack enable

--- a/.github/workflows/kmp-checks.yml
+++ b/.github/workflows/kmp-checks.yml
@@ -98,7 +98,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode.app
 
       - name: Build Measure iOS xcframework
-        run: ./kmp/measure-kmp/Scripts/build-xcframework.sh
+        run: ./Scripts/build-xcframework.sh
 
       - name: Assemble
         run: ./gradlew assemble --no-daemon --no-parallel --no-configuration-cache --stacktrace

--- a/android/measure-android/gradle/libs.versions.toml
+++ b/android/measure-android/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ robolectric = "4.16"
 orchestrator = "1.6.1"
 androidx-baselineprofile = "1.4.1"
 androidx-profileinstaller = "1.4.1"
-kolinx-binary-compatibility-validator = "0.18.1"
+kolinx-binary-compatibility-validator = "0.18.0"
 mavenPublish = "0.34.0"
 
 [libraries]

--- a/kmp/measure-kmp/Scripts/build-xcframework.sh
+++ b/kmp/measure-kmp/Scripts/build-xcframework.sh
@@ -30,6 +30,16 @@ DERIVED_DATA="$OUTPUT_DIR/DerivedData"
 
 mkdir -p "$OUTPUT_DIR"
 
+# In CI the framework is pre-built and cached before xcodebuild starts.
+# The Xcode build phase still invokes this script, so we exit early when
+# in CI and the xcframework is already present. The cache key is derived
+# from ios/ sources, so a hit means the cached result is correct.
+# Local dev is unaffected: $CI is not set outside GitHub Actions.
+if [ -d "$XCFRAMEWORK" ] && [ "${CI:-}" = "true" ]; then
+  echo "Measure.xcframework already present in CI — skipping rebuild"
+  exit 0
+fi
+
 run_xcodebuild() {
   env -i \
     PATH="$PATH" \


### PR DESCRIPTION
# Description

- Downgrade the binary compatibility plugin version to fix build failure
- Reduce iOS build time by adding caching and removing duplicate `xcframework` build.

## Related issue
References #3503 