### PR TITLE
fix(backend): guard against nil team in MCP app resolution

### DIFF
--- a/backend/api/measure/mcp.go
+++ b/backend/api/measure/mcp.go
@@ -1438,6 +1438,9 @@ func mcpResolveAppAccess(ctx context.Context, rawAppID string) (uuid.UUID, uuid.
 	if err != nil {
 		return uuid.UUID{}, uuid.UUID{}, fmt.Errorf("failed to get app team: %v", err)
 	}
+	if team == nil {
+		return uuid.UUID{}, uuid.UUID{}, fmt.Errorf("no team exists for app %s", appID)
+	}
 
 	return appID, *team.ID, nil
 }


### PR DESCRIPTION
# Description

app.getTeam returns (nil, nil) when no app row exists, so consumers must nil-check the result before dereferencing team.ID. The MCP app resolver was the only one of the getTeam call sites missing this guard.

In practice it could not nil-deref because app existence is verified just above via the team_membership count check, but the explicit guard makes it consistent with every other call site and robust if that upstream check is ever removed.

## Related issue
Closes #515 



