### PR TITLE
chore(kmp): improve release pipeline

### DIFF
--- a/.github/workflows/kmp-checks.yml
+++ b/.github/workflows/kmp-checks.yml
@@ -1,4 +1,4 @@
-name: KMP Checks
+name: 'KMP: Checks'
 
 on:
   pull_request:
@@ -11,6 +11,10 @@ on:
     paths:
       - 'kmp/**'
       - '!docs/**'
+
+concurrency:
+  group: kmp-checks-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   JAVA_VERSION: 17

--- a/.github/workflows/kmp-prepare-next.yml
+++ b/.github/workflows/kmp-prepare-next.yml
@@ -1,4 +1,4 @@
-name: Prepare Next KMP Version
+name: 'KMP: Prepare Next Version'
 on:
   workflow_dispatch:
     inputs:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   prepare-next:
-    name: Prepare Next Development Version
+    name: Prepare next version
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/kmp-prepare-release.yml
+++ b/.github/workflows/kmp-prepare-release.yml
@@ -1,4 +1,4 @@
-name: Prepare KMP Release
+name: 'KMP: Prepare Release'
 
 on:
   workflow_dispatch:
@@ -11,10 +11,18 @@ on:
         description: 'Next SNAPSHOT version (e.g., 0.2.0-SNAPSHOT)'
         required: true
         type: string
+      android_version:
+        description: 'Native Android SDK version this release builds against (e.g., 0.18.0). Must be a released android-v tag.'
+        required: true
+        type: string
+      ios_version:
+        description: 'Native iOS SDK version this release builds against (e.g., 0.11.0). Must be a released ios-v tag.'
+        required: true
+        type: string
 
 jobs:
   prepare-release:
-    name: Prepare KMP SDK Release
+    name: Prepare release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,18 +41,33 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Validate input version format
+      - name: Validate inputs
         run: |
           if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
-            echo "Error: Version must match semantic versioning pattern:"
-            echo "  - x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Error: version must match x.y.z or x.y.z-(alpha|beta).n. Got: ${{ inputs.version }}"
             exit 1
           fi
