### PR TITLE
chore(backend): build and use new api for app health plot

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -96,6 +96,7 @@ func main() {
 	{
 		apps.GET(":id/journey", measure.GetAppJourney)
 		apps.GET(":id/metrics", measure.GetAppMetrics)
+		apps.GET(":id/health/plots/instances", measure.GetHealthOverviewPlotInstances)
 		apps.GET(":id/filters", measure.GetAppFilters)
 
 		// crashes

--- a/backend/api/measure/app_health.go
+++ b/backend/api/measure/app_health.go
@@ -1,0 +1,311 @@
+package measure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"backend/api/config"
+	"backend/api/event"
+	"backend/api/filter"
+	"backend/api/server"
+	"backend/libs/logcomment"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/leporo/sqlf"
+	"golang.org/x/sync/errgroup"
+)
+
+// healthInstance is a single time-bucketed data point for one
+// series (sessions, crashes or ANRs) of the health overview plot.
+type healthInstance struct {
+	DateTime  string
+	Instances uint64
+}
+
+// GetHealthPlotInstances computes the sessions, crashes and ANRs time
+// series for the health overview plot, bucketed by the filter's plot
+// time group.
+func (a App) GetHealthPlotInstances(ctx context.Context, af *filter.AppFilter) (sessions, crashes, anrs []healthInstance, err error) {
+	if af.Timezone == "" {
+		return nil, nil, nil, errors.New("missing timezone filter")
+	}
+
+	if !af.HasPlotTimeGroup() {
+		af.SetDefaultPlotTimeGroup()
+	}
+
+	groupExpr, err := getPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var healthGroup errgroup.Group
+
+	// session counts
+	healthGroup.Go(func() (err error) {
+		lc := logcomment.New(2)
+		settings := clickhouse.Settings{
+			"log_comment": lc.MustPut(logcomment.Root, logcomment.Health).String(),
+		}
+		sctx := logcomment.WithSettingsPut(ctx, settings, lc, logcomment.Name, "plots_instances")
+
+		stmt := sqlf.From(config.AppMetricsTable).
+			Select(groupExpr.BucketExpr+" as datetime_bucket", af.Timezone).
+			Select("formatDateTime(datetime_bucket, ?) as datetime", groupExpr.DatetimeFormat).
+			Select("uniqMerge(unique_sessions) as instances").
+			Where("team_id = toUUID(?)", a.TeamId).
+			Where("app_id = toUUID(?)", a.ID).
+			Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
+		defer stmt.Close()
+
+		if af.HasVersions() {
+			selectedVersions, errV := af.VersionPairs()
+			if errV != nil {
+				return errV
+			}
+			stmt.Where("app_version in (?)", selectedVersions.Parameterize())
+		}
+
+		stmt.GroupBy("datetime_bucket").OrderBy("datetime_bucket")
+
+		rows, err := server.Server.RchPool.Query(sctx, stmt.String(), stmt.Args()...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var instance healthInstance
+			var datetimeBucket time.Time
+			if err := rows.Scan(&datetimeBucket, &instance.DateTime, &instance.Instances); err != nil {
+				return err
+			}
+			if instance.Instances > 0 {
+				sessions = append(sessions, instance)
+			}
+		}
+
+		return rows.Err()
+	})
+
+	// crashes (fatal exceptions) & ANRs
+	healthGroup.Go(func() (err error) {
+		lc := logcomment.New(2)
+		settings := clickhouse.Settings{
+			"log_comment": lc.MustPut(logcomment.Root, logcomment.Health).String(),
+		}
+		ectx := logcomment.WithSettingsPut(ctx, settings, lc, logcomment.Name, "plots_instances")
+		const fatalExpr = "(`exception.severity` = 'fatal' OR (`exception.severity` = '' AND `exception.handled` = false))"
+
+		stmt := sqlf.From("events final").
+			Select(groupExpr.BucketExpr+" as datetime_bucket", af.Timezone).
+			Select("formatDateTime(datetime_bucket, ?) as datetime", groupExpr.DatetimeFormat).
+			Select("countIf(type = ? and "+fatalExpr+") as crashes", event.TypeException).
+			Select("countIf(type = ?) as anrs", event.TypeANR).
+			Where("team_id = toUUID(?)", a.TeamId).
+			Where("app_id = toUUID(?)", a.ID).
+			Where("timestamp >= ? and timestamp <= ?", af.From, af.To).
+			Where("type in (?, ?)", event.TypeException, event.TypeANR)
+		defer stmt.Close()
+
+		if af.HasVersions() {
+			stmt.Where("attribute.app_version").In(af.Versions)
+			stmt.Where("attribute.app_build").In(af.VersionCodes)
+		}
+
+		stmt.GroupBy("datetime_bucket").OrderBy("datetime_bucket")
+
+		rows, err := server.Server.RchPool.Query(ectx, stmt.String(), stmt.Args()...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var datetimeBucket time.Time
+			var datetime string
+			var crashCount, anrCount uint64
+			if err := rows.Scan(&datetimeBucket, &datetime, &crashCount, &anrCount); err != nil {
+				return err
+			}
+			if crashCount > 0 {
+				crashes = append(crashes, healthInstance{DateTime: datetime, Instances: crashCount})
+			}
+			if anrCount > 0 {
+				anrs = append(anrs, healthInstance{DateTime: datetime, Instances: anrCount})
+			}
+		}
+
+		return rows.Err()
+	})
+
+	if err = healthGroup.Wait(); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return
+}
+
+func GetHealthOverviewPlotInstances(c *gin.Context) {
+	ctx := c.Request.Context()
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	af := filter.AppFilter{
+		AppID: id,
+		Limit: filter.DefaultPaginationLimit,
+	}
+
+	if err := c.ShouldBindQuery(&af); err != nil {
+		msg := `failed to parse query parameters`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if err := af.Expand(ctx); err != nil {
+		msg := `failed to expand filters`
+		fmt.Println(msg, err)
+		status := http.StatusInternalServerError
+		if errors.Is(err, pgx.ErrNoRows) {
+			status = http.StatusNotFound
+		}
+		c.JSON(status, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	msg := `health overview request validation failed`
+
+	if err := af.Validate(); err != nil {
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if !af.HasTimezone() {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "missing required field `timezone`",
+		})
+		return
+	}
+
+	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
+		if err := af.ValidateVersions(); err != nil {
+			fmt.Println(msg, err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   msg,
+				"details": err.Error(),
+			})
+			return
+		}
+	}
+
+	if !af.HasTimeRange() {
+		af.SetDefaultTimeRange()
+	}
+
+	app := App{
+		ID: &id,
+	}
+	team, err := app.getTeam(ctx)
+	if err != nil {
+		msg := "failed to get team from app id"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+	if team == nil {
+		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	userId := c.GetString("userId")
+	okTeam, err := PerformAuthz(userId, team.ID.String(), *ScopeTeamRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if !okTeam || !okApp {
+		msg := `you are not authorized to access this app`
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	app.TeamId = *team.ID
+
+	sessions, crashes, anrs, err := app.GetHealthPlotInstances(ctx, &af)
+	if err != nil {
+		msg := `failed to query data for health overview plot`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	type series struct {
+		ID   string  `json:"id"`
+		Data []gin.H `json:"data"`
+	}
+
+	build := func(id string, points []healthInstance) series {
+		s := series{ID: id, Data: []gin.H{}}
+		for i := range points {
+			s.Data = append(s.Data, gin.H{
+				"datetime":  points[i].DateTime,
+				"instances": points[i].Instances,
+			})
+		}
+		return s
+	}
+
+	c.JSON(http.StatusOK, []series{
+		build("sessions", sessions),
+		build("crashes", crashes),
+		build("anrs", anrs),
+	})
+}

--- a/backend/api/measure/app_health_data_test.go
+++ b/backend/api/measure/app_health_data_test.go
@@ -1,0 +1,210 @@
+//go:build integration
+
+package measure
+
+import (
+	"testing"
+	"time"
+
+	"backend/api/filter"
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+// Only data within [from, to] is counted; earlier and later data is excluded
+// from all three series.
+func TestGetHealthPlotInstancesTimeRange(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	before := ts.AddDate(0, 0, -30)
+	after := ts.AddDate(0, 0, 30)
+
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 5, 1, 1)     // in range
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), before, 9, 9, 9) // before from
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), after, 9, 9, 9)  // after to
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+	if got := sumHealthInstances(sessions); got != 7 {
+		t.Errorf("sessions = %d, want 7 (out-of-range excluded)", got)
+	}
+	if got := sumHealthInstances(crashes); got != 1 {
+		t.Errorf("crashes = %d, want 1 (out-of-range excluded)", got)
+	}
+	if got := sumHealthInstances(anrs); got != 1 {
+		t.Errorf("anrs = %d, want 1 (out-of-range excluded)", got)
+	}
+}
+
+// Data is scoped to the requesting team AND app: another app in the same team,
+// and the same app id under a different team, are both excluded.
+func TestGetHealthPlotInstancesAppTeamIsolation(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 5, 1, 1) // this app
+
+	// same team, different app → excluded by app_id filter.
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), uuid.NewString(), ts, 9, 9, 9)
+	// different team, same app id → excluded by team_id filter.
+	seedAppMetrics(f.ctx, t, uuid.NewString(), f.appIDStr(), ts, 9, 9, 9)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+	if got := sumHealthInstances(sessions); got != 7 {
+		t.Errorf("sessions = %d, want 7 (other app/team excluded)", got)
+	}
+	if got := sumHealthInstances(crashes); got != 1 {
+		t.Errorf("crashes = %d, want 1 (other app/team excluded)", got)
+	}
+	if got := sumHealthInstances(anrs); got != 1 {
+		t.Errorf("anrs = %d, want 1 (other app/team excluded)", got)
+	}
+}
+
+// Each series is independent: a metric with no data comes back empty while the
+// others are populated.
+func TestGetHealthPlotInstancesPartialSeries(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+	base := func() *filter.AppFilter {
+		return f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	}
+
+	t.Run("only sessions, no errors", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedGenericEvents(f.ctx, t, team, app, 5, ts)
+
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, base())
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 5 {
+			t.Errorf("sessions = %d, want 5", got)
+		}
+		if len(crashes) != 0 || len(anrs) != 0 {
+			t.Errorf("expected no crashes/anrs, got crashes=%v anrs=%v", crashes, anrs)
+		}
+	})
+
+	t.Run("crashes without ANRs", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedGenericEvents(f.ctx, t, team, app, 3, ts)
+		seedIssueEvent(f.ctx, t, team, app, "exception", "", false, ts) // fatal crash
+
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, base())
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 4 {
+			t.Errorf("sessions = %d, want 4", got)
+		}
+		if got := sumHealthInstances(crashes); got != 1 {
+			t.Errorf("crashes = %d, want 1", got)
+		}
+		if len(anrs) != 0 {
+			t.Errorf("expected no anrs, got %v", anrs)
+		}
+	})
+
+	t.Run("ANRs without crashes", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedGenericEvents(f.ctx, t, team, app, 3, ts)
+		seedIssueEvent(f.ctx, t, team, app, "anr", "", false, ts)
+
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, base())
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 4 {
+			t.Errorf("sessions = %d, want 4", got)
+		}
+		if got := sumHealthInstances(anrs); got != 1 {
+			t.Errorf("anrs = %d, want 1", got)
+		}
+		if len(crashes) != 0 {
+			t.Errorf("expected no crashes, got %v", crashes)
+		}
+	})
+
+	t.Run("only non-fatal exceptions yields no crashes", func(t *testing.T) {
+		cleanupAll(f.ctx, t)
+		seedIssueEventWithSeverity(f.ctx, t, team, app, "", "handled", ts)
+		seedIssueEventWithSeverity(f.ctx, t, team, app, "", "unhandled", ts)
+
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, base())
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		// the two exceptions are still sessions, but neither is a crash.
+		if got := sumHealthInstances(sessions); got != 2 {
+			t.Errorf("sessions = %d, want 2", got)
+		}
+		if len(crashes) != 0 {
+			t.Errorf("expected no crashes from non-fatal exceptions, got %v", crashes)
+		}
+		if len(anrs) != 0 {
+			t.Errorf("expected no anrs, got %v", anrs)
+		}
+	})
+}
+
+// Data from multiple app versions in the same bucket is summed when unfiltered,
+// and narrowed to the selected version when a version filter is applied — across
+// all three series.
+func TestGetHealthPlotInstancesMultipleVersions(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	// v1: 5 generic sessions + 1 crash. v2: 3 generic sessions + 1 crash + 1 anr.
+	seedEventRows(f.ctx, t, team, app, 5, testinfra.EventRow{AppVersion: "v1", AppBuild: "1", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 1, testinfra.EventRow{Type: "exception", AppVersion: "v1", AppBuild: "1", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 3, testinfra.EventRow{AppVersion: "v2", AppBuild: "2", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 1, testinfra.EventRow{Type: "exception", AppVersion: "v2", AppBuild: "2", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 1, testinfra.EventRow{Type: "anr", AppVersion: "v2", AppBuild: "2", Timestamp: ts})
+
+	t.Run("no version filter sums across versions", func(t *testing.T) {
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 11 { // 6 (v1) + 5 (v2)
+			t.Errorf("sessions = %d, want 11", got)
+		}
+		if got := sumHealthInstances(crashes); got != 2 {
+			t.Errorf("crashes = %d, want 2", got)
+		}
+		if got := sumHealthInstances(anrs); got != 1 {
+			t.Errorf("anrs = %d, want 1", got)
+		}
+	})
+
+	t.Run("version filter selects a single version", func(t *testing.T) {
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.Versions = []string{"v2"}
+		af.VersionCodes = []string{"2"}
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 5 { // 3 generic + 1 crash + 1 anr
+			t.Errorf("sessions = %d, want 5", got)
+		}
+		if got := sumHealthInstances(crashes); got != 1 {
+			t.Errorf("crashes = %d, want 1", got)
+		}
+		if got := sumHealthInstances(anrs); got != 1 {
+			t.Errorf("anrs = %d, want 1", got)
+		}
+	})
+}

--- a/backend/api/measure/app_health_handler_test.go
+++ b/backend/api/measure/app_health_handler_test.go
@@ -1,0 +1,224 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// healthSeriesResp mirrors one element of the handler's JSON response array.
+type healthSeriesResp struct {
+	ID   string `json:"id"`
+	Data []struct {
+		Datetime  string `json:"datetime"`
+		Instances uint64 `json:"instances"`
+	} `json:"data"`
+}
+
+func decodeHealthSeries(t *testing.T, w *httptest.ResponseRecorder) []healthSeriesResp {
+	t.Helper()
+	var got []healthSeriesResp
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v; body=%s", err, w.Body.String())
+	}
+	return got
+}
+
+func sumSeries(series []healthSeriesResp, id string) uint64 {
+	for _, s := range series {
+		if s.ID != id {
+			continue
+		}
+		var total uint64
+		for _, d := range s.Data {
+			total += d.Instances
+		}
+		return total
+	}
+	return 0
+}
+
+func TestGetHealthOverviewPlotInstancesHandler(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid app id returns 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		c, w := newTestGinContext("GET", "/apps/not-a-uuid/health/plots/instances?timezone=UTC", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "id invalid or missing")
+	})
+
+	t.Run("missing timezone returns 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		appID := uuid.New()
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "timezone")
+	})
+
+	t.Run("versions without version_codes returns 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		appID := uuid.New()
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC&versions=v1", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "details", "version_codes")
+	})
+
+	t.Run("app with no team returns 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		appID := uuid.New() // never seeded, so it has no team
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC", nil)
+		c.Set("userId", uuid.New().String())
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "no team exists for app")
+	})
+
+	t.Run("user without membership returns 500", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedUser(ctx, t, userID, "health-no-membership@test.com")
+		seedTeam(ctx, t, teamID, "health-team")
+		seedApp(ctx, t, appID, teamID, 30)
+
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "authoriz")
+	})
+
+	t.Run("missing userId returns 500", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, "health-team")
+		seedApp(ctx, t, appID, teamID, 30)
+
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC", nil)
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}} // no userId set
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "authoriz")
+	})
+
+	// This is a read endpoint guarded by ScopeTeamRead + ScopeAppRead, which
+	// every role holds — so all roles get 200 (there is no forbidden role).
+	t.Run("all team roles can read", func(t *testing.T) {
+		for _, role := range []string{"owner", "admin", "developer", "viewer"} {
+			role := role
+			t.Run(role, func(t *testing.T) {
+				defer cleanupAll(ctx, t)
+
+				userID, teamID := seedTeamAndMemberWithRole(t, ctx, role)
+				appID := uuid.New()
+				seedApp(ctx, t, appID, teamID, 30)
+
+				c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC", nil)
+				c.Set("userId", userID)
+				c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+				GetHealthOverviewPlotInstances(c)
+
+				if w.Code != http.StatusOK {
+					t.Fatalf("%s: status = %d, want 200, body: %s", role, w.Code, w.Body.String())
+				}
+
+				// Always three series, in order, even with no data.
+				series := decodeHealthSeries(t, w)
+				wantIDs := []string{"sessions", "crashes", "anrs"}
+				if len(series) != len(wantIDs) {
+					t.Fatalf("%s: got %d series, want 3: %s", role, len(series), w.Body.String())
+				}
+				for i, want := range wantIDs {
+					if series[i].ID != want {
+						t.Errorf("%s: series[%d].id = %q, want %q", role, i, series[i].ID, want)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("returns sessions, crashes and ANRs counts", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+
+		// within the default last-7-days window
+		ts := time.Now().UTC().Add(-1 * time.Hour)
+		seedAppMetrics(ctx, t, teamID.String(), appID.String(), ts, 10, 2, 1)
+
+		c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/health/plots/instances?timezone=UTC", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+		GetHealthOverviewPlotInstances(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		series := decodeHealthSeries(t, w)
+		if got := sumSeries(series, "sessions"); got != 13 {
+			t.Errorf("sessions = %d, want 13", got)
+		}
+		if got := sumSeries(series, "crashes"); got != 2 {
+			t.Errorf("crashes = %d, want 2", got)
+		}
+		if got := sumSeries(series, "anrs"); got != 1 {
+			t.Errorf("anrs = %d, want 1", got)
+		}
+	})
+}

--- a/backend/api/measure/app_health_test.go
+++ b/backend/api/measure/app_health_test.go
@@ -1,0 +1,237 @@
+//go:build integration
+
+package measure
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"backend/api/filter"
+)
+
+// sumHealthInstances returns the total instances across all buckets of a series.
+func sumHealthInstances(items []healthInstance) uint64 {
+	var total uint64
+	for _, it := range items {
+		total += it.Instances
+	}
+	return total
+}
+
+// healthByDate maps each bucket's datetime label to its instance count.
+func healthByDate(items []healthInstance) map[string]uint64 {
+	m := make(map[string]uint64, len(items))
+	for _, it := range items {
+		m[it.DateTime] = it.Instances
+	}
+	return m
+}
+
+// dateOf returns the first bucket's datetime label, or "" when empty. Used
+// alongside requireSingleDateBucket, which asserts the single-bucket invariant.
+func dateOf(items []healthInstance) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return items[0].DateTime
+}
+
+// With no data seeded, every series comes back empty.
+func TestGetHealthPlotInstancesEmpty(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+	if len(sessions) != 0 || len(crashes) != 0 || len(anrs) != 0 {
+		t.Fatalf("expected all series empty, got sessions=%v crashes=%v anrs=%v", sessions, crashes, anrs)
+	}
+}
+
+// Sessions are counted like the adoption metric (uniqMerge over app_metrics),
+// crashes are fatal exceptions and ANRs are anr events — all in one bucket.
+func TestGetHealthPlotInstancesCounts(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	// 10 plain sessions, 2 crash sessions (unhandled exceptions), 1 ANR session.
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 10, 2, 1)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+
+	requireSingleDateBucket(t, sessions, dateOf(sessions), "2026-01-05", "sessions")
+	if got := sumHealthInstances(sessions); got != 13 {
+		t.Errorf("sessions = %d, want 13 (10 generic + 2 crash + 1 anr)", got)
+	}
+	requireSingleDateBucket(t, crashes, dateOf(crashes), "2026-01-05", "crashes")
+	if got := sumHealthInstances(crashes); got != 2 {
+		t.Errorf("crashes = %d, want 2", got)
+	}
+	requireSingleDateBucket(t, anrs, dateOf(anrs), "2026-01-05", "anrs")
+	if got := sumHealthInstances(anrs); got != 1 {
+		t.Errorf("anrs = %d, want 1", got)
+	}
+}
+
+// Crashes count fatal exceptions only, bridging the new exception.severity field
+// and legacy data (empty severity falls back to exception.handled = false).
+// Non-fatal exceptions (unhandled/handled severity, or legacy handled) are excluded.
+func TestGetHealthPlotInstancesCrashSeverity(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	// New-SDK severity-tagged exceptions.
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "fatal", ts)     // crash
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "unhandled", ts) // not a crash
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "handled", ts)   // not a crash
+	// Legacy exceptions without severity: the handled flag decides fatality.
+	seedIssueEvent(f.ctx, t, team, app, "exception", "", false, ts) // crash (legacy fatal)
+	seedIssueEvent(f.ctx, t, team, app, "exception", "", true, ts)  // not a crash (handled)
+	// One ANR.
+	seedIssueEvent(f.ctx, t, team, app, "anr", "", false, ts)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+
+	if got := sumHealthInstances(crashes); got != 2 {
+		t.Errorf("crashes = %d, want 2 (severity=fatal + legacy handled=false)", got)
+	}
+	if got := sumHealthInstances(anrs); got != 1 {
+		t.Errorf("anrs = %d, want 1", got)
+	}
+	// Each seeded event uses a unique session, so app_metrics sees 6 sessions.
+	if got := sumHealthInstances(sessions); got != 6 {
+		t.Errorf("sessions = %d, want 6", got)
+	}
+}
+
+// Version filtering applies to all three series: the seeded version returns
+// counts; an unknown version returns nothing.
+func TestGetHealthPlotInstancesVersionFilter(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	// Seed helpers tag every event with app_version "v1" / build "1".
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 5, 1, 1)
+
+	t.Run("matching version returns counts", func(t *testing.T) {
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.Versions = []string{"v1"}
+		af.VersionCodes = []string{"1"}
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if got := sumHealthInstances(sessions); got != 7 {
+			t.Errorf("sessions = %d, want 7", got)
+		}
+		if got := sumHealthInstances(crashes); got != 1 {
+			t.Errorf("crashes = %d, want 1", got)
+		}
+		if got := sumHealthInstances(anrs); got != 1 {
+			t.Errorf("anrs = %d, want 1", got)
+		}
+	})
+
+	t.Run("non-matching version returns nothing", func(t *testing.T) {
+		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+		af.Versions = []string{"v2"}
+		af.VersionCodes = []string{"2"}
+		sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+		if err != nil {
+			t.Fatalf("GetHealthPlotInstances: %v", err)
+		}
+		if len(sessions) != 0 || len(crashes) != 0 || len(anrs) != 0 {
+			t.Fatalf("expected empty series for unknown version, got sessions=%v crashes=%v anrs=%v", sessions, crashes, anrs)
+		}
+	})
+}
+
+// Data spanning multiple days is split into per-day buckets, and crash/ANR
+// series stay sparse (a bucket with no crashes/ANRs is absent).
+func TestGetHealthPlotInstancesTimeBuckets(t *testing.T) {
+	f := newPlotFixture(t)
+	day1 := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC)
+
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), day1, 3, 2, 0) // day1: 5 sessions, 2 crashes
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), day2, 2, 0, 3) // day2: 5 sessions, 3 anrs
+
+	af := f.appFilter(day1.Add(-time.Hour), day2.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	sessions, crashes, anrs, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+
+	if s := healthByDate(sessions); len(s) != 2 || s["2026-01-05"] != 5 || s["2026-01-06"] != 5 {
+		t.Errorf("sessions by date = %v, want {2026-01-05:5, 2026-01-06:5}", s)
+	}
+	if c := healthByDate(crashes); len(c) != 1 || c["2026-01-05"] != 2 {
+		t.Errorf("crashes by date = %v, want {2026-01-05:2}", c)
+	}
+	if a := healthByDate(anrs); len(a) != 1 || a["2026-01-06"] != 3 {
+		t.Errorf("anrs by date = %v, want {2026-01-06:3}", a)
+	}
+}
+
+// A missing timezone is rejected before any query runs.
+func TestGetHealthPlotInstancesMissingTimezone(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", filter.PlotTimeGroupDays)
+
+	_, _, _, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err == nil || !strings.Contains(err.Error(), "timezone") {
+		t.Fatalf("expected timezone error, got %v", err)
+	}
+}
+
+// When plot_time_group is unset it defaults to daily buckets.
+func TestGetHealthPlotInstancesDefaultsPlotTimeGroup(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 4, 1, 0)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "") // no plot_time_group
+	sessions, crashes, _, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+	requireSingleDateBucket(t, sessions, dateOf(sessions), "2026-01-05", "sessions")
+	if got := sumHealthInstances(sessions); got != 5 {
+		t.Errorf("sessions = %d, want 5", got)
+	}
+	if got := sumHealthInstances(crashes); got != 1 {
+		t.Errorf("crashes = %d, want 1", got)
+	}
+}
+
+// Buckets are computed in the request timezone for both the sessions and the
+// crash/ANR queries, so they agree. 23:30 UTC on Jan 5 is Jan 6 in Asia/Kolkata.
+func TestGetHealthPlotInstancesTimezoneBucketing(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 23, 30, 0, 0, time.UTC)
+	seedAppMetrics(f.ctx, t, f.teamIDStr(), f.appIDStr(), ts, 1, 1, 0)
+
+	af := f.appFilter(
+		time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 6, 23, 59, 0, 0, time.UTC),
+		"Asia/Kolkata", filter.PlotTimeGroupDays)
+	sessions, crashes, _, err := f.app.GetHealthPlotInstances(f.ctx, af)
+	if err != nil {
+		t.Fatalf("GetHealthPlotInstances: %v", err)
+	}
+	requireSingleDateBucket(t, sessions, dateOf(sessions), "2026-01-06", "sessions")
+	requireSingleDateBucket(t, crashes, dateOf(crashes), "2026-01-06", "crashes")
+}

