### PR TITLE
chore(backend): support muli-value for error & severity filtering

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -277,6 +277,9 @@ func makeTitle(t, m string) (typeMessage string) {
 	return
 }
 
+// Severity classifies an error event's impact level. fatal = unhandled
+// exception or ANR; unhandled = nonfatal exception that was not caught;
+// handled = explicitly caught and reported exception.
 type Severity string
 
 const (
@@ -292,6 +295,29 @@ func (s Severity) String() string {
 func (s Severity) IsValid() bool {
 	switch s {
 	case SeverityFatal, SeverityHandled, SeverityUnhandled:
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrorType distinguishes the two error source tables: exception events
+// (fatal + nonfatal) and ANR events. Used by the ?type query parameter to
+// route queries to the correct ClickHouse tables.
+type ErrorType string
+
+const (
+	ErrorTypeError ErrorType = "error" // all exceptions (fatal and nonfatal)
+	ErrorTypeANR   ErrorType = "anr"   // application-not-responding events
+)
+
+func (e ErrorType) String() string {
+	return string(e)
+}
+
+func (e ErrorType) IsValid() bool {
+	switch e {
+	case ErrorTypeError, ErrorTypeANR:
 		return true
 	default:
 		return false

--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -125,17 +125,19 @@ type AppFilter struct {
 	// consider ANR events.
 	ANR bool `form:"anr"`
 
-	// Error indicates the filtering should only
-	// consider error events.
-	Error bool `form:"error"`
+	// Severity is the raw comma-separated severity filter value.
+	// Valid values: any combination of "fatal", "unhandled", "handled".
+	Severity string `form:"severity"`
 
-	// Severity indicates the type of the error
-	// whether:
-	//
-	// - fatal
-	// - unhandled
-	// - handled
-	Severity event.Severity `form:"severity"`
+	// Severities holds the parsed severity values, populated in Expand.
+	Severities []event.Severity
+
+	// ErrorType is the raw comma-separated error type filter value.
+	// Valid values: any combination of "error", "anr".
+	ErrorType string `form:"type"`
+
+	// ErrorTypes holds the parsed error type values, populated in Expand.
+	ErrorTypes []event.ErrorType
 
 	// CustomError indicates if the filtering should
 	// consider only custom errors.
@@ -377,6 +379,18 @@ func (af *AppFilter) Expand(ctx context.Context) (err error) {
 		af.NetworkGenerations = text.SplitTrimEmpty(af.NetworkGenerations[0], ",")
 	}
 
+	if af.Severity != "" {
+		for _, s := range text.SplitTrimEmpty(af.Severity, ",") {
+			af.Severities = append(af.Severities, event.Severity(s))
+		}
+	}
+
+	if af.ErrorType != "" {
+		for _, t := range text.SplitTrimEmpty(af.ErrorType, ",") {
+			af.ErrorTypes = append(af.ErrorTypes, event.ErrorType(t))
+		}
+	}
+
 	if len(af.UDExpressionRaw) > 0 {
 		af.UDExpressionRaw = strings.TrimSpace(af.UDExpressionRaw)
 	}
@@ -451,9 +465,15 @@ func (af *AppFilter) Validate() error {
 		}
 	}
 
-	if af.Severity != "" {
-		if !af.Severity.IsValid() {
-			return fmt.Errorf("`severity` must be one of: %s, %s, %s", event.SeverityFatal, event.SeverityUnhandled, event.SeverityHandled)
+	for _, s := range af.Severities {
+		if !s.IsValid() {
+			return fmt.Errorf("`severity` must be any combination of: %s, %s, %s", event.SeverityFatal, event.SeverityUnhandled, event.SeverityHandled)
+		}
+	}
+
+	for _, t := range af.ErrorTypes {
+		if !t.IsValid() {
+			return fmt.Errorf("`type` must be any combination of: %s, %s", event.ErrorTypeError, event.ErrorTypeANR)
 		}
 	}
 

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -283,8 +283,6 @@ func (a App) GetExceptionGroupPlotInstances(ctx context.Context, fingerprint str
 	return
 }
 
-// GetErrorGroupsWithFilter fetches error groups
-// of an app.
 // anrAllowed returns whether the ANR source should be queried given the
 // AppFilter. ANRs are never custom-captured, so CustomError=true forces ANR
 // off regardless of the requested value. Use this as the single source of
@@ -301,18 +299,22 @@ func anrAllowed(af *filter.AppFilter, requested bool) bool {
 // branch is active and which exception.handled rows the exception branch
 // should match. When no severity flag is set, all sources are included.
 func resolveErrorSources(af *filter.AppFilter) (queryANR, wantHandledTrue, wantHandledFalse bool) {
-	queryANR = af.ANR
-	wantHandledTrue = af.Severity == event.SeverityHandled || af.Error
-	wantHandledFalse = af.Severity == event.SeverityFatal ||
-		af.Severity == event.SeverityUnhandled ||
-		af.Crash ||
-		af.Error
+	includeANR := (len(af.ErrorTypes) == 0 && len(af.Severities) == 0) || slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+	includeError := len(af.ErrorTypes) == 0 || slices.Contains(af.ErrorTypes, event.ErrorTypeError)
 
-	if !queryANR && !wantHandledTrue && !wantHandledFalse {
+	if includeANR {
 		queryANR = true
-		wantHandledTrue = true
-		wantHandledFalse = true
 	}
+
+	if includeError {
+		hasFatal := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityFatal)
+		hasUnhandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityUnhandled)
+		hasHandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityHandled)
+
+		wantHandledTrue = hasHandled
+		wantHandledFalse = hasFatal || hasUnhandled
+	}
+
 	queryANR = anrAllowed(af, queryANR)
 	return
 }
@@ -333,9 +335,16 @@ func unionStmts(stmts []*sqlf.Stmt) *sqlf.Stmt {
 }
 
 func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter) (groups []group.ErrorGroup, next, previous bool, err error) {
-	queryANR := af.ANR
-	queryFatal := af.Severity == event.SeverityFatal || af.Crash
-	queryNonfatal := af.Severity == event.SeverityHandled || af.Severity == event.SeverityUnhandled || af.Error
+	includeANR := (len(af.ErrorTypes) == 0 && len(af.Severities) == 0) || slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+	includeError := len(af.ErrorTypes) == 0 || slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+
+	hasFatal := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityFatal)
+	hasUnhandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityUnhandled)
+	hasHandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityHandled)
+
+	queryANR := includeANR
+	queryFatal := includeError && hasFatal
+	queryNonfatal := includeError && (hasHandled || hasUnhandled)
 
 	if !queryANR && !queryFatal && !queryNonfatal {
 		return
@@ -440,6 +449,11 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			err = errBranch
 			return
 		}
+		if hasHandled && !hasUnhandled {
+			s.Where("handled = true")
+		} else if !hasHandled && hasUnhandled {
+			s.Where("handled = false")
+		}
 		groupsBranches = append(groupsBranches, s)
 	}
 
@@ -489,9 +503,9 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			GroupBy("app_id").
 			GroupBy("id")
 
-		if af.Severity == event.SeverityHandled {
+		if !queryFatal && hasHandled && !hasUnhandled {
 			s.Where("`exception.handled` = true")
-		} else if af.Severity == event.SeverityUnhandled {
+		} else if !queryFatal && !hasHandled && hasUnhandled {
 			s.Where("`exception.handled` = false")
 		}
 
@@ -986,17 +1000,16 @@ func (a App) GetErrorGroupAttributesDistribution(ctx context.Context, fingerprin
 // the filter's severity flags. When no severity flag is set, all
 // sources are queried.
 func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *filter.AppFilter) (events []any, next, previous bool, err error) {
-	queryANR := af.ANR
-	queryFatal := af.Severity == event.SeverityFatal || af.Crash
-	queryNonfatal := af.Severity == event.SeverityHandled ||
-		af.Severity == event.SeverityUnhandled ||
-		af.Error
+	includeANR := (len(af.ErrorTypes) == 0 && len(af.Severities) == 0) || slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+	includeError := len(af.ErrorTypes) == 0 || slices.Contains(af.ErrorTypes, event.ErrorTypeError)
 
-	if !queryANR && !queryFatal && !queryNonfatal {
-		queryANR = true
-		queryFatal = true
-		queryNonfatal = true
-	}
+	hasFatal := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityFatal)
+	hasUnhandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityUnhandled)
+	hasHandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityHandled)
+
+	queryANR := includeANR
+	queryFatal := includeError && hasFatal
+	queryNonfatal := includeError && (hasHandled || hasUnhandled)
 
 	queryANR = anrAllowed(af, queryANR)
 
@@ -1068,9 +1081,9 @@ func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *fi
 		if queryFatal && !queryNonfatal {
 			stmt.Where("exception.handled = false")
 		} else if queryNonfatal && !queryFatal {
-			if af.Severity == event.SeverityHandled {
+			if hasHandled && !hasUnhandled {
 				stmt.Where("exception.handled = true")
-			} else if af.Severity == event.SeverityUnhandled {
+			} else if hasUnhandled && !hasHandled {
 				stmt.Where("exception.handled = false")
 			}
 		}

--- a/backend/api/measure/error_groups_test.go
+++ b/backend/api/measure/error_groups_test.go
@@ -59,11 +59,7 @@ func TestGetErrorGroupsWithFilterTypeAndSeverity(t *testing.T) {
 	seedAllErrorSources(f, t, ts)
 
 	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", "")
-	// GetErrorGroupsWithFilter returns empty when no severity flag is set;
-	// enable all three branches explicitly.
-	af.Crash = true
-	af.Error = true
-	af.ANR = true
+	af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
 
 	groups, _, _, err := f.app.GetErrorGroupsWithFilter(f.ctx, af)
 	if err != nil {
@@ -109,46 +105,116 @@ func TestGetErrorGroupsWithFilterSeverityFiltering(t *testing.T) {
 		wantType map[string]string
 	}{
 		{
-			name:     "crash flag returns fatal only",
-			modify:   func(af *filter.AppFilter) { af.Crash = true },
+			name: "type=error with severity=fatal returns fatal only",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+				af.Severities = []event.Severity{event.SeverityFatal}
+			},
 			wantIDs:  map[string]event.Severity{fpGroupFatal: event.SeverityFatal},
 			wantType: map[string]string{fpGroupFatal: "exception"},
 		},
 		{
 			name:     "severity=fatal returns fatal only",
-			modify:   func(af *filter.AppFilter) { af.Severity = event.SeverityFatal },
+			modify:   func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityFatal} },
 			wantIDs:  map[string]event.Severity{fpGroupFatal: event.SeverityFatal},
 			wantType: map[string]string{fpGroupFatal: "exception"},
 		},
 		{
 			name:     "severity=handled returns handled nonfatal only",
-			modify:   func(af *filter.AppFilter) { af.Severity = event.SeverityHandled },
+			modify:   func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityHandled} },
 			wantIDs:  map[string]event.Severity{fpGroupHandled: event.SeverityHandled},
 			wantType: map[string]string{fpGroupHandled: "exception"},
 		},
 		{
 			name:     "severity=unhandled returns unhandled nonfatal only",
-			modify:   func(af *filter.AppFilter) { af.Severity = event.SeverityUnhandled },
+			modify:   func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityUnhandled} },
 			wantIDs:  map[string]event.Severity{fpGroupUnhandled: event.SeverityUnhandled},
 			wantType: map[string]string{fpGroupUnhandled: "exception"},
 		},
 		{
-			name:   "anr flag returns ANR only",
-			modify: func(af *filter.AppFilter) { af.ANR = true },
+			name:   "type=anr returns ANR only",
+			modify: func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeANR} },
 			wantIDs: map[string]event.Severity{
 				fpGroupANR: event.SeverityFatal,
 			},
 			wantType: map[string]string{fpGroupANR: "anr"},
 		},
 		{
-			name:   "error flag returns both nonfatal severities",
-			modify: func(af *filter.AppFilter) { af.Error = true },
+			name: "type=error with nonfatal severities returns both nonfatal",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+				af.Severities = []event.Severity{event.SeverityHandled, event.SeverityUnhandled}
+			},
 			wantIDs: map[string]event.Severity{
 				fpGroupHandled:   event.SeverityHandled,
 				fpGroupUnhandled: event.SeverityUnhandled,
 			},
 			wantType: map[string]string{
 				fpGroupHandled:   "exception",
+				fpGroupUnhandled: "exception",
+			},
+		},
+		{
+			// ANR is unaffected by severity — must appear alongside fatal exception.
+			name: "type=error,anr with severity=fatal returns fatal exception and ANR",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
+				af.Severities = []event.Severity{event.SeverityFatal}
+			},
+			wantIDs: map[string]event.Severity{
+				fpGroupFatal: event.SeverityFatal,
+				fpGroupANR:   event.SeverityFatal,
+			},
+			wantType: map[string]string{
+				fpGroupFatal: "exception",
+				fpGroupANR:   "anr",
+			},
+		},
+		{
+			// ANR must appear alongside handled exception when severity=handled.
+			name: "type=error,anr with severity=handled returns handled exception and ANR",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
+				af.Severities = []event.Severity{event.SeverityHandled}
+			},
+			wantIDs: map[string]event.Severity{
+				fpGroupHandled: event.SeverityHandled,
+				fpGroupANR:     event.SeverityFatal,
+			},
+			wantType: map[string]string{
+				fpGroupHandled: "exception",
+				fpGroupANR:     "anr",
+			},
+		},
+		{
+			name: "type=error,anr with severity=fatal,handled returns fatal, handled exception and ANR",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
+				af.Severities = []event.Severity{event.SeverityFatal, event.SeverityHandled}
+			},
+			wantIDs: map[string]event.Severity{
+				fpGroupFatal:   event.SeverityFatal,
+				fpGroupHandled: event.SeverityHandled,
+				fpGroupANR:     event.SeverityFatal,
+			},
+			wantType: map[string]string{
+				fpGroupFatal:   "exception",
+				fpGroupHandled: "exception",
+				fpGroupANR:     "anr",
+			},
+		},
+		{
+			name: "type=error with severity=fatal,unhandled returns fatal and unhandled exception",
+			modify: func(af *filter.AppFilter) {
+				af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+				af.Severities = []event.Severity{event.SeverityFatal, event.SeverityUnhandled}
+			},
+			wantIDs: map[string]event.Severity{
+				fpGroupFatal:     event.SeverityFatal,
+				fpGroupUnhandled: event.SeverityUnhandled,
+			},
+			wantType: map[string]string{
+				fpGroupFatal:     "exception",
 				fpGroupUnhandled: "exception",
 			},
 		},
