### PR TITLE
chore(backend): refactor app filters to use multi-value error types

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -917,12 +918,16 @@ func (af AppFilter) getAppVersions(ctx context.Context) (versions, versionCodes 
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -981,12 +986,16 @@ func (af AppFilter) getOSVersions(ctx context.Context) (osNames, osVersions []st
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1035,12 +1044,16 @@ func (af AppFilter) getCountries(ctx context.Context) (countries []string, err e
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1087,12 +1100,16 @@ func (af AppFilter) getNetworkProviders(ctx context.Context) (networkProviders [
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1139,12 +1156,16 @@ func (af AppFilter) getNetworkTypes(ctx context.Context) (networkTypes []string,
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1191,12 +1212,16 @@ func (af AppFilter) getNetworkGenerations(ctx context.Context) (networkGeneratio
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1246,12 +1271,16 @@ func (af AppFilter) getDeviceLocales(ctx context.Context) (deviceLocales []strin
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1298,12 +1327,16 @@ func (af AppFilter) getDeviceManufacturers(ctx context.Context) (deviceManufactu
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)
@@ -1350,12 +1383,16 @@ func (af AppFilter) getDeviceNames(ctx context.Context) (deviceNames []string, e
 
 	defer stmt.Close()
 
-	if af.Crash && !af.Span {
-		stmt.Where("exception=true")
-	}
-
-	if af.ANR && !af.Span {
-		stmt.Where("anr=true")
+	if !af.Span && len(af.ErrorTypes) > 0 {
+		includeError := slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+		includeANR := slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+		if includeError && includeANR {
+			stmt.Where("(exception=true OR anr=true)")
+		} else if includeError {
+			stmt.Where("exception=true")
+		} else if includeANR {
+			stmt.Where("anr=true")
+		}
 	}
 
 	rows, err := server.Server.RchPool.Query(ctx, stmt.String(), stmt.Args()...)

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -6006,6 +6006,15 @@ func GetAppFilters(c *gin.Context) {
 		return
 	}
 
+	if err := af.Expand(ctx); err != nil {
+		msg := "failed to expand app filter"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
 	if err := af.Validate(); err != nil {
 		msg := "app filters request validation failed"
 		fmt.Println(msg, err)

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -1178,10 +1178,11 @@ Fetch an app's filters.
 #### Usage Notes
 
 - App's UUID must be passed in the URI
-- Pass `crash=1` as query string parameter to only return filters for crashes
-- Pass `anr=1` as query string parameter to only return filters for ANRs
+- Pass `type=error` to only return filters relevant to exception events (fatal + nonfatal)
+- Pass `type=anr` to only return filters relevant to ANR events
+- Pass `type=error,anr` to return filters relevant to both exceptions and ANRs
 - Pass `ud_attr_keys=1` as query string parameter to return user defined attribute keys
-- If no query string parameters are passed, the API computes filters from all events
+- If `type` is omitted, filters are computed from all events
 
 #### Authorization & Content Type
 


### PR DESCRIPTION
## Summary

This PR refactors the app filters calculation logic to support multi-value error types, moving away from individual boolean flags. This ensures consistency with the recent API changes for event filtering & allows the dashboard to correctly compute available filter values (like versions & device names) when multiple error types are selected.

## Tasks

- [x] Replace af.Crash & af.ANR flags with af.ErrorTypes slice in AppFilter
- [x] Update query logic in AppFilter methods to support multiple error types
- [x] Call af.Expand(ctx) in GetAppFilters to ensure proper filter expansion
- [x] Update dashboard API documentation to reflect new type query parameter

