### PR TITLE
chore(backend): expand session filtering & storage for exception seve…

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -296,6 +296,39 @@ func anrAllowed(af *filter.AppFilter, requested bool) bool {
 	return requested
 }
 
+// sessionErrorOrExprs returns the OR-clauses for exception/ANR filtering on
+// the sessions table. Returns nil when both type and severity are absent
+// (show-all behaviour). When type is absent, both error and ANR sources are
+// in scope (same as type=error,anr). ANRs are unaffected by severity.
+func sessionErrorOrExprs(af *filter.AppFilter) []string {
+	if len(af.ErrorTypes) == 0 && len(af.Severities) == 0 {
+		return nil
+	}
+
+	includeError := len(af.ErrorTypes) == 0 || slices.Contains(af.ErrorTypes, event.ErrorTypeError)
+	includeANR := len(af.ErrorTypes) == 0 || slices.Contains(af.ErrorTypes, event.ErrorTypeANR)
+
+	var orExprs []string
+	if includeError {
+		hasFatal := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityFatal)
+		hasUnhandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityUnhandled)
+		hasHandled := len(af.Severities) == 0 || slices.Contains(af.Severities, event.SeverityHandled)
+		if hasFatal {
+			orExprs = append(orExprs, "fatal_exception_count >= 1")
+		}
+		if hasUnhandled {
+			orExprs = append(orExprs, "unhandled_exception_count >= 1")
+		}
+		if hasHandled {
+			orExprs = append(orExprs, "handled_exception_count >= 1")
+		}
+	}
+	if includeANR {
+		orExprs = append(orExprs, "anr_count >= 1")
+	}
+	return orExprs
+}
+
 // resolveErrorSources maps an AppFilter's severity flags onto the underlying
 // event sources for the unified error endpoints. Returns whether the ANR
 // branch is active and which exception.handled rows the exception branch
@@ -2681,6 +2714,7 @@ func (a App) GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter)
 			Select("groupUniqArrayArray(unique_strings) as unique_strings").
 			Select("groupUniqArrayArray(unique_view_classnames) as unique_view_classnames").
 			Select("groupUniqArrayArray(unique_subview_classnames) as unique_subview_classnames").
+			Select("groupUniqArrayArray(unique_fatal_exceptions) as unique_fatal_exceptions").
 			Select("groupUniqArrayArray(unique_unhandled_exceptions) as unique_unhandled_exceptions").
 			Select("groupUniqArrayArray(unique_handled_exceptions) as unique_handled_exceptions").
 			Select("groupUniqArrayArray(unique_errors) as unique_errors").
@@ -2705,13 +2739,7 @@ func (a App) GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter)
 		orExprs := []string{}
 		andExprs := []string{}
 
-		if slices.Contains(af.ErrorTypes, event.ErrorTypeError) {
-			orExprs = append(orExprs, "crash_count >= 1")
-		}
-
-		if slices.Contains(af.ErrorTypes, event.ErrorTypeANR) {
-			orExprs = append(orExprs, "anr_count >= 1")
-		}
+		orExprs = append(orExprs, sessionErrorOrExprs(af)...)
 
 		if af.BugReport {
 			orExprs = append(orExprs, "bug_report_count >= 1")
@@ -2866,9 +2894,11 @@ func (a App) GetSessionsInstancesPlot(ctx context.Context, af *filter.AppFilter)
 				Clause("or").
 				Clause("arrayExists(x -> x ilike ?, unique_subview_classnames)", partial).
 				Clause("or").
-				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_unhandled_exceptions)", slices.Repeat([]any{partial}, 5)...).
+				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_fatal_exceptions)", slices.Repeat([]any{partial}, 5)...).
 				Clause("or").
 				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_handled_exceptions)", slices.Repeat([]any{partial}, 5)...).
+				Clause("or").
+				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_unhandled_exceptions)", slices.Repeat([]any{partial}, 5)...).
 				Clause("or").
 				Clause("arrayExists(x -> x ilike ?, unique_errors)", partial).
 				Clause("or").
