### PR TITLE
ci: scope frank android gradle cache to deps only

### DIFF
--- a/.github/workflows/frank.yml
+++ b/.github/workflows/frank.yml
@@ -41,11 +41,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/jars-*
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: gradle-${{ runner.os }}-
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
           channel: stable


### PR DESCRIPTION
# Description

The gradle cache was growing indefinitely as it was caching a lot more than needed. This started hitting out of disk space error. This PR scopes the gradle cache only to dependencies and uses the official gradle cache action.

https://github.com/measure-sh/measure/actions/runs/26289660766/job/77386205714?pr=3683

## Related issue
Fixes CI failure: https://github.com/measure-sh/measure/actions/runs/26289660766/job/77386205714?pr=3683

