### PR TITLE
chore(flutter): update exception schema

### DIFF
--- a/flutter/packages/measure_flutter/lib/measure_flutter.dart
+++ b/flutter/packages/measure_flutter/lib/measure_flutter.dart
@@ -92,6 +92,7 @@ import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:measure_flutter/src/gestures/click_data.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
 import 'package:measure_flutter/src/gestures/scroll_data.dart';
@@ -547,7 +548,8 @@ class Measure implements MeasureApi {
   }) {
     if (_isInitialized) {
       final details = FlutterErrorDetails(exception: error, stack: stack);
-      return _measure.trackError(details, handled: true, attributes: attributes);
+      return _measure.trackError(details,
+          severity: ExceptionSeverity.handled, attributes: attributes);
     }
     return Future.value();
   }
@@ -1044,7 +1046,7 @@ class Measure implements MeasureApi {
   Future<void> _initFlutterOnError() async {
     final originalHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) async {
-      await _measure.trackError(details, handled: false);
+      await _measure.trackError(details, severity: ExceptionSeverity.unhandled);
       if (originalHandler != null) {
         originalHandler(details);
       }
@@ -1057,7 +1059,7 @@ class Measure implements MeasureApi {
         exception: exception,
         stack: stackTrace,
       );
-      _measure.trackError(details, handled: false);
+      _measure.trackError(details, severity: ExceptionSeverity.unhandled);
       return false;
     };
   }

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_collector.dart
@@ -5,6 +5,7 @@ import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/config/config_provider.dart';
 import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/exception/exception_factory.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
