### PR TITLE
fix(backend): unify severity filter across errorGroups endpoints

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -33,6 +33,8 @@ type Attribute struct {
 	// - android
 	// - ios
 	// - flutter
+	//
+	// Deprecated: Use OSName instead.
 	Platform string `json:"platform" binding:"required"`
 
 	// ThreadName is the thread on which the

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -354,6 +354,38 @@ func resolveErrorSources(af *filter.AppFilter) (queryANR, wantHandledTrue, wantH
 	return
 }
 
+// applyExceptionSeverityFilter adds a WHERE clause to s restricting events to
+// those matching severities. Bridges new data (exception.severity populated)
+// and legacy data (exception.severity = '', falls back to exception.handled).
+// Legacy mapping: handled=false matches both fatal and unhandled
+// (indistinguishable in legacy data); handled=true matches handled.
+//
+// No-op when severities is empty.
+func applyExceptionSeverityFilter(s *sqlf.Stmt, severities []event.Severity) {
+	if len(severities) == 0 {
+		return
+	}
+	hasFatal := slices.Contains(severities, event.SeverityFatal)
+	hasHandled := slices.Contains(severities, event.SeverityHandled)
+	hasUnhandled := slices.Contains(severities, event.SeverityUnhandled)
+
+	wantLegacyFalse := hasFatal || hasUnhandled
+	var legacyClause string
+	if wantLegacyFalse && hasHandled {
+		legacyClause = "`exception.severity` = ''"
+	} else if wantLegacyFalse {
+		legacyClause = "`exception.severity` = '' AND `exception.handled` = false"
+	} else if hasHandled {
+		legacyClause = "`exception.severity` = '' AND `exception.handled` = true"
+	}
+
+	if legacyClause != "" {
+		s.Where("(`exception.severity` IN (?) OR ("+legacyClause+"))", severities)
+	} else {
+		s.Where("`exception.severity`").In(severities)
+	}
+}
+
 // unionStmts combines one or more sqlf statements with UNION ALL.
 // Returns the single statement unchanged when len == 1.
 func unionStmts(stmts []*sqlf.Stmt) *sqlf.Stmt {
@@ -538,11 +570,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			GroupBy("app_id").
 			GroupBy("id")
 
-		if !queryFatal && hasHandled && !hasUnhandled {
-			s.Where("`exception.handled` = true")
-		} else if !queryFatal && !hasHandled && hasUnhandled {
-			s.Where("`exception.handled` = false")
-		}
+		applyExceptionSeverityFilter(s, af.Severities)
 
 		if af.CustomError {
 			s.Where("`exception.is_custom` = true")
@@ -719,13 +747,9 @@ func (a App) GetErrorPlotInstances(ctx context.Context, af *filter.AppFilter) (i
 
 	if wantHandledTrue || wantHandledFalse {
 		s := newBranch().Where("type = ?", event.TypeException)
-		if wantHandledTrue && !wantHandledFalse {
-			s.Where("exception.handled = true")
-		} else if !wantHandledTrue && wantHandledFalse {
-			s.Where("exception.handled = false")
-		}
+		applyExceptionSeverityFilter(s, af.Severities)
 		if af.CustomError {
-			s.Where("exception.is_custom = true")
+			s.Where("`exception.is_custom` = true")
 		}
 		applyCommonFilters(s)
 		branches = append(branches, s)
@@ -849,14 +873,10 @@ func (a App) GetErrorGroupPlotInstances(ctx context.Context, fingerprint string,
 	if wantHandledTrue || wantHandledFalse {
 		s := newBranch().
 			Where("type = ?", event.TypeException).
-			Where("exception.fingerprint = ?", fingerprint)
-		if wantHandledTrue && !wantHandledFalse {
-			s.Where("exception.handled = true")
-		} else if !wantHandledTrue && wantHandledFalse {
-			s.Where("exception.handled = false")
-		}
+			Where("`exception.fingerprint` = ?", fingerprint)
+		applyExceptionSeverityFilter(s, af.Severities)
 		if af.CustomError {
-			s.Where("exception.is_custom = true")
+			s.Where("`exception.is_custom` = true")
 		}
 		applyCommonFilters(s)
 		branches = append(branches, s)
@@ -972,14 +992,10 @@ func (a App) GetErrorGroupAttributesDistribution(ctx context.Context, fingerprin
 	if wantHandledTrue || wantHandledFalse {
 		s := newBranch().
 			Where("type = ?", event.TypeException).
-			Where("exception.fingerprint = ?", fingerprint)
-		if wantHandledTrue && !wantHandledFalse {
-			s.Where("exception.handled = true")
-		} else if !wantHandledTrue && wantHandledFalse {
-			s.Where("exception.handled = false")
-		}
+			Where("`exception.fingerprint` = ?", fingerprint)
+		applyExceptionSeverityFilter(s, af.Severities)
 		if af.CustomError {
-			s.Where("exception.is_custom = true")
+			s.Where("`exception.is_custom` = true")
 		}
 		applyCommonFilters(s)
 		branches = append(branches, s)
@@ -1116,18 +1132,10 @@ func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *fi
 			Where("type = ?", event.TypeException).
 			Where("exception.fingerprint = ?", fingerprint)
 
-		if queryFatal && !queryNonfatal {
-			stmt.Where("exception.handled = false")
-		} else if queryNonfatal && !queryFatal {
-			if hasHandled && !hasUnhandled {
-				stmt.Where("exception.handled = true")
-			} else if hasUnhandled && !hasHandled {
-				stmt.Where("exception.handled = false")
-			}
-		}
+		applyExceptionSeverityFilter(stmt, af.Severities)
 
 		if af.CustomError {
-			stmt.Where("exception.is_custom = true")
+			stmt.Where("`exception.is_custom` = true")
 		}
 
 		applyCommonFilters(stmt)

--- a/backend/api/measure/error_plot_test.go
+++ b/backend/api/measure/error_plot_test.go
@@ -17,6 +17,9 @@ const (
 	fpErrUnhandled = "00000000000000000000000000000001"
 	fpErrHandled   = "00000000000000000000000000000002"
 	fpErrANR       = "00000000000000000000000000000003"
+	fpFatalNew     = "00000000000000000000000000000004"
+	fpHandledNew   = "00000000000000000000000000000005"
+	fpUnhandledNew = "00000000000000000000000000000006"
 )
 
 // sumIssueInstances totals the .Instances pointer values across rows.
@@ -31,7 +34,8 @@ func sumIssueInstances(items []event.IssueInstance) uint64 {
 }
 
 // seedErrorMixWithFingerprints seeds one unhandled exception, one handled
-// exception, and one ANR — each with its own fingerprint.
+// exception, and one ANR — each with its own fingerprint. All exception
+// events have empty exception.severity (legacy-data shape).
 func seedErrorMixWithFingerprints(
 	ctx context.Context,
 	t *testing.T,
@@ -42,6 +46,38 @@ func seedErrorMixWithFingerprints(
 	seedIssueEvent(ctx, t, teamID, appID, "exception", fpErrUnhandled, false, ts)
 	seedIssueEvent(ctx, t, teamID, appID, "exception", fpErrHandled, true, ts)
 	seedIssueEvent(ctx, t, teamID, appID, "anr", fpErrANR, false, ts)
+}
+
+// seedErrorMixNewData seeds three exception events with exception.severity
+// populated — one fatal, one handled, one unhandled. Mimics the new-SDK
+// ingestion shape where severity is set explicitly. No ANR events; this
+// helper targets the severity-aware exception branch only.
+func seedErrorMixNewData(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID string,
+	ts time.Time,
+) {
+	t.Helper()
+	seedIssueEventWithSeverity(ctx, t, teamID, appID, fpFatalNew, "fatal", ts)
+	seedIssueEventWithSeverity(ctx, t, teamID, appID, fpHandledNew, "handled", ts)
+	seedIssueEventWithSeverity(ctx, t, teamID, appID, fpUnhandledNew, "unhandled", ts)
+}
+
+// seedErrorMixLegacyAndNew seeds two legacy exception events (handled=false,
+// handled=true, both with severity='') and three new-data exception events
+// (fatal, handled, unhandled with severity populated). Used to verify the
+// severity-aware OR clause bridges both data shapes. No ANR events.
+func seedErrorMixLegacyAndNew(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID string,
+	ts time.Time,
+) {
+	t.Helper()
+	seedIssueEvent(ctx, t, teamID, appID, "exception", fpErrUnhandled, false, ts)
+	seedIssueEvent(ctx, t, teamID, appID, "exception", fpErrHandled, true, ts)
+	seedErrorMixNewData(ctx, t, teamID, appID, ts)
 }
 
 // --------------------------------------------------------------------------
@@ -78,6 +114,129 @@ func TestGetErrorPlotInstancesRoutesBySeverity(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cleanupAll(f.ctx, t)
 			seedErrorMixWithFingerprints(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts)
+
+			af := base()
+			c.modify(af)
+
+			items, err := f.app.GetErrorPlotInstances(f.ctx, af)
+			if err != nil {
+				t.Fatalf("GetErrorPlotInstances: %v", err)
+			}
+			if got := sumIssueInstances(items); got != c.wantTotal {
+				t.Fatalf("instances = %d, want %d, items=%+v", got, c.wantTotal, items)
+			}
+		})
+	}
+}
+
+func TestGetErrorPlotInstancesNewDataSeverity(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	base := func() *filter.AppFilter {
+		return f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	}
+
+	cases := []struct {
+		name      string
+		modify    func(af *filter.AppFilter)
+		wantTotal uint64
+	}{
+		{"severity=fatal returns only the fatal exception", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal}
+		}, 1},
+		{"severity=handled returns only the handled exception", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityHandled}
+		}, 1},
+		{"severity=unhandled returns only the unhandled exception", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityUnhandled}
+		}, 1},
+		{"severity=fatal,handled returns both", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityHandled}
+		}, 2},
+		{"severity=fatal,unhandled returns both", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityUnhandled}
+		}, 2},
+		{"severity=handled,unhandled returns both", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityHandled, event.SeverityUnhandled}
+		}, 2},
+		{"severity=fatal,handled,unhandled returns all three exceptions", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityHandled, event.SeverityUnhandled}
+		}, 3},
+		{"type=error returns all three exceptions", func(af *filter.AppFilter) {
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+		}, 3},
+		{"no flags returns all three exceptions", func(af *filter.AppFilter) {}, 3},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			cleanupAll(f.ctx, t)
+			seedErrorMixNewData(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts)
+
+			af := base()
+			c.modify(af)
+
+			items, err := f.app.GetErrorPlotInstances(f.ctx, af)
+			if err != nil {
+				t.Fatalf("GetErrorPlotInstances: %v", err)
+			}
+			if got := sumIssueInstances(items); got != c.wantTotal {
+				t.Fatalf("instances = %d, want %d, items=%+v", got, c.wantTotal, items)
+			}
+		})
+	}
+}
+
+func TestGetErrorPlotInstancesMixedLegacyAndNew(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	base := func() *filter.AppFilter {
+		return f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	}
+
+	cases := []struct {
+		name      string
+		modify    func(af *filter.AppFilter)
+		wantTotal uint64
+	}{
+		// Legacy handled=false event maps to fatal AND unhandled.
+		// Legacy handled=true event maps to handled.
+		// Seeded: 2 legacy exc (false, true) + 3 new exc (fatal, handled, unhandled).
+		{"severity=fatal: 1 legacy(false) + 1 new(fatal)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal}
+		}, 2},
+		{"severity=unhandled: 1 legacy(false) + 1 new(unhandled)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityUnhandled}
+		}, 2},
+		{"severity=handled: 1 legacy(true) + 1 new(handled)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityHandled}
+		}, 2},
+		{"severity=fatal,unhandled: 1 legacy(false) + 2 new(fatal,unhandled)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityUnhandled}
+		}, 3},
+		{"severity=fatal,handled: 2 legacy + 2 new(fatal,handled)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityHandled}
+		}, 4},
+		{"severity=handled,unhandled: 2 legacy + 2 new(handled,unhandled)", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityHandled, event.SeverityUnhandled}
+		}, 4},
+		{"severity=fatal,handled,unhandled: 2 legacy + 3 new", func(af *filter.AppFilter) {
+			af.Severities = []event.Severity{event.SeverityFatal, event.SeverityHandled, event.SeverityUnhandled}
+		}, 5},
+		{"type=error: 2 legacy + 3 new exceptions", func(af *filter.AppFilter) {
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+		}, 5},
+		{"no flags: all 5 exception events", func(af *filter.AppFilter) {}, 5},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			cleanupAll(f.ctx, t)
+			seedErrorMixLegacyAndNew(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts)
 
 			af := base()
 			c.modify(af)

