### PR TITLE
fix(frontend): limit KMB formatting to 2 decimals

### DIFF
--- a/frontend/dashboard/__tests__/utils/number_utils.test.ts
+++ b/frontend/dashboard/__tests__/utils/number_utils.test.ts
@@ -1,127 +1,143 @@
-import { formatBytesSI, kilobytesToMegabytes, numberToKMB, toKiloBytes, toMegaBytes } from '@/app/utils/number_utils'
-import { describe, expect, it } from '@jest/globals'
+import {
+  formatBytesSI,
+  kilobytesToMegabytes,
+  numberToKMB,
+  toKiloBytes,
+  toMegaBytes,
+} from "@/app/utils/number_utils";
+import { describe, expect, it } from "@jest/globals";
 
-describe('number_utils', () => {
-  describe('kilobytesToMegabytes', () => {
-    it('should convert kilobytes to megabytes', () => {
-      expect(kilobytesToMegabytes(10485760)).toBe(10240)
-      expect(kilobytesToMegabytes(1024)).toBe(1)
-    })
+describe("number_utils", () => {
+  describe("kilobytesToMegabytes", () => {
+    it("should convert kilobytes to megabytes", () => {
+      expect(kilobytesToMegabytes(10485760)).toBe(10240);
+      expect(kilobytesToMegabytes(1024)).toBe(1);
+    });
 
-    it('should return 0 when input is 0', () => {
-      expect(kilobytesToMegabytes(0)).toBe(0)
-    })
+    it("should return 0 when input is 0", () => {
+      expect(kilobytesToMegabytes(0)).toBe(0);
+    });
 
-    it('should return -1 when input is negative', () => {
-      expect(kilobytesToMegabytes(-1024)).toBe(-1)
-    })
-  })
+    it("should return -1 when input is negative", () => {
+      expect(kilobytesToMegabytes(-1024)).toBe(-1);
+    });
+  });
 
-  describe('toKiloBytes', () => {
-    it('should convert bytes to kilobytes', () => {
-      expect(toKiloBytes(1024)).toBe(1)
-      expect(toKiloBytes(2048)).toBe(2)
-    })
+  describe("toKiloBytes", () => {
+    it("should convert bytes to kilobytes", () => {
+      expect(toKiloBytes(1024)).toBe(1);
+      expect(toKiloBytes(2048)).toBe(2);
+    });
 
-    it('should return 0 when input is 0', () => {
-      expect(toKiloBytes(0)).toBe(0)
-    })
-  })
+    it("should return 0 when input is 0", () => {
+      expect(toKiloBytes(0)).toBe(0);
+    });
+  });
 
-  describe('toMegaBytes', () => {
-    it('should convert bytes to megabytes', () => {
-      expect(toMegaBytes(1024 * 1024)).toBe(1)
-      expect(toMegaBytes(2 * 1024 * 1024)).toBe(2)
-    })
+  describe("toMegaBytes", () => {
+    it("should convert bytes to megabytes", () => {
+      expect(toMegaBytes(1024 * 1024)).toBe(1);
+      expect(toMegaBytes(2 * 1024 * 1024)).toBe(2);
+    });
 
-    it('should return 0 when input is 0', () => {
-      expect(toMegaBytes(0)).toBe(0)
-    })
-  })
+    it("should return 0 when input is 0", () => {
+      expect(toMegaBytes(0)).toBe(0);
+    });
+  });
 
-  describe('formatBytesSI', () => {
-    it('should format bytes', () => {
-      expect(formatBytesSI(0)).toBe('0 B')
-      expect(formatBytesSI(512)).toBe('512 B')
-      expect(formatBytesSI(999)).toBe('999 B')
-    })
+  describe("formatBytesSI", () => {
+    it("should format bytes", () => {
+      expect(formatBytesSI(0)).toBe("0 B");
+      expect(formatBytesSI(512)).toBe("512 B");
+      expect(formatBytesSI(999)).toBe("999 B");
+    });
 
-    it('should format kilobytes (decimal: 1 KB = 1000 B)', () => {
-      expect(formatBytesSI(1000)).toBe('1.0 KB')
-      expect(formatBytesSI(1500)).toBe('1.5 KB')
-      expect(formatBytesSI(50_000)).toBe('50.0 KB')
-    })
+    it("should format kilobytes (decimal: 1 KB = 1000 B)", () => {
+      expect(formatBytesSI(1000)).toBe("1.0 KB");
+      expect(formatBytesSI(1500)).toBe("1.5 KB");
+      expect(formatBytesSI(50_000)).toBe("50.0 KB");
+    });
 
-    it('should format megabytes (decimal: 1 MB = 1_000_000 B)', () => {
-      expect(formatBytesSI(1_000_000)).toBe('1.0 MB')
-      expect(formatBytesSI(1_500_000)).toBe('1.5 MB')
-      expect(formatBytesSI(500_000_000)).toBe('500.0 MB')
-    })
+    it("should format megabytes (decimal: 1 MB = 1_000_000 B)", () => {
+      expect(formatBytesSI(1_000_000)).toBe("1.0 MB");
+      expect(formatBytesSI(1_500_000)).toBe("1.5 MB");
+      expect(formatBytesSI(500_000_000)).toBe("500.0 MB");
+    });
 
-    it('should format gigabytes (decimal: 1 GB = 1_000_000_000 B)', () => {
-      expect(formatBytesSI(1_000_000_000)).toBe('1.00 GB')
-      expect(formatBytesSI(5_000_000_000)).toBe('5.00 GB')
-      expect(formatBytesSI(2_500_000_000)).toBe('2.50 GB')
-    })
+    it("should format gigabytes (decimal: 1 GB = 1_000_000_000 B)", () => {
+      expect(formatBytesSI(1_000_000_000)).toBe("1.00 GB");
+      expect(formatBytesSI(5_000_000_000)).toBe("5.00 GB");
+      expect(formatBytesSI(2_500_000_000)).toBe("2.50 GB");
+    });
 
-    it('should format terabytes (decimal: 1 TB = 1e12 B)', () => {
-      expect(formatBytesSI(1e12)).toBe('1.00 TB')
-      expect(formatBytesSI(3.75e12)).toBe('3.75 TB')
-    })
+    it("should format terabytes (decimal: 1 TB = 1e12 B)", () => {
+      expect(formatBytesSI(1e12)).toBe("1.00 TB");
+      expect(formatBytesSI(3.75e12)).toBe("3.75 TB");
+    });
 
-    it('should format petabytes (decimal: 1 PB = 1e15 B)', () => {
-      expect(formatBytesSI(1e15)).toBe('1.00 PB')
-      expect(formatBytesSI(2e15)).toBe('2.00 PB')
-    })
+    it("should format petabytes (decimal: 1 PB = 1e15 B)", () => {
+      expect(formatBytesSI(1e15)).toBe("1.00 PB");
+      expect(formatBytesSI(2e15)).toBe("2.00 PB");
+    });
 
-    it('should handle negative values', () => {
-      expect(formatBytesSI(-1000)).toBe('-1.0 KB')
-      expect(formatBytesSI(-1_000_000)).toBe('-1.0 MB')
-      expect(formatBytesSI(-1_000_000_000)).toBe('-1.00 GB')
-      expect(formatBytesSI(-1e12)).toBe('-1.00 TB')
-      expect(formatBytesSI(-1e15)).toBe('-1.00 PB')
-    })
-  })
+    it("should handle negative values", () => {
+      expect(formatBytesSI(-1000)).toBe("-1.0 KB");
+      expect(formatBytesSI(-1_000_000)).toBe("-1.0 MB");
+      expect(formatBytesSI(-1_000_000_000)).toBe("-1.00 GB");
+      expect(formatBytesSI(-1e12)).toBe("-1.00 TB");
+      expect(formatBytesSI(-1e15)).toBe("-1.00 PB");
+    });
+  });
 
-  describe('numberToKMB', () => {
-    it('should return value as string for numbers less than 1000', () => {
-      expect(numberToKMB(0)).toBe('0')
-      expect(numberToKMB(999)).toBe('999')
-      expect(numberToKMB(-1)).toBe('-1')
-    })
+  describe("numberToKMB", () => {
+    it("should return value as string for numbers less than 1000", () => {
+      expect(numberToKMB(0)).toBe("0");
+      expect(numberToKMB(999)).toBe("999");
+      expect(numberToKMB(-1)).toBe("-1");
+    });
 
-    it('should convert thousands to K', () => {
-      expect(numberToKMB(1000)).toBe('1K')
-      expect(numberToKMB(1500)).toBe('1.5K')
-      expect(numberToKMB(1999)).toBe('1.999K')
-      expect(numberToKMB(2000)).toBe('2K')
-      expect(numberToKMB(12345)).toBe('12.345K')
-    })
+    it("should convert thousands to K", () => {
+      expect(numberToKMB(1000)).toBe("1K");
+      expect(numberToKMB(1500)).toBe("1.5K");
+      expect(numberToKMB(1100)).toBe("1.1K");
+      expect(numberToKMB(2000)).toBe("2K");
+      expect(numberToKMB(12345)).toBe("12.35K");
+    });
 
-    it('should convert millions to M', () => {
-      expect(numberToKMB(1_000_000)).toBe('1M')
-      expect(numberToKMB(1_500_000)).toBe('1.5M')
-      expect(numberToKMB(2_000_000)).toBe('2M')
-      expect(numberToKMB(12_345_678)).toBe('12.345678M')
-    })
+    it("should convert millions to M", () => {
+      expect(numberToKMB(1_000_000)).toBe("1M");
+      expect(numberToKMB(1_500_000)).toBe("1.5M");
+      expect(numberToKMB(2_000_000)).toBe("2M");
+      expect(numberToKMB(12_345_678)).toBe("12.35M");
+    });
 
-    it('should convert billions to B', () => {
-      expect(numberToKMB(1_000_000_000)).toBe('1B')
-      expect(numberToKMB(1_500_000_000)).toBe('1.5B')
-      expect(numberToKMB(2_000_000_000)).toBe('2B')
-      expect(numberToKMB(12_345_678_901)).toBe('12.345678901B')
-    })
+    it("should convert billions to B", () => {
+      expect(numberToKMB(1_000_000_000)).toBe("1B");
+      expect(numberToKMB(1_500_000_000)).toBe("1.5B");
+      expect(numberToKMB(2_000_000_000)).toBe("2B");
+      expect(numberToKMB(12_345_678_901)).toBe("12.35B");
+    });
 
-    it('should handle negative numbers', () => {
-      expect(numberToKMB(-1000)).toBe('-1K')
-      expect(numberToKMB(-1_000_000)).toBe('-1M')
-      expect(numberToKMB(-1_000_000_000)).toBe('-1B')
-    })
+    it("should cap the fractional part at 2 decimal places", () => {
+      expect(numberToKMB(6_694_181)).toBe("6.69M");
+      expect(numberToKMB(25_310_755)).toBe("25.31M");
+      expect(numberToKMB(1234)).toBe("1.23K");
+      expect(numberToKMB(1_556_000)).toBe("1.56M");
+      expect(numberToKMB(1_554_000)).toBe("1.55M");
+      expect(numberToKMB(1999)).toBe("2K");
+    });
 
-    it('should remove trailing .0 for integer results', () => {
-      expect(numberToKMB(2000)).toBe('2K')
-      expect(numberToKMB(2_000_000)).toBe('2M')
-      expect(numberToKMB(2_000_000_000)).toBe('2B')
-    })
-  })
-})
+    it("should handle negative numbers", () => {
+      expect(numberToKMB(-1000)).toBe("-1K");
+      expect(numberToKMB(-1_000_000)).toBe("-1M");
+      expect(numberToKMB(-1_000_000_000)).toBe("-1B");
+      expect(numberToKMB(-1_500_000)).toBe("-1.5M");
+    });
+
+    it("should remove trailing zeros for integer results", () => {
+      expect(numberToKMB(2000)).toBe("2K");
+      expect(numberToKMB(2_000_000)).toBe("2M");
+      expect(numberToKMB(2_000_000_000)).toBe("2B");
+    });
+  });
+});

