### PR TITLE
chore(ios): update exception data json structure

### DIFF
--- a/docs/features/feature-error-tracking.md
+++ b/docs/features/feature-error-tracking.md
@@ -68,13 +68,13 @@ You can optionally include attributes and enable stack trace collection.
 Measure.trackError(error, attributes: [
     "screen": .string("Login"),
     "retryCount": .int(2)
-], collectStackTraces: true)
+])
 ```
 
 You can track handled NSError objects from Objective-C code as well using `trackError` method.
 
 ```objc
-[Measure trackError:error attributes:@{ @"screen": @"Login", @"retryCount": 2 } collectStackTraces:YES];
+[Measure trackError:error attributes:@{ @"screen": @"Login", @"retryCount": 2 }];
 ```
 
 #### Flutter

--- a/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
+++ b/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
@@ -34,7 +34,9 @@
         @"Segmentation Fault (SIGSEGV)",
         @"Abnormal Termination (SIGABRT)",
         @"Illegal Instruction (SIGILL)",
-        @"Bus Error (SIGBUS)"
+        @"Bus Error (SIGBUS)",
+        @"Track Handled NSException",
+        @"Track Handled NSError"
     ];
 
     self.httpEventTypes = @[@"Track HTTP Event"];
@@ -276,6 +278,20 @@
     } else if ([type isEqualToString:@"Bus Error (SIGBUS)"]) {
         int *invalidAddress = (int *)0x1;
         *invalidAddress = 0;
+    } else if ([type isEqualToString:@"Track Handled NSException"]) {
+        NSException *exception = [NSException exceptionWithName:@"NamedException"
+                                                         reason:@"Something happened"
+                                                       userInfo:nil];
+        [Measure trackException:exception
+                     attributes:@{@"swiftui": @YES, @"lat": @64.0f, @"long": @14.0f, @"string": @"string"}];
+    } else if ([type isEqualToString:@"Track Handled NSError"]) {
+        NSError *error = nil;
+        [NSString stringWithContentsOfFile:@"/path/that/does/not/exist.txt"
+                                  encoding:NSUTF8StringEncoding
+                                     error:&error];
+        if (error) {
+            [Measure trackError:error attributes:nil];
+        }
     } else {
         NSLog(@"Unknown crash type.");
     }

--- a/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
+++ b/ios/DemoApp/DemoApp/Controller/ObjcDetailViewController.m
@@ -36,7 +36,9 @@
         @"Illegal Instruction (SIGILL)",
         @"Bus Error (SIGBUS)",
         @"Track Handled NSException",
-        @"Track Handled NSError"
+        @"Track Handled NSError",
+        @"Track NSException (main thread)",
+        @"Track NSError with Attributes (main thread)"
     ];
 
     self.httpEventTypes = @[@"Track HTTP Event"];
@@ -279,18 +281,37 @@
         int *invalidAddress = (int *)0x1;
         *invalidAddress = 0;
     } else if ([type isEqualToString:@"Track Handled NSException"]) {
-        NSException *exception = [NSException exceptionWithName:@"NamedException"
-                                                         reason:@"Something happened"
-                                                       userInfo:nil];
-        [Measure trackException:exception
-                     attributes:@{@"swiftui": @YES, @"lat": @64.0f, @"long": @14.0f, @"string": @"string"}];
+        dispatch_async(dispatch_queue_create("sh.measure.demoapp.background", NULL), ^{
+            NSException *exception = [NSException exceptionWithName:@"NamedException"
+                                                             reason:@"Something happened"
+                                                           userInfo:nil];
+            [Measure trackException:exception
+                         attributes:@{@"swiftui": @YES, @"lat": @64.0f, @"long": @14.0f, @"string": @"string"}];
+        });
     } else if ([type isEqualToString:@"Track Handled NSError"]) {
+        dispatch_async(dispatch_queue_create("sh.measure.demoapp.background", NULL), ^{
+            NSError *error = nil;
+            [NSString stringWithContentsOfFile:@"/path/that/does/not/exist.txt"
+                                      encoding:NSUTF8StringEncoding
+                                         error:&error];
+            if (error) {
+                [Measure trackError:error attributes:nil];
+            }
+        });
+    } else if ([type isEqualToString:@"Track NSException (main thread)"]) {
+        NSException *exception = [NSException exceptionWithName:@"NamedException"
+                                                         reason:@"Something happened on main thread"
+                                                       userInfo:@{@"key": @"value"}];
+        [Measure trackException:exception
+                     attributes:@{@"source": @"objc-main-thread"}];
+    } else if ([type isEqualToString:@"Track NSError with Attributes (main thread)"]) {
         NSError *error = nil;
         [NSString stringWithContentsOfFile:@"/path/that/does/not/exist.txt"
                                   encoding:NSUTF8StringEncoding
                                      error:&error];
         if (error) {
-            [Measure trackError:error attributes:nil];
+            [Measure trackError:error
+                     attributes:@{@"source": @"objc-main-thread", @"retries": @3}];
         }
     } else {
         NSLog(@"Unknown crash type.");

--- a/ios/DemoApp/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/ViewController.swift
@@ -37,7 +37,9 @@ import Measure
                       "Segmentation Fault (SIGSEGV)",
                       "Abnormal Termination (SIGABRT)",
                       "Illegal Instruction (SIGILL)",
-                      "Bus Error (SIGBUS)"]
+                      "Bus Error (SIGBUS)",
+                      "Track Handled NSException",
+                      "Track Handled NSError"]
 
     let httpEventTypes = ["GET – 200 OK (JSON)",
                           "POST – 201 Created (JSON body)",
@@ -67,13 +69,6 @@ import Measure
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
-        Measure.trackEvent(name: "custom_user_event", attributes: ["name": .string("Adwin"), "age": .int(34)])
-        do {
-            let path = "/path/that/does/not/exist.txt"
-            _ = try String(contentsOfFile: path, encoding: .utf8)
-        } catch {
-            Measure.trackError(error, collectStackTraces: true)
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -337,6 +332,19 @@ import Measure
         case "Stack Overflow":
             func recurse() { recurse() }
             recurse()
+        case "Track Handled NSException":
+            let exception = NSException(name: NSExceptionName(rawValue: "NamedException"),
+                                        reason: "Something happened",
+                                        userInfo: nil)
+            Measure.trackException(exception,
+                                   attributes: ["swiftui": .boolean(true), "lat": .float(64.0), "long": .float(14.0), "string": .string("string")])
+        case "Track Handled NSError":
+            do {
+                let path = "/path/that/does/not/exist.txt"
+                _ = try String(contentsOfFile: path, encoding: .utf8)
+            } catch {
+                Measure.trackError(error)
+            }
         default:
             fatalError("Triggered crash: \(type)")
         }

--- a/ios/DemoApp/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/ViewController.swift
@@ -39,7 +39,9 @@ import Measure
                       "Illegal Instruction (SIGILL)",
                       "Bus Error (SIGBUS)",
                       "Track Handled NSException",
-                      "Track Handled NSError"]
+                      "Track Handled NSError",
+                      "Track Swift Error (main thread)",
+                      "Track NSException (main thread)"]
 
     let httpEventTypes = ["GET – 200 OK (JSON)",
                           "POST – 201 Created (JSON body)",
@@ -349,6 +351,18 @@ import Measure
                     Measure.trackError(error)
                 }
             }
+        case "Track Swift Error (main thread)":
+            do {
+                let path = "/path/that/does/not/exist.txt"
+                _ = try String(contentsOfFile: path, encoding: .utf8)
+            } catch {
+                Measure.trackError(error)
+            }
+        case "Track NSException (main thread)":
+            let exception = NSException(name: NSExceptionName(rawValue: "NamedException"),
+                                        reason: "Something happened on main thread",
+                                        userInfo: ["key": "value"])
+            Measure.trackException(exception, attributes: ["source": .string("swift-main-thread")])
         default:
             fatalError("Triggered crash: \(type)")
         }

--- a/ios/DemoApp/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/ViewController.swift
@@ -333,17 +333,21 @@ import Measure
             func recurse() { recurse() }
             recurse()
         case "Track Handled NSException":
-            let exception = NSException(name: NSExceptionName(rawValue: "NamedException"),
-                                        reason: "Something happened",
-                                        userInfo: nil)
-            Measure.trackException(exception,
-                                   attributes: ["swiftui": .boolean(true), "lat": .float(64.0), "long": .float(14.0), "string": .string("string")])
+            DispatchQueue(label: "sh.measure.dempapp.background").async {
+                let exception = NSException(name: NSExceptionName(rawValue: "NamedException"),
+                                            reason: "Something happened",
+                                            userInfo: nil)
+                Measure.trackException(exception,
+                                       attributes: ["swiftui": .boolean(true), "lat": .float(64.0), "long": .float(14.0), "string": .string("string")])
+            }
         case "Track Handled NSError":
-            do {
-                let path = "/path/that/does/not/exist.txt"
-                _ = try String(contentsOfFile: path, encoding: .utf8)
-            } catch {
-                Measure.trackError(error)
+            DispatchQueue(label: "sh.measure.dempapp.background").async {
+                do {
+                    let path = "/path/that/does/not/exist.txt"
+                    _ = try String(contentsOfFile: path, encoding: .utf8)
+                } catch {
+                    Measure.trackError(error)
+                }
             }
         default:
             fatalError("Triggered crash: \(type)")

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -226,7 +226,6 @@
 		CF48773F2DEEB26B00311F57 /* UIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48773E2DEEB26B00311F57 /* UIApplication+Extension.swift */; };
 		CF4877412DEEB2C000311F57 /* UIWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4877402DEEB2C000311F57 /* UIWindow+Extension.swift */; };
 		CF48E3562DF95E8100FCD26D /* ExceptionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48E3552DF95E8100FCD26D /* ExceptionGenerator.swift */; };
-		CF48E3982E01866400FCD26D /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48E3972E01866400FCD26D /* Error.swift */; };
 		CF49F7BF2F977B5D0067EDB8 /* libMeasureWebP.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CF49F7BC2F977B390067EDB8 /* libMeasureWebP.a */; };
 		CF4EA2D52EA243EB0020FC71 /* UserTriggeredEventCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4EA2D42EA243EB0020FC71 /* UserTriggeredEventCollectorTests.swift */; };
 		CF4EA2D72EA246700020FC71 /* MockExceptionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4EA2D62EA246700020FC71 /* MockExceptionGenerator.swift */; };
@@ -253,6 +252,8 @@
 		CF893DD52E950BF000D99D45 /* EventToAttachmentMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF893DD42E950BF000D99D45 /* EventToAttachmentMigrationPolicy.swift */; };
 		CF893DDB2E950DEE00D99D45 /* EventOb+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF893DDA2E950DEE00D99D45 /* EventOb+CoreDataProperties.swift */; };
 		CF90E9E52F6B16DB00D3351B /* MockAttachmentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF90E9E42F6B16DB00D3351B /* MockAttachmentProcessor.swift */; };
+		CF9619EF2FC18993000FE152 /* ExceptionSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9619EE2FC18993000FE152 /* ExceptionSeverity.swift */; };
+		CF9619F02FC18993000FE152 /* CodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9619ED2FC18993000FE152 /* CodableValue.swift */; };
 		CF9D74C52E6169F3007D6D30 /* LifecycleManagerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */; };
 		CF9D75792E66C0FA007D6D30 /* SessionStartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */; };
 		CF9EDCFA2F0E2BAA00029281 /* RecentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9EDCF92F0E2BAA00029281 /* RecentSession.swift */; };
@@ -596,7 +597,6 @@
 		CF48773E2DEEB26B00311F57 /* UIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extension.swift"; sourceTree = "<group>"; };
 		CF4877402DEEB2C000311F57 /* UIWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Extension.swift"; sourceTree = "<group>"; };
 		CF48E3552DF95E8100FCD26D /* ExceptionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionGenerator.swift; sourceTree = "<group>"; };
-		CF48E3972E01866400FCD26D /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		CF49F7B72F977B380067EDB8 /* MeasureWebP.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MeasureWebP.xcodeproj; path = Sources/MeasureWebP/MeasureWebP.xcodeproj; sourceTree = "<group>"; };
 		CF4EA2D42EA243EB0020FC71 /* UserTriggeredEventCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTriggeredEventCollectorTests.swift; sourceTree = "<group>"; };
 		CF4EA2D62EA246700020FC71 /* MockExceptionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExceptionGenerator.swift; sourceTree = "<group>"; };
@@ -626,6 +626,8 @@
 		CF893DD42E950BF000D99D45 /* EventToAttachmentMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventToAttachmentMigrationPolicy.swift; sourceTree = "<group>"; };
 		CF893DDA2E950DEE00D99D45 /* EventOb+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventOb+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		CF90E9E42F6B16DB00D3351B /* MockAttachmentProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAttachmentProcessor.swift; sourceTree = "<group>"; };
+		CF9619ED2FC18993000FE152 /* CodableValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableValue.swift; sourceTree = "<group>"; };
+		CF9619EE2FC18993000FE152 /* ExceptionSeverity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionSeverity.swift; sourceTree = "<group>"; };
 		CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleManagerInternal.swift; sourceTree = "<group>"; };
 		CF9D75782E66C0FA007D6D30 /* SessionStartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStartData.swift; sourceTree = "<group>"; };
 		CF9EDCF92F0E2BAA00029281 /* RecentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSession.swift; sourceTree = "<group>"; };
@@ -866,13 +868,14 @@
 			isa = PBXGroup;
 			children = (
 				529B319A2D5B85FC007A8E45 /* BinaryImage.swift */,
+				CF9619ED2FC18993000FE152 /* CodableValue.swift */,
 				526D17C92D5A1913009A2E90 /* Exception.swift */,
 				526D17CA2D5A1913009A2E90 /* ExceptionDetail.swift */,
 				CF48E3552DF95E8100FCD26D /* ExceptionGenerator.swift */,
+				CF9619EE2FC18993000FE152 /* ExceptionSeverity.swift */,
 				69694F0E2DE04619008D1AF1 /* Framework.swift */,
 				526D17CB2D5A1913009A2E90 /* StackFrame.swift */,
 				526D17CC2D5A1913009A2E90 /* ThreadDetail.swift */,
-				CF48E3972E01866400FCD26D /* Error.swift */,
 			);
 			path = Exception;
 			sourceTree = "<group>";
@@ -1807,7 +1810,6 @@
 				CF1BB4FD2DDF317300588506 /* MotionManager.swift in Sources */,
 				CF83E2E32E0D21EB00FE7041 /* MeasureDispatchQueue.swift in Sources */,
 				CF48773F2DEEB26B00311F57 /* UIApplication+Extension.swift in Sources */,
-				CF48E3982E01866400FCD26D /* Error.swift in Sources */,
 				526D187B2D5A1913009A2E90 /* NSObject+Extension.swift in Sources */,
 				526D188D2D5A1913009A2E90 /* UserPermissionManager.swift in Sources */,
 				526D18612D5A1913009A2E90 /* HttpInterceptorCallbacks.swift in Sources */,
@@ -1850,6 +1852,8 @@
 				526D18742D5A1913009A2E90 /* MemoryUsageCalculator.swift in Sources */,
 				526D18302D5A1913009A2E90 /* ConfigProvider.swift in Sources */,
 				526D18902D5A1913009A2E90 /* Measure.swift in Sources */,
+				CF9619EF2FC18993000FE152 /* ExceptionSeverity.swift in Sources */,
+				CF9619F02FC18993000FE152 /* CodableValue.swift in Sources */,
 				CF9EDCFA2F0E2BAA00029281 /* RecentSession.swift in Sources */,
 				526D18782D5A1913009A2E90 /* ScreenshotGenerator.swift in Sources */,
 				CFD88D012DA4D4910095115E /* SpanData.swift in Sources */,

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -1124,9 +1124,9 @@
 		52B7F0F12D757F81001498BC /* CrashReporter */ = {
 			isa = PBXGroup;
 			children = (
-				CFE1DD4C2F62C668003BD29B /* CrashReports */,
 				CFE1DD512F62E201003BD29B /* CrashDataFormatterTests.swift */,
 				CFE1DD532F62EC6C003BD29B /* CrashReportManagerTests.swift */,
+				CFE1DD4C2F62C668003BD29B /* CrashReports */,
 			);
 			path = CrashReporter;
 			sourceTree = "<group>";

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -370,10 +370,10 @@ extension Measure.Measure {
   public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Measure.AttributeValue]? = nil)
   @objc public static func trackBugReport(description: Swift.String, attachments: [Measure.MsrAttachment] = [], attributes: [Swift.String : Any]? = nil)
   @objc public static func captureScreenshot(for viewController: UIKit.UIViewController, completion: @escaping (Measure.MsrAttachment?) -> Swift.Void)
-  public static func trackError(_ error: any Swift.Error, attributes: [Swift.String : Measure.AttributeValue]? = nil, collectStackTraces: Swift.Bool = false)
-  @objc public static func trackError(_ error: Foundation.NSError, attributes: [Swift.String : Any]? = nil, collectStackTraces: Swift.Bool = false)
-  public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Measure.AttributeValue]? = nil, collectStackTraces: Swift.Bool = false)
-  @objc public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Any]? = nil, collectStackTraces: Swift.Bool = false)
+  public static func trackError(_ error: any Swift.Error, attributes: [Swift.String : Measure.AttributeValue]? = nil)
+  @objc public static func trackError(_ error: Foundation.NSError, attributes: [Swift.String : Any]? = nil)
+  public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Measure.AttributeValue]? = nil)
+  @objc public static func trackException(_ exception: Foundation.NSException, attributes: [Swift.String : Any]? = nil)
   public static func internalGetAttachmentDirectory() -> Swift.String?
   public static func internalEncodeWebP(pixels: Foundation.Data, width: Swift.Int, height: Swift.Int, completion: @escaping (Foundation.Data?) -> Swift.Void)
   public static func internalGetDynamicConfigPath() -> Swift.String?

--- a/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
@@ -35,7 +35,8 @@ final class BaseSignalStore: SignalStore {
         let eventEntity = EventEntity(event, needsReporting: needsReporting)
 
         var isCrashEvent = false
-        if let exception = event.exception, exception.severity == .fatal {
+        if let exception = event.exception,
+           exception.severity == .fatal || exception.severity == .unhandled {
             isCrashEvent = true
         }
         let isBugReportEvent = event.type == .bugReport

--- a/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/SignalStore.swift
@@ -35,7 +35,7 @@ final class BaseSignalStore: SignalStore {
         let eventEntity = EventEntity(event, needsReporting: needsReporting)
 
         var isCrashEvent = false
-        if let exception = event.exception, !exception.handled {
+        if let exception = event.exception, exception.severity == .fatal {
             isCrashEvent = true
         }
         let isBugReportEvent = event.type == .bugReport

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -34,9 +34,10 @@ final class CrashDataFormatter {
         let crashedThreadDict = threadDicts.first { $0["crashed"] as? Bool == true || $0["crashed"] as? Int == 1 }
         let otherThreadDicts  = threadDicts.filter { $0["crashed"] as? Bool != true && $0["crashed"] as? Int != 1 }
 
-        let crashedThread   = crashedThreadDict.map { parseThread($0) }
+        let isHandled       = severity == .handled
+        let crashedThread   = crashedThreadDict.map { parseThread($0, isHandled: isHandled) }
         let exceptionDetail = parseExceptionDetail(crashedThread: crashedThread)
-        let otherThreads    = otherThreadDicts.map { parseThread($0) }
+        let otherThreads    = otherThreadDicts.map { parseThread($0, isHandled: isHandled) }
 
         guard let crashedThread else {
             return Exception(exceptions: [exceptionDetail],
@@ -105,11 +106,11 @@ final class CrashDataFormatter {
             ?? (stats["application_in_foreground"] as? Int).map { $0 != 0 }
     }
 
-    func parseThread(_ dict: [String: Any]) -> ThreadDetail {
+    func parseThread(_ dict: [String: Any], isHandled: Bool = false) -> ThreadDetail {
         let index   = dict["index"]   as? Int  ?? 0
         let crashed = dict["crashed"] as? Bool ?? (dict["crashed"] as? Int == 1)
         let name    = dict["name"]    as? String
-                   ?? (crashed ? "Thread \(index) Crashed" : "Thread \(index)")
+                   ?? (crashed && !isHandled ? "Thread \(index) Crashed" : "Thread \(index)")
         let frames  = parseFrames(dict)
         return ThreadDetail(name: name, frames: frames, sequence: Number(index))
     }

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -27,7 +27,11 @@ final class CrashDataFormatter {
         self.isLp64 = resolveIsLp64(binaryImageDicts: binaryImageDicts)
     }
 
-    func getException(_ handled: Bool = false, error: MsrError? = nil) -> Exception {
+    func getException(_ handled: Bool = false,
+                      severity: ExceptionSeverity? = nil,
+                      numCode: Int64? = nil,
+                      code: String? = nil,
+                      meta: [String: CodableValue]? = nil) -> Exception {
         let crashedThreadDict = threadDicts.first { $0["crashed"] as? Bool == true || $0["crashed"] as? Int == 1 }
         let otherThreadDicts  = threadDicts.filter { $0["crashed"] as? Bool != true && $0["crashed"] as? Int != 1 }
 
@@ -42,7 +46,11 @@ final class CrashDataFormatter {
                              threads: nil,
                              binaryImages: nil,
                              framework: Framework.apple,
-                             error: error)
+                             severity: severity,
+                             isCustom: nil,
+                             numCode: numCode,
+                             code: code,
+                             meta: meta)
         }
 
         let allThreads   = [crashedThread] + otherThreads
@@ -54,7 +62,11 @@ final class CrashDataFormatter {
                          threads: otherThreads,
                          binaryImages: binaryImages,
                          framework: Framework.apple,
-                         error: error)
+                         severity: severity,
+                         isCustom: nil,
+                         numCode: numCode,
+                         code: code,
+                         meta: meta)
     }
 
     func parseExceptionDetail(crashedThread: ThreadDetail?) -> ExceptionDetail {

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -40,8 +40,7 @@ final class CrashDataFormatter {
         let otherThreads    = otherThreadDicts.map { parseThread($0) }
 
         guard let crashedThread else {
-            return Exception(handled: handled,
-                             exceptions: [exceptionDetail],
+            return Exception(exceptions: [exceptionDetail],
                              foreground: parseForeground(),
                              threads: nil,
                              binaryImages: nil,
@@ -56,8 +55,7 @@ final class CrashDataFormatter {
         let allThreads   = [crashedThread] + otherThreads
         let binaryImages = parseBinaryImages(threads: allThreads)
 
-        return Exception(handled: handled,
-                         exceptions: [exceptionDetail],
+        return Exception(exceptions: [exceptionDetail],
                          foreground: parseForeground(),
                          threads: otherThreads,
                          binaryImages: binaryImages,

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -30,12 +30,14 @@ final class CrashDataFormatter {
     func getException(severity: ExceptionSeverity? = nil,
                       numCode: Int64? = nil,
                       code: String? = nil,
-                      meta: [String: CodableValue]? = nil) -> Exception {
+                      meta: [String: CodableValue]? = nil,
+                      framesToStrip: Int = 0) -> Exception {
         let crashedThreadDict = threadDicts.first { $0["crashed"] as? Bool == true || $0["crashed"] as? Int == 1 }
         let otherThreadDicts  = threadDicts.filter { $0["crashed"] as? Bool != true && $0["crashed"] as? Int != 1 }
 
-        let isHandled       = severity == .handled
-        let crashedThread   = crashedThreadDict.map { parseThread($0, isHandled: isHandled) }
+        let isHandled              = severity == .handled
+        let effectiveFramesToStrip = hasMeasureBinaryImage() ? 0 : framesToStrip
+        let crashedThread   = crashedThreadDict.map { parseThread($0, isHandled: isHandled, framesToStrip: effectiveFramesToStrip) }
         let exceptionDetail = parseExceptionDetail(crashedThread: crashedThread)
         let otherThreads    = otherThreadDicts.map { parseThread($0, isHandled: isHandled) }
 
@@ -106,20 +108,24 @@ final class CrashDataFormatter {
             ?? (stats["application_in_foreground"] as? Int).map { $0 != 0 }
     }
 
-    func parseThread(_ dict: [String: Any], isHandled: Bool = false) -> ThreadDetail {
+    func parseThread(_ dict: [String: Any], isHandled: Bool = false, framesToStrip: Int = 0) -> ThreadDetail {
         let index   = dict["index"]   as? Int  ?? 0
         let crashed = dict["crashed"] as? Bool ?? (dict["crashed"] as? Int == 1)
         let name    = dict["name"]    as? String
                    ?? (crashed && !isHandled ? "Thread \(index) Crashed" : "Thread \(index)")
-        let frames  = parseFrames(dict)
+        let frames  = parseFrames(dict, framesToStrip: framesToStrip)
         return ThreadDetail(name: name, frames: frames, sequence: Number(index))
     }
 
-    func parseFrames(_ threadDict: [String: Any]) -> [StackFrame] {
+    func parseFrames(_ threadDict: [String: Any], framesToStrip: Int = 0) -> [StackFrame] {
         guard
             let bt       = threadDict["backtrace"] as? [String: Any],
-            let contents = bt["contents"]          as? [[String: Any]]
+            var contents = bt["contents"]          as? [[String: Any]]
         else { return [] }
+
+        if framesToStrip > 0 {
+            contents = Array(contents.dropFirst(min(framesToStrip, contents.count)))
+        }
 
         return contents.enumerated().map { idx, frame in
             parseFrame(frame, index: idx)
@@ -227,6 +233,10 @@ final class CrashDataFormatter {
         case CPU_TYPE_POWERPC: return "powerpc"
         default:               return "???"
         }
+    }
+
+    private func hasMeasureBinaryImage() -> Bool {
+        return binaryImageDicts.contains { ($0["name"] as? String)?.hasPrefix("Measure") == true }
     }
 
     private func isAppBinary(name: String?) -> Bool {

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataFormatter.swift
@@ -27,8 +27,7 @@ final class CrashDataFormatter {
         self.isLp64 = resolveIsLp64(binaryImageDicts: binaryImageDicts)
     }
 
-    func getException(_ handled: Bool = false,
-                      severity: ExceptionSeverity? = nil,
+    func getException(severity: ExceptionSeverity? = nil,
                       numCode: Int64? = nil,
                       code: String? = nil,
                       meta: [String: CodableValue]? = nil) -> Exception {

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
@@ -117,7 +117,7 @@ final class BaseCrashReportingManager: CrashReportManager {
         do {
             let reportDict = try crashReporter.loadCrashReport()
             let formatter  = CrashDataFormatter(reportDict, sysCtl: sysCtl)
-            let exception  = formatter.getException()
+            let exception  = formatter.getException(severity: .fatal)
 
             let timestamp = (reportDict["report"] as? [String: Any])?["timestamp"] as? TimeInterval
             let date = timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()

--- a/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
@@ -9,9 +9,9 @@ import Foundation
 
 protocol UserTriggeredEventCollector {
     func trackScreenView(_ screenName: String, attributes: [String: AttributeValue]?)
-    func trackError(_ error: Error, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
-    func trackError(_ error: NSError, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?, collectStackTraces: Bool)
+    func trackError(_ error: Error, attributes: [String: AttributeValue]?)
+    func trackError(_ error: NSError, attributes: [String: AttributeValue]?)
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?)
     func trackHttpEvent(url: String,
                         method: String,
                         startTime: UInt64,
@@ -78,29 +78,29 @@ final class BaseUserTriggeredEventCollector: UserTriggeredEventCollector {
               needsReporting: signalSampler.shouldTrackJourneyForSession(sessionId: sessionManager.sessionId))
     }
 
-    func trackError(_ error: Error, attributes: [String: AttributeValue]?, collectStackTraces: Bool) {
+    func trackError(_ error: Error, attributes: [String: AttributeValue]?) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(error as NSError, collectStackTraces: collectStackTraces) {
+        if let exception = exceptionGenerator.generate(error as NSError) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }
 
-    func trackError(_ error: NSError, attributes: [String: AttributeValue]?, collectStackTraces: Bool) {
+    func trackError(_ error: NSError, attributes: [String: AttributeValue]?) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(error, collectStackTraces: collectStackTraces) {
+        if let exception = exceptionGenerator.generate(error) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }
 
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?, collectStackTraces: Bool) {
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(exception, collectStackTraces: collectStackTraces) {
+        if let exception = exceptionGenerator.generate(exception) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/UserTriggeredEventCollector.swift
@@ -9,9 +9,9 @@ import Foundation
 
 protocol UserTriggeredEventCollector {
     func trackScreenView(_ screenName: String, attributes: [String: AttributeValue]?)
-    func trackError(_ error: Error, attributes: [String: AttributeValue]?)
-    func trackError(_ error: NSError, attributes: [String: AttributeValue]?)
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?)
+    func trackError(_ error: Error, attributes: [String: AttributeValue]?, framesToStrip: Int)
+    func trackError(_ error: NSError, attributes: [String: AttributeValue]?, framesToStrip: Int)
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?, framesToStrip: Int)
     func trackHttpEvent(url: String,
                         method: String,
                         startTime: UInt64,
@@ -78,29 +78,29 @@ final class BaseUserTriggeredEventCollector: UserTriggeredEventCollector {
               needsReporting: signalSampler.shouldTrackJourneyForSession(sessionId: sessionManager.sessionId))
     }
 
-    func trackError(_ error: Error, attributes: [String: AttributeValue]?) {
+    func trackError(_ error: Error, attributes: [String: AttributeValue]?, framesToStrip: Int) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(error as NSError) {
+        if let exception = exceptionGenerator.generate(error as NSError, framesToStrip: framesToStrip) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }
 
-    func trackError(_ error: NSError, attributes: [String: AttributeValue]?) {
+    func trackError(_ error: NSError, attributes: [String: AttributeValue]?, framesToStrip: Int) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(error) {
+        if let exception = exceptionGenerator.generate(error, framesToStrip: framesToStrip) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }
 
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?) {
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]?, framesToStrip: Int) {
         guard isEnabled.get() else { return }
         guard attributeValueValidator.validateAttributes(name: "trackError", attributes: attributes) else { return }
 
-        if let exception = exceptionGenerator.generate(exception) {
+        if let exception = exceptionGenerator.generate(exception, framesToStrip: framesToStrip) {
             track(exception, type: .exception, userDefinedAttributes: EventSerializer.serializeUserDefinedAttribute(attributes), needsReporting: false)
         }
     }

--- a/ios/Sources/MeasureSDK/Swift/Exception/CodableValue.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/CodableValue.swift
@@ -1,24 +1,12 @@
 //
-//  Error.swift
-//  Measure
+//  CodableValue.swift
+//  MeasureSDK
 //
-//  Created by Adwin Ross on 17/06/25.
+//  Created by Adwin Ross on 23/05/26.
 //
 
 import Foundation
 
-struct MsrError: Codable {
-    /// Numeric code that describes the error
-    let numcode: Int64?
-
-    /// String code that describes the error
-    let code: String?
-
-    /// Object containing arbitrary fields for error's metdata
-    let meta: [String: CodableValue]?
-}
-
-/// CodableValue is a simple wrapper for heterogenous dictionary values
 enum CodableValue: Codable {
     case string(String)
     case int(Int64)

--- a/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
@@ -26,8 +26,20 @@ struct Exception: Codable {
     /// Specifies the framework where the exception originated from.
     let framework: String?
 
-    /// An optional object for tracking error(s).
-    let error: MsrError?
+    /// Severity level of the exception.
+    let severity: ExceptionSeverity?
+
+    /// `true` for user-tracked errors. Defaults to `false`.
+    let isCustom: Bool?
+
+    /// Numeric code that describes the exception.
+    let numCode: Int64?
+
+    /// String code that describes the exception.
+    let code: String?
+
+    /// Object containing arbitrary fields for the exception's metadata.
+    let meta: [String: CodableValue]?
 
     enum CodingKeys: String, CodingKey {
         case handled
@@ -36,6 +48,10 @@ struct Exception: Codable {
         case threads
         case binaryImages = "binary_images"
         case framework
-        case error
+        case severity
+        case isCustom = "is_custom"
+        case numCode = "num_code"
+        case code
+        case meta
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/Exception.swift
@@ -8,9 +8,6 @@
 import Foundation
 
 struct Exception: Codable {
-    /// A boolean indicating whether the exception was handled.
-    let handled: Bool
-
     /// An array of `ExceptionDetail` objects representing the exceptions.
     let exceptions: [ExceptionDetail]
 
@@ -42,7 +39,6 @@ struct Exception: Codable {
     let meta: [String: CodableValue]?
 
     enum CodingKeys: String, CodingKey {
-        case handled
         case exceptions
         case foreground
         case threads

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -13,8 +13,8 @@ import KSCrash
 import Foundation
 
 protocol ExceptionGenerator {
-    func generate(_ error: NSError, collectStackTraces: Bool) -> Exception?
-    func generate(_ exception: NSException, collectStackTraces: Bool) -> Exception?
+    func generate(_ error: NSError) -> Exception?
+    func generate(_ exception: NSException) -> Exception?
 }
 
 final class BaseExceptionGenerator: ExceptionGenerator {
@@ -28,36 +28,33 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         self.sysCtl = sysCtl
     }
 
-    func generate(_ error: NSError, collectStackTraces: Bool) -> Exception? {
+    func generate(_ error: NSError) -> Exception? {
         let nsException = NSException(name: NSExceptionName(rawValue: error.domain),
                                       reason: error.localizedDescription,
                                       userInfo: error.userInfo)
         return generateException(nsException,
-                                 collectStackTraces: collectStackTraces,
                                  numCode: Int64(error.code),
                                  code: error.domain,
                                  meta: convertToCodableValue(error.userInfo))
     }
 
-    func generate(_ exception: NSException, collectStackTraces: Bool) -> Exception? {
+    func generate(_ exception: NSException) -> Exception? {
         let userInfo = exception.userInfo?.reduce(into: [String: Any]()) { result, pair in
             if let key = pair.key as? String {
                 result[key] = pair.value
             }
         }
         return generateException(exception,
-                                 collectStackTraces: collectStackTraces,
                                  numCode: nil,
                                  code: "\(exception.name.rawValue), \(exception.reason ?? "")",
                                  meta: userInfo.map { convertToCodableValue($0) })
     }
 
     private func generateException(_ exception: NSException,
-                                   collectStackTraces: Bool,
                                    numCode: Int64?,
                                    code: String?,
                                    meta: [String: CodableValue]?) -> Exception? {
-        KSCrash.shared.report(exception, logAllThreads: collectStackTraces)
+        KSCrash.shared.report(exception, logAllThreads: true)
 
         guard let store = KSCrash.shared.reportStore,
               let reportID = store.reportIDs.last,
@@ -67,7 +64,8 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
 
         let formatter = CrashDataFormatter(report.value, sysCtl: sysCtl)
-        let result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta)
+        var result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta)
+        result.foreground = crashDataPersistence.isForeground
         store.deleteReport(with: Int64(truncating: reportID))
         crashDataPersistence.clearCrashData()
 

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -32,10 +32,11 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         let nsException = NSException(name: NSExceptionName(rawValue: error.domain),
                                       reason: error.localizedDescription,
                                       userInfo: error.userInfo)
-        let msrError = MsrError(numcode: Int64(error.code),
-                                code: error.domain,
-                                meta: convertToCodableValue(error.userInfo))
-        return generateException(nsException, collectStackTraces: collectStackTraces, msrError: msrError)
+        return generateException(nsException,
+                                 collectStackTraces: collectStackTraces,
+                                 numCode: Int64(error.code),
+                                 code: error.domain,
+                                 meta: convertToCodableValue(error.userInfo))
     }
 
     func generate(_ exception: NSException, collectStackTraces: Bool) -> Exception? {
@@ -44,13 +45,18 @@ final class BaseExceptionGenerator: ExceptionGenerator {
                 result[key] = pair.value
             }
         }
-        let msrError = MsrError(numcode: nil,
-                                code: "\(exception.name.rawValue), \(exception.reason ?? "")",
-                                meta: userInfo.map { convertToCodableValue($0) })
-        return generateException(exception, collectStackTraces: collectStackTraces, msrError: msrError)
+        return generateException(exception,
+                                 collectStackTraces: collectStackTraces,
+                                 numCode: nil,
+                                 code: "\(exception.name.rawValue), \(exception.reason ?? "")",
+                                 meta: userInfo.map { convertToCodableValue($0) })
     }
 
-    private func generateException(_ exception: NSException, collectStackTraces: Bool, msrError: MsrError?) -> Exception? {
+    private func generateException(_ exception: NSException,
+                                   collectStackTraces: Bool,
+                                   numCode: Int64?,
+                                   code: String?,
+                                   meta: [String: CodableValue]?) -> Exception? {
         KSCrash.shared.report(exception, logAllThreads: collectStackTraces)
 
         guard let store = KSCrash.shared.reportStore,
@@ -61,7 +67,7 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
 
         let formatter = CrashDataFormatter(report.value, sysCtl: sysCtl)
-        let result = formatter.getException(true, error: msrError)
+        let result = formatter.getException(true, severity: .handled, numCode: numCode, code: code, meta: meta)
         store.deleteReport(with: Int64(truncating: reportID))
         crashDataPersistence.clearCrashData()
 

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -12,9 +12,25 @@ import KSCrash
 #endif
 import Foundation
 
+/// Generates an `Exception` from a handled error or exception by triggering a KSCrash live report
+/// and parsing the resulting stack trace.
+///
+/// `framesToStrip` controls how many frames are removed from the top of the crashed thread's stack
+/// before the exception is reported. This is necessary because the SDK's own call stack (e.g.
+/// `generateException`, `generate`, `trackError`) always appears at the top of the trace and is
+/// not useful to the caller.
+///
+/// The correct value depends on the call path:
+/// - Swift `trackError(_:Error)`      → 3
+/// - ObjC  `trackError(_:NSError)`    → 4  (one extra frame for the `@objc` bridge)
+/// - Swift `trackException`           → 3
+/// - ObjC  `trackException`           → 4  (one extra frame for the `@objc` bridge)
+///
+/// If the Measure SDK is present as a dynamic framework (i.e. "Measure" or "Measure.dylib" appears
+/// in the crash report's binary images), stripping is skipped entirely.
 protocol ExceptionGenerator {
-    func generate(_ error: NSError) -> Exception?
-    func generate(_ exception: NSException) -> Exception?
+    func generate(_ error: NSError, framesToStrip: Int) -> Exception?
+    func generate(_ exception: NSException, framesToStrip: Int) -> Exception?
 }
 
 final class BaseExceptionGenerator: ExceptionGenerator {
@@ -28,17 +44,18 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         self.sysCtl = sysCtl
     }
 
-    func generate(_ error: NSError) -> Exception? {
+    func generate(_ error: NSError, framesToStrip: Int) -> Exception? {
         let nsException = NSException(name: NSExceptionName(rawValue: error.domain),
                                       reason: error.localizedDescription,
                                       userInfo: error.userInfo)
         return generateException(nsException,
                                  numCode: Int64(error.code),
                                  code: error.domain,
-                                 meta: convertToCodableValue(error.userInfo))
+                                 meta: convertToCodableValue(error.userInfo),
+                                 framesToStrip: framesToStrip)
     }
 
-    func generate(_ exception: NSException) -> Exception? {
+    func generate(_ exception: NSException, framesToStrip: Int) -> Exception? {
         let userInfo = exception.userInfo?.reduce(into: [String: Any]()) { result, pair in
             if let key = pair.key as? String {
                 result[key] = pair.value
@@ -47,13 +64,15 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         return generateException(exception,
                                  numCode: nil,
                                  code: "\(exception.name.rawValue), \(exception.reason ?? "")",
-                                 meta: userInfo.map { convertToCodableValue($0) })
+                                 meta: userInfo.map { convertToCodableValue($0) },
+                                 framesToStrip: framesToStrip)
     }
 
     private func generateException(_ exception: NSException,
                                    numCode: Int64?,
                                    code: String?,
-                                   meta: [String: CodableValue]?) -> Exception? {
+                                   meta: [String: CodableValue]?,
+                                   framesToStrip: Int) -> Exception? {
         KSCrash.shared.report(exception, logAllThreads: true)
 
         guard let store = KSCrash.shared.reportStore,
@@ -64,7 +83,7 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
 
         let formatter = CrashDataFormatter(report.value, sysCtl: sysCtl)
-        var result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta)
+        var result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta, framesToStrip: framesToStrip)
         result.foreground = crashDataPersistence.isForeground
         store.deleteReport(with: Int64(truncating: reportID))
         crashDataPersistence.clearCrashData()

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -67,7 +67,7 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         }
 
         let formatter = CrashDataFormatter(report.value, sysCtl: sysCtl)
-        let result = formatter.getException(true, severity: .handled, numCode: numCode, code: code, meta: meta)
+        let result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta)
         store.deleteReport(with: Int64(truncating: reportID))
         crashDataPersistence.clearCrashData()
 

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionSeverity.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionSeverity.swift
@@ -1,0 +1,12 @@
+//
+//  ExceptionSeverity.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 23/05/26.
+//
+
+enum ExceptionSeverity: String, Codable {
+    case fatal
+    case handled
+    case unhandled
+}

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -263,24 +263,24 @@ import UIKit
         }
     }
 
-    func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool = false) {
+    func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil) {
         guard let measureInternal = self.measureInternal else { return }
-        return measureInternal.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
+        return measureInternal.trackError(error, attributes: attributes)
     }
 
-    @objc func trackError(_ error: NSError, attributes: [String: Any]? = nil, collectStackTraces: Bool = false) {
+    @objc func trackError(_ error: NSError, attributes: [String: Any]? = nil) {
         guard let measureInternal = self.measureInternal else { return }
-        return measureInternal.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
+        return measureInternal.trackError(error, attributes: attributes)
     }
 
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool = false) {
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil) {
         guard let measureInternal = self.measureInternal else { return }
-        return measureInternal.trackException(exception, attributes: attributes, collectStackTraces: collectStackTraces)
+        return measureInternal.trackException(exception, attributes: attributes)
     }
 
-    @objc func trackException(_ exception: NSException, attributes: [String: Any]? = nil, collectStackTraces: Bool = false) {
+    @objc func trackException(_ exception: NSException, attributes: [String: Any]? = nil) {
         guard let measureInternal = self.measureInternal else { return }
-        return measureInternal.trackException(exception, attributes: attributes, collectStackTraces: collectStackTraces)
+        return measureInternal.trackException(exception, attributes: attributes)
     }
 
     func internalGetAttachmentDirectory() -> String? {
@@ -811,36 +811,32 @@ extension Measure {
     /// - Parameters:
     ///   - error: The Swift `Error` instance to track. Use this for native Swift errors (e.g. enums or structs conforming to `Error`).
     ///   - attributes: Optional key-value pairs for additional metadata about the error (e.g. request ID, user action, component).
-    ///   - collectStackTraces: If `true`, captures the current stack trace to aid in debugging.
-    public static func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool = false) {
-        Measure.shared.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
+    public static func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil) {
+        Measure.shared.trackError(error, attributes: attributes)
     }
 
     /// Tracks a handled Objective-C style error (`NSError`) for backward compatibility or bridging scenarios.
     /// - Parameters:
     ///   - error: The `NSError` instance to track. Ideal for errors coming from Apple frameworks or Objective-C code.
     ///   - attributes: Optional key-value pairs for additional metadata about the error (e.g. file path, HTTP status, method name).
-    ///   - collectStackTraces: If `true`, captures the current stack trace to aid in debugging.
-    @objc public static func trackError(_ error: NSError, attributes: [String: Any]? = nil, collectStackTraces: Bool = false) {
-        Measure.shared.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
+    @objc public static func trackError(_ error: NSError, attributes: [String: Any]? = nil) {
+        Measure.shared.trackError(error, attributes: attributes)
     }
 
     /// Tracks a handled NSException and records it as part of the monitoring system.
     /// - Parameters:
     ///   - exception: The NSException instance to track.
     ///   - attributes: Optional key-value pairs for additional metadata about the error (e.g. request ID, user action, component).
-    ///   - collectStackTraces: If `true`, captures the current stack trace to aid in debugging.
-    public static func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool = false) {
-        Measure.shared.trackException(exception, attributes: attributes, collectStackTraces: collectStackTraces)
+    public static func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil) {
+        Measure.shared.trackException(exception, attributes: attributes)
     }
 
     /// Tracks a handled NSException and records it as part of the monitoring system.
     /// - Parameters:
     ///   - exception: The NSException instance to track.
     ///   - attributes: Optional key-value pairs for additional metadata about the error (e.g. request ID, user action, component).
-    ///   - collectStackTraces: If `true`, captures the current stack trace to aid in debugging.
-    @objc public static func trackException(_ exception: NSException, attributes: [String: Any]? = nil, collectStackTraces: Bool = false) {
-        Measure.shared.trackException(exception, attributes: attributes, collectStackTraces: collectStackTraces)
+    @objc public static func trackException(_ exception: NSException, attributes: [String: Any]? = nil) {
+        Measure.shared.trackException(exception, attributes: attributes)
     }
 
     /// An internal method get the directory path wheere attachments are stored, used by cross-platform frameworks

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -397,30 +397,30 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
         trackBugReport(description: description, attachments: attachments, attributes: transformedAttributes)
     }
 
-    func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool) {
+    func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil) {
         guard isStarted else { return }
 
-        userTriggeredEventCollector.trackError(error, attributes: attributes, collectStackTraces: collectStackTraces)
+        userTriggeredEventCollector.trackError(error, attributes: attributes)
     }
 
-    func trackError(_ error: NSError, attributes: [String: Any]? = nil, collectStackTraces: Bool) {
+    func trackError(_ error: NSError, attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
         let transformedAttributes = attributeTransformer.transformAttributes(attributes)
-        userTriggeredEventCollector.trackError(error, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
+        userTriggeredEventCollector.trackError(error, attributes: transformedAttributes)
     }
 
-    func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil, collectStackTraces: Bool) {
+    func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil) {
         guard isStarted else { return }
 
-        userTriggeredEventCollector.trackException(exception, attributes: attributes, collectStackTraces: collectStackTraces)
+        userTriggeredEventCollector.trackException(exception, attributes: attributes)
     }
 
-    func trackException(_ exception: NSException, attributes: [String: Any]? = nil, collectStackTraces: Bool) {
+    func trackException(_ exception: NSException, attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
         let transformedAttributes = attributeTransformer.transformAttributes(attributes)
-        userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes, collectStackTraces: collectStackTraces)
+        userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes)
     }
 
     func getAttachmentDirectoryPath() -> String? {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -400,27 +400,27 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     func trackError(_ error: Error, attributes: [String: AttributeValue]? = nil) {
         guard isStarted else { return }
 
-        userTriggeredEventCollector.trackError(error, attributes: attributes)
+        userTriggeredEventCollector.trackError(error, attributes: attributes, framesToStrip: swiftErrorFramesToStrip)
     }
 
     func trackError(_ error: NSError, attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
         let transformedAttributes = attributeTransformer.transformAttributes(attributes)
-        userTriggeredEventCollector.trackError(error, attributes: transformedAttributes)
+        userTriggeredEventCollector.trackError(error, attributes: transformedAttributes, framesToStrip: objcErrorFramesToStrip)
     }
 
     func trackException(_ exception: NSException, attributes: [String: AttributeValue]? = nil) {
         guard isStarted else { return }
 
-        userTriggeredEventCollector.trackException(exception, attributes: attributes)
+        userTriggeredEventCollector.trackException(exception, attributes: attributes, framesToStrip: swiftErrorFramesToStrip)
     }
 
     func trackException(_ exception: NSException, attributes: [String: Any]? = nil) {
         guard isStarted else { return }
 
         let transformedAttributes = attributeTransformer.transformAttributes(attributes)
-        userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes)
+        userTriggeredEventCollector.trackException(exception, attributes: transformedAttributes, framesToStrip: objcErrorFramesToStrip)
     }
 
     func getAttachmentDirectoryPath() -> String? {

--- a/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
@@ -53,6 +53,8 @@ let screenshotContentTypePng = "image/png"
 let layoutSnapshotContentType = "image/svg+xml"
 let layoutSnapshotJsonContentType = "application/json"
 let layoutSnapshotJsonContentEncoding = "gzip"
+let swiftErrorFramesToStrip = 3
+let objcErrorFramesToStrip = 4
 
 struct AttributeConstants {
     static let deviceManufacturer = "Apple"

--- a/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
@@ -101,6 +101,28 @@ final class BaseSignalStoreTests: XCTestCase {
         XCTAssertTrue(events.first!.needsReporting)
     }
 
+    func testMarksTimelineForUnhandledExceptionEvent() {
+        let exception = Exception(exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: .unhandled, isCustom: nil, numCode: nil, code: nil, meta: nil)
+
+        let event = makeBaseEvent(type: .exception, data: exception)
+
+        signalStore.store(event, needsReporting: false)
+
+        let events = eventStore.getAllEvents()
+        XCTAssertEqual(events.count, 1)
+        XCTAssertTrue(events.first!.needsReporting)
+    }
+
+    func testUnhandledExceptionUsesCrashTimelineDuration() {
+        let exception = Exception(exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: .unhandled, isCustom: nil, numCode: nil, code: nil, meta: nil)
+
+        let event = makeBaseEvent(type: .exception, data: exception)
+
+        signalStore.store(event, needsReporting: false)
+
+        XCTAssertEqual(eventStore.lastMarkTimelineDurationSeconds, config.crashTimelineDurationSeconds)
+    }
+
     func testDoesNotMarkTimelineForHandledException() {
         let exception = Exception(exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: .handled, isCustom: nil, numCode: nil, code: nil, meta: nil)
 

--- a/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
@@ -79,7 +79,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testMarksTimelineForCrashEvent() {
-        let exception = Exception(handled: false, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
+        let exception = Exception(handled: false, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: nil, isCustom: nil, numCode: nil, code: nil, meta: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 
@@ -102,7 +102,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testDoesNotMarkTimelineForHandledException() {
-        let exception = Exception(handled: true, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, error: nil)
+        let exception = Exception(handled: true, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: nil, isCustom: nil, numCode: nil, code: nil, meta: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 

--- a/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
+++ b/ios/Tests/MeasureSDKTests/CoreData/SignalStoreTests.swift
@@ -79,7 +79,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testMarksTimelineForCrashEvent() {
-        let exception = Exception(handled: false, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: nil, isCustom: nil, numCode: nil, code: nil, meta: nil)
+        let exception = Exception(exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: .fatal, isCustom: nil, numCode: nil, code: nil, meta: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 
@@ -102,7 +102,7 @@ final class BaseSignalStoreTests: XCTestCase {
     }
 
     func testDoesNotMarkTimelineForHandledException() {
-        let exception = Exception(handled: true, exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: nil, isCustom: nil, numCode: nil, code: nil, meta: nil)
+        let exception = Exception(exceptions: [ExceptionDetail(type: nil, message: nil, frames: nil, signal: nil, threadName: nil, threadSequence: 0, osBuildNumber: nil)], threads: nil, binaryImages: nil, framework: nil, severity: .handled, isCustom: nil, numCode: nil, code: nil, meta: nil)
 
         let event = makeBaseEvent(type: .exception, data: exception)
 

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
@@ -195,6 +195,13 @@ final class CrashDataFormatterTests: XCTestCase {
         XCTAssertTrue(result.name.contains("Crashed"))
     }
 
+    func test_parseThread_doesNotAppendCrashedSuffixWhenIsHandled() {
+        let sut = makeFormatter()
+        let result = sut.parseThread(makeThreadDict(index: 2, crashed: true), isHandled: true)
+        XCTAssertEqual(result.name, "Thread 2")
+        XCTAssertFalse(result.name.contains("Crashed"))
+    }
+
     func test_parseThread_returnsEmptyFramesWhenBacktraceMissing() {
         let sut = makeFormatter()
         var dict = makeThreadDict()

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
@@ -604,13 +604,12 @@ final class CrashDataFormatterTests: XCTestCase {
         XCTAssertEqual(sut.getException().foreground, true)
     }
 
-    func test_getException_passesMsrErrorThrough() {
+    func test_getException_passesNumCodeAndCodeThrough() {
         let sut = makeFormatter()
-        let msrError = MsrError(numcode: 100, code: "Error", meta: nil)
-        let result = sut.getException(false, error: msrError)
-        XCTAssertNotNil(result.error)
-        XCTAssertEqual(result.error?.numcode, 100)
-        XCTAssertEqual(result.error?.code, "Error")
+        let result = sut.getException(false, numCode: 100, code: "Error", meta: nil)
+        XCTAssertEqual(result.numCode, 100)
+        XCTAssertEqual(result.code, "Error")
+        XCTAssertNil(result.meta)
     }
 
     func test_getException_setsFrameworkToApple() {

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashDataFormatterTests.swift
@@ -545,18 +545,6 @@ final class CrashDataFormatterTests: XCTestCase {
         XCTAssertEqual(parsed?.first?.path, fullPath)
     }
 
-    func test_getException_setsHandledFlag() {
-        let sut = makeFormatter()
-        let result = sut.getException(true)
-        XCTAssertTrue(result.handled)
-    }
-
-    func test_getException_setsFalseHandledFlag() {
-        let sut = makeFormatter()
-        let result = sut.getException(false)
-        XCTAssertFalse(result.handled)
-    }
-
     func test_getException_putsCrashedThreadFramesInExceptionDetail() {
         let frame = makeFrame()
         let crashedThread = makeThreadDict(index: 0, crashed: true, frames: [frame])
@@ -606,14 +594,31 @@ final class CrashDataFormatterTests: XCTestCase {
 
     func test_getException_passesNumCodeAndCodeThrough() {
         let sut = makeFormatter()
-        let result = sut.getException(false, numCode: 100, code: "Error", meta: nil)
+        let result = sut.getException(numCode: 100, code: "Error")
         XCTAssertEqual(result.numCode, 100)
         XCTAssertEqual(result.code, "Error")
-        XCTAssertNil(result.meta)
     }
 
-    func test_getException_setsFrameworkToApple() {
+    func test_getException_passesMetaThrough() throws {
         let sut = makeFormatter()
-        XCTAssertEqual(sut.getException().framework, Framework.apple)
+        let meta: [String: CodableValue] = ["key": .string("value"), "count": .int(42)]
+        let result = sut.getException(meta: meta)
+        XCTAssertNotNil(result.meta)
+        guard let returnedMeta = result.meta else { return }
+        if case .string(let str) = returnedMeta["key"] {
+            XCTAssertEqual(str, "value")
+        } else {
+            XCTFail("Expected string value for meta key 'key'")
+        }
+        if case .int(let count) = returnedMeta["count"] {
+            XCTAssertEqual(count, 42)
+        } else {
+            XCTFail("Expected int value for meta key 'count'")
+        }
+    }
+
+    func test_getException_severityIsNilByDefault() {
+        let sut = makeFormatter()
+        XCTAssertNil(sut.getException().severity)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
@@ -215,7 +215,11 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
             threads: [ThreadDetail(name: "main", frames: [stackFrame], sequence: 1)],
             binaryImages: [binaryImage],
             framework: "ios",
-            error: nil
+            severity: nil,
+            isCustom: nil,
+            numCode: nil,
+            code: nil,
+            meta: nil
         )
 
         // Event setup

--- a/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
@@ -209,7 +209,6 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
         )
 
         let exception = Exception(
-            handled: false,
             exceptions: [exceptionDetail],
             foreground: true,
             threads: [ThreadDetail(name: "main", frames: [stackFrame], sequence: 1)],
@@ -247,7 +246,6 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
             let jsonDict = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
 
             if let exceptionDict = jsonDict?["exception"] as? [String: Any] {
-                XCTAssertEqual(exceptionDict["handled"] as? Bool, false)
                 XCTAssertEqual(exceptionDict["foreground"] as? Bool, true)
 
                 if let exceptionDetails = exceptionDict["exceptions"] as? [[String: Any]],
@@ -311,6 +309,63 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
             } else {
                 XCTFail("Exception data is not present in the serialized event.")
             }
+        } catch {
+            XCTFail("Invalid JSON object: \(error.localizedDescription)")
+        }
+    }
+
+    func testEventEntity_ExceptionSerializes() {
+        let exceptionDetail = ExceptionDetail(
+            type: "NSError",
+            message: "Something went wrong",
+            frames: nil,
+            signal: nil,
+            threadName: "main",
+            threadSequence: 0,
+            osBuildNumber: nil
+        )
+
+        let exception = Exception(
+            exceptions: [exceptionDetail],
+            foreground: nil,
+            threads: nil,
+            binaryImages: nil,
+            framework: "apple",
+            severity: .fatal,
+            isCustom: true,
+            numCode: 42,
+            code: "NSPOSIXErrorDomain",
+            meta: nil
+        )
+
+        let event = Event(
+            id: "new-fields-test",
+            sessionId: "sessionId",
+            timestamp: "2024-10-22T10:03:00Z",
+            timestampInMillis: 123456792,
+            type: .exception,
+            data: exception,
+            attachments: [],
+            attributes: TestDataGenerator.generateAttributes(),
+            userTriggered: false
+        )
+
+        guard let jsonData = eventSerializer.getSerialisedEvent(for: EventEntity(event, needsReporting: true)) else {
+            XCTFail("getSerialisedEvent cannot be nil")
+            return
+        }
+
+        do {
+            let jsonDict = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
+            guard let exceptionDict = jsonDict?["exception"] as? [String: Any] else {
+                XCTFail("Exception data is not present in the serialized event.")
+                return
+            }
+            XCTAssertEqual(exceptionDict["severity"] as? String, "fatal")
+            XCTAssertEqual(exceptionDict["is_custom"] as? Bool, true)
+            XCTAssertEqual(exceptionDict["num_code"] as? Int, 42)
+            XCTAssertEqual(exceptionDict["code"] as? String, "NSPOSIXErrorDomain")
+            XCTAssertNil(exceptionDict["handled"], "handled key must not be present in the serialized output")
         } catch {
             XCTFail("Invalid JSON object: \(error.localizedDescription)")
         }

--- a/ios/Tests/MeasureSDKTests/Helper/Exception+Extension.swift
+++ b/ios/Tests/MeasureSDKTests/Helper/Exception+Extension.swift
@@ -10,8 +10,6 @@ import Foundation
 
 extension Exception: Equatable {
     public static func == (lhs: Exception, rhs: Exception) -> Bool {
-        guard lhs.handled == rhs.handled else { return false }
-
         guard lhs.exceptions.count == rhs.exceptions.count else { return false }
         for (lhsException, rhsException) in zip(lhs.exceptions, rhs.exceptions) {
             guard lhsException == rhsException else { return false }
@@ -23,6 +21,11 @@ extension Exception: Equatable {
         for (lhsThread, rhsThread) in zip(lhs.threads ?? [], rhs.threads ?? []) {
             guard lhsThread == rhsThread else { return false }
         }
+
+        guard lhs.severity == rhs.severity else { return false }
+        guard lhs.isCustom == rhs.isCustom else { return false }
+        guard lhs.numCode == rhs.numCode else { return false }
+        guard lhs.code == rhs.code else { return false }
 
         return true
     }

--- a/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
+++ b/ios/Tests/MeasureSDKTests/MeasureInternalTests.swift
@@ -172,7 +172,7 @@ final class MeasureInternalTests: XCTestCase {
         XCTAssertNil(screenshotAttachment, "captureScreenshot should not create an attachment if not started")
 
         // Test `trackError`
-        measureInternal.trackError(NSError(domain: "Test", code: 1), attributes: [:], collectStackTraces: false)
+        measureInternal.trackError(NSError(domain: "Test", code: 1), attributes: [:])
         XCTAssertFalse(logger.logs.contains(where: { $0.contains("Event processed") }), "trackError should not proceed if not started")
     }
 

--- a/ios/Tests/MeasureSDKTests/Mocks/MockEventStore.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockEventStore.swift
@@ -11,6 +11,7 @@ import Foundation
 final class MockEventStore: EventStore {
     private var events: [String: EventEntity] = [:]
     private let lock = NSLock()
+    private(set) var lastMarkTimelineDurationSeconds: Int64?
 
     func insertEvent(event: EventEntity) {
         lock.lock()
@@ -126,6 +127,7 @@ final class MockEventStore: EventStore {
     ) {
         lock.lock()
         defer { lock.unlock() }
+        lastMarkTimelineDurationSeconds = durationSeconds
 
         let start = eventTimestampMillis
         let end = eventTimestampMillis + (durationSeconds * 1000)

--- a/ios/Tests/MeasureSDKTests/Mocks/MockExceptionGenerator.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockExceptionGenerator.swift
@@ -11,11 +11,11 @@ import Foundation
 final class MockExceptionGenerator: ExceptionGenerator {
     var exception: Exception?
 
-    func generate(_ error: NSError, collectStackTraces: Bool) -> Exception? {
+    func generate(_ error: NSError) -> Exception? {
         return exception
     }
 
-    func generate(_ exception: NSException, collectStackTraces: Bool) -> Exception? {
+    func generate(_ exception: NSException) -> Exception? {
         return self.exception
     }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockExceptionGenerator.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockExceptionGenerator.swift
@@ -11,11 +11,11 @@ import Foundation
 final class MockExceptionGenerator: ExceptionGenerator {
     var exception: Exception?
 
-    func generate(_ error: NSError) -> Exception? {
+    func generate(_ error: NSError, framesToStrip: Int) -> Exception? {
         return exception
     }
 
-    func generate(_ exception: NSException) -> Exception? {
+    func generate(_ exception: NSException, framesToStrip: Int) -> Exception? {
         return self.exception
     }
 }

--- a/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/Measure.ios.kt
+++ b/kmp/measure-kmp/src/appleMain/kotlin/sh/measure/kmp/Measure.ios.kt
@@ -58,7 +58,6 @@ actual object Measure {
         IosMeasure.trackException(
             throwable.asNSException(appendCausedBy = true),
             attributes.toNative(),
-            collectStackTraces = false,
         )
     }
 

--- a/samples/frank/ios/FrankensteinApp/NativeIOSViewController.swift
+++ b/samples/frank/ios/FrankensteinApp/NativeIOSViewController.swift
@@ -354,7 +354,7 @@ private struct NativeIOSScreen: View {
             do {
                 _ = try String(contentsOfFile: "/nonexistent/path.txt", encoding: .utf8)
             } catch {
-                Measure.trackError(error, collectStackTraces: true)
+                Measure.trackError(error)
             }
         case .createSpan:
             let span = Measure.startSpan(name: "load-data")


### PR DESCRIPTION
# Description

Updates the iOS exception JSON structure to align with the latest API spec.

- Removed `handled: Bool`
- Removed `error: MsrError?`
- Added `severity: ExceptionSeverity?`
- Added `num_code: Int64?`, `code: String?`, `meta: [String: CodableValue]?` as top-level fields
- Added `is_custom: Bool?` — reserved for user-tracked errors, currently always `nil`.
- `is_custom` is wired up but always `nil` for now.
- Strip measure frames for handled errors.
- Collect session timeline for fatal and unhandled errors automatically
- Updated tests.

  ## Severity logic

  | Scenario | `severity` |
  |---|---|
  | Unhandled crash (KSCrash) | `fatal` |
  | User-tracked error (`NSError` / `NSException`) | `handled` |
  | `unhandled` | Not produced by iOS SDK currently |

## Related issue
Closes #3692 
Closes #3742 