### PR TITLE
chore(android): flush on app foreground transition

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -130,6 +130,7 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         measure.sessionManager.onAppForeground()
         if (isStarted) {
             resumeCollectorsOnForeground()
+            measure.exporter.flush()
         }
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
@@ -189,6 +189,20 @@ class MeasureInternalTest {
     }
 
     @Test
+    fun `onAppForeground triggers flush`() {
+        val initializer = mockMeasureInitializer()
+        val manifest = ManifestMetadata("https://api.measure.sh", "msrsh_123")
+        whenever(initializer.manifestReader.load()).thenReturn(manifest)
+        val measureInternal = MeasureInternal(initializer)
+        measureInternal.init()
+        measureInternal.start()
+
+        measureInternal.onAppForeground()
+
+        verify(initializer.exporter).flush()
+    }
+
+    @Test
     fun `init with null manifest does not initialize`() {
         val initializer = mockMeasureInitializer()
         whenever(initializer.manifestReader.load()).thenReturn(null)


### PR DESCRIPTION
# Description

Background exports keep getting killed agressively by the OS on modern Android versions. Attempt export for existing batches when app comes to foreground.

## Related issue
References: #3650 to make it same as iOS.


