### PR TITLE
chore(flutter): prepare measure_flutter release 0.6.0

### DIFF
--- a/.github/workflows/flutter-prepare-release.yml
+++ b/.github/workflows/flutter-prepare-release.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_flutter/pubspec.yaml
           sed -i 's/api("sh.measure:measure-android:.*")/api("sh.measure:measure-android:${{ inputs.android_sdk_version }}")/' flutter/packages/measure_flutter/android/build.gradle
-          sed -i "s/s.dependency 'measure-sh', '.*'/s.dependency 'measure-sh', '${{ inputs.ios_sdk_version }}'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
+          sed -i "s/s.dependency 'measure-sh', '.*'/s.dependency 'measure-sh', '~> ${{ inputs.ios_sdk_version }}'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
           sed -i "s/measure_flutter: ^.*/measure_flutter: ^${{ inputs.version }}/" flutter/packages/measure_flutter/README.md
           sed -i "s/measure_flutter: ^.*/measure_flutter: ^${{ inputs.version }}/" docs/sdk-integration-guide.md
 

--- a/docs/sdk-integration-guide.md
+++ b/docs/sdk-integration-guide.md
@@ -380,7 +380,7 @@ Add the following dependency to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  measure_flutter: ^0.5.0
+  measure_flutter: ^0.6.0
 ```
 
 ### Initialize the SDK

--- a/flutter/packages/measure_flutter/CHANGELOG.md
+++ b/flutter/packages/measure_flutter/CHANGELOG.md
@@ -5,10 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [measure_flutter-v0.6.0] - 2026-06-11
+
+### :sparkles: New features
+
+- (**flutter**): Mask sensitive content in screenshots (#3779) by @abhaysood in #3779
+
+### :hammer: Misc
+
+- (**flutter**): Update exception schema (#3728) by @abhaysood in #3728
+- (**flutter**): Add diagnostic mode for SDK logging (#3593) by @abhaysood in #3593
+- (**flutter**): Fix screenshot rendering in bug reports (#3615) by @abhaysood in #3615
+- (**flutter**): Compress flutter screenshots to webp (#3545) by @abhaysood in #3545
+- (**flutter**): Prepare next measure_flutter version 0.6.0 (#3450) by @abhaysood in #3450
+
 ## [measure_flutter-v0.5.0] - 2026-04-08
 
 ### :hammer: Misc
 
+- (**flutter**): Prepare measure_flutter release 0.5.0 (#3449) by @abhaysood in #3449
 - (**flutter**): Prepare measure_dio-v0.4.0 (#3317) by @abhaysood in #3317
 
 ## [measure_flutter-v0.4.0] - 2026-02-19

--- a/flutter/packages/measure_flutter/README.md
+++ b/flutter/packages/measure_flutter/README.md
@@ -23,7 +23,7 @@ Add the following dependency to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  measure_flutter: ^0.5.0
+  measure_flutter: ^0.6.0
 ```
 
 ### Initialize the SDK

--- a/flutter/packages/measure_flutter/android/build.gradle
+++ b/flutter/packages/measure_flutter/android/build.gradle
@@ -47,7 +47,7 @@ android {
     }
 
     dependencies {
-        api("sh.measure:measure-android:0.18.0-SNAPSHOT")
+        api("sh.measure:measure-android:0.18.0")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
     }
 

--- a/flutter/packages/measure_flutter/ios/measure_flutter.podspec
+++ b/flutter/packages/measure_flutter/ios/measure_flutter.podspec
@@ -14,7 +14,7 @@ Measure Flutter iOS Plugin.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'measure-sh'
+  s.dependency 'measure-sh', '~> 0.11.0'
   s.platform = :ios, '12.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.10'


### PR DESCRIPTION
This PR prepares measure_flutter for release version 0.6.0.

<!-- release-meta
NEXT_VERSION=0.7.0
ANDROID_SNAPSHOT_VERSION=0.18.0-SNAPSHOT
MEASURE_FLUTTER_VERSION=
-->