### PR TITLE
chore(frontend): hide custom errors toggle

### DIFF
--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -113,6 +113,11 @@ const defaultFreeTextPlaceholder = "Search anything...";
 
 const SEARCH_INPUT_ID = "free-text";
 
+// Custom errors aren't a supported feature yet, so the errors "Custom Only"
+// filter toggle stays hidden regardless of the per-page showCustomErrors prop.
+// Flip to true to surface it once custom errors are supported.
+const CUSTOM_ERRORS_ENABLED = false;
+
 // Errors-only Severity filter: store holds lowercase values; the dropdown
 // shows capitalized labels.
 const SEVERITY_DISPLAY_ITEMS: string[] = ["Fatal", "Unhandled", "Handled"];
@@ -1601,7 +1606,7 @@ const FiltersComponent = forwardRef<
                     onChangeCustomErrorsOnly={(custom) =>
                       store.setCustomErrorsOnly(custom)
                     }
-                    showCustomToggle={showCustomErrors}
+                    showCustomToggle={showCustomErrors && CUSTOM_ERRORS_ENABLED}
                     open={errorsTypeOpen}
                     onOpenChange={setErrorsTypeOpen}
                   />


### PR DESCRIPTION
# Description

Custom errors aren't supported yet so we hide the toggle now and flip it back on later.

## Related issue
Closes #3834



