### PR TITLE
feat(backend): track app OS names as a single-family set)

### DIFF
--- a/backend/api/filter/appfilter.go
+++ b/backend/api/filter/appfilter.go
@@ -51,9 +51,6 @@ type AppFilter struct {
 	// ID is the unique id of the app.
 	AppID uuid.UUID
 
-	// AppOSName is the OSName value of the app.
-	AppOSName string
-
 	// From represents the lower time bound of
 	// the filter time range.
 	From time.Time `form:"from" time_format:"2006-01-02T15:04:05.000Z" time_utc:"1"`

--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -47,7 +47,7 @@ type App struct {
 	TeamId       uuid.UUID  `json:"team_id"`
 	AppName      string     `json:"name" binding:"required"`
 	UniqueId     string     `json:"unique_identifier"`
-	OSName       string     `json:"os_name"`
+	OSNames      []string   `json:"os_names"`
 	APIKey       *APIKey    `json:"api_key"`
 	Retention    int        `json:"retention"`
 	FirstVersion string     `json:"first_version"`
@@ -55,6 +55,16 @@ type App struct {
 	OnboardedAt  time.Time  `json:"onboarded_at"`
 	CreatedAt    time.Time  `json:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+// Family returns the app's OS family. os_names is guaranteed to be
+// single-family by the ingest reconciliation and the Postgres constraint,
+// so any element determines the family.
+func (a App) Family() string {
+	if len(a.OSNames) == 0 {
+		return opsys.Unknown
+	}
+	return opsys.ToFamily(a.OSNames[0])
 }
 
 type plotTimeGroupExpr struct {
@@ -93,16 +103,16 @@ func (a App) MarshalJSON() ([]byte, error) {
 	type Alias App
 	return json.Marshal(&struct {
 		*Alias
-		OSName      *string    `json:"os_name"`
+		OSNames     *[]string  `json:"os_names"`
 		OnboardedAt *time.Time `json:"onboarded_at"`
 		UniqueId    *string    `json:"unique_identifier"`
 		Retention   *int       `json:"retention"`
 	}{
-		OSName: func() *string {
-			if a.OSName == "" {
+		OSNames: func() *[]string {
+			if len(a.OSNames) == 0 {
 				return nil
 			}
-			return &a.OSName
+			return &a.OSNames
 		}(),
 		UniqueId: func() *string {
 			if a.UniqueId == "" {
@@ -2472,7 +2482,7 @@ func (a App) GetIssueFreeMetrics(
 	crashFree = &metrics.CrashFreeSession{}
 	perceivedCrashFree = &metrics.PerceivedCrashFreeSession{}
 
-	switch a.OSName {
+	switch a.Family() {
 	case opsys.Android:
 		anrFree = &metrics.ANRFreeSession{}
 		perceivedANRFree = &metrics.PerceivedANRFreeSession{}
@@ -2491,7 +2501,7 @@ func (a App) GetIssueFreeMetrics(
 		Select("uniqMergeIf(perceived_crash_sessions, app_version in (?)) as selected_perceived_crash_sessions", selectedVersions.Parameterize()).
 		Select("uniqMergeIf(perceived_crash_sessions, app_version not in (?)) as unselected_perceived_crash_sessions", selectedVersions.Parameterize())
 
-	switch a.OSName {
+	switch a.Family() {
 	case opsys.Android:
 		stmt.
 			Select("uniqMergeIf(anr_sessions, app_version in (?)) as selected_anr_sessions", selectedVersions.Parameterize()).
@@ -2528,7 +2538,7 @@ func (a App) GetIssueFreeMetrics(
 		&perceivedCrashUnselected,
 	}
 
-	switch a.OSName {
+	switch a.Family() {
 	case opsys.Android:
 		dest = append(dest, &anrSelected, &anrUnselected, &perceivedANRSelected, &perceivedANRUnselected)
 	}
@@ -2541,7 +2551,7 @@ func (a App) GetIssueFreeMetrics(
 		crashFree.CrashFreeSessions = math.NaN()
 		perceivedCrashFree.CrashFreeSessions = math.NaN()
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			anrFree.ANRFreeSessions = math.NaN()
 			perceivedANRFree.ANRFreeSessions = math.NaN()
@@ -2550,7 +2560,7 @@ func (a App) GetIssueFreeMetrics(
 		crashFree.CrashFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(crashSelected) / float64(selected))) * 100)
 		perceivedCrashFree.CrashFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedCrashSelected) / float64(selected))) * 100)
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			anrFree.ANRFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(anrSelected) / float64(selected))) * 100)
 			perceivedANRFree.ANRFreeSessions = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedANRSelected) / float64(selected))) * 100)
@@ -2561,7 +2571,7 @@ func (a App) GetIssueFreeMetrics(
 		crashFreeUnselected = math.NaN()
 		perceivedCrashFreeUnselected = math.NaN()
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			anrFreeUnselected = math.NaN()
 			perceivedANRFreeUnselected = math.NaN()
@@ -2570,7 +2580,7 @@ func (a App) GetIssueFreeMetrics(
 		crashFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(crashUnselected) / float64(unselected))) * 100)
 		perceivedCrashFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedCrashUnselected) / float64(unselected))) * 100)
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			anrFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(anrUnselected) / float64(unselected))) * 100)
 			perceivedANRFreeUnselected = numeric.RoundTwoDecimalsFloat64((1 - (float64(perceivedANRUnselected) / float64(unselected))) * 100)
@@ -2593,7 +2603,7 @@ func (a App) GetIssueFreeMetrics(
 			perceivedCrashFree.Delta = 1
 		}
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			if anrFreeUnselected != 0 {
 				anrFree.Delta = numeric.RoundTwoDecimalsFloat64(anrFree.ANRFreeSessions / anrFreeUnselected)
@@ -2621,7 +2631,7 @@ func (a App) GetIssueFreeMetrics(
 			perceivedCrashFree.Delta = 1
 		}
 
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			if anrFree.ANRFreeSessions != 0 {
 				anrFree.Delta = 1
@@ -2636,7 +2646,7 @@ func (a App) GetIssueFreeMetrics(
 	crashFree.SetNaNs()
 	perceivedCrashFree.SetNaNs()
 
-	switch a.OSName {
+	switch a.Family() {
 	case opsys.Android:
 		anrFree.SetNaNs()
 		perceivedANRFree.SetNaNs()
@@ -4352,7 +4362,7 @@ func (a App) UpdateBugReportStatusById(ctx context.Context, bugReportId string, 
 func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts filter.JourneyOpts) (events []event.EventField, err error) {
 	whereVals := []any{}
 
-	switch opsys.ToFamily(a.OSName) {
+	switch a.Family() {
 	case opsys.Android:
 		whereVals = append(
 			whereVals,
@@ -4385,7 +4395,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 	whereVals = append(whereVals, event.TypeScreenView)
 
 	if opts.All {
-		switch opsys.ToFamily(a.OSName) {
+		switch a.Family() {
 		case opsys.Android:
 			whereVals = append(whereVals, event.TypeException, false, event.TypeANR)
 		case opsys.AppleFamily:
@@ -4394,7 +4404,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 	} else if opts.Exceptions {
 		whereVals = append(whereVals, event.TypeException, false)
 	} else if opts.ANRs {
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			whereVals = append(whereVals, event.TypeANR)
 		}
@@ -4419,7 +4429,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 
 	stmt.Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
 
-	switch opsys.ToFamily(a.OSName) {
+	switch a.Family() {
 	case opsys.Android:
 		stmt.
 			Select(`lifecycle_activity.type`).
@@ -4437,7 +4447,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 	}
 
 	if opts.All {
-		switch opsys.ToFamily(a.OSName) {
+		switch a.Family() {
 		case opsys.Android:
 			stmt.Where("((type = ? and `lifecycle_activity.type` in ?) or (type = ? and `lifecycle_fragment.type` in ?) or (type = ?) or ((type = ? and `exception.handled` = ?) or type = ?))", whereVals...)
 		case opsys.AppleFamily:
@@ -4446,7 +4456,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 	} else if opts.Exceptions {
 		stmt.Where("((type = ? and `lifecycle_activity.type` in ?) or (type = ? and `lifecycle_fragment.type` in ?) or (type = ?) or (type = ? and `exception.handled` = ?))", whereVals...)
 	} else if opts.ANRs {
-		switch a.OSName {
+		switch a.Family() {
 		case opsys.Android:
 			stmt.Where("((type = ? and `lifecycle_activity.type` in ?) or (type = ? and `lifecycle_fragment.type` in ?) or (type = ?) or (type = ?))", whereVals...)
 		}
@@ -4487,7 +4497,7 @@ func (a App) getJourneyEvents(ctx context.Context, af *filter.AppFilter, opts fi
 			&anrFingerprint,
 		}
 
-		switch opsys.ToFamily(a.OSName) {
+		switch a.Family() {
 		case opsys.Android:
 			dest = append(
 				dest,
@@ -4582,7 +4592,6 @@ func (a *App) add(tx pgx.Tx) (*APIKey, error) {
 func (a *App) getWithTeam(id uuid.UUID) (*App, error) {
 	var appName pgtype.Text
 	var uniqueId pgtype.Text
-	var osName pgtype.Text
 	var firstVersion pgtype.Text
 	var onboarded pgtype.Bool
 	var onboardedAt pgtype.Timestamptz
@@ -4596,7 +4605,7 @@ func (a *App) getWithTeam(id uuid.UUID) (*App, error) {
 	cols := []string{
 		"apps.app_name",
 		"apps.unique_identifier",
-		"apps.os_name",
+		"apps.os_names",
 		"apps.first_version",
 		"apps.onboarded",
 		"apps.onboarded_at",
@@ -4620,7 +4629,7 @@ func (a *App) getWithTeam(id uuid.UUID) (*App, error) {
 	dest := []any{
 		&appName,
 		&uniqueId,
-		&osName,
+		&a.OSNames,
 		&firstVersion,
 		&onboarded,
 		&onboardedAt,
@@ -4649,12 +4658,6 @@ func (a *App) getWithTeam(id uuid.UUID) (*App, error) {
 		a.UniqueId = uniqueId.String
 	} else {
 		a.UniqueId = ""
-	}
-
-	if osName.Valid {
-		a.OSName = osName.String
-	} else {
-		a.OSName = ""
 	}
 
 	if firstVersion.Valid {
@@ -4720,7 +4723,7 @@ func (a *App) Populate(ctx context.Context) (err error) {
 		Select("team_id::UUID").
 		Select("unique_identifier").
 		Select("app_name").
-		Select("os_name").
+		Select("os_names").
 		Select("first_version").
 		Select("onboarded").
 		Select("onboarded_at").
@@ -4730,28 +4733,7 @@ func (a *App) Populate(ctx context.Context) (err error) {
 
 	defer stmt.Close()
 
-	return server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&a.TeamId, &a.UniqueId, &a.AppName, &a.OSName, &a.FirstVersion, &a.Onboarded, &a.OnboardedAt, &a.CreatedAt, &a.UpdatedAt)
-}
-
-func (a *App) Onboard(ctx context.Context, tx *pgx.Tx, uniqueIdentifier, osName, firstVersion string) error {
-	now := time.Now()
-	stmt := sqlf.PostgreSQL.Update("apps").
-		Set("onboarded", true).
-		Set("unique_identifier", uniqueIdentifier).
-		Set("os_name", osName).
-		Set("first_version", firstVersion).
-		Set("onboarded_at", now).
-		Set("updated_at", now).
-		Where("id = ?", a.ID)
-
-	defer stmt.Close()
-
-	_, err := (*tx).Exec(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&a.TeamId, &a.UniqueId, &a.AppName, &a.OSNames, &a.FirstVersion, &a.Onboarded, &a.OnboardedAt, &a.CreatedAt, &a.UpdatedAt)
 }
 
 // GetSessionEvents fetches all the events of an app's session.
@@ -4898,7 +4880,7 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 		`custom.name`,
 	}
 
-	switch opsys.ToFamily(a.OSName) {
+	switch a.Family() {
 	case opsys.Android:
 		cols = append(cols, []string{
 			`anr.fingerprint`,
@@ -5194,7 +5176,7 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			&custom.Name,
 		}
 
-		switch opsys.ToFamily(a.OSName) {
+		switch a.Family() {
 		case opsys.Android:
 			dest = append(dest, []any{
 				// anr
@@ -5324,7 +5306,7 @@ func (a *App) GetSessionEvents(ctx context.Context, sessionId uuid.UUID) (*Sessi
 			// for now, only unmarshal exception.error for Apple
 			// family of OSes. support can - of course, be extended
 			// to other OSes on a "need to" basis.
-			switch opsys.ToFamily(a.OSName) {
+			switch a.Family() {
 			case opsys.AppleFamily:
 				if exceptionError != "" {
 					if err := json.Unmarshal([]byte(exceptionError), &exception.Error); err != nil {
@@ -5472,7 +5454,6 @@ func NewApp(teamId uuid.UUID) *App {
 func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 	var onboarded pgtype.Bool
 	var uniqueId pgtype.Text
-	var os pgtype.Text
 	var firstVersion pgtype.Text
 
 	stmt := sqlf.PostgreSQL.
@@ -5480,7 +5461,7 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		Select("team_id").
 		Select("onboarded").
 		Select("unique_identifier").
-		Select("os_name").
+		Select("os_names").
 		Select("first_version").
 		From("apps").
 		Where("id = ?", id)
@@ -5491,7 +5472,7 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app = &App{}
 	}
 
-	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &uniqueId, &os, &firstVersion); err != nil {
+	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &uniqueId, &app.OSNames, &firstVersion); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		} else {
@@ -5509,12 +5490,6 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app.UniqueId = uniqueId.String
 	} else {
 		app.UniqueId = ""
-	}
-
-	if os.Valid {
-		app.OSName = os.String
-	} else {
-		app.OSName = ""
 	}
 
 	if firstVersion.Valid {
@@ -5667,7 +5642,7 @@ func GetAppJourney(c *gin.Context) {
 		if journeyEvents[i].IsFatalException() {
 			issueEvents = append(issueEvents, journeyEvents[i])
 		}
-		if app.OSName == opsys.Android && journeyEvents[i].IsANR() {
+		if app.Family() == opsys.Android && journeyEvents[i].IsANR() {
 			issueEvents = append(issueEvents, journeyEvents[i])
 		}
 	}
@@ -5693,7 +5668,7 @@ func GetAppJourney(c *gin.Context) {
 	var nodes []Node
 	var links []Link
 
-	switch opsys.ToFamily(app.OSName) {
+	switch app.Family() {
 	case opsys.Android:
 		journeyGraph = journey.NewJourneyAndroid(journeyEvents, &journey.Options{
 			BiGraph: af.BiGraph,
@@ -5931,8 +5906,6 @@ func GetAppMetrics(c *gin.Context) {
 		return
 	}
 
-	af.AppOSName = app.OSName
-
 	team := &Team{
 		ID: &app.TeamId,
 	}
@@ -6145,8 +6118,6 @@ func GetAppFilters(c *gin.Context) {
 		})
 		return
 	}
-
-	af.AppOSName = app.OSName
 
 	team, err := app.getTeam(ctx)
 	if err != nil {

--- a/backend/api/measure/mcp.go
+++ b/backend/api/measure/mcp.go
@@ -1496,7 +1496,6 @@ func mcpBuildAppFilter(ctx context.Context, appID uuid.UUID, cf mcpCommonFilters
 		}
 		filtersAF := &filter.AppFilter{AppID: appID}
 		filtersAF.SetDefaultTimeRange()
-		filtersAF.AppOSName = app.OSName
 		filterCtx := ambient.WithTeamId(ctx, app.TeamId)
 
 		var fl filter.FilterList
@@ -1574,13 +1573,13 @@ func mcpListApps(ctx context.Context, _ mcpListAppsInput) (*mcpsdk.CallToolResul
 
 	pgPool := server.Server.PgPool
 	type appRow struct {
-		ID               string `json:"id"`
-		Name             string `json:"name"`
-		Platform         string `json:"platform"`
-		UniqueIdentifier string `json:"unique_identifier"`
+		ID               string   `json:"id"`
+		Name             string   `json:"name"`
+		OsNames          []string `json:"os_names"`
+		UniqueIdentifier string   `json:"unique_identifier"`
 	}
 	rows, err := pgPool.Query(ctx,
-		`SELECT a.id, a.app_name, coalesce(a.os_name, ''), coalesce(a.unique_identifier, '')
+		`SELECT a.id, a.app_name, coalesce(a.os_names, '{}'), coalesce(a.unique_identifier, '')
 		 FROM measure.apps a
 		 JOIN measure.team_membership tm ON a.team_id = tm.team_id
 		 WHERE tm.user_id = $1
@@ -1594,7 +1593,7 @@ func mcpListApps(ctx context.Context, _ mcpListAppsInput) (*mcpsdk.CallToolResul
 	var apps []appRow
 	for rows.Next() {
 		var row appRow
-		if err := rows.Scan(&row.ID, &row.Name, &row.Platform, &row.UniqueIdentifier); err != nil {
+		if err := rows.Scan(&row.ID, &row.Name, &row.OsNames, &row.UniqueIdentifier); err != nil {
 			return nil, nil, fmt.Errorf("failed to query apps: %w", err)
 		}
 		apps = append(apps, row)
@@ -1638,7 +1637,6 @@ func mcpGetFilters(ctx context.Context, in mcpGetFiltersInput) (*mcpsdk.CallTool
 	if err != nil {
 		return nil, nil, err
 	}
-	af.AppOSName = app.OSName
 	filterCtx := ambient.WithTeamId(ctx, app.TeamId)
 
 	var fl filter.FilterList
@@ -1674,7 +1672,6 @@ func mcpGetMetrics(ctx context.Context, in mcpGetMetricsInput) (*mcpsdk.CallTool
 	if err := app.Populate(ctx); err != nil {
 		return nil, nil, err
 	}
-	af.AppOSName = app.OSName
 	metricsCtx := ambient.WithTeamId(ctx, teamID)
 
 	adoption, err := app.GetAdoptionMetrics(metricsCtx, af)

--- a/backend/api/measure/team.go
+++ b/backend/api/measure/team.go
@@ -74,7 +74,7 @@ func (t *Team) getApps(ctx context.Context) ([]App, error) {
 		Select(`apps.app_name`, nil).
 		Select(`apps.team_id`, nil).
 		Select(`apps.unique_identifier`, nil).
-		Select(`apps.os_name`, nil).
+		Select(`apps.os_names`, nil).
 		Select(`apps.first_version`, nil).
 		Select(`apps.onboarded`, nil).
 		Select(`apps.onboarded_at`, nil).
@@ -100,7 +100,6 @@ func (t *Team) getApps(ctx context.Context) ([]App, error) {
 	for rows.Next() {
 		var a App
 		var uniqueId pgtype.Text
-		var osName pgtype.Text
 		var firstVersion pgtype.Text
 		var onboardedAt pgtype.Timestamptz
 		var apiKeyLastSeen pgtype.Timestamptz
@@ -108,7 +107,7 @@ func (t *Team) getApps(ctx context.Context) ([]App, error) {
 
 		apiKey := new(APIKey)
 
-		if err := rows.Scan(&a.ID, &a.AppName, &a.TeamId, &uniqueId, &osName, &firstVersion, &a.Onboarded, &onboardedAt, &apiKey.keyPrefix, &apiKey.keyValue, &apiKey.checksum, &apiKeyLastSeen, &apiKeyCreatedAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		if err := rows.Scan(&a.ID, &a.AppName, &a.TeamId, &uniqueId, &a.OSNames, &firstVersion, &a.Onboarded, &onboardedAt, &apiKey.keyPrefix, &apiKey.keyValue, &apiKey.checksum, &apiKeyLastSeen, &apiKeyCreatedAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
 			return nil, err
 		}
 
@@ -116,12 +115,6 @@ func (t *Team) getApps(ctx context.Context) ([]App, error) {
 			a.UniqueId = uniqueId.String
 		} else {
 			a.UniqueId = ""
-		}
-
-		if osName.Valid {
-			a.OSName = osName.String
-		} else {
-			a.OSName = ""
 		}
 
 		if firstVersion.Valid {

--- a/backend/ingest-worker/measure/app.go
+++ b/backend/ingest-worker/measure/app.go
@@ -15,7 +15,7 @@ import (
 type App struct {
 	ID           *uuid.UUID `json:"id"`
 	TeamId       uuid.UUID  `json:"team_id"`
-	OSName       string     `json:"os_name"`
+	OSNames      []string   `json:"os_names"`
 	FirstVersion string     `json:"first_version"`
 	Onboarded    bool       `json:"onboarded"`
 	OnboardedAt  time.Time  `json:"onboarded_at"`
@@ -24,14 +24,13 @@ type App struct {
 // SelectApp selects app by its id.
 func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 	var onboarded pgtype.Bool
-	var os pgtype.Text
 	var firstVersion pgtype.Text
 
 	stmt := sqlf.PostgreSQL.
 		Select("id").
 		Select("team_id").
 		Select("onboarded").
-		Select("os_name").
+		Select("os_names").
 		Select("first_version").
 		From("apps").
 		Where("id = ?", id)
@@ -42,7 +41,7 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app = &App{}
 	}
 
-	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &os, &firstVersion); err != nil {
+	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &app.OSNames, &firstVersion); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		} else {
@@ -56,12 +55,6 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app.Onboarded = false
 	}
 
-	if os.Valid {
-		app.OSName = os.String
-	} else {
-		app.OSName = ""
-	}
-
 	if firstVersion.Valid {
 		app.FirstVersion = firstVersion.String
 	} else {
@@ -71,12 +64,11 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 	return
 }
 
-func (a *App) Onboard(ctx context.Context, tx *pgx.Tx, uniqueIdentifier, osName, firstVersion string) error {
+func (a *App) Onboard(ctx context.Context, tx *pgx.Tx, uniqueIdentifier, firstVersion string) error {
 	now := time.Now()
 	stmt := sqlf.PostgreSQL.Update("apps").
 		Set("onboarded", true).
 		Set("unique_identifier", uniqueIdentifier).
-		Set("os_name", osName).
 		Set("first_version", firstVersion).
 		Set("onboarded_at", now).
 		Set("updated_at", now).
@@ -90,4 +82,22 @@ func (a *App) Onboard(ctx context.Context, tx *pgx.Tx, uniqueIdentifier, osName,
 	}
 
 	return nil
+}
+
+// AddOSName appends osName to the app's os_names array if it is not already
+// present. The conditional WHERE keeps concurrent appends from parallel batch
+// workers race-safe: the row lock serializes them and the predicate prevents
+// duplicate entries.
+func (a *App) AddOSName(ctx context.Context, osName string) error {
+	now := time.Now()
+	stmt := sqlf.PostgreSQL.Update("apps").
+		SetExpr("os_names", "array_append(os_names, ?)", osName).
+		Set("updated_at", now).
+		Where("id = ?", a.ID).
+		Where("NOT (? = ANY(os_names))", osName)
+
+	defer stmt.Close()
+
+	_, err := server.Server.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
+	return err
 }

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -205,14 +206,22 @@ func (e eventreq) hasANRs() bool {
 	return len(e.anrIds) > 0
 }
 
-// getOSName extracts the operating system name
-// of the app from ingest batch.
+// getOSName extracts the operating system name of the app from the ingest
+// batch, taken from the first event (or the first span, for span-only
+// batches). Returns "" if the batch has neither.
 func (e eventreq) getOSName() (osName string) {
 	if len(e.events) > 0 {
 		return strings.ToLower(e.events[0].Attribute.OSName)
 	}
 
-	return strings.ToLower(e.spans[0].Attributes.OSName)
+	if len(e.spans) > 0 {
+		return strings.ToLower(e.spans[0].Attributes.OSName)
+	}
+
+	// Unreachable in practice: ingest guarantees every event/span carries a
+	// valid, non-empty os_name, and onboarding only calls this when the batch
+	// has at least one. This guard only avoids an index-out-of-range panic.
+	return ""
 }
 
 // getOSVersion extracts the operating system version
@@ -1453,7 +1462,7 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 		osName := eventReq.getOSName()
 		version := eventReq.getOSVersion()
 
-		if err := app.Onboard(ingestCtx, &tx, uniqueID, osName, version); err != nil {
+		if err := app.Onboard(ingestCtx, &tx, uniqueID, version); err != nil {
 			return fmt.Errorf("failed to onboard app: %w", err)
 		}
 
@@ -1462,6 +1471,25 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 		}
 
 		fireFirstIngestionEvents(ingestCtx, *app.ID, app.TeamId, osName)
+	}
+
+	// Keep the app's recorded os_names current on every batch (not just at
+	// onboarding) so an app that later reports another OS of the same family
+	// — e.g. ipados in addition to ios — is captured. The in-memory guard
+	// means a write happens only when a genuinely new OS appears. The set is
+	// kept single-family here; cross-family values are skipped. Best-effort:
+	// a failure must not fail ingestion — a later batch with the OS retries.
+	if eventReq.onboardable() {
+		batchOS := eventReq.getOSName()
+		if batchOS != "" && !slices.Contains(app.OSNames, batchOS) {
+			if len(app.OSNames) == 0 || opsys.SameFamily(batchOS, app.OSNames[0]) {
+				if err := app.AddOSName(ingestCtx, batchOS); err != nil {
+					fmt.Printf("failed to update os_names for app %s: %v\n", app.ID, err)
+				}
+			} else {
+				fmt.Printf("ignoring cross-family os_name %q for app %s (existing family %q)\n", batchOS, app.ID, app.OSNames[0])
+			}
+		}
 	}
 
 	// Track usage with Autumn as the very last step. Must come after

--- a/backend/ingest-worker/symbolicator/symbolicator_test.go
+++ b/backend/ingest-worker/symbolicator/symbolicator_test.go
@@ -546,8 +546,8 @@ func seedApp(ctx context.Context, t *testing.T, appID uuid.UUID) {
 	}
 
 	_, err = pgPool.Exec(ctx,
-		`INSERT INTO apps (id, team_id, app_name, unique_identifier, os_name, first_version, onboarded, onboarded_at, retention, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		appID, teamID, "test-app", "sh.measure.test", "android", "1.0.0", true, now, 90, now, now)
+		`INSERT INTO apps (id, team_id, app_name, unique_identifier, os_names, first_version, onboarded, onboarded_at, retention, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		appID, teamID, "test-app", "sh.measure.test", []string{"android"}, "1.0.0", true, now, 90, now, now)
 	if err != nil {
 		t.Fatalf("seed app: %v", err)
 	}

--- a/backend/ingest/measure/app.go
+++ b/backend/ingest/measure/app.go
@@ -15,7 +15,7 @@ import (
 type App struct {
 	ID           *uuid.UUID `json:"id"`
 	TeamId       uuid.UUID  `json:"team_id"`
-	OSName       string     `json:"os_name"`
+	OSNames      []string   `json:"os_names"`
 	FirstVersion string     `json:"first_version"`
 	Onboarded    bool       `json:"onboarded"`
 	OnboardedAt  time.Time  `json:"onboarded_at"`
@@ -24,14 +24,13 @@ type App struct {
 // SelectApp selects app by its id.
 func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 	var onboarded pgtype.Bool
-	var os pgtype.Text
 	var firstVersion pgtype.Text
 
 	stmt := sqlf.PostgreSQL.
 		Select("id").
 		Select("team_id").
 		Select("onboarded").
-		Select("os_name").
+		Select("os_names").
 		Select("first_version").
 		From("apps").
 		Where("id = ?", id)
@@ -42,7 +41,7 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app = &App{}
 	}
 
-	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &os, &firstVersion); err != nil {
+	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &app.OSNames, &firstVersion); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		} else {
@@ -54,12 +53,6 @@ func SelectApp(ctx context.Context, id uuid.UUID) (app *App, err error) {
 		app.Onboarded = onboarded.Bool
 	} else {
 		app.Onboarded = false
-	}
-
-	if os.Valid {
-		app.OSName = os.String
-	} else {
-		app.OSName = ""
 	}
 
 	if firstVersion.Valid {

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -266,6 +266,22 @@ func (e *eventreq) checkSeen(ctx context.Context) (err error) {
 
 // readMultipartRequest parses and validates the event request payload for
 // events and attachments.
+// getOSName returns the batch's operating system, taken from the first event
+// (or the first span, for span-only batches). Returns "" if the batch has
+// neither.
+func (e *eventreq) getOSName() string {
+	if len(e.events) > 0 {
+		return strings.ToLower(e.events[0].Attribute.OSName)
+	}
+	if len(e.spans) > 0 {
+		return strings.ToLower(e.spans[0].Attributes.OSName)
+	}
+	// Unreachable in practice: ingest rejects any batch without at least one
+	// event or span and any with an empty or unrecognized os_name. This guard
+	// only avoids an index-out-of-range panic.
+	return ""
+}
+
 func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 	form, err := c.MultipartForm()
 	if err != nil {
@@ -362,13 +378,6 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 		// compute launch timings
 		ev.ComputeLaunchTimes()
 
-		// read OS name from payload
-		// if we haven't figured out
-		// already.
-		if e.osName == "" {
-			e.osName = strings.ToLower(ev.Attribute.OSName)
-		}
-
 		e.events = append(e.events, ev)
 	}
 
@@ -395,13 +404,6 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 
 		e.bumpSize(uint64(len(bytes)))
 		sp.AppID = e.appId
-
-		// read OS name from payload
-		// if we haven't figured out
-		// already.
-		if e.osName == "" {
-			e.osName = strings.ToLower(sp.Attributes.OSName)
-		}
 
 		e.spans = append(e.spans, sp)
 	}
@@ -519,11 +521,6 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 		// compute launch timings
 		ev.ComputeLaunchTimes()
 
-		// read OS name from payload if we haven't figured out already
-		if e.osName == "" {
-			e.osName = strings.ToLower(ev.Attribute.OSName)
-		}
-
 		e.events = append(e.events, ev)
 	}
 
@@ -546,11 +543,6 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 
 		e.bumpSize(uint64(len(bytes)))
 		sp.AppID = e.appId
-
-		// read OS name from payload if we haven't figured out already
-		if e.osName == "" {
-			e.osName = strings.ToLower(sp.Attributes.OSName)
-		}
 
 		e.spans = append(e.spans, sp)
 	}
@@ -822,7 +814,6 @@ func PutEvents(c *gin.Context) {
 		appId:       appId,
 		teamId:      app.TeamId,
 		json:        strings.HasPrefix(c.ContentType(), "application/json"),
-		osName:      app.OSName,
 		attachments: make(map[uuid.UUID]*blob),
 	}
 
@@ -866,6 +857,12 @@ func PutEvents(c *gin.Context) {
 			return
 		}
 	}
+
+	// Resolve the batch's OS from its own events/spans. This drives
+	// symbolication routing, which must follow the batch's actual runtime OS
+	// rather than the app's stored os_names (an app can span multiple OSes of
+	// a family).
+	eventReq.osName = eventReq.getOSName()
 
 	if err := eventReq.checkSeen(ingestReqCtx); err != nil {
 		msg := "failed to check for duplicate event request batch"

--- a/backend/libs/opsys/opsys.go
+++ b/backend/libs/opsys/opsys.go
@@ -34,3 +34,20 @@ func ToFamily(osName string) string {
 		return Unknown
 	}
 }
+
+// family groups OS names such that members of the same family share a key.
+// ios and ipados belong to the apple family; every other value is its own
+// family.
+func family(osName string) string {
+	switch strings.ToLower(osName) {
+	case IOS, IPad:
+		return AppleFamily
+	default:
+		return strings.ToLower(osName)
+	}
+}
+
+// SameFamily reports whether two OS names belong to the same family.
+func SameFamily(a, b string) bool {
+	return family(a) == family(b)
+}

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -143,8 +143,8 @@ func (h *TestHelper) SeedApp(ctx context.Context, t *testing.T, appID, teamID, a
 	now := time.Now()
 
 	_, err := h.PgPool.Exec(ctx,
-		`INSERT INTO apps (id, team_id, app_name, unique_identifier, os_name, first_version, onboarded, onboarded_at, retention, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		appID, teamID, appName, appName, "android", "1.0.0", true, now, retention, now, now)
+		`INSERT INTO apps (id, team_id, app_name, unique_identifier, os_names, first_version, onboarded, onboarded_at, retention, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		appID, teamID, appName, appName, []string{"android"}, "1.0.0", true, now, retention, now, now)
 	if err != nil {
 		t.Fatalf("seed app: %v", err)
 	}

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -420,14 +420,14 @@ Payload must contain the app version info, build info and optional build mapping
 }
 ```
 
-| Field          | Type   | Optional | Comment                                                                                                                                 |
-| -------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `version_name` | string | No       | Version name of the build. Like "1.0"                                                                                                   |
-| `version_code` | string | No       | Version code of the build. Like "999"                                                                                                   |
-| `build_size`   | string | No       | Size of app in bytes                                                                                                                    |
-| `build_type`   | string | No       | Type of the build.<br />- `aab`, `apk` for Android<br />- `ipa` for iOS                                                                 |
+| Field          | Type   | Optional | Comment                                                                                                                                    |
+| -------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `version_name` | string | No       | Version name of the build. Like "1.0"                                                                                                      |
+| `version_code` | string | No       | Version code of the build. Like "999"                                                                                                      |
+| `build_size`   | string | No       | Size of app in bytes                                                                                                                       |
+| `build_type`   | string | No       | Type of the build.<br />- `aab`, `apk` for Android<br />- `ipa` for iOS                                                                    |
 | `patch_id`     | string | Yes      | Optional UUID identifying an Over-The-Air patch this build's mappings belong to. Omit when uploading a regular (non-OTA) build's mappings. |
-| `mappings`     | array  | Yes      | List of mapping files objects.                                                                                                          |
+| `mappings`     | array  | Yes      | List of mapping files objects.                                                                                                             |
 
 ##### Mappings
 
@@ -590,7 +590,7 @@ Events can contain the following attributes, some of which are mandatory.
 | `device_locale`                     | string  | Yes      | Locale based on RFC 5646, eg. en-US                                         |
 | `device_low_power_mode`             | bool    | Yes      | `true` when low power mode is enabled                                       |
 | `device_thermal_throttling_enabled` | bool    | Yes      | `true` when thermal throttling is enabled                                   |
-| `os_name`                           | string  | Yes      | Operating system name. One of:<br/>- android</br>- ios</br>- ipados         |
+| `os_name`                           | string  | No       | Operating system name. One of:<br/>- android</br>- ios</br>- ipados         |
 | `os_version`                        | string  | Yes      | Operating system version                                                    |
 | `os_page_size`                      | uint8   | Yes      | Operating system memory page size                                           |
 | `network_type`                      | string  | No       | One of<br/>- wifi<br/>- cellular<br/>- vpn<br/>- unknown<br/>- no_network   |
@@ -903,7 +903,7 @@ Use the `string` type when sending unstructured or structured logs. Make sure st
 
 Use the `gesture_long_click` body type for longer press and hold gestures.
 
-| Field             | Type    | Optional | Comment                                                            |
+| Field             | Type    | Optional | Comment                                                           |
 | ----------------- | ------- | -------- | ----------------------------------------------------------------- |
 | `target`          | string  | Yes      | Class/Instance name of the originating view                       |
 | `target_id`       | string  | Yes      | Unique identifier for the target                                  |

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -131,7 +131,7 @@ function makeApp(id: string, onboarded = true): App {
     onboarded,
     created_at: "",
     updated_at: "",
-    os_name: "android",
+    os_names: ["android"],
     onboarded_at: null,
     unique_identifier: null,
   };

--- a/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
+++ b/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
@@ -152,7 +152,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -170,7 +170,7 @@ describe("SdkConfigurator Component", () => {
     expect(screen.getByText("Screenshot Masking")).toBeInTheDocument();
   });
 
-  it("hides ANR section when osName is iOS, shows it for Android and null", () => {
+  it("hides ANR section when osNames is iOS, shows it for Android and null", () => {
     // Test with iOS
     const { unmount } = render(
       <SdkConfigurator
@@ -178,7 +178,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName="ios"
+        osNames={["ios"]}
       />,
     );
 
@@ -192,7 +192,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName="android"
+        osNames={["android"]}
       />,
     );
 
@@ -206,7 +206,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -220,7 +220,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -242,7 +242,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={false}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -282,7 +282,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -346,7 +346,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -407,7 +407,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -464,7 +464,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -519,7 +519,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -617,7 +617,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -673,7 +673,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -720,7 +720,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -785,7 +785,7 @@ describe("SdkConfigurator Component", () => {
           ],
         }}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -852,7 +852,7 @@ describe("SdkConfigurator Component", () => {
           screenshot_mask_level: "sensitive_fields_only",
         }}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -871,7 +871,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -929,7 +929,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -985,7 +985,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1037,7 +1037,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1087,7 +1087,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1137,7 +1137,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1187,7 +1187,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1282,7 +1282,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1331,7 +1331,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={false}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1377,7 +1377,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1405,7 +1405,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1433,7 +1433,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1461,7 +1461,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1509,7 +1509,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1537,7 +1537,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 
@@ -1565,7 +1565,7 @@ describe("SdkConfigurator Component", () => {
         appName="Test App"
         initialConfig={mockInitialConfig}
         currentUserCanChangeAppSettings={true}
-        osName={null}
+        osNames={null}
       />,
     );
 

--- a/frontend/dashboard/__tests__/integration/apps_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/apps_msw_test.tsx
@@ -188,7 +188,7 @@ describe("Apps Page (MSW integration)", () => {
       await renderAndWaitForData();
       expect(screen.getByText("Unique Identifier")).toBeTruthy();
       expect(screen.getByText("sh.measure.demo")).toBeTruthy();
-      expect(screen.getByText("Operating System")).toBeTruthy();
+      expect(screen.getByText("Operating Systems")).toBeTruthy();
       expect(screen.getByText("android")).toBeTruthy();
       expect(screen.getByText("Created at")).toBeTruthy();
     });
@@ -455,7 +455,7 @@ describe("Apps Page — not-onboarded app", () => {
     server.use(
       http.get("*/api/teams/:teamId/apps", () => {
         return HttpResponse.json([
-          makeAppFixture({ unique_identifier: null, os_name: null }),
+          makeAppFixture({ unique_identifier: null, os_names: null }),
         ]);
       }),
     );
@@ -470,7 +470,7 @@ describe("Apps Page — not-onboarded app", () => {
     );
     expect(screen.getByText(/Follow our/)).toBeTruthy();
     expect(screen.queryByText("Unique Identifier")).toBeNull();
-    expect(screen.queryByText("Operating System")).toBeNull();
+    expect(screen.queryByText("Operating Systems")).toBeNull();
   });
 });
 
@@ -542,7 +542,7 @@ describe("Apps Page — create app", () => {
       team_id: "test-team",
       name: "My New App",
       unique_identifier: null,
-      os_name: null,
+      os_names: null,
       api_key: {
         key: "msw-new-app-key",
         revoked: false,
@@ -777,7 +777,7 @@ describe("Apps Page — SDK configurator", () => {
     it("hides ANRs accordion for iOS app", async () => {
       server.use(
         http.get("*/api/teams/:teamId/apps", () => {
-          return HttpResponse.json([makeAppFixture({ os_name: "ios" })]);
+          return HttpResponse.json([makeAppFixture({ os_names: ["ios"] })]);
         }),
       );
       renderWithProviders(

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -17,7 +17,7 @@ export function makeAppFixture(overrides: Record<string, any> = {}) {
     team_id: "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
     name: "measure demo",
     unique_identifier: "sh.measure.demo",
-    os_name: "android",
+    os_names: ["android"],
     api_key: {
       key: "msw-test-api-key-0000",
       revoked: false,

--- a/frontend/dashboard/__tests__/pages/apps_test.tsx
+++ b/frontend/dashboard/__tests__/pages/apps_test.tsx
@@ -28,7 +28,7 @@ const baseMockApp = {
   onboarded: true,
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
-  os_name: "Android",
+  os_names: ["android"],
   onboarded_at: "2025-01-01T00:00:00Z",
   unique_identifier: "com.example.app",
 };

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -45,7 +45,7 @@ function makeApp(id: string, overrides: Partial<App> = {}): App {
     onboarded: true,
     created_at: "",
     updated_at: "",
-    os_name: "android",
+    os_names: ["android"],
     onboarded_at: null,
     unique_identifier: null,
     ...overrides,

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -481,35 +481,44 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
           <div className="font-body">
             <div className="flex flex-col mt-8">
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="font-display text-muted-foreground">
-                  Unique Identifier
-                </p>
-              )}
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="text-sm mt-0.5">
-                  {filters.app!.unique_identifier}
-                </p>
-              )}
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="font-display text-muted-foreground mt-6">
-                  Operating System
-                </p>
-              )}
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="text-sm mt-0.5">{filters.app!.os_name}</p>
-              )}
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="font-display text-muted-foreground mt-6">
-                  Created at
-                </p>
-              )}
-              {filters.app!.unique_identifier && filters.app!.os_name && (
-                <p className="text-sm mt-0.5">
-                  {formatDateToHumanReadableDateTime(filters.app!.created_at)}
-                </p>
-              )}
-              {(!filters.app!.unique_identifier || !filters.app!.os_name) && (
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="font-display text-muted-foreground">
+                    Unique Identifier
+                  </p>
+                )}
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="text-sm mt-0.5">
+                    {filters.app!.unique_identifier}
+                  </p>
+                )}
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="font-display text-muted-foreground mt-6">
+                    Operating Systems
+                  </p>
+                )}
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="text-sm mt-0.5">
+                    {filters.app!.os_names?.join(", ")}
+                  </p>
+                )}
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="font-display text-muted-foreground mt-6">
+                    Created at
+                  </p>
+                )}
+              {filters.app!.unique_identifier &&
+                !!filters.app!.os_names?.length && (
+                  <p className="text-sm mt-0.5">
+                    {formatDateToHumanReadableDateTime(filters.app!.created_at)}
+                  </p>
+                )}
+              {(!filters.app!.unique_identifier ||
+                !filters.app!.os_names?.length) && (
                 <p className="font-body text-sm">
                   Follow our{" "}
                   <Link className={underlineLinkStyle} href="/docs">
@@ -573,7 +582,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
             <SdkConfigurator
               appId={filters.app!.id}
               appName={filters.app!.name}
-              osName={filters.app!.os_name}
+              osNames={filters.app!.os_names}
               initialConfig={sdkConfig!}
               currentUserCanChangeAppSettings={canWriteSdkConfig}
             />

--- a/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_timelines/page.tsx
@@ -98,7 +98,7 @@ export default function SessionTimelinesOverview(props: {
     track("session_searched", {
       team_id: params.teamId,
       app_id: filters.app?.id,
-      app_platform: filters.app?.os_name,
+      app_platform: filters.app?.os_names?.join(","),
       feature_area: "sessions",
       entry_point: "direct",
     });

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -565,7 +565,7 @@ export type App = {
   onboarded: boolean;
   created_at: string;
   updated_at: string;
-  os_name: string | null;
+  os_names: string[] | null;
   onboarded_at: string | null;
   unique_identifier: string | null;
 };

--- a/frontend/dashboard/app/components/sdk_configurator.tsx
+++ b/frontend/dashboard/app/components/sdk_configurator.tsx
@@ -29,7 +29,7 @@ interface SdkConfiguratorProps {
   appName: string;
   initialConfig: SdkConfig;
   currentUserCanChangeAppSettings: boolean;
-  osName?: string | null;
+  osNames?: string[] | null;
 }
 
 type SectionSaveStatus = "idle" | "saving" | "saved" | "error";
@@ -41,7 +41,7 @@ export default function SdkConfigurator({
   appName,
   initialConfig,
   currentUserCanChangeAppSettings,
-  osName,
+  osNames,
 }: SdkConfiguratorProps) {
   // Local editable state
   const [sdkConfig, setSdkConfigState] = useState<SdkConfig | null>(
@@ -167,7 +167,7 @@ export default function SdkConfigurator({
           track("sampling_adjusted", {
             team_id: routeParams?.teamId,
             app_id: appId,
-            app_platform: osName,
+            app_platform: osNames?.join(","),
             feature_area: "sampling",
             entry_point: "direct",
             section: sectionKey,
@@ -277,11 +277,10 @@ export default function SdkConfigurator({
 
   const getHeaderPlaceholder = () => ["X-User-ID", "X-API-Key"].join("\n");
 
-  // Helper to check if ANR should be shown
+  // Helper to check if ANR should be shown. ANR is Android-only, so show it
+  // when the OS is unknown or the app reports on Android.
   const shouldShowAnr =
-    osName === null ||
-    osName === undefined ||
-    osName.toLowerCase() === "android";
+    !osNames?.length || osNames.some((os) => os.toLowerCase() === "android");
 
   // Confirmation dialog body generators
   const getCrashesConfirmBody = () => {

--- a/self-host/postgres/20260606120000_alter_apps_table.sql
+++ b/self-host/postgres/20260606120000_alter_apps_table.sql
@@ -1,0 +1,35 @@
+-- migrate:up
+alter table if exists measure.apps
+drop constraint if exists apps_os_name_check;
+
+alter table if exists measure.apps
+add column if not exists os_names text[] not null default '{}';
+
+update measure.apps
+set os_names = array[os_name]
+where os_name is not null and os_name <> '';
+
+alter table if exists measure.apps
+drop column if exists os_name;
+
+-- os_names must hold values of a single OS family (ios and ipados together
+-- form the apple family). This is enforced in ingest code. We deliberate dropped this
+-- as a constraint as we need to support more OS names in the future wihout having to runs
+-- migrations.
+comment on column measure.apps.os_names is 'names of the operating systems the app runs on (single family)';
+
+-- migrate:down
+alter table if exists measure.apps
+add column if not exists os_name varchar(256);
+
+update measure.apps
+set os_name = os_names[1]
+where cardinality(os_names) > 0;
+
+alter table if exists measure.apps
+drop column if exists os_names;
+
+alter table if exists measure.apps
+add constraint apps_os_name_check check (
+  os_name::text = any (array['ios', 'android', 'flutter', 'react-native', 'unity', 'ipados']::text[])
+);


### PR DESCRIPTION
# Description

Apps can run on more than one OS of the same family — most commonly an Apple app on both iPhone (ios) and iPad (ipados). The app's OS was stored once as a scalar `os_name`, written only at onboarding from the first event, so it recorded whichever device happened to report first.

Replace it with `os_names` (a set), kept current on every ingest batch.

Backend:
- Migration renames `apps.os_name` (varchar) to `os_names` (text[]) and backfills existing values into single-element arrays. The single-family rule is enforced in ingest code, dropping the previous os_name DB constraint.
- ingest-worker reconciles `os_names` on every batch instead of only at onboarding, appending a newly seen OS via a race-safe conditional UPDATE. Cross-family values are skipped via an `opsys.SameFamily` check; the write is best-effort so it never fails ingestion.
- Symbolication now routes off the batch's own events/spans rather than the app's stored OS, fixing mis-routing for cross-platform apps. OS resolution in the receiver moved to a single post-parse step.
- App reads/structs, JSON responses, and MCP `list_apps` now expose `os_names`. A single `app.Family()` helper replaces the per-family branching that read the scalar field. Removed the unused `AppFilter.AppOSName`.

Frontend:
- Dashboard App type, app settings display, and SDK configurator (ANR visibility) updated to the array; analytics send the joined list.

Docs:
- Mark `attribute.os_name` as required, matching the existing ingest validation.

## Related issue
Closes #3813



