### PR TITLE
fix(backend): per-severity error group counts

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -472,7 +472,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 		return nil
 	}
 
-	newGroupsBranch := func(table, sourceType, severityExpr, isCustomExpr string) (*sqlf.Stmt, error) {
+	newGroupsBranch := func(table, sourceType, severityClass, severityExpr, isCustomExpr string) (*sqlf.Stmt, error) {
 		s := sqlf.
 			From(table).
 			Select("team_id").
@@ -485,6 +485,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			Select("argMax(line_number, timestamp) as line_number").
 			Select("any(timestamp) as last_occurrence").
 			Select("'" + sourceType + "' as source_type").
+			Select("'" + severityClass + "' as severity_class").
 			Select(severityExpr + " as severity").
 			Select(isCustomExpr + " as is_custom")
 		return s, applyGroupFilters(s)
@@ -493,7 +494,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 	var groupsBranches []*sqlf.Stmt
 
 	if queryANR {
-		s, errBranch := newGroupsBranch("anr_groups final", "anr", "'fatal'", "false")
+		s, errBranch := newGroupsBranch("anr_groups final", "anr", "fatal", "'fatal'", "false")
 		if errBranch != nil {
 			err = errBranch
 			return
@@ -502,7 +503,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 	}
 
 	if queryFatal {
-		s, errBranch := newGroupsBranch("fatal_exception_groups final", "exception", "'fatal'", "argMax(is_custom, timestamp)")
+		s, errBranch := newGroupsBranch("fatal_exception_groups final", "exception", "fatal", "'fatal'", "argMax(is_custom, timestamp)")
 		if errBranch != nil {
 			err = errBranch
 			return
@@ -511,7 +512,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 	}
 
 	if queryNonfatal {
-		s, errBranch := newGroupsBranch("nonfatal_exception_groups final", "exception", "if(argMax(handled, timestamp), 'handled', 'unhandled')", "argMax(is_custom, timestamp)")
+		s, errBranch := newGroupsBranch("nonfatal_exception_groups final", "exception", "nonfatal", "if(argMax(handled, timestamp), 'handled', 'unhandled')", "argMax(is_custom, timestamp)")
 		if errBranch != nil {
 			err = errBranch
 			return
@@ -534,6 +535,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			Select("anr.fingerprint as id").
 			Select("count() as event_count").
 			Select("'anr' as source_type").
+			Select("'fatal' as severity_class").
 			Where("team_id = toUUID(?)", a.TeamId).
 			Where("app_id = toUUID(?)", a.ID).
 			Where("timestamp >= toDateTime64(?, 3, 'UTC')", af.From).
@@ -552,7 +554,13 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 		countsBranches = append(countsBranches, s)
 	}
 
-	if queryFatal || queryNonfatal {
+	// Exception counts are split into one branch per severity_class so the
+	// counts mirror the groups CTE: a fingerprint living in both
+	// fatal_exception_groups and nonfatal_exception_groups gets a separate
+	// count per class instead of a single combined total joined to both rows.
+	// Each branch counts only the events matching its bucket's severities; the
+	// groups-driven LEFT JOIN drops counts whose group is absent for that class.
+	newExceptionCountsBranch := func(severityClass string, severities []event.Severity) *sqlf.Stmt {
 		s := sqlf.
 			From("events").
 			Select("team_id").
@@ -560,6 +568,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			Select("exception.fingerprint as id").
 			Select("count() as event_count").
 			Select("'exception' as source_type").
+			Select("'"+severityClass+"' as severity_class").
 			Where("team_id = toUUID(?)", a.TeamId).
 			Where("app_id = toUUID(?)", a.ID).
 			Where("timestamp >= toDateTime64(?, 3, 'UTC')", af.From).
@@ -570,7 +579,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			GroupBy("app_id").
 			GroupBy("id")
 
-		applyExceptionSeverityFilter(s, af.Severities)
+		applyExceptionSeverityFilter(s, severities)
 
 		if af.CustomError {
 			s.Where("`exception.is_custom` = true")
@@ -581,7 +590,22 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 			s.Where("attribute.app_build in ?", af.VersionCodes)
 		}
 
-		countsBranches = append(countsBranches, s)
+		return s
+	}
+
+	if queryFatal {
+		countsBranches = append(countsBranches, newExceptionCountsBranch("fatal", []event.Severity{event.SeverityFatal}))
+	}
+
+	if queryNonfatal {
+		var nonfatalSeverities []event.Severity
+		if hasHandled {
+			nonfatalSeverities = append(nonfatalSeverities, event.SeverityHandled)
+		}
+		if hasUnhandled {
+			nonfatalSeverities = append(nonfatalSeverities, event.SeverityUnhandled)
+		}
+		countsBranches = append(countsBranches, newExceptionCountsBranch("nonfatal", nonfatalSeverities))
 	}
 
 	groupsCTE := unionStmts(groupsBranches)
@@ -604,7 +628,7 @@ func (a App) GetErrorGroupsWithFilter(ctx context.Context, af *filter.AppFilter)
 		Select("c.event_count as event_count").
 		Select("round((event_count * 100.0) / sum(event_count) over (), 2) as contribution").
 		From("groups as g").
-		LeftJoin("counts as c", "c.team_id = g.team_id and c.app_id = g.app_id and c.id = g.id and c.source_type = g.source_type").
+		LeftJoin("counts as c", "c.team_id = g.team_id and c.app_id = g.app_id and c.id = g.id and c.source_type = g.source_type and c.severity_class = g.severity_class").
 		Where("c.event_count > 0").
 		OrderBy("event_count desc, g.last_occurrence desc, g.id")
 

--- a/backend/api/measure/error_groups_test.go
+++ b/backend/api/measure/error_groups_test.go
@@ -254,6 +254,151 @@ func TestGetErrorGroupsWithFilterSeverityFiltering(t *testing.T) {
 	}
 }
 
+// 32-char fingerprints shared across the fatal and nonfatal group tables —
+// the same crash reported both fatally and nonfatally, which is the scenario
+// the per-severity count split must handle.
+const (
+	fpSharedFatalHandled   = "00000000000000000000000000000020"
+	fpSharedFatalUnhandled = "00000000000000000000000000000021"
+)
+
+// seedSharedFingerprintCounts writes two fingerprints that each live in BOTH
+// fatal_exception_groups and nonfatal_exception_groups, with asymmetric event
+// counts per severity. This reproduces the count-duplication bug: a single
+// counts row joined to two per-severity group rows handed both the combined
+// total.
+//
+//   - fpSharedFatalHandled:   1 fatal event + 3 handled events
+//   - fpSharedFatalUnhandled: 1 fatal event + 2 unhandled events
+//
+// This seed is for the case where error groups were not symbolicated, but we still want the final instance count to be accurate no matter the severity.
+func seedSharedFingerprintCounts(f plotFixture, t *testing.T, ts time.Time) {
+	t.Helper()
+	teamID, appID := f.teamIDStr(), f.appIDStr()
+
+	seedExceptionGroup(f.ctx, t, teamID, appID, fpSharedFatalHandled)
+	seedNonfatalExceptionGroup(f.ctx, t, teamID, appID, fpSharedFatalHandled, true, false)
+	seedSeverityEvents(f, t, fpSharedFatalHandled, "fatal", 1, ts)
+	seedSeverityEvents(f, t, fpSharedFatalHandled, "handled", 3, ts)
+
+	seedExceptionGroup(f.ctx, t, teamID, appID, fpSharedFatalUnhandled)
+	seedNonfatalExceptionGroup(f.ctx, t, teamID, appID, fpSharedFatalUnhandled, false, false)
+	seedSeverityEvents(f, t, fpSharedFatalUnhandled, "fatal", 1, ts)
+	seedSeverityEvents(f, t, fpSharedFatalUnhandled, "unhandled", 2, ts)
+}
+
+func seedSeverityEvents(f plotFixture, t *testing.T, fingerprint, severity string, n int, ts time.Time) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		seedIssueEventWithSeverity(f.ctx, t, f.teamIDStr(), f.appIDStr(), fingerprint, severity, ts)
+	}
+}
+
+// wantCount pairs an expected fingerprint+severity row with its event count.
+type wantCount struct {
+	id       string
+	severity event.Severity
+	count    uint64
+}
+
+// TestGetErrorGroupsWithFilterSharedFingerprintCounts guards against the
+// count-duplication bug where a fingerprint present in both the fatal and
+// nonfatal group tables had the combined event total reported on every
+// per-severity row. Each row must carry only the count for its own severity.
+func TestGetErrorGroupsWithFilterSharedFingerprintCounts(t *testing.T) {
+	cases := []struct {
+		name       string
+		severities []event.Severity
+		want       []wantCount
+	}{
+		{
+			name:       "fatal,handled splits counts per severity",
+			severities: []event.Severity{event.SeverityFatal, event.SeverityHandled},
+			want: []wantCount{
+				{fpSharedFatalHandled, event.SeverityFatal, 1},
+				{fpSharedFatalHandled, event.SeverityHandled, 3},
+				// unhandled twin contributes only its fatal row here.
+				{fpSharedFatalUnhandled, event.SeverityFatal, 1},
+			},
+		},
+		{
+			name:       "fatal,unhandled splits counts per severity",
+			severities: []event.Severity{event.SeverityFatal, event.SeverityUnhandled},
+			want: []wantCount{
+				{fpSharedFatalHandled, event.SeverityFatal, 1},
+				{fpSharedFatalUnhandled, event.SeverityFatal, 1},
+				{fpSharedFatalUnhandled, event.SeverityUnhandled, 2},
+			},
+		},
+		{
+			name:       "handled,unhandled excludes fatal events",
+			severities: []event.Severity{event.SeverityHandled, event.SeverityUnhandled},
+			want: []wantCount{
+				{fpSharedFatalHandled, event.SeverityHandled, 3},
+				{fpSharedFatalUnhandled, event.SeverityUnhandled, 2},
+			},
+		},
+		{
+			name:       "fatal,handled,unhandled covers every row",
+			severities: []event.Severity{event.SeverityFatal, event.SeverityHandled, event.SeverityUnhandled},
+			want: []wantCount{
+				{fpSharedFatalHandled, event.SeverityFatal, 1},
+				{fpSharedFatalHandled, event.SeverityHandled, 3},
+				{fpSharedFatalUnhandled, event.SeverityFatal, 1},
+				{fpSharedFatalUnhandled, event.SeverityUnhandled, 2},
+			},
+		},
+		{
+			name:       "fatal returns fatal counts only",
+			severities: []event.Severity{event.SeverityFatal},
+			want: []wantCount{
+				{fpSharedFatalHandled, event.SeverityFatal, 1},
+				{fpSharedFatalUnhandled, event.SeverityFatal, 1},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			f := newPlotFixture(t)
+			ts := time.Now().UTC()
+			seedSharedFingerprintCounts(f, t, ts)
+
+			af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", "")
+			af.ErrorTypes = []event.ErrorType{event.ErrorTypeError}
+			af.Severities = c.severities
+
+			groups, _, _, err := f.app.GetErrorGroupsWithFilter(f.ctx, af)
+			if err != nil {
+				t.Fatalf("GetErrorGroupsWithFilter: %v", err)
+			}
+			if len(groups) != len(c.want) {
+				t.Fatalf("got %d rows, want %d: %+v", len(groups), len(c.want), groups)
+			}
+			for _, w := range c.want {
+				g := findErrorGroupBySeverity(groups, w.id, w.severity)
+				if g == nil {
+					t.Errorf("missing row for fingerprint %s severity %s", w.id, w.severity)
+					continue
+				}
+				if g.Count != w.count {
+					t.Errorf("fingerprint %s severity %s: count = %d, want %d", w.id, w.severity, g.Count, w.count)
+				}
+			}
+		})
+	}
+}
+
+func findErrorGroupBySeverity(groups []group.ErrorGroup, id string, severity event.Severity) *group.ErrorGroup {
+	for i := range groups {
+		if groups[i].ID == id && groups[i].Severity == severity {
+			return &groups[i]
+		}
+	}
+	return nil
+}
+
 // 32-char fingerprints for is_custom tests.
 const (
 	fpGroupCustomFatal    = "0000000000000000000000000000000e"


### PR DESCRIPTION
## Summary

This PR fixes `errorGroups` API reported inflated `count` & `percentage_contribution` when a fingerprint existed in both `fatal_exception_groups` & `nonfatal_exception_groups` (e.g. a SIGABRT reported both fatally & handled).
## Tasks

- [x] Split exception `counts` CTE into `fatal` & `nonfatal` branches, joined on a new `severity_class`
- [x] Fixes inflated `count` & `percentage_contribution` when a fingerprint exists in both group tables
- [x] Add test covering shared fingerprints across severity combinations

## See also

- fixes #3825