### PR TITLE
chore(ios): export data once dynamic config is loaded

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
@@ -9,11 +9,18 @@ import Foundation
 
 /// A protocol that defines the methods for loading configuration data either a cache or a network source.
 protocol ConfigLoader {
+    var isConfigLoaded: Bool { get }
     func loadDynamicConfig(onLoaded: @escaping (DynamicConfig) -> Void)
 }
 
 /// A base implementation of the `ConfigLoader` protocol.
 struct BaseConfigLoader: ConfigLoader {
+    private final class ConfigState {
+        var isConfigLoaded: Bool = false
+    }
+
+    private let state = ConfigState()
+    var isConfigLoaded: Bool { state.isConfigLoaded }
     private let userDefaultStorage: UserDefaultStorage
     private let fileManager: SystemFileManager
     private let networkClient: NetworkClient
@@ -46,6 +53,7 @@ struct BaseConfigLoader: ConfigLoader {
 
     func loadDynamicConfig(onLoaded: @escaping (DynamicConfig) -> Void) {
         let cachedConfig = loadConfigFromDisk()
+        state.isConfigLoaded = true
         onLoaded(cachedConfig ?? BaseDynamicConfig())
         refreshConfigFromServer()
     }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -484,7 +484,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         self.sessionManager.applicationWillEnterForeground()
         self.lifecycleCollector.applicationWillEnterForeground()
         self.registedCollectors()
-        self.exporter.export()
+        if self.configLoader.isConfigLoaded {
+            self.exporter.export()
+        }
     }
 
     private func applicationWillTerminate() {

--- a/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
+++ b/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
@@ -199,6 +199,31 @@ final class MeasureInternalTests: XCTestCase {
         XCTAssertEqual(exporter.exportCallCount, before + 2, "exporter.export() should be called once per foreground transition")
     }
 
+    func testApplicationWillEnterForeground_doesNotTriggerExport_whenConfigNotLoaded() {
+        let mockConfigLoader = MockConfigLoader(autoSetConfigLoaded: false)
+        let initializer = MockMeasureInitializer(
+            configLoader: mockConfigLoader,
+            configProvider: MockConfigProvider()
+        )
+        let sut = MeasureInternal(initializer)
+        let exporter = initializer.exporter as! MockExporter // swiftlint:disable:this force_cast
+        let before = exporter.exportCallCount
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        XCTAssertEqual(exporter.exportCallCount, before, "export() should not be called when config has not been loaded")
+        _ = sut
+    }
+
+    func testApplicationWillEnterForeground_triggersExport_whenConfigIsLoaded() {
+        let exporter = mockMeasureInitializer.exporter as! MockExporter // swiftlint:disable:this force_cast
+        let before = exporter.exportCallCount
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        XCTAssertEqual(exporter.exportCallCount, before + 1, "export() should be called when config has been loaded")
+    }
+
     func testEncodeWebP_completesOnMainThreadWithEncodedBytes() {
         // Use a synchronous dispatch queue + a config-provider with a known quality.
         // Verifies the orchestrator (a) ran the codec, (b) hopped back to main

--- a/ios/Tests/MeasureSDKTests/Mocks/MockConfigLoader.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockConfigLoader.swift
@@ -10,14 +10,20 @@ import Foundation
 
 final class MockConfigLoader: ConfigLoader {
     private let config: DynamicConfig
+    private let autoSetConfigLoaded: Bool
 
+    private(set) var isConfigLoaded: Bool = false
     private(set) var didLoadConfig: Bool = false
 
-    init(config: DynamicConfig = BaseDynamicConfig()) {
+    init(config: DynamicConfig = BaseDynamicConfig(), autoSetConfigLoaded: Bool = true) {
         self.config = config
+        self.autoSetConfigLoaded = autoSetConfigLoaded
     }
 
     func loadDynamicConfig(onLoaded: @escaping (DynamicConfig) -> Void) {
+        if autoSetConfigLoaded {
+            isConfigLoaded = true
+        }
         onLoaded(config)
     }
 }


### PR DESCRIPTION
# Description

This PR contains below changes:
- Run data export only when dynamic config gets loaded.
- Update tests.

## Related issue
References #3650