@@ -45,11 +46,12 @@ final class ExceptionCollector {
 
   Future<void> trackError(
     FlutterErrorDetails details, {
-    required bool handled,
+    required ExceptionSeverity severity,
     required Map<String, AttributeValue> attributes,
   }) async {
     if (!_enabled) return;
-    final ExceptionData? exceptionData = ExceptionFactory.from(details, handled);
+    final ExceptionData? exceptionData =
+        ExceptionFactory.from(details, severity);
     if (exceptionData == null) {
       logger.log(LogLevel.error, "Failed to parse exception");
       return;
@@ -57,7 +59,8 @@ final class ExceptionCollector {
 
     final attachments = <MsrAttachment>[];
 
-    if (configProvider.crashTakeScreenshot && !handled) {
+    if (configProvider.crashTakeScreenshot &&
+        severity != ExceptionSeverity.handled) {
       await _addScreenshot(attachments);
     }
 

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_data.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_data.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:measure_flutter/src/serialization/json_serializable.dart';
 
 part 'exception_data.g.dart';
@@ -9,14 +10,18 @@ class ExceptionData implements JsonSerialized {
   /// A list of exceptions that were thrown. Multiple exceptions represent "chained" exceptions.
   final List<ExceptionUnit> exceptions;
 
-  /// Whether the exception was handled or not.
-  final bool handled;
+  /// The severity of the exception.
+  final ExceptionSeverity severity;
 
   /// The stacktrace of all the threads at the time of the exception.
   final List<MeasureThread> threads;
 
   /// Whether the app was in the foreground or not when the exception occurred.
   final bool foreground;
+
+  /// `true` for user-tracked errors. Reserved for future use, currently always null.
+  @JsonKey(name: "is_custom")
+  final bool? isCustom;
 
   @JsonKey(name: "binary_images")
   final List<BinaryImage> binaryImages;
@@ -26,11 +31,12 @@ class ExceptionData implements JsonSerialized {
 
   ExceptionData({
     required this.exceptions,
-    required this.handled,
+    required this.severity,
     required this.threads,
     required this.foreground,
     required this.binaryImages,
     required this.framework,
+    this.isCustom,
   });
 
   @override
@@ -45,18 +51,20 @@ class ExceptionData implements JsonSerialized {
       other is ExceptionData &&
           runtimeType == other.runtimeType &&
           exceptions == other.exceptions &&
-          handled == other.handled &&
+          severity == other.severity &&
           threads == other.threads &&
           foreground == other.foreground &&
+          isCustom == other.isCustom &&
           binaryImages == other.binaryImages &&
           framework == other.framework;
 
   @override
   int get hashCode =>
       exceptions.hashCode ^
-      handled.hashCode ^
+      severity.hashCode ^
       threads.hashCode ^
       foreground.hashCode ^
+      isCustom.hashCode ^
       binaryImages.hashCode ^
       framework.hashCode;
 }

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_data.g.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_data.g.dart
@@ -11,7 +11,7 @@ ExceptionData _$ExceptionDataFromJson(Map<String, dynamic> json) =>
       exceptions: (json['exceptions'] as List<dynamic>)
           .map((e) => ExceptionUnit.fromJson(e as Map<String, dynamic>))
           .toList(),
-      handled: json['handled'] as bool,
+      severity: $enumDecode(_$ExceptionSeverityEnumMap, json['severity']),
       threads: (json['threads'] as List<dynamic>)
           .map((e) => MeasureThread.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -20,17 +20,25 @@ ExceptionData _$ExceptionDataFromJson(Map<String, dynamic> json) =>
           .map((e) => BinaryImage.fromJson(e as Map<String, dynamic>))
           .toList(),
       framework: json['framework'] as String,
+      isCustom: json['is_custom'] as bool?,
     );
 
 Map<String, dynamic> _$ExceptionDataToJson(ExceptionData instance) =>
     <String, dynamic>{
       'exceptions': instance.exceptions.map((e) => e.toJson()).toList(),
-      'handled': instance.handled,
+      'severity': _$ExceptionSeverityEnumMap[instance.severity]!,
       'threads': instance.threads.map((e) => e.toJson()).toList(),
       'foreground': instance.foreground,
+      'is_custom': instance.isCustom,
       'binary_images': instance.binaryImages.map((e) => e.toJson()).toList(),
       'framework': instance.framework,
     };
+
+const _$ExceptionSeverityEnumMap = {
+  ExceptionSeverity.fatal: 'fatal',
+  ExceptionSeverity.handled: 'handled',
+  ExceptionSeverity.unhandled: 'unhandled',
+};
 
 MeasureThread _$MeasureThreadFromJson(Map<String, dynamic> json) =>
     MeasureThread(

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_factory.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_factory.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/exception/exception_framework.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 final class ExceptionFactory {
@@ -12,7 +13,8 @@ final class ExceptionFactory {
   static final _buildIdRegex = RegExp(r"build_id: *'([A-Fa-f0-9]+)'");
   static final _archRegex = RegExp(r'arch[:=] *([A-Za-z0-9]+)');
 
-  static ExceptionData? from(FlutterErrorDetails details, bool handled) {
+  static ExceptionData? from(
+      FlutterErrorDetails details, ExceptionSeverity severity) {
     var stackTrace = details.stack;
     if (stackTrace == null) {
       return null;
@@ -43,7 +45,7 @@ final class ExceptionFactory {
     // in Flutter.
     return ExceptionData(
       exceptions: exceptions,
-      handled: handled,
+      severity: severity,
       threads: [],
       foreground: true,
       binaryImages: _createBinaryImage(stackTrace),

--- a/flutter/packages/measure_flutter/lib/src/exception/exception_severity.dart
+++ b/flutter/packages/measure_flutter/lib/src/exception/exception_severity.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// The severity of an exception.
+enum ExceptionSeverity {
+  /// An unhandled exception or ANR that crashed the app.
+  /// Not produced by the Flutter SDK; reserved for schema parity.
+  @JsonValue('fatal')
+  fatal,
+
+  /// An exception tracked explicitly by the app using the public API.
+  @JsonValue('handled')
+  handled,
+
+  /// An unhandled exception that did not crash the app.
+  @JsonValue('unhandled')
+  unhandled,
+}

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -5,6 +5,7 @@ import 'package:measure_flutter/src/bug_report/shake_detector.dart';
 import 'package:measure_flutter/src/config/config_loader.dart';
 import 'package:measure_flutter/src/events/custom_event_collector.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:measure_flutter/src/gestures/click_data.dart';
 import 'package:measure_flutter/src/gestures/gesture_collector.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
@@ -104,10 +105,10 @@ final class MeasureInternal {
 
   Future<void> trackError(
     FlutterErrorDetails details, {
-    required bool handled,
+    required ExceptionSeverity severity,
     Map<String, AttributeValue> attributes = const {},
   }) {
-    return _exceptionCollector.trackError(details, handled: handled, attributes: attributes);
+    return _exceptionCollector.trackError(details, severity: severity, attributes: attributes);
   }
 
   void triggerNativeCrash() {

--- a/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/exception/exception_collector_test.dart
@@ -5,6 +5,7 @@ import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/exception/exception_data.dart';
 import 'package:measure_flutter/src/exception/exception_framework.dart';
+import 'package:measure_flutter/src/exception/exception_severity.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
 import '../utils/fake_config_provider.dart';
@@ -101,7 +102,7 @@ void main() {
             ],
           ),
         ],
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         threads: [],
         foreground: true,
         binaryImages: [],
@@ -111,7 +112,7 @@ void main() {
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         attributes: {},
       );
 
@@ -152,7 +153,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
             ],
           ),
         ],
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         threads: [],
         foreground: true,
         binaryImages: [
@@ -168,7 +169,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         attributes: {},
       );
 
@@ -225,7 +226,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
             ],
           ),
         ],
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         threads: [],
         foreground: true,
         binaryImages: [],
@@ -235,7 +236,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         attributes: {},
       );
 
@@ -246,6 +247,29 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
         signalProcessor.trackedExceptions[0].toJson(),
         exceptionData.toJson(),
         reason: 'Exception data does not match',
+      );
+    });
+
+    test('does not take screenshot for handled severity', () async {
+      configProvider.crashTakeScreenshot = true;
+
+      final error = Object();
+      final stackTrace = StackTrace.fromString([
+        '#0      _MyAppState._throwException (package:measure_flutter_example/main.dart:84:5)',
+      ].join('\n'));
+
+      collector.register();
+      await collector.trackError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+        severity: ExceptionSeverity.handled,
+        attributes: {},
+      );
+
+      expect(signalProcessor.trackedEvents.length, 1);
+      expect(signalProcessor.trackedEvents.first.attachments?.length, 0);
+      expect(
+        signalProcessor.trackedExceptions[0].severity,
+        ExceptionSeverity.handled,
       );
     });
 
@@ -261,7 +285,7 @@ isolate_instructions: 7af70ecb40, vm_instructions: 7af70d6000
       collector.register();
       await collector.trackError(
         FlutterErrorDetails(exception: error, stack: stackTrace),
-        handled: false,
+        severity: ExceptionSeverity.unhandled,
         attributes: attributes,
       );
 

--- a/samples/frank/flutter/lib/flutter_demo_screen.dart
+++ b/samples/frank/flutter/lib/flutter_demo_screen.dart
@@ -119,10 +119,6 @@ class _FlutterDemoScreenState extends State<FlutterDemoScreen>
     }
   }
 
-  void _throwChainedException() {
-    throw _CustomException('Chained: root cause').toString();
-  }
-
   void _noMethodChannel() async {
     await const MethodChannel('non_existent_channel')
         .invokeMethod('non_existent_method');
@@ -196,6 +192,18 @@ class _FlutterDemoScreenState extends State<FlutterDemoScreen>
   }
 
   // -- Misc --
+
+  void _trackHandledError() {
+    try {
+      throw _CustomException('Handled error caught by the app');
+    } catch (error, stack) {
+      Measure.instance.trackHandledError(
+        error,
+        stack,
+        attributes: AttributeBuilder().add('order_id', 'order-12345').build(),
+      );
+    }
+  }
 
   void _trackCustomEvent() {
     final attrs = AttributeBuilder()
@@ -403,6 +411,12 @@ class _FlutterDemoScreenState extends State<FlutterDemoScreen>
         ),
 
         // Misc
+        _DemoItem(
+          title: 'Handled Error',
+          description: 'Reports a caught exception via trackHandledError',
+          category: _DemoCategory.misc,
+          action: _trackHandledError,
+        ),
         _DemoItem(
           title: 'Custom Event',
           description: 'Tracks an event with attributes',


### PR DESCRIPTION
# Description

  Updates the Flutter SDK's exception data structure to align with the new exception schema, matching the iOS (#3694) and Android changes.

  - Removed the handled flag
  - Added a severity field with three levels: fatal, handled, and unhandled
  - Added an is_custom field, reserved for user-tracked errors (currently always unset)


  Severity mapping

  The Flutter SDK only captures Dart-level errors, none of which terminate the app process. Truly fatal crashes are captured by the native layer, not Dart. So severity is assigned as:
  
  
  | Source | Severity |
  |---|---|
  | Unhandled errors from the global handlers | unhandled |
  | User-tracked errors (trackHandledError) | handled |
  
## Related issue
Closes #3726 