### PR TITLE
chore(rn): update package.json

### DIFF
--- a/react-native/expo-module.config.json
+++ b/react-native/expo-module.config.json
@@ -2,6 +2,7 @@
   "name": "@measuresh/react-native",
   "platforms": ["android", "ios"],
   "android": {
+    "name": "measuresh_react-native",
     "modulesClassNames": ["sh.measure.rn.MeasurePackage"]
   },
   "ios": {

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -21,6 +21,7 @@
     "cpp",
     "*.podspec",
     "react-native.config.js",
+    "expo-module.config.json",
     "!ios/build",
     "!android/build",
     "!android/gradle",
@@ -81,6 +82,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "react": "19.0.0",
+    "react-native": "0.79.5",
     "react-native-builder-bob": "^0.40.13",
     "release-it": "^17.10.0",
     "typescript": "^5.8.3"

--- a/react-native/src/globals.d.ts
+++ b/react-native/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __DEV__: boolean;

--- a/react-native/yarn.lock
+++ b/react-native/yarn.lock
@@ -2906,6 +2906,7 @@ __metadata:
     jest: ^29.7.0
     prettier: ^3.0.3
     react: 19.0.0
+    react-native: 0.79.5
     react-native-builder-bob: ^0.40.13
     release-it: ^17.10.0
     typescript: ^5.8.3


### PR DESCRIPTION
# Description

This PR updates the below things:

- Fix Gradle 9.0.0 build failure in Expo projects: When @measuresh/react-native is used in an Expo project, both Expo's autolinking and React Native's autolinking register the same module as separate Gradle subprojects with different names (measuresh-react-native vs measuresh_react-native). Fixed by setting "name": "measuresh_react-native" in expo-module.config.json.
- Add expo-module.config.json to published files.
- Add react-native as a devDependency.
- Add src/globals.d.ts.