### PR TITLE
chore(gradle): upload flutter symbols on clean builds

### DIFF
--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -13,13 +13,13 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -93,9 +93,8 @@ abstract class BuildUploadTask : DefaultTask() {
     @get:InputFile
     abstract val mappingFileProperty: RegularFileProperty
 
-    @get:Optional
-    @get:InputDirectory
-    abstract val flutterSymbolsDirProperty: DirectoryProperty
+    @get:InputFiles
+    abstract val flutterSymbolsFiles: ConfigurableFileCollection
 
     @get:InputFile
     abstract val manifestFileProperty: RegularFileProperty
@@ -114,13 +113,13 @@ abstract class BuildUploadTask : DefaultTask() {
         val manifestFile = manifestFileProperty.get().asFile
         val mappingFile = mappingFileProperty.getOrNull()?.asFile
         val buildMetadataFile = buildMetadataFileProperty.get().asFile
-        val flutterSymbolsDir = flutterSymbolsDirProperty.getOrNull()?.asFile
+        val flutterSymbols = flutterSymbolsFiles.files
 
         val manifestData = readManifestData(manifestFile)
         val (buildSize, buildType) = readBuildMetadata(buildMetadataFile)
 
         val client = httpClientProvider.get().client
-        val mappings = collectMappingInfo(mappingFile, flutterSymbolsDir)
+        val mappings = collectMappingInfo(mappingFile, flutterSymbols)
         val buildsRequest = createBuildsRequest(manifestData, buildSize, buildType, mappings)
 
         sendBuildsRequest(
@@ -129,13 +128,13 @@ abstract class BuildUploadTask : DefaultTask() {
             buildsRequest,
             mappings,
             mappingFile,
-            flutterSymbolsDir,
+            flutterSymbols,
         )
     }
 
     private fun collectMappingInfo(
         mappingFile: File?,
-        flutterSymbolsDir: File?,
+        flutterSymbols: Set<File>,
     ): List<MappingInfo> {
         val mappings = mutableListOf<MappingInfo>()
 
@@ -146,10 +145,9 @@ abstract class BuildUploadTask : DefaultTask() {
             logger.warn("measure: mapping file not found, symbolication will not work")
         }
 
-        flutterSymbolsDir?.let { symbolsDir ->
-            val symbolsFiles = symbolsDir.listFiles { file -> file.extension == "symbols" }
-            logger.info("measure: ${symbolsFiles.size} flutter symbol files found at ${symbolsDir.absolutePath}")
-            symbolsFiles?.forEach { symbolsFile ->
+        if (flutterSymbols.isNotEmpty()) {
+            logger.info("measure: ${flutterSymbols.size} flutter symbol files found")
+            flutterSymbols.forEach { symbolsFile ->
                 mappings.add(MappingInfo(type = TYPE_FLUTTER_SYMBOLS, filename = symbolsFile.name))
             }
         }
@@ -178,11 +176,11 @@ abstract class BuildUploadTask : DefaultTask() {
         buildsRequest: BuildsApiRequest,
         mappings: List<MappingInfo>,
         mappingFile: File?,
-        flutterSymbolsDir: File?,
+        flutterSymbols: Set<File>,
     ) {
         val buildsResponse = callBuildsApi(client, manifestData, buildsRequest)
         if (buildsResponse != null && mappings.isNotEmpty()) {
-            uploadMappingFiles(client, buildsResponse, mappingFile, flutterSymbolsDir)
+            uploadMappingFiles(client, buildsResponse, mappingFile, flutterSymbols)
         }
     }
 
@@ -228,15 +226,12 @@ abstract class BuildUploadTask : DefaultTask() {
         client: okhttp3.OkHttpClient,
         buildsResponse: BuildsApiResponse,
         mappingFile: File?,
-        flutterSymbolsDir: File?,
+        flutterSymbols: Set<File>,
     ) {
         buildsResponse.mappings.forEach { mapping ->
             val file = when (mapping.type) {
                 TYPE_PROGUARD -> mappingFile
-                TYPE_FLUTTER_SYMBOLS -> {
-                    flutterSymbolsDir?.listFiles { f -> f.extension == "symbols" && f.name == mapping.filename }
-                        ?.firstOrNull()
-                }
+                TYPE_FLUTTER_SYMBOLS -> flutterSymbols.firstOrNull { it.name == mapping.filename }
                 else -> null
             }
 

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -111,8 +111,10 @@ class MeasurePlugin : Plugin<Project> {
                 ) {
                     it.manifestFileProperty.set(manifestDataFileProvider(project, variant))
                     it.mappingFileProperty.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
-                    getFlutterSymbolsDirPath(project)?.takeIf { path -> path.exists() }?.let { path ->
-                        it.flutterSymbolsDirProperty.set(path)
+                    getFlutterSymbolsDirPath(project)?.let { dir ->
+                        it.flutterSymbolsFiles.from(
+                            project.fileTree(dir) { tree -> tree.include("**/*.symbols") },
+                        )
                     }
                     it.buildMetadataFileProperty.set(appSizeFileProvider(project, variant))
                     it.retriesProperty.set(DEFAULT_RETRIES)
@@ -196,7 +198,8 @@ class MeasurePlugin : Plugin<Project> {
                         ?: continue
                 val flutterSourceDir = flutterProject.file(source)
                 if (!File(flutterSourceDir, "pubspec.yaml").exists()) continue
-                return File(flutterSourceDir, splitDebugInfoPath)
+                val symbolsDir = File(splitDebugInfoPath)
+                return if (symbolsDir.isAbsolute) symbolsDir else File(flutterSourceDir, splitDebugInfoPath)
             } catch (e: Exception) {
                 project.logger.error("measure: Error accessing Flutter source directory: ${e.message}")
             }

--- a/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
+++ b/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
@@ -66,7 +66,7 @@ class BuildUploadTaskTest {
         task.manifestFileProperty.set(manifestDataFile)
         task.mappingFileProperty.set(mappingFile)
         task.buildMetadataFileProperty.set(appSizeFile)
-        task.flutterSymbolsDirProperty.set(project.file(flutterSymbolsDir))
+        task.flutterSymbolsFiles.from(project.fileTree(flutterSymbolsDir) { it.include("*.symbols") })
         task.requestHeadersProperty.set(customHeaders)
     }
 
@@ -129,6 +129,26 @@ class BuildUploadTaskTest {
         assertEquals(2, buildsRequest.mappings.size)
         assertTrue(buildsRequest.mappings.any { it.type == "proguard" && it.filename == "mapping.txt" })
         assertTrue(buildsRequest.mappings.any { it.type == "elf_debug" && it.filename == "app.android-arm64.symbols" })
+    }
+
+    @Test
+    fun `tolerates a non-existent flutter symbols directory`() {
+        task.flutterSymbolsFiles.setFrom()
+        val missingDir = temporaryFolder.root.resolve("does-not-exist")
+        task.flutterSymbolsFiles.from(project.fileTree(missingDir) { it.include("*.symbols") })
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
+        )
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+
+        val requestBody = recordedRequest.body.readUtf8()
+        val buildsRequest = Json.decodeFromString(BuildsApiRequest.serializer(), requestBody)
+
+        assertEquals(1, buildsRequest.mappings.size)
+        assertEquals("proguard", buildsRequest.mappings[0].type)
+        assertTrue(buildsRequest.mappings.none { it.type == "elf_debug" })
     }
 
     @Test

--- a/samples/frank/gradle/libs.versions.toml
+++ b/samples/frank/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ktor = "3.0.3"
 firebase-bom = "34.11.0"
 google-services = "4.4.4"
 crashlytics-gradle = "3.0.6"
-measure-plugin='0.11.0'
+measure-plugin='0.12.0-SNAPSHOT'
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }

--- a/samples/frank/settings.gradle.kts
+++ b/samples/frank/settings.gradle.kts
@@ -18,6 +18,8 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    includeBuild("../../android/measure-gradle-plugin")
 }
 
 plugins {


### PR DESCRIPTION
# Description

Resolve the flutter symbols directory lazily so symbols produced during execution are uploaded on clean/CI builds.
Wire sample app to the plugin via composite build so dev and CI use the current plugin source.