@@ -2931,6 +2961,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 			Select("groupUniqArrayArray(unique_strings) as unique_strings").
 			Select("groupUniqArrayArray(unique_view_classnames) as unique_view_classnames").
 			Select("groupUniqArrayArray(unique_subview_classnames) as unique_subview_classnames").
+			Select("groupUniqArrayArray(unique_fatal_exceptions) as unique_fatal_exceptions").
 			Select("groupUniqArrayArray(unique_unhandled_exceptions) as unique_unhandled_exceptions").
 			Select("groupUniqArrayArray(unique_handled_exceptions) as unique_handled_exceptions").
 			Select("groupUniqArrayArray(unique_errors) as unique_errors").
@@ -2955,13 +2986,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 		orExprs := []string{}
 		andExprs := []string{}
 
-		if slices.Contains(af.ErrorTypes, event.ErrorTypeError) {
-			orExprs = append(orExprs, "crash_count >= 1")
-		}
-
-		if slices.Contains(af.ErrorTypes, event.ErrorTypeANR) {
-			orExprs = append(orExprs, "anr_count >= 1")
-		}
+		orExprs = append(orExprs, sessionErrorOrExprs(af)...)
 
 		if af.BugReport {
 			orExprs = append(orExprs, "bug_report_count >= 1")
@@ -3146,9 +3171,11 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 				Clause("or").
 				Clause("arrayExists(x -> x ilike ?, unique_subview_classnames)", partial).
 				Clause("or").
-				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_unhandled_exceptions)", slices.Repeat([]any{partial}, 5)...).
+				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_fatal_exceptions)", slices.Repeat([]any{partial}, 5)...).
 				Clause("or").
 				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_handled_exceptions)", slices.Repeat([]any{partial}, 5)...).
+				Clause("or").
+				Clause("arrayExists(x -> (x.type ilike ? or x.message ilike ? or x.file_name ilike ? or x.class_name ilike ? or x.method_name ilike ?), unique_unhandled_exceptions)", slices.Repeat([]any{partial}, 5)...).
 				Clause("or").
 				Clause("arrayExists(x -> x ilike ?, unique_errors)", partial).
 				Clause("or").
@@ -3167,6 +3194,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 			Select("unique_strings").
 			Select("unique_view_classnames").
 			Select("unique_subview_classnames").
+			Select("unique_fatal_exceptions").
 			Select("unique_unhandled_exceptions").
 			Select("unique_handled_exceptions").
 			Select("unique_errors").
