### PR TITLE
chore(backend): use multi-value error types for session filtering

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -120,10 +120,14 @@ type AppFilter struct {
 
 	// Crash indicates the filtering should
 	// only consider fatal exception events.
+	//
+	// Deprecated: Use ErrorType instead.
 	Crash bool `form:"crash"`
 
 	// ANR indicates the filtering should only
 	// consider ANR events.
+	//
+	// Deprecated: Use ErrorType instead.
 	ANR bool `form:"anr"`
 
 	// Severity is the raw comma-separated severity filter value.

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -2698,11 +2698,11 @@ func (a App) GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter)
 		orExprs := []string{}
 		andExprs := []string{}
 
-		if af.Crash {
+		if slices.Contains(af.ErrorTypes, event.ErrorTypeError) {
 			orExprs = append(orExprs, "crash_count >= 1")
 		}
 
-		if af.ANR {
+		if slices.Contains(af.ErrorTypes, event.ErrorTypeANR) {
 			orExprs = append(orExprs, "anr_count >= 1")
 		}
 
@@ -2948,11 +2948,11 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 		orExprs := []string{}
 		andExprs := []string{}
 
-		if af.Crash {
+		if slices.Contains(af.ErrorTypes, event.ErrorTypeError) {
 			orExprs = append(orExprs, "crash_count >= 1")
 		}
 
-		if af.ANR {
+		if slices.Contains(af.ErrorTypes, event.ErrorTypeANR) {
 			orExprs = append(orExprs, "anr_count >= 1")
 		}
 

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -3745,8 +3745,7 @@ Fetch an app's sessions by applying various optional filters.
   - `to` (_optional_) - ISO8601 timestamp to include sessions before this time.
   - `versions` (_optional_) - List of comma separated app version identifier strings to return only matching sessions.
   - `version_codes` (_optional_) - List of comma separated app version codes to return only matching sessions.
-  - `crash` (_optional_) - Boolean true/false to control if only sessions containing at least 1 crash should be fetched.
-  - `anr` (_optional_) - Boolean true/false to control if only sessions containing at least 1 ANR should be fetched.
+  - `type` (_optional_) - Comma-separated list of event source types to filter sessions by. Accepted values: any combination of `error`, `anr`. `error` returns sessions with at least one exception event; `anr` returns sessions with at least one ANR. When omitted, all sessions are returned.
   - `bug_report` (_optional_) - Boolean true/false to control if only sessions containing at least 1 bug report should be fetched.
   - `background` (_optional_) - Boolean true/false to control if only background sessions should be fetched.
   - `foreground` (_optional_) - Boolean true/false to control if only foreground sessions should be fetched.
@@ -4023,8 +4022,7 @@ Fetch an app's sessions instances plot by applying various optional filters.
   - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
   - `versions` (_optional_) - List of comma separated app version identifier strings to return only matching sessions.
   - `version_codes` (_optional_) - List of comma separated app version codes to return only matching sessions.
-  - `crash` (_optional_) - Boolean true/false to control if only sessions containing at least 1 crash should be fetched.
-  - `anr` (_optional_) - Boolean true/false to control if only sessions containing at least 1 ANR should be fetched.
+  - `type` (_optional_) - Comma-separated list of event source types to filter sessions by. Accepted values: any combination of `error`, `anr`. `error` returns sessions with at least one exception event; `anr` returns sessions with at least one ANR. When omitted, all sessions are returned.
   - `bug_report` (_optional_) - Boolean true/false to control if only sessions containing at least 1 bug report should be fetched.
   - `background` (_optional_) - Boolean true/false to control if only background sessions should be fetched.
   - `foreground` (_optional_) - Boolean true/false to control if only foreground sessions should be fetched.


### PR DESCRIPTION
## Summary

This PR refactors session filtering logic in `GetSessionsInstancesPlot` and `GetSessionsWithFilter` to use the multi-value type parameter (represented by af.ErrorTypes in the backend) instead of individual `crash` and `anr` boolean flags. This aligns the sessions API with the recent changes in event filtering.

## Tasks

- [x] Replace af.Crash & af.ANR flags with af.ErrorTypes in GetSessionsInstancesPlot & GetSessionsWithFilter
- [x] Update dashboard API documentation to reflect type parameter instead of crash & anr boolean flags