### PR TITLE
chore(flutter): prepare measure_dio release 0.6.0

### DIFF
--- a/flutter/packages/measure_dio/CHANGELOG.md
+++ b/flutter/packages/measure_dio/CHANGELOG.md
@@ -5,33 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [measure-dio-v0.5.0]
-
-Update to measure_flutter-v0.5.0
-
-
-## [measure-dio-v0.4.0]
-
-Update to measure_flutter-v0.4.0
-
-## [measure-dio-v0.3.0]
-
-Update to measure_flutter-v0.3.0
-
-## [measure-dio-v0.2.0]
-
-Update to measure_flutter-v0.2.0
-
-## [measure-dio-v0.1.1]
-
-- (**flutter**): Fix changelog and prepare new release (#2438) by @abhaysood in #2438
-
-## [measure-dio-v0.1.0]
-
-### :sparkles: New features
-
-- (**flutter**): Track http events using dio (#2294) by @abhaysood in #2294
+## [measure_dio-v0.6.0] - 2026-06-11
 
 ### :hammer: Misc
 
+- (**flutter**): Prepare next measure_dio version 0.6.0 (#3452) by @abhaysood in #3452
+
+## [measure_dio-v0.5.0] - 2026-04-08
+
+### :hammer: Misc
+
+- (**flutter**): Prepare measure_dio release 0.5.0 (#3451) by @abhaysood in #3451
+
+## [measure_dio-v0.4.0] - 2026-03-20
+
+### :sparkles: New features
+
+- (**flutter**): Add layout snapshot with widget analyzer (#2751) by @abhaysood in #2751
+- (**flutter**): Add dynamic config and modify initialization (#3090) by @abhaysood in #3090
+
+### :bug: Bug fixes
+
+- (**flutter**): Bump measure flutter package in dio (#3316) by @abhaysood in #3316
+- (**flutter**): Update compatibility and dependency constraints (#3088) by @abhaysood in #3088
+
+### :hammer: Misc
+
+- (**flutter**): Prepare measure_dio-v0.4.0 (#3317) by @abhaysood in #3317
+- (**flutter**): Prepare measure_flutter-v0.3.1 (#3014) by @abhaysood in #3014
+
+## [measure_dio-v0.3.0] - 2025-12-09
+
+### :bug: Bug fixes
+
+- (**flutter**): Compatibility with older flutter versions (#3001) by @abhaysood in #3001
+
+### :hammer: Misc
+
+- (**flutter**): Prepare measure_dio-v0.3.0 (#3003) by @abhaysood in #3003
+
+## [measure_dio-v0.2.0] - 2025-10-22
+
+### :sparkles: New features
+
+- (**flutter**): Add custom attributes to trackHandledError (#2523) by @abhaysood in #2523
+- (**flutter**): Track gestures (#2367) by @abhaysood in #2367
+- (**flutter**): Implement bug reporting (#2353) by @abhaysood in #2353
+- (**flutter**): Expose api to get session id (#2338) by @abhaysood in #2338
+- (**flutter**): Expose apis to set and clear user id (#2337) by @abhaysood in #2337
+- (**flutter**): Implement tracing (#2316) by @abhaysood in #2316
+- (**flutter**): Manually start or stop the SDK (#2320) by @abhaysood in #2320
+
+### :hammer: Misc
+
+- (**flutter**): Prepare measure_dio-v0.2.0 (#2793) by @abhaysood in #2793
+- (**flutter**): Fix changelog and prepare new release (#2438) by @abhaysood in #2438
+- (**flutter**): Improve pub listing score (#2436) by @abhaysood in #2436
+- (**flutter**): Prepare measure_dio-v0.1.0 (#2429) by @abhaysood in #2429
+- (**flutter**): Prepare for pub.dev listing (#2389) by @abhaysood in #2389
 - (**flutter**): Validate http events (#2385) by @abhaysood in #2385
+- (**flutter**): Implement sdk configuration (#2302) by @abhaysood in #2302
+- (**flutter**): Add example app (#2301) by @abhaysood in #2301
+- (**flutter**): Implement http tracking using dio (#2294) by @abhaysood in #2294
+
+### :recycle: Refactor
+
+- (**flutter**): Use time provider (#2383) by @abhaysood in #2383
+

--- a/flutter/packages/measure_dio/pubspec.yaml
+++ b/flutter/packages/measure_dio/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   dio: ^5.3.4
-  measure_flutter: ^0.5.0
+  measure_flutter: ^0.6.0
 
 dev_dependencies:
   flutter_test:
@@ -21,6 +21,3 @@ dev_dependencies:
   mocktail: ^1.0.4
   http_mock_adapter: ^0.6.1
 
-dependency_overrides:
-  measure_flutter:
-    path: ../measure_flutter


### PR DESCRIPTION
This PR prepares measure_dio for release version 0.6.0.

<!-- release-meta
NEXT_VERSION=0.7.0
ANDROID_SNAPSHOT_VERSION=0.18.0-SNAPSHOT
MEASURE_FLUTTER_VERSION=0.6.0
-->