--- a/backend/api/measure/test_helpers_test.go
+++ b/backend/api/measure/test_helpers_test.go
@@ -127,6 +127,15 @@ func seedIssueEvent(
 	th.SeedIssueEvent(ctx, t, teamID, appID, eventType, fingerprint, handled, ts)
 }
 
+func seedIssueEventWithSeverity(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, fingerprint, severity string,
+	ts time.Time,
+) {
+	th.SeedIssueEventWithSeverity(ctx, t, teamID, appID, fingerprint, severity, ts)
+}
+
 func seedExceptionGroup(ctx context.Context, t *testing.T, teamID, appID, fingerprint string) {
 	th.SeedExceptionGroup(ctx, t, teamID, appID, fingerprint)
 }

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -288,6 +288,32 @@ func (h *TestHelper) SeedIssueEventWithDataInSession(
 	}
 }
 
+// SeedIssueEventWithSeverity inserts an exception event with an explicit
+// exception.severity column value, mimicking new-SDK ingestion. The handled
+// bool is set consistently with severity ("handled" → true, others → false).
+// Use this to test the new-data path of severity-aware queries.
+func (h *TestHelper) SeedIssueEventWithSeverity(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, fingerprint, severity string,
+	ts time.Time,
+) {
+	t.Helper()
+	handled := severity == "handled"
+	query := fmt.Sprintf(
+		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
+			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
+			"`attribute.app_unique_id`, `attribute.os_name`, `attribute.measure_sdk_version`, "+
+			"`exception.handled`, `exception.foreground`, `exception.fingerprint`, `exception.severity`) "+
+			`VALUES ('%s', 'exception', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', 'android', '0.1', %t, true, '%s', '%s')`,
+		uuid.New().String(), uuid.New().String(), appID, teamID,
+		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String(),
+		handled, fingerprint, severity)
+	if err := h.ChConn.Exec(ctx, query); err != nil {
+		t.Fatalf("seed issue event with severity (%s): %v", severity, err)
+	}
+}
+
 // SeedNavigationEventInSession inserts a navigation event with a known
 // session_id and destination screen name.
 func (h *TestHelper) SeedNavigationEventInSession(ctx context.Context, t *testing.T, teamID, appID, sessionID, destination string, ts time.Time) {


### PR DESCRIPTION
## Summary

This PR fixes an event count mismatch between the errorGroups list & plot endpoints by extracting a shared `applyExceptionSeverityFilter` helper & applying it across all five error-API callers. The helper bridges new data (`exception.severity` populated) & legacy data (`exception.severity = ''` falling back to `exception.handled`), with `handled=false` mapping to fatal OR unhandled & `handled=true` to handled. Adds testinfra support & integration tests for both data shapes.


## Tasks

- [x] Fix `GetErrorGroupsWithFilter` events count CTE under-filtering for `severity=fatal` (leaked `handled=true` events into the count)
- [x] Extract `applyExceptionSeverityFilter` helper covering new data (`exception.severity` populated) & legacy data (`exception.severity = ''` with `exception.handled` fallback)
- [x] Apply helper in `GetErrorGroupsWithFilter`, `GetErrorPlotInstances`, `GetErrorGroupPlotInstances`, `GetErrorGroupAttributesDistribution` & `GetErrorsWithFilter`
- [x] Mark `Attribute.Platform` as deprecated in favor of `OSName`
- [x] Add `SeedIssueEventWithSeverity` testinfra helper using `attribute.os_name`
- [x] Add integration tests for the new-data path & legacy/new bridge

## See also

- fixes #3722
