### PR TITLE
fix(ios): enabled kscrash before checking for crash reports

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
@@ -33,6 +33,11 @@ final class BaseSystemCrashReporter: SystemCrashReporter {
     init(logger: Logger, crashDataPersistence: CrashDataPersistence) {
         self.logger = logger
         self.crashDataPersistence = crashDataPersistence
+        do {
+            try enable()
+        } catch {
+            logger.internalLog(level: .error, message: "MeasureInternal: KSCrash enable failed.", error: error, data: nil)
+        }
     }
 
     func enable() throws {


### PR DESCRIPTION
# Description

The crashes were not getting tracked in ios because KSCrash needs to be enabled to check weather there are pending crash reports available. This PR ensures KSCrash gets enabled as early as possible in the sdk initialization cycle.

## Related issue
Fixes #3880 