### PR TITLE
fix(ios): send correct user defined attributes for bug report

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportCollector.swift
@@ -66,7 +66,7 @@ final class BaseBugReportCollector: BugReportCollector {
                                                attributes: nil,
                                                sessionId: nil,
                                                attachments: attachments,
-                                               userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(userDefinedAttributes),
+                                               userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes),
                                                threadName: nil,
                                                needsReporting: true)
             sessionManager.markCurrentSessionAsCrashed()


### PR DESCRIPTION
# Description

Track user defined attributes correctly for manual bug reports.

## Related issue
Closes #3644 