### PR TITLE
chore(gradle): upload RN and Flutter mappings even if minification is disabled

### DIFF
--- a/.github/workflows/frank.yml
+++ b/.github/workflows/frank.yml
@@ -75,11 +75,6 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: yarn-${{ hashFiles('react-native/yarn.lock', 'samples/frank/react_native/yarn.lock') }}
           restore-keys: yarn-
-      - name: Build Measure React Native SDK
-        run: |
-          yarn install
-          npx bob build --target module
-        working-directory: react-native
       - name: Install React Native dependencies
         run: yarn install
         working-directory: samples/frank/react_native
@@ -160,11 +155,6 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: yarn-${{ hashFiles('react-native/yarn.lock', 'samples/frank/react_native/yarn.lock') }}
           restore-keys: yarn-
-      - name: Build Measure React Native SDK
-        run: |
-          yarn install
-          npx bob build --target module
-        working-directory: react-native
       - name: Install React Native dependencies
         run: yarn install
         working-directory: samples/frank/react_native

--- a/android/measure-gradle-plugin/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
+++ b/android/measure-gradle-plugin/src/functionalTest/kotlin/sh/measure/MeasurePluginTest.kt
@@ -107,6 +107,24 @@ class MeasurePluginTest {
 
     @ParameterizedTest
     @MethodSource("versions")
+    fun `minification disabled, assert upload request is still created`(
+        agpVersion: SemVer,
+        gradleVersion: GradleVersion,
+    ) {
+        server.enqueue(MockResponse().setResponseCode(200))
+        server.start(8080)
+        val project = MeasurePluginFixture(
+            agpVersion,
+            minifyEnabled = false,
+            setMeasureApiKey = true,
+            measureApiUrl = "http://localhost:8080"
+        ).gradleProject
+        build(gradleVersion, project.rootDir, ":app:assembleRelease")
+        assertEquals(1, server.requestCount)
+    }
+
+    @ParameterizedTest
+    @MethodSource("versions")
     fun `API_KEY is not set in manifest, assert logs error`(
         agpVersion: SemVer,
         gradleVersion: GradleVersion,

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/BuildUploadTask.kt
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.io.IOException
@@ -95,9 +94,12 @@ abstract class BuildUploadTask : DefaultTask() {
     @get:Internal
     abstract val httpClientProvider: Property<MeasureHttpClient>
 
-    @get:Optional
-    @get:InputFile
-    abstract val mappingFileProperty: RegularFileProperty
+    // A file collection rather than an @InputFile so the task does not fail when R8
+    // is disabled and the proguard mapping artifact is absent or points to a file
+    // that is never produced. This lets Flutter and React Native mappings (and build
+    // metadata) still be uploaded.
+    @get:InputFiles
+    abstract val mappingFiles: ConfigurableFileCollection
 
     @get:InputFiles
     abstract val flutterSymbolsFiles: ConfigurableFileCollection
@@ -120,7 +122,7 @@ abstract class BuildUploadTask : DefaultTask() {
     @TaskAction
     fun upload() {
         val manifestFile = manifestFileProperty.get().asFile
-        val mappingFile = mappingFileProperty.getOrNull()?.asFile
+        val mappingFile = mappingFiles.files.firstOrNull { it.exists() }
         val buildMetadataFile = buildMetadataFileProperty.get().asFile
         val flutterSymbols = flutterSymbolsFiles.files
         val rnBundleArchives = reactNativeBundleArchives.files
@@ -154,7 +156,7 @@ abstract class BuildUploadTask : DefaultTask() {
             logger.info("measure: proguard mapping file found at ${mappingFile.absolutePath}")
             mappings.add(MappingInfo(type = TYPE_PROGUARD, filename = mappingFile.name))
         } else {
-            logger.warn("measure: mapping file not found, symbolication will not work")
+            logger.info("measure: no proguard mapping file found, skipping upload")
         }
 
         if (flutterSymbols.isNotEmpty()) {

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/MeasurePlugin.kt
@@ -120,7 +120,15 @@ class MeasurePlugin : Plugin<Project> {
                     BuildUploadTask::class.java,
                 ) {
                     it.manifestFileProperty.set(manifestDataFileProvider(project, variant))
-                    it.mappingFileProperty.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
+                    // When R8 is disabled the obfuscation mapping artifact is absent or
+                    // points to a file that is never produced. orElse keeps the collection
+                    // (and task graph) resolvable in that case, while still depending on the
+                    // R8 task when a mapping is produced; upload() filters to files that exist.
+                    it.mappingFiles.from(
+                        variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+                            .map { mapping -> listOf(mapping.asFile) }
+                            .orElse(emptyList()),
+                    )
                     getFlutterSymbolsDirPath(project)?.let { dir ->
                         it.flutterSymbolsFiles.from(
                             project.fileTree(dir) { tree -> tree.include("**/*.symbols") },

--- a/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
+++ b/android/measure-gradle-plugin/src/test/kotlin/sh/measure/BuildUploadTaskTest.kt
@@ -64,7 +64,7 @@ class BuildUploadTaskTest {
         task.retriesProperty.set(retriesCount)
         task.httpClientProvider.set(httpClient)
         task.manifestFileProperty.set(manifestDataFile)
-        task.mappingFileProperty.set(mappingFile)
+        task.mappingFiles.setFrom(mappingFile)
         task.buildMetadataFileProperty.set(appSizeFile)
         task.flutterSymbolsFiles.from(project.fileTree(flutterSymbolsDir) { it.include("*.symbols") })
         task.requestHeadersProperty.set(customHeaders)
@@ -152,6 +152,22 @@ class BuildUploadTaskTest {
     }
 
     @Test
+    fun `tolerates a non-existent proguard mapping file`() {
+        val missingMapping = temporaryFolder.root.resolve("does-not-exist/mapping.txt")
+        task.mappingFiles.setFrom(missingMapping)
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
+        )
+        task.upload()
+        val recordedRequest = mockWebServer.takeRequest()
+        val buildsRequest =
+            Json.decodeFromString(BuildsApiRequest.serializer(), recordedRequest.body.readUtf8())
+
+        assertEquals(0, buildsRequest.mappings.size)
+    }
+
+    @Test
     fun `sends request with React Native bundle and source map archives when available`() {
         val bundleArchive = temporaryFolder.newFile("index.android.bundle.tgz").apply {
             writeText("bundle tarball")
@@ -210,7 +226,7 @@ class BuildUploadTaskTest {
             writeText("source map tarball")
         }
         task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
-        task.mappingFileProperty.set(null as File?)
+        task.mappingFiles.setFrom()
 
         mockWebServer.enqueue(
             MockResponse().setResponseCode(200).setBody("""{"ok": "uploaded build info"}""")
@@ -237,7 +253,7 @@ class BuildUploadTaskTest {
             writeText(sourceMapContent)
         }
         task.reactNativeBundleArchives.from(bundleArchive, sourceMapArchive)
-        task.mappingFileProperty.set(null as File?)
+        task.mappingFiles.setFrom()
 
         val bundleUploadUrl = mockWebServer.url("/upload-rn-bundle").toString()
         val sourceMapUploadUrl = mockWebServer.url("/upload-rn-source-map").toString()
@@ -394,8 +410,7 @@ class BuildUploadTaskTest {
         )
 
         // Clear mapping file to test no-mappings scenario
-        val file: File? = null
-        task.mappingFileProperty.set(file)
+        task.mappingFiles.setFrom()
 
         task.upload()
         val recordedRequest = mockWebServer.takeRequest()

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -340,10 +340,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 
 		// configure module for jvm symbolication
 		if s.jvmSymbolicator != nil {
-			if err := s.jvmSymbolicator.configureModule(mappings); err != nil {
-				fmt.Printf("Error configuring module for app id %s, version %s, build %s: %v\n", appId, name, code, err)
-				continue
-			}
+			s.jvmSymbolicator.configureModule(mappings)
 		}
 	}
 
@@ -371,7 +368,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 // symbolicate performs symbolication for
 // the JVM symbolicator.
 func (js *jvmSymbolicator) symbolicate(events []event.EventField, spans []span.SpanField, origin string, sources []SentrySource, lambdaWorkaround bool) (err error) {
-	if js.request != nil {
+	if js.request != nil && len(js.request.Modules) > 0 {
 		sr := &SymbolicatorRequest{}
 		if err = sr.prepareJvmRequest(js, origin, sources); err != nil {
 			return
@@ -408,7 +405,11 @@ func (js *jvmSymbolicator) symbolicate(events []event.EventField, spans []span.S
 // configureModule configures the module
 // required by symbolicator for JVM
 // symbolication.
-func (js *jvmSymbolicator) configureModule(mappings map[string]symbol.MappingType) (err error) {
+//
+// A build can legitimately have no proguard mapping (e.g. R8 disabled, or a
+// Flutter/RN build that only uploads its own mappings). In that case no module
+// is added and symbolicate skips the request, leaving JVM frames untouched.
+func (js *jvmSymbolicator) configureModule(mappings map[string]symbol.MappingType) {
 	if js.request == nil {
 		// no JVM events to symbolicate
 		return
@@ -425,12 +426,9 @@ func (js *jvmSymbolicator) configureModule(mappings map[string]symbol.MappingTyp
 		}
 	}
 	if debugId == "" {
-		err = errors.New("no proguard mapping found")
 		return
 	}
 	js.request.AddModule(debugId, symbol.TypeProguard.String())
-
-	return
 }
 
 // splitClassName splits a fully qualified JVM class name into

--- a/samples/frank/README.md
+++ b/samples/frank/README.md
@@ -50,21 +50,7 @@ This reads the `.env` file and generates:
 * `ios/MeasureDebug.xcconfig` — Measure API keys for the iOS debug build
 * `ios/MeasureRelease.xcconfig` — Measure API keys for the iOS release build
 
-
-#### 2. Build Measure React Native SDK
-
-The React Native SDK is linked from local source (`link:../../../react-native`)
-but the JS entry point is a build artifact (`lib/module/index.js`). Build it
-first:
-
-```bash
-cd ../../react-native
-yarn install
-npx bob build --target module
-cd ../samples/frank
-```
-
-#### 3. Set up Flutter module
+#### 2. Set up Flutter module
 
 ```bash
 cd flutter
@@ -75,7 +61,7 @@ cd ..
 This generates the `.android/` and `.ios/` integration directories required by
 the Gradle and CocoaPods build systems.
 
-#### 4. Set up React Native module
+#### 3. Set up React Native module
 
 ```bash
 cd react_native
@@ -83,7 +69,7 @@ yarn install
 cd ..
 ```
 
-#### 5. Set up iOS dependencies
+#### 4. Set up iOS dependencies
 
 ```bash
 cd ios
@@ -154,10 +140,11 @@ conflicts with the Kotlin plugin's default JVM target.
 "@measuresh/react-native": "link:../../../react-native"
 ```
 
-The symlink means changes to the RN SDK source are visible immediately. The
-native Android code is compiled from source via React Native autolinking
-(configured in `settings.gradle.kts`). The native iOS code is pulled in via
-the SDK's podspec through `use_react_native!` in the Podfile.
+The symlink means SDK changes are picked up on the next build, with no publish
+or `bob build` step (`react_native/metro.config.js` bundles the SDK from
+TypeScript source). The native Android code is compiled from source via React
+Native autolinking (configured in `settings.gradle.kts`). The native iOS code
+is pulled in via the SDK's podspec through `use_react_native!` in the Podfile.
 
 ### Flutter
 

--- a/samples/frank/android/app/build.gradle.kts
+++ b/samples/frank/android/app/build.gradle.kts
@@ -114,7 +114,12 @@ val bundleReactNativeDebug by tasks.registering(Exec::class) {
         "--entry-file", "index.js",
         "--bundle-output", bundleOutput.absolutePath,
     )
-    inputs.files(fileTree(rnDir) { include("index.js", "src/**/*.js", "src/**/*.ts", "src/**/*.tsx") })
+    // Metro bundles the SDK from its `src` (see react_native/metro.config.js),
+    // so track that for incremental builds.
+    inputs.files(
+        fileTree(rnDir) { include("index.js", "src/**/*.js", "src/**/*.ts", "src/**/*.tsx") },
+        fileTree(rnDir.resolve("node_modules/@measuresh/react-native/src")),
+    )
     outputs.file(bundleOutput)
 }
 

--- a/samples/frank/react_native/metro.config.js
+++ b/samples/frank/react_native/metro.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const {getDefaultConfig} = require('@react-native/metro-config');
+const exclusionList = require('metro-config/private/defaults/exclusionList').default;
 
 const measureReactNativePath = path.resolve(__dirname, '../../../react-native');
 
@@ -13,8 +14,21 @@ config.resolver.nodeModulesPaths = [
   path.resolve(measureReactNativePath, 'node_modules'),
 ];
 
-// Prefer "source" entry point so the Measure RN SDK is resolved from
-// TypeScript source instead of requiring a prior `npx bob build`.
-config.resolver.resolverMainFields = ['source', 'react-native', 'browser', 'main'];
+// Force react / react-native to this app's copies. The SDK's own node_modules
+// pin older versions; a second react-native in the bundle breaks native module
+// lookup at runtime ("PlatformConstants could not be found").
+const escapedSdkPath = measureReactNativePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+config.resolver.blockList = exclusionList([
+  new RegExp(`${escapedSdkPath}/node_modules/(react|react-native)/.*`),
+]);
+
+// Resolve the Measure RN SDK from its TypeScript `source` instead of compiled
+// `lib/`, so SDK edits need no `bob build` and can't go stale. The SDK's
+// `exports` map gates source behind the "source" condition, which Metro's
+// package-exports resolution only honors when it's an active condition.
+config.resolver.unstable_conditionNames = [
+  'source',
+  ...config.resolver.unstable_conditionNames,
+];
 
 module.exports = config;


### PR DESCRIPTION
# Description

- React Native sourcemaps and Flutter debug symbols now upload even when minification is disabled. Previously they were only uploaded for R8-enabled builds, so symbolication broke for unminified builds.
- Backend symbolication now tolerates builds with no Proguard mapping (R8 off, or RN/Flutter-only builds): their JVM events ingest cleanly instead of logging an error.
