### PR TITLE
chore(android): omit severity field from ANR events

### DIFF
--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/EventsTest.kt
@@ -460,7 +460,6 @@ class EventsTest {
             data = ExceptionData(
                 exceptions = emptyList(),
                 threads = emptyList(),
-                severity = ExceptionSeverity.Fatal,
                 foreground = true,
             ),
             timestamp = 987654321L,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -7,7 +7,6 @@ import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
-import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.mainHandler
 import sh.measure.android.utils.ProcessInfoProvider
 
@@ -48,7 +47,6 @@ internal class AnrCollector(
 
     private fun toMeasureException(anr: AnrError): ExceptionData = ExceptionFactory.createMeasureException(
         throwable = anr,
-        severity = ExceptionSeverity.Fatal,
         thread = anr.thread,
         foreground = processInfo.isForegroundProcess(),
     )

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionData.kt
@@ -20,7 +20,7 @@ internal data class ExceptionData(
     /**
      * The severity of the exception.
      */
-    val severity: ExceptionSeverity,
+    val severity: ExceptionSeverity? = null,
 
     /**
      * Whether the app was in the foreground or not when the exception occurred.

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exceptions/ExceptionFactory.kt
@@ -9,7 +9,7 @@ internal object ExceptionFactory {
      */
     fun createMeasureException(
         throwable: Throwable,
-        severity: ExceptionSeverity,
+        severity: ExceptionSeverity? = null,
         thread: Thread,
         foreground: Boolean,
         framework: String? = ExceptionFramework.JVM,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -15,7 +15,6 @@ import sh.measure.android.events.Attachment
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
-import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.fakes.FakeProcessInfoProvider
 import sh.measure.android.fakes.NoopLogger
 
@@ -76,7 +75,7 @@ class AnrCollectorTest {
 
         assertEquals(EventType.ANR, typeCaptor.firstValue)
         assertEquals(expectedAnrError.timestamp, timestampCaptor.firstValue)
-        assertEquals(ExceptionSeverity.Fatal, dataCaptor.firstValue.severity)
+        assertEquals(null, dataCaptor.firstValue.severity)
         assertEquals(processInfo.isForegroundProcess(), dataCaptor.firstValue.foreground)
     }
 }


### PR DESCRIPTION
# Description

Omit severity field from ANR events as its not required.

## Related issue
References #3727 



