### PR TITLE
chore(gradle): strip absolute paths from RN source map

### DIFF
--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -11,7 +11,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -188,6 +187,8 @@ class MeasurePlugin : Plugin<Project> {
 
     private fun packageReactNativeSourceMapTaskName(variant: Variant) = "packageReactNativeSourceMap${variant.name.capitalize()}"
 
+    private fun rewriteReactNativeSourceMapTaskName(variant: Variant) = "rewriteReactNativeSourceMap${variant.name.capitalize()}"
+
     // The builds API expects the JS bundle and its source map as two separate
     // jsbundle mappings, each a .tgz wrapping a single file. Symbolication pairs
     // them server-side via the inner filename's .map suffix.
@@ -213,11 +214,24 @@ class MeasurePlugin : Plugin<Project> {
             packageReactNativeBundleTaskName(variant),
             bundleFile,
         )
+        val rewriteSourceMapTask = project.tasks.register(
+            rewriteReactNativeSourceMapTaskName(variant),
+            RewriteJsSourceMapTask::class.java,
+        ) {
+            it.sourceMapInputProperty.set(sourceMapFile)
+            it.sourceMapOutputProperty.set(
+                project.layout.buildDirectory.file(
+                    sourceMapFile.map { map ->
+                        "intermediates/measure/${variant.name}/rn-sourcemap/${map.asFile.name}"
+                    },
+                ),
+            )
+        }
         val packageSourceMapTask = registerPackageArchiveTask(
             project,
             variant,
             packageReactNativeSourceMapTaskName(variant),
-            sourceMapFile,
+            rewriteSourceMapTask.flatMap { it.sourceMapOutputProperty },
         )
 
         project.tasks.matching { it.name in candidateNames }.configureEach { bundleTask ->
@@ -235,7 +249,7 @@ class MeasurePlugin : Plugin<Project> {
         project: Project,
         variant: Variant,
         taskName: String,
-        file: RegularFileProperty,
+        file: Provider<RegularFile>,
     ): TaskProvider<Tar> = project.tasks.register(taskName, Tar::class.java) {
         it.compression = Compression.GZIP
         it.archiveFileName.set(file.map { f -> "${f.asFile.name}.tgz" })

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/RewriteJsSourceMapTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/RewriteJsSourceMapTask.kt
@@ -1,0 +1,80 @@
+package sh.measure
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+private const val SOURCES_KEY = "sources"
+private const val NODE_MODULES = "node_modules"
+
+// The React Native source map's "sources" array holds absolute filesystem paths
+// (e.g. /Users/name/app/node_modules/react-native/...), which leak the build
+// machine's directory layout once uploaded. node_modules always sits at the
+// project root, so we use it to locate that root and rewrite every source to a
+// path relative to it.
+abstract class RewriteJsSourceMapTask : DefaultTask() {
+    init {
+        group = MeasurePlugin.GROUP_NAME
+        description = "Strips absolute filesystem paths from the React Native source map before upload"
+    }
+
+    @get:InputFile
+    abstract val sourceMapInputProperty: RegularFileProperty
+
+    @get:OutputFile
+    abstract val sourceMapOutputProperty: RegularFileProperty
+
+    @TaskAction
+    fun rewrite() {
+        val inputFile = sourceMapInputProperty.get().asFile
+        val outputFile = sourceMapOutputProperty.get().asFile
+        outputFile.parentFile?.mkdirs()
+
+        val root = Json.parseToJsonElement(inputFile.readText()) as? JsonObject
+        val sources = root?.get(SOURCES_KEY) as? JsonArray
+        if (root == null || sources == null) {
+            inputFile.copyTo(outputFile, overwrite = true)
+            return
+        }
+
+        val sourcePaths = sources.map { (it as? JsonPrimitive)?.contentOrNull }
+        val projectRoot = findProjectRoot(sourcePaths)
+        if (projectRoot == null) {
+            inputFile.copyTo(outputFile, overwrite = true)
+            return
+        }
+
+        val rewrittenSources = JsonArray(
+            sources.zip(sourcePaths) { element, path ->
+                if (path == null) element else JsonPrimitive(stripRoot(path, projectRoot))
+            },
+        )
+        val rewritten = JsonObject(root.toMutableMap().apply { put(SOURCES_KEY, rewrittenSources) })
+        outputFile.writeText(Json.encodeToString(JsonObject.serializer(), rewritten))
+    }
+
+    private fun findProjectRoot(sources: List<String?>): String? {
+        for (source in sources) {
+            if (source == null) continue
+            val index = source.indexOf(NODE_MODULES)
+            if (index > 0) {
+                return source.substring(0, index).trimEnd('/', '\\')
+            }
+        }
+        return null
+    }
+
+    private fun stripRoot(path: String, projectRoot: String): String {
+        if (path.startsWith(projectRoot)) {
+            return path.substring(projectRoot.length).trimStart('/', '\\')
+        }
+        return path
+    }
+}

--- a/android/measure-gradle-plugin/src/test/kotlin/sh/measure/RewriteJsSourceMapTaskTest.kt
+++ b/android/measure-gradle-plugin/src/test/kotlin/sh/measure/RewriteJsSourceMapTaskTest.kt
@@ -1,0 +1,102 @@
+package sh.measure
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import org.gradle.api.Project
+import org.gradle.internal.impldep.org.junit.Rule
+import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+internal class RewriteJsSourceMapTaskTest {
+
+    @field:Rule
+    lateinit var temporaryFolder: TemporaryFolder
+    private lateinit var inputFile: File
+    private lateinit var outputFile: File
+    private lateinit var project: Project
+    private lateinit var task: RewriteJsSourceMapTask
+
+    @Before
+    fun setup() {
+        temporaryFolder = TemporaryFolder()
+        temporaryFolder.create()
+        inputFile = temporaryFolder.newFile("index.android.bundle.map")
+        outputFile = temporaryFolder.newFile("output.map")
+    }
+
+    @Test
+    fun `strips absolute project root from source paths using node_modules as anchor`() {
+        inputFile.writeText(
+            """
+            {"version":3,"sources":[
+                "/Users/jane/app/node_modules/react-native/Libraries/Core/setUpErrorHandling.js",
+                "/Users/jane/app/App.tsx"
+            ],"sourcesContent":["a","b"],"names":[],"mappings":"AAAA"}
+            """.trimIndent(),
+        )
+        configureTask()
+        task.rewrite()
+
+        Assert.assertEquals(
+            listOf(
+                "node_modules/react-native/Libraries/Core/setUpErrorHandling.js",
+                "App.tsx",
+            ),
+            readSources(outputFile),
+        )
+    }
+
+    @Test
+    fun `preserves other source map fields`() {
+        inputFile.writeText(
+            """{"version":3,"sources":["/Users/jane/app/node_modules/x.js"],"mappings":"AAAA","names":["foo"]}""",
+        )
+        configureTask()
+        task.rewrite()
+
+        val output = Json.parseToJsonElement(outputFile.readText()) as JsonObject
+        Assert.assertEquals("AAAA", (output["mappings"] as JsonPrimitive).content)
+        Assert.assertEquals(JsonPrimitive(3), output["version"])
+        Assert.assertEquals(listOf("node_modules/x.js"), readSources(outputFile))
+    }
+
+    @Test
+    fun `leaves sources untouched when no node_modules path is present`() {
+        inputFile.writeText(
+            """{"version":3,"sources":["App.tsx","src/index.js"],"mappings":"AAAA"}""",
+        )
+        configureTask()
+        task.rewrite()
+
+        Assert.assertEquals(listOf("App.tsx", "src/index.js"), readSources(outputFile))
+    }
+
+    @Test
+    fun `copies through when sources key is missing`() {
+        val content = """{"version":3,"mappings":"AAAA"}"""
+        inputFile.writeText(content)
+        configureTask()
+        task.rewrite()
+
+        Assert.assertEquals(content, outputFile.readText())
+    }
+
+    private fun readSources(file: File): List<String?> {
+        val root = Json.parseToJsonElement(file.readText()) as JsonObject
+        return (root["sources"] as JsonArray).map { (it as JsonPrimitive).contentOrNull }
+    }
+
+    private fun configureTask() {
+        project = ProjectBuilder.builder().withProjectDir(temporaryFolder.root).build()
+        task = project.tasks.create("task", RewriteJsSourceMapTask::class.java)
+        task.sourceMapInputProperty.set(inputFile)
+        task.sourceMapOutputProperty.set(outputFile)
+    }
+}


### PR DESCRIPTION
# Description

Strip absolute paths from RN source maps using a new gradle task.

## Related issue
closes #3869 