### PR TITLE
fix(rn): implement native module for start and stop sdk apis

### DIFF
--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -23,6 +23,26 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     override fun getName(): String = ModuleConstants.MODULE_NAME
 
     @ReactMethod
+    fun start(promise: Promise) {
+        try {
+            Measure.start()
+            promise.resolve("Started successfully")
+        } catch (e: Exception) {
+            promise.reject("START_ERROR", "Failed to start", e)
+        }
+    }
+
+    @ReactMethod
+    fun stop(promise: Promise) {
+        try {
+            Measure.stop()
+            promise.resolve("Stopped successfully")
+        } catch (e: Exception) {
+            promise.reject("STOP_ERROR", "Failed to stop", e)
+        }
+    }
+
+    @ReactMethod
     fun trackEvent(
         data: ReadableMap,
         type: String,

--- a/react-native/example/expo/src/HomeScreen.tsx
+++ b/react-native/example/expo/src/HomeScreen.tsx
@@ -50,7 +50,6 @@ const trackCustomEvent = () => {
     action: 'Track Custom Event',
     timestamped: true,
   });
-  console.log('Custom event tracked: button_click');
 };
 
 const setUserIdExample = () => {
@@ -77,12 +76,6 @@ const trackHttpEventManually = () => {
     requestBody: null,
     responseBody: '{"result": "success"}',
   })
