### PR TITLE
docs(backend): add usage notes for patch_id

### DIFF
--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -314,6 +314,7 @@ to the returned URLs. For uploading the files, you can issue a standard http req
   - A second `.tgz` containing the matching sourcemap (e.g. `main.jsbundle.map`, `index.android.bundle.map`).
 
   Symbolication pairs the two server-side via the inner filename's `.map` suffix, so the inner filenames must follow the `<bundle>` / `<bundle>.map` convention.
+- `patch_id` is optional. When supplied, it must be a valid UUID. Every mapping in the request is associated with this `patch_id` and the value is echoed back on each mapping object in the response. Use this to tag mappings that belong to an Over-The-Air patch (e.g. CodePush for React Native, Shorebird for Flutter) so the SDK can later refer to the exact mapping at symbolication time. When omitted, mappings are stored without a patch reference and are looked up by `version_name` + `version_code` instead.
 - For mapping filename, only provide the filename, not a path.
 - When `mappings` is present, the server returns a mappings array containing the pre-signed URL for uploading each mapping file.
 - Each pre-signed mapping file upload URL has an expiry set which is the same as the `expires_at` field.
@@ -361,7 +362,8 @@ curl -X PUT \
         "headers": {
           "x-amz-meta-mapping_id": "e2bbcad8-0566-44ea-af43-9dd114c64e8c",
           "x-amz-meta-original_file_name": "DemoApp.app.dSYM.tgz"
-        }
+        },
+        "patch_id": "550e8400-e29b-41d4-a716-446655440000"
       },
       {
         "id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
@@ -372,11 +374,14 @@ curl -X PUT \
         "headers": {
           "x-amz-meta-mapping_id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
           "x-amz-meta-original_file_name": "app.symbols"
-        }
+        },
+        "patch_id": "550e8400-e29b-41d4-a716-446655440000"
       }
     ]
   }
   ```
+
+  Each mapping object includes a `patch_id` field only when the request supplied one. It is omitted otherwise.
 
 #### Request Body
 
@@ -393,6 +398,7 @@ Payload must contain the app version info, build info and optional build mapping
   "version_code": "10",
   "build_size": 10241024,
   "build_type": "ipa",
+  "patch_id": "550e8400-e29b-41d4-a716-446655440000",
   "mappings": [
     {
       "type": "dsym",
@@ -414,13 +420,14 @@ Payload must contain the app version info, build info and optional build mapping
 }
 ```
 
-| Field          | Type   | Optional | Comment                                                                 |
-| -------------- | ------ | -------- | ----------------------------------------------------------------------- |
-| `version_name` | string | No       | Version name of the build. Like "1.0"                                   |
-| `version_code` | string | No       | Version code of the build. Like "999"                                   |
-| `build_size`   | string | No       | Size of app in bytes                                                    |
-| `build_type`   | string | No       | Type of the build.<br />- `aab`, `apk` for Android<br />- `ipa` for iOS |
-| `mappings`     | array  | Yes      | List of mapping files objects.                                          |
+| Field          | Type   | Optional | Comment                                                                                                                                 |
+| -------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `version_name` | string | No       | Version name of the build. Like "1.0"                                                                                                   |
+| `version_code` | string | No       | Version code of the build. Like "999"                                                                                                   |
+| `build_size`   | string | No       | Size of app in bytes                                                                                                                    |
+| `build_type`   | string | No       | Type of the build.<br />- `aab`, `apk` for Android<br />- `ipa` for iOS                                                                 |
+| `patch_id`     | string | Yes      | Optional UUID identifying an Over-The-Air patch this build's mappings belong to. Omit when uploading a regular (non-OTA) build's mappings. |
+| `mappings`     | array  | Yes      | List of mapping files objects.                                                                                                          |
 
 ##### Mappings
 


### PR DESCRIPTION
## Summary

This PR updates the SDK API docs to explain the usage of `patch_id.`

## Tasks

- [x] Update SDK API docs to explain usage of `patch_id`