### PR TITLE
chore(gradle): fix RN bundle gradle task graph

### DIFF
--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -39,8 +39,8 @@ class MeasurePlugin : Plugin<Project> {
         if (!project.plugins.hasPlugin("com.android.application")) {
             project.logger.warn(
                 """
-                WARNING: Measure gradle plugin can only be applied to Android application projects, 
-                that is, projects that have the com.android.application plugin applied. 
+                WARNING: Measure gradle plugin can only be applied to Android application projects,
+                that is, projects that have the com.android.application plugin applied.
                 Applying the plugin to other project types has no effect.
                 """.trimIndent(),
             )
@@ -235,6 +235,7 @@ class MeasurePlugin : Plugin<Project> {
             packageReactNativeBundleTaskName(variant),
             bundleFile,
         )
+        packageBundleTask.configure { it.dependsOn(emptyBundleTask) }
         val rewriteSourceMapTask = project.tasks.register(
             rewriteReactNativeSourceMapTaskName(variant),
             RewriteJsSourceMapTask::class.java,

--- a/react-native/example/rnExample/android/app/build.gradle
+++ b/react-native/example/rnExample/android/app/build.gradle
@@ -55,7 +55,7 @@ react {
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)


### PR DESCRIPTION
# Description

Wire up the `packageBundleTask` on `emptyBundleTask` so that empty bundle task for hermes runs correctly.

## Related issue
References #3868 



