### PR TITLE
chore(backend): limit to 5 event attachments

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -71,9 +71,9 @@ const (
 	maxCustomNameChars                        = 64
 	maxLayoutElementIDChars                   = 512
 	maxLayoutElementLabelChars                = 512
-	maxBugReportScreenShots                   = 5
 	maxBugReportDescChars                     = 4000
 	maxErrorMetaBytes                         = 4096 // Maximum size for marshaled Error.Meta in bytes
+	maxEventAttachments                       = 5
 	customNameKeyPattern                      = "^[a-zA-Z0-9_-]+$"
 )
 
@@ -756,6 +756,10 @@ func (e *EventField) Validate(opts ...ingest.ValidationOptions) error {
 
 	if e.Attribute.SessionStartTime.After(e.Timestamp) {
 		return fmt.Errorf("%q must not be greater than %q", `attribute.session_start_time`, `timestamp`)
+	}
+
+	if len(e.Attachments) > maxEventAttachments {
+		return fmt.Errorf(`%q exceeds maximum allowed count of (%d)`, `attachments`, maxEventAttachments)
 	}
 
 	// Don't allow batches that contain events too far in the past or future

--- a/backend/api/event/event_test.go
+++ b/backend/api/event/event_test.go
@@ -986,3 +986,46 @@ func TestValidateAppleFrameworkOSName(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateAttachmentLimit(t *testing.T) {
+	makeEvent := func(n int) EventField {
+		attachments := make([]Attachment, n)
+		for i := range attachments {
+			attachments[i] = Attachment{
+				ID:   uuid.New(),
+				Name: "screenshot.png",
+				Type: "screenshot",
+			}
+		}
+		return EventField{
+			ID:          uuid.New(),
+			AppID:       uuid.New(),
+			Type:        TypeString,
+			Timestamp:   time.Now(),
+			Attribute:   Attribute{OSName: "android"},
+			LogString:   &LogString{String: "log line"},
+			Attachments: attachments,
+		}
+	}
+
+	t.Run("Accepts event with no attachments", func(t *testing.T) {
+		ev := makeEvent(0)
+		if err := ev.Validate(); err != nil {
+			t.Errorf("Expected no validation error for 0 attachments, got %v", err)
+		}
+	})
+
+	t.Run("Accepts event at the attachment limit", func(t *testing.T) {
+		ev := makeEvent(maxEventAttachments)
+		if err := ev.Validate(); err != nil {
+			t.Errorf("Expected no validation error for %d attachments, got %v", maxEventAttachments, err)
+		}
+	})
+
+	t.Run("Rejects event over the attachment limit", func(t *testing.T) {
+		ev := makeEvent(maxEventAttachments + 1)
+		if err := ev.Validate(); err == nil {
+			t.Errorf("Expected validation error for %d attachments, got nil", maxEventAttachments+1)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR limits the maximum number of attachments in an event to 5.

## See also

- fixes #2568
