### PR TITLE
fix(frontend): give session timeline events unique React keys

### DIFF
--- a/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/session_timelines_msw_test.tsx
@@ -86,7 +86,9 @@ import {
 import { server } from "../msw/server";
 
 jest.spyOn(console, "log").mockImplementation(() => {});
-jest.spyOn(console, "error").mockImplementation(() => {});
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation(() => {});
 
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
@@ -1303,6 +1305,78 @@ describe("Session Timeline Detail (MSW integration)", () => {
       // The detail URL should NOT contain filter params
       expect(detailUrls[0]).not.toContain("free_text=");
       expect(detailUrls[0]).not.toContain("filter_short_code=");
+    });
+  });
+
+  // ================================================================
+  // DUPLICATE EVENT KEYS (regression)
+  // ================================================================
+  describe("duplicate event keys", () => {
+    it("renders events sharing type, thread, and timestamp without a duplicate React key warning", async () => {
+      // Two lifecycle_view_controller callbacks fired on the same thread in the
+      // same millisecond. (event type, thread, timestamp) is therefore not a
+      // unique identity, which previously produced a shared React key and the
+      // "Encountered two children with the same key" warning.
+      server.use(
+        http.get("*/api/apps/:appId/sessions/:sessionId", () => {
+          return HttpResponse.json(
+            makeSessionTimelineDetailFixture({
+              threads: {
+                "com.apple.main-thread": [
+                  {
+                    event_type: "lifecycle_view_controller",
+                    thread_name: "com.apple.main-thread",
+                    class_name: "HomeViewController",
+                    type: "viewWillAppear",
+                    timestamp: "2026-05-26T10:18:42.322Z",
+                  },
+                  {
+                    event_type: "lifecycle_view_controller",
+                    thread_name: "com.apple.main-thread",
+                    class_name: "HomeViewController",
+                    type: "viewDidAppear",
+                    timestamp: "2026-05-26T10:18:42.322Z",
+                  },
+                ],
+              },
+              traces: [],
+            }),
+          );
+        }),
+      );
+
+      renderWithProviders(
+        <SessionDetail
+          params={promiseParams({
+            teamId: "test-team",
+            appId: "app-1",
+            sessionId: "sess-001",
+          })}
+        />,
+      );
+
+      // Both colliding events must actually render, otherwise the scenario
+      // that triggers the warning isn't exercised.
+      await waitFor(
+        () => {
+          expect(
+            screen.getByText("HomeViewController: viewWillAppear"),
+          ).toBeTruthy();
+          expect(
+            screen.getByText("HomeViewController: viewDidAppear"),
+          ).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      const duplicateKeyWarning = consoleErrorSpy.mock.calls.find((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.includes("two children with the same key"),
+        ),
+      );
+      expect(duplicateKeyWarning).toBeUndefined();
     });
   });
 });

--- a/frontend/dashboard/app/components/session_timeline.tsx
+++ b/frontend/dashboard/app/components/session_timeline.tsx
@@ -360,7 +360,7 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
   };
 
   const { events, threads, eventTypes } = useMemo(() => {
-    const events: {
+    const collected: {
       eventType: string;
       timestamp: string;
       thread: string;
@@ -373,7 +373,7 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
     Object.keys(sessionTimeline.threads).forEach((item) =>
       // @ts-ignore
       sessionTimeline.threads[item].forEach((subItem: any) => {
-        events.push({
+        collected.push({
           eventType: subItem.event_type,
           timestamp: subItem.timestamp,
           thread: item,
@@ -387,7 +387,7 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
     if (sessionTimeline.traces !== null) {
       eventTypesSet.add(traceEventType);
       sessionTimeline.traces.forEach((item: any) => {
-        events.push({
+        collected.push({
           eventType: traceEventType,
           timestamp: item.start_time,
           thread: item.thread_name,
@@ -398,12 +398,20 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
       });
     }
 
-    events.sort((a, b) => {
+    collected.sort((a, b) => {
       const dateA = DateTime.fromISO(a.timestamp, { zone: "utc" });
       const dateB = DateTime.fromISO(b.timestamp, { zone: "utc" });
 
       return dateA.toMillis() - dateB.toMillis();
     });
+
+    // Several events can share an event type, thread, and millisecond-precision
+    // timestamp, so pair each with its sorted position to give it a stable,
+    // unique identity for React keys and expansion state.
+    const events = collected.map((e, index) => ({
+      ...e,
+      key: `${e.eventType}|${e.thread}|${e.timestamp}|${index}`,
+    }));
 
     return {
       events,
@@ -677,14 +685,6 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
   const [indicatorTimestamp, setIndicatorTimestamp] = useState<string | null>(
     events.length > 0 ? events[0].timestamp : null,
   );
-
-  function eventKey(e: {
-    eventType: string;
-    timestamp: string;
-    thread: string;
-  }) {
-    return `${e.eventType}|${e.thread}|${e.timestamp}`;
-  }
 
   const toggleExpansion = (key: string) => {
     setExpandedKeys((prev) => {
@@ -1077,7 +1077,7 @@ const SessionTimeline: React.FC<SessionTimelineProps> = ({
       {/* Events list — natural page-level scroll, no fixed height. */}
       <div className="flex flex-col w-full">
         {filteredEvents.map((e, index) => {
-          const key = eventKey(e);
+          const key = e.key;
           return (
             <div
               key={key}


### PR DESCRIPTION
# Description

Events were keyed on `eventType|thread|timestamp`, which is not unique — two events of the same type can fire on the same thread within the same millisecond (e.g. consecutive lifecycle_view_controller callbacks). This collided on a shared React key, triggering "Encountered two children with the same key" and risking duplicated/omitted rows.

Derive a stable per-event identity instead: pair the content key with the event's position in the deterministically-sorted list, assigned once in the data-prep memo. Computing it there (rather than from the filtered render index) keeps identity stable across re-renders and intact when thread/event-type filters change, so per-event expansion state stays correct.

Add an integration regression test that renders two events sharing type, thread, and timestamp and asserts no duplicate-key warning is logged.

## Related issue
Fixes #3821



