### PR TITLE
chore(android): prepare next development version 0.19.0-SNAPSHOT

### DIFF
--- a/android/measure-android/gradle.properties
+++ b/android/measure-android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.18.0
+MEASURE_VERSION_NAME=0.19.0-SNAPSHOT
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/measure-gradle-plugin/gradle/libs.versions.toml
+++ b/android/measure-gradle-plugin/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ squareup-okio = "3.7.0"
 kotlinx-serialization-json = "1.6.2"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests.
-measure-android = "0.18.0"
+measure-android = "0.19.0-SNAPSHOT"
 semver = "1.1.2"
 junit = "4.13.2"
 junit-jupiter = "5.10.2"


### PR DESCRIPTION
This PR prepares the next development version of the Android SDK.

**Changes:**
- Updated version to `0.19.0-SNAPSHOT` in gradle.properties
- Updated version to `0.19.0-SNAPSHOT` in libs.versions.toml

**Version:** 0.19.0-SNAPSHOT