### PR TITLE
chore(android): update exception schema

### DIFF
--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
@@ -19,6 +19,7 @@ import sh.measure.android.config.DynamicConfig
 import sh.measure.android.config.MeasureConfig
 import sh.measure.android.events.EventType
 import sh.measure.android.exceptions.ExceptionData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.lifecycle.ActivityLifecycleType
 import sh.measure.android.lifecycle.AppLifecycleType
 import java.util.concurrent.TimeUnit
@@ -445,7 +446,7 @@ class EventsTest {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                severity = ExceptionSeverity.Fatal,
                 foreground = true,
             ),
             timestamp = 987654321L,
@@ -459,7 +460,7 @@ class EventsTest {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                severity = ExceptionSeverity.Fatal,
                 foreground = true,
             ),
             timestamp = 987654321L,

--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/SessionTestRobot.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.fail
 import sh.measure.android.config.MeasureConfig
 import sh.measure.android.events.EventType
 import sh.measure.android.exceptions.ExceptionData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.logger.AndroidLogger
 import sh.measure.android.storage.DatabaseImpl
 import sh.measure.android.storage.SessionsTable
@@ -80,7 +81,7 @@ class SessionTestRobot {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                handled = false,
+                severity = ExceptionSeverity.Fatal,
                 foreground = true,
             ),
             timestamp = 987654321L,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -7,6 +7,7 @@ import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.mainHandler
 import sh.measure.android.utils.ProcessInfoProvider
 
@@ -47,7 +48,7 @@ internal class AnrCollector(
 
     private fun toMeasureException(anr: AnrError): ExceptionData = ExceptionFactory.createMeasureException(
         throwable = anr,
-        handled = false,
+        severity = ExceptionSeverity.Fatal,
         thread = anr.thread,
         foreground = processInfo.isForegroundProcess(),
     )

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
@@ -7,6 +7,7 @@ import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.bugreport.BugReportData
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.exceptions.ExceptionData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.gestures.ClickData
 import sh.measure.android.gestures.LongClickData
 import sh.measure.android.gestures.ScrollData
@@ -81,7 +82,7 @@ internal class InternalSignalCollector(
                         )
                     }
                     val extractedData = extractExceptionEventData(data)