@@ -3186,6 +3214,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 	for rows.Next() {
 		var uniqueUserIds, uniqueTypes, uniqueCustomTypeNames,
 			uniqueStrings, uniqueViewClassnames, uniqueSubviewClassnames, uniqueErrors []string
+		uniqueFatalExceptions := []map[string]string{}
 		uniqueUnhandledExceptions := []map[string]string{}
 		uniqueHandledExceptions := []map[string]string{}
 		uniqueANRs := []map[string]string{}
@@ -3220,6 +3249,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 				&uniqueStrings,
 				&uniqueViewClassnames,
 				&uniqueSubviewClassnames,
+				&uniqueFatalExceptions,
 				&uniqueUnhandledExceptions,
 				&uniqueHandledExceptions,
 				&uniqueErrors,
@@ -3273,6 +3303,7 @@ func (a App) GetSessionsWithFilter(ctx context.Context, af *filter.AppFilter) (s
 			uniqueViewClassnames,
 			uniqueSubviewClassnames,
 			uniqueErrors,
+			uniqueFatalExceptions,
 			uniqueUnhandledExceptions,
 			uniqueHandledExceptions,
 			uniqueANRs,
@@ -4756,6 +4787,11 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 		`gesture_scroll.end_x`,
 		`gesture_scroll.end_y`,
 		`gesture_scroll.direction`,
+		`exception.num_code`,
+		`exception.code`,
+		`exception.meta`,
+		`exception.is_custom`,
+		`exception.severity`,
 		`exception.handled`,
 		`exception.fingerprint`,
 		`exception.foreground`,
@@ -4944,6 +4980,8 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 		var hotLaunchDuration uint32
 
 		var exceptionError string
+		var exceptionMeta string
+		var exceptionSeverity string
 		var lifecycleViewController event.LifecycleViewController
 		var lifecycleSwiftUI event.LifecycleSwiftUI
 		var memoryUsageAbs event.MemoryUsageAbs
@@ -5021,6 +5059,11 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			&gestureScroll.Direction,
 
 			// excpetion
+			&exception.NumCode,
+			&exception.Code,
+			&exceptionMeta,
+			&exception.IsCustom,
+			&exceptionSeverity,
 			&exception.Handled,
 			&exception.Fingerprint,
 			&exception.Foreground,
@@ -5205,16 +5248,30 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			ev.ANR = &anr
 			session.Events = append(session.Events, ev)
 		case event.TypeException:
-			if err := json.Unmarshal([]byte(exceptionExceptions), &exception.Exceptions); err != nil {
-				return nil, err
+			exception.Severity = event.Severity(exceptionSeverity)
+
+			if exceptionExceptions != "" {
+				if err := json.Unmarshal([]byte(exceptionExceptions), &exception.Exceptions); err != nil {
+					return nil, err
+				}
 			}
 
-			if err := json.Unmarshal([]byte(exceptionThreads), &exception.Threads); err != nil {
-				return nil, err
+			if exceptionThreads != "" {
+				if err := json.Unmarshal([]byte(exceptionThreads), &exception.Threads); err != nil {
+					return nil, err
+				}
 			}
 
-			if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-				return nil, err
+			if attachments != "" {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
+
+			if exceptionMeta != "" {
+				if err := json.Unmarshal([]byte(exceptionMeta), &exception.Meta); err != nil {
+					return nil, err
+				}
 			}
 
 			// for now, only unmarshal exception.error for Apple
@@ -5222,7 +5279,6 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			// to other OSes on a "need to" basis.
 			switch opsys.ToFamily(a.OSName) {
 			case opsys.AppleFamily:
-				fmt.Println("exceptionError", exceptionError)
 				if exceptionError != "" {
 					if err := json.Unmarshal([]byte(exceptionError), &exception.Error); err != nil {
 						return nil, err

--- a/backend/api/session/match.go
+++ b/backend/api/session/match.go
@@ -13,7 +13,7 @@ func ExtractMatches(
 	needle, userId, sessionId string,
 	types, customTypeNames, logStrings,
 	viewClassnames, subviewClassnames, exceptionErrors []string,
-	unhandledExceptions, handledExceptions, anrs []map[string]string,
+	fatalExceptions, unhandledExceptions, handledExceptions, anrs []map[string]string,
 	clickTargets, longclickTargets, scrollTargets [][]string,
 ) (matched string) {
 	if needle == "" {
@@ -72,33 +72,49 @@ func ExtractMatches(
 		}
 	}
 
+	// fatal exceptions
+	for i := range fatalExceptions {
+		length := len(buff)
+
+		if strings.Contains(strings.ToLower(fatalExceptions[i]["type"]), strings.ToLower(needle)) {
+			buff = append(buff, fmt.Sprintf("CrashType: %s", fatalExceptions[i]["type"]))
+		}
+		if strings.Contains(strings.ToLower(fatalExceptions[i]["message"]), strings.ToLower(needle)) {
+			buff = append(buff, fmt.Sprintf("CrashMessage: %s", fatalExceptions[i]["message"]))
+		}
+		if strings.Contains(strings.ToLower(fatalExceptions[i]["file_name"]), strings.ToLower(needle)) {
+			buff = append(buff, fmt.Sprintf("CrashFile: %s", fatalExceptions[i]["file_name"]))
+		}
+		if strings.Contains(strings.ToLower(fatalExceptions[i]["class_name"]), strings.ToLower(needle)) {
+			buff = append(buff, fmt.Sprintf("CrashClass: %s", fatalExceptions[i]["class_name"]))
+		}
+		if strings.Contains(strings.ToLower(fatalExceptions[i]["method_name"]), strings.ToLower(needle)) {
+			buff = append(buff, fmt.Sprintf("CrashMethod: %s", fatalExceptions[i]["method_name"]))
+		}
+
+		if len(buff)-length > 2 {
+			break
+		}
+	}
+
 	// unhandled exceptions
 	for i := range unhandledExceptions {
 		length := len(buff)
 
-		// type
 		if strings.Contains(strings.ToLower(unhandledExceptions[i]["type"]), strings.ToLower(needle)) {
-			buff = append(buff, fmt.Sprintf("CrashType: %s", unhandledExceptions[i]["type"]))
+			buff = append(buff, fmt.Sprintf("UnhandledType: %s", unhandledExceptions[i]["type"]))
 		}
-
-		// message
 		if strings.Contains(strings.ToLower(unhandledExceptions[i]["message"]), strings.ToLower(needle)) {
-			buff = append(buff, fmt.Sprintf("CrashMessage: %s", unhandledExceptions[i]["message"]))
+			buff = append(buff, fmt.Sprintf("UnhandledMessage: %s", unhandledExceptions[i]["message"]))
 		}
-
-		// file name
 		if strings.Contains(strings.ToLower(unhandledExceptions[i]["file_name"]), strings.ToLower(needle)) {
-			buff = append(buff, fmt.Sprintf("CrashFile: %s", unhandledExceptions[i]["file_name"]))
+			buff = append(buff, fmt.Sprintf("UnhandledFile: %s", unhandledExceptions[i]["file_name"]))
 		}
-
-		// class name
 		if strings.Contains(strings.ToLower(unhandledExceptions[i]["class_name"]), strings.ToLower(needle)) {
-			buff = append(buff, fmt.Sprintf("CrashClass: %s", unhandledExceptions[i]["class_name"]))
+			buff = append(buff, fmt.Sprintf("UnhandledClass: %s", unhandledExceptions[i]["class_name"]))
 		}
-
-		// method name
 		if strings.Contains(strings.ToLower(unhandledExceptions[i]["method_name"]), strings.ToLower(needle)) {
-			buff = append(buff, fmt.Sprintf("CrashMethod: %s", unhandledExceptions[i]["method_name"]))
+			buff = append(buff, fmt.Sprintf("UnhandledMethod: %s", unhandledExceptions[i]["method_name"]))
 		}
 
 		if len(buff)-length > 2 {

--- a/backend/api/timeline/critical.go
+++ b/backend/api/timeline/critical.go
@@ -17,13 +17,17 @@ type Exception struct {
 	UDAttribute   *udattr.UDAttribute `json:"user_defined_attribute"`
 	UserTriggered bool                `json:"user_triggered"`
 	GroupId       string              `json:"group_id"`
+	Severity      string              `json:"severity"`
+	IsCustom      bool                `json:"is_custom"`
+	NumCode       int32               `json:"num_code"`
+	Code          string              `json:"code"`
+	Meta          map[string]any      `json:"meta"`
 	Type          string              `json:"type"`
 	Message       string              `json:"message"`
 	MethodName    string              `json:"method_name"`
 	FileName      string              `json:"file_name"`
 	LineNumber    int32               `json:"line_number"`
 	ThreadName    string              `json:"thread_name"`
-	Handled       bool                `json:"handled"`
 	Stacktrace    string              `json:"stacktrace"`
 	Foreground    bool                `json:"foreground"`
 	Error         *event.Error        `json:"error"`
@@ -47,6 +51,7 @@ func (e Exception) GetTimestamp() time.Time {
 // for session timeline.
 type ANR struct {
 	EventType   string              `json:"event_type"`
+	Severity    string              `json:"severity"`
 	UDAttribute *udattr.UDAttribute `json:"user_defined_attribute"`
 	GroupId     string              `json:"group_id"`
 	Type        string              `json:"type"`
@@ -76,24 +81,33 @@ func (a ANR) GetTimestamp() time.Time {
 // ComputeExceptions computes exceptions
 // for session timeline.
 func ComputeExceptions(ctx context.Context, appId *uuid.UUID, events []event.EventField) (result []ThreadGrouper, err error) {
-	for _, event := range events {
+	for _, e := range events {
+		eventType := e.Type
+		if eventType == event.TypeException {
+			eventType = "error"
+		}
+
 		exceptions := Exception{
-			event.Type,
-			&event.UserDefinedAttribute,
-			event.UserTriggered,
-			event.Exception.Fingerprint,
-			event.Exception.GetType(),
-			event.Exception.GetMessage(),
-			event.Exception.GetMethodName(),
-			event.Exception.GetFileName(),
-			event.Exception.GetLineNumber(),
-			event.Attribute.ThreadName,
-			event.Exception.Handled,
-			event.Exception.Stacktrace(),
-			event.Exception.Foreground,
-			event.Exception.Error,
-			event.Timestamp,
-			event.Attachments,
+			eventType,
+			&e.UserDefinedAttribute,
+			e.UserTriggered,
+			e.Exception.Fingerprint,
+			e.Exception.GetSeverity().String(),
+			e.Exception.IsCustom,
+			e.Exception.NumCode,
+			e.Exception.Code,
+			e.Exception.Meta,
+			e.Exception.GetType(),
+			e.Exception.GetMessage(),
+			e.Exception.GetMethodName(),
+			e.Exception.GetFileName(),
+			e.Exception.GetLineNumber(),
+			e.Attribute.ThreadName,
+			e.Exception.Stacktrace(),
+			e.Exception.Foreground,
+			e.Exception.Error,
+			e.Timestamp,
+			e.Attachments,
 		}
 		result = append(result, exceptions)
 	}
@@ -104,21 +118,22 @@ func ComputeExceptions(ctx context.Context, appId *uuid.UUID, events []event.Eve
 // ComputeANR computes anrs
 // for session timeline.
 func ComputeANRs(ctx context.Context, appId *uuid.UUID, events []event.EventField) (result []ThreadGrouper, err error) {
-	for _, event := range events {
+	for _, e := range events {
 		anrs := ANR{
-			event.Type,
-			&event.UserDefinedAttribute,
-			event.ANR.Fingerprint,
-			event.ANR.GetType(),
-			event.ANR.GetMessage(),
-			event.ANR.GetMethodName(),
-			event.ANR.GetFileName(),
-			event.ANR.GetLineNumber(),
-			event.Attribute.ThreadName,
-			event.ANR.Stacktrace(),
-			event.ANR.Foreground,
-			event.Timestamp,
-			event.Attachments,
+			e.Type,
+			event.SeverityFatal.String(),
+			&e.UserDefinedAttribute,
+			e.ANR.Fingerprint,
+			e.ANR.GetType(),
+			e.ANR.GetMessage(),
+			e.ANR.GetMethodName(),
+			e.ANR.GetFileName(),
+			e.ANR.GetLineNumber(),
+			e.Attribute.ThreadName,
+			e.ANR.Stacktrace(),
+			e.ANR.Foreground,
+			e.Timestamp,
+			e.Attachments,
 		}
 		result = append(result, anrs)
 	}

--- a/self-host/clickhouse/20260507061729_alter_fatal_exception_groups_table.sql
+++ b/self-host/clickhouse/20260507061729_alter_fatal_exception_groups_table.sql
@@ -5,7 +5,7 @@ alter table fatal_exception_groups
     modify comment 'fatal exception groups';
 
 -- migrate:down
-alter table if exists fatal_exception_groups
+alter table fatal_exception_groups
     drop column if exists is_custom,
     drop column if exists handled,
     modify comment 'unhandled exception groups';

--- a/self-host/clickhouse/20260522061059_alter_sessions_table.sql
+++ b/self-host/clickhouse/20260522061059_alter_sessions_table.sql
@@ -1,0 +1,65 @@
+-- migrate:up
+alter table sessions
+  drop index if exists crash_count_minmax_idx,
+  rename column if exists crash_count to fatal_exception_count,
+  rename column if exists unique_unhandled_exceptions to unique_fatal_exceptions,
+  add column if not exists `unhandled_exception_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(3)) after fatal_exception_count,
+  add column if not exists `handled_exception_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(3)) after unhandled_exception_count
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table sessions
+  drop column if exists handled_exception_count,
+  drop column if exists unhandled_exception_count,
+  rename column if exists unique_fatal_exceptions to unique_unhandled_exceptions,
+  rename column if exists fatal_exception_count to crash_count,
+  add index if not exists crash_count_minmax_idx crash_count type minmax granularity 1 after last_event_timestamp_minmax_idx
+settings mutations_sync = 2;
+
+-- migrate:up
+-- separate statement so the rename above commits before the IF NOT EXISTS check
+alter table sessions
+  add column if not exists `unique_unhandled_exceptions` SimpleAggregateFunction(groupUniqArrayArray, Array(Tuple(
+    type String,
+    message String,
+    file_name String,
+    class_name String,
+    method_name String))) CODEC(ZSTD(3)) after unique_fatal_exceptions
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table sessions
+  drop column if exists unique_unhandled_exceptions
+settings mutations_sync = 2;
+
+-- migrate:up
+alter table sessions
+  comment column if exists fatal_exception_count 'count of fatal exception events in this session',
+  comment column if exists unhandled_exception_count 'count of nonfatal unhandled exception events in this session',
+  comment column if exists handled_exception_count 'count of nonfatal handled exception events in this session',
+  comment column if exists unique_fatal_exceptions 'list of unique tuples of fatal exception details',
+  comment column if exists unique_unhandled_exceptions 'list of unique tuples of nonfatal unhandled exception details',
+  comment column if exists unique_handled_exceptions 'list of unique tuples of nonfatal handled exception details';
+
+-- migrate:down
+alter table sessions
+  comment column if exists fatal_exception_count 'count of crash events in this session',
+  comment column if exists unique_fatal_exceptions 'list of unique tuples of unhandled exception details',
+  comment column if exists unique_handled_exceptions 'list of unique tuples of handled exception details',
+  modify column if exists unhandled_exception_count remove comment,
+  modify column if exists handled_exception_count remove comment,
+  modify column if exists unique_unhandled_exceptions remove comment;
+
+-- migrate:up
+alter table sessions
+  add index if not exists fatal_exception_count_minmax_idx fatal_exception_count type minmax granularity 1 after last_event_timestamp_minmax_idx,
+  add index if not exists unhandled_exception_count_minmax_idx unhandled_exception_count type minmax granularity 1 after fatal_exception_count_minmax_idx,
+  add index if not exists handled_exception_count_minmax_idx handled_exception_count type minmax granularity 1 after unhandled_exception_count_minmax_idx
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table sessions
+  drop index if exists handled_exception_count_minmax_idx,
+  drop index if exists unhandled_exception_count_minmax_idx,
+  drop index if exists fatal_exception_count_minmax_idx
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260522074231_alter_sessions_mv_mv.sql
+++ b/self-host/clickhouse/20260522074231_alter_sessions_mv_mv.sql
@@ -1,0 +1,160 @@
+-- migrate:up
+alter table sessions_mv
+modify query
+select
+    session_id,
+    team_id,
+    app_id,
+    minSimpleState(timestamp) as first_event_timestamp,
+    maxSimpleState(timestamp) as last_event_timestamp,
+    (attribute.app_version, attribute.app_build) as app_version,
+    (attribute.os_name, attribute.os_version) as os_version,
+    groupUniqArrayArraySimpleState(if(inet.country_code != '', [inet.country_code], [])) as country_codes,
+    groupUniqArrayArraySimpleState(if(attribute.network_provider != '', [attribute.network_provider], [])) as network_providers,
+    groupUniqArrayArraySimpleState(if(attribute.network_type != '', [attribute.network_type], [])) as network_types,
+    groupUniqArrayArraySimpleState(if(attribute.network_generation != '', [attribute.network_generation], [])) as network_generations,
+    groupUniqArrayArraySimpleState([attribute.device_locale]) as device_locales,
+    argMax(attribute.device_name, timestamp) as device_name,
+    argMax(attribute.device_manufacturer, timestamp) as device_manufacturer,
+    argMax(attribute.device_model, timestamp) as device_model,
+    groupUniqArrayArraySimpleState(if(attribute.user_id != '', [attribute.user_id], [])) as user_ids,
+    groupUniqArrayArraySimpleState([type]) as unique_types,
+    groupUniqArrayArraySimpleState(if(type = 'custom', [custom.name], [])) as unique_custom_type_names,
+    groupUniqArrayArraySimpleState(if(`string.string` != '', [`string.string`], [])) as unique_strings,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_activity') and (lifecycle_activity.class_name != ''), [lifecycle_activity.class_name], [])) as unique_view_classnames,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_fragment') and (lifecycle_fragment.class_name != ''), [lifecycle_fragment.class_name], [])) as unique_subview_classnames,
+    -- fatal: severity='fatal' or (severity='' and handled=0)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_fatal_exceptions,
+    -- handled: severity='handled' or (severity='' and handled=1)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_handled_exceptions,
+    -- nonfatal unhandled: strictly new, severity='unhandled' only
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_unhandled_exceptions,
+    groupUniqArrayArraySimpleState(if(
+        (type = 'exception') and (
+            exception.num_code != 0 or
+            (exception.code != '' and exception.code != '{}') or
+            (exception.meta != '' and exception.meta != '{}')
+        ),
+        [concat(
+            '{"num_code":', toString(exception.num_code),
+            ',"code":', toJSONString(exception.code),
+            ',"meta":', if(exception.meta = '' or exception.meta = '{}', '{}', exception.meta),
+            '}'
+        )],
+        []
+    )) as unique_errors,
+    groupUniqArrayArraySimpleState(if(type = 'anr', [(simpleJSONExtractString(`anr.exceptions`, 'type'), simpleJSONExtractString(`anr.exceptions`, 'message'), simpleJSONExtractString(`anr.exceptions`, 'file_name'), simpleJSONExtractString(`anr.exceptions`, 'class_name'), simpleJSONExtractString(`anr.exceptions`, 'method_name'))], [])) as unique_anrs,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_click', [(gesture_click.target, gesture_click.target_id)], [])) as unique_click_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_long_click', [(gesture_long_click.target, gesture_long_click.target_id)], [])) as unique_longclick_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_scroll', [(gesture_scroll.target, gesture_scroll.target_id)], [])) as unique_scroll_targets,
+    sumSimpleState(toUInt64(1)) as event_count,
+    -- fatal count: legacy handled=0 or new severity='fatal'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as fatal_exception_count,
+    -- handled count: legacy handled=1 or new severity='handled'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as handled_exception_count,
+    -- nonfatal unhandled count: strictly new
+    sumSimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        toUInt64(1), toUInt64(0)
+    )) as unhandled_exception_count,
+    sumSimpleState(if(type = 'anr', toUInt64(1), toUInt64(0))) as anr_count,
+    sumSimpleState(if(type = 'bug_report', toUInt64(1), toUInt64(0))) as bug_report_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'background'), toUInt64(1), toUInt64(0))) as background_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'foreground'), toUInt64(1), toUInt64(0))) as foreground_count,
+    sumMapSimpleState(map(type, toUInt64(1))) as event_type_counts
+from events
+group by
+    team_id,
+    app_id,
+    session_id,
+    app_version,
+    os_version;
+
+-- migrate:down
+alter table sessions_mv
+modify query
+select
+    session_id,
+    team_id,
+    app_id,
+    minSimpleState(timestamp) as first_event_timestamp,
+    maxSimpleState(timestamp) as last_event_timestamp,
+    (attribute.app_version, attribute.app_build) as app_version,
+    (attribute.os_name, attribute.os_version) as os_version,
+    groupUniqArrayArraySimpleState(if(inet.country_code != '', [inet.country_code], [])) as country_codes,
+    groupUniqArrayArraySimpleState(if(attribute.network_provider != '', [attribute.network_provider], [])) as network_providers,
+    groupUniqArrayArraySimpleState(if(attribute.network_type != '', [attribute.network_type], [])) as network_types,
+    groupUniqArrayArraySimpleState(if(attribute.network_generation != '', [attribute.network_generation], [])) as network_generations,
+    groupUniqArrayArraySimpleState([attribute.device_locale]) as device_locales,
+    argMax(attribute.device_name, timestamp) as device_name,
+    argMax(attribute.device_manufacturer, timestamp) as device_manufacturer,
+    argMax(attribute.device_model, timestamp) as device_model,
+    groupUniqArrayArraySimpleState(if(attribute.user_id != '', [attribute.user_id], [])) as user_ids,
+    groupUniqArrayArraySimpleState([type]) as unique_types,
+    groupUniqArrayArraySimpleState(if(type = 'custom', [custom.name], [])) as unique_custom_type_names,
+    groupUniqArrayArraySimpleState(if(`string.string` != '', [`string.string`], [])) as unique_strings,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_activity') and (lifecycle_activity.class_name != ''), [lifecycle_activity.class_name], [])) as unique_view_classnames,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_fragment') and (lifecycle_fragment.class_name != ''), [lifecycle_fragment.class_name], [])) as unique_subview_classnames,
+    groupUniqArrayArraySimpleState(if((type = 'exception') and (exception.handled = 0), [(simpleJSONExtractString(`exception.exceptions`, 'type'), simpleJSONExtractString(`exception.exceptions`, 'message'), simpleJSONExtractString(`exception.exceptions`, 'file_name'), simpleJSONExtractString(`exception.exceptions`, 'class_name'), simpleJSONExtractString(`exception.exceptions`, 'method_name'))], [])) as unique_unhandled_exceptions,
+    groupUniqArrayArraySimpleState(if((type = 'exception') and (exception.handled = 1), [(simpleJSONExtractString(`exception.exceptions`, 'type'), simpleJSONExtractString(`exception.exceptions`, 'message'), simpleJSONExtractString(`exception.exceptions`, 'file_name'), simpleJSONExtractString(`exception.exceptions`, 'class_name'), simpleJSONExtractString(`exception.exceptions`, 'method_name'))], [])) as unique_handled_exceptions,
+    groupUniqArrayArraySimpleState(if((type = 'exception') and (exception.error != '') and (exception.error != '{}'), [exception.error], [])) as unique_errors,
+    groupUniqArrayArraySimpleState(if(type = 'anr', [(simpleJSONExtractString(`anr.exceptions`, 'type'), simpleJSONExtractString(`anr.exceptions`, 'message'), simpleJSONExtractString(`anr.exceptions`, 'file_name'), simpleJSONExtractString(`anr.exceptions`, 'class_name'), simpleJSONExtractString(`anr.exceptions`, 'method_name'))], [])) as unique_anrs,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_click', [(gesture_click.target, gesture_click.target_id)], [])) as unique_click_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_long_click', [(gesture_long_click.target, gesture_long_click.target_id)], [])) as unique_longclick_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_scroll', [(gesture_scroll.target, gesture_scroll.target_id)], [])) as unique_scroll_targets,
+    sumSimpleState(toUInt64(1)) as event_count,
+    sumSimpleState(if((type = 'exception') and (exception.handled = 0), toUInt64(1), toUInt64(0))) as crash_count,
+    sumSimpleState(if(type = 'anr', toUInt64(1), toUInt64(0))) as anr_count,
+    sumSimpleState(if(type = 'bug_report', toUInt64(1), toUInt64(0))) as bug_report_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'background'), toUInt64(1), toUInt64(0))) as background_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'foreground'), toUInt64(1), toUInt64(0))) as foreground_count,
+    sumMapSimpleState(map(type, toUInt64(1))) as event_type_counts
+from events
+group by
+    team_id,
+    app_id,
+    session_id,
+    app_version,
+    os_version;


### PR DESCRIPTION
## Summary

This PR expands backend support for different exception severities (`fatal`, `unhandled`, & `handled`) during session filtering & retrieval. Updates ClickHouse schema to track these severities as distinct metrics within sessions & their associated unique arrays.

## Tasks

- [x] Refactor session filtering to support fatal, unhandled, & handled severities
- [x] Rename crash_count to fatal_exception_count & unique_unhandled_exceptions to unique_fatal_exceptions in Clickhouse
- [x] Add unhandled_exception_count, handled_exception_count, & unique_unhandled_exceptions to sessions table
- [x] Update sessions_mv materialized view to populate new exception columns based on severity & handled status
- [x] Include additional exception fields (num_code, code, meta, is_custom, severity) in session event retrieval
- [x] Support matching on fatal exceptions in session search

## See also

- fixes #3669
