### PR TITLE
chore(backend): expand severity & error types in app filter

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -336,6 +336,18 @@ func (af *AppFilter) Expand(ctx context.Context) (err error) {
 			af.UDExpressionRaw = filters.UDExpressionRaw
 		}
 
+		if af.Severity != "" {
+			for _, s := range text.SplitTrimEmpty(af.Severity, ",") {
+				af.Severities = append(af.Severities, event.Severity(s))
+			}
+		}
+
+		if af.ErrorType != "" {
+			for _, t := range text.SplitTrimEmpty(af.ErrorType, ",") {
+				af.ErrorTypes = append(af.ErrorTypes, event.ErrorType(t))
+			}
+		}
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

This PR expands comma-separated severity and error_type strings into their respective slices in the AppFilter.Expand method. This allows the backend to process multiple filter values for severities and error types during request expansion.

## Tasks

- [x] Expand af.Severity string into af.Severities slice
- [x] Expand af.ErrorType string into af.ErrorTypes slice