--- a/backend/api/measure/test_helpers_test.go
+++ b/backend/api/measure/test_helpers_test.go
@@ -117,6 +117,14 @@ func seedGenericEvents(ctx context.Context, t *testing.T, teamID, appID string, 
 	th.SeedGenericEvents(ctx, t, teamID, appID, count, ts)
 }
 
+func seedAppMetrics(ctx context.Context, t *testing.T, teamID, appID string, ts time.Time, genericCount, crashCount, anrCount int) {
+	th.SeedAppMetrics(ctx, t, teamID, appID, ts, genericCount, crashCount, anrCount)
+}
+
+func seedEventRows(ctx context.Context, t *testing.T, teamID, appID string, count int, row testinfra.EventRow) {
+	th.SeedEventRows(ctx, t, teamID, appID, count, row)
+}
+
 func seedIssueEvent(
 	ctx context.Context,
 	t *testing.T,

--- a/backend/libs/logcomment/keys.go
+++ b/backend/libs/logcomment/keys.go
@@ -32,6 +32,10 @@ const Filters = "filters"
 // logcomment.
 const Metrics = "metrics"
 
+// Health is the root key for `health`
+// logcomment.
+const Health = "health"
+
 // Journeys is the root key for the `journeys`
 // logcomment.
 const Journeys = "journeys"

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -193,36 +193,131 @@ func (h *TestHelper) SeedIngestionUsage(ctx context.Context, t *testing.T, teamI
 	}
 }
 
