### PR TITLE
refactor(frontend): consolidate pill styling

### DIFF
--- a/frontend/dashboard/__tests__/components/pill_test.tsx
+++ b/frontend/dashboard/__tests__/components/pill_test.tsx
@@ -70,6 +70,78 @@ describe("Pill", () => {
     });
   });
 
+  describe("session event pills (per-event types)", () => {
+    // Exhaustive over every SessionEvent* type that carries a default label:
+    // label, colour-family tint, and the rounded-sm shape that distinguishes
+    // these from the pill-shaped filter/status chips.
+    const sessionCases: Array<[PillType, string, RegExp]> = [
+      [PillType.SessionEventFatalError, "Fatal Error", /border-red-400/],
+      [
+        PillType.SessionEventUnhandledError,
+        "Unhandled Error",
+        /border-amber-400/,
+      ],
+      [PillType.SessionEventHandledError, "Handled Error", /border-yellow-400/],
+      [PillType.SessionEventError, "Error", /border-red-400/],
+      [PillType.SessionEventAnr, "ANR", /border-red-400/],
+      [PillType.SessionEventBugReport, "Bug Report", /border-red-400/],
+      [PillType.SessionEventGestureClick, "Click", /border-emerald-400/],
+      [
+        PillType.SessionEventGestureLongClick,
+        "Long Click",
+        /border-emerald-400/,
+      ],
+      [PillType.SessionEventGestureScroll, "Scroll", /border-emerald-400/],
+      [PillType.SessionEventHttp, "HTTP", /border-cyan-400/],
+      [PillType.SessionEventLifecycleActivity, "Activity", /border-indigo-400/],
+      [PillType.SessionEventLifecycleFragment, "Fragment", /border-indigo-400/],
+      [
+        PillType.SessionEventLifecycleViewController,
+        "View Controller",
+        /border-indigo-400/,
+      ],
+      [PillType.SessionEventLifecycleSwiftUI, "SwiftUI", /border-indigo-400/],
+      [PillType.SessionEventLifecycleApp, "App", /border-indigo-400/],
+      [PillType.SessionEventAppExit, "App Exit", /border-indigo-400/],
+      [PillType.SessionEventNavigation, "Navigation", /border-fuchsia-400/],
+      [PillType.SessionEventScreenView, "Screen View", /border-fuchsia-400/],
+      [PillType.SessionEventColdLaunch, "Cold Launch", /border-indigo-400/],
+      [PillType.SessionEventWarmLaunch, "Warm Launch", /border-indigo-400/],
+      [PillType.SessionEventHotLaunch, "Hot Launch", /border-indigo-400/],
+      [PillType.SessionEventLowMemory, "Low Memory", /border-indigo-400/],
+      [PillType.SessionEventTrimMemory, "Trim Memory", /border-indigo-400/],
+      [PillType.SessionEventTrace, "Trace", /border-pink-400/],
+      [PillType.SessionEventCustom, "Custom", /border-purple-400/],
+      [PillType.SessionEventLog, "Log", /border-indigo-400/],
+    ];
+
+    it.each(sessionCases)(
+      "renders %s with its default label and tint",
+      (type, label, tintPattern) => {
+        render(<Pill type={type} />);
+        const badge = findBadge(label);
+        expect(badge).not.toBeNull();
+        expect(badge!.className).toMatch(tintPattern);
+        expect(badge!.className).toMatch(/rounded-sm/);
+      },
+    );
+
+    it("renders SessionEventDefault from children with indigo tint", () => {
+      render(<Pill type={PillType.SessionEventDefault}>weird_event</Pill>);
+      const badge = findBadge("weird_event");
+      expect(badge).not.toBeNull();
+      expect(badge!.className).toMatch(/border-indigo-400/);
+      expect(badge!.className).toMatch(/rounded-sm/);
+    });
+
+    it("renders null for SessionEventDefault with no children", () => {
+      const { container } = render(
+        <Pill type={PillType.SessionEventDefault} />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
   describe("children override default label", () => {
     it("uses children over the typed default label", () => {
       render(<Pill type={PillType.Error}>Custom</Pill>);

--- a/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
@@ -127,6 +127,8 @@ describe("SessionTimelineEventCell", () => {
         { class_name: "ContentView", type: "onAppear" },
         "SwiftUI",
       ],
+      ["string", { string: "a log line" }, "Log"],
+      ["unknown_event_type", {}, "unknown_event_type"],
     ])("shows %s pill label", (eventType, eventDetails, expectedLabel) => {
       renderCell({ eventType, eventDetails });
       expect(screen.getByText(expectedLabel)).toBeInTheDocument();
@@ -134,24 +136,65 @@ describe("SessionTimelineEventCell", () => {
   });
 
   describe("Pill colour", () => {
-    // The pill carries the colour now (not a dot). We assert one Tailwind
-    // class per bucket as a smoke test that the colour helper still maps.
+    // The pill carries the colour now (not a dot). Exhaustive over every event
+    // type so the cell's event -> pill-type mapping stays in sync with the
+    // colour families defined in pill.tsx.
     it.each([
       ["error", { type: "NPE", severity: "fatal" }, "bg-red-100"],
       ["error", { type: "NPE", severity: "unhandled" }, "bg-amber-100"],
       ["error", { type: "NPE", severity: "handled" }, "bg-yellow-100"],
+      ["error", { type: "NPE" }, "bg-red-100"],
       ["anr", { type: "ANR" }, "bg-red-100"],
       ["bug_report", { description: "Bug" }, "bg-red-100"],
       ["gesture_click", { target: "Button" }, "bg-emerald-100"],
-      ["navigation", { to: "/home" }, "bg-fuchsia-100"],
+      ["gesture_long_click", { target: "Button" }, "bg-emerald-100"],
+      ["gesture_scroll", { target: "List" }, "bg-emerald-100"],
       ["http", { method: "get", status_code: 200, url: "/api" }, "bg-cyan-100"],
+      [
+        "lifecycle_activity",
+        { class_name: "MainActivity", type: "created" },
+        "bg-indigo-100",
+      ],
+      [
+        "lifecycle_fragment",
+        { class_name: "HomeFragment", type: "resumed" },
+        "bg-indigo-100",
+      ],
+      [
+        "lifecycle_view_controller",
+        { class_name: "HomeVC", type: "viewDidLoad" },
+        "bg-indigo-100",
+      ],
+      [
+        "lifecycle_swift_ui",
+        { class_name: "ContentView", type: "onAppear" },
+        "bg-indigo-100",
+      ],
+      ["lifecycle_app", { type: "foreground" }, "bg-indigo-100"],
+      ["app_exit", { reason: "USER_REQUEST" }, "bg-indigo-100"],
+      ["navigation", { to: "/home" }, "bg-fuchsia-100"],
+      ["screen_view", { name: "Home" }, "bg-fuchsia-100"],
+      ["cold_launch", {}, "bg-indigo-100"],
+      ["warm_launch", {}, "bg-indigo-100"],
+      ["hot_launch", {}, "bg-indigo-100"],
+      ["low_memory", {}, "bg-indigo-100"],
+      ["trim_memory", {}, "bg-indigo-100"],
       ["trace", { trace_name: "checkout" }, "bg-pink-100"],
       ["custom", { name: "event" }, "bg-purple-100"],
-      ["cold_launch", {}, "bg-indigo-100"],
+      ["string", { string: "a log line" }, "bg-indigo-100"],
+      ["unknown_event_type", {}, "bg-indigo-100"],
     ])("applies %s pill bg", (eventType, eventDetails, expectedClass) => {
       const { container } = renderCell({ eventType, eventDetails });
       const pill = container.querySelector(`.${expectedClass}`);
       expect(pill).not.toBeNull();
+    });
+
+    it("renders the event pill square-ish (rounded-sm)", () => {
+      const { container } = renderCell({
+        eventType: "custom",
+        eventDetails: { name: "event" },
+      });
+      expect(container.querySelector(".rounded-sm")).not.toBeNull();
     });
   });
 

--- a/frontend/dashboard/app/components/pill.tsx
+++ b/frontend/dashboard/app/components/pill.tsx
@@ -24,6 +24,36 @@ export enum PillType {
   StatusUnset = "status-unset",
   StatusOkay = "status-okay",
   StatusError = "status-error",
+  // Session timeline events — one type per event, coloured by family and
+  // (for errors) severity. Square-ish (rounded-sm) to set them apart from the
+  // pill-shaped filter/status chips above.
+  SessionEventFatalError = "session_event_fatal_error",
+  SessionEventUnhandledError = "session_event_unhandled_error",
+  SessionEventHandledError = "session_event_handled_error",
+  SessionEventError = "session_event_error",
+  SessionEventAnr = "session_event_anr",
+  SessionEventBugReport = "session_event_bug_report",
+  SessionEventGestureClick = "session_event_gesture_click",
+  SessionEventGestureLongClick = "session_event_gesture_long_click",
+  SessionEventGestureScroll = "session_event_gesture_scroll",
+  SessionEventHttp = "session_event_http",
+  SessionEventLifecycleActivity = "session_event_lifecycle_activity",
+  SessionEventLifecycleFragment = "session_event_lifecycle_fragment",
+  SessionEventLifecycleViewController = "session_event_lifecycle_view_controller",
+  SessionEventLifecycleSwiftUI = "session_event_lifecycle_swift_ui",
+  SessionEventLifecycleApp = "session_event_lifecycle_app",
+  SessionEventAppExit = "session_event_app_exit",
+  SessionEventNavigation = "session_event_navigation",
+  SessionEventScreenView = "session_event_screen_view",
+  SessionEventColdLaunch = "session_event_cold_launch",
+  SessionEventWarmLaunch = "session_event_warm_launch",
+  SessionEventHotLaunch = "session_event_hot_launch",
+  SessionEventLowMemory = "session_event_low_memory",
+  SessionEventTrimMemory = "session_event_trim_memory",
+  SessionEventTrace = "session_event_trace",
+  SessionEventCustom = "session_event_custom",
+  SessionEventLog = "session_event_log",
+  SessionEventDefault = "session_event_default",
 }
 
 // Action button shown on the right half of the pill. "clear" empties the
@@ -47,6 +77,30 @@ interface PillProps {
   action?: PillAction;
   className?: string;
 }
+
+// Session-event tints. Shared by colour family across the per-event types
+// below, and square-ish (rounded-sm) to override the badge's pill shape.
+// Spelled out in full because Tailwind can't see interpolated class names.
+const sessionRed =
+  "rounded-sm border-red-400 text-red-700 bg-red-100 dark:border-red-400 dark:text-red-400 dark:bg-red-950/40";
+const sessionAmber =
+  "rounded-sm border-amber-400 text-amber-700 bg-amber-100 dark:border-amber-400 dark:text-amber-400 dark:bg-amber-950/40";
+const sessionYellow =
+  "rounded-sm border-yellow-400 text-yellow-700 bg-yellow-100 dark:border-yellow-400 dark:text-yellow-400 dark:bg-yellow-950/40";
+const sessionEmerald =
+  "rounded-sm border-emerald-400 text-emerald-700 bg-emerald-100 dark:border-emerald-400 dark:text-emerald-400 dark:bg-emerald-950/40";
+const sessionFuchsia =
+  "rounded-sm border-fuchsia-400 text-fuchsia-700 bg-fuchsia-100 dark:border-fuchsia-400 dark:text-fuchsia-400 dark:bg-fuchsia-950/40";
+const sessionCyan =
+  "rounded-sm border-cyan-400 text-cyan-700 bg-cyan-100 dark:border-cyan-400 dark:text-cyan-400 dark:bg-cyan-950/40";
+const sessionPink =
+  "rounded-sm border-pink-400 text-pink-700 bg-pink-100 dark:border-pink-400 dark:text-pink-400 dark:bg-pink-950/40";
+const sessionPurple =
+  "rounded-sm border-purple-400 text-purple-700 bg-purple-100 dark:border-purple-400 dark:text-purple-400 dark:bg-purple-950/40";
+// Indigo is the catch-all for lifecycle, launches, memory, logs and any
+// otherwise-unmapped event.
+const sessionIndigo =
+  "rounded-sm border-indigo-400 text-indigo-700 bg-indigo-100 dark:border-indigo-400 dark:text-indigo-400 dark:bg-indigo-950/40";
 
 // Typed defaults: each PillType carries its display label (when no children
 // are passed) and its colour tint.
@@ -89,6 +143,80 @@ const pillDefaults: Record<PillType, { label?: string; tint: string }> = {
     label: "Error",
     tint: "border-red-400 text-red-700 bg-red-100 dark:border-red-400 dark:text-red-400 dark:bg-red-950/40",
   },
+  [PillType.SessionEventFatalError]: { label: "Fatal Error", tint: sessionRed },
+  [PillType.SessionEventUnhandledError]: {
+    label: "Unhandled Error",
+    tint: sessionAmber,
+  },
+  [PillType.SessionEventHandledError]: {
+    label: "Handled Error",
+    tint: sessionYellow,
+  },
+  [PillType.SessionEventError]: { label: "Error", tint: sessionRed },
+  [PillType.SessionEventAnr]: { label: "ANR", tint: sessionRed },
+  [PillType.SessionEventBugReport]: { label: "Bug Report", tint: sessionRed },
+  [PillType.SessionEventGestureClick]: { label: "Click", tint: sessionEmerald },
+  [PillType.SessionEventGestureLongClick]: {
+    label: "Long Click",
+    tint: sessionEmerald,
+  },
+  [PillType.SessionEventGestureScroll]: {
+    label: "Scroll",
+    tint: sessionEmerald,
+  },
+  [PillType.SessionEventHttp]: { label: "HTTP", tint: sessionCyan },
+  [PillType.SessionEventLifecycleActivity]: {
+    label: "Activity",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventLifecycleFragment]: {
+    label: "Fragment",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventLifecycleViewController]: {
+    label: "View Controller",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventLifecycleSwiftUI]: {
+    label: "SwiftUI",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventLifecycleApp]: { label: "App", tint: sessionIndigo },
+  [PillType.SessionEventAppExit]: { label: "App Exit", tint: sessionIndigo },
+  [PillType.SessionEventNavigation]: {
+    label: "Navigation",
+    tint: sessionFuchsia,
+  },
+  [PillType.SessionEventScreenView]: {
+    label: "Screen View",
+    tint: sessionFuchsia,
+  },
+  [PillType.SessionEventColdLaunch]: {
+    label: "Cold Launch",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventWarmLaunch]: {
+    label: "Warm Launch",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventHotLaunch]: {
+    label: "Hot Launch",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventLowMemory]: {
+    label: "Low Memory",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventTrimMemory]: {
+    label: "Trim Memory",
+    tint: sessionIndigo,
+  },
+  [PillType.SessionEventTrace]: { label: "Trace", tint: sessionPink },
+  [PillType.SessionEventCustom]: { label: "Custom", tint: sessionPurple },
+  [PillType.SessionEventLog]: { label: "Log", tint: sessionIndigo },
+  // No label: the cell passes the raw event type as children for unknown
+  // events, mirroring the old `return eventType` fallback.
+  [PillType.SessionEventDefault]: { tint: sessionIndigo },
 };
 
 const tooltipChars = 1000;

--- a/frontend/dashboard/app/components/session_timeline_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_cell.tsx
@@ -3,8 +3,52 @@
 import { Camera, ChevronDown } from "lucide-react";
 import { formatToCamelCase } from "../utils/string_utils";
 import { formatDateToHumanReadableDateTime } from "../utils/time_utils";
-import Pill from "./pill";
+import Pill, { PillType } from "./pill";
 import SessionTimelineEventDetails from "./session_timeline_event_details";
+
+// Maps an event type with a fixed label/colour to its pill type. Errors depend
+// on severity too, so they're resolved in pillTypeForEvent below rather than
+// here.
+const eventPillTypes: Record<string, PillType> = {
+  anr: PillType.SessionEventAnr,
+  bug_report: PillType.SessionEventBugReport,
+  gesture_click: PillType.SessionEventGestureClick,
+  gesture_long_click: PillType.SessionEventGestureLongClick,
+  gesture_scroll: PillType.SessionEventGestureScroll,
+  http: PillType.SessionEventHttp,
+  lifecycle_activity: PillType.SessionEventLifecycleActivity,
+  lifecycle_fragment: PillType.SessionEventLifecycleFragment,
+  lifecycle_view_controller: PillType.SessionEventLifecycleViewController,
+  lifecycle_swift_ui: PillType.SessionEventLifecycleSwiftUI,
+  lifecycle_app: PillType.SessionEventLifecycleApp,
+  app_exit: PillType.SessionEventAppExit,
+  navigation: PillType.SessionEventNavigation,
+  screen_view: PillType.SessionEventScreenView,
+  cold_launch: PillType.SessionEventColdLaunch,
+  warm_launch: PillType.SessionEventWarmLaunch,
+  hot_launch: PillType.SessionEventHotLaunch,
+  low_memory: PillType.SessionEventLowMemory,
+  trim_memory: PillType.SessionEventTrimMemory,
+  trace: PillType.SessionEventTrace,
+  custom: PillType.SessionEventCustom,
+  string: PillType.SessionEventLog,
+};
+
+function pillTypeForEvent(eventType: string, eventDetails: any): PillType {
+  if (eventType === "error") {
+    if (eventDetails.severity === "unhandled") {
+      return PillType.SessionEventUnhandledError;
+    }
+    if (eventDetails.severity === "handled") {
+      return PillType.SessionEventHandledError;
+    }
+    if (eventDetails.severity === "fatal") {
+      return PillType.SessionEventFatalError;
+    }
+    return PillType.SessionEventError;
+  }
+  return eventPillTypes[eventType] ?? PillType.SessionEventDefault;
+}
 
 type SessionTimelineEventCellProps = {
   teamId: string;
@@ -29,72 +73,6 @@ export default function SessionTimelineEventCell({
   expanded,
   onToggle,
 }: SessionTimelineEventCellProps) {
-  function getPillColorClasses(): string {
-    // Errors get coloured by severity so the timeline visually mirrors the
-    // errors-list badges: red = fatal, amber = unhandled, yellow = handled.
-    // ANRs and bug reports stay red.
-    if (eventType === "error") {
-      if (eventDetails.severity === "unhandled") {
-        return "border-amber-400 rounded-sm text-amber-700 bg-amber-100 dark:border-amber-400 dark:text-amber-400 dark:bg-amber-950/40";
-      }
-      if (eventDetails.severity === "handled") {
-        return "border-yellow-400 rounded-sm text-yellow-700 bg-yellow-100 dark:border-yellow-400 dark:text-yellow-400 dark:bg-yellow-950/40";
-      }
-      return "border-red-400 rounded-sm text-red-700 bg-red-100 dark:border-red-400 dark:text-red-400 dark:bg-red-950/40";
-    }
-    if (eventType === "anr" || eventType === "bug_report") {
-      return "border-red-400 rounded-sm text-red-700 bg-red-100 dark:border-red-400 dark:text-red-400 dark:bg-red-950/40";
-    }
-    if (eventType.includes("gesture")) {
-      return "border-emerald-400 rounded-sm text-emerald-700 bg-emerald-100 dark:border-emerald-400 dark:text-emerald-400 dark:bg-emerald-950/40";
-    }
-    if (eventType === "navigation" || eventType === "screen_view") {
-      return "border-fuchsia-400 rounded-sm text-fuchsia-700 bg-fuchsia-100 dark:border-fuchsia-400 dark:text-fuchsia-400 dark:bg-fuchsia-950/40";
-    }
-    if (eventType === "http") {
-      return "border-cyan-400 rounded-sm text-cyan-700 bg-cyan-100 dark:border-cyan-400 dark:text-cyan-400 dark:bg-cyan-950/40";
-    }
-    if (eventType === "trace") {
-      return "border-pink-400 rounded-sm text-pink-700 bg-pink-100 dark:border-pink-400 dark:text-pink-400 dark:bg-pink-950/40";
-    }
-    if (eventType === "custom") {
-      return "border-purple-400 rounded-sm text-purple-700 bg-purple-100 dark:border-purple-400 dark:text-purple-400 dark:bg-purple-950/40";
-    }
-    return "border-indigo-400 rounded-sm text-indigo-700 bg-indigo-100 dark:border-indigo-400 dark:text-indigo-400 dark:bg-indigo-950/40";
-  }
-
-  function getPillLabel(): string {
-    if (eventType === "error") {
-      if (eventDetails.severity === "fatal") return "Fatal Error";
-      if (eventDetails.severity === "unhandled") return "Unhandled Error";
-      if (eventDetails.severity === "handled") return "Handled Error";
-      return "Error";
-    }
-    if (eventType === "anr") return "ANR";
-    if (eventType === "bug_report") return "Bug Report";
-    if (eventType === "gesture_click") return "Click";
-    if (eventType === "gesture_long_click") return "Long Click";
-    if (eventType === "gesture_scroll") return "Scroll";
-    if (eventType === "http") return "HTTP";
-    if (eventType === "lifecycle_activity") return "Activity";
-    if (eventType === "lifecycle_fragment") return "Fragment";
-    if (eventType === "lifecycle_view_controller") return "View Controller";
-    if (eventType === "lifecycle_swift_ui") return "SwiftUI";
-    if (eventType === "lifecycle_app") return "App";
-    if (eventType === "app_exit") return "App Exit";
-    if (eventType === "navigation") return "Navigation";
-    if (eventType === "screen_view") return "Screen View";
-    if (eventType === "cold_launch") return "Cold Launch";
-    if (eventType === "warm_launch") return "Warm Launch";
-    if (eventType === "hot_launch") return "Hot Launch";
-    if (eventType === "low_memory") return "Low Memory";
-    if (eventType === "trim_memory") return "Trim Memory";
-    if (eventType === "trace") return "Trace";
-    if (eventType === "custom") return "Custom";
-    if (eventType === "string") return "Log";
-    return eventType;
-  }
-
   function getTitle(): string {
     if (eventType === "error" || eventType === "anr") {
       return `${eventDetails.type}${eventDetails.message ? `: ${eventDetails.message}` : ""}`;
@@ -176,6 +154,7 @@ export default function SessionTimelineEventCell({
 
   const title = getTitle();
   const snapshot = hasSnapshot();
+  const pillType = pillTypeForEvent(eventType, eventDetails);
 
   return (
     <div className="border-b border-border">
@@ -185,8 +164,8 @@ export default function SessionTimelineEventCell({
         className="w-full text-left px-3 py-4 font-display outline-none transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:ring-ring/50 focus-visible:ring-[2px] focus-visible:ring-inset"
       >
         <div className="flex flex-row items-center gap-3">
-          <Pill className={`${getPillColorClasses()} shrink-0 w-28`}>
-            {getPillLabel()}
+          <Pill type={pillType} className="shrink-0 w-28">
+            {pillType === PillType.SessionEventDefault ? eventType : null}
           </Pill>
           {title && (
             <p className="text-sm line-clamp-2 grow min-w-0 break-words">


### PR DESCRIPTION
# Description

Consolidates pill styling to be in pill.tsx instead of being split between pill and session timeline event cells.

## Related issue
Closes #3765



