### PR TITLE
fix(backend): restrict bug report status updates roles

### DIFF
--- a/backend/api/measure/app.go
+++ b/backend/api/measure/app.go
@@ -10121,7 +10121,7 @@ func GetBugReportsOverview(c *gin.Context) {
 		return
 	}
 
-	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeBugReportRead)
 	if err != nil {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)
@@ -10274,7 +10274,7 @@ func GetBugReportsInstancesPlot(c *gin.Context) {
 		return
 	}
 
-	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeBugReportRead)
 	if err != nil {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)
@@ -10388,7 +10388,7 @@ func GetBugReport(c *gin.Context) {
 		return
 	}
 
-	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeBugReportRead)
 	if err != nil {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)
@@ -10475,7 +10475,7 @@ func UpdateBugReportStatus(c *gin.Context) {
 		return
 	}
 
-	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeAppRead)
+	okApp, err := PerformAuthz(userId, team.ID.String(), *ScopeBugReportAll)
 	if err != nil {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)

--- a/backend/api/measure/authz.go
+++ b/backend/api/measure/authz.go
@@ -98,6 +98,8 @@ var (
 	ScopeAlertRead                 = newScope("alert", "read")
 	ScopeAppAll                    = newScope("app", "*")
 	ScopeAppRead                   = newScope("app", "read")
+	ScopeBugReportAll              = newScope("bugReport", "*")
+	ScopeBugReportRead             = newScope("bugReport", "read")
 )
 
 type scope struct {
@@ -125,10 +127,10 @@ func (s scope) getRolesSameOrLower(r rank) []rank {
 }
 
 var scopeMap = map[rank][]scope{
-	owner:     {*ScopeBillingAll, *ScopeTeamAll, *ScopeAlertAll, *ScopeAppAll},
-	admin:     {*ScopeBillingAll, *ScopeAlertAll, *ScopeAppAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
-	developer: {*ScopeBillingRead, *ScopeAlertAll, *ScopeAppRead, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
-	viewer:    {*ScopeBillingRead, *ScopeAlertRead, *ScopeTeamRead, *ScopeTeamInviteSameOrLower, *ScopeAppRead},
+	owner:     {*ScopeBillingAll, *ScopeTeamAll, *ScopeAlertAll, *ScopeAppAll, *ScopeBugReportAll},
+	admin:     {*ScopeBillingAll, *ScopeAlertAll, *ScopeAppAll, *ScopeBugReportAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
+	developer: {*ScopeBillingRead, *ScopeAlertAll, *ScopeAppRead, *ScopeBugReportAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
+	viewer:    {*ScopeBillingRead, *ScopeAlertRead, *ScopeTeamRead, *ScopeTeamInviteSameOrLower, *ScopeAppRead, *ScopeBugReportRead},
 }
 
 var roleMap = map[string]rank{
@@ -188,6 +190,21 @@ func PerformAuthz(uid string, rid string, scope scope) (bool, error) {
 			return true, nil
 		}
 		if slices.Contains(roleScope, *ScopeAppRead) {
+			return true, nil
+		}
+
+		return false, nil
+	case *ScopeBugReportAll:
+		if slices.Contains(roleScope, *ScopeBugReportAll) {
+			return true, nil
+		}
+
+		return false, nil
+	case *ScopeBugReportRead:
+		if slices.Contains(roleScope, *ScopeBugReportAll) {
+			return true, nil
+		}
+		if slices.Contains(roleScope, *ScopeBugReportRead) {
 			return true, nil
 		}
 
@@ -321,9 +338,11 @@ func GetAuthzRoles(c *gin.Context) {
 	canRenameTeam := slices.Contains(scopeMap[userRole], *ScopeTeamAll)
 	canManageSlack := slices.Contains(scopeMap[userRole], *ScopeTeamAll)
 	canChangeAppThresholdPrefs := slices.Contains(scopeMap[userRole], *ScopeAppAll)
+	canUpdateBugReports := slices.Contains(scopeMap[userRole], *ScopeBugReportAll)
 
 	c.JSON(http.StatusOK, gin.H{
 		"can_invite_roles":               inviteeRoles,
+		"can_update_bug_reports":         canUpdateBugReports,
 		"can_change_billing":             canChangeBilling,
 		"can_create_app":                 canCreateApp,
 		"can_rename_app":                 canRenameApp,

--- a/backend/api/measure/authz_test.go
+++ b/backend/api/measure/authz_test.go
@@ -234,11 +234,13 @@ func TestScopeMap_AppScopes(t *testing.T) {
 		wantAppRead    bool
 		wantBillingAll bool
 		wantTeamAll    bool
+		wantBugAll     bool
+		wantBugRead    bool
 	}{
-		{name: "owner", role: owner, wantAppAll: true, wantAppRead: false, wantBillingAll: true, wantTeamAll: true},
-		{name: "admin", role: admin, wantAppAll: true, wantAppRead: false, wantBillingAll: true, wantTeamAll: false},
-		{name: "developer", role: developer, wantAppAll: false, wantAppRead: true, wantBillingAll: false, wantTeamAll: false},
-		{name: "viewer", role: viewer, wantAppAll: false, wantAppRead: true, wantBillingAll: false, wantTeamAll: false},
+		{name: "owner", role: owner, wantAppAll: true, wantAppRead: false, wantBillingAll: true, wantTeamAll: true, wantBugAll: true, wantBugRead: false},
+		{name: "admin", role: admin, wantAppAll: true, wantAppRead: false, wantBillingAll: true, wantTeamAll: false, wantBugAll: true, wantBugRead: false},
+		{name: "developer", role: developer, wantAppAll: false, wantAppRead: true, wantBillingAll: false, wantTeamAll: false, wantBugAll: true, wantBugRead: false},
+		{name: "viewer", role: viewer, wantAppAll: false, wantAppRead: true, wantBillingAll: false, wantTeamAll: false, wantBugAll: false, wantBugRead: true},
 	}
 
 	for _, tt := range tests {
@@ -255,6 +257,12 @@ func TestScopeMap_AppScopes(t *testing.T) {
 			}
 			if got := slices.Contains(roleScopes, *ScopeTeamAll); got != tt.wantTeamAll {
 				t.Fatalf("ScopeTeamAll = %v, want %v", got, tt.wantTeamAll)
+			}
+			if got := slices.Contains(roleScopes, *ScopeBugReportAll); got != tt.wantBugAll {
+				t.Fatalf("ScopeBugReportAll = %v, want %v", got, tt.wantBugAll)
+			}
+			if got := slices.Contains(roleScopes, *ScopeBugReportRead); got != tt.wantBugRead {
+				t.Fatalf("ScopeBugReportRead = %v, want %v", got, tt.wantBugRead)
 			}
 		})
 	}
@@ -337,6 +345,12 @@ func TestPerformAuthzMatrix(t *testing.T) {
 		{name: "owner team all allowed", role: "owner", scope: *ScopeTeamAll, wantAllow: true},
 		{name: "admin team all denied", role: "admin", scope: *ScopeTeamAll, wantAllow: false},
 		{name: "viewer team read allowed", role: "viewer", scope: *ScopeTeamRead, wantAllow: true},
+		{name: "owner bug report all allowed", role: "owner", scope: *ScopeBugReportAll, wantAllow: true},
+		{name: "admin bug report all allowed", role: "admin", scope: *ScopeBugReportAll, wantAllow: true},
+		{name: "developer bug report all allowed", role: "developer", scope: *ScopeBugReportAll, wantAllow: true},
+		{name: "viewer bug report all denied", role: "viewer", scope: *ScopeBugReportAll, wantAllow: false},
+		{name: "viewer bug report read allowed", role: "viewer", scope: *ScopeBugReportRead, wantAllow: true},
+		{name: "developer bug report read allowed", role: "developer", scope: *ScopeBugReportRead, wantAllow: true},
 	}
 
 	for _, tc := range tests {

--- a/backend/api/measure/mcp.go
+++ b/backend/api/measure/mcp.go
@@ -2411,6 +2411,16 @@ func mcpUpdateBugReportStatus(ctx context.Context, in mcpUpdateBugReportStatusIn
 		return nil, nil, err
 	}
 
+	// Updating a bug report is a write; membership alone is not enough.
+	userID, _ := mcpUserIDFromContext(ctx)
+	allowed, err := PerformAuthz(userID, teamID.String(), *ScopeBugReportAll)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to perform authorization: %v", err)
+	}
+	if !allowed {
+		return nil, nil, fmt.Errorf("you are not authorized to update bug reports; ask a team admin for access")
+	}
+
 	app := &App{ID: &appID, TeamId: teamID}
 	if err := app.UpdateBugReportStatusById(ctx, in.BugReportID, uint8(status)); err != nil {
 		return nil, nil, fmt.Errorf("failed to update bug report status: %v", err)

--- a/backend/api/measure/mcp_test.go
+++ b/backend/api/measure/mcp_test.go
@@ -3640,6 +3640,35 @@ func TestMCPUpdateBugReportStatus(t *testing.T) {
 			t.Errorf("want ok=done, got %v", result["ok"])
 		}
 	})
+
+	t.Run("viewer cannot update bug report status", func(t *testing.T) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), "ubrviewer@mcp.test")
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "viewer team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "viewer")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_ubrviewer"
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+		bugReportID := uuid.New().String()
+		seedBugReport(ctx, t, teamID.String(), appID.String(), bugReportID, "viewer test bug", time.Now().UTC())
+
+		resp := callMCPTool(t, rawToken, "update_bug_report_status", map[string]any{"app_id": appID.String(), "bug_report_id": bugReportID, "status": 1})
+		if !isToolError(resp) {
+			t.Fatal("want tool error: viewers must not update bug reports")
+		}
+		if content := extractTextContent(t, resp); !strings.Contains(content, "not authorized") {
+			t.Errorf("want authorization error, got %q", content)
+		}
+
+		// Reads stay allowed for viewers.
+		readResp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String()})
+		if isToolError(readResp) {
+			t.Errorf("viewer should still read bug reports, got error: %q", extractTextContent(t, readResp))
+		}
+	})
 }
 
 // --------------------------------------------------------------------------

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -84,6 +84,7 @@ jest.mock("@nivo/line", () => ({
 // --- MSW ---
 import {
   makeAppFixture,
+  makeAuthzAndMembersFixture,
   makeBugReportDetailFixture,
   makeBugReportsOverviewFixture,
   makeBugReportsPlotFixture,
@@ -1513,6 +1514,32 @@ describe("Bug Report Detail (MSW integration)", () => {
   // PAGE LOAD
   // ================================================================
   describe("page load", () => {
+    it("enables status toggle when user can update bug reports", async () => {
+      await renderDetail();
+      const button = screen
+        .getByText("Close Bug Report")
+        .closest("button") as HTMLButtonElement;
+      await waitFor(() => {
+        expect(button?.disabled).toBe(false);
+      });
+    });
+
+    it("disables status toggle when user cannot update bug reports", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/authz", () => {
+          return HttpResponse.json(
+            makeAuthzAndMembersFixture({ can_update_bug_reports: false }),
+          );
+        }),
+      );
+
+      await renderDetail();
+      const button = screen
+        .getByText("Close Bug Report")
+        .closest("button") as HTMLButtonElement;
+      expect(button?.disabled).toBe(true);
+    });
+
     it("renders description", async () => {
       await renderDetail();
       expect(

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -1231,6 +1231,7 @@ export function makeNetworkEndpointStatusCodesFixture() {
 export function makeAuthzFixture(overrides: Record<string, any> = {}) {
   return {
     can_create_app: true,
+    can_update_bug_reports: true,
     can_rename_app: true,
     can_change_retention: true,
     can_rotate_api_key: true,
@@ -1303,6 +1304,7 @@ export function makeAuthzAndMembersFixture(
     can_invite_roles: ["owner", "admin", "viewer"],
     can_change_billing: true,
     can_create_app: true,
+    can_update_bug_reports: true,
     can_rename_app: true,
     can_change_retention: true,
     can_rotate_api_key: true,

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -803,6 +803,7 @@ export const emptyErrorGroupDetails = {
 
 export const defaultAuthzAndMembers = {
   can_invite_roles: ["viewer"],
+  can_update_bug_reports: false,
   can_change_billing: false,
   can_create_app: false,
   can_rename_app: false,

--- a/frontend/dashboard/app/components/bug_report.tsx
+++ b/frontend/dashboard/app/components/bug_report.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/app/components/button";
 import { buttonVariants } from "@/app/components/button_variants";
 import { Skeleton } from "@/app/components/skeleton";
 import {
+  useAuthzAndMembersQuery,
   useBugReportQuery,
   useToggleBugReportStatusMutation,
 } from "@/app/query/hooks";
@@ -87,6 +88,11 @@ export default function BugReport({
     demo ? "" : params.bugReportId,
   );
   const toggleStatusMutation = useToggleBugReportStatusMutation();
+  const { data: authzAndMembers } = useAuthzAndMembersQuery(
+    demo ? undefined : params.teamId,
+  );
+  const canUpdateStatus =
+    demo || authzAndMembers?.can_update_bug_reports === true;
 
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
   const [demoStatusToggled, setDemoStatusToggled] = useState(false);
@@ -252,6 +258,7 @@ export default function BugReport({
               variant="outline"
               className="w-fit"
               disabled={
+                !canUpdateStatus ||
                 displayUpdateStatus === UpdateBugReportStatusApiStatus.Loading
               }
               onClick={handleToggleStatus}


### PR DESCRIPTION
# Description

Bug report updates were not restricted to developer role and above so viewers could update them. This commit introduces bug report authz scopes and ensures that only developer role and above can update bug report status via dashboard and mcp.



