### PR TITLE
fix(backend): include message to group js errors

### DIFF
--- a/backend/api/event/event.go
+++ b/backend/api/event/event.go
@@ -1951,12 +1951,35 @@ func (e *Exception) ComputeFingerprint() (err error) {
 		if frame.FileName != "" {
 			input += sep + frame.FileName
 		}
-	case FrameworkDart, FrameworkJS:
+	case FrameworkDart:
 		// get the outermost exception
 		outermostException := e.Exceptions[0]
 
 		// initialize fingerprint data with the exception type
 		input = outermostException.Type
+
+		if len(outermostException.Frames) > 0 {
+			methodName := outermostException.Frames[0].MethodName
+			fileName := outermostException.Frames[0].FileName
+
+			// Include any non-empty information
+			if methodName != "" {
+				input += sep + methodName
+			}
+			if fileName != "" {
+				input += sep + fileName
+			}
+		}
+	case FrameworkJS:
+		// get the outermost exception
+		outermostException := e.Exceptions[0]
+
+		// initialize fingerprint data with the exception type
+		input = outermostException.Type
+
+		if outermostException.Message != "" {
+			input += sep + outermostException.Message
+		}
 
 		if len(outermostException.Frames) > 0 {
 			methodName := outermostException.Frames[0].MethodName

--- a/backend/api/event/event_test.go
+++ b/backend/api/event/event_test.go
@@ -1029,3 +1029,255 @@ func TestValidateAttachmentLimit(t *testing.T) {
 		}
 	})
 }
+
+func TestComputeFingerprint(t *testing.T) {
+	t.Run("FrameworkJS with message", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkJS,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "TypeError",
+					Message: "Cannot read property 'foo' of undefined",
+					Frames: Frames{
+						{
+							MethodName: "render",
+							FileName:   "App.js",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing JS fingerprint: %v", err)
+		}
+
+		expected := "a8c01be01b06e5284186a69934ec04f6"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkJS with different message", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkJS,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "TypeError",
+					Message: "Cannot read property 'bar' of undefined",
+					Frames: Frames{
+						{
+							MethodName: "render",
+							FileName:   "App.js",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing JS fingerprint: %v", err)
+		}
+
+		expected := "56f894bf670623086c843b1d462c5c44"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkJS with empty message", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkJS,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "TypeError",
+					Message: "",
+					Frames: Frames{
+						{
+							MethodName: "render",
+							FileName:   "App.js",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing JS fingerprint: %v", err)
+		}
+
+		expected := "f7a09ac70683ba3a38cc8dbf537d51b4"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkDart with invalid double message", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkDart,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "FormatException",
+					Message: "Invalid double",
+					Frames: Frames{
+						{
+							MethodName: "parseDouble",
+							FileName:   "parser.dart",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing Dart fingerprint: %v", err)
+		}
+
+		expected := "20bb2b941c29aefcd6b81b2cba2d3511"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkDart with invalid float message (retains same fingerprint)", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkDart,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "FormatException",
+					Message: "Invalid float",
+					Frames: Frames{
+						{
+							MethodName: "parseDouble",
+							FileName:   "parser.dart",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing Dart fingerprint: %v", err)
+		}
+
+		expected := "20bb2b941c29aefcd6b81b2cba2d3511"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkJVM with nested exceptions uses innermost", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkJVM,
+			Exceptions: ExceptionUnits{
+				{
+					Type:    "java.lang.RuntimeException",
+					Message: "Nested exception wrapper",
+					Frames: Frames{
+						{
+							MethodName: "outerMethod",
+							FileName:   "OuterClass.java",
+						},
+					},
+				},
+				{
+					Type:    "java.lang.NullPointerException",
+					Message: "Null pointer occurred",
+					Frames: Frames{
+						{
+							MethodName: "innerMethod",
+							FileName:   "InnerClass.java",
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing JVM fingerprint: %v", err)
+		}
+
+		expected := "a74cd8f37b38b20c7505f5da3bc83df3"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+
+	t.Run("FrameworkApple selects relevant in-app frame", func(t *testing.T) {
+		e := Exception{
+			Framework: FrameworkApple,
+			Exceptions: ExceptionUnits{
+				{
+					ExceptionUnitiOS: &ExceptionUnitiOS{
+						Signal: "SIGABRT",
+					},
+					Frames: Frames{
+						{
+							MethodName: "systemMethod",
+							FileName:   "libsystem_kernel.dylib",
+							InApp:      false,
+						},
+						{
+							MethodName: "myInAppMethod",
+							FileName:   "ViewController.swift",
+							InApp:      true,
+						},
+					},
+				},
+			},
+		}
+
+		err := e.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing Apple fingerprint: %v", err)
+		}
+
+		expected := "53f373bcd16b29f5033e1c4477a8f5cd"
+		if e.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, e.Fingerprint)
+		}
+	})
+}
+
+func TestANRComputeFingerprint(t *testing.T) {
+	t.Run("ANR with nested exceptions uses innermost", func(t *testing.T) {
+		a := ANR{
+			Exceptions: ExceptionUnits{
+				{
+					Type: "AppNotResponding",
+					Frames: Frames{
+						{
+							MethodName: "systemWait",
+							FileName:   "native.c",
+						},
+					},
+				},
+				{
+					Type: "MainThreadBlocked",
+					Frames: Frames{
+						{
+							MethodName: "blockerMethod",
+							FileName:   "MainActivity.java",
+						},
+					},
+				},
+			},
+		}
+
+		err := a.ComputeFingerprint()
+		if err != nil {
+			t.Fatalf("Unexpected error computing ANR fingerprint: %v", err)
+		}
+
+		expected := "575ddc443e854d811e7e1b2b04868356"
+		if a.Fingerprint != expected {
+			t.Errorf("Expected fingerprint %q, but got %q", expected, a.Fingerprint)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR modifies how JS error groups fingerprint is computed by including `message` when available. Retains existing fingerprint compute behavior for other frameworks. Adds tests for all cases of fingerprint compute.

## Tasks

- [x] Include message in JS exception fingerprinting
- [x] Retain existing fingerprinting behavior for other frameworks
- [x] Add test for exception fingerprint compute
- [x] Add test for anr fingerprinting compute

## See also

- fixes #3864