### PR TITLE
chore(kmp): prepare sdk release 0.1.0-alpha.1

### DIFF
--- a/kmp/CHANGELOG.md
+++ b/kmp/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :hammer: Misc
 
+- (**kmp**): Pin native SDK versions and simplify CI/release (#3933) by @abhaysood in #3933
+- (**kmp**): Prepare sdk release 0.1.0-alpha.1 (#3932) by @abhaysood in #3932
 - (**kmp**): Update documentation and improve release workflow (#3930) by @abhaysood in #3930
 
 


### PR DESCRIPTION
This PR prepares the KMP SDK for release version 0.1.0-alpha.1.

Changes:
- Updated version to 0.1.0-alpha.1 in gradle.properties
- Pinned native Android SDK version to 0.18.0 (android-v0.18.0)
- Pinned native iOS SDK version to 0.11.0 (ios-v0.11.0)
- Generated changelog for version 0.1.0-alpha.1

<!-- release-meta
NEXT_VERSION=0.1.0-SNAPSHOT
-->