@@ -230,9 +296,7 @@ func TestGetErrorGroupsWithFilterCustomErrorFilter(t *testing.T) {
 	seedCustomMix(f, t, ts)
 
 	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", "")
-	af.Crash = true
-	af.Error = true
-	af.ANR = true
+	af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
 	af.CustomError = true
 
 	groups, _, _, err := f.app.GetErrorGroupsWithFilter(f.ctx, af)
@@ -266,9 +330,7 @@ func TestGetErrorGroupsWithFilterIsCustomPopulated(t *testing.T) {
 	seedCustomMix(f, t, ts)
 
 	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", "")
-	af.Crash = true
-	af.Error = true
-	af.ANR = true
+	af.ErrorTypes = []event.ErrorType{event.ErrorTypeError, event.ErrorTypeANR}
 
 	groups, _, _, err := f.app.GetErrorGroupsWithFilter(f.ctx, af)
 	if err != nil {

--- a/backend/api/measure/error_plot_test.go
+++ b/backend/api/measure/error_plot_test.go
@@ -61,12 +61,15 @@ func TestGetErrorPlotInstancesRoutesBySeverity(t *testing.T) {
 		modify    func(af *filter.AppFilter)
 		wantTotal uint64
 	}{
-		{"crash flag returns only the unhandled exception", func(af *filter.AppFilter) { af.Crash = true }, 1},
-		{"severity=fatal returns only the unhandled exception", func(af *filter.AppFilter) { af.Severity = event.SeverityFatal }, 1},
-		{"severity=unhandled returns only the unhandled exception", func(af *filter.AppFilter) { af.Severity = event.SeverityUnhandled }, 1},
-		{"severity=handled returns only the handled exception", func(af *filter.AppFilter) { af.Severity = event.SeverityHandled }, 1},
-		{"error flag returns both exception events", func(af *filter.AppFilter) { af.Error = true }, 2},
-		{"anr flag returns only the ANR", func(af *filter.AppFilter) { af.ANR = true }, 1},
+		{"type=error with severity=fatal returns only the unhandled exception", func(af *filter.AppFilter) {
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+			af.Severities = []event.Severity{event.SeverityFatal}
+		}, 1},
+		{"severity=fatal returns only the unhandled exception", func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityFatal} }, 1},
+		{"severity=unhandled returns only the unhandled exception", func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityUnhandled} }, 1},
+		{"severity=handled returns only the handled exception", func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityHandled} }, 1},
+		{"type=error returns both exception events", func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeError} }, 2},
+		{"type=anr returns only the ANR", func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeANR} }, 1},
 		{"no flags defaults to all sources", func(af *filter.AppFilter) {}, 3},
 	}
 
