### PR TITLE
fix(frontend): show error code, meta, and num_code when available

### DIFF
--- a/frontend/dashboard/__tests__/integration/errors_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/errors_msw_test.tsx
@@ -319,6 +319,33 @@ describe("Errors Detail (MSW integration)", () => {
     );
   }
 
+  // Renders the detail route with a single event whose fields are taken from
+  // `overrides`, then waits for it to paint. Used by the extra-attribute
+  // (num_code / code / meta / user_defined_attribute) cases below.
+  async function renderDetailWithEvent(overrides: Record<string, any>) {
+    server.use(
+      http.get("*/api/apps/:appId/errorGroups/:groupId/errors", () => {
+        return HttpResponse.json(makeExceptionInstanceFixture(overrides));
+      }),
+    );
+    renderWithProviders(
+      <ErrorDetailsPage
+        params={promiseParams({
+          teamId: "test-team",
+          appId: makeAppFixture().id,
+          errorGroupId: "crash-group-001",
+          errorGroupName: "test",
+        })}
+      />,
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Id: instance-001/)).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+  }
+
   it("renders details plot, distribution plot, and common path", async () => {
     await renderDetailAndWait();
     // 1 line chart for details plot
@@ -418,54 +445,103 @@ describe("Errors Detail (MSW integration)", () => {
     ).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders num_code, code, and user_defined_attribute rows above threads when present", async () => {
-    server.use(
-      http.get("*/api/apps/:appId/errorGroups/:groupId/errors", () => {
-        return HttpResponse.json(
-          makeExceptionInstanceFixture({
-            num_code: 137,
-            code: "OUT_OF_MEMORY",
-            user_defined_attribute: {
-              user_tier: "premium",
-              account_age_days: 142,
-            },
-          }),
-        );
-      }),
-    );
-
-    renderWithProviders(
-      <ErrorDetailsPage
-        params={promiseParams({
-          teamId: "test-team",
-          appId: makeAppFixture().id,
-          errorGroupId: "crash-group-001",
-          errorGroupName: "test",
-        })}
-      />,
-    );
-
-    await waitFor(
-      () => {
-        expect(screen.getByText(/Id: instance-001/)).toBeTruthy();
+  it("renders num_code, code, meta, and user_defined_attribute rows above threads when present", async () => {
+    await renderDetailWithEvent({
+      num_code: 137,
+      code: "OUT_OF_MEMORY",
+      meta: {
+        error_domain: "PaymentDomain",
+        recoverable: false,
       },
-      { timeout: 5000 },
-    );
+      user_defined_attribute: {
+        user_tier: "premium",
+        account_age_days: 142,
+      },
+    });
 
     expect(screen.getByText("num_code")).toBeTruthy();
     expect(screen.getByText("137")).toBeTruthy();
     expect(screen.getByText("code")).toBeTruthy();
     expect(screen.getByText("OUT_OF_MEMORY")).toBeTruthy();
+    expect(screen.getByText("meta")).toBeTruthy();
+    expect(screen.getByText(/error_domain/)).toBeTruthy();
     expect(screen.getByText("user_defined_attribute")).toBeTruthy();
     expect(screen.getByText(/user_tier/)).toBeTruthy();
     expect(screen.getByText(/premium/)).toBeTruthy();
   });
 
-  it("omits num_code, code, and user_defined_attribute rows when default/empty", async () => {
+  it("omits num_code, code, meta, and user_defined_attribute rows when default/empty", async () => {
     await renderDetailAndWait();
     expect(screen.queryByText("num_code")).toBeNull();
     expect(screen.queryByText("code")).toBeNull();
+    expect(screen.queryByText("meta")).toBeNull();
     expect(screen.queryByText("user_defined_attribute")).toBeNull();
+  });
+
+  // The detail endpoint returns num_code (number | null), code (string), and
+  // meta (object | null) independently, so any combination can arrive. Each
+  // row must show only when its value is available: num_code when it is a
+  // number (including 0), code when it is a non-empty string, meta when it is
+  // a non-null object with keys. The three cases below mirror real iOS error
+  // payloads where exactly that mix occurs.
+
+  it("shows num_code 0 and meta, hides empty code", async () => {
+    await renderDetailWithEvent({
+      num_code: 0,
+      code: "",
+      meta: {
+        NSFilePath: "//invalid/file",
+        NSURL: null,
+        NSUnderlyingError: null,
+        NSUserStringVariant: ["Remove"],
+      },
+    });
+
+    // num_code === 0 is a real value, not "absent" — it must be shown.
+    expect(screen.getByText("num_code")).toBeTruthy();
+    // meta is a non-empty object → shown as JSON.
+    expect(screen.getByText("meta")).toBeTruthy();
+    expect(screen.getByText(/NSFilePath/)).toBeTruthy();
+    // code is an empty string → hidden.
+    expect(screen.queryByText("code")).toBeNull();
+  });
+
+  it("shows num_code 0 and code, hides null meta", async () => {
+    await renderDetailWithEvent({
+      num_code: 0,
+      code: "NamedException, Something happened",
+      meta: null,
+    });
+
+    expect(screen.getByText("num_code")).toBeTruthy();
+    expect(screen.getByText("code")).toBeTruthy();
+    expect(screen.getByText("NamedException, Something happened")).toBeTruthy();
+    // meta is null → hidden.
+    expect(screen.queryByText("meta")).toBeNull();
+  });
+
+  it("shows num_code, code, and meta together", async () => {
+    await renderDetailWithEvent({
+      num_code: 260,
+      code: "NSCocoaErrorDomain",
+      meta: {
+        NSFilePath: "/path/that/does/not/exist.txt",
+        NSURL: null,
+        NSUnderlyingError: null,
+      },
+    });
+
+    expect(screen.getByText("num_code")).toBeTruthy();
+    expect(screen.getByText("260")).toBeTruthy();
+    expect(screen.getByText("code")).toBeTruthy();
+    expect(screen.getByText("NSCocoaErrorDomain")).toBeTruthy();
+    expect(screen.getByText("meta")).toBeTruthy();
+    expect(screen.getByText(/NSFilePath/)).toBeTruthy();
+  });
+
+  it("hides the meta row when meta is an empty object", async () => {
+    await renderDetailWithEvent({ meta: {} });
+    expect(screen.queryByText("meta")).toBeNull();
   });
 });
 

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -772,7 +772,7 @@ const emptyErrorGroupDetailsItem = {
     stacktrace: "",
   } as { title: string; stacktrace: string } | null,
   severity: "",
-  num_code: 0,
+  num_code: 0 as number | null,
   code: "",
   meta: null as Record<string, unknown> | null,
   user_defined_attribute: null as Record<string, unknown> | null,

--- a/frontend/dashboard/app/components/errors_details.tsx
+++ b/frontend/dashboard/app/components/errors_details.tsx
@@ -278,14 +278,14 @@ export const ErrorsDetails: React.FC<ErrorsDetailsProps> = ({
 
   const extraAttributeRows: Array<[string, unknown]> = [];
   if (firstResult) {
-    if (
-      typeof firstResult.num_code === "number" &&
-      firstResult.num_code !== 0
-    ) {
+    if (typeof firstResult.num_code === "number") {
       extraAttributeRows.push(["num_code", firstResult.num_code]);
     }
     if (typeof firstResult.code === "string" && firstResult.code !== "") {
       extraAttributeRows.push(["code", firstResult.code]);
+    }
+    if (firstResult.meta && Object.keys(firstResult.meta).length > 0) {
+      extraAttributeRows.push(["meta", firstResult.meta]);
     }
     if (
       firstResult.user_defined_attribute &&


### PR DESCRIPTION
# Description

On the error details page, an event's code (string), meta (object or null), and num_code (number or null) arrive independently. meta was never rendered, and num_code was hidden when 0 — treating a valid 0 as absent rather than missing.

Render each row only when its value is actually available: num_code when it is a number (including 0), code when it is a non-empty string, and meta when it is a non-null object with keys. meta displays as pretty-printed JSON alongside the existing extra-attribute rows.

Make num_code's type nullable (number | null) to match the payload.

Cover the combinations with MSW integration tests, including the iOS payloads where num_code 0, empty code, and null or empty meta occur.



