### PR TITLE
fix(backend): handled exceptions were incorrectly grouped

### DIFF
--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -282,7 +282,7 @@ func (e eventreq) bucketExceptions(ctx context.Context) (err error) {
 			events[i].Exception.GetMethodName(),
 			events[i].Exception.GetFileName(),
 			events[i].Exception.GetLineNumber(),
-			events[i].Exception.Handled,
+			events[i].Exception.GetSeverity() == event.SeverityHandled,
 			events[i].Exception.GetSeverity() == event.SeverityFatal,
 			events[i].Exception.IsCustom,
 			events[i].Timestamp,


### PR DESCRIPTION
## Summary

This PR fixes exception grouping where a nonfatal error was getting incorrectly grouped as fatal.

## See also

- fixes #3707

