### PR TITLE
chore(rn): keep React Native view class names for gesture target

### DIFF
--- a/react-native/android/build.gradle.kts
+++ b/react-native/android/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {

--- a/react-native/android/consumer-rules.pro
+++ b/react-native/android/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Required to find gesture target for React Native views
+-keepnames class com.facebook.react.views.** { *; }


### PR DESCRIPTION
# Description

Minified release builds obfuscate React Native view classes, so the gesture target was captured as a single letter (e.g. "e") instead of a readable class name. Ship a consumer ProGuard rule keeping the names of `com.facebook.react.views.**` so `view.javaClass.simpleName` resolves to the real class (e.g. ReactViewGroup).

## Related issue
Closes #3914