### PR TITLE
chore(rn): add github workflow to prepare release

### DIFF
--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -1,6 +1,9 @@
 name: Prepare React Native Release
 
 on:
+  push:
+    branches:
+      - rn-add-ci-workflows
   workflow_dispatch:
     inputs:
       version:
@@ -28,6 +31,11 @@ jobs:
       contents: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      VERSION: ${{ inputs.version || '0.2.0' }}
+      ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version || '0.18.0' }}
+      IOS_SDK_VERSION: ${{ inputs.ios_sdk_version || '0.11.0' }}
+      ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version || '0.13.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,59 +51,59 @@ jobs:
 
       - name: Validate version format
         run: |
-          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "${{ env.VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must match pattern x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: ${{ env.VERSION }}"
             exit 1
           fi
 
       - name: Update package.json version
         run: |
-          jq --arg v "${{ inputs.version }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
+          jq --arg v "${{ env.VERSION }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
 
       - name: Update MeasureReactNative.podspec
         run: |
-          sed -i "s/s\.version[[:space:]]*=[[:space:]]*\"[^\"]*\"/s.version          = \"${{ inputs.version }}\"/" react-native/MeasureReactNative.podspec
-          sed -i "s/s\.dependency 'measure-sh', '[^']*'/s.dependency 'measure-sh', '${{ inputs.ios_sdk_version }}'/" react-native/MeasureReactNative.podspec
+          sed -i "s/s\.version[[:space:]]*=[[:space:]]*\"[^\"]*\"/s.version          = \"${{ env.VERSION }}\"/" react-native/MeasureReactNative.podspec
+          sed -i "s/s\.dependency 'measure-sh', '[^']*'/s.dependency 'measure-sh', '${{ env.IOS_SDK_VERSION }}'/" react-native/MeasureReactNative.podspec
 
       - name: Update android/build.gradle.kts
         run: |
-          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
+          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}\")| " react-native/android/build.gradle.kts
 
       - name: Update react-native/README.md
         run: |
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/README.md
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/README.md
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" react-native/README.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" react-native/README.md
 
       - name: Update docs/sdk-integration-guide.md
         run: |
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" docs/sdk-integration-guide.md
-          sed -i "s|branch: \"ios-v[0-9]*\.[0-9]*\.[0-9]*\"|branch: \"ios-v${{ inputs.ios_sdk_version }}\"|g" docs/sdk-integration-guide.md
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" docs/sdk-integration-guide.md
-          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ inputs.version }}|g" docs/sdk-integration-guide.md
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" docs/sdk-integration-guide.md
+          sed -i "s|branch: \"ios-v[0-9]*\.[0-9]*\.[0-9]*\"|branch: \"ios-v${{ env.IOS_SDK_VERSION }}\"|g" docs/sdk-integration-guide.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" docs/sdk-integration-guide.md
+          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ env.VERSION }}|g" docs/sdk-integration-guide.md
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:
           config: react-native/cliff.toml
-          args: --output react-native/CHANGELOG.md --tag rn-v${{ inputs.version }} --include-path "react-native/**"
+          args: --output react-native/CHANGELOG.md --tag rn-v${{ env.VERSION }} --include-path "react-native/**"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.SDK_RELEASE }}
-          commit-message: "chore(rn): prepare release ${{ inputs.version }}"
-          branch: rn-v${{ inputs.version }}
+          commit-message: "chore(rn): prepare release ${{ env.VERSION }}"
+          branch: rn-v${{ env.VERSION }}
           delete-branch: false
-          title: "chore(rn): prepare release ${{ inputs.version }}"
+          title: "chore(rn): prepare release ${{ env.VERSION }}"
           body: |
-            This PR prepares the React Native SDK for release version ${{ inputs.version }}.
+            This PR prepares the React Native SDK for release version ${{ env.VERSION }}.
 
             Changes:
-            - Bumped version to ${{ inputs.version }}
-            - Updated Measure Android SDK to ${{ inputs.android_sdk_version }}
-            - Updated Measure iOS SDK to ${{ inputs.ios_sdk_version }}
-            - Updated Measure Android Gradle Plugin to ${{ inputs.android_gradle_plugin_version }}
+            - Bumped version to ${{ env.VERSION }}
+            - Updated Measure Android SDK to ${{ env.ANDROID_SDK_VERSION }}
+            - Updated Measure iOS SDK to ${{ env.IOS_SDK_VERSION }}
+            - Updated Measure Android Gradle Plugin to ${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}
             - Updated CHANGELOG.md
           base: main
           labels: react-native

--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -1,9 +1,6 @@
 name: Prepare React Native Release
 
 on:
-  push:
-    branches:
-      - rn-add-ci-workflows
   workflow_dispatch:
     inputs:
       version:
