### PR TITLE
chore(backend): upgrade to clickhouse 26.2

### DIFF
--- a/backend/alerts/server/server.go
+++ b/backend/alerts/server/server.go
@@ -212,7 +212,7 @@ func Init(config *ServerConfig) {
 
 	chOpts.Settings = clickhouse.Settings{
 		// read more: https://clickhouse.com/docs/operations/settings/settings#compatibility
-		"compatibility": "25.12",
+		"compatibility": "26.2",
 	}
 
 	chPool, err = clickhouse.Open(chOpts)

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -469,7 +469,7 @@ func Init(config *ServerConfig) {
 
 	if gin.Mode() == gin.ReleaseMode {
 		// read more: https://clickhouse.com/docs/operations/settings/settings#compatibility
-		compatibility := "25.12"
+		compatibility := "26.2"
 		chOpts.Settings = clickhouse.Settings{
 			"wait_for_async_insert":         1,
 			"wait_for_async_insert_timeout": 1000,

--- a/backend/ingest-worker/server/server.go
+++ b/backend/ingest-worker/server/server.go
@@ -360,7 +360,7 @@ func Init(config *ServerConfig) {
 		chOpts.Settings = clickhouse.Settings{
 			"wait_for_async_insert":         1,
 			"wait_for_async_insert_timeout": 1000,
-			"compatibility":                 "25.10",
+			"compatibility":                 "26.2",
 		}
 
 		chOpts.Compression = &clickhouse.Compression{

--- a/backend/ingest/server/server.go
+++ b/backend/ingest/server/server.go
@@ -312,7 +312,7 @@ func Init(config *ServerConfig) {
 		chOpts.Settings = clickhouse.Settings{
 			"wait_for_async_insert":         1,
 			"wait_for_async_insert_timeout": 1000,
-			"compatibility":                 "25.12",
+			"compatibility":                 "26.2",
 		}
 
 		chOpts.Compression = &clickhouse.Compression{

--- a/backend/testinfra/testinfra.go
+++ b/backend/testinfra/testinfra.go
@@ -24,7 +24,7 @@ import (
 const (
 	// Test database credentials.
 	postgresImage   = "postgres:16.3-alpine"
-	clickhouseImage = "clickhouse/clickhouse-server:25.12-alpine"
+	clickhouseImage = "clickhouse/clickhouse-server:26.2-alpine"
 	valkeyImage     = "valkey/valkey:8-alpine"
 	testDBUser      = "test"
 	testDBPassword  = "test"

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -654,7 +654,7 @@ services:
       - ./postgres/init-postgres.sh:/docker-entrypoint-initdb.d/init-postgres.sh
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12-alpine
+    image: clickhouse/clickhouse-server:26.2-alpine
     environment:
       - CLICKHOUSE_DB=measure
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}


### PR DESCRIPTION
## Summary

This PR upgrades to clickhouse 26.2 & sets version compatibility across all services.

## Tasks

- [x] Upgrade to clickhouse 26.2
- [x] Set clickhouse version compatibility to 26.2

## See also

- fixes #3806

