### PR TITLE
chore(kmp): prepare sdk release 0.1.0-alpha.1

### DIFF
--- a/kmp/CHANGELOG.md
+++ b/kmp/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [kmp-v0.1.0-alpha.1] - 2026-06-19
+
+### :sparkles: New features
+
+- (**kmp**): Implement KMP sdk (#3503) by @abhaysood in #3503
+
+### :hammer: Misc
+
+- (**kmp**): Update documentation and improve release workflow (#3930) by @abhaysood in #3930
+
+

--- a/kmp/measure-kmp/gradle.properties
+++ b/kmp/measure-kmp/gradle.properties
@@ -9,7 +9,7 @@ kotlin.code.style=official
 kotlin.mpp.enableCInteropCommonization=true
 
 GROUP=sh.measure
-MEASURE_KMP_VERSION_NAME=0.1.0-SNAPSHOT
+MEASURE_KMP_VERSION_NAME=0.1.0-alpha.1
 
 # Version of sh.measure:measure-android resolved when this module is built
 # standalone (e.g. published to Maven Central). For local development the


### PR DESCRIPTION
This PR prepares the KMP SDK for release version 0.1.0-alpha.1.

Changes:
- Updated version to 0.1.0-alpha.1 in gradle.properties
- Generated changelog for version 0.1.0-alpha.1

<!-- release-meta
NEXT_VERSION=0.1.0-SNAPSHOT
-->