@@ -31,11 +28,6 @@ jobs:
       contents: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      VERSION: ${{ inputs.version || '0.2.0' }}
-      ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version || '0.19.0' }}
-      IOS_SDK_VERSION: ${{ inputs.ios_sdk_version || '0.12.0' }}
-      ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version || '0.14.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,64 +43,64 @@ jobs:
 
       - name: Validate version format
         run: |
-          if ! [[ "${{ env.VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must match pattern x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ env.VERSION }}"
+            echo "Got: ${{ inputs.version }}"
             exit 1
           fi
 
       - name: Update package.json version
         run: |
-          jq --arg v "${{ env.VERSION }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
+          jq --arg v "${{ inputs.version }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
 
       - name: Update MeasureReactNative.podspec
         run: |
-          sed -i "s/s\.version[[:space:]]*=[[:space:]]*\"[^\"]*\"/s.version          = \"${{ env.VERSION }}\"/" react-native/MeasureReactNative.podspec
-          sed -i "s/s\.dependency 'measure-sh', '[^']*'/s.dependency 'measure-sh', '${{ env.IOS_SDK_VERSION }}'/" react-native/MeasureReactNative.podspec
+          sed -i "s/s\.version[[:space:]]*=[[:space:]]*\"[^\"]*\"/s.version          = \"${{ inputs.version }}\"/" react-native/MeasureReactNative.podspec
+          sed -i "s/s\.dependency 'measure-sh', '[^']*'/s.dependency 'measure-sh', '${{ inputs.ios_sdk_version }}'/" react-native/MeasureReactNative.podspec
 
       - name: Update android/build.gradle.kts
         run: |
-          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}\")| " react-native/android/build.gradle.kts
+          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
 
       - name: Update plugin/index.js
         run: |
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" react-native/plugin/index.js
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" react-native/plugin/index.js
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/plugin/index.js
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/plugin/index.js
 
       - name: Update react-native/README.md
         run: |
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" react-native/README.md
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" react-native/README.md
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/README.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/README.md
 
       - name: Update docs/sdk-integration-guide.md
         run: |
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" docs/sdk-integration-guide.md
-          sed -i "s|branch: \"ios-v[0-9]*\.[0-9]*\.[0-9]*\"|branch: \"ios-v${{ env.IOS_SDK_VERSION }}\"|g" docs/sdk-integration-guide.md
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" docs/sdk-integration-guide.md
-          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ env.VERSION }}|g" docs/sdk-integration-guide.md
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" docs/sdk-integration-guide.md
+          sed -i "s|branch: \"ios-v[0-9]*\.[0-9]*\.[0-9]*\"|branch: \"ios-v${{ inputs.ios_sdk_version }}\"|g" docs/sdk-integration-guide.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" docs/sdk-integration-guide.md
+          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ inputs.version }}|g" docs/sdk-integration-guide.md
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:
           config: react-native/cliff.toml
-          args: --output react-native/CHANGELOG.md --tag rn-v${{ env.VERSION }} --include-path "react-native/**"
+          args: --output react-native/CHANGELOG.md --tag rn-v${{ inputs.version }} --include-path "react-native/**"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.SDK_RELEASE }}
-          commit-message: "chore(rn): prepare release ${{ env.VERSION }}"
-          branch: rn-v${{ env.VERSION }}
+          commit-message: "chore(rn): prepare release ${{ inputs.version }}"
+          branch: rn-v${{ inputs.version }}
           delete-branch: false
-          title: "chore(rn): prepare release ${{ env.VERSION }}"
+          title: "chore(rn): prepare release ${{ inputs.version }}"
           body: |
-            This PR prepares the React Native SDK for release version ${{ env.VERSION }}.
+            This PR prepares the React Native SDK for release version ${{ inputs.version }}.
 
             Changes:
-            - Bumped version to ${{ env.VERSION }}
-            - Updated Measure Android SDK to ${{ env.ANDROID_SDK_VERSION }}
-            - Updated Measure iOS SDK to ${{ env.IOS_SDK_VERSION }}
-            - Updated Measure Android Gradle Plugin to ${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}
+            - Bumped version to ${{ inputs.version }}
+            - Updated Measure Android SDK to ${{ inputs.android_sdk_version }}
+            - Updated Measure iOS SDK to ${{ inputs.ios_sdk_version }}
+            - Updated Measure Android Gradle Plugin to ${{ inputs.android_gradle_plugin_version }}
             - Updated CHANGELOG.md
           base: main
           labels: react-native

