### PR TITLE
chore(backend): switch to pgsty minio

### DIFF
--- a/backend/ingest-worker/symbolicator/symbolicator_test.go
+++ b/backend/ingest-worker/symbolicator/symbolicator_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 	// 3. Start MinIO
 	minioContainer, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "quay.io/minio/minio:latest",
+			Image:        "pgsty/minio:latest",
 			ExposedPorts: []string{"9000/tcp"},
 			Env: map[string]string{
 				"MINIO_ROOT_USER":     "minioadmin",

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -512,7 +512,7 @@ services:
     command: ["run", "-c", "/etc/symbolicator/config.yml"]
 
   minio:
-    image: quay.io/minio/minio
+    image: pgsty/minio
     ports:
       - "9119:9000"
       - "9229:9001"


### PR DESCRIPTION
## Summary

This PR switches to a community trusted minio image. [pgsty/minio](https://hub.docker.com/r/pgsty/minio)

## See also

- fixes #2801
