### PR TITLE
fix(backend): prevent panic in apple symbolication

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -776,6 +776,13 @@ func (e *EventField) Validate(opts ...ingest.ValidationOptions) error {
 		f := e.Exception.GetFramework()
 		switch f {
 		case FrameworkApple:
+			// Apple framework is exclusive to Apple operating
+			// systems, unlike "js" or "dart" which are
+			// cross-platform.
+			if opsys.ToFamily(e.Attribute.OSName) != opsys.AppleFamily {
+				return fmt.Errorf(`%q framework requires an Apple os_name, got %q`, f, e.Attribute.OSName)
+			}
+
 			// Apple exceptions may contain error with stacktrace or
 			// may not contain error. If it does not contain error,
 			// then validate that stacktrace must be present.

--- a/backend/api/event/event_test.go
+++ b/backend/api/event/event_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 func readException(path string) (exception Exception, err error) {
@@ -939,6 +942,47 @@ func TestHasJSFrames(t *testing.T) {
 
 		if e.HasJSFrames() {
 			t.Errorf("Expected HasJSFrames to return false for non-JS framework, got true")
+		}
+	})
+}
+
+func TestValidateAppleFrameworkOSName(t *testing.T) {
+	makeEvent := func(osName string) EventField {
+		return EventField{
+			ID:        uuid.New(),
+			AppID:     uuid.New(),
+			Type:      TypeException,
+			Timestamp: time.Now(),
+			Attribute: Attribute{OSName: osName},
+			Exception: &Exception{
+				Framework: FrameworkApple,
+				Exceptions: ExceptionUnits{
+					{
+						Type: "EXC_BAD_ACCESS",
+						ExceptionUnitiOS: &ExceptionUnitiOS{
+							Signal: "SIGSEGV",
+						},
+						Frames: Frames{{}},
+					},
+				},
+				Threads: Threads{
+					{Name: "main", Frames: Frames{{}}},
+				},
+			},
+		}
+	}
+
+	t.Run("Rejects apple framework on non-Apple os_name", func(t *testing.T) {
+		ev := makeEvent("android")
+		if err := ev.Validate(); err == nil {
+			t.Error("Expected validation error for apple framework with android os_name, got nil")
+		}
+	})
+
+	t.Run("Accepts apple framework on Apple os_name", func(t *testing.T) {
+		ev := makeEvent("ios")
+		if err := ev.Validate(); err != nil {
+			t.Errorf("Expected no validation error for apple framework with ios os_name, got %v", err)
 		}
 	})
 }

--- a/backend/ingest-worker/symbolicator/apple_test.go
+++ b/backend/ingest-worker/symbolicator/apple_test.go
@@ -1,0 +1,88 @@
+package symbolicator
+
+import (
+	"backend/api/event"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// makeAppleExceptionEvent builds a minimal apple-framework
+// exception event with the given exception units.
+func makeAppleExceptionEvent(units event.ExceptionUnits) event.EventField {
+	return event.EventField{
+		ID:        uuid.New(),
+		SessionID: uuid.New(),
+		Timestamp: time.Now(),
+		Type:      event.TypeException,
+		Attribute: event.Attribute{OSName: "ios"},
+		Exception: &event.Exception{
+			Framework:  event.FrameworkApple,
+			Exceptions: units,
+			Threads: event.Threads{
+				{Name: "main", Frames: event.Frames{}},
+			},
+		},
+	}
+}
+
+// TestSymbolicateAppleEventWithoutAppleSymbolicator verifies that an
+// apple-framework exception event in a batch whose Symbolicator was
+// initialized for a non-Apple OS is skipped instead of panicking on
+// the nil appleSymbolicator receiver. This was the root cause of a
+// production SIGSEGV in makeAppleCrashReport.
+func TestSymbolicateAppleEventWithoutAppleSymbolicator(t *testing.T) {
+	s := New("http://localhost:3021", "android", nil, nil)
+
+	units := event.ExceptionUnits{
+		{
+			Type: "EXC_BAD_ACCESS",
+			ExceptionUnitiOS: &event.ExceptionUnitiOS{
+				Signal: "SIGSEGV",
+			},
+			Frames: event.Frames{},
+		},
+	}
+	evs := []event.EventField{makeAppleExceptionEvent(units)}
+
+	// Must not panic. The apple event is skipped before any
+	// database or symbolicator service access.
+	if err := s.Symbolicate(context.Background(), nil, uuid.New(), evs, nil); err != nil {
+		t.Errorf("Expected no error symbolicating batch, got %v", err)
+	}
+}
+
+// TestMakeAppleCrashReportNilExceptionUnitiOS verifies that exception
+// units lacking iOS unit data are skipped instead of panicking on the
+// nil embedded ExceptionUnitiOS pointer.
+func TestMakeAppleCrashReportNilExceptionUnitiOS(t *testing.T) {
+	units := event.ExceptionUnits{
+		{
+			Type: "EXC_BAD_ACCESS",
+			ExceptionUnitiOS: &event.ExceptionUnitiOS{
+				Signal:        "SIGSEGV",
+				ThreadName:    "main",
+				OSBuildNumber: "22F76",
+			},
+			Frames: event.Frames{},
+		},
+		{
+			Type:   "NSGenericException",
+			Frames: event.Frames{},
+		},
+	}
+	ev := makeAppleExceptionEvent(units)
+
+	as := &appleSymbolicator{}
+
+	// Must not panic.
+	as.makeAppleCrashReport(ev)
+
+	report := string(as.appleCrashReport)
+	if got := strings.Count(report, "Exception Type:"); got != 1 {
+		t.Errorf("Expected exactly 1 crash report section, got %d:\n%s", got, report)
+	}
+}

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -231,6 +231,10 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 		// in place and do not need any
 		// further processing
 		if ev.Type == event.TypeException && ev.Exception.GetFramework() == event.FrameworkApple {
+			if s.appleSymbolicator == nil {
+				fmt.Printf("skipping apple symbolication for event %s: symbolicator initialized for os %q\n", ev.ID, s.OSName)
+				continue
+			}
 			s.appleSymbolicator.symbolicate(ev, s.Origin, s.Sources)
 			continue
 		}
@@ -717,6 +721,14 @@ func (as *appleSymbolicator) makeAppleCrashReport(event event.EventField) {
 	var b strings.Builder
 
 	for j, exception := range event.Exception.Exceptions {
+		// a unit without signal/thread info cannot produce
+		// a meaningful crash report section
+		if exception.ExceptionUnitiOS == nil {
+			unit, _ := json.Marshal(exception)
+			fmt.Printf("skipping apple crash report section for event %s: exception unit %d has no iOS unit data: %s\n", event.ID, j, string(unit))
+			continue
+		}
+
 		// write os info
 		b.WriteString(fmt.Sprintf("Version: %s (%s)\n", event.Attribute.AppVersion, event.Attribute.AppBuild))
 


### PR DESCRIPTION
## Summary

This PR fixes an Apple symbolication edge case that might happen when a batch contain mixed OS events.

## Tasks

- [x] Guard against nil `appleSymbolicator` in `Symbolicate`
- [x] Reject `apple` framework exceptions on non-Apple `os_name`
- [x] Skip exception units lacking `ExceptionUnitiOS` data
- [x] Add tests for panic & validation paths