### PR TITLE
chore(backend): send user defined attributes in error details

### DIFF
--- a/backend/api/event/issue.go
+++ b/backend/api/event/issue.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"backend/libs/chrono"
+	"backend/libs/udattr"
 
 	"github.com/google/uuid"
 )
@@ -46,8 +47,9 @@ type EventException struct {
 	Code          string         `json:"code"`
 	Meta          map[string]any `json:"meta"`
 	Severity      Severity       `json:"severity"`
-	Attachments   []Attachment   `json:"attachments"`
-	Threads       []ThreadView   `json:"threads"`
+	Attachments          []Attachment       `json:"attachments"`
+	Threads              []ThreadView       `json:"threads"`
+	UserDefinedAttribute udattr.UDAttribute `json:"user_defined_attribute"`
 }
 
 type ExceptionView struct {

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -1129,6 +1129,7 @@ func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *fi
 			Select("exception.meta as meta").
 			Select("if(exception.severity = '', if(exception.handled, 'handled', 'fatal'), exception.severity) as severity").
 			Select("attachments").
+			Select("user_defined_attribute").
 			Where("type = ?", event.TypeException).
 			Where("exception.fingerprint = ?", fingerprint)
 
@@ -1154,6 +1155,7 @@ func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *fi
 			var meta string
 			var severity string
 			var attachments string
+			var userDefAttr map[string][]any
 			if err = rows.Scan(
 				&e.ID,
 				&e.Type,
@@ -1172,10 +1174,14 @@ func (a App) GetErrorsWithFilter(ctx context.Context, fingerprint string, af *fi
 				&meta,
 				&severity,
 				&attachments,
+				&userDefAttr,
 			); err != nil {
 				return
 			}
 			e.Severity = event.Severity(severity)
+			if len(userDefAttr) > 0 {
+				e.UserDefinedAttribute.Scan(userDefAttr)
+			}
 
 			if err = json.Unmarshal([]byte(exceptions), &e.Exception.Exceptions); err != nil {
 				return

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -3335,8 +3335,8 @@ The required headers must be present in each request.
 #### Response Body
 
 - Each result is either an exception event or an ANR event, distinguished by the `type` field (`"exception"` or `"anr"`).
-- Exception events include `exception`, `severity`, `num_code`, `code`, and `meta` fields. `severity` is `"fatal"`, `"unhandled"`, or `"handled"`.
-- ANR events include an `anr` field instead of `exception`. `severity` is always `"fatal"` for ANRs.
+- Exception events include `exception`, `severity`, `num_code`, `code`, `meta`, and `user_defined_attribute` fields. `severity` is `"fatal"`, `"unhandled"`, or `"handled"`.
+- ANR events include an `anr` field instead of `exception`. `severity` is always `"fatal"` for ANRs. ANR events do not include `user_defined_attribute`.
 
 - Response
 
@@ -3394,6 +3394,10 @@ The required headers must be present in each request.
         "num_code": 0,
         "code": "",
         "meta": null,
+        "user_defined_attribute": {
+          "username": "alice",
+          "paid_user": true
+        },
         "attachments": [
           {
             "id": "e5f6a7b8-c9d0-1234-abcd-ef5678901234",


### PR DESCRIPTION
## Summary

This PR updates the GET `/apps/:id/errorGroups/:id/errors` API to return user defined attributes when `type` query parameter contains "error". User defined attributes will not be sent for ANR events.

## Tasks

- [x] Send user defined attributes in error details api
- [x] Update dashboard API documentation

## See also

- fixes #3732