@@ -131,16 +134,22 @@ func TestGetErrorGroupPlotInstancesRoutesBySeverity(t *testing.T) {
 		modify      func(af *filter.AppFilter)
 		wantTotal   uint64
 	}{
-		{"crash flag, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Crash = true }, 1},
-		{"crash flag, handled fingerprint returns nothing", fpErrHandled, func(af *filter.AppFilter) { af.Crash = true }, 0},
-		{"severity=fatal, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Severity = event.SeverityFatal }, 1},
-		{"severity=unhandled, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Severity = event.SeverityUnhandled }, 1},
-		{"severity=handled, handled fingerprint", fpErrHandled, func(af *filter.AppFilter) { af.Severity = event.SeverityHandled }, 1},
-		{"severity=handled, unhandled fingerprint returns nothing", fpErrUnhandled, func(af *filter.AppFilter) { af.Severity = event.SeverityHandled }, 0},
-		{"error flag, handled fingerprint", fpErrHandled, func(af *filter.AppFilter) { af.Error = true }, 1},
-		{"error flag, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Error = true }, 1},
-		{"anr flag, ANR fingerprint", fpErrANR, func(af *filter.AppFilter) { af.ANR = true }, 1},
-		{"anr flag, exception fingerprint returns nothing", fpErrUnhandled, func(af *filter.AppFilter) { af.ANR = true }, 0},
+		{"type=error+severity=fatal, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) {
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+			af.Severities = []event.Severity{event.SeverityFatal}
+		}, 1},
+		{"type=error+severity=fatal, handled fingerprint returns nothing", fpErrHandled, func(af *filter.AppFilter) {
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+			af.Severities = []event.Severity{event.SeverityFatal}
+		}, 0},
+		{"severity=fatal, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityFatal} }, 1},
+		{"severity=unhandled, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityUnhandled} }, 1},
+		{"severity=handled, handled fingerprint", fpErrHandled, func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityHandled} }, 1},
+		{"severity=handled, unhandled fingerprint returns nothing", fpErrUnhandled, func(af *filter.AppFilter) { af.Severities = []event.Severity{event.SeverityHandled} }, 0},
+		{"type=error, handled fingerprint", fpErrHandled, func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeError} }, 1},
+		{"type=error, unhandled fingerprint", fpErrUnhandled, func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeError} }, 1},
+		{"type=anr, ANR fingerprint", fpErrANR, func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeANR} }, 1},
+		{"type=anr, exception fingerprint returns nothing", fpErrUnhandled, func(af *filter.AppFilter) { af.ErrorTypes = []event.ErrorType{event.ErrorTypeANR} }, 0},
 		{"no flags default, ANR fingerprint", fpErrANR, func(af *filter.AppFilter) {}, 1},
 		{"no flags default, unhandled exception fingerprint", fpErrUnhandled, func(af *filter.AppFilter) {}, 1},
 		{"no flags default, handled exception fingerprint", fpErrHandled, func(af *filter.AppFilter) {}, 1},

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -3067,16 +3067,14 @@ Fetch an app's error overview. Returns fatal exceptions, handled exceptions, and
   - `network_providers` (_optional_) - List of comma separated network providers.
   - `network_types` (_optional_) - List of comma separated network types.
   - `network_generations` (_optional_) - List of comma separated network generations.
