### PR TITLE
fix(frontend): strip HTML comments to a fixed point in docs

### DIFF
--- a/frontend/dashboard/__tests__/docs/docs_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_test.ts
@@ -224,6 +224,12 @@ describe("cleanContent", () => {
   it("handles empty string", () => {
     expect(cleanContent("")).toBe("");
   });
+
+  it("removes comments that a single pass would reintroduce", () => {
+    // One replace turns `<!-<!-- -->->` into `<!-->`, re-forming `<!--`.
+    // Iterating to a fixed point ensures no complete comment survives.
+    expect(cleanContent("<!-<!-- -->->")).not.toMatch(/<!--.*?-->/s);
+  });
 });
 
 describe("extractTitle", () => {

--- a/frontend/dashboard/app/docs/docs.ts
+++ b/frontend/dashboard/app/docs/docs.ts
@@ -76,9 +76,21 @@ function slugToFilePath(docsDir: string, slug: string[]): string | null {
 
 /**
  * Strip HTML comments like <!-- omit in toc --> from markdown content.
+ * A single regex pass is incomplete because an input like `<!-<!-- -->->`
+ * leaves `<!-->` behind after one replace — iterating to a fixed point
+ * removes any residue. The regex always consumes ≥7 chars per match, so
+ * the loop is guaranteed to terminate.
  */
 export function cleanContent(content: string): string {
-  return content.replace(/<!--.*?-->/gs, "");
+  let out = content;
+  for (let i = 0; i < 50; i++) {
+    const next = out.replace(/<!--.*?-->/gs, "");
+    if (next === out) {
+      return next;
+    }
+    out = next;
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
# Description

`cleanContent` stripped HTML comments in a single regex pass, which can re-form a comment after one replace (e.g. `<!-<!-- -->->` -> `<!-->`). Iterate the replace until the string stops changing so no complete comment survives.

## Related issue
Fixes CodeQL alert [102](https://github.com/measure-sh/measure/security/code-scanning/102)



