### PR TITLE
chore(frontend): use yellow tint for handled error pills

### DIFF
--- a/frontend/dashboard/__tests__/components/pill_test.tsx
+++ b/frontend/dashboard/__tests__/components/pill_test.tsx
@@ -43,10 +43,10 @@ describe("Pill", () => {
       expect(badge!.className).toMatch(/border-amber-300/);
     });
 
-    it("renders 'Handled' label with emerald tint for PillType.Handled", () => {
+    it("renders 'Handled' label with yellow tint for PillType.Handled", () => {
       render(<Pill type={PillType.Handled} />);
       const badge = findBadge("Handled");
-      expect(badge!.className).toMatch(/border-emerald-300/);
+      expect(badge!.className).toMatch(/border-yellow-300/);
     });
 
     it("renders 'Open' label with green tint for PillType.OpenStatus", () => {

--- a/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
@@ -139,7 +139,7 @@ describe("SessionTimelineEventCell", () => {
     it.each([
       ["error", { type: "NPE", severity: "fatal" }, "bg-red-50"],
       ["error", { type: "NPE", severity: "unhandled" }, "bg-amber-50"],
-      ["error", { type: "NPE", severity: "handled" }, "bg-emerald-50"],
+      ["error", { type: "NPE", severity: "handled" }, "bg-yellow-50"],
       ["anr", { type: "ANR" }, "bg-red-50"],
       ["bug_report", { description: "Bug" }, "bg-red-50"],
       ["gesture_click", { target: "Button" }, "bg-emerald-50"],

--- a/frontend/dashboard/app/components/pill.tsx
+++ b/frontend/dashboard/app/components/pill.tsx
@@ -70,7 +70,7 @@ const pillDefaults: Record<PillType, { label?: string; tint: string }> = {
   },
   [PillType.Handled]: {
     label: "Handled",
-    tint: "border-emerald-300 text-emerald-700 bg-emerald-50 dark:border-emerald-900 dark:text-emerald-400 dark:bg-emerald-950/40",
+    tint: "border-yellow-300 text-yellow-700 bg-yellow-50 dark:border-yellow-900 dark:text-yellow-400 dark:bg-yellow-950/40",
   },
   [PillType.OpenStatus]: {
     label: "Open",

--- a/frontend/dashboard/app/components/session_timeline_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_cell.tsx
@@ -31,14 +31,14 @@ export default function SessionTimelineEventCell({
 }: SessionTimelineEventCellProps) {
   function getPillColorClasses(): string {
     // Errors get coloured by severity so the timeline visually mirrors the
-    // errors-list badges: red = fatal, amber = unhandled, emerald = handled.
+    // errors-list badges: red = fatal, amber = unhandled, yellow = handled.
     // ANRs and bug reports stay red.
     if (eventType === "error") {
       if (eventDetails.severity === "unhandled") {
         return "border-amber-300 text-amber-700 bg-amber-50 dark:border-amber-900 dark:text-amber-400 dark:bg-amber-950/40";
       }
       if (eventDetails.severity === "handled") {
-        return "border-emerald-300 text-emerald-700 bg-emerald-50 dark:border-emerald-900 dark:text-emerald-400 dark:bg-emerald-950/40";
+        return "border-yellow-300 text-yellow-700 bg-yellow-50 dark:border-yellow-900 dark:text-yellow-400 dark:bg-yellow-950/40";
       }
       return "border-red-300 text-red-700 bg-red-50 dark:border-red-900 dark:text-red-400 dark:bg-red-950/40";
     }


### PR DESCRIPTION
# Description

Uses yellow tint for handled error pills

## Related issue
Closes #3731



