### PR TITLE
fix(backend): allow anr source when custom filter is active

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -284,11 +284,13 @@ func (a App) GetExceptionGroupPlotInstances(ctx context.Context, fingerprint str
 }
 
 // anrAllowed returns whether the ANR source should be queried given the
-// AppFilter. ANRs are never custom-captured, so CustomError=true forces ANR
-// off regardless of the requested value. Use this as the single source of
-// truth in every error-endpoint flow.
+// AppFilter. ANRs are never custom-captured, so when custom=1 and the caller
+// explicitly asked for error-only (type=error), ANRs are suppressed. When
+// type is absent or includes anr, the requested value is respected.
+// Use this as the single source of truth in every error-endpoint flow.
 func anrAllowed(af *filter.AppFilter, requested bool) bool {
-	if af.CustomError {
+	explicitErrorOnly := len(af.ErrorTypes) > 0 && !slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+	if af.CustomError && explicitErrorOnly {
 		return false
 	}
 	return requested

--- a/backend/api/measure/error_groups_test.go
+++ b/backend/api/measure/error_groups_test.go
@@ -265,8 +265,8 @@ const (
 
 // seedCustomMix seeds two custom-captured exceptions (one fatal, one handled
 // nonfatal), two native exceptions (one fatal, one unhandled nonfatal), and
-// one ANR. ANRs are never custom — they exist to confirm CustomError=true
-// excludes them.
+// one ANR. ANRs are never custom — they exist to verify is_custom is false
+// on ANR rows and that type=error+custom=1 still excludes them.
 func seedCustomMix(f plotFixture, t *testing.T, ts time.Time) {
 	t.Helper()
 	teamID, appID := f.teamIDStr(), f.appIDStr()
@@ -287,9 +287,10 @@ func seedCustomMix(f plotFixture, t *testing.T, ts time.Time) {
 	seedIssueEvent(f.ctx, t, teamID, appID, "anr", fpGroupCustomANRish, false, ts)
 }
 
-// TestGetErrorGroupsWithFilterCustomErrorFilter confirms that ?custom=true
-// restricts the result to custom-captured exceptions (excludes native
-// exceptions and all ANRs) and that the is_custom field is populated.
+// TestGetErrorGroupsWithFilterCustomErrorFilter confirms that ?custom=true with
+// type=error,anr returns custom exceptions AND ANRs (ANRs are always included
+// when explicitly requested), while native exceptions are excluded.
+// is_custom is true for custom exceptions and false for ANRs.
 func TestGetErrorGroupsWithFilterCustomErrorFilter(t *testing.T) {
 	f := newPlotFixture(t)
 	ts := time.Now().UTC()
@@ -304,19 +305,24 @@ func TestGetErrorGroupsWithFilterCustomErrorFilter(t *testing.T) {
 		t.Fatalf("GetErrorGroupsWithFilter: %v", err)
 	}
 
-	wantIDs := map[string]bool{
+	// ANRs are included because type=error,anr explicitly requests them;
+	// is_custom is false for ANR rows since ANRs are never custom-captured.
+	wantIsCustom := map[string]bool{
 		fpGroupCustomFatal:   true,
 		fpGroupCustomHandled: true,
+		fpGroupCustomANRish:  false,
 	}
-	if len(groups) != len(wantIDs) {
-		t.Fatalf("got %d rows, want %d (custom only): %+v", len(groups), len(wantIDs), groups)
+	if len(groups) != len(wantIsCustom) {
+		t.Fatalf("got %d rows, want %d: %+v", len(groups), len(wantIsCustom), groups)
 	}
 	for _, g := range groups {
-		if !wantIDs[g.ID] {
-			t.Errorf("unexpected row %s in custom-only result", g.ID)
+		want, ok := wantIsCustom[g.ID]
+		if !ok {
+			t.Errorf("unexpected row %s in result", g.ID)
+			continue
 		}
-		if !g.IsCustom {
-			t.Errorf("row %s: is_custom = false, want true", g.ID)
+		if g.IsCustom != want {
+			t.Errorf("row %s: is_custom = %t, want %t", g.ID, g.IsCustom, want)
 		}
 	}
 }
@@ -360,7 +366,8 @@ func TestGetErrorGroupsWithFilterIsCustomPopulated(t *testing.T) {
 }
 
 // TestGetErrorPlotInstancesCustomErrorFilter confirms the overview plot
-// honors ?custom=true on the exception branch.
+// honors ?custom=true: custom exceptions and ANRs (no explicit type = include
+// all) are counted, while native exceptions are excluded.
 func TestGetErrorPlotInstancesCustomErrorFilter(t *testing.T) {
 	f := newPlotFixture(t)
 	ts := time.Now().UTC()
@@ -373,7 +380,8 @@ func TestGetErrorPlotInstancesCustomErrorFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetErrorPlotInstances: %v", err)
 	}
-	if got := sumIssueInstances(items); got != 2 {
-		t.Fatalf("instances = %d, want 2 (two custom exception events), items=%+v", got, items)
+	// 2 custom exception events + 1 ANR event (type omitted → ANRs included).
+	if got := sumIssueInstances(items); got != 3 {
+		t.Fatalf("instances = %d, want 3 (two custom exceptions + one ANR), items=%+v", got, items)
 	}
 }

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -3070,12 +3070,13 @@ Fetch an app's error overview. Returns fatal exceptions, handled exceptions, and
   - `network_generations` (_optional_) - List of comma separated network generations.
   - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
   - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
-  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
+  - `custom` (_optional_) - `true` to restrict exception results to custom-tracked only. ANRs are unaffected by this flag — they are included whenever their source is in scope (i.e. `type` is omitted or includes `anr`).
   - `limit` (_optional_) - Number of items to return. Defaults to 10, max 1000.
   - `offset` (_optional_) - Number of items to skip. Defaults to 0.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
 - When neither `type` nor `severity` is set, all sources (fatal exceptions, nonfatal exceptions, ANRs) are returned.
+- `custom=true` filters exceptions to custom-tracked only and does not suppress ANRs. To exclude ANRs explicitly, use `type=error`.
 
 #### Authorization & Content Type
 
@@ -3202,7 +3203,7 @@ Fetch an app's error overview instances plot aggregated by date range & version.
   - `version_codes` (_optional_) - List of comma separated version codes.
   - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
   - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
-  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
+  - `custom` (_optional_) - `true` to restrict exception results to custom-tracked only. ANRs are unaffected by this flag — they are included whenever their source is in scope (i.e. `type` is omitted or includes `anr`).
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
 - Both `from` and `to` **MUST** be present when specifying date range.
@@ -3308,7 +3309,7 @@ Fetch an error group's individual error events.
   - `network_generations` (_optional_) - List of comma separated network generations.
   - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
   - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
-  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
+  - `custom` (_optional_) - `true` to restrict exception results to custom-tracked only. ANRs are unaffected by this flag — they are included whenever their source is in scope (i.e. `type` is omitted or includes `anr`).
   - `limit` (_optional_) - Number of items to return. Defaults to 10, max 1000.
   - `offset` (_optional_) - Number of items to skip. Defaults to 0.
   - `filter_short_code` (_optional_) - Code representing combination of filters.
@@ -3544,7 +3545,7 @@ Fetch an app's error detail instances aggregated by date range & version.
   - `version_codes` (_optional_) - List of comma separated version codes.
   - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
   - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
-  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
+  - `custom` (_optional_) - `true` to restrict exception results to custom-tracked only. ANRs are unaffected by this flag — they are included whenever their source is in scope (i.e. `type` is omitted or includes `anr`).
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
 - Both `from` and `to` **MUST** be present when specifying date range.
@@ -3648,7 +3649,7 @@ Fetch an error group's attribute distribution — occurrence counts broken down 
   - `network_generations` (_optional_) - List of comma separated network generations.
   - `type` (_optional_) - Comma-separated list of error source types to include. Accepted values: any combination of `error`, `anr`. When omitted, all sources are returned.
   - `severity` (_optional_) - Comma-separated list of severity levels to filter by. Accepted values: any combination of `fatal`, `unhandled`, `handled`. Applies only to exception events (`type=error`); ANRs are unaffected.
-  - `custom` (_optional_) - `true` to restrict to custom-tracked errors.
+  - `custom` (_optional_) - `true` to restrict exception results to custom-tracked only. ANRs are unaffected by this flag — they are included whenever their source is in scope (i.e. `type` is omitted or includes `anr`).
   - `filter_short_code` (_optional_) - Code representing combination of filters.
   - `ud_expression` (_optional_) - Expression in JSON to filter using user defined attributes.
 


### PR DESCRIPTION
## Summary

This PR refines the error filtering logic to ensure ANRs are included when the custom filter is active, unless the caller explicitly restricts the result to errors only (type=error). This aligns the API behavior with the fact that ANRs are never custom-captured but should still be visible alongside custom errors by default.

## Tasks

- [x] Update `anrAllowed` to only suppress anr if `type=error` is explicitly requested
- [x] Allow anr when `custom=true` if type is absent or includes anr
- [x] Update `docs/api/dashboard/README.md` to clarify custom flag scope
- [x] Adjust `backend/api/measure/error_groups_test.go` to verify new behavior

## See also

- fixes #3670
