### PR TITLE
refactor(frontend): rename middleware to proxy for Next 16

### DIFF
--- a/frontend/dashboard/__tests__/integration/page_md_route_msw_test.ts
+++ b/frontend/dashboard/__tests__/integration/page_md_route_msw_test.ts
@@ -2,7 +2,7 @@
  * Integration tests for the markdown content-negotiation route handler at
  * `app/page-md/[...path]/route.ts`.
  *
- * The middleware unit tests cover the *rewrite decision* — given a
+ * The proxy unit tests cover the *rewrite decision* — given a
  * pathname + matcher, what URL does the function emit? They can't cover
  * what actually happens after the rewrite hits the route handler, which
  * is where the markdown source is resolved, the response is built, and

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -6,7 +6,7 @@
  * error states, empty data, etc.
  *
  * URL paths use the /api/* prefix that the frontend sends. The Next.js
- * middleware strips /api and proxies to the Go backend in production,
+ * proxy strips /api and proxies to the Go backend in production,
  * but in tests MSW intercepts before that happens.
  */
 import { http, HttpResponse } from "msw";

--- a/frontend/dashboard/__tests__/proxy_test.ts
+++ b/frontend/dashboard/__tests__/proxy_test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 
-// Mock next/server before importing the middleware so the import picks up
+// Mock next/server before importing the proxy so the import picks up
 // the mock. NextResponse.rewrite captures the destination URL as a string.
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -9,13 +9,17 @@ jest.mock("next/server", () => ({
   },
 }));
 
-import { config, middleware } from "@/middleware";
+import { config, proxy } from "@/proxy";
 
-// Build a minimal stub of NextRequest. The middleware only touches
+// Build a minimal stub of NextRequest. The proxy only touches
 // `request.nextUrl.pathname`, `request.nextUrl.search`, and the cloned
 // URL returned by `request.nextUrl.clone()`. Headers are not inspected
 // by the function — they're filtered upstream by `config.matcher`.