--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -1,0 +1,102 @@
+name: Prepare React Native Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 0.2.0)'
+        required: true
+        type: string
+      android_sdk_version:
+        description: 'Measure Android SDK version (e.g., 0.18.0)'
+        required: true
+        type: string
+      ios_sdk_version:
+        description: 'Measure iOS SDK version (e.g., 0.11.0)'
+        required: true
+        type: string
+      android_gradle_plugin_version:
+        description: 'Measure Android Gradle Plugin version (e.g., 0.13.0)'
+        required: true
+        type: string
+
+jobs:
+  prepare-release:
+    name: Prepare React Native Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          fetch-depth: 0
+          token: ${{ secrets.SDK_RELEASE }}
+
+      - name: Setup Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must match pattern x.y.z (e.g. 1.2.3)"
+            echo "Got: ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Update package.json version
+        run: |
+          jq --arg v "${{ inputs.version }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
+
+      - name: Update MeasureReactNative.podspec
+        run: |
+          sed -i "s/s\.version[[:space:]]*=[[:space:]]*\"[^\"]*\"/s.version          = \"${{ inputs.version }}\"/" react-native/MeasureReactNative.podspec
+          sed -i "s/s\.dependency 'measure-sh', '[^']*'/s.dependency 'measure-sh', '${{ inputs.ios_sdk_version }}'/" react-native/MeasureReactNative.podspec
+
+      - name: Update android/build.gradle.kts
+        run: |
+          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
+
+      - name: Update react-native/README.md
+        run: |
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/README.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/README.md
+
+      - name: Update docs/sdk-integration-guide.md
+        run: |
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" docs/sdk-integration-guide.md
+          sed -i "s|branch: \"ios-v[0-9]*\.[0-9]*\.[0-9]*\"|branch: \"ios-v${{ inputs.ios_sdk_version }}\"|g" docs/sdk-integration-guide.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" docs/sdk-integration-guide.md
+          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ inputs.version }}|g" docs/sdk-integration-guide.md
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: react-native/cliff.toml
+          args: --output react-native/CHANGELOG.md --tag rn-v${{ inputs.version }} --include-path "react-native/**"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.SDK_RELEASE }}
+          commit-message: "chore(rn): prepare release ${{ inputs.version }}"
+          branch: rn-v${{ inputs.version }}
+          delete-branch: false
+          title: "chore(rn): prepare release ${{ inputs.version }}"
+          body: |
+            This PR prepares the React Native SDK for release version ${{ inputs.version }}.
+
+            Changes:
+            - Bumped version to ${{ inputs.version }}
+            - Updated Measure Android SDK to ${{ inputs.android_sdk_version }}
+            - Updated Measure iOS SDK to ${{ inputs.ios_sdk_version }}
+            - Updated Measure Android Gradle Plugin to ${{ inputs.android_gradle_plugin_version }}
+            - Updated CHANGELOG.md
+          base: main
+          labels: react-native
+          assignees: adwinross

--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -33,9 +33,9 @@ jobs:
     timeout-minutes: 15
     env:
       VERSION: ${{ inputs.version || '0.2.0' }}
-      ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version || '0.18.0' }}
-      IOS_SDK_VERSION: ${{ inputs.ios_sdk_version || '0.11.0' }}
-      ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version || '0.13.0' }}
+      ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version || '0.19.0' }}
+      IOS_SDK_VERSION: ${{ inputs.ios_sdk_version || '0.12.0' }}
+      ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version || '0.14.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -69,6 +69,11 @@ jobs:
       - name: Update android/build.gradle.kts
         run: |
           sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}\")| " react-native/android/build.gradle.kts
+
+      - name: Update plugin/index.js
+        run: |
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ env.ANDROID_GRADLE_PLUGIN_VERSION }}|g" react-native/plugin/index.js
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ env.ANDROID_SDK_VERSION }}|g" react-native/plugin/index.js
 
       - name: Update react-native/README.md
         run: |

--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: react-native
     permissions:
-      contents: read
+      contents: write
       id-token: write
     timeout-minutes: 15
 
@@ -52,6 +52,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Generate release notes
+        if: ${{ inputs.dry_run != true }}
+        uses: orhun/git-cliff-action@v4
+        id: release-notes
+        with:
+          config: react-native/cliff.toml
+          args: --latest --strip header --include-path "react-native/**"
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create GitHub release
         if: ${{ inputs.dry_run != true }}
         env:
@@ -61,4 +71,5 @@ jobs:
             --title "${{ github.ref_name }}" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
+            --notes "${{ steps.release-notes.outputs.content }}" \
             --verify-tag

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -130,7 +130,7 @@
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}"
+      "tagName": "rn-v${version}"
     },
     "npm": {
       "publish": true


### PR DESCRIPTION
# Description

This PR makes below change:

- Fixed HTTP 403 on GitHub Release creation by changing contents: read to contents: write
- Added changelog generation via git-cliff
- Fixed release-it tag format from v${version} to rn-v${version} to match the workflow trigger
- Added Prepare React Native Release workflow to automate pre-release version bumps across package.json, podspec, gradle, Expo plugin, react-native/readme and sdk integration guide.

## Related issue
Closes #3926 