-    .then(() => {
-      console.log('Manual HTTP event tracked successfully');
-    })
-    .catch((err) => {
-      console.error('Failed to track manual HTTP event:', err);
-    });
 };
 
 const trackBugReport = () => {

--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -13,6 +13,24 @@ class MeasureModule: NSObject, RCTBridgeModule {
     }
     
     @objc
+    func start(_ resolve: @escaping RCTPromiseResolveBlock,
+               rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async {
+            Measure.start()
+            resolve("Started successfully")
+        }
+    }
+
+    @objc
+    func stop(_ resolve: @escaping RCTPromiseResolveBlock,
+              rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async {
+            Measure.stop()
+            resolve("Stopped successfully")
+        }
+    }
+
+    @objc
     func trackEvent(_ data: NSDictionary,
                     type: NSString,
                     timestamp: NSNumber,

--- a/react-native/ios/MeasureModuleBridge.m
+++ b/react-native/ios/MeasureModuleBridge.m
@@ -3,6 +3,10 @@
 
 @interface RCT_EXTERN_MODULE(MeasureModule, NSObject)
 
+RCT_EXTERN_METHOD(start:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(stop:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(trackEvent:(NSDictionary *)data
                   type:(NSString *)type
                   timestamp:(nonnull NSNumber *)timestamp

--- a/react-native/src/__mock__/react-native.ts
+++ b/react-native/src/__mock__/react-native.ts
@@ -1,5 +1,7 @@
 export const NativeModules = {
   MeasureModule: {
+    start: jest.fn(() => Promise.resolve()),
+    stop: jest.fn(() => Promise.resolve()),
     trackEvent: jest.fn(() => Promise.resolve()),
     trackSpan: jest.fn(() => Promise.resolve()),
     setUserId: jest.fn(() => Promise.resolve()),

--- a/react-native/src/__tests__/events/customEventCollector.test.ts
+++ b/react-native/src/__tests__/events/customEventCollector.test.ts
@@ -18,7 +18,7 @@ describe('CustomEventCollector', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    logger = { log: jest.fn() };
+    logger = { log: jest.fn(), internalLog: jest.fn() };
     timeProvider = { now: jest.fn(() => 123456789) };
     configProvider = {
       maxEventNameLength: 10,

--- a/react-native/src/__tests__/measure.test.ts
+++ b/react-native/src/__tests__/measure.test.ts
@@ -1,46 +1,94 @@
-import { Measure } from '../measure';
-import { MeasureInternal } from '../measureInternal';
 import { MeasureConfig } from '../config/measureConfig';
 
-jest.mock('../measureInitializer');
-jest.mock('../measureInternal');
+function setupMocks(
+  mockInit: jest.Mock,
+  mockStart: jest.Mock,
+  mockStop: jest.Mock
+) {
+  jest.mock('../measureInitializer', () => ({
+    MeasureInitializer: jest.fn(),
+  }));
+  jest.mock('../measureInternal', () => ({
+    MeasureInternal: jest.fn().mockImplementation(() => ({
+      init: mockInit,
+      start: mockStart,
+      stop: mockStop,
+    })),
+  }));
+}
 
 describe('Measure.init', () => {
-  let config: MeasureConfig;
+  let Measure: any;
   let mockInit: jest.Mock;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-
-    config = new MeasureConfig({
-      enableLogging: true,
-      autoStart: true,
-    });
-
-    // Make init return a real resolved promise
+    jest.resetModules();
     mockInit = jest.fn(() => Promise.resolve());
-
-    // Mock MeasureInternal implementation
-    (MeasureInternal as jest.Mock).mockImplementation(() => ({
-      init: mockInit,
-      start: jest.fn(),
-      stop: jest.fn(),
-    }));
+    setupMocks(mockInit, jest.fn(), jest.fn());
+    Measure = require('../measure').Measure;
   });
 
   it('should only initialize once', async () => {
-    // First call to init
+    const config = new MeasureConfig({ enableLogging: true, autoStart: true });
+
     const firstPromise = Measure.init(config);
     expect(mockInit).toHaveBeenCalledTimes(1);
 
-    // Second call to init (should not trigger init again)
     const secondPromise = Measure.init(config);
     expect(mockInit).toHaveBeenCalledTimes(1);
 
-    // Both promises should be the same
     expect(secondPromise).toBe(firstPromise);
 
-    // Await the promise to resolve properly
     await firstPromise;
+  });
+});
+
+describe('Measure.start', () => {
+  let Measure: any;
+  let mockStart: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockStart = jest.fn(() => Promise.resolve());
+    setupMocks(jest.fn(() => Promise.resolve()), mockStart, jest.fn());
+    Measure = require('../measure').Measure;
+  });
+
+  it('returns a resolved Promise when not initialized', async () => {
+    await expect(Measure.start()).resolves.toBeUndefined();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('delegates to measureInternal.start() and returns its Promise', async () => {
+    const config = new MeasureConfig({ autoStart: false });
+    await Measure.init(config);
+
+    await expect(Measure.start()).resolves.toBeUndefined();
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Measure.stop', () => {
+  let Measure: any;
+  let mockStop: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockStop = jest.fn(() => Promise.resolve());
+    setupMocks(jest.fn(() => Promise.resolve()), jest.fn(), mockStop);
+    Measure = require('../measure').Measure;
+  });
+
+  it('returns a resolved Promise when not initialized', async () => {
+    await expect(Measure.stop()).resolves.toBeUndefined();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('delegates to measureInternal.stop() and returns its Promise', async () => {
+    const config = new MeasureConfig({ autoStart: true });
+    await Measure.init(config);
+
+    await expect(Measure.stop()).resolves.toBeUndefined();
+    expect(mockStop).toHaveBeenCalledTimes(1);
   });
 });

--- a/react-native/src/__tests__/measureInternal.test.ts
+++ b/react-native/src/__tests__/measureInternal.test.ts
@@ -1,0 +1,192 @@
+import { MeasureInternal } from '../measureInternal';
+import * as measureBridge from '../native/measureBridge';
+
+jest.mock('../native/measureBridge', () => ({
+  enableNativeModule: jest.fn(),
+  disableNativeModule: jest.fn(),
+  start: jest.fn(() => Promise.resolve()),
+  stop: jest.fn(() => Promise.resolve()),
+  setShakeListener: jest.fn(),
+  getSessionId: jest.fn(() => Promise.resolve('mock-session-id')),
+}));
+
+jest.mock('../exception/measureErrorHandlers', () => ({
+  setupErrorHandlers: jest.fn(),
+}));
+
+function makeMockInitializer() {
+  return {
+    logger: { internalLog: jest.fn(), log: jest.fn() },
+    configLoader: { loadDynamicConfig: jest.fn(() => Promise.resolve(null)) },
+    configProvider: { setDynamicConfig: jest.fn() },
+    spanProcessor: { onConfigLoaded: jest.fn() },
+    customEventCollector: { register: jest.fn(), unregister: jest.fn() },
+    userTriggeredEventCollector: { register: jest.fn(), unregister: jest.fn() },
+    spanCollector: { register: jest.fn(), unregister: jest.fn() },
+    bugReportCollector: { register: jest.fn(), unregister: jest.fn() },
+  } as any;
+}
+
+describe('MeasureInternal.start', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers collectors, enables native module, and calls native start', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.start();
+
+    expect(initializer.customEventCollector.register).toHaveBeenCalledTimes(1);
+    expect(initializer.userTriggeredEventCollector.register).toHaveBeenCalledTimes(1);
+    expect(initializer.spanCollector.register).toHaveBeenCalledTimes(1);
+    expect(initializer.bugReportCollector.register).toHaveBeenCalledTimes(1);
+    expect(measureBridge.enableNativeModule).toHaveBeenCalledTimes(1);
+    expect(measureBridge.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a resolved Promise', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+    await expect(sdk.start()).resolves.toBeUndefined();
+  });
+
+  it('warns and does nothing when already started', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.start();
+    jest.clearAllMocks();
+
+    await sdk.start();
+
+    expect(initializer.logger.internalLog).toHaveBeenCalledWith(
+      'warning',
+      'Measure.start() called but Measure is already started.'
+    );
+    expect(initializer.customEventCollector.register).not.toHaveBeenCalled();
+    expect(measureBridge.enableNativeModule).not.toHaveBeenCalled();
+    expect(measureBridge.start).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately without side effects when already started', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+    await sdk.start();
+    await expect(sdk.start()).resolves.toBeUndefined();
+  });
+});
+
+describe('MeasureInternal.stop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('unregisters collectors, disables native module, and calls native stop', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.start();
+    jest.clearAllMocks();
+
+    await sdk.stop();
+
+    expect(initializer.customEventCollector.unregister).toHaveBeenCalledTimes(1);
+    expect(initializer.userTriggeredEventCollector.unregister).toHaveBeenCalledTimes(1);
+    expect(initializer.spanCollector.unregister).toHaveBeenCalledTimes(1);
+    expect(initializer.bugReportCollector.unregister).toHaveBeenCalledTimes(1);
+    expect(measureBridge.disableNativeModule).toHaveBeenCalledTimes(1);
+    expect(measureBridge.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a resolved Promise', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+    await sdk.start();
+    await expect(sdk.stop()).resolves.toBeUndefined();
+  });
+
+  it('warns and does nothing when not started', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.stop();
+
+    expect(initializer.logger.internalLog).toHaveBeenCalledWith(
+      'warning',
+      'Measure.stop() called but Measure is not started.'
+    );
+    expect(initializer.customEventCollector.unregister).not.toHaveBeenCalled();
+    expect(measureBridge.disableNativeModule).not.toHaveBeenCalled();
+    expect(measureBridge.stop).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately without side effects when not started', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+    await expect(sdk.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe('MeasureInternal start/stop lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('can be stopped after starting', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+    await sdk.start();
+    await expect(sdk.stop()).resolves.toBeUndefined();
+    expect(measureBridge.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be restarted after stopping', async () => {
+    const sdk = new MeasureInternal(makeMockInitializer());
+
+    await sdk.start();
+    await sdk.stop();
+    jest.clearAllMocks();
+
+    await sdk.start();
+
+    expect(measureBridge.start).toHaveBeenCalledTimes(1);
+    expect(measureBridge.enableNativeModule).toHaveBeenCalledTimes(1);
+  });
+
+  it('start → stop → start does not double-register collectors', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.start();
+    await sdk.stop();
+    await sdk.start();
+
+    expect(initializer.customEventCollector.register).toHaveBeenCalledTimes(2);
+    expect(initializer.customEventCollector.unregister).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MeasureInternal.init with autoStart', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers collectors and calls native start when autoStart is true', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ autoStart: true } as any);
+
+    expect(initializer.customEventCollector.register).toHaveBeenCalledTimes(1);
+    expect(measureBridge.enableNativeModule).toHaveBeenCalledTimes(1);
+    expect(measureBridge.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register collectors or call native start when autoStart is false', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ autoStart: false } as any);
+
+    expect(initializer.customEventCollector.register).not.toHaveBeenCalled();
+    expect(measureBridge.enableNativeModule).not.toHaveBeenCalled();
+    expect(measureBridge.start).not.toHaveBeenCalled();
+  });
+});

--- a/react-native/src/__tests__/native/measureBridge.test.ts
+++ b/react-native/src/__tests__/native/measureBridge.test.ts
@@ -1,0 +1,61 @@
+describe('measureBridge.start', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('resolves without calling native when start method is absent', async () => {
+    const { NativeModules } = require('react-native');
+    (NativeModules.MeasureModule as any).start = undefined;
+
+    const { start } = require('../../native/measureBridge');
+    await expect(start()).resolves.toBeUndefined();
+  });
+
+  it('calls native start and resolves', async () => {
+    const { NativeModules } = require('react-native');
+    NativeModules.MeasureModule.start = jest.fn(() => Promise.resolve());
+
+    const { start } = require('../../native/measureBridge');
+    await expect(start()).resolves.toBeUndefined();
+    expect(NativeModules.MeasureModule.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves safely when native start returns undefined instead of a Promise', async () => {
+    const { NativeModules } = require('react-native');
+    NativeModules.MeasureModule.start = jest.fn(() => undefined);
+
+    const { start } = require('../../native/measureBridge');
+    await expect(start()).resolves.toBeUndefined();
+  });
+});
+
+describe('measureBridge.stop', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('resolves without calling native when stop method is absent', async () => {
+    const { NativeModules } = require('react-native');
+    (NativeModules.MeasureModule as any).stop = undefined;
+
+    const { stop } = require('../../native/measureBridge');
+    await expect(stop()).resolves.toBeUndefined();
+  });
+
+  it('calls native stop and resolves', async () => {
+    const { NativeModules } = require('react-native');
+    NativeModules.MeasureModule.stop = jest.fn(() => Promise.resolve());
+
+    const { stop } = require('../../native/measureBridge');
+    await expect(stop()).resolves.toBeUndefined();
+    expect(NativeModules.MeasureModule.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves safely when native stop returns undefined instead of a Promise', async () => {
+    const { NativeModules } = require('react-native');
+    NativeModules.MeasureModule.stop = jest.fn(() => undefined);
+
+    const { stop } = require('../../native/measureBridge');
+    await expect(stop()).resolves.toBeUndefined();
+  });
+});

--- a/react-native/src/bugReport/bugReportCollector.ts
+++ b/react-native/src/bugReport/bugReportCollector.ts
@@ -51,6 +51,11 @@ export class BugReportCollector implements IBugReportCollector {
     attachments: MsrAttachment[] = [],
     attributes: Record<string, ValidAttributeValue> = {}
   ): Promise<void> {
+    if (!this.isRegistered) {
+      this.logger.internalLog('warning', 'Measure SDK is stopped. trackBugReport() will be ignored.');
+      return;
+    }
+
     try {
       this.logger.internalLog('info', '[BugReportCollector] Tracking bug report...', {
         description,
@@ -70,6 +75,11 @@ export class BugReportCollector implements IBugReportCollector {
     bugReportConfig: Record<string, any> = {},
     attributes: Record<string, ValidAttributeValue> = {}
   ): Promise<void> {
+    if (!this.isRegistered) {
+      this.logger.internalLog('warning', 'Measure SDK is stopped. launchBugReport() will be ignored.');
+      return;
+    }
+
     this.logger.internalLog('info', '[BugReportCollector] Launching native bug report UI...', {
       takeScreenshot,
       bugReportConfig,

--- a/react-native/src/events/customEventCollector.ts
+++ b/react-native/src/events/customEventCollector.ts
@@ -63,6 +63,7 @@ export class CustomEventCollector implements ICustomEventCollector {
     timestamp?: number
   ): Promise<void> {
     if (!this.enabled) {
+      this.logger.internalLog('warning', 'Measure SDK is stopped. trackEvent() will be ignored.');
       return;
     }
 

--- a/react-native/src/events/userTriggeredEventCollector.ts
+++ b/react-native/src/events/userTriggeredEventCollector.ts
@@ -86,6 +86,7 @@ export class UserTriggeredEventCollector implements IUserTriggeredEventCollector
     attributes?: Record<string, ValidAttributeValue>
   ): Promise<void> {
     if (!this.enabled) {
+      this.logger.internalLog('warning', 'Measure SDK is stopped. trackScreenView() will be ignored.');
       return;
     }
 
@@ -139,7 +140,10 @@ export class UserTriggeredEventCollector implements IUserTriggeredEventCollector
   requestBody?: string | null;
   responseBody?: string | null;
 }): Promise<void> {
-  if (!this.enabled) return;
+  if (!this.enabled) {
+    this.logger.internalLog('warning', 'Measure SDK is stopped. trackHttpEvent() will be ignored.');
+    return;
+  }
 
   const {
     url,

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -71,10 +71,10 @@ export const Measure = {
   /**
    * Start the Measure SDK manually (if `autoStart` is false).
    */
-  start(): void {
+  start(): Promise<void> {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
-      return;
+      return Promise.resolve();
     }
     return _measureInternal.start();
   },
@@ -82,10 +82,10 @@ export const Measure = {
   /**
    * Stop the Measure SDK.
    */
-  stop(): void {
+  stop(): Promise<void> {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
-      return;
+      return Promise.resolve();
     }
     return _measureInternal.stop();
   },

--- a/react-native/src/measureInitializer.ts
+++ b/react-native/src/measureInitializer.ts
@@ -127,7 +127,7 @@ export class MeasureInitializer implements IMeasureInitializer {
       this.spanProcessor,
       this.traceSampler
     );
-    this.spanCollector = new SpanCollector(this.tracer);
+    this.spanCollector = new SpanCollector(this.tracer, this.logger);
     this.nativeApiProcessor = new NativeApiProcessor({
       logger: this.logger,
     });

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -7,6 +7,8 @@ import {
   getSessionId as getNativeSessionId,
   enableNativeModule,
   disableNativeModule,
+  start as nativeStart,
+  stop as nativeStop,
 } from './native/measureBridge';
 import type { Span } from './tracing/span';
 import type { SpanBuilder } from './tracing/spanBuilder';
@@ -70,33 +72,36 @@ export class MeasureInternal {
       this.started = true;
       this.registerCollectors();
       enableNativeModule();
+      nativeStart();
     }
   }
 
-  start(): void {
+  start(): Promise<void> {
     if (this.started) {
       this.measureInitializer.logger.internalLog(
         'warning',
         'Measure.start() called but Measure is already started.'
       );
-      return;
+      return Promise.resolve();
     }
     this.started = true;
     this.registerCollectors();
     enableNativeModule();
+    return nativeStart();
   }
 
-  stop(): void {
+  stop(): Promise<void> {
     if (!this.started) {
       this.measureInitializer.logger.internalLog(
         'warning',
         'Measure.stop() called but Measure is not started.'
       );
-      return;
+      return Promise.resolve();
     }
     this.started = false;
     this.unregisterCollectors();
     disableNativeModule();
+    return nativeStop();
   }
 
   trackEvent = (

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -42,6 +42,20 @@ function getShakeEmitter() {
   return ShakeEmitter;
 }
 
+export function start(): Promise<void> {
+  if (!MeasureModule.start) {
+    return Promise.resolve();
+  }
+  return Promise.resolve(MeasureModule.start());
+}
+
+export function stop(): Promise<void> {
+  if (!MeasureModule.stop) {
+    return Promise.resolve();
+  }
+  return Promise.resolve(MeasureModule.stop());
+}
+
 export function trackEvent(
   data: Record<string, any>,
   type: string,

--- a/react-native/src/tracing/spanCollector.ts
+++ b/react-native/src/tracing/spanCollector.ts
@@ -2,6 +2,7 @@ import { InvalidSpan } from "./invalidSpan";
 import type { Span } from "./span";
 import type { SpanBuilder } from "./spanBuilder";
 import type { Tracer } from "./tracer";
+import type { Logger } from "../utils/logger";
 
 export interface ISpanCollector {
     register(): void;
@@ -19,9 +20,11 @@ export interface ISpanCollector {
 export class SpanCollector implements ISpanCollector {
     tracer: Tracer;
     isEnabled: boolean = false;
+    private logger: Logger;
 
-    constructor(tracer: Tracer) {
+    constructor(tracer: Tracer, logger: Logger) {
         this.tracer = tracer;
+        this.logger = logger;
     }
 
     register(): void {
@@ -41,8 +44,8 @@ export class SpanCollector implements ISpanCollector {
     }
 
     createSpan(name: string): SpanBuilder | undefined {
-        // Equivalent to guard isEnabled.get() else { return nil }
         if (!this.isEnabled) {
+            this.logger.internalLog('warning', 'Measure SDK is stopped. createSpan() will be ignored.');
             return undefined;
         }
         return this.tracer.spanBuilder(name);
@@ -50,6 +53,7 @@ export class SpanCollector implements ISpanCollector {
 
     startSpan(name: string, timestampMs?: number): Span {
         if (!this.isEnabled) {
+            this.logger.internalLog('warning', 'Measure SDK is stopped. startSpan() will be ignored.');
             return new InvalidSpan();
         }
 


### PR DESCRIPTION
# Description

This PR contains below changes

  - Fix start() and stop() not calling native SDK.
  - Android: add start and stop to MeasureModule.kt.
  - iOS: add start and stop to MeasureModule.swift and MeasureModuleBridge.m.
  - Update public API signatures to return a Promise<void>.
  - Update tests

## Related issue
Fixes #3643 