-function makeRequest(pathname: string, search = "", origin = "https://measure.sh") {
+function makeRequest(
+  pathname: string,
+  search = "",
+  origin = "https://measure.sh",
+) {
   return {
     nextUrl: {
       pathname,
@@ -27,7 +31,7 @@ function makeRequest(pathname: string, search = "", origin = "https://measure.sh
   } as any;
 }
 
-describe("middleware", () => {
+describe("proxy", () => {
   const originalApi = process.env.API_BASE_URL;
   const originalPosthog = process.env.POSTHOG_HOST;
 
@@ -51,61 +55,71 @@ describe("middleware", () => {
 
   describe("/api proxy", () => {
     it("rewrites /api/foo to the default API origin", () => {
-      const result: any = middleware(makeRequest("/api/foo"));
+      const result: any = proxy(makeRequest("/api/foo"));
       expect(result.type).toBe("rewrite");
       expect(result.url).toBe("http://api:8080/foo");
     });
 
     it("preserves query string", () => {
-      const result: any = middleware(makeRequest("/api/users", "?limit=10&offset=20"));
+      const result: any = proxy(
+        makeRequest("/api/users", "?limit=10&offset=20"),
+      );
       expect(result.url).toBe("http://api:8080/users?limit=10&offset=20");
     });
 
     it("uses API_BASE_URL env var when set", () => {
       process.env.API_BASE_URL = "https://api.example.com:9000";
-      const result: any = middleware(makeRequest("/api/foo"));
+      const result: any = proxy(makeRequest("/api/foo"));
       expect(result.url).toBe("https://api.example.com:9000/foo");
     });
 
     it("replaces only the first /api occurrence", () => {
       // /api/api-keys → after replace("/api", "") → /api-keys (not //-keys)
-      const result: any = middleware(makeRequest("/api/api-keys"));
+      const result: any = proxy(makeRequest("/api/api-keys"));
       expect(result.url).toBe("http://api:8080/api-keys");
     });
 
     it("handles a bare /api with no trailing path", () => {
       // After replacement pathname becomes "" — URL normalizes to "/"
-      const result: any = middleware(makeRequest("/api"));
+      const result: any = proxy(makeRequest("/api"));
       expect(result.url).toBe("http://api:8080/");
     });
 
     it("handles a deeply nested path", () => {
-      const result: any = middleware(makeRequest("/api/teams/abc/apps/xyz/sessions"));
+      const result: any = proxy(
+        makeRequest("/api/teams/abc/apps/xyz/sessions"),
+      );
       expect(result.url).toBe("http://api:8080/teams/abc/apps/xyz/sessions");
     });
 
     it("falls back to http://api:8080 when API_BASE_URL is empty string", () => {
       process.env.API_BASE_URL = "";
-      const result: any = middleware(makeRequest("/api/foo"));
+      const result: any = proxy(makeRequest("/api/foo"));
       expect(result.url).toBe("http://api:8080/foo");
     });
   });
 
   describe("/yrtmlt/static proxy", () => {
     it("rewrites /yrtmlt/static/array.js to PostHog assets CDN", () => {
-      const result: any = middleware(makeRequest("/yrtmlt/static/array.js"));
-      expect(result.url).toBe("https://us-assets.i.posthog.com/static/array.js");
+      const result: any = proxy(makeRequest("/yrtmlt/static/array.js"));
+      expect(result.url).toBe(
+        "https://us-assets.i.posthog.com/static/array.js",
+      );
     });
 
     it("preserves nested static paths", () => {
-      const result: any = middleware(makeRequest("/yrtmlt/static/recorder/recorder.js"));
-      expect(result.url).toBe("https://us-assets.i.posthog.com/static/recorder/recorder.js");
+      const result: any = proxy(
+        makeRequest("/yrtmlt/static/recorder/recorder.js"),
+      );
+      expect(result.url).toBe(
+        "https://us-assets.i.posthog.com/static/recorder/recorder.js",
+      );
     });
 
     it("static branch takes precedence over generic /yrtmlt branch", () => {
       // Path starts with /yrtmlt/static/ so it must hit the assets CDN,
       // not the POSTHOG_HOST branch (which doesn't need to be set).
-      const result: any = middleware(makeRequest("/yrtmlt/static/foo.js"));
+      const result: any = proxy(makeRequest("/yrtmlt/static/foo.js"));
       expect(result.url).toContain("us-assets.i.posthog.com");
     });
   });
@@ -113,13 +127,13 @@ describe("middleware", () => {
   describe("/yrtmlt non-static proxy", () => {
     it("rewrites /yrtmlt/decide to POSTHOG_HOST", () => {
       process.env.POSTHOG_HOST = "https://us.posthog.com";
-      const result: any = middleware(makeRequest("/yrtmlt/decide"));
+      const result: any = proxy(makeRequest("/yrtmlt/decide"));
       expect(result.url).toBe("https://us.posthog.com/decide");
     });
 
     it("handles POSTHOG_HOST with a custom port", () => {
       process.env.POSTHOG_HOST = "http://posthog.local:8000";
-      const result: any = middleware(makeRequest("/yrtmlt/e"));
+      const result: any = proxy(makeRequest("/yrtmlt/e"));
       expect(result.url).toBe("http://posthog.local:8000/e");
     });
 
@@ -127,46 +141,50 @@ describe("middleware", () => {
       // "/yrtmlt/static".startsWith("/yrtmlt/static/") is false, so this
       // falls through to the generic /yrtmlt branch.
       process.env.POSTHOG_HOST = "https://us.posthog.com";
-      const result: any = middleware(makeRequest("/yrtmlt/static"));
+      const result: any = proxy(makeRequest("/yrtmlt/static"));
       expect(result.url).toBe("https://us.posthog.com/static");
     });
 
     it("throws when POSTHOG_HOST is unset (documented behavior)", () => {
-      // The middleware constructs `new URL(process.env.POSTHOG_HOST || "")`.
+      // The proxy constructs `new URL(process.env.POSTHOG_HOST || "")`.
       // Empty string is not a valid URL, so this throws — the runtime
       // contract assumes POSTHOG_HOST is set whenever /yrtmlt routes are live.
-      expect(() => middleware(makeRequest("/yrtmlt/foo"))).toThrow();
+      expect(() => proxy(makeRequest("/yrtmlt/foo"))).toThrow();
     });
   });
 
   describe("markdown content negotiation (fall-through)", () => {
     it("rewrites / to /page-md/index (homepage sentinel)", () => {
-      const result: any = middleware(makeRequest("/"));
+      const result: any = proxy(makeRequest("/"));
       expect(result.url).toBe("https://measure.sh/page-md/index");
     });
 
     it("rewrites /about to /page-md/about", () => {
-      const result: any = middleware(makeRequest("/about"));
+      const result: any = proxy(makeRequest("/about"));
       expect(result.url).toBe("https://measure.sh/page-md/about");
     });
 
     it("rewrites nested product paths", () => {
-      const result: any = middleware(makeRequest("/product/mcp"));
+      const result: any = proxy(makeRequest("/product/mcp"));
       expect(result.url).toBe("https://measure.sh/page-md/product/mcp");
     });
 
     it("rewrites docs paths so /page-md/[...path]/route.ts can serve them", () => {
-      const result: any = middleware(makeRequest("/docs/sdk-integration-guide"));
-      expect(result.url).toBe("https://measure.sh/page-md/docs/sdk-integration-guide");
+      const result: any = proxy(makeRequest("/docs/sdk-integration-guide"));
+      expect(result.url).toBe(
+        "https://measure.sh/page-md/docs/sdk-integration-guide",
+      );
     });
 
     it("rewrites pages with query strings (search params preserved on the URL)", () => {
-      const result: any = middleware(makeRequest("/about", "?utm=email"));
+      const result: any = proxy(makeRequest("/about", "?utm=email"));
       expect(result.url).toBe("https://measure.sh/page-md/about?utm=email");
     });
 
     it("preserves the original origin", () => {
-      const result: any = middleware(makeRequest("/pricing", "", "http://localhost:3000"));
+      const result: any = proxy(
+        makeRequest("/pricing", "", "http://localhost:3000"),
+      );
       expect(result.url).toBe("http://localhost:3000/page-md/pricing");
     });
   });
@@ -197,9 +215,7 @@ describe("middleware", () => {
     it("third entry's source excludes Next internals, the markdown route itself, API and PostHog proxies, and favicon", () => {
       const m: any = config.matcher[2];
       const sourceRegex = new RegExp(
-        m.source
-          .replace("/((?!", "^/(?!")
-          .replace(").*)", ").*$"),
+        m.source.replace("/((?!", "^/(?!").replace(").*)", ").*$"),
       );
       // Should NOT match (filtered by negative lookahead)
       expect(sourceRegex.test("/_next/static/foo.js")).toBe(false);
@@ -237,29 +253,29 @@ describe("middleware", () => {
   describe("path edge cases", () => {
     it("/api/ with trailing slash rewrites to API origin root", () => {
       // pathname.replace("/api", "") → "/", URL keeps it
-      const result: any = middleware(makeRequest("/api/"));
+      const result: any = proxy(makeRequest("/api/"));
       expect(result.url).toBe("http://api:8080/");
     });
 
     it("/api/foo/ preserves trailing slash on the rewritten path", () => {
-      const result: any = middleware(makeRequest("/api/foo/"));
+      const result: any = proxy(makeRequest("/api/foo/"));
       expect(result.url).toBe("http://api:8080/foo/");
     });
 
     it("preserves percent-encoded segments through the API rewrite", () => {
-      const result: any = middleware(makeRequest("/api/teams/team%20one"));
+      const result: any = proxy(makeRequest("/api/teams/team%20one"));
       expect(result.url).toBe("http://api:8080/teams/team%20one");
     });
 
     it("preserves a leading double slash after /api stripping", () => {
       // /api//foo → pathname.replace("/api", "") → "//foo"
       // URL does not collapse the double slash; documents existing behavior.
-      const result: any = middleware(makeRequest("/api//foo"));
+      const result: any = proxy(makeRequest("/api//foo"));
       expect(result.url).toBe("http://api:8080//foo");
     });
 
     it("markdown rewrite preserves a trailing slash on marketing paths", () => {
-      const result: any = middleware(makeRequest("/about/"));
+      const result: any = proxy(makeRequest("/about/"));
       expect(result.url).toBe("https://measure.sh/page-md/about/");
     });
   });
@@ -277,7 +293,7 @@ describe("middleware", () => {
         get: (name: string) =>
           name.toLowerCase() === "accept" ? "text/markdown" : null,
       };
-      const result: any = middleware(req);
+      const result: any = proxy(req);
       expect(result.url).toBe("http://api:8080/foo");
     });
   });
@@ -285,15 +301,15 @@ describe("middleware", () => {
   describe("POSTHOG_HOST configuration edge cases", () => {
     it("throws when POSTHOG_HOST is a non-URL string", () => {
       process.env.POSTHOG_HOST = "not-a-url";
-      expect(() => middleware(makeRequest("/yrtmlt/foo"))).toThrow();
+      expect(() => proxy(makeRequest("/yrtmlt/foo"))).toThrow();
     });
 
     it("silently drops the path component of POSTHOG_HOST", () => {
-      // The middleware reads only protocol/hostname/port off POSTHOG_HOST
+      // The proxy reads only protocol/hostname/port off POSTHOG_HOST
       // and overwrites pathname with the rewritten /yrtmlt/* path. Any
       // path in POSTHOG_HOST (e.g. /proxy) is therefore discarded.
       process.env.POSTHOG_HOST = "https://us.posthog.com/proxy";
-      const result: any = middleware(makeRequest("/yrtmlt/decide"));
+      const result: any = proxy(makeRequest("/yrtmlt/decide"));
       expect(result.url).toBe("https://us.posthog.com/decide");
     });
   });

--- a/frontend/dashboard/app/page-md/[...path]/route.ts
+++ b/frontend/dashboard/app/page-md/[...path]/route.ts
@@ -34,7 +34,7 @@ function markdownResponse(body: string) {
 
 /**
  * Resolve URL segments to a colocated `page.md` next to the route's
- * `page.tsx`. The middleware rewrites `/` to `/_md/index` so the homepage
+ * `page.tsx`. The proxy rewrites `/` to `/page-md/index` so the homepage
  * lands here as ["index"] — translate that back to `app/page.md`.
  */
 function resolvePageMd(segments: string[]): string | null {

--- a/frontend/dashboard/next.config.js
+++ b/frontend/dashboard/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   output: "standalone",
   poweredByHeader: false,
   experimental: {
-    // middleware.ts reverse-proxies /api/* and /yrtmlt/* to external origins
+    // proxy.ts reverse-proxies /api/* and /yrtmlt/* to external origins
     // via NextResponse.rewrite(). Raise the proxy timeout from the 30s default
     // so long-running API requests aren't cut off.
     proxyTimeout: 90000,

--- a/frontend/dashboard/proxy.ts
+++ b/frontend/dashboard/proxy.ts
@@ -33,7 +33,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (pathname.startsWith("/api")) {

--- a/frontend/dashboard/tsconfig.json
+++ b/frontend/dashboard/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,26 +11,23 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
-        "name": "next"
-      }
+        "name": "next",
+      },
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
+      "@/*": ["./*"],
+    },
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
# Description

Next 16 deprecated the `middleware` file convention in favor of `proxy` (nextjs.org/docs/messages/middleware-to-proxy). Rename the file and exported function; the `config.matcher` export and all behavior are unchanged — it still reverse-proxies /api and /yrtmlt and handles markdown content negotiation.

- middleware.ts -> proxy.ts, middleware() -> proxy()
- middleware_test.ts -> proxy_test.ts (import, call sites, describe)
- update stale "middleware" comment references

Also sync tsconfig.json with what Next 16 generates on dev/build:
- jsx: preserve -> react-jsx (aligns with the React 19 automatic runtime; affects type-checking/IDE only, since Turbopack/SWC does the transpile)
- add .next/dev/types/**/*.ts to include (Turbopack emits dev type helpers under .next/dev)

Fix an unrelated stale comment in route.ts: the homepage rewrites to /page-md/index, not /_md/index.



