### PR TITLE
fix(backend): intelligently sort app versions

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -14,7 +14,6 @@ import (
 	"backend/api/server"
 	"backend/libs/ambient"
 	"backend/libs/logcomment"
-	"backend/libs/opsys"
 	"backend/libs/text"
 	"backend/libs/udattr"
 
@@ -923,18 +922,8 @@ func (af AppFilter) getAppVersions(ctx context.Context) (versions, versionCodes 
 		v.Add(version, code)
 	}
 
-	// attempt to sort versions depending on
-	// app os requirements and conventions
-	switch opsys.ToFamily(af.AppOSName) {
-	case opsys.AppleFamily:
-		if !v.IsValidSemver() {
-			break
-		}
-
-		if err = v.SemverSortByVersionDesc(); err != nil {
-			return
-		}
-	}
+	// intelligently sort versions
+	v.Sort()
 
 	versions = v.Versions()
 	versionCodes = v.Codes()

--- a/backend/api/filter/versions.go
+++ b/backend/api/filter/versions.go
@@ -1,11 +1,17 @@
 package filter
 
 import (
+	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/blang/semver/v4"
 )
+
+// numericRe matches a dot-separated numeric segment
+// (e.g. "1", "1.2", "10.20.30").
+var numericRe = regexp.MustCompile(`^([0-9]+\.?){1,3}$`)
 
 // Versions represents a list of
 // (version, code) pairs.
@@ -20,56 +26,98 @@ func (v *Versions) Add(name, code string) {
 	v.codes = append(v.codes, code)
 }
 
-// SemverSortByVersionDesc sorts version names in
-// descending semver order keeping version code in
-// lock-step with version name.
-// Assumes version name is valid semver.
-func (v *Versions) SemverSortByVersionDesc() (err error) {
-	if len(v.names) < 1 {
+// Sort sorts the (name, code) pairs in place according to these rules:
+//
+// Case A — names are valid semver, all codes are numeric:
+//
+//	sort descending numerically by code, then descending by semver name.
+//
+// Case B — names are not valid semver:
+//
+//	B.1 all names and codes are numeric: sort descending numerically by code, then descending by name.
+//	B.2 names are non-numeric, codes are numeric: sort descending numerically by code, then descending alphabetically by name.
+//	B.3 any code is non-numeric: sort descending alphabetically by code, then descending by name.
+//
+// When names are valid semver but codes are not all numeric, B.3 applies.
+func (v *Versions) Sort() {
+	n := len(v.names)
+	if n <= 1 {
 		return
 	}
 
-	type pair struct {
-		ver  semver.Version
-		name string
-		code string
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
 	}
 
-	pairs := make([]pair, len(v.names))
+	switch {
+	case v.IsValidSemver() && allNumeric(v.codes):
+		// Case A
+		sort.SliceStable(idx, func(i, j int) bool {
+			cmp := compareNumeric(v.codes[idx[i]], v.codes[idx[j]])
+			if cmp != 0 {
+				return cmp > 0
+			}
+			si, _ := semver.Parse(v.names[idx[i]])
+			sj, _ := semver.Parse(v.names[idx[j]])
+			return si.GT(sj)
+		})
 
-	for i, name := range v.names {
-		semver, err := semver.Parse(name)
-		if err != nil {
-			return err
-		}
-		pairs[i] = pair{
-			ver:  semver,
-			name: name,
-			code: v.codes[i],
-		}
+	case !v.IsValidSemver() && allNumeric(v.names) && allNumeric(v.codes):
+		// Case B.1
+		sort.SliceStable(idx, func(i, j int) bool {
+			cmp := compareNumeric(v.codes[idx[i]], v.codes[idx[j]])
+			if cmp != 0 {
+				return cmp > 0
+			}
+			return compareNumeric(v.names[idx[i]], v.names[idx[j]]) > 0
+		})
+
+	case !v.IsValidSemver() && !allNumeric(v.names) && allNumeric(v.codes):
+		// Case B.2
+		sort.SliceStable(idx, func(i, j int) bool {
+			cmp := compareNumeric(v.codes[idx[i]], v.codes[idx[j]])
+			if cmp != 0 {
+				return cmp > 0
+			}
+			return v.names[idx[i]] > v.names[idx[j]]
+		})
+
+	default:
+		// Case B.3 (and A with non-numeric codes as fallback)
+		sort.SliceStable(idx, func(i, j int) bool {
+			ci, cj := v.codes[idx[i]], v.codes[idx[j]]
+			if ci != cj {
+				return ci > cj
+			}
+			return v.names[idx[i]] > v.names[idx[j]]
+		})
 	}
 
-	sort.SliceStable(pairs, func(i, j int) bool {
-		if pairs[i].ver.EQ(pairs[j].ver) {
-			ci, _ := strconv.ParseInt(pairs[i].code, 10, 64)
-			cj, _ := strconv.ParseInt(pairs[j].code, 10, 64)
-			return ci > cj
-		}
-		return pairs[i].ver.GT(pairs[j].ver)
-	})
-
-	sortedNames := make([]string, len(pairs))
-	sortedCodes := make([]string, len(pairs))
-
-	for i, p := range pairs {
-		sortedNames[i] = p.name
-		sortedCodes[i] = p.code
+	newNames := make([]string, n)
+	newCodes := make([]string, n)
+	for i, k := range idx {
+		newNames[i] = v.names[k]
+		newCodes[i] = v.codes[k]
 	}
+	v.names = newNames
+	v.codes = newCodes
+}
 
-	v.names = sortedNames
-	v.codes = sortedCodes
+// Versions gets the version names.
+func (v Versions) Versions() []string {
+	return v.names
+}
 
-	return
+// Codes gets the version codes.
+func (v Versions) Codes() []string {
+	return v.codes
+}
+
+// HasVersions returns true if at least
+// 1 (version, code) pair exists.
+func (v Versions) HasVersions() bool {
+	return len(v.names) > 0
 }
 
 // IsValidSemver determines if all version names
@@ -87,20 +135,39 @@ func (v Versions) IsValidSemver() bool {
 	return true
 }
 
-// HasVersions returns true if at least
-// 1 (version, code) pair exists.
-func (v Versions) HasVersions() bool {
-	return len(v.names) > 0
+// allNumeric reports whether every string in strs consists solely of
+// dot-separated numeric segments (e.g. "1", "1.2", "10.20.30").
+// Returns true for an empty slice.
+func allNumeric(strs []string) bool {
+	for _, s := range strs {
+		if !numericRe.MatchString(s) {
+			return false
+		}
+	}
+	return true
 }
 
-// Versions gets the version names.
-func (v Versions) Versions() []string {
-	return v.names
-}
-
-// Codes gets the version codes.
-func (v Versions) Codes() []string {
-	return v.codes
+// compareNumeric compares two numeric strings component-by-component.
+// Returns -1, 0, or 1.
+func compareNumeric(a, b string) int {
+	pa, pb := strings.Split(a, "."), strings.Split(b, ".")
+	n := max(len(pa), len(pb))
+	for i := range n {
+		var na, nb int
+		if i < len(pa) {
+			na, _ = strconv.Atoi(pa[i])
+		}
+		if i < len(pb) {
+			nb, _ = strconv.Atoi(pb[i])
+		}
+		if na != nb {
+			if na > nb {
+				return 1
+			}
+			return -1
+		}
+	}
+	return 0
 }
 
 // exclude figures out the set of excluded versions

--- a/backend/api/filter/versions_test.go
+++ b/backend/api/filter/versions_test.go
@@ -67,155 +67,6 @@ func TestIsValidSemver(t *testing.T) {
 	}
 }
 
-func TestSemverSortByVersionDesc(t *testing.T) {
-	// empty versions should neither sort
-	// nor return error.
-	{
-		empty := Versions{
-			names: []string{},
-			codes: []string{},
-		}
-
-		err := empty.SemverSortByVersionDesc()
-
-		if err != nil {
-			t.Errorf("Expected %v, but got %v", nil, err)
-		}
-
-		if len(empty.names) != 0 {
-			t.Errorf("Expected empty names, but got %v", empty.names)
-		}
-
-		if len(empty.codes) != 0 {
-			t.Errorf("Expected empty codes, but got %v", empty.codes)
-		}
-	}
-
-	// invalid semver versions should always return error.
-	{
-		invalid := Versions{
-			names: []string{
-				"1.2.3",
-				"x.1.y",
-			},
-			codes: []string{
-				"1",
-				"2",
-			},
-		}
-
-		err := invalid.SemverSortByVersionDesc()
-
-		if err == nil {
-			t.Errorf("Expected non nil err, but got %v", err)
-		}
-	}
-
-	// unsorted versions should sort in descending order
-	// keeping codes in lock-step.
-	{
-		desc := Versions{
-			names: []string{
-				"1.2.3",
-				"4.5.6",
-				"1.0.0-alpha.beta",
-				"1.0.0-rc.1",
-			},
-			codes: []string{
-				"98",
-				"2",
-				"234",
-				"99238",
-			},
-		}
-
-		expected := Versions{
-			names: []string{
-				"4.5.6",
-				"1.2.3",
-				"1.0.0-rc.1",
-				"1.0.0-alpha.beta",
-			},
-			codes: []string{
-				"2",
-				"98",
-				"99238",
-				"234",
-			},
-		}
-
-		err := desc.SemverSortByVersionDesc()
-
-		if err != nil {
-			t.Errorf("Expected nil err, but got %v", err)
-		}
-
-		if !reflect.DeepEqual(expected.Versions(), desc.Versions()) {
-			t.Errorf("Expected %v, but got %v", expected.Versions(), desc.Versions())
-		}
-
-		if !reflect.DeepEqual(expected.Codes(), desc.Codes()) {
-			t.Errorf("Expected %v, but got %v", expected.Codes(), desc.Codes())
-		}
-	}
-
-	// duplicate semver versions should sort in descending
-	// order keeping codes in lock-step.
-	{
-		duplicates := Versions{
-			names: []string{
-				"1.2.3",
-				"4.5.6",
-				"1.2.3",
-				"7.8.9",
-				"1.2.3",
-				"1.2.3",
-			},
-			codes: []string{
-				"9",
-				"32",
-				"8",
-				"0",
-				"7",
-				"10",
-			},
-		}
-
-		expected := Versions{
-			names: []string{
-				"7.8.9",
-				"4.5.6",
-				"1.2.3",
-				"1.2.3",
-				"1.2.3",
-				"1.2.3",
-			},
-			codes: []string{
-				"0",
-				"32",
-				"10",
-				"9",
-				"8",
-				"7",
-			},
-		}
-
-		err := duplicates.SemverSortByVersionDesc()
-
-		if err != nil {
-			t.Errorf("Expected nil err, but got %v", err)
-		}
-
-		if !reflect.DeepEqual(expected.Versions(), duplicates.Versions()) {
-			t.Errorf("Expected %v, but got %v", expected.Versions(), duplicates.Versions())
-		}
-
-		if !reflect.DeepEqual(expected.Codes(), duplicates.Codes()) {
-			t.Errorf("Expected %v, but got %v", expected.Codes(), duplicates.Codes())
-		}
-	}
-}
-
 func TestExclude(t *testing.T) {
 	// no selected versions match
 	{
@@ -378,6 +229,377 @@ func TestExclude(t *testing.T) {
 
 		if len(got.Codes()) > 0 {
 			t.Errorf("Expected %d length, but got %d length", len(expected.Codes()), len(got.Codes()))
+		}
+	}
+}
+
+func TestAllNumeric(t *testing.T) {
+	// empty slice should return true.
+	{
+		expected := true
+		got := allNumeric([]string{})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// single numeric segment should return true.
+	{
+		expected := true
+		got := allNumeric([]string{"1", "42", "100"})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// zero preceded numbers should return true.
+	{
+		expected := true
+		got := allNumeric([]string{"1", "042", "100"})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// dot-separated numeric segments should return true.
+	{
+		expected := true
+		got := allNumeric([]string{"1.2", "1.0.0", "10.20.30"})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// alphabetic strings should return false.
+	{
+		expected := false
+		got := allNumeric([]string{"1.2.3", "abc"})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// semver pre-release strings should return false.
+	{
+		expected := false
+		got := allNumeric([]string{"1.0.0-alpha", "1.0.0-rc.1"})
+
+		if got != expected {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+}
+
+func TestCompareNumeric(t *testing.T) {
+	// equal versions should return 0.
+	{
+		if got := compareNumeric("1.2.3", "1.2.3"); got != 0 {
+			t.Errorf("Expected 0, but got %v", got)
+		}
+	}
+
+	// greater major version should return 1.
+	{
+		if got := compareNumeric("2.0.0", "1.9.9"); got != 1 {
+			t.Errorf("Expected 1, but got %v", got)
+		}
+	}
+
+	// lesser major version should return -1.
+	{
+		if got := compareNumeric("1.0.0", "2.0.0"); got != -1 {
+			t.Errorf("Expected -1, but got %v", got)
+		}
+	}
+
+	// greater minor version should return 1.
+	{
+		if got := compareNumeric("1.3.0", "1.2.9"); got != 1 {
+			t.Errorf("Expected 1, but got %v", got)
+		}
+	}
+
+	// greater patch version should return 1.
+	{
+		if got := compareNumeric("1.2.4", "1.2.3"); got != 1 {
+			t.Errorf("Expected 1, but got %v", got)
+		}
+	}
+
+	// missing segment should be treated as 0.
+	{
+		if got := compareNumeric("1.2", "1.2.0"); got != 0 {
+			t.Errorf("Expected 0, but got %v", got)
+		}
+	}
+
+	// longer version with higher trailing segment should return 1.
+	{
+		if got := compareNumeric("1.2.0.1", "1.2.0"); got != 1 {
+			t.Errorf("Expected 1, but got %v", got)
+		}
+	}
+}
+
+func TestSort(t *testing.T) {
+	// empty slice should be a no-op.
+	{
+		v := Versions{names: []string{}, codes: []string{}}
+		v.Sort()
+		if len(v.names) != 0 || len(v.codes) != 0 {
+			t.Errorf("Expected empty, but got names=%v codes=%v", v.names, v.codes)
+		}
+	}
+
+	// single entry should be a no-op.
+	{
+		v := Versions{names: []string{"1.2.3"}, codes: []string{"42"}}
+		v.Sort()
+		if v.names[0] != "1.2.3" || v.codes[0] != "42" {
+			t.Errorf("Expected unchanged, but got names=%v codes=%v", v.names, v.codes)
+		}
+	}
+
+	// Case A: valid semver names + numeric codes — sort descending by code,
+	// then by semver name on tie.
+	{
+		v := Versions{
+			names: []string{"1.0.0", "2.0.0", "1.5.0", "3.0.0"},
+			codes: []string{"10", "30", "10", "20"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"2.0.0", "3.0.0", "1.5.0", "1.0.0"}
+		expectedCodes := []string{"30", "20", "10", "10"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case A names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case A codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case A: valid semver names + dotted numeric codes (e.g. "1.2.3" style
+	// build codes) — compareNumeric orders segments individually so "1.10.0"
+	// beats "1.9.0".
+	{
+		v := Versions{
+			names: []string{"1.0.0", "2.0.0", "3.0.0", "1.5.0"},
+			codes: []string{"1.9.0", "1.10.0", "1.9.0", "2.0.0"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"1.5.0", "2.0.0", "3.0.0", "1.0.0"}
+		expectedCodes := []string{"2.0.0", "1.10.0", "1.9.0", "1.9.0"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case A dotted codes names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case A dotted codes codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case A: valid semver names + three-segment dotted numeric codes
+	// (e.g. "10.20.30") — numeric comparison treats each segment independently.
+	{
+		v := Versions{
+			names: []string{"1.0.0", "2.0.0", "3.0.0"},
+			codes: []string{"10.20.30", "10.9.99", "10.20.30"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"3.0.0", "1.0.0", "2.0.0"}
+		expectedCodes := []string{"10.20.30", "10.20.30", "10.9.99"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case A three-segment codes names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case A three-segment codes codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case A: code tie broken by semver descending (pre-release < release).
+	{
+		v := Versions{
+			names: []string{"1.0.0-alpha", "1.0.0", "1.0.0-rc.1"},
+			codes: []string{"5", "5", "5"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"1.0.0", "1.0.0-rc.1", "1.0.0-alpha"}
+		expectedCodes := []string{"5", "5", "5"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case A pre-release tie names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case A pre-release tie codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case A: names and codes kept in lock-step after sort.
+	{
+		v := Versions{
+			names: []string{"1.0.0", "2.0.0", "3.0.0"},
+			codes: []string{"1", "3", "2"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"2.0.0", "3.0.0", "1.0.0"}
+		expectedCodes := []string{"3", "2", "1"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case A lock-step names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case A lock-step codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.1: non-semver numeric names + numeric codes — sort descending
+	// numerically by code, then by name on tie.
+	{
+		v := Versions{
+			names: []string{"10", "9", "10", "2"},
+			codes: []string{"3", "1", "3", "5"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"2", "10", "10", "9"}
+		expectedCodes := []string{"5", "3", "3", "1"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.1 names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.1 codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.1: dotted numeric names (e.g. Android-style version codes) —
+	// numeric comparison treats "1.10" as greater than "1.9".
+	{
+		v := Versions{
+			names: []string{"1.0", "2.0", "1.10"},
+			codes: []string{"100", "200", "100"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"2.0", "1.10", "1.0"}
+		expectedCodes := []string{"200", "100", "100"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.1 dotted names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.1 dotted codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.2: non-semver non-numeric names + numeric codes — sort descending
+	// numerically by code, tie broken descending alphabetically by name.
+	{
+		v := Versions{
+			names: []string{"beta", "alpha", "gamma"},
+			codes: []string{"30", "10", "30"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"gamma", "beta", "alpha"}
+		expectedCodes := []string{"30", "30", "10"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.2 names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.2 codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.2: numeric code ordering is numeric, not lexicographic —
+	// code "9" must rank below "10".
+	{
+		v := Versions{
+			names: []string{"stable", "canary"},
+			codes: []string{"9", "10"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"canary", "stable"}
+		expectedCodes := []string{"10", "9"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.2 numeric ordering names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.2 numeric ordering codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.2: tie on code broken descending alphabetically by name.
+	{
+		v := Versions{
+			names: []string{"nightly", "beta", "alpha", "nightly"},
+			codes: []string{"9", "10", "10", "11"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"nightly", "beta", "alpha", "nightly"}
+		expectedCodes := []string{"11", "10", "10", "9"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.2 tie by name names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.2 tie by name codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.3: valid semver names but non-numeric codes fall through to
+	// alphabetic sort.
+	{
+		v := Versions{
+			names: []string{"1.0.0", "2.0.0", "3.0.0"},
+			codes: []string{"build-c", "build-a", "build-b"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"1.0.0", "3.0.0", "2.0.0"}
+		expectedCodes := []string{"build-c", "build-b", "build-a"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.3 semver+non-numeric codes names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.3 semver+non-numeric codes codes: expected %v, got %v", expectedCodes, v.codes)
+		}
+	}
+
+	// Case B.3: non-numeric codes with equal code values — tie broken by name
+	// descending alphabetically.
+	{
+		v := Versions{
+			names: []string{"apple", "cherry", "banana"},
+			codes: []string{"v1", "v1", "v1"},
+		}
+		v.Sort()
+
+		expectedNames := []string{"cherry", "banana", "apple"}
+		expectedCodes := []string{"v1", "v1", "v1"}
+
+		if !reflect.DeepEqual(v.names, expectedNames) {
+			t.Errorf("Case B.3 tie by name names: expected %v, got %v", expectedNames, v.names)
+		}
+		if !reflect.DeepEqual(v.codes, expectedCodes) {
+			t.Errorf("Case B.3 tie by name codes: expected %v, got %v", expectedCodes, v.codes)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR refactors the version sorting logic to be more robust & "intelligent" across different platforms & versioning schemes. Instead of relying on OS-specific conventions, the new implementation uses a multi-case approach that prioritizes numeric version codes while falling back to semver or alphabetical sorting for version names. This ensures consistent & predictable ordering for Android, iOS, & other version formats.

## Tasks

- [x] Refactor Versions.Sort to handle semver & numeric versions
- [x] Implement multi-case sorting logic for names & codes
- [x] Add helper functions for numeric segment comparison
- [x] Remove OS-specific sorting in appfilter.go
- [x] Add comprehensive tests for new sorting logic

## See also

- fixes #3629