### PR TITLE
chore(rn): use named parameters instead of positional parameter

### DIFF
--- a/react-native/example/expo/src/App.tsx
+++ b/react-native/example/expo/src/App.tsx
@@ -22,17 +22,17 @@ export default function App() {
     try {
       const measureConfig = new MeasureConfig({
         enableLogging: true,
-        autoStart: true,
+        autoStart: false,
         enableFullCollectionMode: false,
         enableDiagnosticMode: true,
       });
 
-      await Measure.init(measureConfig);
+      await Measure.init({ config: measureConfig });
 
-      Measure.onShake(() => {
+      Measure.onShake({ handler: () => {
         console.log('Shake detected — launching bug report flow!');
-        Measure.launchBugReport(true, { source: 'shake' }, { screen: 'Home' });
-      });
+        Measure.launchBugReport({ takeScreenshot: true, bugReportConfig: { source: 'shake' }, attributes: { screen: 'Home' } });
+      }});
     } catch (error) {
       console.error('Failed to initialize Measure:', error);
     }

--- a/react-native/example/expo/src/ComponentScreen.tsx
+++ b/react-native/example/expo/src/ComponentScreen.tsx
@@ -37,9 +37,12 @@ export default function ComponentScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      Measure.trackScreenView('ComponentScreen', {
-        screen: 'ComponentScreen',
-        timestamped: true,
+      Measure.trackScreenView({
+        screenName: 'ComponentScreen',
+        attributes: {
+          screen: 'ComponentScreen',
+          timestamped: true,
+        },
       }).catch(err =>
         console.error('Failed to track screen view:', err)
       );

--- a/react-native/example/expo/src/HomeScreen.tsx
+++ b/react-native/example/expo/src/HomeScreen.tsx
@@ -45,15 +45,18 @@ const simulateInfiniteLoop = () => {
 };
 
 const trackCustomEvent = () => {
-  Measure.trackEvent('button_click', {
-    screen: 'Home',
-    action: 'Track Custom Event',
-    timestamped: true,
+  Measure.trackEvent({
+    name: 'button_click',
+    attributes: {
+      screen: 'Home',
+      action: 'Track Custom Event',
+      timestamped: true,
+    },
   });
 };
 
 const setUserIdExample = () => {
-  Measure.setUserId('sample_user_123');
+  Measure.setUserId({ userId: 'sample_user_123' });
 };
 
 const clearUserIdExample = () => {
@@ -79,11 +82,11 @@ const trackHttpEventManually = () => {
 };
 
 const trackBugReport = () => {
-  Measure.launchBugReport(
-    true,
-    { theme: 'light' },
-    { userId: '123', screen: 'Home' }
-  );
+  Measure.launchBugReport({
+    takeScreenshot: true,
+    bugReportConfig: { theme: 'light' },
+    attributes: { userId: '123', screen: 'Home' },
+  });
 };
 
 const trackManualBugReport = async () => {
@@ -95,11 +98,11 @@ const trackManualBugReport = async () => {
       (attachment) => attachment !== null
     );
 
-    await Measure.trackBugReport(
-      'Manual bug report triggered from example app',
+    await Measure.trackBugReport({
+      description: 'Manual bug report triggered from example app',
       attachments,
-      { source: 'example_app', screen: 'Home' }
-    );
+      attributes: { source: 'example_app', screen: 'Home' },
+    });
 
     console.log('Manual bug report with screenshot sent!');
   } catch (err) {

--- a/react-native/example/expo/src/TracesScreen.tsx
+++ b/react-native/example/expo/src/TracesScreen.tsx
@@ -54,7 +54,7 @@ export default function TracesScreen() {
     }
 
     try {
-      const builder = Measure.createSpanBuilder('ParentSpan_Demo');
+      const builder = Measure.createSpanBuilder({ name: 'ParentSpan_Demo' });
       
       if (!builder) {
         Alert.alert('Initialization Error', 'Measure SDK may not be initialized or tracing is disabled.');
@@ -103,7 +103,7 @@ export default function TracesScreen() {
     try {
       const childName = 'ChildSpan_Demo_Task';
 
-      const builder = Measure.createSpanBuilder(childName);
+      const builder = Measure.createSpanBuilder({ name: childName });
       if (!builder) {
         Alert.alert('Initialization Error', 'Measure SDK may not be initialized.');
         return;

--- a/react-native/example/rnExample/App.tsx
+++ b/react-native/example/rnExample/App.tsx
@@ -41,12 +41,12 @@ const App = (): React.JSX.Element => {
         enableDiagnosticMode: true,
       });
 
-    await Measure.init(measureConfig);
+    await Measure.init({ config: measureConfig });
 
-    Measure.onShake(() => {
+    Measure.onShake({ handler: () => {
       console.log('Shake detected — launching bug report flow!');
-      Measure.launchBugReport(true, {source: 'shake'}, {screen: 'Home'});
-    });
+      Measure.launchBugReport({takeScreenshot: true, bugReportConfig: {source: 'shake'}, attributes: {screen: 'Home'}});
+    }});
   };
 
   useEffect(() => {
@@ -62,10 +62,13 @@ const App = (): React.JSX.Element => {
   };
 
   const trackCustomEvent = () => {
-    Measure.trackEvent('button_click', {
-      screen: 'Home',
-      action: 'Track Custom Event',
-      timestamped: true,
+    Measure.trackEvent({
+      name: 'button_click',
+      attributes: {
+        screen: 'Home',
+        action: 'Track Custom Event',
+        timestamped: true,
+      },
     });
   };
 
@@ -96,7 +99,7 @@ const App = (): React.JSX.Element => {
   /** === Simulation Helpers === */
   const launchBugReport = () => {
     console.log('Launching bug report flow manually');
-    Measure.launchBugReport(true, {source: 'manual'}, {screen: 'Home'});
+    Measure.launchBugReport({takeScreenshot: true, bugReportConfig: {source: 'manual'}, attributes: {screen: 'Home'}});
   };
 
   const trackManualBugReport = async () => {
@@ -108,11 +111,11 @@ const App = (): React.JSX.Element => {
         attachment => attachment !== null,
       );
 
-      await Measure.trackBugReport(
-        'Manual bug report triggered from example app',
+      await Measure.trackBugReport({
+        description: 'Manual bug report triggered from example app',
         attachments,
-        {source: 'example_app', screen: 'Home'},
-      );
+        attributes: {source: 'example_app', screen: 'Home'},
+      });
 
       console.log('Manual bug report with attachments sent!');
     } catch (err) {

--- a/react-native/src/__tests__/events/customEventCollector.test.ts
+++ b/react-native/src/__tests__/events/customEventCollector.test.ts
@@ -39,13 +39,13 @@ describe('CustomEventCollector', () => {
 
   it('does nothing when disabled', async () => {
     collector.unregister();
-    await collector.trackCustomEvent('test');
+    await collector.trackCustomEvent({ name: 'test' });
     expect(signalProcessor.trackEvent).not.toHaveBeenCalled();
     expect(logger.log).not.toHaveBeenCalled();
   });
 
   it('logs error if name is empty', async () => {
-    await collector.trackCustomEvent('');
+    await collector.trackCustomEvent({ name: '' });
     expect(logger.log).toHaveBeenCalledWith(
       'error',
       'Invalid event: name is empty'
@@ -54,7 +54,7 @@ describe('CustomEventCollector', () => {
   });
 
   it('logs error if name is too long', async () => {
-    await collector.trackCustomEvent('toolongnamehere');
+    await collector.trackCustomEvent({ name: 'toolongnamehere' });
     expect(logger.log).toHaveBeenCalledWith(
       'error',
       'Invalid event(toolongnamehere): exceeds maximum length of 10 characters'
@@ -63,7 +63,7 @@ describe('CustomEventCollector', () => {
   });
 
   it('logs error if name fails regex', async () => {
-    await collector.trackCustomEvent('bad-name!');
+    await collector.trackCustomEvent({ name: 'bad-name!' });
     expect(logger.log).toHaveBeenCalledWith(
       'error',
       'Invalid event(bad-name!) format'
@@ -110,7 +110,7 @@ describe('CustomEventCollector', () => {
   it('logs error if signalProcessor.trackEvent throws', async () => {
     signalProcessor.trackEvent.mockRejectedValueOnce(new Error('boom'));
 
-    await collector.trackCustomEvent('event2');
+    await collector.trackCustomEvent({ name: 'event2' });
 
     expect(logger.log).toHaveBeenCalledWith(
       'error',

--- a/react-native/src/__tests__/events/customEventCollector.test.ts
+++ b/react-native/src/__tests__/events/customEventCollector.test.ts
@@ -75,7 +75,7 @@ describe('CustomEventCollector', () => {
     (validateAttributes as jest.Mock).mockReturnValueOnce(false);
     const attrs = { good: 'ok', bad: { nested: true } } as any;
 
-    await collector.trackCustomEvent('event1', attrs, 111);
+    await collector.trackCustomEvent({ name: 'event1', attributes: attrs, timestamp: 111 });
 
     expect(signalProcessor.trackEvent).not.toHaveBeenCalled();
     expect(logger.log).toHaveBeenCalledWith(
@@ -87,7 +87,7 @@ describe('CustomEventCollector', () => {
   it('tracks valid custom event successfully', async () => {
     const attrs = { key1: { type: 'string', value: 'abc' } } as any;
 
-    await collector.trackCustomEvent('validEvent', attrs);
+    await collector.trackCustomEvent({ name: 'validEvent', attributes: attrs });
 
     expect(signalProcessor.trackEvent).toHaveBeenCalledWith(
       { name: 'validEvent' },

--- a/react-native/src/__tests__/measureInternal.test.ts
+++ b/react-native/src/__tests__/measureInternal.test.ts
@@ -172,7 +172,7 @@ describe('MeasureInternal.init with autoStart', () => {
     const initializer = makeMockInitializer();
     const sdk = new MeasureInternal(initializer);
 
-    await sdk.init({ autoStart: true } as any);
+    await sdk.init({ config: { autoStart: true } as any });
 
     expect(initializer.customEventCollector.register).toHaveBeenCalledTimes(1);
     expect(measureBridge.enableNativeModule).toHaveBeenCalledTimes(1);
@@ -183,7 +183,7 @@ describe('MeasureInternal.init with autoStart', () => {
     const initializer = makeMockInitializer();
     const sdk = new MeasureInternal(initializer);
 
-    await sdk.init({ autoStart: false } as any);
+    await sdk.init({ config: { autoStart: false } as any });
 
     expect(initializer.customEventCollector.register).not.toHaveBeenCalled();
     expect(measureBridge.enableNativeModule).not.toHaveBeenCalled();

--- a/react-native/src/bugReport/bugReportCollector.ts
+++ b/react-native/src/bugReport/bugReportCollector.ts
@@ -7,17 +7,17 @@ export interface IBugReportCollector {
   register(): void;
   unregister(): void;
 
-  launchBugReport(
-    takeScreenshot?: boolean,
-    bugReportConfig?: Record<string, any>,
-    attributes?: Record<string, ValidAttributeValue>
-  ): Promise<void>;
+  launchBugReport(params?: {
+    takeScreenshot?: boolean;
+    bugReportConfig?: Record<string, any>;
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void>;
 
-  trackBugReport(
-    description: string,
-    attachments?: MsrAttachment[],
-    attributes?: Record<string, ValidAttributeValue>
-  ): Promise<void>;
+  trackBugReport(params: {
+    description: string;
+    attachments?: MsrAttachment[];
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void>;
 }
 
 export class BugReportCollector implements IBugReportCollector {
@@ -46,11 +46,15 @@ export class BugReportCollector implements IBugReportCollector {
     this.logger.internalLog('info', '[BugReportCollector] Unregistered.');
   }
 
-  async trackBugReport(
-    description: string,
-    attachments: MsrAttachment[] = [],
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> {
+  async trackBugReport({
+    description,
+    attachments = [],
+    attributes = {},
+  }: {
+    description: string;
+    attachments?: MsrAttachment[];
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> {
     if (!this.isRegistered) {
       this.logger.internalLog('warning', 'Measure SDK is stopped. trackBugReport() will be ignored.');
       return;
@@ -70,11 +74,15 @@ export class BugReportCollector implements IBugReportCollector {
     }
   }
 
-  async launchBugReport(
-    takeScreenshot: boolean = true,
-    bugReportConfig: Record<string, any> = {},
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> {
+  async launchBugReport({
+    takeScreenshot = true,
+    bugReportConfig = {},
+    attributes = {},
+  }: {
+    takeScreenshot?: boolean;
+    bugReportConfig?: Record<string, any>;
+    attributes?: Record<string, ValidAttributeValue>;
+  } = {}): Promise<void> {
     if (!this.isRegistered) {
       this.logger.internalLog('warning', 'Measure SDK is stopped. launchBugReport() will be ignored.');
       return;

--- a/react-native/src/events/customEventCollector.ts
+++ b/react-native/src/events/customEventCollector.ts
@@ -20,15 +20,15 @@ export interface ICustomEventCollector {
 
   /**
    * Tracks a custom user-triggered event.
-   * @param name The name of the custom event.
-   * @param attributes Optional map of custom attributes.
-   * @param timestamp Optional custom timestamp.
+   * @param params.name The name of the custom event.
+   * @param params.attributes Optional map of custom attributes.
+   * @param params.timestamp Optional custom timestamp.
    */
-  trackCustomEvent(
-    name: string,
-    attributes?: Record<string, ValidAttributeValue>,
-    timestamp?: number
-  ): Promise<void>;
+  trackCustomEvent(params: {
+    name: string;
+    attributes?: Record<string, ValidAttributeValue>;
+    timestamp?: number;
+  }): Promise<void>;
 }
 export class CustomEventCollector implements ICustomEventCollector {
   private logger: Logger;
@@ -57,11 +57,15 @@ export class CustomEventCollector implements ICustomEventCollector {
     this.enabled = false;
   }
 
-  async trackCustomEvent(
-    name: string,
-    attributes?: Record<string, ValidAttributeValue>,
-    timestamp?: number
-  ): Promise<void> {
+  async trackCustomEvent({
+    name,
+    attributes,
+    timestamp,
+  }: {
+    name: string;
+    attributes?: Record<string, ValidAttributeValue>;
+    timestamp?: number;
+  }): Promise<void> {
     if (!this.enabled) {
       this.logger.internalLog('warning', 'Measure SDK is stopped. trackEvent() will be ignored.');
       return;

--- a/react-native/src/events/userTriggeredEventCollector.ts
+++ b/react-native/src/events/userTriggeredEventCollector.ts
@@ -22,15 +22,15 @@ export interface IUserTriggeredEventCollector {
   /**
    * Tracks a screen view event with optional attributes.
    *
-   * @param screenName - The name of the screen being viewed.
-   * @param attributes - Optional key-value pairs providing context.
-   * @param timestamp - Optional timestamp in milliseconds (defaults to now).
+   * @param params.screenName - The name of the screen being viewed.
+   * @param params.attributes - Optional key-value pairs providing context.
+   * @param params.timestamp - Optional timestamp in milliseconds (defaults to now).
    */
-  trackScreenView(
-    screenName: string,
-    attributes?: Record<string, ValidAttributeValue>,
-    timestamp?: number
-  ): Promise<void>;
+  trackScreenView(params: {
+    screenName: string;
+    attributes?: Record<string, ValidAttributeValue>;
+    timestamp?: number;
+  }): Promise<void>;
 
   /**
    * Returns whether the collector is currently enabled.
@@ -81,10 +81,13 @@ export class UserTriggeredEventCollector implements IUserTriggeredEventCollector
     this.enabled = false;
   }
 
-  async trackScreenView(
-    screenName: string,
-    attributes?: Record<string, ValidAttributeValue>
-  ): Promise<void> {
+  async trackScreenView({
+    screenName,
+    attributes,
+  }: {
+    screenName: string;
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> {
     if (!this.enabled) {
       this.logger.internalLog('warning', 'Measure SDK is stopped. trackScreenView() will be ignored.');
       return;

--- a/react-native/src/index.ts
+++ b/react-native/src/index.ts
@@ -2,3 +2,7 @@ export { Measure } from "./measure";
 
 export { MeasureConfig } from './config/measureConfig';
 export type { Span } from './tracing/span';
+export type { SpanBuilder } from './tracing/spanBuilder';
+export { SpanStatus } from './tracing/spanStatus';
+export type { MsrAttachment, AttachmentType } from './events/msrAttachment';
+export type { ValidAttributeValue } from './utils/attributeValueValidator';

--- a/react-native/src/measure.ts
+++ b/react-native/src/measure.ts
@@ -47,7 +47,7 @@ export const Measure = {
    * Measure.init(client, measureConfig);
    *
    */
-  init(config: MeasureConfig | null): Promise<any> {
+  init({ config }: { config: MeasureConfig | null }): Promise<any> {
     if (_initializationPromise) {
       console.warn('Measure SDK is already initialized or being initialized.');
       return _initializationPromise;
@@ -59,7 +59,7 @@ export const Measure = {
       _measureInitializer = new MeasureInitializer(config);
       _measureInternal = new MeasureInternal(_measureInitializer);
 
-      await _measureInternal.init(config);
+      await _measureInternal.init({ config });
     })().catch((error) => {
       _initializationPromise = null;
       throw error;
@@ -95,35 +95,38 @@ export const Measure = {
    *
    * Event names should be clear and consistent to aid in dashboard searches.
    *
-   * @param name - The name of the event (max 64 characters).
-   * @param attributes - Optional key-value pairs providing additional context.
-   * @param timestamp - Optional timestamp in milliseconds (defaults to current time).
+   * @param params.name - The name of the event (max 64 characters).
+   * @param params.attributes - Optional key-value pairs providing additional context.
+   * @param params.timestamp - Optional timestamp in milliseconds (defaults to current time).
    *
    * @example
    * ```ts
    * import { Measure } from '@measure/react-native';
    *
-   * Measure.trackEvent("user_signup", {
-   *   user_name: "Alice",
-   *   premium_user: true,
-   *   signup_age: 23,
+   * Measure.trackEvent({
+   *   name: "user_signup",
+   *   attributes: {
+   *     user_name: "Alice",
+   *     premium_user: true,
+   *     signup_age: 23,
+   *   },
    * }).catch((err) => {
    *   console.error("Failed to track event:", err);
    * });
    * ```
    */
-  trackEvent(
-    name: string,
-    attributes?: Record<string, ValidAttributeValue>,
-    timestamp?: number
-  ): Promise<void> {
+  trackEvent(params: {
+    name: string;
+    attributes?: Record<string, ValidAttributeValue>;
+    timestamp?: number;
+  }): Promise<void> {
     if (!_measureInternal) {
       return Promise.reject(
         new Error('Measure is not initialized. Call init() first.')
       );
     }
 
-    return _measureInternal.trackEvent(name, attributes, timestamp);
+    return _measureInternal.trackEvent(params);
   },
 
   /**
@@ -132,30 +135,33 @@ export const Measure = {
    * This method should be used if your app uses a custom navigation system
    * and you want to manually record screen view events.
    *
-   * @param screenName - The name of the screen being viewed.
-   * @param attributes - Optional key-value pairs providing additional context.
+   * @param params.screenName - The name of the screen being viewed.
+   * @param params.attributes - Optional key-value pairs providing additional context.
    *
    * @example
    * ```ts
    * import { Measure } from '@measure/react-native';
    *
-   * Measure.trackScreenView("Home", {
-   *   user_name: "Alice",
-   *   premium_user: true,
+   * Measure.trackScreenView({
+   *   screenName: "Home",
+   *   attributes: {
+   *     user_name: "Alice",
+   *     premium_user: true,
+   *   },
    * });
    * ```
    */
-  trackScreenView(
-    screenName: string,
-    attributes?: Record<string, ValidAttributeValue>
-  ): Promise<void> {
+  trackScreenView(params: {
+    screenName: string;
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> {
     if (!_measureInternal) {
       return Promise.reject(
         new Error('Measure is not initialized. Call init() first.')
       );
     }
 
-    return _measureInternal.trackScreenView(screenName, attributes);
+    return _measureInternal.trackScreenView(params);
   },
 
   /**
@@ -179,25 +185,25 @@ export const Measure = {
    * @param name - The name to identify this span.
    * @returns A new Span instance if the SDK is initialized, or an invalid no-op span if not initialized.
    */
-  startSpan(name: string): Span {
+  startSpan({ name }: { name: string }): Span {
     if (!_measureInternal) {
       return new InvalidSpan();
     }
-    return _measureInternal.startSpan(name);
+    return _measureInternal.startSpan({ name });
   },
 
   /**
    * Starts a new performance tracing span with the specified name and start timestamp.
    *
-   * @param name - The name to identify this span.
-   * @param timestampMs - The milliseconds since epoch when the span started.
+   * @param params.name - The name to identify this span.
+   * @param params.timestampMs - The milliseconds since epoch when the span started.
    * @returns A new Span instance if the SDK is initialized, or an invalid no-op span if not initialized.
    */
-  startSpanWithTimestamp(name: string, timestampMs: number): Span {
+  startSpanWithTimestamp(params: { name: string; timestampMs: number }): Span {
     if (!_measureInternal) {
       return new InvalidSpan();
     }
-    return _measureInternal.startSpan(name, timestampMs);
+    return _measureInternal.startSpan(params);
   },
 
   /**
@@ -206,11 +212,11 @@ export const Measure = {
    * @param name - The name to identify this span.
    * @returns A SpanBuilder instance to configure the span if the SDK is initialized, or undefined if not.
    */
-  createSpanBuilder(name: string): SpanBuilder | undefined {
+  createSpanBuilder({ name }: { name: string }): SpanBuilder | undefined {
     if (!_measureInternal) {
       return undefined;
     }
-    return _measureInternal.createSpan(name);
+    return _measureInternal.createSpan({ name });
   },
 
   /**
@@ -219,11 +225,11 @@ export const Measure = {
    * @param span - The span to extract the traceparent header value from.
    * @returns A W3C trace context compliant header value (e.g., '00-traceId-spanId-01').
    */
-  getTraceParentHeaderValue(span: Span): string {
+  getTraceParentHeaderValue({ span }: { span: Span }): string {
     if (!_measureInternal) {
       return '';
     }
-    return _measureInternal.getTraceParentHeaderValue(span);
+    return _measureInternal.getTraceParentHeaderValue({ span });
   },
 
   /**
@@ -248,7 +254,7 @@ export const Measure = {
    *
    * @param userId - A non-empty string identifier.
    */
-  setUserId(userId: string): void {
+  setUserId({ userId }: { userId: string }): void {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
       return;
@@ -259,7 +265,7 @@ export const Measure = {
       return;
     }
 
-    _measureInternal.setUserId(userId);
+    _measureInternal.setUserId({ userId });
   },
 
   /**
@@ -317,30 +323,26 @@ export const Measure = {
    * This can be used to allow users or QA testers to report issues directly
    * from within the app, optionally including a screenshot and additional attributes.
    *
-   * @param takeScreenshot - Set to false to disable screenshot capture. Defaults to true.
-   * @param bugReportConfig - Optional configuration for customizing the bug report UI.
-   * @param attributes - Optional metadata key-value pairs describing the context of the report.
+   * @param params.takeScreenshot - Set to false to disable screenshot capture. Defaults to true.
+   * @param params.bugReportConfig - Optional configuration for customizing the bug report UI.
+   * @param params.attributes - Optional metadata key-value pairs describing the context of the report.
    *
    * @example
    * ```ts
-   * Measure.launchBugReport(true, { theme: "dark" }, { userId: "123", screen: "Home" });
+   * Measure.launchBugReport({ takeScreenshot: true, bugReportConfig: { theme: "dark" }, attributes: { userId: "123", screen: "Home" } });
    * ```
    */
-  launchBugReport(
-    takeScreenshot: boolean = true,
-    bugReportConfig: Record<string, any> = {},
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> {
+  launchBugReport(params: {
+    takeScreenshot?: boolean;
+    bugReportConfig?: Record<string, any>;
+    attributes?: Record<string, ValidAttributeValue>;
+  } = {}): Promise<void> {
     if (!_measureInternal) {
       return Promise.reject(
         new Error('Measure is not initialized. Call init() first.')
       );
     }
-    return _measureInternal.launchBugReport(
-      takeScreenshot,
-      bugReportConfig,
-      attributes
-    );
+    return _measureInternal.launchBugReport(params);
   },
 
   /**
@@ -364,13 +366,13 @@ export const Measure = {
    * });
    * ```
    */
-  onShake(handler?: (() => void) | null): void {
+  onShake({ handler }: { handler?: (() => void) | null }): void {
     if (!_measureInternal) {
       console.warn('Measure is not initialized. Call init() first.');
       return;
     }
 
-    _measureInternal.onShake(handler);
+    _measureInternal.onShake({ handler });
   },
 
   /**
@@ -430,37 +432,33 @@ export const Measure = {
    * Attachments may include screenshots, layout snapshots, or any files
    * captured via the Measure attachment APIs.
    *
-   * @param description - A human-readable description of the bug (max 4000 chars).
-   * @param attachments - Optional list of MsrAttachment objects (max 5).
-   * @param attributes - Optional metadata describing the bug context.
+   * @param params.description - A human-readable description of the bug (max 4000 chars).
+   * @param params.attachments - Optional list of MsrAttachment objects (max 5).
+   * @param params.attributes - Optional metadata describing the bug context.
    *
    * @example
    * ```ts
    * const screenshot = await Measure.captureScreenshot();
    *
-   * Measure.trackBugReport(
-   *   "Something broke on the Home screen",
-   *   screenshot ? [screenshot] : [],
-   *   { userId: "123", screen: "Home" }
-   * );
+   * Measure.trackBugReport({
+   *   description: "Something broke on the Home screen",
+   *   attachments: screenshot ? [screenshot] : [],
+   *   attributes: { userId: "123", screen: "Home" },
+   * });
    * ```
    */
-  trackBugReport(
-    description: string,
-    attachments: MsrAttachment[] = [],
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> {
+  trackBugReport(params: {
+    description: string;
+    attachments?: MsrAttachment[];
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> {
     if (!_measureInternal) {
       return Promise.reject(
         new Error('Measure is not initialized. Call init() first.')
       );
     }
 
-    return _measureInternal.trackBugReport(
-      description,
-      attachments,
-      attributes
-    );
+    return _measureInternal.trackBugReport(params);
   },
 
   /**

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -51,7 +51,7 @@ export class MeasureInternal {
     this.measureInitializer.bugReportCollector.unregister();
   }
 
-  async init(config: MeasureConfig | null): Promise<void> {
+  async init({ config }: { config: MeasureConfig | null }): Promise<void> {
     this.measureInitializer.configLoader
       .loadDynamicConfig()
       .then((dynamicConfig) => {
@@ -104,42 +104,38 @@ export class MeasureInternal {
     return nativeStop();
   }
 
-  trackEvent = (
-    name: string,
-    attributes?: Record<string, ValidAttributeValue>,
-    timestamp?: number
-  ): Promise<void> =>
-    this.measureInitializer.customEventCollector.trackCustomEvent(
-      name,
-      attributes ?? {},
-      timestamp
-    );
+  trackEvent = ({
+    name,
+    attributes,
+    timestamp,
+  }: {
+    name: string;
+    attributes?: Record<string, ValidAttributeValue>;
+    timestamp?: number;
+  }): Promise<void> =>
+    this.measureInitializer.customEventCollector.trackCustomEvent({ name, attributes, timestamp });
 
   getCurrentTime(): number {
     return this.measureInitializer.timeProvider.now();
   }
 
-  trackScreenView = (
-    screenName: string,
-    attributes?: Record<string, ValidAttributeValue>
-  ): Promise<void> =>
-    this.measureInitializer.userTriggeredEventCollector.trackScreenView(
-      screenName,
-      attributes ?? {}
-    );
+  trackScreenView = ({
+    screenName,
+    attributes,
+  }: {
+    screenName: string;
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> =>
+    this.measureInitializer.userTriggeredEventCollector.trackScreenView({ screenName, attributes });
 
-  launchBugReport = (
-    takeScreenshot: boolean = true,
-    bugReportConfig: Record<string, any> = {},
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> =>
-    this.measureInitializer.bugReportCollector.launchBugReport(
-      takeScreenshot,
-      bugReportConfig,
-      attributes
-    );
+  launchBugReport = (params: {
+    takeScreenshot?: boolean;
+    bugReportConfig?: Record<string, any>;
+    attributes?: Record<string, ValidAttributeValue>;
+  } = {}): Promise<void> =>
+    this.measureInitializer.bugReportCollector.launchBugReport(params);
 
-  onShake(handler?: (() => void) | null): void {
+  onShake({ handler }: { handler?: (() => void) | null }): void {
     this.shakeHandler = handler;
     const enable = !!this.shakeHandler;
     setShakeListener(enable, this.shakeHandler ?? undefined);
@@ -158,25 +154,23 @@ export class MeasureInternal {
     return this.measureInitializer.layoutSnapshotCollector.capture();
   }
 
-  createSpan(name: string): SpanBuilder | undefined {
-    return this.measureInitializer.spanCollector.createSpan(name);
+  createSpan({ name }: { name: string }): SpanBuilder | undefined {
+    return this.measureInitializer.spanCollector.createSpan({ name });
   }
 
-  startSpan(name: string, timestampMs?: number): Span {
-    return this.measureInitializer.spanCollector.startSpan(name, timestampMs);
+  startSpan({ name, timestampMs }: { name: string; timestampMs?: number }): Span {
+    return this.measureInitializer.spanCollector.startSpan({ name, timestampMs });
   }
 
-  getTraceParentHeaderValue(span: Span): string {
-    return this.measureInitializer.spanCollector.getTraceParentHeaderValue(
-      span
-    );
+  getTraceParentHeaderValue({ span }: { span: Span }): string {
+    return this.measureInitializer.spanCollector.getTraceParentHeaderValue({ span });
   }
 
   getTraceParentHeaderKey(): string {
     return this.measureInitializer.spanCollector.getTraceParentHeaderKey();
   }
 
-  setUserId(userId: string): void {
+  setUserId({ userId }: { userId: string }): void {
     return this.measureInitializer.nativeApiProcessor.setUserId(userId);
   }
 
@@ -202,16 +196,12 @@ export class MeasureInternal {
     );
   }
 
-  trackBugReport(
-    description: string,
-    attachments: MsrAttachment[] = [],
-    attributes: Record<string, ValidAttributeValue> = {}
-  ): Promise<void> {
-    return this.measureInitializer.bugReportCollector.trackBugReport(
-      description,
-      attachments,
-      attributes
-    );
+  trackBugReport(params: {
+    description: string;
+    attachments?: MsrAttachment[];
+    attributes?: Record<string, ValidAttributeValue>;
+  }): Promise<void> {
+    return this.measureInitializer.bugReportCollector.trackBugReport(params);
   }
 
   getSessionId(): Promise<string | null> {

--- a/react-native/src/tracing/spanCollector.ts
+++ b/react-native/src/tracing/spanCollector.ts
@@ -7,10 +7,10 @@ import type { Logger } from "../utils/logger";
 export interface ISpanCollector {
     register(): void;
     unregister(): void;
-    getTraceParentHeaderValue(span: Span): string;
+    getTraceParentHeaderValue(params: { span: Span }): string;
     getTraceParentHeaderKey(): string;
-    createSpan(name: string): SpanBuilder | undefined;
-    startSpan(name: string, timestampMs?: number): Span;
+    createSpan(params: { name: string }): SpanBuilder | undefined;
+    startSpan(params: { name: string; timestampMs?: number }): Span;
 }
 
 /**
@@ -35,7 +35,7 @@ export class SpanCollector implements ISpanCollector {
         this.isEnabled = false;
     }
 
-    getTraceParentHeaderValue(span: Span): string {
+    getTraceParentHeaderValue({ span }: { span: Span }): string {
         return this.tracer.getTraceParentHeaderValue(span);
     }
 
@@ -43,7 +43,7 @@ export class SpanCollector implements ISpanCollector {
         return this.tracer.getTraceParentHeaderKey();
     }
 
-    createSpan(name: string): SpanBuilder | undefined {
+    createSpan({ name }: { name: string }): SpanBuilder | undefined {
         if (!this.isEnabled) {
             this.logger.internalLog('warning', 'Measure SDK is stopped. createSpan() will be ignored.');
             return undefined;
@@ -51,7 +51,7 @@ export class SpanCollector implements ISpanCollector {
         return this.tracer.spanBuilder(name);
     }
 
-    startSpan(name: string, timestampMs?: number): Span {
+    startSpan({ name, timestampMs }: { name: string; timestampMs?: number }): Span {
         if (!this.isEnabled) {
             this.logger.internalLog('warning', 'Measure SDK is stopped. startSpan() will be ignored.');
             return new InvalidSpan();

--- a/samples/frank/react_native/index.js
+++ b/samples/frank/react_native/index.js
@@ -58,7 +58,7 @@ const triggerUIFreeze = () => {
 // -- Bug report actions --
 
 const launchBugReport = () => {
-  Measure.launchBugReport(true, {source: 'manual'}, {screen: 'RNDemos'});
+  Measure.launchBugReport({takeScreenshot: true, bugReportConfig: {source: 'manual'}, attributes: {screen: 'RNDemos'}});
 };
 
 const trackBugReport = async () => {
@@ -66,11 +66,11 @@ const trackBugReport = async () => {
     const screenshot = await Measure.captureScreenshot();
     const layoutSnapshot = await Measure.captureLayoutSnapshot();
     const attachments = [screenshot, layoutSnapshot].filter(a => a !== null);
-    await Measure.trackBugReport(
-      'Bug report from React Native demos',
+    await Measure.trackBugReport({
+      description: 'Bug report from React Native demos',
       attachments,
-      {source: 'rn_demo', screen: 'RNDemos'},
-    );
+      attributes: {source: 'rn_demo', screen: 'RNDemos'},
+    });
   } catch (err) {
     console.error('Failed to send bug report:', err);
   }
@@ -119,14 +119,17 @@ const trackHttpManually = () => {
 // -- Misc actions --
 
 const trackCustomEvent = () => {
-  Measure.trackEvent('button_click', {
-    screen: 'RNDemos',
-    action: 'Track Custom Event',
+  Measure.trackEvent({
+    name: 'button_click',
+    attributes: {
+      screen: 'RNDemos',
+      action: 'Track Custom Event',
+    },
   });
 };
 
 const createSpan = () => {
-  const span = Measure.startSpan('load-data');
+  const span = Measure.startSpan({name: 'load-data'});
   span.setCheckpoint('on-start');
   span.setAttribute('is_premium', false);
   span.setStatus(2); // SpanStatus.Error
@@ -138,7 +141,7 @@ const createSpan = () => {
 };
 
 const setUserId = () => {
-  Measure.setUserId('user-131351');
+  Measure.setUserId({userId: 'user-131351'});
 };
 
 const clearUserId = () => {
@@ -155,18 +158,18 @@ const ReactNativeScreen = () => {
 
   useEffect(() => {
     return () => {
-      Measure.onShake(null);
+      Measure.onShake({handler: null});
     };
   }, []);
 
   const toggleShake = enabled => {
     setShakeEnabled(enabled);
     if (enabled) {
-      Measure.onShake(() => {
-        Measure.launchBugReport(true, {source: 'shake'}, {screen: 'RNDemos'});
-      });
+      Measure.onShake({handler: () => {
+        Measure.launchBugReport({takeScreenshot: true, bugReportConfig: {source: 'shake'}, attributes: {screen: 'RNDemos'}});
+      }});
     } else {
-      Measure.onShake(null);
+      Measure.onShake({handler: null});
     }
   };
 
@@ -464,12 +467,12 @@ const styles = StyleSheet.create({
   },
 });
 
-const measureReady = Measure.init(
-  new MeasureConfig({
+const measureReady = Measure.init({
+  config: new MeasureConfig({
     enableLogging: true,
     enableFullCollectionMode: true,
     enableDiagnosticMode: true,
   }),
-);
+});
 
 AppRegistry.registerComponent('FrankensteinRN', () => ReactNativeScreen);


### PR DESCRIPTION
# Description

  This PR contains below changes:

  - Refactored all functions in measure.ts, measureInternal.ts and internal collectors to use named parameters instead of positional parameters.
  - Exported missing public types from index.ts: SpanBuilder, SpanStatus, MsrAttachment, AttachmentType, and ValidAttributeValue.
  - Update demo apps.
  - Update tests.

## Related issue
Closes #3648 
Closes #3649 