-  - `severity` (_optional_) - Filter by severity. Accepted values: `fatal`, `handled`, `unhandled`.
-  - `error` (_optional_) - `true` to include error events (fatal + nonfatal exceptions).
-  - `crash` (_optional_) - `true` to include only unhandled exception events.
-  - `anr` (_optional_) - `true` to include only ANR events.
+  - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
+  - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
   - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
   - `limit` (_optional_) - Number of items to return. Defaults to 10, max 1000.
   - `offset` (_optional_) - Number of items to skip. Defaults to 0.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
-- When none of `error`, `crash`, `anr`, or `severity` are set, all three sources (fatal exceptions, nonfatal exceptions, ANRs) are returned.
+- When neither `type` nor `severity` is set, all sources (fatal exceptions, nonfatal exceptions, ANRs) are returned.
 
 #### Authorization & Content Type
 
@@ -3201,10 +3199,8 @@ Fetch an app's error overview instances plot aggregated by date range & version.
   - `plot_time_group` (_optional_) - Time bucket granularity. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings.
   - `version_codes` (_optional_) - List of comma separated version codes.
-  - `severity` (_optional_) - Filter by severity. Accepted values: `fatal`, `handled`, `unhandled`.
-  - `error` (_optional_) - `true` to include error events.
-  - `crash` (_optional_) - `true` to include only unhandled exception events.
-  - `anr` (_optional_) - `true` to include only ANR events.
+  - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
+  - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
   - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
