### PR TITLE
chore(android): collect timeline for unhandled errors

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -76,14 +76,18 @@ internal class SignalStoreImpl(
                 )
                 return
             }
-            val isCrashEvent =
-                eventEntity.type == EventType.EXCEPTION &&
-                    (event.data as ExceptionData).severity == ExceptionSeverity.Fatal
+            val severity = (event.data as? ExceptionData)
+                ?.takeIf { eventEntity.type == EventType.EXCEPTION }
+                ?.severity
+            val isFatalError = severity == ExceptionSeverity.Fatal
+            val isUnhandledError = severity == ExceptionSeverity.Unhandled
             val isAnrEvent = eventEntity.type == EventType.ANR
             val isBugReportEvent = eventEntity.type == EventType.BUG_REPORT
+            val collectTimeline =
+                isFatalError || isUnhandledError || isAnrEvent || isBugReportEvent
 
             when {
-                isCrashEvent || isAnrEvent || isBugReportEvent -> {
+                collectTimeline -> {
                     val success = database.insertEvent(eventEntity)
                     flush()
                     if (!success) {
@@ -103,11 +107,11 @@ internal class SignalStoreImpl(
                 }
             }
 
-            if (isCrashEvent || isAnrEvent || isBugReportEvent) {
+            if (collectTimeline) {
                 val timelineDuration = when {
-                    isCrashEvent -> configProvider.crashTimelineDurationSeconds
                     isAnrEvent -> configProvider.anrTimelineDurationSeconds
-                    else -> configProvider.bugReportTimelineDurationSeconds
+                    isBugReportEvent -> configProvider.bugReportTimelineDurationSeconds
+                    else -> configProvider.crashTimelineDurationSeconds
                 }
 
                 database.markTimelineForReporting(

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -477,6 +477,27 @@ internal class SignalStoreTest {
     }
 
     @Test
+    fun `marks timeline for reporting when unhandled exception event is stored`() {
+        // given
+        val crashTimelineDuration = 30
+        configProvider.crashTimelineDurationSeconds = crashTimelineDuration
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
+        val event = exceptionData.toEvent(type = EventType.EXCEPTION)
+        `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
+        `when`(database.insertEvent(any())).thenReturn(true)
+
+        // when
+        signalStore.store(event)
+
+        // then
+        verify(database).markTimelineForReporting(
+            event.timestamp,
+            crashTimelineDuration,
+            event.sessionId,
+        )
+    }
+
+    @Test
     fun `marks timeline for reporting when ANR event is stored`() {
         // given
         val anrTimelineDuration = 30
@@ -667,6 +688,21 @@ internal class SignalStoreTest {
     fun `stores unhandled exception event immediately without queuing`() {
         // given
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
+        val event = exceptionData.toEvent(type = EventType.EXCEPTION)
+        `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
+        `when`(database.insertEvent(any())).thenReturn(true)
+
+        // when
+        signalStore.store(event)
+
+        // then - event should be immediately inserted
+        verify(database).insertEvent(any())
+    }
+
+    @Test
+    fun `stores unhandled exception event immediately without queuing when severity is unhandled`() {
+        // given
+        val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
         `when`(database.insertEvent(any())).thenReturn(true)


### PR DESCRIPTION
# Description

When a fatal or unhandled error is tracked, the native SDK should collect a session timeline. Previously, the
Android SDK only collected a timeline for fatal exceptions (and ANRs / bug reports). Exceptions with
`ExceptionSeverity.Unhandled` were stored as regular events with no timeline.

## Related issue
Closes #3741 