### PR TITLE
fix(rn): convert checkpoint NSNumber values to Int64 in trackSpan

### DIFF
--- a/react-native/ios/MeasureModule.swift
+++ b/react-native/ios/MeasureModule.swift
@@ -78,7 +78,7 @@ class MeasureModule: NSObject, RCTBridgeModule {
                    resolver resolve: @escaping RCTPromiseResolveBlock,
                    rejecter reject: @escaping RCTPromiseRejectBlock) {
         let attrDict = attributes as? [String: Any?] ?? [:]
-        let checkpointDict = checkpoints as? [String: Int64] ?? [:]
+        let checkpointDict = (checkpoints as? [String: NSNumber] ?? [:]).mapValues { $0.int64Value }
         let userAttrs = userDefinedAttrs.transformAttributes()
         
         Measure.internalTrackSpan(


### PR DESCRIPTION
# Description

Checkpoint data was not getting collected properly because the RN side was sending Double where as the ios side was expecting Int64. This PR fixes that issue.

## Related issue
Fixes #3647 