--- a/frontend/dashboard/app/utils/number_utils.ts
+++ b/frontend/dashboard/app/utils/number_utils.ts
@@ -3,49 +3,50 @@
 // pricing is computed. For mobile-app binary sizes, use the binary-aware
 // toKiloBytes / toMegaBytes helpers below.
 export function formatBytesSI(bytes: number): string {
-  const abs = Math.abs(bytes)
+  const abs = Math.abs(bytes);
   if (abs >= 1000 ** 5) {
-    return `${(bytes / 1000 ** 5).toFixed(2)} PB`
+    return `${(bytes / 1000 ** 5).toFixed(2)} PB`;
   }
   if (abs >= 1000 ** 4) {
-    return `${(bytes / 1000 ** 4).toFixed(2)} TB`
+    return `${(bytes / 1000 ** 4).toFixed(2)} TB`;
   }
   if (abs >= 1000 ** 3) {
-    return `${(bytes / 1000 ** 3).toFixed(2)} GB`
+    return `${(bytes / 1000 ** 3).toFixed(2)} GB`;
   }
   if (abs >= 1000 ** 2) {
-    return `${(bytes / 1000 ** 2).toFixed(1)} MB`
+    return `${(bytes / 1000 ** 2).toFixed(1)} MB`;
   }
   if (abs >= 1000) {
-    return `${(bytes / 1000).toFixed(1)} KB`
+    return `${(bytes / 1000).toFixed(1)} KB`;
   }
-  return `${bytes} B`
+  return `${bytes} B`;
 }
 
 export function kilobytesToMegabytes(bytes: number): number {
-  return bytes / 1024
+  return bytes / 1024;
 }
 
 export function toKiloBytes(bytes: number): number {
-  return bytes / 1024
+  return bytes / 1024;
 }
 
 export function toMegaBytes(bytes: number): number {
-  return bytes / 1024 / 1024
+  return bytes / 1024 / 1024;
 }
 
 export function numberToKMB(value: number): string {
-  const absValue = Math.abs(value)
-  const sign = value < 0 ? '-' : ''
+  const absValue = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  // Round to 2 decimals, then drop trailing zeros (and a dangling dot) so
+  // exact values render cleanly: 6.69M, 1.5M, 1M (not 1.00M).
+  const format = (num: number, suffix: string) =>
+    sign + num.toFixed(2).replace(/\.?0+$/, "") + suffix;
   if (absValue >= 1_000_000_000) {
-    const num = absValue / 1_000_000_000
-    return sign + (Number.isInteger(num) ? `${num}B` : `${num.toString().replace(/\.0+$/, '')}B`)
+    return format(absValue / 1_000_000_000, "B");
   } else if (absValue >= 1_000_000) {
-    const num = absValue / 1_000_000
-    return sign + (Number.isInteger(num) ? `${num}M` : `${num.toString().replace(/\.0+$/, '')}M`)
+    return format(absValue / 1_000_000, "M");
   } else if (absValue >= 1000) {
-    const num = absValue / 1000
-    return sign + (Number.isInteger(num) ? `${num}K` : `${num.toString().replace(/\.0+$/, '')}K`)
+    return format(absValue / 1000, "K");
   }
-  return value.toString()
+  return value.toString();
 }


### PR DESCRIPTION
# Description

Limits KMB formatting to 2 decimals

## Related issue
Fixes #3751



