### PR TITLE
fix(frontend): hide empty user def attr in session timeline event cell

### DIFF
--- a/frontend/dashboard/__tests__/components/session_timeline_event_details_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_details_test.tsx
@@ -173,6 +173,15 @@ describe("SessionTimelineEventDetails", () => {
       expect(text).toContain("plan");
       expect(text).toContain("premium");
     });
+
+    it("skips an empty user_defined_attribute object", () => {
+      renderDetails({
+        eventDetails: { name: "test", user_defined_attribute: {} },
+      });
+      expect(
+        screen.queryByText("user_defined_attribute"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("Details links", () => {

--- a/frontend/dashboard/app/components/session_timeline_event_details.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_details.tsx
@@ -98,6 +98,14 @@ export default function SessionTimelineEventDetails({
       ) {
         return;
       }
+      if (
+        key === "user_defined_attribute" &&
+        typeof value === "object" &&
+        value !== null &&
+        Object.keys(value as Record<string, unknown>).length === 0
+      ) {
+        return;
+      }
       if (typeof value === "object") {
         entries.push([key, value]);
         return;


### PR DESCRIPTION
# Description

Hide empty user defined attributes in session timeline event cell

## Related issue
Fixes #3746