-                    if (!extractedData.handled) {
+                    if (extractedData.severity == ExceptionSeverity.Fatal) {
                         // ignoring session ID and user triggered properties
                         // this should be safe as handled exceptions are not tracked in
                         // a separate session and are not user triggered.

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
@@ -5,6 +5,7 @@ import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.bugreport.BugReportData
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.exceptions.ExceptionFactory
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.navigation.ScreenViewData
@@ -178,7 +179,7 @@ internal class UserTriggeredEventCollectorImpl(
         signalProcessor.trackUserTriggered(
             data = ExceptionFactory.createMeasureException(
                 throwable = throwable,
-                handled = true,
+                severity = ExceptionSeverity.Handled,
                 thread = thread,
                 foreground = processInfoProvider.isForegroundProcess(),
             ),

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
@@ -33,6 +33,21 @@ internal data class ExceptionData(
     val is_custom: Boolean? = null,
 
     /**
+     * A numeric code that describes the exception.
+     */
+    val num_code: Long? = null,
+
+    /**
+     * A string code that describes the exception.
+     */
+    val code: String? = null,
+
+    /**
+     * Arbitrary key-value metadata associated with the exception.
+     */
+    val meta: Map<String, String>? = null,
+
+    /**
      * The list of binary images loaded in the process.
      */
     val binary_images: List<BinaryImage> = listOf(),

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
@@ -18,14 +18,19 @@ internal data class ExceptionData(
     val threads: List<MeasureThread>,
 
     /**
-     * Whether the exception was handled or not.
+     * The severity of the exception.
      */
-    val handled: Boolean,
+    val severity: ExceptionSeverity,
 
     /**
      * Whether the app was in the foreground or not when the exception occurred.
      */
     val foreground: Boolean,
+
+    /**
+     * Marks this exception as a custom error.
+     */
+    val is_custom: Boolean? = null,
 
     /**
      * The list of binary images loaded in the process.

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
@@ -5,11 +5,11 @@ internal object ExceptionFactory {
      * Creates [ExceptionData] from a [Throwable].
      *
      * @param throwable The [Throwable] to create the [ExceptionData] from.
-     * @param handled Whether the exception was handled or not.
+     * @param severity The severity of the exception.
      */
     fun createMeasureException(
         throwable: Throwable,
-        handled: Boolean,
+        severity: ExceptionSeverity,
         thread: Thread,
         foreground: Boolean,
         framework: String? = ExceptionFramework.JVM,
@@ -57,7 +57,7 @@ internal object ExceptionFactory {
         return ExceptionData(
             exceptions,
             threads = threads,
-            handled = handled,
+            severity = severity,
             foreground = foreground,
             framework = framework,
         )

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionSeverity.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionSeverity.kt
@@ -1,0 +1,28 @@
+package sh.measure.android.exceptions
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The severity of an exception.
+ */
+@Serializable
+internal enum class ExceptionSeverity {
+    /**
+     * An unhandled exception or ANR that crashed the app.
+     */
+    @SerialName("fatal")
+    Fatal,
+
+    /**
+     * An exception tracked explicitly by the app using the public API.
+     */
+    @SerialName("handled")
+    Handled,
+
+    /**
+     * An unhandled exception that did not crash the app.
+     */
+    @SerialName("unhandled")
+    Unhandled,
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/UnhandledExceptionCollector.kt
@@ -40,7 +40,7 @@ internal class UnhandledExceptionCollector(
             signalProcessor.trackCrash(
                 data = ExceptionFactory.createMeasureException(
                     throwable,
-                    handled = false,
+                    severity = ExceptionSeverity.Fatal,
                     thread = thread,
                     foreground = processInfo.isForegroundProcess(),
                 ),

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -6,6 +6,7 @@ import sh.measure.android.config.ConfigProvider
 import sh.measure.android.events.Event
 import sh.measure.android.events.EventType
 import sh.measure.android.exceptions.ExceptionData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.okhttp.HttpData
@@ -76,7 +77,8 @@ internal class SignalStoreImpl(
                 return
             }
             val isCrashEvent =
-                eventEntity.type == EventType.EXCEPTION && !(event.data as ExceptionData).handled
+                eventEntity.type == EventType.EXCEPTION &&
+                    (event.data as ExceptionData).severity == ExceptionSeverity.Fatal
             val isAnrEvent = eventEntity.type == EventType.ANR
             val isBugReportEvent = eventEntity.type == EventType.BUG_REPORT
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -15,6 +15,7 @@ import sh.measure.android.events.Attachment
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.fakes.FakeProcessInfoProvider
 import sh.measure.android.fakes.NoopLogger
 
@@ -75,7 +76,7 @@ class AnrCollectorTest {
 
         assertEquals(EventType.ANR, typeCaptor.firstValue)
         assertEquals(expectedAnrError.timestamp, timestampCaptor.firstValue)
-        assertEquals(false, dataCaptor.firstValue.handled)
+        assertEquals(ExceptionSeverity.Fatal, dataCaptor.firstValue.severity)
         assertEquals(processInfo.isForegroundProcess(), dataCaptor.firstValue.foreground)
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
@@ -23,6 +23,7 @@ import sh.measure.android.MsrAttachment
 import sh.measure.android.attributes.AttributeProcessor
 import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.bugreport.BugReportData
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeProcessInfoProvider
 import sh.measure.android.fakes.FakeSessionManager
@@ -294,7 +295,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks un-obfuscated flutter exception event`() {
-        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(handled = false)
+        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(severity = ExceptionSeverity.Fatal)
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION
@@ -331,7 +332,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks obfuscated flutter exception event`() {
-        val exceptionData = TestData.getObfuscatedFlutterExceptionData(handled = false)
+        val exceptionData = TestData.getObfuscatedFlutterExceptionData(severity = ExceptionSeverity.Fatal)
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION
@@ -368,7 +369,7 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks handled flutter exception event`() {
-        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(handled = true)
+        val exceptionData = TestData.getUnObfuscatedFlutterExceptionData(severity = ExceptionSeverity.Handled)
         val jsonElement = jsonSerializer.encodeToJsonElement(exceptionData)
         val data = jsonToMap(jsonElement.jsonObject)
         val type = EventType.EXCEPTION

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exceptions/ExceptionFactoryTest.kt
@@ -1,7 +1,6 @@
 package sh.measure.android.exceptions
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -15,7 +14,7 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            severity = ExceptionSeverity.Handled,
             thread = thread,
             foreground = true,
         )
@@ -40,7 +39,7 @@ class ExceptionFactoryTest {
         // When
         val measureException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            severity = ExceptionSeverity.Handled,
             thread = thread,
             foreground = true,
         )
@@ -61,38 +60,27 @@ class ExceptionFactoryTest {
     }
 
     @Test
-    fun `ExceptionFactory sets handled to true when the exception is handled`() {
+    fun `ExceptionFactory sets the severity passed to it`() {
         // Given
         val exception = IllegalArgumentException("Test exception")
         val thread = Thread.currentThread()
 
         // When
-        val measureException = ExceptionFactory.createMeasureException(
+        val handledException = ExceptionFactory.createMeasureException(
             exception,
-            handled = true,
+            severity = ExceptionSeverity.Handled,
+            thread = thread,
+            foreground = true,
+        )
+        val fatalException = ExceptionFactory.createMeasureException(
+            exception,
+            severity = ExceptionSeverity.Fatal,
             thread = thread,
             foreground = true,
         )
 
         // Then
-        assertTrue(measureException.handled)
-    }
-
-    @Test
-    fun `ExceptionFactory sets handled to false when the exception is unhandled`() {
-        // Given
-        val exception = IllegalArgumentException("Test exception")
-        val thread = Thread.currentThread()
-
-        // When
-        val measureException = ExceptionFactory.createMeasureException(
-            exception,
-            handled = false,
-            thread = thread,
-            foreground = true,
-        )
-
-        // Then
-        assertFalse(measureException.handled)
+        assertEquals(ExceptionSeverity.Handled, handledException.severity)
+        assertEquals(ExceptionSeverity.Fatal, fatalException.severity)
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -15,6 +15,7 @@ import sh.measure.android.events.Event
 import sh.measure.android.events.EventType
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.exceptions.ExceptionUnit
 import sh.measure.android.exceptions.Frame
 import sh.measure.android.gestures.ClickData
@@ -50,18 +51,18 @@ internal object TestData {
 
     fun getExceptionData(
         exception: Exception = IllegalArgumentException("Test exception"),
-        handled: Boolean = true,
+        severity: ExceptionSeverity = ExceptionSeverity.Handled,
         thread: Thread = Thread.currentThread(),
         foreground: Boolean = true,
     ): ExceptionData = ExceptionFactory.createMeasureException(
         exception,
-        handled,
+        severity,
         thread,
         foreground,
     )
 
     fun getUnObfuscatedFlutterExceptionData(
-        handled: Boolean = false,
+        severity: ExceptionSeverity = ExceptionSeverity.Fatal,
         foreground: Boolean = true,
     ): ExceptionData = ExceptionData(
         exceptions = listOf(
@@ -99,13 +100,13 @@ internal object TestData {
                 ),
             ),
         ),
-        handled = handled,
+        severity = severity,
         threads = listOf(),
         foreground = foreground,
     )
 
     fun getObfuscatedFlutterExceptionData(
-        handled: Boolean = false,
+        severity: ExceptionSeverity = ExceptionSeverity.Fatal,
         foreground: Boolean = true,
     ): ExceptionData = ExceptionData(
         exceptions = listOf(
@@ -126,7 +127,7 @@ internal object TestData {
                 ),
             ),
         ),
-        handled = handled,
+        severity = severity,
         threads = listOf(),
         foreground = foreground,
     )

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import sh.measure.android.attributes.StringAttr
 import sh.measure.android.events.EventType
+import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeIdProvider
 import sh.measure.android.fakes.FakeSampler
@@ -42,7 +43,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores exception event data in file storage and stores the path in database`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         val eventsCaptor = argumentCaptor<EventEntity>()
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
@@ -459,7 +460,7 @@ internal class SignalStoreTest {
         // given
         val crashTimelineDuration = 30
         configProvider.crashTimelineDurationSeconds = crashTimelineDuration
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)
@@ -585,7 +586,7 @@ internal class SignalStoreTest {
     @Test
     fun `given event insertion in db fails, deletes event and attachment data from file storage`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(
             type = EventType.EXCEPTION,
             attachments = mutableListOf(
@@ -607,7 +608,7 @@ internal class SignalStoreTest {
     @Test
     fun `given event data fails to write to file storage, does not insert event in db`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(
             type = EventType.EXCEPTION,
             attachments = mutableListOf(
@@ -645,7 +646,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores handled exception event in queue`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = true)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Handled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
 
@@ -665,7 +666,7 @@ internal class SignalStoreTest {
     @Test
     fun `stores unhandled exception event immediately without queuing`() {
         // given
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)
@@ -681,7 +682,7 @@ internal class SignalStoreTest {
     fun `marks timeline for reporting on crash`() {
         // given
         sampler.isCrashTimelineSampled = true
-        val exceptionData = TestData.getExceptionData(handled = false)
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)


### PR DESCRIPTION
# Description

Updates the Android exception data structure to align with the latest API spec, mirroring the equivalent iOS change (#3694).

  - Removed the handled flag
  - Added a severity field with three levels: fatal, handled, and unhandled
  - Added an is_custom field, reserved for user-tracked errors (currently always unset)
  - Added num_code, code and meta for correctly parsing RN exceptions 


  | Source | Severity |
  |---|---|
  | Unhandled crash | fatal |
  | ANR | fatal |
  | User-tracked exception | handled |

## Related issue
Closes #3726 

