### PR TITLE
fix(frontend): refresh app display after api key rotation

### DIFF
--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -501,6 +501,80 @@ describe("Filters — store state after queries resolve", () => {
   });
 });
 
+describe("Filters — selectedApp sync on refetch", () => {
+  it("updates selectedApp when a refetch returns the same id with a rotated api_key", async () => {
+    setAppsSuccess([makeApp("a")]);
+    setFiltersSuccess();
+    await renderFilters();
+    await waitFor(() => {
+      expect(storeInstance.getState().selectedApp?.id).toBe("a");
+      expect(storeInstance.getState().selectedApp?.api_key.key).toBe("k");
+    });
+
+    // Same app id, new key — exactly what an API key rotation produces.
+    const next: App = {
+      ...makeApp("a"),
+      api_key: {
+        created_at: "",
+        key: "rotated-key",
+        last_seen: null,
+        revoked: false,
+      },
+    };
+    setAppsSuccess([next]);
+    await act(async () => {
+      // Mirrors the refetch landing in the store; forces the sync effect
+      // (keyed on appsQuery.data) to re-run against the fresh apps list.
+      storeInstance.getState().setApps([next], AppsApiStatus.Success);
+    });
+
+    await waitFor(() => {
+      expect(storeInstance.getState().selectedApp?.api_key.key).toBe(
+        "rotated-key",
+      );
+    });
+  });
+
+  it("updates selectedApp when a refetch flips the onboarded flag for the same id", async () => {
+    setAppsSuccess([makeApp("a", false)]);
+    setFiltersSuccess();
+    await renderFilters();
+    await waitFor(() => {
+      expect(storeInstance.getState().selectedApp?.onboarded).toBe(false);
+    });
+
+    const next = makeApp("a", true);
+    setAppsSuccess([next]);
+    await act(async () => {
+      storeInstance.getState().setApps([next], AppsApiStatus.Success);
+    });
+
+    await waitFor(() => {
+      expect(storeInstance.getState().selectedApp?.onboarded).toBe(true);
+    });
+  });
+
+  it("does not replace selectedApp when a refetch returns identical content", async () => {
+    setAppsSuccess([makeApp("a")]);
+    setFiltersSuccess();
+    await renderFilters();
+    await waitFor(() => {
+      expect(storeInstance.getState().selectedApp?.id).toBe("a");
+    });
+    const before = storeInstance.getState().selectedApp;
+
+    // A refetch hands back a fresh object with identical content.
+    const refetched = makeApp("a");
+    setAppsSuccess([refetched]);
+    await act(async () => {
+      storeInstance.getState().setApps([refetched], AppsApiStatus.Success);
+    });
+
+    // appsEqual sees no change, so the store keeps the same object reference.
+    expect(storeInstance.getState().selectedApp).toBe(before);
+  });
+});
+
 describe("Filters — date initialization", () => {
   it("defaults to Last 6 Hours on first-ever mount", async () => {
     setAppsSuccess([makeApp("a")]);

--- a/frontend/dashboard/__tests__/pages/apps_test.tsx
+++ b/frontend/dashboard/__tests__/pages/apps_test.tsx
@@ -1483,6 +1483,75 @@ describe("Apps Page", () => {
     ).toBeInTheDocument();
   });
 
+  describe("editable state on app change", () => {
+    // Make unsaved retention (30 → 90) and threshold (good 95 → 90) edits.
+    const makeEdits = async () => {
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("retention-select-90"));
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("error-good-threshold-input"), {
+          target: { value: "90" },
+        });
+      });
+    };
+
+    // Retention and rename are the two plain "Save" buttons (retention first);
+    // the threshold button is labelled "Save thresholds".
+    const retentionSave = () =>
+      screen.getAllByRole("button", { name: "Save" })[0];
+    const thresholdSave = () =>
+      screen.getByRole("button", { name: "Save thresholds" });
+
+    it("keeps unsaved retention and threshold edits when the current app is renamed", async () => {
+      await renderLoadedPage();
+      await makeEdits();
+
+      expect(retentionSave()).not.toBeDisabled();
+      expect(thresholdSave()).not.toBeDisabled();
+
+      // A rename lands via a filters refresh: same id, new name.
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            app: { ...getAppPayload(), name: "Renamed App" },
+            serialisedFilters: "app=app-1",
+          },
+        });
+      });
+
+      // The name input follows the rename...
+      expect(screen.getByDisplayValue("Renamed App")).toBeInTheDocument();
+      // ...but the unsaved edits survive because the id is unchanged.
+      expect(retentionSave()).not.toBeDisabled();
+      expect(thresholdSave()).not.toBeDisabled();
+    });
+
+    it("drops unsaved retention and threshold edits when switching to a different app", async () => {
+      await renderLoadedPage();
+      await makeEdits();
+
+      expect(retentionSave()).not.toBeDisabled();
+      expect(thresholdSave()).not.toBeDisabled();
+
+      // Switch to a different app (new id) via a filters update.
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            app: { ...getAppPayload(), id: "app-2", name: "Other App" },
+            serialisedFilters: "app=app-2",
+          },
+        });
+      });
+
+      // Edits reset to the saved values, so both save buttons disable again.
+      expect(retentionSave()).toBeDisabled();
+      expect(thresholdSave()).toBeDisabled();
+    });
+  });
+
   describe("Threshold Preferences", () => {
     it("shows threshold sections after app filters load", async () => {
       await renderLoadedPage();

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -22,6 +22,7 @@ jest.mock("@/app/query/query_client", () => ({
 
 import {
   applyFilterOptions,
+  appsEqual,
   AppVersionsInitialSelectionType,
   createFiltersStore,
   type FilterOptionsData,
@@ -135,6 +136,52 @@ describe("pickApp", () => {
   it("skips invalid URL appId and falls through to next priority", () => {
     const picked = pickApp(apps, initConfig({ appId: "no-such" }, "b"), null);
     expect(picked?.id).toBe("b");
+  });
+});
+
+describe("appsEqual", () => {
+  it("returns true for the same reference", () => {
+    const a = makeApp("a");
+    expect(appsEqual(a, a)).toBe(true);
+  });
+
+  it("returns true for distinct objects with identical content", () => {
+    expect(appsEqual(makeApp("a"), makeApp("a"))).toBe(true);
+  });
+
+  it("returns false when the api_key changes (rotation, same id)", () => {
+    const before = makeApp("a");
+    const after = makeApp("a", {
+      api_key: { ...before.api_key, key: "rotated" },
+    });
+    expect(appsEqual(before, after)).toBe(false);
+  });
+
+  it("returns false when the name changes (rename, same id)", () => {
+    expect(appsEqual(makeApp("a"), makeApp("a", { name: "Renamed" }))).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the onboarded flag flips (same id)", () => {
+    expect(
+      appsEqual(
+        makeApp("a", { onboarded: false }),
+        makeApp("a", { onboarded: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when the id differs", () => {
+    expect(appsEqual(makeApp("a"), makeApp("b"))).toBe(false);
+  });
+
+  it("returns false when a nested api_key field other than the key changes", () => {
+    const before = makeApp("a");
+    const after = makeApp("a", {
+      api_key: { ...before.api_key, last_seen: "2026-01-01T00:00:00Z" },
+    });
+    expect(appsEqual(before, after)).toBe(false);
   });
 });
 

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -116,13 +116,22 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
   const filtersRef = useRef<any>(null);
 
-  // Sync app name when filters become ready or change.
+  // Sync the editable name input to the selected app. Keyed on name so a
+  // rename (which updates filters.app in place) re-syncs the input to the
+  // server's stored value.
   const [prevAppName, setPrevAppName] = useState<string>("");
   if (filters.ready && filters.app && filters.app.name !== prevAppName) {
     setPrevAppName(filters.app.name);
     setAppName(filters.app.name);
     setSaveAppNameButtonDisabled(true);
-    // Reset editable state when app changes
+  }
+
+  // Drop unsaved retention/threshold edits when the selected app actually
+  // changes. Keyed on id so renaming the current app doesn't discard
+  // in-progress edits.
+  const [prevAppId, setPrevAppId] = useState<string>("");
+  if (filters.ready && filters.app && filters.app.id !== prevAppId) {
+    setPrevAppId(filters.app.id);
     setUpdatedRetention(null);
     setEditableThresholdPrefs(null);
   }

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -38,6 +38,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import {
   applyFilterOptions,
+  appsEqual,
   AppVersionsInitialSelectionType,
   defaultSessionTypes,
   expandRangesToArray,
@@ -666,13 +667,11 @@ const FiltersComponent = forwardRef<
       if (!picked) {
         return;
       }
-      // Skip the setter when nothing changed — apps reference churns on
-      // every refetch even when the picked app is the same.
-      if (!selectedApp || selectedApp.id !== picked.id) {
-        store.setSelectedApp(picked);
-      } else if (selectedApp.onboarded !== picked.onboarded) {
-        // Same id, new onboarded flag (poller saw verification). Update
-        // in place without wiping selections.
+      // Sync selectedApp when the refetched app differs in any field, not
+      // just id: a rotated api_key, rename, or onboarded flip keeps the
+      // same id. A same-id update is fine since setSelectedApp only clears
+      // the user's version/OS filter selections when the id changes.
+      if (!selectedApp || !appsEqual(selectedApp, picked)) {
         store.setSelectedApp(picked);
       }
     }, [appsQuery.status, appsQuery.data, teamId]);

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -891,6 +891,17 @@ export function pickApp(
   return apps[0];
 }
 
+// True when two apps carry identical data. A refetch hands back a brand-new
+// app object every time, so reference identity can't distinguish "same app,
+// fresh fields" (e.g. a rotated api_key or a flipped onboarded flag) from
+// "genuinely unchanged". Structural equality can — and stays correct as the
+// App shape grows, since it compares whatever fields exist rather than a
+// hand-picked subset. Both apps originate from the same apps query response,
+// so their key order matches and stringify comparison is reliable.
+export function appsEqual(a: App, b: App): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 export function resolveRootSpanName(
   rootSpanNames: string[],
   initConfig: InitConfig,


### PR DESCRIPTION
# Description

After a rotation the apps query refetches with the new key, but selectedApp was only re-synced when the app id or onboarded flag changed. A rotated key (or a rename) keeps the same id, so the displayed key/name stayed stale.

Sync selectedApp whenever the refetched app differs in any field, via a structural compare (appsEqual). setSelectedApp only clears per-app filter selections on an id change, so a same-id update is safe.

Also split the apps page's app-change effect: the name input stays keyed on name, while the retention/threshold edit reset moves to an id check so renaming the current app no longer discards unsaved edits.

Add tests for appsEqual, the refetch sync, and rename/switch behavior.

## Related issue
Fixes #3811



