### PR TITLE
ci(kmp): init submodules in pinned iOS release worktree

### DIFF
--- a/.github/workflows/kmp-release.yml
+++ b/.github/workflows/kmp-release.yml
@@ -56,6 +56,8 @@ jobs:
             exit 1
           fi
           git worktree add --detach "$RUNNER_TEMP/ios-pinned" "ios-v$IOS_VERSION"
+          # libwebp ships as a submodule; the worktree needs it for MeasureWebP.
+          git -C "$RUNNER_TEMP/ios-pinned" submodule update --init --recursive
           echo "src=$RUNNER_TEMP/ios-pinned/ios" >> $GITHUB_OUTPUT
 
       - name: Build Measure iOS xcframework


### PR DESCRIPTION
## Description

The `KMP: Release` workflow failed at *Build Measure iOS xcframework*:

```
error: Build input file cannot be found:
'.../ios-pinned/ios/Sources/MeasureWebP/libwebp/src/dsp/yuv_sse41.c'
```

The release builds the iOS cinterop bindings against the pinned `ios-v<version>` tag via a `git worktree`. `libwebp` (used by `MeasureWebP`) is a git submodule, and `git worktree add` does not populate submodules, so the worktree was missing libwebp's sources.

This pR fixes this by running `git submodule update --init --recursive` inside the pinned worktree after creating it.