### PR TITLE
fix(backend): send iam auth token for js symbolication

### DIFF
--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -1070,6 +1070,33 @@ func getGCSCreds() (*auth.Credentials, error) {
 	return gcsCreds.creds, nil
 }
 
+// mintSymboloaderToken returns the bearer credential used for
+// requests to symboloader's /symbols and /symbols/js endpoints.
+//
+// On cloud it mints a Google OIDC ID token scoped to the
+// symboloader origin, satisfying symboloader's Cloud Run IAM
+// invoker check. The token is audience-scoped to the service, so
+// a single value authorizes both the ProGuard and JS lookups
+// regardless of the app's OS. On self-host it returns the static
+// placeholder symboloader currently accepts.
+//
+// Callers must guard on a non-empty SymboloaderOrigin before
+// calling; the cloud path needs it as the token audience.
+func mintSymboloaderToken(ctx context.Context, config *server.ServerConfig) (token string, err error) {
+	if !config.IsCloud() {
+		return "measure", nil
+	}
+	ts, err := idtoken.NewTokenSource(ctx, config.SymboloaderOrigin)
+	if err != nil {
+		return
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return
+	}
+	return tok.AccessToken, nil
+}
+
 // PushHandler handles incoming Pub/Sub push messages containing
 // ingest batches published by the ingest service.
 func PushHandler(c *gin.Context) {
@@ -1242,6 +1269,20 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 		sources := []symbolicator.Source{}
 		var sentrySources []symbolicator.SentrySource
 
+		// Mint the symboloader bearer token once per batch. The same
+		// audience-scoped token authorizes both the ProGuard (/symbols)
+		// and JS (/symbols/js) lookups, so it is computed here rather
+		// than per-OS. Stays empty on a cloud minting failure; the
+		// sources below skip rather than send an invalid token.
+		var symboloaderTok string
+		if config.SymboloaderOrigin != "" {
+			if tok, tokErr := mintSymboloaderToken(ingestCtx, config); tokErr != nil {
+				fmt.Printf("failed to obtain symboloader token: %v\n", tokErr)
+			} else {
+				symboloaderTok = tok
+			}
+		}
+
 		switch opsys.ToFamily(osName) {
 		case opsys.Android:
 			if config.IsCloud() {
@@ -1256,19 +1297,8 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 			} else {
 				sources = append(sources, symbolicator.NewS3SourceAndroid("msr-symbols", config.SymbolsBucket, config.SymbolsBucketRegion, config.AWSEndpoint, config.SymbolsAccessKey, config.SymbolsSecretAccessKey))
 			}
-			if config.SymboloaderOrigin != "" {
-				if config.IsCloud() {
-					ts, err := idtoken.NewTokenSource(ingestCtx, config.SymboloaderOrigin)
-					if err != nil {
-						fmt.Printf("failed to create identity token source for symboloader: %v\n", err)
-					} else if tok, err := ts.Token(); err != nil {
-						fmt.Printf("failed to generate identity token for symboloader: %v\n", err)
-					} else {
-						sentrySources = append(sentrySources, symbolicator.NewSentrySource("msr-symbols-sentry", config.SymboloaderOrigin+"/symbols", tok.AccessToken))
-					}
-				} else {
-					sentrySources = append(sentrySources, symbolicator.NewSentrySource("msr-symbols-sentry", config.SymboloaderOrigin+"/symbols", "measure"))
-				}
+			if symboloaderTok != "" {
+				sentrySources = append(sentrySources, symbolicator.NewSentrySource("msr-symbols-sentry", config.SymboloaderOrigin+"/symbols", symboloaderTok))
 			}
 		case opsys.AppleFamily:
 			if config.IsCloud() {
@@ -1293,6 +1323,7 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 
 		symblctr := symbolicator.New(origin, osName, sources, sentrySources)
 		symblctr.SymboloaderOrigin = config.SymboloaderOrigin
+		symblctr.SymboloaderToken = symboloaderTok
 
 		_, symbolicationSpan := ingestTracer.Start(ingestCtx, "symbolicate-events")
 		defer symbolicationSpan.End()

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -153,6 +153,13 @@ type Symbolicator struct {
 	// will be pointed at the /symbols/js endpoint hosted
 	// on symboloader. If empty, JS symbolication is skipped.
 	SymboloaderOrigin string
+	// SymboloaderToken is the bearer credential sent to the
+	// symboloader /symbols/js endpoint. On cloud it is a Google
+	// OIDC ID token (audience = SymboloaderOrigin) required by
+	// symboloader's Cloud Run IAM invoker check; on self-host it
+	// is the static placeholder. Set by the caller after New,
+	// alongside SymboloaderOrigin.
+	SymboloaderToken string
 	// jvmLambdaWorkaround determines if each of the
 	// JVM stacktrace class names should be matched
 	// and replaced during the rewrite stage of
@@ -281,7 +288,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 				}
 				s.jsSymbolicator.ensureRequestInitialized()
 				s.jsSymbolicator.parseExceptions(ev.Exception.Exceptions, i)
-				s.jsSymbolicator.configureSource(s.SymboloaderOrigin, appId, ev.Attribute.AppVersion, ev.Attribute.AppBuild)
+				s.jsSymbolicator.configureSource(s.SymboloaderOrigin, s.SymboloaderToken, appId, ev.Attribute.AppVersion, ev.Attribute.AppBuild)
 				s.jsSymbolicator.populateModules(ev)
 			}
 		case event.TypeANR:
@@ -1004,9 +1011,13 @@ func (js *jsSymbolicator) parseExceptions(exceptions event.ExceptionUnits, index
 // itself isn't checked against anything; the /symbols/js
 // endpoint ignores it and scopes via app_id + version.
 //
-// The token is a placeholder for now — /symbols/js does not
-// validate it. Real per-app authentication is a follow-up.
-func (js *jsSymbolicator) configureSource(symboloaderOrigin string, appID uuid.UUID, versionName, versionCode string) {
+// token is the bearer credential Symbolicator forwards verbatim
+// as `Authorization: Bearer <token>` when it GETs /symbols/js. On
+// cloud it is a Google OIDC ID token that satisfies symboloader's
+// Cloud Run IAM invoker check; on self-host it is the static
+// placeholder. It is minted by the caller (see
+// mintSymboloaderToken) and supplied via Symbolicator.SymboloaderToken.
+func (js *jsSymbolicator) configureSource(symboloaderOrigin, token string, appID uuid.UUID, versionName, versionCode string) {
 	q := url.Values{}
 	q.Set("app_id", appID.String())
 	q.Set("version_name", versionName)
@@ -1017,7 +1028,7 @@ func (js *jsSymbolicator) configureSource(symboloaderOrigin string, appID uuid.U
 	js.request.Source = NewSentrySource(
 		"measure-symboloader",
 		sourceURL,
-		"measure",
+		token,
 	)
 	js.request.Release = versionName + "+" + versionCode
 }

--- a/backend/ingest-worker/symbolicator/symbolicator_test.go
+++ b/backend/ingest-worker/symbolicator/symbolicator_test.go
@@ -1411,6 +1411,9 @@ func TestJSExceptionSymbolicationNonOTA(t *testing.T) {
 	// SymboloaderOrigin inside configureSource. Pass nils.
 	symb := New(symbolicatorOrigin, "ios", nil, nil)
 	symb.SymboloaderOrigin = symboloaderOriginURL
+	// Mirror the self-host wire shape: the static placeholder
+	// bearer. The test symboloader does not validate it.
+	symb.SymboloaderToken = "measure"
 
 	if err := symb.Symbolicate(ctx, pgPool, appID, events, nil); err != nil {
 		t.Fatalf("Symbolicate failed: %v", err)


### PR DESCRIPTION
## Summary

This PR fixes JS symbolication on cloud with a `401` — Symbolicator's `GET /symbols/js` to symboloader was rejected by Cloud Run IAM, since it sent a static `"measure"` bearer instead of a Google OIDC ID token. This mints a real ID token in ingest-worker, mirroring the existing ProGuard `/symbols` path.


## Tasks

- [x] Mint a Google OIDC ID token in ingest-worker for `/symbols/js` requests, fixing the `401` from symboloader's Cloud Run IAM invoker check
- [x] Add `mintSymboloaderToken` helper: ID token (audience = `SymboloaderOrigin`) on cloud, `"measure"` placeholder on self-host
- [x] Compute the token once per batch & share it across the ProGuard (`/symbols`) & JS (`/symbols/js`) lookups, covering both Android & iOS RN
- [x] Thread the token through `Symbolicator.SymboloaderToken` into `configureSource`, replacing the hardcoded `"measure"`
- [x] Collapse the Android-only ProGuard token block to reuse the shared token
- [x] Self-host & ProGuard paths remain behaviorally unchanged