+          if ! [[ ${{ inputs.android_version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: android_version must match x.y.z. Got: ${{ inputs.android_version }}"
+            exit 1
+          fi
+          if ! [[ ${{ inputs.ios_version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: ios_version must match x.y.z. Got: ${{ inputs.ios_version }}"
+            exit 1
+          fi
+          # The KMP release must pin published native versions to build against.
+          for tag in "android-v${{ inputs.android_version }}" "ios-v${{ inputs.ios_version }}"; do
+            if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "Error: tag $tag does not exist."
+              exit 1
+            fi
+          done
 
       - name: Update version in gradle.properties
         run: |
           sed -i "s/MEASURE_KMP_VERSION_NAME=.*/MEASURE_KMP_VERSION_NAME=${{ inputs.version }}/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=${{ inputs.android_version }}/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_IOS_VERSION=.*/MEASURE_IOS_VERSION=${{ inputs.ios_version }}/" kmp/measure-kmp/gradle.properties
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -65,6 +88,8 @@ jobs:
 
             Changes:
             - Updated version to ${{ inputs.version }} in gradle.properties
+            - Pinned native Android SDK version to ${{ inputs.android_version }} (android-v${{ inputs.android_version }})
+            - Pinned native iOS SDK version to ${{ inputs.ios_version }} (ios-v${{ inputs.ios_version }})
             - Generated changelog for version ${{ inputs.version }}
 
             <!-- release-meta

--- a/.github/workflows/kmp-release.yml
+++ b/.github/workflows/kmp-release.yml
@@ -1,4 +1,4 @@
-name: Release KMP SDK
+name: 'KMP: Release'
 
 on:
   push:
@@ -8,12 +8,10 @@ on:
 env:
   JAVA_VERSION: 17
   JAVA_DISTRIBUTION: 'temurin'
-  SPM_REPO: measure-sh/measure-kmp-spm
-  SPM_CHECKOUT_DIR: kmp/measure-kmp/build/measure-kmp-spm
 
 jobs:
   publish-kmp:
-    name: Publish KMP SDK
+    name: Publish
     runs-on: macos-latest
     permissions:
       contents: write
@@ -41,26 +39,29 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${GITHUB_REF_NAME#kmp-v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Clean Gradle build outputs
         working-directory: kmp/measure-kmp
         run: ./gradlew clean --no-daemon --no-configuration-cache --stacktrace
 
-      - name: Clone SPM distribution repo
-        env:
-          GH_TOKEN: ${{ secrets.SDK_RELEASE }}
+      - name: Pin native iOS SDK version
+        id: ios
         run: |
-          git clone https://x-access-token:${GH_TOKEN}@github.com/${SPM_REPO}.git ${SPM_CHECKOUT_DIR}
-          git -C ${SPM_CHECKOUT_DIR} config user.name "github-actions[bot]"
-          git -C ${SPM_CHECKOUT_DIR} config user.email "github-actions[bot]@users.noreply.github.com"
+          IOS_VERSION=$(grep '^MEASURE_IOS_VERSION=' kmp/measure-kmp/gradle.properties | cut -d= -f2)
+          if [ -z "$IOS_VERSION" ]; then
+            echo "MEASURE_IOS_VERSION is not set in gradle.properties"
+            exit 1
+          fi
+          if ! git rev-parse -q --verify "refs/tags/ios-v$IOS_VERSION" >/dev/null; then
+            echo "tag ios-v$IOS_VERSION not found; cannot build bindings against a published iOS version"
+            exit 1
+          fi
+          git worktree add --detach "$RUNNER_TEMP/ios-pinned" "ios-v$IOS_VERSION"
+          echo "src=$RUNNER_TEMP/ios-pinned/ios" >> $GITHUB_OUTPUT
 
       - name: Build Measure iOS xcframework
         run: ./kmp/measure-kmp/Scripts/build-xcframework.sh
+        env:
+          MEASURE_IOS_SRC: ${{ steps.ios.outputs.src }}
 
       - name: Publish KMP artifacts to Maven Central
         working-directory: kmp/measure-kmp
@@ -70,28 +71,6 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_ARTIFACT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_ARTIFACT_SIGNING_PASSWORD }}
-
-      - name: Publish iOS xcframework via KMMBridge
-        working-directory: kmp/measure-kmp
-        run: ./gradlew kmmBridgePublish --no-daemon --no-parallel --no-configuration-cache --stacktrace
-        env:
-          ENABLE_PUBLISHING: 'true'
-          GITHUB_PUBLISH_TOKEN: ${{ secrets.SDK_RELEASE }}
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Commit and tag SPM Package.swift
-        working-directory: ${{ env.SPM_CHECKOUT_DIR }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          git add Package.swift
-          if git diff --cached --quiet; then
-            echo "⚠️ No Package.swift changes to commit"
-            exit 1
-          fi
-          git commit -m "Release $VERSION"
-          git tag "$VERSION"
-          git push origin HEAD:main
-          git push origin "$VERSION"
 
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4
@@ -128,5 +107,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SDK_RELEASE }}
         run: |
-          gh workflow run "Prepare Next KMP Version" \
+          gh workflow run kmp-prepare-next.yml \
             -f version="${{ steps.meta.outputs.next_version }}"

--- a/.github/workflows/kmp-snapshots.yml
+++ b/.github/workflows/kmp-snapshots.yml
@@ -1,4 +1,4 @@
-name: Publish KMP SDK Snapshots
+name: 'KMP: Publish Snapshots'
 
 on:
   push:
@@ -7,13 +7,17 @@ on:
     paths:
       - 'kmp/**'
 
+concurrency:
+  group: kmp-snapshots-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   JAVA_VERSION: 17
   JAVA_DISTRIBUTION: 'temurin'
 
 jobs:
   publish-snapshots:
-    name: Publish KMP SDK Snapshots
+    name: Publish snapshots
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/kmp/measure-kmp/Scripts/build-xcframework.sh
+++ b/kmp/measure-kmp/Scripts/build-xcframework.sh
@@ -1,25 +1,22 @@
 #!/usr/bin/env bash
 #
-# Builds Measure.xcframework from ios/Sources for measure-kmp's cinterop.
-# Relies on xcodebuild's own DerivedData-based incremental build — no
-# script-level freshness check. Trades ~5–15s on a no-op rerun for "always
-# correct" (the previous bash gate missed Xcode project/workspace edits and
-# script-flag changes, silently shipping stale frameworks).
+# Builds Measure.xcframework from the native iOS SDK sources. measure-kmp's
+# cinterop binds against it for headers only; the binary is not linked (see
+# the cinterop block in build.gradle.kts).
 #
-# Why this is a shell script and not a Gradle task:
-# When invoked from Xcode's Run Script build phase, a child process inherits
-# Xcode's build-system env vars (BUILD_DIR, OBJROOT, BUILT_PRODUCTS_DIR, …).
-# A nested xcodebuild that inherits those vars contends with the parent
-# Xcode IDE's XCBBuildService session and crashes with
-# "The Xcode build system has crashed. Build again to continue."
-# We sidestep this by invoking xcodebuild via `env -i PATH=$PATH HOME=$HOME`
-# so the nested build is fully isolated from the parent Xcode env.
+# Runs as a shell script rather than a Gradle task because Xcode's Run Script
+# phase (used by the Frank sample) exports build-system env vars such as
+# BUILD_DIR and OBJROOT. A nested xcodebuild that inherits them contends with
+# the parent XCBBuildService and crashes, so run_xcodebuild isolates the child
+# with `env -i`.
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KMP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-IOS_SDK_DIR="$(cd "$KMP_DIR/../../ios" && pwd)"
+# Native iOS SDK sources. Defaults to in-repo ios/; release sets MEASURE_IOS_SRC
+# to a pinned ios-v<version> checkout.
+IOS_SDK_DIR="$(cd "${MEASURE_IOS_SRC:-$KMP_DIR/../../ios}" && pwd)"
 OUTPUT_DIR="$KMP_DIR/build/xcframework"
 DEVICE_ARCHIVE="$OUTPUT_DIR/Measure-ios.xcarchive"
 SIMULATOR_ARCHIVE="$OUTPUT_DIR/Measure-sim.xcarchive"
@@ -30,13 +27,11 @@ DERIVED_DATA="$OUTPUT_DIR/DerivedData"
 
 mkdir -p "$OUTPUT_DIR"
 
-# In CI the framework is pre-built and cached before xcodebuild starts.
-# The Xcode build phase still invokes this script, so we exit early when
-# in CI and the xcframework is already present. The cache key is derived
-# from ios/ sources, so a hit means the cached result is correct.
-# Local dev is unaffected: $CI is not set outside GitHub Actions.
+# In CI the xcframework is built once up front; later Xcode Run Script
+# invocations (e.g. the Frank app build) reuse it instead of rebuilding.
+# $CI is unset locally, so local dev always builds.
 if [ -d "$XCFRAMEWORK" ] && [ "${CI:-}" = "true" ]; then
-  echo "Measure.xcframework already present in CI — skipping rebuild"
+  echo "Measure.xcframework already present in CI, skipping rebuild"
   exit 0
 fi
 
@@ -56,7 +51,6 @@ run_xcodebuild archive \
   -archivePath "$DEVICE_ARCHIVE" \
   -derivedDataPath "$DERIVED_DATA" \
   SKIP_INSTALL=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
   CODE_SIGNING_ALLOWED=NO \
   CODE_SIGNING_REQUIRED=NO \
   CODE_SIGN_IDENTITY=
@@ -68,7 +62,6 @@ run_xcodebuild archive \
   -archivePath "$SIMULATOR_ARCHIVE" \
   -derivedDataPath "$DERIVED_DATA" \
   SKIP_INSTALL=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
   CODE_SIGNING_ALLOWED=NO \
   CODE_SIGNING_REQUIRED=NO \
   CODE_SIGN_IDENTITY=

--- a/kmp/measure-kmp/build.gradle.kts
+++ b/kmp/measure-kmp/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     kotlin("multiplatform") version "2.3.20"
     id("com.android.kotlin.multiplatform.library") version "8.13.0"
     id("com.vanniktech.maven.publish") version "0.34.0"
-    id("co.touchlab.kmmbridge.github") version "1.2.1"
     id("com.diffplug.spotless") version "8.0.0"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
 }
@@ -37,11 +36,8 @@ kotlin {
     }
 
     listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { target ->
-        target.binaries.framework {
-            baseName = "MeasureKMP"
-            isStatic = true
-            binaryOption("bundleId", "sh.measure.kmp")
-        }
+        // Binds against the native Measure module headers without embedding its
+        // binary; the consuming app links a single native Measure instance.
         target.compilations.getByName("main").cinterops.create("Measure") {
             defFile(project.file("src/appleMain/cinterop/Measure.def"))
             val slice = if (target.name == "iosArm64") "ios-arm64" else "ios-arm64_x86_64-simulator"
@@ -126,19 +122,5 @@ fun configureSpotlessKotlin(spotlessExtension: SpotlessExtension) {
             )
         }
         target("src/**/*.kt")
-    }
-}
-
-kmmbridge {
-    gitHubReleaseArtifacts()
-    spm(
-        spmDirectory =
-            layout.buildDirectory
-                .dir("measure-kmp-spm")
-                .get()
-                .asFile.absolutePath,
-        swiftToolVersion = "5.7",
-    ) {
-        iOS { v("12") }
     }
 }

--- a/kmp/measure-kmp/gradle.properties
+++ b/kmp/measure-kmp/gradle.properties
@@ -16,3 +16,7 @@ MEASURE_KMP_VERSION_NAME=0.1.0-alpha.1
 # dependency is substituted with the in-repo Gradle project via
 # settings.gradle.kts (`includeBuild ../../android/measure-android`).
 MEASURE_ANDROID_VERSION=0.18.0
+
+# Native iOS SDK version the published cinterop bindings are built against.
+# Release pins bindings to this ios-v<version> tag; local builds use in-repo ios/.
+MEASURE_IOS_VERSION=0.11.0


### PR DESCRIPTION
# Description

Pin the native Android and iOS SDK versions for KMP release. CI builds iOS cinterop bindings against the pinned `ios-v` tag, local builds use the in-repo `ios/` sources. Remove the KMMBridge/SPM distribution (plugin, framework export, SPM publish steps); the KMP SDK ships via Maven Central.

## Related issue
References #3494 



