### PR TITLE
fix(backend): redact source secrets in symbolicator request logs

### DIFF
--- a/backend/ingest-worker/symbolicator/request.go
+++ b/backend/ingest-worker/symbolicator/request.go
@@ -194,11 +194,11 @@ func (sr *SymbolicatorRequest) prepareJvmRequest(js *jvmSymbolicator, origin str
 	}
 
 	if logRequest {
-		var dst bytes.Buffer
-		if err = json.Indent(&dst, reqBytes, "", "  "); err != nil {
-			return
+		logReq := *js.request
+		logReq.Sources = redactSentrySources(logReq.Sources)
+		if out, errLog := json.MarshalIndent(logReq, "", "  "); errLog == nil {
+			fmt.Printf("jvm symbolicator request\n%s\n", out)
 		}
-		fmt.Printf("jvm symbolicator request\n%s\n", dst.String())
 	}
 
 	sr.req, err = http.NewRequest("POST", url, &reqBody)
@@ -225,11 +225,11 @@ func (sr *SymbolicatorRequest) prepareJSRequest(js *jsSymbolicator, origin strin
 	}
 
 	if logRequest {
-		var dst bytes.Buffer
-		if err = json.Indent(&dst, reqBytes, "", "  "); err != nil {
-			return
+		logReq := *js.request
+		logReq.Source = logReq.Source.redactSecrets()
+		if out, errLog := json.MarshalIndent(logReq, "", "  "); errLog == nil {
+			fmt.Printf("js symbolicator request\n%s\n", out)
 		}
-		fmt.Printf("js symbolicator request\n%s\n", dst.String())
 	}
 
 	sr.req, err = http.NewRequest("POST", url, &reqBody)
@@ -259,11 +259,11 @@ func (sr *SymbolicatorRequest) prepareNativeRequest(ns *nativeSymbolicator, orig
 	}
 
 	if logRequest {
-		var dst bytes.Buffer
-		if err = json.Indent(&dst, reqBytes, "", "  "); err != nil {
-			return
+		logReq := *ns.request
+		logReq.Sources = redactSources(logReq.Sources)
+		if out, errLog := json.MarshalIndent(logReq, "", "  "); errLog == nil {
+			fmt.Printf("native symbolicator request\n%s\n", out)
 		}
-		fmt.Printf("native symbolicator request\n%s\n", dst.String())
 	}
 
 	sr.req, err = http.NewRequest("POST", url, &reqBody)

--- a/backend/ingest-worker/symbolicator/source.go
+++ b/backend/ingest-worker/symbolicator/source.go
@@ -159,3 +159,62 @@ func NewSentrySource(id, url, token string) SentrySource {
 	}
 }
 
+// secretPlaceholder is substituted for sensitive source fields
+// before a request is logged. Real values are still sent over
+// the wire; only the logged copy is redacted.
+const secretPlaceholder = "[redacted]"
+
+// maskSecret replaces a non-empty secret with a placeholder,
+// leaving empty values untouched so the redacted shape matches
+// the original.
+func maskSecret(v string) string {
+	if v == "" {
+		return ""
+	}
+	return secretPlaceholder
+}
+
+// redactSecrets returns a copy of the source with its secret fields
+// masked. Identifiers and non-secret fields — id, bucket, region, and
+// the access key ID (the public half of an AWS key pair) — are kept so
+// the log stays useful for debugging.
+func (s Source) redactSecrets() Source {
+	s.SecretKey = maskSecret(s.SecretKey)
+	s.PrivateKey = maskSecret(s.PrivateKey)
+	s.BearerToken = maskSecret(s.BearerToken)
+	s.Token = maskSecret(s.Token)
+	return s
+}
+
+// redactSecrets returns a copy of the Sentry source with its auth
+// token masked, safe for logging.
+func (s SentrySource) redactSecrets() SentrySource {
+	s.Token = maskSecret(s.Token)
+	return s
+}
+
+// redactSources returns a copy of the sources with every credential
+// masked, safe for logging.
+func redactSources(sources []Source) []Source {
+	if sources == nil {
+		return nil
+	}
+	out := make([]Source, len(sources))
+	for i := range sources {
+		out[i] = sources[i].redactSecrets()
+	}
+	return out
+}
+
+// redactSentrySources returns a copy of the Sentry sources with
+// every token masked, safe for logging.
+func redactSentrySources(sources []SentrySource) []SentrySource {
+	if sources == nil {
+		return nil
+	}
+	out := make([]SentrySource, len(sources))
+	for i := range sources {
+		out[i] = sources[i].redactSecrets()
+	}
+	return out
+}

--- a/backend/ingest-worker/symbolicator/source_test.go
+++ b/backend/ingest-worker/symbolicator/source_test.go
@@ -2,6 +2,7 @@ package symbolicator
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -62,5 +63,114 @@ func TestNewSentrySource(t *testing.T) {
 		if expected != got {
 			t.Errorf("Expected %v, but got %v", expected, got)
 		}
+	}
+}
+
+func TestSourceRedactSecrets(t *testing.T) {
+	// A Source can carry any of these secrets regardless of the
+	// constructor that built it, so redactSecrets must mask them all.
+	source := Source{
+		ID:          "my-id",
+		Type:        "s3",
+		Bucket:      "my-bucket",
+		AccessKey:   "my-access-key",
+		SecretKey:   "my-secret-key",
+		PrivateKey:  "my-private-key",
+		BearerToken: "my-bearer-token",
+		Token:       "my-token",
+	}
+
+	redacted := source.redactSecrets()
+
+	{
+		bytes, _ := json.Marshal(redacted)
+		got := string(bytes)
+
+		for _, secret := range []string{"my-secret-key", "my-private-key", "my-bearer-token", "my-token"} {
+			if strings.Contains(got, secret) {
+				t.Errorf("redacted source leaks %q: %v", secret, got)
+			}
+		}
+
+		// non-secret fields, including the access key ID (an identifier,
+		// not a secret), are preserved so logs stay useful
+		for _, keep := range []string{"my-id", "my-bucket", "my-access-key"} {
+			if !strings.Contains(got, keep) {
+				t.Errorf("redacted source dropped %q: %v", keep, got)
+			}
+		}
+	}
+
+	// value receiver: the original must be left untouched
+	if source.SecretKey != "my-secret-key" {
+		t.Errorf("redactSecrets mutated the original source: %v", source.SecretKey)
+	}
+}
+
+func TestRedactSourcesAppleAndAndroid(t *testing.T) {
+	// Apple and Android S3 sources land in the same []Source slice that
+	// the native request logs (see event.go), so redactSources must mask
+	// secrets for every element regardless of platform.
+	sources := []Source{
+		NewS3SourceApple("apple-id", "apple-bucket", "region", "origin", "apple-access-key", "apple-secret-key"),
+		NewS3SourceAndroid("android-id", "android-bucket", "region", "origin", "android-access-key", "android-secret-key"),
+	}
+
+	redacted := redactSources(sources)
+
+	bytes, _ := json.Marshal(redacted)
+	got := string(bytes)
+
+	for _, secret := range []string{"apple-secret-key", "android-secret-key"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redactSources leaks %q: %v", secret, got)
+		}
+	}
+
+	// access key IDs are identifiers, not secrets, so they stay visible
+	for _, keep := range []string{"apple-access-key", "android-access-key"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("redactSources dropped %q: %v", keep, got)
+		}
+	}
+
+	// originals are untouched so the real request still authenticates
+	if sources[0].SecretKey != "apple-secret-key" {
+		t.Errorf("redactSources mutated the original Apple source: %v", sources[0].SecretKey)
+	}
+}
+
+func TestSentrySourceRedactSecrets(t *testing.T) {
+	source := NewSentrySource("my-id", "http://symboloader:8083/symbols", "my-token")
+
+	redacted := source.redactSecrets()
+
+	{
+		bytes, _ := json.Marshal(redacted)
+
+		expected := `{"id":"my-id","type":"sentry","url":"http://symboloader:8083/symbols","token":"[redacted]"}`
+		got := string(bytes)
+
+		if expected != got {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	if source.Token != "my-token" {
+		t.Errorf("redactSecrets mutated the original source: %v", source.Token)
+	}
+}
+
+func TestRedactSourcesPreservesEmptyAndNil(t *testing.T) {
+	if redactSources(nil) != nil {
+		t.Error("redactSources(nil) should return nil")
+	}
+	if redactSentrySources(nil) != nil {
+		t.Error("redactSentrySources(nil) should return nil")
+	}
+
+	// an unset secret stays empty rather than being masked
+	if got := maskSecret(""); got != "" {
+		t.Errorf("maskSecret(\"\") should stay empty, got %q", got)
 	}
 }


### PR DESCRIPTION
# Description

The symbolicator logged each request as JSON with logRequest always on, exposing source credentials (secret/access/private keys, bearer tokens) in clear text in logs.

This commit masks these fields on a copy before logging; the request sent over the wire is unchanged. Covers the native, JVM, and JS paths.

## Related issue
Fixes CodeQL alert [#105](https://github.com/measure-sh/measure/security/code-scanning/105).