-func (h *TestHelper) SeedEvents(ctx context.Context, t *testing.T, teamID, appID string, count int) {
+// EventRow describes one or more rows to insert into the events table. It is
+// the single source of truth for seeding events: every higher-level helper
+// (generic, issue, severity, app-metrics, …) builds an EventRow and delegates
+// to SeedEventRows, so any attribute — app version, severity, handled state,
+// session — can be varied without adding new helpers.
+//
+// Zero-value fields fall back to defaults applied by (EventRow).filled:
+//   - Type:       "test"
+//   - AppVersion: "v1", AppBuild: "1"
+//   - Timestamp:  time.Now().UTC()
+//   - SessionID:  a fresh UUID per inserted row
+type EventRow struct {
+	Type       string
+	SessionID  string
+	Timestamp  time.Time
+	AppVersion string
+	AppBuild   string
+
+	// Exception/ANR payload, written only for issue events (Type "exception"
+	// or "anr"). Severity, ExceptionsJSON and IsCustom are written only when
+	// set, leaving ClickHouse column defaults otherwise.
+	Handled        bool
+	Fingerprint    string
+	Severity       string
+	ExceptionsJSON string
+	IsCustom       bool
+}
+
+func (r EventRow) filled() EventRow {
+	if r.Type == "" {
+		r.Type = "test"
+	}
+	if r.AppVersion == "" {
+		r.AppVersion = "v1"
+	}
+	if r.AppBuild == "" {
+		r.AppBuild = "1"
+	}
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now().UTC()
+	}
+	return r
+}
+
+// SeedEventRows inserts count rows described by row into the events table using
+// a single bulk INSERT … SELECT FROM numbers(count). Each row gets a fresh id
+// and installation id; the session id is fresh per row unless row.SessionID
+// pins it, so a batch of generic events represents distinct sessions. Issue
+// payload columns are emitted only for exception/anr events.
+func (h *TestHelper) SeedEventRows(ctx context.Context, t *testing.T, teamID, appID string, count int, row EventRow) {
 	t.Helper()
-	for i := 0; i < count; i++ {
-		query := fmt.Sprintf(
-			`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-				"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-				"`attribute.app_unique_id`, `attribute.platform`, `attribute.measure_sdk_version`) "+
-				`VALUES ('%s', 'test', '%s', '%s', '%s', now(), false, '%s', 'v1', '1', 'com.test', 'android', '0.1')`,
-			uuid.New().String(), uuid.New().String(), appID, teamID, uuid.New().String())
-		if err := h.ChConn.Exec(ctx, query); err != nil {
-			t.Fatalf("seed events: %v", err)
+	if count <= 0 {
+		return
+	}
+	row = row.filled()
+	ts := row.Timestamp.UTC().Format("2006-01-02 15:04:05")
+	isIssue := row.Type == "exception" || row.Type == "anr"
+
+	quote := func(s string) string { return "'" + s + "'" }
+	boolLit := func(b bool) string {
+		if b {
+			return "true"
 		}
+		return "false"
+	}
+
+	// generateUUIDv4() is evaluated per row by ClickHouse, so id, installation
+	// id and (unpinned) session id are unique across the batch.
+	sessionExpr := "generateUUIDv4()"
+	if row.SessionID != "" {
+		sessionExpr = quote(row.SessionID)
+	}
+
+	cols := []string{
+		"id", "type", "session_id", "app_id", "team_id", "timestamp", "user_triggered",
+		"`attribute.installation_id`", "`attribute.app_version`", "`attribute.app_build`",
+		"`attribute.app_unique_id`", "`attribute.platform`", "`attribute.measure_sdk_version`",
+	}
+	vals := []string{
+		"generateUUIDv4()", quote(row.Type), sessionExpr, quote(appID), quote(teamID),
+		quote(ts), "false", "generateUUIDv4()",
+		quote(row.AppVersion), quote(row.AppBuild), "'com.test'", "'android'", "'0.1'",
+	}
+
+	if isIssue {
+		cols = append(cols,
+			"`exception.handled`", "`exception.foreground`", "`exception.fingerprint`",
+			"`anr.handled`", "`anr.foreground`", "`anr.fingerprint`")
+		vals = append(vals,
+			boolLit(row.Handled), "true", quote(row.Fingerprint),
+			boolLit(row.Handled), "true", quote(row.Fingerprint))
+
+		if row.ExceptionsJSON != "" {
+			cols = append(cols, "`exception.exceptions`", "`anr.exceptions`")
+			vals = append(vals, quote(row.ExceptionsJSON), quote(row.ExceptionsJSON))
+		}
+		if row.Severity != "" {
+			cols = append(cols, "`exception.severity`")
+			vals = append(vals, quote(row.Severity))
+		}
+		if row.IsCustom {
+			cols = append(cols, "`exception.is_custom`")
+			vals = append(vals, "true")
+		}
+	}
+
+	query := fmt.Sprintf("INSERT INTO measure.events (%s) SELECT %s FROM numbers(%d)",
+		strings.Join(cols, ", "), strings.Join(vals, ", "), count)
+	if err := h.ChConn.Exec(ctx, query); err != nil {
+		t.Fatalf("seed event (%s): %v", row.Type, err)
 	}
 }
 
+// SeedEvents inserts count generic ("test") events at the current time.
+func (h *TestHelper) SeedEvents(ctx context.Context, t *testing.T, teamID, appID string, count int) {
+	t.Helper()
+	h.SeedEventRows(ctx, t, teamID, appID, count, EventRow{})
+}
+
 // SeedGenericEvents inserts count generic ("test" type) events at the given
-// timestamp using a single bulk INSERT…SELECT FROM numbers(count). Each row
-// gets a server-generated UUID for its id, session_id, and installation_id,
-// so every event represents a distinct session.
+// timestamp. Each row gets a fresh id, session id and installation id, so
+// every event represents a distinct session.
 func (h *TestHelper) SeedGenericEvents(ctx context.Context, t *testing.T, teamID, appID string, count int, ts time.Time) {
 	t.Helper()
-	query := fmt.Sprintf(
-		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-			"`attribute.app_unique_id`, `attribute.platform`, `attribute.measure_sdk_version`) "+
-			`SELECT generateUUIDv4(), 'test', generateUUIDv4(), '%s', '%s', '%s', false, generateUUIDv4(), 'v1', '1', 'com.test', 'android', '0.1' FROM numbers(%d)`,
-		appID, teamID, ts.UTC().Format("2006-01-02 15:04:05"), count)
-	if err := h.ChConn.Exec(ctx, query); err != nil {
-		t.Fatalf("seed generic events: %v", err)
-	}
+	h.SeedEventRows(ctx, t, teamID, appID, count, EventRow{Timestamp: ts})
 }
 
 // SeedIssueEvent inserts a single exception or ANR event with explicit handled
@@ -273,19 +368,14 @@ func (h *TestHelper) SeedIssueEventWithDataInSession(
 	ts time.Time,
 ) {
 	t.Helper()
-	query := fmt.Sprintf(
-		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-			"`attribute.app_unique_id`, `attribute.platform`, `attribute.measure_sdk_version`, "+
-			"`exception.handled`, `exception.foreground`, `exception.fingerprint`, `exception.exceptions`, "+
-			"`anr.handled`, `anr.foreground`, `anr.fingerprint`, `anr.exceptions`) "+
-			`VALUES ('%s', '%s', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', 'android', '0.1', %t, true, '%s', '%s', %t, true, '%s', '%s')`,
-		uuid.New().String(), eventType, sessionID, appID, teamID,
-		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String(),
-		handled, fingerprint, exceptionsJSON, handled, fingerprint, exceptionsJSON)
-	if err := h.ChConn.Exec(ctx, query); err != nil {
-		t.Fatalf("seed issue event with data (%s): %v", eventType, err)
-	}
+	h.SeedEventRows(ctx, t, teamID, appID, 1, EventRow{
+		Type:           eventType,
+		SessionID:      sessionID,
+		Fingerprint:    fingerprint,
+		Handled:        handled,
+		ExceptionsJSON: exceptionsJSON,
+		Timestamp:      ts,
+	})
 }
 
 // SeedIssueEventWithSeverity inserts an exception event with an explicit
@@ -299,19 +389,13 @@ func (h *TestHelper) SeedIssueEventWithSeverity(
 	ts time.Time,
 ) {
 	t.Helper()
-	handled := severity == "handled"
-	query := fmt.Sprintf(
-		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-			"`attribute.app_unique_id`, `attribute.os_name`, `attribute.measure_sdk_version`, "+
-			"`exception.handled`, `exception.foreground`, `exception.fingerprint`, `exception.severity`) "+
-			`VALUES ('%s', 'exception', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', 'android', '0.1', %t, true, '%s', '%s')`,
-		uuid.New().String(), uuid.New().String(), appID, teamID,
-		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String(),
-		handled, fingerprint, severity)
-	if err := h.ChConn.Exec(ctx, query); err != nil {
-		t.Fatalf("seed issue event with severity (%s): %v", severity, err)
-	}
+	h.SeedEventRows(ctx, t, teamID, appID, 1, EventRow{
+		Type:        "exception",
+		Fingerprint: fingerprint,
+		Severity:    severity,
+		Handled:     severity == "handled",
+		Timestamp:   ts,
+	})
 }
 
 // SeedNavigationEventInSession inserts a navigation event with a known
@@ -335,16 +419,7 @@ func (h *TestHelper) SeedNavigationEventInSession(ctx context.Context, t *testin
 // sessions_index gets populated via the materialized view.
 func (h *TestHelper) SeedEventWithSession(ctx context.Context, t *testing.T, teamID, appID, sessionID string, ts time.Time) {
 	t.Helper()
-	query := fmt.Sprintf(
-		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-			"`attribute.app_unique_id`, `attribute.platform`, `attribute.measure_sdk_version`) "+
-			`VALUES ('%s', 'test', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', 'android', '0.1')`,
-		uuid.New().String(), sessionID, appID, teamID,
-		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String())
-	if err := h.ChConn.Exec(ctx, query); err != nil {
-		t.Fatalf("seed event with session: %v", err)
-	}
+	h.SeedEventRows(ctx, t, teamID, appID, 1, EventRow{SessionID: sessionID, Timestamp: ts})
 }
 
 // SeedExceptionGroup inserts a row into fatal_exception_groups so that
@@ -473,18 +548,13 @@ func (h *TestHelper) SeedIssueEventWithCustomFlag(
 	ts time.Time,
 ) {
 	t.Helper()
-	query := fmt.Sprintf(
-		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
-			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
-			"`attribute.app_unique_id`, `attribute.platform`, `attribute.measure_sdk_version`, "+
-			"`exception.handled`, `exception.foreground`, `exception.fingerprint`, `exception.is_custom`) "+
-			`VALUES ('%s', 'exception', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', 'android', '0.1', %t, true, '%s', %t)`,
-		uuid.New().String(), uuid.New().String(), appID, teamID,
-		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String(),
-		handled, fingerprint, isCustom)
-	if err := h.ChConn.Exec(ctx, query); err != nil {
-		t.Fatalf("seed issue event with custom flag: %v", err)
-	}
+	h.SeedEventRows(ctx, t, teamID, appID, 1, EventRow{
+		Type:        "exception",
+		Fingerprint: fingerprint,
+		Handled:     handled,
+		IsCustom:    isCustom,
+		Timestamp:   ts,
+	})
 }
 
 // SeedAnrGroup inserts a row into anr_groups so that ANR-alert group-info

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -54,359 +54,364 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-4)
     - [Response Body](#response-body-7)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-7)
-  - [GET `/apps/:id/filters`](#get-appsidfilters)
+  - [GET `/apps/:id/health/plots/instances`](#get-appsidhealthplotsinstances)
     - [Usage Notes](#usage-notes-8)
     - [Authorization \& Content Type](#authorization--content-type-5)
     - [Response Body](#response-body-8)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-8)
-  - [GET `/apps/:id/crashGroups`](#get-appsidcrashgroups)
+  - [GET `/apps/:id/filters`](#get-appsidfilters)
     - [Usage Notes](#usage-notes-9)
     - [Authorization \& Content Type](#authorization--content-type-6)
     - [Response Body](#response-body-9)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-9)
-  - [GET `/apps/:id/crashGroups/plots/instances`](#get-appsidcrashgroupsplotsinstances)
+  - [GET `/apps/:id/crashGroups`](#get-appsidcrashgroups)
     - [Usage Notes](#usage-notes-10)
     - [Authorization \& Content Type](#authorization--content-type-7)
     - [Response Body](#response-body-10)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-10)
-  - [GET `/apps/:id/crashGroups/:id/crashes`](#get-appsidcrashgroupsidcrashes)
+  - [GET `/apps/:id/crashGroups/plots/instances`](#get-appsidcrashgroupsplotsinstances)
     - [Usage Notes](#usage-notes-11)
     - [Authorization \& Content Type](#authorization--content-type-8)
     - [Response Body](#response-body-11)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-11)
-  - [GET `/apps/:id/crashGroups/:id/path`](#get-appsidcrashgroupsidpath)
+  - [GET `/apps/:id/crashGroups/:id/crashes`](#get-appsidcrashgroupsidcrashes)
     - [Usage Notes](#usage-notes-12)
     - [Authorization \& Content Type](#authorization--content-type-9)
     - [Response Body](#response-body-12)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-12)
-  - [GET `/apps/:id/crashGroups/:id/plots/instances`](#get-appsidcrashgroupsidplotsinstances)
+  - [GET `/apps/:id/crashGroups/:id/path`](#get-appsidcrashgroupsidpath)
     - [Usage Notes](#usage-notes-13)
     - [Authorization \& Content Type](#authorization--content-type-10)
     - [Response Body](#response-body-13)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-13)
-  - [GET `/apps/:id/crashGroups/:id/plots/journey`](#get-appsidcrashgroupsidplotsjourney)
+  - [GET `/apps/:id/crashGroups/:id/plots/instances`](#get-appsidcrashgroupsidplotsinstances)
     - [Usage Notes](#usage-notes-14)
     - [Authorization \& Content Type](#authorization--content-type-11)
     - [Response Body](#response-body-14)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-14)
-  - [GET `/apps/:id/anrGroups`](#get-appsidanrgroups)
+  - [GET `/apps/:id/crashGroups/:id/plots/journey`](#get-appsidcrashgroupsidplotsjourney)
     - [Usage Notes](#usage-notes-15)
     - [Authorization \& Content Type](#authorization--content-type-12)
     - [Response Body](#response-body-15)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-15)
-  - [GET `/apps/:id/anrGroups/plots/instances`](#get-appsidanrgroupsplotsinstances)
+  - [GET `/apps/:id/anrGroups`](#get-appsidanrgroups)
     - [Usage Notes](#usage-notes-16)
     - [Authorization \& Content Type](#authorization--content-type-13)
     - [Response Body](#response-body-16)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-16)
-  - [GET `/apps/:id/anrGroups/:id/anrs`](#get-appsidanrgroupsidanrs)
+  - [GET `/apps/:id/anrGroups/plots/instances`](#get-appsidanrgroupsplotsinstances)
     - [Usage Notes](#usage-notes-17)
     - [Authorization \& Content Type](#authorization--content-type-14)
     - [Response Body](#response-body-17)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-17)
-  - [GET `/apps/:id/anrGroups/:id/path`](#get-appsidanrgroupsidpath)
+  - [GET `/apps/:id/anrGroups/:id/anrs`](#get-appsidanrgroupsidanrs)
     - [Usage Notes](#usage-notes-18)
     - [Authorization \& Content Type](#authorization--content-type-15)
     - [Response Body](#response-body-18)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-18)
-  - [GET `/apps/:id/anrGroups/:id/plots/instances`](#get-appsidanrgroupsidplotsinstances)
+  - [GET `/apps/:id/anrGroups/:id/path`](#get-appsidanrgroupsidpath)
     - [Usage Notes](#usage-notes-19)
     - [Authorization \& Content Type](#authorization--content-type-16)
     - [Response Body](#response-body-19)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-19)
-  - [GET `/apps/:id/anrGroups/:id/plots/journey`](#get-appsidanrgroupsidplotsjourney)
+  - [GET `/apps/:id/anrGroups/:id/plots/instances`](#get-appsidanrgroupsidplotsinstances)
     - [Usage Notes](#usage-notes-20)
     - [Authorization \& Content Type](#authorization--content-type-17)
     - [Response Body](#response-body-20)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-20)
-  - [GET `/apps/:id/errorGroups`](#get-appsiderrorgroups)
+  - [GET `/apps/:id/anrGroups/:id/plots/journey`](#get-appsidanrgroupsidplotsjourney)
     - [Usage Notes](#usage-notes-21)
     - [Authorization \& Content Type](#authorization--content-type-18)
     - [Response Body](#response-body-21)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-21)
-  - [GET `/apps/:id/errorGroups/plots/instances`](#get-appsiderrorgroupsplotsinstances)
+  - [GET `/apps/:id/errorGroups`](#get-appsiderrorgroups)
     - [Usage Notes](#usage-notes-22)
     - [Authorization \& Content Type](#authorization--content-type-19)
     - [Response Body](#response-body-22)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-22)
-  - [GET `/apps/:id/errorGroups/:errorGroupId/errors`](#get-appsiderrorgroupserrorgroupiderrors)
+  - [GET `/apps/:id/errorGroups/plots/instances`](#get-appsiderrorgroupsplotsinstances)
     - [Usage Notes](#usage-notes-23)
     - [Authorization \& Content Type](#authorization--content-type-20)
     - [Response Body](#response-body-23)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-23)
-  - [GET `/apps/:id/errorGroups/:errorGroupId/path`](#get-appsiderrorgroupserrorgroupidpath)
+  - [GET `/apps/:id/errorGroups/:errorGroupId/errors`](#get-appsiderrorgroupserrorgroupiderrors)
     - [Usage Notes](#usage-notes-24)
     - [Authorization \& Content Type](#authorization--content-type-21)
     - [Response Body](#response-body-24)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-24)
-  - [GET `/apps/:id/errorGroups/:errorGroupId/plots/instances`](#get-appsiderrorgroupserrorgroupidplotsinstances)
+  - [GET `/apps/:id/errorGroups/:errorGroupId/path`](#get-appsiderrorgroupserrorgroupidpath)
     - [Usage Notes](#usage-notes-25)
     - [Authorization \& Content Type](#authorization--content-type-22)
     - [Response Body](#response-body-25)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-25)
-  - [GET `/apps/:id/errorGroups/:errorGroupId/plots/distribution`](#get-appsiderrorgroupserrorgroupidplotsdistribution)
+  - [GET `/apps/:id/errorGroups/:errorGroupId/plots/instances`](#get-appsiderrorgroupserrorgroupidplotsinstances)
     - [Usage Notes](#usage-notes-26)
     - [Authorization \& Content Type](#authorization--content-type-23)
     - [Response Body](#response-body-26)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-26)
-  - [GET `/apps/:id/sessions`](#get-appsidsessions)
+  - [GET `/apps/:id/errorGroups/:errorGroupId/plots/distribution`](#get-appsiderrorgroupserrorgroupidplotsdistribution)
     - [Usage Notes](#usage-notes-27)
     - [Authorization \& Content Type](#authorization--content-type-24)
     - [Response Body](#response-body-27)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-27)
-  - [GET `/apps/:id/sessions/plots/instances`](#get-appsidsessionsplotsinstances)
+  - [GET `/apps/:id/sessions`](#get-appsidsessions)
     - [Usage Notes](#usage-notes-28)
     - [Authorization \& Content Type](#authorization--content-type-25)
     - [Response Body](#response-body-28)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-28)
-  - [GET `/apps/:id/sessions/:id`](#get-appsidsessionsid)
+  - [GET `/apps/:id/sessions/plots/instances`](#get-appsidsessionsplotsinstances)
     - [Usage Notes](#usage-notes-29)
     - [Authorization \& Content Type](#authorization--content-type-26)
     - [Response Body](#response-body-29)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-29)
-  - [PATCH `/apps/:id/rename`](#patch-appsidrename)
+  - [GET `/apps/:id/sessions/:id`](#get-appsidsessionsid)
     - [Usage Notes](#usage-notes-30)
-    - [Request body](#request-body-3)
     - [Authorization \& Content Type](#authorization--content-type-27)
     - [Response Body](#response-body-30)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-30)
-  - [PATCH `/apps/:id/apiKey`](#patch-appsidapikey)
+  - [PATCH `/apps/:id/rename`](#patch-appsidrename)
     - [Usage Notes](#usage-notes-31)
+    - [Request body](#request-body-3)
     - [Authorization \& Content Type](#authorization--content-type-28)
     - [Response Body](#response-body-31)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-31)
-  - [GET `/apps/:id/retention`](#get-appsidretention)
+  - [PATCH `/apps/:id/apiKey`](#patch-appsidapikey)
     - [Usage Notes](#usage-notes-32)
     - [Authorization \& Content Type](#authorization--content-type-29)
     - [Response Body](#response-body-32)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-32)
-  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
+  - [GET `/apps/:id/retention`](#get-appsidretention)
     - [Usage Notes](#usage-notes-33)
-    - [Request body](#request-body-4)
     - [Authorization \& Content Type](#authorization--content-type-30)
     - [Response Body](#response-body-33)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-33)
-  - [GET `/apps/:id/thresholdPrefs`](#get-appsidthresholdprefs)
+  - [PATCH `/apps/:id/retention`](#patch-appsidretention)
     - [Usage Notes](#usage-notes-34)
+    - [Request body](#request-body-4)
     - [Authorization \& Content Type](#authorization--content-type-31)
     - [Response Body](#response-body-34)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-34)
-  - [PATCH `/apps/:id/thresholdPrefs`](#patch-appsidthresholdprefs)
+  - [GET `/apps/:id/thresholdPrefs`](#get-appsidthresholdprefs)
     - [Usage Notes](#usage-notes-35)
-    - [Request Body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-32)
     - [Response Body](#response-body-35)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-35)
-  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
+  - [PATCH `/apps/:id/thresholdPrefs`](#patch-appsidthresholdprefs)
     - [Usage Notes](#usage-notes-36)
-    - [Request body](#request-body-6)
+    - [Request Body](#request-body-5)
     - [Authorization \& Content Type](#authorization--content-type-33)
     - [Response Body](#response-body-36)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-36)
-  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
+  - [POST `/apps/:id/shortFilters`](#post-appsidshortfilters)
     - [Usage Notes](#usage-notes-37)
+    - [Request body](#request-body-6)
     - [Authorization \& Content Type](#authorization--content-type-34)
     - [Response Body](#response-body-37)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-37)
-  - [GET `/apps/:id/spans`](#get-appsidspans)
+  - [GET `/apps/:id/spans/roots/names`](#get-appsidspansrootsnames)
     - [Usage Notes](#usage-notes-38)
     - [Authorization \& Content Type](#authorization--content-type-35)
     - [Response Body](#response-body-38)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-38)
-  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
+  - [GET `/apps/:id/spans`](#get-appsidspans)
     - [Usage Notes](#usage-notes-39)
     - [Authorization \& Content Type](#authorization--content-type-36)
     - [Response Body](#response-body-39)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-39)
-  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
+  - [GET `/apps/:id/spans/plots/metrics`](#get-appsidspansplotsmetrics)
     - [Usage Notes](#usage-notes-40)
     - [Authorization \& Content Type](#authorization--content-type-37)
     - [Response Body](#response-body-40)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-40)
-  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
+  - [GET `/apps/:id/traces/:traceId`](#get-appsidtracestraceid)
     - [Usage Notes](#usage-notes-41)
     - [Authorization \& Content Type](#authorization--content-type-38)
     - [Response Body](#response-body-41)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-41)
-  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
+  - [GET `/apps/:id/bugReports`](#get-appsidbugreports)
     - [Usage Notes](#usage-notes-42)
     - [Authorization \& Content Type](#authorization--content-type-39)
     - [Response Body](#response-body-42)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-42)
-  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/plots/instances`](#get-appsidbugreportsplotsinstances)
     - [Usage Notes](#usage-notes-43)
     - [Authorization \& Content Type](#authorization--content-type-40)
     - [Response Body](#response-body-43)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-43)
-  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
+  - [GET `/apps/:id/bugReports/:bugReportId`](#get-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-44)
-    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-41)
     - [Response Body](#response-body-44)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-44)
-  - [GET `/apps/:id/alerts`](#get-appsidalerts)
+  - [PATCH `/apps/:id/bugReports/:bugReportId`](#patch-appsidbugreportsbugreportid)
     - [Usage Notes](#usage-notes-45)
+    - [Request body](#request-body-7)
     - [Authorization \& Content Type](#authorization--content-type-42)
     - [Response Body](#response-body-45)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-45)
-  - [GET `/apps/:id/config`](#get-appsidconfig)
+  - [GET `/apps/:id/alerts`](#get-appsidalerts)
     - [Usage Notes](#usage-notes-46)
     - [Authorization \& Content Type](#authorization--content-type-43)
     - [Response Body](#response-body-46)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-46)
-  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+  - [GET `/apps/:id/config`](#get-appsidconfig)
     - [Usage Notes](#usage-notes-47)
     - [Authorization \& Content Type](#authorization--content-type-44)
     - [Response Body](#response-body-47)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-47)
-  - [GET `/apps/:id/networkRequests/domains`](#get-appsidnetworkrequestsdomains)
+  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
     - [Usage Notes](#usage-notes-48)
     - [Authorization \& Content Type](#authorization--content-type-45)
     - [Response Body](#response-body-48)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-48)
-  - [GET `/apps/:id/networkRequests/paths`](#get-appsidnetworkrequestspaths)
+  - [GET `/apps/:id/networkRequests/domains`](#get-appsidnetworkrequestsdomains)
     - [Usage Notes](#usage-notes-49)
     - [Authorization \& Content Type](#authorization--content-type-46)
     - [Response Body](#response-body-49)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-49)
-  - [GET `/apps/:id/networkRequests/trends`](#get-appsidnetworkrequeststrends)
+  - [GET `/apps/:id/networkRequests/paths`](#get-appsidnetworkrequestspaths)
     - [Usage Notes](#usage-notes-50)
     - [Authorization \& Content Type](#authorization--content-type-47)
     - [Response Body](#response-body-50)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-50)
-  - [GET `/apps/:id/networkRequests/plots/overviewStatusCodes`](#get-appsidnetworkrequestsplotsoverviewstatuscodes)
+  - [GET `/apps/:id/networkRequests/trends`](#get-appsidnetworkrequeststrends)
     - [Usage Notes](#usage-notes-51)
     - [Authorization \& Content Type](#authorization--content-type-48)
     - [Response Body](#response-body-51)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-51)
-  - [GET `/apps/:id/networkRequests/plots/endpointLatency`](#get-appsidnetworkrequestsplotsendpointlatency)
+  - [GET `/apps/:id/networkRequests/plots/overviewStatusCodes`](#get-appsidnetworkrequestsplotsoverviewstatuscodes)
     - [Usage Notes](#usage-notes-52)
     - [Authorization \& Content Type](#authorization--content-type-49)
     - [Response Body](#response-body-52)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-52)
-  - [GET `/apps/:id/networkRequests/plots/endpointStatusCodes`](#get-appsidnetworkrequestsplotsendpointstatuscodes)
+  - [GET `/apps/:id/networkRequests/plots/endpointLatency`](#get-appsidnetworkrequestsplotsendpointlatency)
     - [Usage Notes](#usage-notes-53)
     - [Authorization \& Content Type](#authorization--content-type-50)
     - [Response Body](#response-body-53)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-53)
-  - [GET `/apps/:id/networkRequests/plots/overviewTimeline`](#get-appsidnetworkrequestsplotsoverviewtimeline)
+  - [GET `/apps/:id/networkRequests/plots/endpointStatusCodes`](#get-appsidnetworkrequestsplotsendpointstatuscodes)
     - [Usage Notes](#usage-notes-54)
     - [Authorization \& Content Type](#authorization--content-type-51)
     - [Response Body](#response-body-54)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-54)
-  - [GET `/apps/:id/networkRequests/plots/endpointTimeline`](#get-appsidnetworkrequestsplotsendpointtimeline)
+  - [GET `/apps/:id/networkRequests/plots/overviewTimeline`](#get-appsidnetworkrequestsplotsoverviewtimeline)
     - [Usage Notes](#usage-notes-55)
     - [Authorization \& Content Type](#authorization--content-type-52)
     - [Response Body](#response-body-55)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-55)
-- [Teams](#teams)
-  - [POST `/teams`](#post-teams)
-    - [Authorization \& Content Type](#authorization--content-type-53)
-    - [Request Body](#request-body-8)
+  - [GET `/apps/:id/networkRequests/plots/endpointTimeline`](#get-appsidnetworkrequestsplotsendpointtimeline)
     - [Usage Notes](#usage-notes-56)
+    - [Authorization \& Content Type](#authorization--content-type-53)
     - [Response Body](#response-body-56)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-56)
-  - [GET `/teams`](#get-teams)
+- [Teams](#teams)
+  - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-54)
+    - [Request Body](#request-body-8)
+    - [Usage Notes](#usage-notes-57)
     - [Response Body](#response-body-57)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-57)
-  - [GET `/teams/:id/apps`](#get-teamsidapps)
-    - [Usage Notes](#usage-notes-57)
+  - [GET `/teams`](#get-teams)
     - [Authorization \& Content Type](#authorization--content-type-55)
     - [Response Body](#response-body-58)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-58)
-  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
+  - [GET `/teams/:id/apps`](#get-teamsidapps)
     - [Usage Notes](#usage-notes-58)
     - [Authorization \& Content Type](#authorization--content-type-56)
     - [Response Body](#response-body-59)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-59)
-  - [POST `/teams/:id/apps`](#post-teamsidapps)
+  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
     - [Usage Notes](#usage-notes-59)
-    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-57)
     - [Response Body](#response-body-60)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-60)
-  - [GET `/teams/:id/invites`](#get-teamsidinvites)
+  - [POST `/teams/:id/apps`](#post-teamsidapps)
     - [Usage Notes](#usage-notes-60)
+    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-58)
     - [Response Body](#response-body-61)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-61)
-  - [POST `/teams/:id/invite`](#post-teamsidinvite)
+  - [GET `/teams/:id/invites`](#get-teamsidinvites)
     - [Usage Notes](#usage-notes-61)
-    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-59)
     - [Response Body](#response-body-62)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-62)
-  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
+  - [POST `/teams/:id/invite`](#post-teamsidinvite)
     - [Usage Notes](#usage-notes-62)
+    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-60)
     - [Response Body](#response-body-63)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-63)
-  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
+  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
     - [Usage Notes](#usage-notes-63)
     - [Authorization \& Content Type](#authorization--content-type-61)
     - [Response Body](#response-body-64)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-64)
-  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
+  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
     - [Usage Notes](#usage-notes-64)
-    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-62)
     - [Response Body](#response-body-65)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-65)
-  - [GET `/teams/:id/members`](#get-teamsidmembers)
+  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
     - [Usage Notes](#usage-notes-65)
+    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-63)
     - [Response Body](#response-body-66)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-66)
-  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
+  - [GET `/teams/:id/members`](#get-teamsidmembers)
     - [Usage Notes](#usage-notes-66)
     - [Authorization \& Content Type](#authorization--content-type-64)
     - [Response Body](#response-body-67)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-67)
-  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
+  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
     - [Usage Notes](#usage-notes-67)
-    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-65)
     - [Response Body](#response-body-68)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-68)
-  - [GET `/teams/:id/authz`](#get-teamsidauthz)
+  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
     - [Usage Notes](#usage-notes-68)
+    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-66)
     - [Response Body](#response-body-69)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-69)
-  - [GET `/teams/:id/usage`](#get-teamsidusage)
+  - [GET `/teams/:id/authz`](#get-teamsidauthz)
     - [Usage Notes](#usage-notes-69)
     - [Authorization \& Content Type](#authorization--content-type-67)
     - [Response Body](#response-body-70)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-70)
-  - [GET `/teams/:id/slack`](#get-teamsidslack)
+  - [GET `/teams/:id/usage`](#get-teamsidusage)
     - [Usage Notes](#usage-notes-70)
     - [Authorization \& Content Type](#authorization--content-type-68)
     - [Response Body](#response-body-71)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-71)
-  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+  - [GET `/teams/:id/slack`](#get-teamsidslack)
     - [Usage Notes](#usage-notes-71)
-    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-69)
     - [Response Body](#response-body-72)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-72)
-  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
     - [Usage Notes](#usage-notes-72)
+    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-70)
     - [Response Body](#response-body-73)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-73)
-- [Prefs](#prefs)
-  - [GET `/prefs/notifPrefs`](#get-prefsnotifprefs)
+  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
     - [Usage Notes](#usage-notes-73)
     - [Authorization \& Content Type](#authorization--content-type-71)
     - [Response Body](#response-body-74)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-74)
-  - [PATCH `/prefs/notifPrefs`](#patch-prefsnotifprefs)
+- [Prefs](#prefs)
+  - [GET `/prefs/notifPrefs`](#get-prefsnotifprefs)
     - [Usage Notes](#usage-notes-74)
-    - [Request body](#request-body-14)
     - [Authorization \& Content Type](#authorization--content-type-72)
     - [Response Body](#response-body-75)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-75)
+  - [PATCH `/prefs/notifPrefs`](#patch-prefsnotifprefs)
+    - [Usage Notes](#usage-notes-75)
+    - [Request body](#request-body-14)
+    - [Authorization \& Content Type](#authorization--content-type-73)
+    - [Response Body](#response-body-76)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-76)
 
 ## Auth
 
@@ -850,6 +855,7 @@ List of HTTP status codes for success and failures.
 
 - [**GET `/apps/:id/journey`**](#get-appsidjourney) - Fetch an app's issue journey map for a time range &amp; version.
 - [**GET `/apps/:id/metrics`**](#get-appsidmetrics) - Fetch an app's health metrics for a time range &amp; version.
+- [**GET `/apps/:id/health/plots/instances`**](#get-appsidhealthplotsinstances) - Fetch an app's health overview instances plot (sessions, crashes &amp; ANRs) aggregated by date range &amp; version.
 - [**GET `/apps/:id/filters`**](#get-appsidfilters) - Fetch an app's filters.
 - [**GET `/apps/:id/crashGroups`**](#get-appsidcrashgroups) - _(deprecated)_ Fetch an app's crash overview.
 - [**GET `/apps/:id/crashGroups/plots/instances`**](#get-appsidcrashgroupsplotsinstances) - _(deprecated)_ Fetch an app's crash overview instances plot aggregated by date range & version.
@@ -1141,6 +1147,102 @@ The required headers must be present in each request.
       "p95": 0
     }
   }
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes & Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+### GET `/apps/:id/health/plots/instances`
+
+Fetch an app's health overview instances plot. The response is a time series of three metrics bucketed by datetime: sessions, crashes (fatal exceptions) &amp; ANRs. Filter time range using `from` &amp; `to` query string parameters. Filter version using `versions` &amp; `version_codes` query string parameters.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI.
+- Accepted query parameters
+  - `from` (_optional_) - ISO8601 timestamp to include data after this time.
+  - `to` (_optional_) - ISO8601 timestamp to include data before this time.
+  - `timezone` (_required_) - IANA timezone used to bucket and format datetime values in the response.
+  - `plot_time_group` (_optional_) - Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`.
+  - `versions` (_optional_) - List of comma separated app version identifier strings to return only matching data.
+  - `version_codes` (_optional_) - List of comma separated app version codes to return only matching data.
+  - `filter_short_code` (_optional_) - Code representing combination of filters.
+- `from` &amp; `to` will default to a last 7 days time range if not supplied.
+- Both `versions` &amp; `version_codes` should be present if any one of them is present, and must contain the same number of items.
+- For multiple comma separated fields, make sure no whitespace characters exist before or after comma.
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- The response is an array of three series identified by `id`: `sessions`, `crashes` &amp; `anrs`. Each series holds a sparse list of datetime buckets that had data, so a bucket with no crashes or ANRs is simply absent from that series.
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+  [
+    {
+      "id": "sessions",
+      "data": [
+        { "datetime": "2024-10-02", "instances": 12044 },
+        { "datetime": "2024-10-03", "instances": 13890 }
+      ]
+    },
+    {
+      "id": "crashes",
+      "data": [
+        { "datetime": "2024-10-02", "instances": 32 },
+        { "datetime": "2024-10-03", "instances": 28 }
+      ]
+    },
+    {
+      "id": "anrs",
+      "data": [{ "datetime": "2024-10-02", "instances": 4 }]
+    }
+  ]
   ```
 
   </details>

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -83,7 +83,7 @@ import {
   fetchPendingInvitesFromServer,
   fetchRootSpanNamesFromServer,
   fetchSdkConfigFromServer,
-  fetchSessionsVsErrorsPlotFromServer,
+  fetchAppHealthPlotFromServer,
   fetchSessionTimelineFromServer,
   fetchSessionTimelinesOverviewFromServer,
   fetchSessionTimelinesOverviewPlotFromServer,
@@ -125,7 +125,7 @@ import {
   SdkConfig,
   SdkConfigApiStatus,
   sendTestSlackAlertFromServer,
-  SessionsVsErrorsPlotApiStatus,
+  AppHealthPlotApiStatus,
   SessionTimelineApiStatus,
   SessionTimelinesOverviewApiStatus,
   SessionTimelinesOverviewPlotApiStatus,
@@ -631,41 +631,70 @@ describe("fetchJourneyFromServer", () => {
 });
 
 // ========================================================================
-// fetchSessionsVsErrorsPlotFromServer — composite fetch
+// fetchAppHealthPlotFromServer — single /health/plots/instances fetch
 // ========================================================================
-describe("fetchSessionsVsErrorsPlotFromServer", () => {
-  it("returns Success when all 3 child fetches return Success", async () => {
-    // Sessions plot
+describe("fetchAppHealthPlotFromServer", () => {
+  it("returns Success and maps the three server series to display series", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
-      successResponse([{ data: [{ datetime: "2026-01-01", instances: 100 }] }]),
-    );
-    // Crashes plot
-    mockApiClientFetch.mockResolvedValueOnce(
-      successResponse([{ data: [{ datetime: "2026-01-01", instances: 10 }] }]),
-    );
-    // ANRs plot
-    mockApiClientFetch.mockResolvedValueOnce(
-      successResponse([{ data: [{ datetime: "2026-01-01", instances: 1 }] }]),
+      successResponse([
+        { id: "sessions", data: [{ datetime: "2026-01-01", instances: 100 }] },
+        { id: "crashes", data: [{ datetime: "2026-01-01", instances: 10 }] },
+        { id: "anrs", data: [{ datetime: "2026-01-01", instances: 1 }] },
+      ]),
     );
 
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.Success);
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.Success);
+    expect(r.data?.map((s: any) => s.id)).toEqual([
+      "Sessions",
+      "Crashes",
+      "ANRs",
+    ]);
   });
 
-  it("returns Error if any child fetch errors", async () => {
+  it("hits the health plots endpoint", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
+    await fetchAppHealthPlotFromServer(makeFilters());
+    expect(mockApiClientFetch.mock.calls[0][0]).toContain(
+      "/health/plots/instances",
+    );
+  });
+
+  it("returns Error when the fetch returns a non-ok response", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.Error);
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.Error);
   });
 
-  it("returns NoData when all child datasets are empty", async () => {
+  it("returns NoData when the response body is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.NoData);
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.NoData);
+  });
+
+  it("returns NoData when every series value is zero", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(
+      successResponse([
+        { id: "sessions", data: [{ datetime: "2026-01-01", instances: 0 }] },
+        { id: "crashes", data: [{ datetime: "2026-01-01", instances: 0 }] },
+        { id: "anrs", data: [{ datetime: "2026-01-01", instances: 0 }] },
+      ]),
+    );
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.NoData);
+  });
+
+  it("drops the ANRs series when all ANR values are zero", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(
+      successResponse([
+        { id: "sessions", data: [{ datetime: "2026-01-01", instances: 100 }] },
+        { id: "crashes", data: [{ datetime: "2026-01-01", instances: 10 }] },
+        { id: "anrs", data: [{ datetime: "2026-01-01", instances: 0 }] },
+      ]),
+    );
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.Success);
+    expect(r.data?.map((s: any) => s.id)).toEqual(["Sessions", "Crashes"]);
   });
 });
 
@@ -1573,28 +1602,10 @@ describe("additional branch coverage", () => {
     expect(r.status).toBe(SpanMetricsPlotApiStatus.NoData);
   });
 
-  it("fetchSessionsVsErrorsPlotFromServer returns Error when sessions child errors", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(errorResponse()); // sessions
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.Error);
-  });
-
-  it("fetchSessionsVsErrorsPlotFromServer returns Error when crashes child errors", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    mockApiClientFetch.mockResolvedValueOnce(errorResponse()); // crashes
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.Error);
-  });
-
-  it("fetchSessionsVsErrorsPlotFromServer returns Error when anrs child errors", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    mockApiClientFetch.mockResolvedValueOnce(errorResponse()); // anrs
-    const r = await fetchSessionsVsErrorsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SessionsVsErrorsPlotApiStatus.Error);
+  it("fetchAppHealthPlotFromServer returns Error when the fetch throws", async () => {
+    mockApiClientFetch.mockRejectedValueOnce(new Error("network down"));
+    const r = await fetchAppHealthPlotFromServer(makeFilters());
+    expect(r.status).toBe(AppHealthPlotApiStatus.Error);
   });
 
   it("appends all span statuses (Unset/Ok/Error) to span endpoint URLs", async () => {

--- a/frontend/dashboard/__tests__/components/app_health_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/app_health_plot_test.tsx
@@ -1,4 +1,4 @@
-import SessionsVsErrorsPlot from "@/app/components/sessions_vs_errors_overview_plot";
+import AppHealthPlot from "@/app/components/app_health_plot";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
@@ -16,7 +16,7 @@ jest.mock("@/app/components/skeleton", () => ({
   SkeletonPlot: () => <div data-testid="skeleton-mock">loading</div>,
 }));
 
-const mockUseSessionsVsErrorsPlotQuery = jest.fn(
+const mockUseAppHealthPlotQuery = jest.fn(
   (): { data: any; status: string; error: Error | null } => ({
     data: undefined,
     status: "pending",
@@ -26,7 +26,7 @@ const mockUseSessionsVsErrorsPlotQuery = jest.fn(
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useSessionsVsErrorsPlotQuery: () => mockUseSessionsVsErrorsPlotQuery(),
+  useAppHealthPlotQuery: () => mockUseAppHealthPlotQuery(),
 }));
 
 jest.mock("@/app/stores/provider", () => {
@@ -51,7 +51,7 @@ const filters = {
   endDate: "2026-02-01T06:00:00Z",
 };
 
-describe("SessionsVsErrorsPlot", () => {
+describe("AppHealthPlot", () => {
   beforeEach(() => {
     lastLineProps = null;
     useFiltersStore.setState({
@@ -62,7 +62,7 @@ describe("SessionsVsErrorsPlot", () => {
         endDate: "",
       },
     });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: undefined,
       status: "pending",
       error: null,
@@ -71,47 +71,47 @@ describe("SessionsVsErrorsPlot", () => {
 
   it("renders no data state", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: null,
       status: "success",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
     expect(screen.getByText("No Data")).toBeInTheDocument();
   });
 
   it("renders error state", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: undefined,
       status: "error",
       error: new Error("test"),
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
     expect(screen.getByText(/Error fetching plot/)).toBeInTheDocument();
   });
 
   it("renders loading state", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: undefined,
       status: "pending",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 
   it("uses demo data and bypasses API in demo mode", () => {
     useFiltersStore.setState({ filters });
-    render(<SessionsVsErrorsPlot demo />);
+    render(<AppHealthPlot demo />);
     expect(screen.getByTestId("line-mock")).toBeInTheDocument();
     expect(lastLineProps.data[0].id).toBe("Sessions");
   });
 
   it("renders data and minute precision axis for sub-12h range", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         {
           id: "Sessions",
@@ -121,7 +121,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
 
     expect(screen.getByTestId("line-mock")).toBeInTheDocument();
     expect(lastLineProps.xScale.precision).toBe("minute");
@@ -136,7 +136,7 @@ describe("SessionsVsErrorsPlot", () => {
       endDate: "2026-02-06T00:00:00Z",
     };
     useFiltersStore.setState({ filters: hourFilters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         {
           id: "Sessions",
@@ -146,7 +146,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    const { unmount: u1 } = render(<SessionsVsErrorsPlot />);
+    const { unmount: u1 } = render(<AppHealthPlot />);
     expect(lastLineProps.xScale.precision).toBe("hour");
     u1();
 
@@ -157,7 +157,7 @@ describe("SessionsVsErrorsPlot", () => {
       endDate: "2026-03-15T00:00:00Z",
     };
     useFiltersStore.setState({ filters: dayFilters });
-    const { unmount: u2 } = render(<SessionsVsErrorsPlot />);
+    const { unmount: u2 } = render(<AppHealthPlot />);
     expect(lastLineProps.xScale.precision).toBe("day");
     u2();
 
@@ -168,13 +168,13 @@ describe("SessionsVsErrorsPlot", () => {
       endDate: "2026-01-01T00:00:00Z",
     };
     useFiltersStore.setState({ filters: monthFilters });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
     expect(lastLineProps.axisBottom.format).toBe("%d %b, %Y");
   });
 
   it("renders tooltip in Sessions, Crashes, ANRs order", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         { id: "ANRs", data: [{ id: "a1", x: "2026-02-01T01:00:00", y: 1 }] },
         {
@@ -186,7 +186,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
     expect(screen.getByTestId("line-mock")).toBeInTheDocument();
 
     const tooltip = lastLineProps.sliceTooltip({
@@ -219,7 +219,7 @@ describe("SessionsVsErrorsPlot", () => {
 
   it("skips missing tooltip series and keeps known ordering", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         {
           id: "Sessions",
@@ -230,7 +230,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
 
     const tooltip = lastLineProps.sliceTooltip({
       slice: {
@@ -258,7 +258,7 @@ describe("SessionsVsErrorsPlot", () => {
 
   it("uses fallback color for unknown series id", () => {
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         {
           id: "Sessions",
@@ -268,7 +268,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
 
     expect(lastLineProps.colors({ id: "Unknown" })).toBe("#888");
     expect(lastLineProps.pointBorderColor({ serieId: "Unknown" })).toBe("#888");
@@ -277,7 +277,7 @@ describe("SessionsVsErrorsPlot", () => {
   it("hides stale chart while new range data is loading", () => {
     // First render with data
     useFiltersStore.setState({ filters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: [
         {
           id: "Sessions",
@@ -287,7 +287,7 @@ describe("SessionsVsErrorsPlot", () => {
       status: "success",
       error: null,
     });
-    const { unmount } = render(<SessionsVsErrorsPlot />);
+    const { unmount } = render(<AppHealthPlot />);
     expect(screen.getByTestId("line-mock")).toBeInTheDocument();
     unmount();
 
@@ -298,12 +298,12 @@ describe("SessionsVsErrorsPlot", () => {
       endDate: "2026-02-01T03:00:00Z",
     };
     useFiltersStore.setState({ filters: newFilters });
-    mockUseSessionsVsErrorsPlotQuery.mockReturnValue({
+    mockUseAppHealthPlotQuery.mockReturnValue({
       data: undefined,
       status: "pending",
       error: null,
     });
-    render(<SessionsVsErrorsPlot />);
+    render(<AppHealthPlot />);
 
     expect(screen.getByText("loading")).toBeInTheDocument();
     expect(screen.queryByTestId("line-mock")).not.toBeInTheDocument();

--- a/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
@@ -75,8 +75,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   makeAppFixture,
   makeFiltersFixture,
+  makeHealthPlotFixture,
   makeMetricsFixture,
-  makeSessionPlotFixture,
 } from "../msw/fixtures";
 import { server } from "../msw/server";
 
@@ -206,9 +206,9 @@ describe("Overview page (MSW integration)", () => {
     );
   });
 
-  it("renders chart error when sessions plot API fails", async () => {
+  it("renders chart error when the health plot API fails", async () => {
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return new HttpResponse(null, { status: 500 });
       }),
     );
@@ -224,12 +224,9 @@ describe("Overview page (MSW integration)", () => {
   });
 
   it("renders metrics even when the plot API fails", async () => {
-    // Plot APIs all fail, but metrics should still load independently
+    // Plot API fails, but metrics should still load independently
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
-        return new HttpResponse(null, { status: 500 });
-      }),
-      http.get("*/api/apps/:appId/errorGroups/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return new HttpResponse(null, { status: 500 });
       }),
     );
@@ -323,9 +320,7 @@ describe("Overview page — filter interactions", () => {
   // Common test infra: captured requests
   let shortFilterBodies: any[];
   let metricsRequests: { url: string; appId: string }[];
-  let sessionPlotRequests: { url: string }[];
-  let crashPlotRequests: { url: string }[];
-  let anrPlotRequests: { url: string }[];
+  let healthPlotRequests: { url: string }[];
   let filtersRequests: { url: string; appId: string }[];
 
   const defaultInitConfig = {
@@ -337,9 +332,7 @@ describe("Overview page — filter interactions", () => {
   beforeEach(() => {
     shortFilterBodies = [];
     metricsRequests = [];
-    sessionPlotRequests = [];
-    crashPlotRequests = [];
-    anrPlotRequests = [];
+    healthPlotRequests = [];
     filtersRequests = [];
 
     // Install request-tracking handlers for ALL overview endpoints
@@ -357,23 +350,10 @@ describe("Overview page — filter interactions", () => {
         });
         return HttpResponse.json(makeMetricsFixture());
       }),
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
-        sessionPlotRequests.push({ url: request.url });
-        return HttpResponse.json(makeSessionPlotFixture());
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
+        healthPlotRequests.push({ url: request.url });
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
-      http.get(
-        "*/api/apps/:appId/errorGroups/plots/instances",
-        ({ request }) => {
-          const url = new URL(request.url);
-          const typeParam = url.searchParams.get("type") ?? "";
-          if (typeParam.includes("anr")) {
-            anrPlotRequests.push({ url: request.url });
-          } else {
-            crashPlotRequests.push({ url: request.url });
-          }
-          return HttpResponse.json([]);
-        },
-      ),
       http.get("*/api/apps/:appId/filters", ({ request, params }) => {
         filtersRequests.push({
           url: request.url,
@@ -449,11 +429,9 @@ describe("Overview page — filter interactions", () => {
       );
     });
 
-    it("switching app refetches all 3 plot endpoints for the new app", async () => {
+    it("switching app refetches the health plot endpoint for the new app", async () => {
       await renderAndWaitForData();
-      sessionPlotRequests.length = 0;
-      crashPlotRequests.length = 0;
-      anrPlotRequests.length = 0;
+      healthPlotRequests.length = 0;
 
       await act(async () => {
         filtersStore.getState().setSelectedApp(app2);
@@ -461,9 +439,7 @@ describe("Overview page — filter interactions", () => {
 
       await waitFor(
         () => {
-          expect(sessionPlotRequests.length).toBeGreaterThan(0);
-          expect(crashPlotRequests.length).toBeGreaterThan(0);
-          expect(anrPlotRequests.length).toBeGreaterThan(0);
+          expect(healthPlotRequests.length).toBeGreaterThan(0);
         },
         { timeout: 5000 },
       );
@@ -698,11 +674,9 @@ describe("Overview page — filter interactions", () => {
       );
     });
 
-    it("version change triggers all 3 plot refetches", async () => {
+    it("version change triggers a health plot refetch", async () => {
       await renderAndWaitForData();
-      sessionPlotRequests.length = 0;
-      crashPlotRequests.length = 0;
-      anrPlotRequests.length = 0;
+      healthPlotRequests.length = 0;
 
       await act(async () => {
         filtersStore
@@ -712,9 +686,7 @@ describe("Overview page — filter interactions", () => {
 
       await waitFor(
         () => {
-          expect(sessionPlotRequests.length).toBeGreaterThan(0);
-          expect(crashPlotRequests.length).toBeGreaterThan(0);
-          expect(anrPlotRequests.length).toBeGreaterThan(0);
+          expect(healthPlotRequests.length).toBeGreaterThan(0);
         },
         { timeout: 5000 },
       );
@@ -739,10 +711,10 @@ describe("Overview page — filter interactions", () => {
         { timeout: 5000 },
       );
 
-      const sessionUrl = sessionPlotRequests.find((r) =>
+      const healthUrl = healthPlotRequests.find((r) =>
         r.url.includes("filter_short_code="),
       );
-      expect(sessionUrl?.url).toContain("filter_short_code=test-fsc-999");
+      expect(healthUrl?.url).toContain("filter_short_code=test-fsc-999");
     });
 
     it("switching version back to original does not fire duplicate POST (cache hit)", async () => {
@@ -843,11 +815,9 @@ describe("Overview page — filter interactions", () => {
       );
     });
 
-    it("changing to Last Week refetches all 3 plot endpoints", async () => {
+    it("changing to Last Week refetches the health plot endpoint", async () => {
       await renderAndWaitForData();
-      sessionPlotRequests.length = 0;
-      crashPlotRequests.length = 0;
-      anrPlotRequests.length = 0;
+      healthPlotRequests.length = 0;
 
       const now = new Date();
       const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -855,9 +825,7 @@ describe("Overview page — filter interactions", () => {
 
       await waitFor(
         () => {
-          expect(sessionPlotRequests.length).toBeGreaterThan(0);
-          expect(crashPlotRequests.length).toBeGreaterThan(0);
-          expect(anrPlotRequests.length).toBeGreaterThan(0);
+          expect(healthPlotRequests.length).toBeGreaterThan(0);
         },
         { timeout: 5000 },
       );
@@ -1071,9 +1039,9 @@ describe("Overview page — filter interactions", () => {
     });
 
     it("metrics and plots refetch independently — one can succeed while other fails", async () => {
-      // Override session plot to return error, keep metrics working
+      // Override the health plot to return error, keep metrics working
       server.use(
-        http.get("*/api/apps/:appId/sessions/plots/instances", () => {
+        http.get("*/api/apps/:appId/health/plots/instances", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       );
@@ -1631,26 +1599,31 @@ describe("Overview page — rendered values", () => {
 
     it("chart does NOT show ANRs series when all ANR values are zero", async () => {
       server.use(
-        http.get(
-          "*/api/apps/:appId/errorGroups/plots/instances",
-          ({ request }) => {
-            const url = new URL(request.url);
-            const typeParam = url.searchParams.get("type") ?? "";
-            if (typeParam.includes("anr")) {
-              return HttpResponse.json([
-                {
-                  id: "3.1.0",
-                  data: [
-                    { datetime: "2026-04-01T00:00:00Z", instances: 0 },
-                    { datetime: "2026-04-02T00:00:00Z", instances: 0 },
-                  ],
-                },
-              ]);
-            }
-            // Default crash/error response
-            return HttpResponse.json([]);
-          },
-        ),
+        http.get("*/api/apps/:appId/health/plots/instances", () => {
+          return HttpResponse.json([
+            {
+              id: "sessions",
+              data: [
+                { datetime: "2026-04-01T00:00:00Z", instances: 1000 },
+                { datetime: "2026-04-02T00:00:00Z", instances: 1100 },
+              ],
+            },
+            {
+              id: "crashes",
+              data: [
+                { datetime: "2026-04-01T00:00:00Z", instances: 5 },
+                { datetime: "2026-04-02T00:00:00Z", instances: 7 },
+              ],
+            },
+            {
+              id: "anrs",
+              data: [
+                { datetime: "2026-04-01T00:00:00Z", instances: 0 },
+                { datetime: "2026-04-02T00:00:00Z", instances: 0 },
+              ],
+            },
+          ]);
+        }),
       );
 
       await renderAndWaitForData();
@@ -1773,9 +1746,9 @@ describe("Overview page — error edge cases", () => {
     );
   });
 
-  it("crashes plot error + ANR plot error but sessions plot success → chart shows error", async () => {
+  it("health plot error → chart shows error", async () => {
     server.use(
-      http.get("*/api/apps/:appId/errorGroups/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return new HttpResponse(null, { status: 500 });
       }),
     );
@@ -1790,12 +1763,9 @@ describe("Overview page — error edge cases", () => {
     );
   });
 
-  it("all plot endpoints return empty data → chart shows No Data", async () => {
+  it("health plot returns null → chart shows No Data", async () => {
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
-        return HttpResponse.json(null);
-      }),
-      http.get("*/api/apps/:appId/errorGroups/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return HttpResponse.json(null);
       }),
     );
@@ -2192,9 +2162,9 @@ describe("Overview page — URL params in data-fetch requests", () => {
         allUrls.push(request.url);
         return HttpResponse.json(makeMetricsFixture());
       }),
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
         allUrls.push(request.url);
-        return HttpResponse.json(makeSessionPlotFixture());
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
     );
 
@@ -2208,9 +2178,9 @@ describe("Overview page — URL params in data-fetch requests", () => {
   it("plot URLs include plot_time_group param", async () => {
     const plotUrls: string[] = [];
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
         plotUrls.push(request.url);
-        return HttpResponse.json(makeSessionPlotFixture());
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
     );
 
@@ -2224,9 +2194,9 @@ describe("Overview page — URL params in data-fetch requests", () => {
     // Default is Last 6 Hours → ≤24h → "minutes"
     const plotUrls: string[] = [];
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
         plotUrls.push(request.url);
-        return HttpResponse.json(makeSessionPlotFixture());
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
     );
 
@@ -2237,9 +2207,9 @@ describe("Overview page — URL params in data-fetch requests", () => {
   it('Last Week date range produces "hours" plot_time_group', async () => {
     const plotUrls: string[] = [];
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
         plotUrls.push(request.url);
-        return HttpResponse.json(makeSessionPlotFixture());
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
     );
 
@@ -2272,9 +2242,9 @@ describe("Overview page — URL params in data-fetch requests", () => {
   it('Last 3 Months date range produces "days" plot_time_group', async () => {
     const plotUrls: string[] = [];
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", ({ request }) => {
+      http.get("*/api/apps/:appId/health/plots/instances", ({ request }) => {
         plotUrls.push(request.url);
-        return HttpResponse.json(makeSessionPlotFixture());
+        return HttpResponse.json(makeHealthPlotFixture());
       }),
     );
 
@@ -2313,15 +2283,17 @@ describe("Overview page — URL params in data-fetch requests", () => {
 describe("Overview page — data shape edge cases", () => {
   it("null instances in plot data are treated as zero", async () => {
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return HttpResponse.json([
           {
-            id: "3.1.0",
+            id: "sessions",
             data: [
               { datetime: "2026-04-01T00:00:00Z", instances: null },
               { datetime: "2026-04-02T00:00:00Z", instances: 100 },
             ],
           },
+          { id: "crashes", data: [] },
+          { id: "anrs", data: [] },
         ]);
       }),
     );
@@ -2358,28 +2330,22 @@ describe("Overview page — data shape edge cases", () => {
 
   it("single data point in plot renders chart", async () => {
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return HttpResponse.json([
           {
-            id: "3.1.0",
+            id: "sessions",
             data: [{ datetime: "2026-04-01T00:00:00Z", instances: 500 }],
+          },
+          {
+            id: "crashes",
+            data: [{ datetime: "2026-04-01T00:00:00Z", instances: 5 }],
+          },
+          {
+            id: "anrs",
+            data: [{ datetime: "2026-04-01T00:00:00Z", instances: 1 }],
           },
         ]);
       }),
-      http.get(
-        "*/api/apps/:appId/errorGroups/plots/instances",
-        ({ request }) => {
-          const url = new URL(request.url);
-          const typeParam = url.searchParams.get("type") ?? "";
-          const instances = typeParam.includes("anr") ? 1 : 5;
-          return HttpResponse.json([
-            {
-              id: "3.1.0",
-              data: [{ datetime: "2026-04-01T00:00:00Z", instances }],
-            },
-          ]);
-        },
-      ),
     );
 
     renderWithProviders(<Overview params={{ teamId: "test-team" }} />);
@@ -2393,36 +2359,32 @@ describe("Overview page — data shape edge cases", () => {
     );
   });
 
-  it("multi-version plot data merges correctly into unique dates", async () => {
-    // Two versions with overlapping dates — mergeSeries sums instances
-    // per date. All 3 child datasets need same dates so the union size
-    // matches expectations.
-    const twoDates = [
-      { datetime: "2026-04-01T00:00:00Z", instances: 10 },
-      { datetime: "2026-04-02T00:00:00Z", instances: 20 },
-    ];
+  it("merges unique dates across the three series", async () => {
+    // The client unions datetimes across sessions/crashes/anrs and
+    // zero-fills gaps, so every series gets padded to the union size.
     server.use(
-      http.get("*/api/apps/:appId/sessions/plots/instances", () => {
+      http.get("*/api/apps/:appId/health/plots/instances", () => {
         return HttpResponse.json([
           {
-            id: "3.1.0",
+            id: "sessions",
             data: [
               { datetime: "2026-04-01T00:00:00Z", instances: 100 },
               { datetime: "2026-04-02T00:00:00Z", instances: 200 },
             ],
           },
           {
-            id: "3.0.2",
+            id: "crashes",
             data: [
-              { datetime: "2026-04-01T00:00:00Z", instances: 50 },
-              { datetime: "2026-04-02T00:00:00Z", instances: 75 },
-              { datetime: "2026-04-03T00:00:00Z", instances: 25 },
+              { datetime: "2026-04-01T00:00:00Z", instances: 5 },
+              { datetime: "2026-04-02T00:00:00Z", instances: 7 },
+              { datetime: "2026-04-03T00:00:00Z", instances: 3 },
             ],
           },
+          {
+            id: "anrs",
+            data: [{ datetime: "2026-04-02T00:00:00Z", instances: 1 }],
+          },
         ]);
-      }),
-      http.get("*/api/apps/:appId/errorGroups/plots/instances", () => {
-        return HttpResponse.json([{ id: "3.1.0", data: twoDates }]);
       }),
     );
 
@@ -2430,8 +2392,8 @@ describe("Overview page — data shape edge cases", () => {
 
     await waitFor(
       () => {
-        // 3 unique dates across the 2 session versions (A01, A02, A03).
-        // All series get padded to 3 points (the union of all dates).
+        // 3 unique dates across the series (A01, A02, A03). All series get
+        // padded to 3 points (the union of all dates).
         const sessions = screen.getByTestId("chart-series-Sessions");
         expect(sessions.textContent).toContain("3 points");
       },

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -175,6 +175,46 @@ export function makeAnrPlotFixture() {
   ];
 }
 
+// --- Health Plot (GET /apps/:appId/health/plots/instances) ---
+// Single endpoint backing the overview app health plot. Response is
+// three series keyed by id: "sessions" | "crashes" | "anrs", each with
+// sparse { datetime, instances } points.
+
+export function makeHealthPlotFixture() {
+  return [
+    {
+      id: "sessions",
+      data: [
+        { datetime: "2026-04-01T00:00:00Z", instances: 1200 },
+        { datetime: "2026-04-02T00:00:00Z", instances: 1350 },
+        { datetime: "2026-04-03T00:00:00Z", instances: 1100 },
+        { datetime: "2026-04-04T00:00:00Z", instances: 1400 },
+        { datetime: "2026-04-05T00:00:00Z", instances: 1250 },
+      ],
+    },
+    {
+      id: "crashes",
+      data: [
+        { datetime: "2026-04-01T00:00:00Z", instances: 15 },
+        { datetime: "2026-04-02T00:00:00Z", instances: 12 },
+        { datetime: "2026-04-03T00:00:00Z", instances: 18 },
+        { datetime: "2026-04-04T00:00:00Z", instances: 10 },
+        { datetime: "2026-04-05T00:00:00Z", instances: 14 },
+      ],
+    },
+    {
+      id: "anrs",
+      data: [
+        { datetime: "2026-04-01T00:00:00Z", instances: 3 },
+        { datetime: "2026-04-02T00:00:00Z", instances: 2 },
+        { datetime: "2026-04-03T00:00:00Z", instances: 5 },
+        { datetime: "2026-04-04T00:00:00Z", instances: 1 },
+        { datetime: "2026-04-05T00:00:00Z", instances: 4 },
+      ],
+    },
+  ];
+}
+
 // --- Metrics (GET /apps/:appId/metrics) ---
 // Go structs: metrics.LaunchMetric, metrics.SessionAdoption, etc.
 // in backend/api/metrics/metrics.go

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -26,6 +26,7 @@ import {
   makeExceptionInstanceFixture,
   makeExceptionsOverviewFixture,
   makeFiltersFixture,
+  makeHealthPlotFixture,
   makeJourneyFixture,
   makeMetricsFixture,
   makeNetworkDomainsFixture,
@@ -82,6 +83,11 @@ export const handlers = [
       return HttpResponse.json(makeAnrPlotFixture());
     }
     return HttpResponse.json(makeCrashPlotFixture());
+  }),
+
+  // 6. GET /api/apps/:appId/health/plots/instances (overview app health plot)
+  http.get("*/api/apps/:appId/health/plots/instances", () => {
+    return HttpResponse.json(makeHealthPlotFixture());
   }),
 
   // 7. GET /api/apps/:appId/metrics

--- a/frontend/dashboard/__tests__/pages/overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/overview_test.tsx
@@ -39,12 +39,12 @@ jest.mock("@/app/components/filters", () => ({
 
 const { useFiltersStore } = require("@/app/stores/provider") as any;
 
-// Mock SessionsVsErrorsOverviewPlot component
-jest.mock("@/app/components/sessions_vs_errors_overview_plot", () => ({
+// Mock AppHealthPlot component
+jest.mock("@/app/components/app_health_plot", () => ({
   __esModule: true, // Ensures the mock behaves like an ES module
   default: () => (
-    <div data-testid="sessions-vs-errors-overview-plot-mock">
-      SessionsVsErrorsOverviewPlot Component Rendered
+    <div data-testid="app-health-plot-mock">
+      AppHealthPlot Component Rendered
     </div>
   ),
 }));
@@ -89,7 +89,7 @@ describe("Overview Component", () => {
     });
 
     expect(
-      await screen.findByTestId("sessions-vs-errors-overview-plot-mock"),
+      await screen.findByTestId("app-health-plot-mock"),
     ).toBeInTheDocument();
     expect(
       await screen.findByTestId("metrics-overview-mock"),

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -84,7 +84,7 @@ export enum FilterSource {
   Errors,
 }
 
-export enum SessionsVsErrorsPlotApiStatus {
+export enum AppHealthPlotApiStatus {
   Loading,
   Success,
   Error,
@@ -1756,68 +1756,57 @@ export const fetchFiltersFromServer = async (
   }
 };
 
-export const fetchSessionsVsErrorsPlotFromServer = async (filters: Filters) => {
-  // Fetch all three datasets in parallel
-  const [sessionsRes, crashesRes, anrsRes] = await Promise.all([
-    fetchSessionTimelinesOverviewPlotFromServer(filters),
-    fetchErrorsOverviewPlotFromServer({
-      ...filters,
-      selectedErrorTypes: ["error"],
-    }),
-    fetchErrorsOverviewPlotFromServer({
-      ...filters,
-      selectedErrorTypes: ["anr"],
-    }),
-  ]);
+export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
+  let url = `/api/apps/${filters.app!.id}/health/plots/instances?`;
 
-  // Handle error/no data
-  if (
-    sessionsRes.status !== SessionTimelinesOverviewPlotApiStatus.Success &&
-    sessionsRes.status !== SessionTimelinesOverviewPlotApiStatus.NoData
-  ) {
-    return { status: SessionsVsErrorsPlotApiStatus.Error, data: null };
-  }
-  if (
-    crashesRes.status !== ErrorsOverviewPlotApiStatus.Success &&
-    crashesRes.status !== ErrorsOverviewPlotApiStatus.NoData
-  ) {
-    return { status: SessionsVsErrorsPlotApiStatus.Error, data: null };
-  }
-  if (
-    anrsRes.status !== ErrorsOverviewPlotApiStatus.Success &&
-    anrsRes.status !== ErrorsOverviewPlotApiStatus.NoData
-  ) {
-    return { status: SessionsVsErrorsPlotApiStatus.Error, data: null };
-  }
+  url = await applyGenericFiltersToUrl(url, filters, null, null);
+  url = appendPlotTimeGroupToUrl(url, filters);
 
-  // Helper to flatten and merge all series of a type into a map of date -> count
-  function mergeSeries(seriesArr: any[], valueKey: string = "instances") {
-    const dateMap: Record<string, number> = {};
-    for (const series of seriesArr || []) {
-      for (const point of series.data || []) {
-        const date = point.datetime || point.x;
-        const value = point[valueKey] ?? point.y ?? 0;
-        dateMap[date] = (dateMap[date] || 0) + value;
-      }
+  let data: any;
+  try {
+    const res = await apiClient.fetch(url);
+
+    if (!res.ok) {
+      return { status: AppHealthPlotApiStatus.Error, data: null };
     }
-    return dateMap;
+
+    data = await res.json();
+  } catch {
+    return { status: AppHealthPlotApiStatus.Error, data: null };
   }
 
-  // Merge all series for each type
-  const sessionsMap = mergeSeries(sessionsRes.data || []);
-  const crashesMap = mergeSeries(crashesRes.data || []);
-  const anrsMap = mergeSeries(anrsRes.data || []);
+  if (data === null) {
+    return { status: AppHealthPlotApiStatus.NoData, data: null };
+  }
 
-  // Get all unique dates
+  // The server returns three sparse series keyed by id: "sessions", "crashes"
+  // and "anrs", each with { datetime, instances } points. Collapse each into a
+  // date -> count map.
+  const dateMaps: Record<string, Record<string, number>> = {
+    sessions: {},
+    crashes: {},
+    anrs: {},
+  };
+  for (const series of data || []) {
+    const dateMap = dateMaps[series.id];
+    if (dateMap === undefined) {
+      continue;
+    }
+    for (const point of series.data || []) {
+      dateMap[point.datetime] =
+        (dateMap[point.datetime] || 0) + (point.instances ?? 0);
+    }
+  }
+
+  // Align all three series on the same sorted set of dates, zero-filling gaps.
   const allDates = Array.from(
     new Set([
-      ...Object.keys(sessionsMap),
-      ...Object.keys(crashesMap),
-      ...Object.keys(anrsMap),
+      ...Object.keys(dateMaps.sessions),
+      ...Object.keys(dateMaps.crashes),
+      ...Object.keys(dateMaps.anrs),
     ]),
   ).sort();
 
-  // Build the final series arrays
   function buildSeries(id: string, map: Record<string, number>) {
     return {
       id,
@@ -1830,14 +1819,14 @@ export const fetchSessionsVsErrorsPlotFromServer = async (filters: Filters) => {
   }
 
   const result = [
-    buildSeries("Sessions", sessionsMap),
-    buildSeries("Crashes", crashesMap),
-    buildSeries("ANRs", anrsMap),
+    buildSeries("Sessions", dateMaps.sessions),
+    buildSeries("Crashes", dateMaps.crashes),
+    buildSeries("ANRs", dateMaps.anrs),
   ];
 
   // If all are empty, return NoData
   if (result.every((series) => series.data.every((point) => point.y === 0))) {
-    return { status: SessionsVsErrorsPlotApiStatus.NoData, data: null };
+    return { status: AppHealthPlotApiStatus.NoData, data: null };
   }
 
   // Remove ANRs if all y values are 0
@@ -1849,7 +1838,7 @@ export const fetchSessionsVsErrorsPlotFromServer = async (filters: Filters) => {
   });
 
   return {
-    status: SessionsVsErrorsPlotApiStatus.Success,
+    status: AppHealthPlotApiStatus.Success,
     data: filteredResult,
   };
 };

--- a/frontend/dashboard/app/components/app_health_plot.tsx
+++ b/frontend/dashboard/app/components/app_health_plot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSessionsVsErrorsPlotQuery } from "@/app/query/hooks";
+import { useAppHealthPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
 import { ResponsiveLine } from "@nivo/line";
 import { DateTime } from "luxon";
@@ -128,15 +128,13 @@ const demoPlot = [
   },
 ];
 
-interface SessionsVsErrorsPlotProps {
+interface AppHealthPlotProps {
   demo?: boolean;
 }
 
-const SessionsVsErrorsPlot: React.FC<SessionsVsErrorsPlotProps> = ({
-  demo = false,
-}) => {
+const AppHealthPlot: React.FC<AppHealthPlotProps> = ({ demo = false }) => {
   const filters = useFiltersStore((state) => state.filters);
-  const { data: queryPlot, status } = useSessionsVsErrorsPlotQuery();
+  const { data: queryPlot, status } = useAppHealthPlotQuery();
   const { theme } = useTheme();
   const chartColor = useChartColor();
   const plotTimeGroup = getPlotTimeGroupForRange(
@@ -261,4 +259,4 @@ const SessionsVsErrorsPlot: React.FC<SessionsVsErrorsPlotProps> = ({
   );
 };
 
-export default SessionsVsErrorsPlot;
+export default AppHealthPlot;

--- a/frontend/dashboard/app/components/overview.tsx
+++ b/frontend/dashboard/app/components/overview.tsx
@@ -5,7 +5,7 @@ import Filters, {
   AppVersionsInitialSelectionType,
 } from "@/app/components/filters";
 import MetricsOverview from "@/app/components/metrics_overview";
-import SessionsVsErrorsPlot from "@/app/components/sessions_vs_errors_overview_plot";
+import AppHealthPlot from "@/app/components/app_health_plot";
 import { Skeleton, SkeletonPlot } from "@/app/components/skeleton";
 import { useFiltersStore } from "@/app/stores/provider";
 import { useRouter } from "next/navigation";
@@ -88,7 +88,7 @@ export default function Overview({
 
       {(demo || filters.ready) && (
         <>
-          <SessionsVsErrorsPlot demo={demo} />
+          <AppHealthPlot demo={demo} />
           <div className="py-8" />
           <MetricsOverview demo={demo} />
         </>

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -48,7 +48,7 @@ import {
   SessionTimelineApiStatus,
   SessionTimelinesOverviewApiStatus,
   SessionTimelinesOverviewPlotApiStatus,
-  SessionsVsErrorsPlotApiStatus,
+  AppHealthPlotApiStatus,
   SpanMetricsPlotApiStatus,
   SpansApiStatus,
   Team,
@@ -105,7 +105,7 @@ import {
   fetchSessionTimelineFromServer,
   fetchSessionTimelinesOverviewFromServer,
   fetchSessionTimelinesOverviewPlotFromServer,
-  fetchSessionsVsErrorsPlotFromServer,
+  fetchAppHealthPlotFromServer,
   fetchSpanMetricsPlotFromServer,
   fetchSpansFromServer,
   fetchTeamSlackConnectUrlFromServer,
@@ -758,16 +758,16 @@ export function useSessionTimelinesOverviewPlotQuery() {
   });
 }
 
-export function useSessionsVsErrorsPlotQuery() {
+export function useAppHealthPlotQuery() {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
-    queryKey: ["sessionsVsErrorsPlot", filters.serialisedFilters] as const,
+    queryKey: ["appHealthPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
-      const result = await fetchSessionsVsErrorsPlotFromServer(filters);
-      if (result.status === SessionsVsErrorsPlotApiStatus.Error) {
-        throw new Error("Failed to fetch sessions vs errors plot");
+      const result = await fetchAppHealthPlotFromServer(filters);
+      if (result.status === AppHealthPlotApiStatus.Error) {
+        throw new Error("Failed to fetch app health plot");
       }
-      if (result.status === SessionsVsErrorsPlotApiStatus.NoData) {
+      if (result.status === AppHealthPlotApiStatus.NoData) {
         return null;
       }
       return result.data;


### PR DESCRIPTION
# Description

Overview app health plot (previously called sessions vs errors overview plot) used to make 3 different api calls to stitch the plot. It also had a bug where instead of using full session count, it would only query session with timelines skewing the count.

This commit:
- adds a new `app/:id/health/plots/instances` that returns session counts against crashes and anrs
- queries sessions from app metrics for consistency
- adds tests
- refactors related test seed helpers to take multiple parameters instead of hardcoding them
- renames `sessions_vs _errors_overview_plot` to `app_health_plot`

## Related issue
Fixes #3752



