### PR TITLE
chore(rn): add release workflow

### DIFF
--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: react-native
     permissions:
-      contents: write
+      contents: read
       id-token: write
     timeout-minutes: 15
 
@@ -30,9 +30,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack

--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -1,0 +1,64 @@
+name: Release React Native SDK
+
+on:
+  push:
+    tags:
+      - 'rn-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — simulate publish without uploading to npm or creating a release'
+        type: boolean
+        default: true
+
+jobs:
+  publish-rn:
+    name: Publish React Native SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: react-native
+    permissions:
+      contents: write
+      id-token: write
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Use Correct Yarn Version
+        run: corepack prepare yarn@3.6.1 --activate
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn prepare
+
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance ${{ inputs.dry_run == true && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --draft \
+            ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
+            --verify-tag


### PR DESCRIPTION
# Description

Add github action to automate React Native release.

When a git tag with format `rn-v*` is pushed, the action starts automatically, publishes the package to npm and generate a draft github release.

## Related issue
Closes #3894 