@@ -3309,10 +3305,8 @@ Fetch an error group's individual error events.
   - `network_providers` (_optional_) - List of comma separated network providers.
   - `network_types` (_optional_) - List of comma separated network types.
   - `network_generations` (_optional_) - List of comma separated network generations.
-  - `severity` (_optional_) - Filter by severity. Accepted values: `fatal`, `handled`, `unhandled`.
-  - `error` (_optional_) - `true` to include error events.
-  - `crash` (_optional_) - `true` to include only unhandled exception events.
-  - `anr` (_optional_) - `true` to include only ANR events.
+  - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
+  - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
   - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
   - `limit` (_optional_) - Number of items to return. Defaults to 10, max 1000.
   - `offset` (_optional_) - Number of items to skip. Defaults to 0.
@@ -3547,6 +3541,9 @@ Fetch an app's error detail instances aggregated by date range & version.
   - `plot_time_group` (_optional_) - Time bucket granularity. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated version identifier strings.
   - `version_codes` (_optional_) - List of comma separated version codes.
+  - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
+  - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
+  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
 - Both `from` and `to` **MUST** be present when specifying date range.
@@ -3648,10 +3645,8 @@ Fetch an error group's attribute distribution — occurrence counts broken down 
   - `network_providers` (_optional_) - List of comma separated network providers.
   - `network_types` (_optional_) - List of comma separated network types.
   - `network_generations` (_optional_) - List of comma separated network generations.
-  - `severity` (_optional_) - Filter by severity. Accepted values: `fatal`, `handled`, `unhandled`.
-  - `error` (_optional_) - `true` to include error events.
-  - `crash` (_optional_) - `true` to include only unhandled exception events.
-  - `anr` (_optional_) - `true` to include only ANR events.
+  - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
+  - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
   - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.


### PR DESCRIPTION
## Summary

This PR  refactors the error filtering logic to support multiple comma-separated values for error types and severities. Replaces the legacy boolean flags (error, crash, anr) with more flexible type & severity query parameters, allowing users to combine different error sources (exceptions vs ANRs) & specific severity levels in a single request.

## Tasks

- [x] Add ErrorType & update Severity to handle multiple comma-separated values
- [x] Replace boolean flags error, crash, anr with type & severity params
- [x] Update query logic in backend/api/measure/app.go for new filter combinations
- [x] Update tests & documentation to reflect API changes

## See also

- fixes #3658