### PR TITLE
feat(backend): support OTA symbolication

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -25,6 +25,13 @@ type Attribute struct {
 	// AppUniqueID is the app's bundle identifier.
 	AppUniqueID string `json:"app_unique_id" binding:"required"`
 
+	// PatchID identifies an Over-The-Air patch (e.g. CodePush
+	// for RN, Shorebird for Flutter). Free-form text supplied by
+	// the mobile team. Optional — when present, symbolication
+	// looks up mapping files by patch_id, ignoring the app
+	// version/build.
+	PatchID string `json:"patch_id"`
+
 	// MeasureSDKVersion is the measure sdk version
 	// identifier.
 	MeasureSDKVersion string `json:"measure_sdk_version" binding:"required"`
@@ -143,6 +150,7 @@ func (a Attribute) Validate() error {
 		maxAppVersionChars         = 128
 		maxAppBuildChars           = 32
 		maxAppUniqueIDChars        = 128
+		maxPatchIDChars            = 1024
 		maxMeasureSDKVersion       = 16
 		maxNetworkTypeChars        = 16
 		maxNetworkGenerationChars  = 8
@@ -193,6 +201,9 @@ func (a Attribute) Validate() error {
 	}
 	if len(a.AppUniqueID) > maxAppUniqueIDChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
+	}
+	if len(a.PatchID) > maxPatchIDChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.patch_id`, maxPatchIDChars)
 	}
 	if len(a.Platform) > maxPlatformChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.platform`, maxPlatformChars)

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -67,6 +67,7 @@ const (
 	maxAppVersionChars         = 128
 	maxAppBuildChars           = 32
 	maxAppUniqueIDChars        = 128
+	maxPatchIDChars            = 1024
 	maxMeasureSDKVersion       = 16
 	maxNetworkTypeChars        = 16
 	maxNetworkGenerationChars  = 8
@@ -82,6 +83,7 @@ type CheckPointField struct {
 type SpanAttributes struct {
 	AppUniqueID              string    `json:"app_unique_id" binding:"required"`
 	InstallationID           uuid.UUID `json:"installation_id" binding:"required"`
+	PatchID                  string    `json:"patch_id"`
 	UserID                   string    `json:"user_id"`
 	MeasureSDKVersion        string    `json:"measure_sdk_version" binding:"required"`
 	AppVersion               string    `json:"app_version" binding:"required"`
@@ -282,6 +284,10 @@ func (s *SpanField) Validate(opts ...ingest.ValidationOptions) error {
 
 	if len(s.Attributes.AppUniqueID) > maxAppUniqueIDChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.app_unique_id`, maxAppUniqueIDChars)
+	}
+
+	if len(s.Attributes.PatchID) > maxPatchIDChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.patch_id`, maxPatchIDChars)
 	}
 
 	if len(s.Attributes.UserID) > maxUserIDChars {

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -499,6 +499,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			Set(`attribute.app_version`, e.events[i].Attribute.AppVersion).
 			Set(`attribute.app_build`, e.events[i].Attribute.AppBuild).
 			Set(`attribute.app_unique_id`, e.events[i].Attribute.AppUniqueID).
+			Set(`attribute.patch_id`, e.events[i].Attribute.PatchID).
 			Set(`attribute.platform`, e.events[i].Attribute.Platform).
 			Set(`attribute.measure_sdk_version`, e.events[i].Attribute.MeasureSDKVersion).
 			Set(`attribute.thread_name`, e.events[i].Attribute.ThreadName).
@@ -1041,6 +1042,7 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 			Set(`end_time`, e.spans[i].EndTime.Format(chrono.MSTimeFormat)).
 			Set(`checkpoints`, formattedCheckpoints).
 			Set(`attribute.app_unique_id`, e.spans[i].Attributes.AppUniqueID).
+			Set(`attribute.patch_id`, e.spans[i].Attributes.PatchID).
 			Set(`attribute.installation_id`, e.spans[i].Attributes.InstallationID).
 			Set(`attribute.user_id`, e.spans[i].Attributes.UserID).
 			Set(`attribute.measure_sdk_version`, e.spans[i].Attributes.MeasureSDKVersion).

--- a/backend/ingest-worker/symbolicator/payload.go
+++ b/backend/ingest-worker/symbolicator/payload.go
@@ -346,6 +346,23 @@ type requestJS struct {
 	Release string `json:"release,omitempty"`
 }
 
+// AddModule binds a frame's abs_path (code_file) to a debug id
+// so Symbolicator resolves the sourcemap by debug id (the OTA
+// patch_id path on /symbols/js). Duplicate code_files are
+// ignored — all frames of one OTA build share a single debug id.
+func (r *requestJS) AddModule(codeFile, debugID string) {
+	for _, m := range r.Modules {
+		if m.CodeFile == codeFile {
+			return
+		}
+	}
+	r.Modules = append(r.Modules, moduleJS{
+		Type:     "sourcemap",
+		CodeFile: codeFile,
+		DebugID:  debugID,
+	})
+}
+
 // responseJS represents the payload received
 // from Sentry's Symbolicator for JavaScript
 // symbolication.

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -218,10 +218,45 @@ func New(origin, operatingSys string, sources []Source, sentrySources []SentrySo
 	return
 }
 
+// resolveBatchPatchID returns the batch's effective Over-The-Air
+// patch_id. If any event or span attribute carries a non-empty
+// patch_id, the first such value is used for the whole batch. An
+// empty string means no patch_id is in play and version-based
+// mapping lookup applies.
+func resolveBatchPatchID(events []event.EventField, spans []span.SpanField) string {
+	for i := range events {
+		if events[i].Attribute.PatchID != "" {
+			return events[i].Attribute.PatchID
+		}
+	}
+	for i := range spans {
+		if spans[i].Attributes.PatchID != "" {
+			return spans[i].Attributes.PatchID
+		}
+	}
+	return ""
+}
+
 // Symbolicate performs symbolication by retrieving
 // appropriate mapping file and managing symbolicator
 // request to response cycle.
 func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appId uuid.UUID, events []event.EventField, spans []span.SpanField) (err error) {
+	// Resolve the batch's effective Over-The-Air patch_id. When any
+	// event or span attribute carries a non-empty patch_id, the whole
+	// batch symbolicates by patch_id (ignoring app version/build).
+	patchID := resolveBatchPatchID(events, spans)
+
+	// A patch_id resolves to the same mapping set for every event in
+	// the batch, so fetch it once. On error, leave it empty and let
+	// the per-event gate skip symbolication (frames stay raw).
+	var patchMappings map[string]symbol.MappingType
+	if patchID != "" {
+		if patchMappings, err = symbol.GetMappingsByPatchID(ctx, conn, appId, patchID); err != nil {
+			fmt.Printf("Error fetching mapping keys for appId %s, patch_id %s: %v\n", appId, patchID, err)
+			err = nil
+		}
+	}
+
 	for i, ev := range events {
 		if !ev.NeedsSymbolication() {
 			continue
@@ -239,13 +274,21 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 			continue
 		}
 
-		// find the mapping keys and mapping types
-		name := ev.Attribute.AppVersion
-		code := ev.Attribute.AppBuild
-		mappings, keyErr := symbol.GetMappings(ctx, conn, appId, name, code)
-		if keyErr != nil {
-			fmt.Printf("Error fetching mapping keys for appId %s, version %s, build %s: %v\n", appId, name, code, keyErr)
-			continue
+		// find the mapping keys and mapping types. when a patch_id is
+		// in play, use the patch_id-scoped set; otherwise fall back to
+		// the (app_id, version_name, version_code) lookup.
+		var mappings map[string]symbol.MappingType
+		if patchID != "" {
+			mappings = patchMappings
+		} else {
+			name := ev.Attribute.AppVersion
+			code := ev.Attribute.AppBuild
+			keyMap, keyErr := symbol.GetMappings(ctx, conn, appId, name, code)
+			if keyErr != nil {
+				fmt.Printf("Error fetching mapping keys for appId %s, version %s, build %s: %v\n", appId, name, code, keyErr)
+				continue
+			}
+			mappings = keyMap
 		}
 
 		if len(mappings) < 1 {
@@ -293,7 +336,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 				s.jsSymbolicator.ensureRequestInitialized()
 				s.jsSymbolicator.parseExceptions(ev.Exception.Exceptions, i)
 				s.jsSymbolicator.configureSource(s.SymboloaderOrigin, s.SymboloaderToken, appId, ev.Attribute.AppVersion, ev.Attribute.AppBuild)
-				s.jsSymbolicator.populateModules(ev)
+				s.jsSymbolicator.populateModules(ev, patchID)
 			}
 		case event.TypeANR:
 			s.jvmSymbolicator.ensureRequestInitialized()
@@ -1043,17 +1086,26 @@ func (js *jsSymbolicator) configureSource(symboloaderOrigin, token string, appID
 	js.request.Release = versionName + "+" + versionCode
 }
 
-// populateModules emits the modules array that binds
-// frame abs_paths to debug ids. Symbolicator uses these
-// entries to resolve sourcemaps by debug id (the OTA
-// patch_id path on the /symbols/js endpoint).
+// populateModules emits the modules array that binds frame
+// abs_paths to the OTA patch_id (as debug id). Symbolicator uses
+// these entries to resolve sourcemaps by debug id — the patch_id
+// path on the /symbols/js endpoint.
 //
-// Where on the event payload the patch_id surfaces is
-// pending product/SDK design. Until that lands, this is
-// a no-op and Symbolicator's URL-fallback path runs —
-// scoped by the app_id + version params on the source URL.
-func (js *jsSymbolicator) populateModules(ev event.EventField) {
-	_ = ev
+// When patchID is empty (non-OTA build), no modules are emitted
+// and Symbolicator's URL-fallback path runs, scoped by the
+// app_id + version params on the source URL.
+func (js *jsSymbolicator) populateModules(ev event.EventField, patchID string) {
+	if patchID == "" {
+		return
+	}
+	for _, excep := range ev.Exception.Exceptions {
+		for _, frame := range excep.Frames {
+			if frame.FileName == "" {
+				continue
+			}
+			js.request.AddModule(frame.FileName, patchID)
+		}
+	}
 }
 
 // symbolicate performs symbolication for

--- a/backend/ingest/main.go
+++ b/backend/ingest/main.go
@@ -60,6 +60,7 @@ func main() {
 	// SDK routes
 	r.PUT("/events", measure.ValidateAPIKey(), measure.PutEvents)
 	r.PUT("/builds", measure.ValidateAPIKey(), measure.PutBuilds)
+	r.PUT("/builds/ota", measure.ValidateAPIKey(), measure.PutOTABuilds)
 	r.GET("/config", measure.ValidateAPIKey(), measure.GetConfigForSdk)
 
 	port := os.Getenv("PORT")

--- a/backend/ingest/measure/build.go
+++ b/backend/ingest/measure/build.go
@@ -38,7 +38,7 @@ type Mapping struct {
 	// PatchID echoes the build's optional patch_id back to the
 	// caller so the build script can confirm the value persisted
 	// against this mapping row.
-	PatchID uuid.NullUUID `json:"patch_id,omitempty"`
+	PatchID string `json:"patch_id,omitempty"`
 }
 
 type Build struct {
@@ -50,15 +50,24 @@ type Build struct {
 	Mappings    []*Mapping `json:"mappings" binding:"dive,required"`
 	AppUniqueID string     `json:"app_unique_id"`
 	// PatchID identifies an Over-The-Air patch (e.g. CodePush
-	// for RN, Shorebird for Flutter). Optional — when absent,
-	// the row's patch_id stays NULL and the build is not
-	// findable via patch_id-based symbolication lookup.
-	// Validated by uuid.NullUUID.UnmarshalJSON only if present.
-	PatchID uuid.NullUUID `json:"patch_id"`
+	// for RN, Shorebird for Flutter). Free-form text. Optional on
+	// this endpoint — when empty, the row's patch_id stays empty
+	// and the build is not findable via patch_id-based
+	// symbolication lookup.
+	PatchID string `json:"patch_id"`
 }
 
 type BuildResponse struct {
 	Mappings []*Mapping `json:"mappings"`
+}
+
+// OTABuild is the request body for PUT /builds/ota. It carries
+// only a free-form patch_id and the mapping files — no app
+// version, build number or build size. The app is resolved from
+// the request's API key (like PutBuilds), never from the body.
+type OTABuild struct {
+	PatchID  string     `json:"patch_id" binding:"required"`
+	Mappings []*Mapping `json:"mappings" binding:"required,dive,required"`
 }
 
 func (b Build) hasMapping() bool {
@@ -292,110 +301,213 @@ func PutBuilds(c *gin.Context) {
 		return
 	}
 
-	config := server.Server.Config
+	if err = presignMappings(ctx, server.Server.Config, &build); err != nil {
+		msg := fmt.Sprintf("failed to presign build mappings: %v", err)
 
-	if config.IsCloud() {
-		client, err := objstore.CreateGCSClient(ctx)
-		if err != nil {
-			msg := fmt.Sprintf("failed to create GCS client: %v", err)
+		fmt.Println(msg)
 
-			fmt.Println(msg)
-
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-
-			return
-		}
-
-		// for creating signed URLs, we need to tie the service account
-		// identity along with the credentials. otherwise, the signed
-		// URLs can't be generated and won't work as expected.
-		iamClient, err := credentials.NewIamCredentialsClient(ctx)
-		if err != nil {
-			msg := fmt.Sprintf("failed to create IAM client: %v", err)
-
-			fmt.Println(msg)
-
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-
-			return
-		}
-		defer iamClient.Close()
-
-		signBytes := func(b []byte) ([]byte, error) {
-			resp, err := iamClient.SignBlob(ctx, &credentialspb.SignBlobRequest{
-				Name:    "projects/-/serviceAccounts/" + config.ServiceAccountEmail,
-				Payload: b,
-			})
-			if err != nil {
-				return nil, err
-			}
-			return resp.SignedBlob, nil
-		}
-
-		for _, mapping := range build.Mappings {
-			ext := filepath.Ext(mapping.Filename)
-			key := fmt.Sprintf("incoming/%s%s", mapping.ID.String(), ext)
-			expiry := time.Now().Add(time.Hour)
-			metadata := []string{
-				fmt.Sprintf("x-goog-meta-mapping_id: %s", mapping.ID.String()),
-				fmt.Sprintf("x-goog-meta-original_file_name: %s", mapping.Filename),
-			}
-
-			signOptions := &storage.SignedURLOptions{
-				GoogleAccessID: config.ServiceAccountEmail,
-				SignBytes:      signBytes,
-				Scheme:         storage.SigningSchemeV4,
-				Method:         "PUT",
-				Expires:        expiry,
-				Headers:        metadata,
-			}
-
-			url, err := objstore.CreateGCSPUTPreSignedURL(client, config.SymbolsBucket, key, signOptions)
-			if err != nil {
-				msg := fmt.Sprintf("failed to create PUT pre-signed URL for %v: %v", mapping.Filename, err)
-
-				fmt.Println(msg)
-
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": msg,
-				})
-
-				return
-			}
-
-			mapping.UploadURL = url
-			mapping.ExpiresAt = expiry
-			mapping.PatchID = build.PatchID
-			mapping.Headers = make(map[string]string)
-			mapping.Headers["x-goog-meta-mapping_id"] = mapping.ID.String()
-			mapping.Headers["x-goog-meta-original_file_name"] = mapping.Filename
-		}
-
-		if !build.hasMapping() {
-			c.JSON(http.StatusOK, gin.H{
-				"ok": "build info updated",
-			})
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"mappings": build.Mappings,
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
 		})
 
 		return
 	}
 
-	client := objstore.CreateS3Client(ctx, config.SymbolsAccessKey, config.SymbolsSecretAccessKey, config.SymbolsBucketRegion, config.AWSEndpoint)
+	if !build.hasMapping() {
+		c.JSON(http.StatusOK, gin.H{
+			"ok": "build info updated",
+		})
+		return
+	}
 
-	// process build mappings
+	c.JSON(http.StatusOK, gin.H{
+		"mappings": build.Mappings,
+	})
+}
+
+// PutOTABuilds handles uploads of Over-The-Air patch mapping
+// files (CodePush / Shorebird). Unlike PutBuilds it is driven
+// solely by a free-form patch_id — it accepts no app version,
+// build number or build size. The mapping rows are stored with
+// empty version columns and the supplied patch_id, which is the
+// sole key for patch_id-based symbolication lookups.
+func PutOTABuilds(c *gin.Context) {
+	ctx := c.Request.Context()
+	appId, err := uuid.Parse(c.GetString("appId"))
+	if err != nil {
+		msg := `failed to parse app id`
+		fmt.Println(msg, err)
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+
+		return
+	}
+
+	var ota OTABuild
+	if err := c.ShouldBindJSON(&ota); err != nil {
+		msg := `failed to parse OTA build info`
+		fmt.Println(msg, err)
+
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+
+		return
+	}
+
+	// model the OTA upload as a build with no version/size; the
+	// patch_id is the sole lookup key for these mapping rows.
+	build := Build{
+		AppID:    appId,
+		PatchID:  ota.PatchID,
+		Mappings: ota.Mappings,
+	}
+
+	// each OTA mapping gets a fresh id; a re-uploaded patch_id
+	// inserts new rows and latest-wins applies at lookup time.
+	for _, m := range build.Mappings {
+		m.ID = uuid.New()
+	}
+
+	tx, err := server.Server.PgPool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.ReadCommitted,
+	})
+	if err != nil {
+		msg := fmt.Sprintf("failed to acquire db transaction while putting OTA builds: %v", err)
+		fmt.Println(msg)
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+
+		return
+	}
+
+	defer tx.Rollback(ctx)
+
+	if err = build.insertNewMappings(ctx, &tx); err != nil {
+		msg := fmt.Sprintf("failed to insert OTA mappings: %v", err)
+		fmt.Println(msg)
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+
+		return
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		msg := fmt.Sprintf("failed to commit transaction while putting OTA builds: %v", err)
+		fmt.Println(msg)
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+
+		return
+	}
+
+	if err = presignMappings(ctx, server.Server.Config, &build); err != nil {
+		msg := fmt.Sprintf("failed to presign OTA mappings: %v", err)
+		fmt.Println(msg)
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"mappings": build.Mappings,
+	})
+}
+
+// presignMappings generates presigned PUT upload URLs for each of
+// the build's mapping files and populates UploadURL, ExpiresAt,
+// PatchID and Headers on every mapping. It dispatches to the cloud
+// (GCS) or self-host (S3) implementation. Shared by PutBuilds and
+// PutOTABuilds.
+func presignMappings(ctx context.Context, config *server.ServerConfig, build *Build) (err error) {
+	if config.IsCloud() {
+		return presignMappingsGCS(ctx, config, build)
+	}
+	return presignMappingsS3(ctx, config, build)
+}
+
+// presignMappingsGCS signs each mapping's upload URL via GCS V4
+// signing. The service account identity must be tied to the
+// credentials, otherwise the signed URLs won't work.
+func presignMappingsGCS(ctx context.Context, config *server.ServerConfig, build *Build) (err error) {
+	client, err := objstore.CreateGCSClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create GCS client: %w", err)
+	}
+
+	iamClient, err := credentials.NewIamCredentialsClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create IAM client: %w", err)
+	}
+	defer iamClient.Close()
+
+	signBytes := func(b []byte) ([]byte, error) {
+		resp, signErr := iamClient.SignBlob(ctx, &credentialspb.SignBlobRequest{
+			Name:    "projects/-/serviceAccounts/" + config.ServiceAccountEmail,
+			Payload: b,
+		})
+		if signErr != nil {
+			return nil, signErr
+		}
+		return resp.SignedBlob, nil
+	}
+
 	for _, mapping := range build.Mappings {
 		ext := filepath.Ext(mapping.Filename)
 		key := fmt.Sprintf("incoming/%s%s", mapping.ID.String(), ext)
-		signedUrl, err := objstore.CreateS3PUTPreSignedURL(ctx, client, &s3.PutObjectInput{
+		expiry := time.Now().Add(time.Hour)
+		metadata := []string{
+			fmt.Sprintf("x-goog-meta-mapping_id: %s", mapping.ID.String()),
+			fmt.Sprintf("x-goog-meta-original_file_name: %s", mapping.Filename),
+		}
+
+		signOptions := &storage.SignedURLOptions{
+			GoogleAccessID: config.ServiceAccountEmail,
+			SignBytes:      signBytes,
+			Scheme:         storage.SigningSchemeV4,
+			Method:         "PUT",
+			Expires:        expiry,
+			Headers:        metadata,
+		}
+
+		url, signErr := objstore.CreateGCSPUTPreSignedURL(client, config.SymbolsBucket, key, signOptions)
+		if signErr != nil {
+			return fmt.Errorf("failed to create PUT pre-signed URL for %v: %w", mapping.Filename, signErr)
+		}
+
+		mapping.UploadURL = url
+		mapping.ExpiresAt = expiry
+		mapping.PatchID = build.PatchID
+		mapping.Headers = make(map[string]string)
+		mapping.Headers["x-goog-meta-mapping_id"] = mapping.ID.String()
+		mapping.Headers["x-goog-meta-original_file_name"] = mapping.Filename
+	}
+
+	return
+}
+
+// presignMappingsS3 signs each mapping's upload URL via the S3 SDK
+// presigner, then wraps it in the API proxy URL used on self-host.
+func presignMappingsS3(ctx context.Context, config *server.ServerConfig, build *Build) (err error) {
+	client := objstore.CreateS3Client(ctx, config.SymbolsAccessKey, config.SymbolsSecretAccessKey, config.SymbolsBucketRegion, config.AWSEndpoint)
+
+	for _, mapping := range build.Mappings {
+		ext := filepath.Ext(mapping.Filename)
+		key := fmt.Sprintf("incoming/%s%s", mapping.ID.String(), ext)
+		signedUrl, signErr := objstore.CreateS3PUTPreSignedURL(ctx, client, &s3.PutObjectInput{
 			Bucket: aws.String(config.SymbolsBucket),
 			Key:    aws.String(key),
 			Metadata: map[string]string{
@@ -403,16 +515,8 @@ func PutBuilds(c *gin.Context) {
 				"original_file_name": mapping.Filename,
 			},
 		}, s3.WithPresignExpires(time.Duration(time.Hour)))
-
-		if err != nil {
-			msg := fmt.Sprintf("failed to create PUT pre-signed URL for %v: %v", mapping.Filename, err)
-
-			fmt.Println(msg)
-
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-			return
+		if signErr != nil {
+			return fmt.Errorf("failed to create PUT pre-signed URL for %v: %w", mapping.Filename, signErr)
 		}
 
 		// proxy the url
@@ -426,14 +530,5 @@ func PutBuilds(c *gin.Context) {
 		mapping.Headers["x-amz-meta-original_file_name"] = mapping.Filename
 	}
 
-	if !build.hasMapping() {
-		c.JSON(http.StatusOK, gin.H{
-			"ok": "build info updated",
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"mappings": build.Mappings,
-	})
+	return
 }

--- a/backend/libs/symbol/dif.go
+++ b/backend/libs/symbol/dif.go
@@ -292,6 +292,54 @@ func GetMappings(
 	return
 }
 
+// GetMappingsByPatchID fetches all mapping file keys from
+// database for a given app and Over-The-Air patch_id, returning
+// a map of keys to their mapping types.
+//
+// Used when an event/span carries a patch_id: the lookup is
+// scoped purely by (app_id, patch_id) and ignores the app
+// version/build. Ordered most-recent first so that, for a
+// patch_id re-uploaded with the same logical files, the latest
+// upload wins when keys collapse into the map.
+func GetMappingsByPatchID(
+	ctx context.Context,
+	db *pgxpool.Pool,
+	appId uuid.UUID,
+	patchID string,
+) (keyMap map[string]MappingType, err error) {
+	stmt := sqlf.PostgreSQL.
+		From("build_mappings").
+		Select("key, mapping_type").
+		Where("app_id = ?", appId).
+		Where("patch_id = ?", patchID).
+		Where("key != ''").
+		OrderBy("last_updated desc")
+
+	defer stmt.Close()
+
+	rows, err := db.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	keyMap = make(map[string]MappingType)
+	for rows.Next() {
+		var key string
+		var mTypeStr string
+		if err = rows.Scan(&key, &mTypeStr); err != nil {
+			return nil, err
+		}
+		keyMap[key] = ParseMappingType(mTypeStr)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return
+}
+
 // ParseMappingType converts a string mapping type to MappingType enum
 func ParseMappingType(s string) MappingType {
 	switch s {

--- a/backend/symboloader/symbolsjs.go
+++ b/backend/symboloader/symbolsjs.go
@@ -92,9 +92,10 @@ type resolvedPair struct {
 // we give it via SentrySourceConfig.url. Two lookup paths
 // supported:
 //
-//  1. OTA / patch-id path: ?debug_id=<uuid> (one or more).
-//     Internally maps to a patch_id column lookup. Used when the
-//     SDK supplies a patch_id via a module entry on the event.
+//  1. OTA / patch-id path: ?debug_id=<patch_id> (one or more),
+//     scoped by ?app_id=<uuid>. Internally maps to a patch_id
+//     column lookup. Used when the SDK supplies a patch_id via a
+//     module entry on the event.
 //
 //  2. URL fallback path: ?app_id=<uuid>&version_name=...&
 //     version_code=...&url=... (?url= repeatable). Used when no
@@ -116,7 +117,7 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 	var err error
 
 	if patchIDs := c.QueryArray("debug_id"); len(patchIDs) > 0 {
-		pairs, err = resolveByPatchID(ctx, patchIDs)
+		pairs, err = resolveByPatchID(ctx, c.Query("app_id"), patchIDs)
 	} else if appID := c.Query("app_id"); appID != "" {
 		versionName := c.Query("version_name")
 		versionCode := c.Query("version_code")
@@ -154,13 +155,14 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 	c.JSON(http.StatusOK, results)
 }
 
-// resolveByPatchID handles the OTA path: caller supplies one
-// or more patch_ids; we look up the matching build_mappings
-// rows and pair bundle + sourcemap per patch_id. Filenames are
-// derived from the row's storage key — no HEAD against object
-// metadata.
-func resolveByPatchID(ctx context.Context, patchIDs []string) (pairs []resolvedPair, err error) {
-	rows, err := queryJsBundleRowsByPatchID(ctx, patchIDs)
+// resolveByPatchID handles the OTA path: caller supplies the
+// scoping app_id and one or more patch_ids; we look up the
+// matching build_mappings rows and pair bundle + sourcemap per
+// patch_id. Filenames are derived from the row's storage key —
+// no HEAD against object metadata. Rows arrive ordered
+// last_updated DESC so re-uploads collapse to the newest per role.
+func resolveByPatchID(ctx context.Context, appID string, patchIDs []string) (pairs []resolvedPair, err error) {
+	rows, err := queryJsBundleRowsByPatchID(ctx, appID, patchIDs)
 	if err != nil {
 		return
 	}
@@ -333,13 +335,17 @@ func setupStorageClients(
 
 // classifyRows splits a group of rows for one patch_id into
 // the bundle and sourcemap entries based on the inner filename
-// suffix (`.map` = sourcemap, anything else = bundle).
+// suffix (`.map` = sourcemap, anything else = bundle). Rows are
+// pre-sorted last_updated DESC, so first-seen-wins per role keeps
+// the most recent upload when a patch_id is re-uploaded.
 func classifyRows(rows []jsbundleRow) (bundle, sourcemap *jsbundleRow) {
 	for i := range rows {
 		r := &rows[i]
 		if r.isSourcemap() {
-			sourcemap = r
-		} else {
+			if sourcemap == nil {
+				sourcemap = r
+			}
+		} else if bundle == nil {
 			bundle = r
 		}
 	}
@@ -347,13 +353,14 @@ func classifyRows(rows []jsbundleRow) (bundle, sourcemap *jsbundleRow) {
 }
 
 // queryJsBundleRowsByPatchID returns build_mappings rows for
-// the given patch_ids whose mapping_type is "jsbundle".
+// the given app_id and patch_ids whose mapping_type is "jsbundle",
+// ordered most-recent first so re-uploads dedupe to the latest.
 //
-// The app_id filter is intentionally absent — Symbolicator has
-// no app context at lookup time in the patch_id path. patch_ids
-// are assumed globally unique (generated as UUIDv4 at build
-// time). Revisit if collisions become a concern.
-func queryJsBundleRowsByPatchID(ctx context.Context, patchIDs []string) (rows []jsbundleRow, err error) {
+// patch_ids are free-form developer-supplied text, so the app_id
+// filter is required to avoid cross-app collisions. The app_id
+// reaches this path via the source URL the ingest-worker sets on
+// the Sentry source (configureSource).
+func queryJsBundleRowsByPatchID(ctx context.Context, appID string, patchIDs []string) (rows []jsbundleRow, err error) {
 	placeholders := make([]string, len(patchIDs))
 	args := make([]any, len(patchIDs))
 	for i, d := range patchIDs {
@@ -364,9 +371,10 @@ func queryJsBundleRowsByPatchID(ctx context.Context, patchIDs []string) (rows []
 	stmt := sqlf.PostgreSQL.
 		From("build_mappings").
 		Select("key, patch_id").
+		Where("app_id = ?", appID).
 		Where("mapping_type = ?", symbol.TypeJsBundle.String()).
-		Where("patch_id IS NOT NULL").
-		Where("patch_id IN ("+strings.Join(placeholders, ",")+")", args...)
+		Where("patch_id IN ("+strings.Join(placeholders, ",")+")", args...).
+		OrderBy("last_updated DESC")
 
 	defer stmt.Close()
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -25,12 +25,18 @@ Find all the endpoints, resources and detailed documentation for Measure SDK RES
     - [Request Body](#request-body-1)
       - [Mappings](#mappings)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-1)
-  - [GET `/config`](#get-config)
+  - [PUT `/builds/ota`](#put-buildsota)
     - [Usage Notes](#usage-notes-2)
     - [Authorization \& Content Type](#authorization--content-type-1)
     - [Response Body](#response-body-2)
-    - [Cache Headers](#cache-headers)
+    - [Request Body](#request-body-2)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-2)
+  - [GET `/config`](#get-config)
+    - [Usage Notes](#usage-notes-3)
+    - [Authorization \& Content Type](#authorization--content-type-2)
+    - [Response Body](#response-body-3)
+    - [Cache Headers](#cache-headers)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-3)
 - [References](#references)
   - [Attributes](#attributes)
   - [User Defined Attributes](#user-defined-attributes)
@@ -73,6 +79,7 @@ Find all the endpoints, resources and detailed documentation for Measure SDK RES
 
 - [**PUT `/events`**](#put-events) - Send a batch of events, spans, attachments, metrics and traces via this endpoint.
 - [**PUT `/builds`**](#put-builds) - Send build mappings and build sizes via this API.
+- [**PUT `/builds/ota`**](#put-buildsota) - Send Over-The-Air patch mappings (CodePush, Shorebird) keyed by `patch_id` via this API.
 
 ### PUT `/events`
 
@@ -314,7 +321,7 @@ to the returned URLs. For uploading the files, you can issue a standard http req
   - A second `.tgz` containing the matching sourcemap (e.g. `main.jsbundle.map`, `index.android.bundle.map`).
 
   Symbolication pairs the two server-side via the inner filename's `.map` suffix, so the inner filenames must follow the `<bundle>` / `<bundle>.map` convention.
-- `patch_id` is optional. When supplied, it must be a valid UUID. Every mapping in the request is associated with this `patch_id` and the value is echoed back on each mapping object in the response. Use this to tag mappings that belong to an Over-The-Air patch (e.g. CodePush for React Native, Shorebird for Flutter) so the SDK can later refer to the exact mapping at symbolication time. When omitted, mappings are stored without a patch reference and are looked up by `version_name` + `version_code` instead.
+- `patch_id` is optional. Use it to tag mappings that belong to an Over-The-Air patch (e.g. CodePush for React Native, Shorebird for Flutter). The value is echoed back on each mapping in the response. For OTA patches without an associated store build, use [`PUT /builds/ota`](#put-buildsota) instead.
 - For mapping filename, only provide the filename, not a path.
 - When `mappings` is present, the server returns a mappings array containing the pre-signed URL for uploading each mapping file.
 - Each pre-signed mapping file upload URL has an expiry set which is the same as the `expires_at` field.
@@ -426,7 +433,7 @@ Payload must contain the app version info, build info and optional build mapping
 | `version_code` | string | No       | Version code of the build. Like "999"                                                                                                      |
 | `build_size`   | string | No       | Size of app in bytes                                                                                                                       |
 | `build_type`   | string | No       | Type of the build.<br />- `aab`, `apk` for Android<br />- `ipa` for iOS                                                                    |
-| `patch_id`     | string | Yes      | Optional UUID identifying an Over-The-Air patch this build's mappings belong to. Omit when uploading a regular (non-OTA) build's mappings. |
+| `patch_id`     | string | Yes      | Identifier tagging an Over-The-Air patch these mappings belong to. Omit for regular builds.                                                |
 | `mappings`     | array  | Yes      | List of mapping files objects.                                                                                                             |
 
 ##### Mappings
@@ -453,6 +460,114 @@ List of HTTP status codes for success and failures.
 | `400 Bad Request`           | Request body is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
 | `401 Unauthorized`          | Either the Measure API key is not present or has expired.                                                               |
 | `413 Content Too Large`     | Build/mapping file size exceeded maximum allowed limit.                                                                 |
+| `429 Too Many Requests`     | Rate limit has exceeded. Retry request respecting `Retry-After` response header.                                        |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                              |
+| `503 Service Unavailable`   | Measure server is temporarily unavailable. Retry request respecting `Retry-After` response header.                      |
+
+</details>
+
+### PUT `/builds/ota`
+
+Uploads mapping files for an Over-The-Air (OTA) patch — a remote update that ships new code without a new store build (e.g. CodePush for React Native, Shorebird for Flutter). It is driven by a `patch_id` and takes no app version, build number or build size.
+
+Like `PUT /builds`, this API accepts metadata and returns pre-signed URLs for uploading the mapping files directly. Upload each file with a standard HTTP **PUT** using the returned `upload_url` and `headers`.
+
+#### Usage Notes
+
+- `patch_id` is **required**. Tag your OTA patch with any identifier; it is echoed back on each mapping in the response.
+- The app is determined from your API key — do **not** send an app identifier in the body.
+- `mappings` is **required** and must contain at least one mapping. `mapping_type` can be `proguard`, `dsym`, `elf_debug`, or `jsbundle` (React Native).
+- For React Native, upload the JS bundle and its sourcemap as **two separate `jsbundle` mappings in the same request** (same tarball and `<bundle>` / `<bundle>.map` conventions as [`PUT /builds`](#usage-notes-1)).
+- For mapping filename, only provide the filename, not a path.
+- Each pre-signed URL expires at `expires_at`, and includes a `headers` object whose entries must all be added to the upload request, otherwise it will fail.
+- File upload requests must use the **PUT** http method.
+
+#### Authorization \& Content Type
+
+1. Set the Measure API key in `Authorization: Bearer <api-key>` format
+
+2. Set the content type as `Content-Type: application/json`.
+
+#### Response Body
+
+The response contains a `mappings` array with the pre-signed upload URL for each mapping file. Each mapping echoes back the request's `patch_id`.
+
+```json
+{
+  "mappings": [
+    {
+      "id": "e2bbcad8-0566-44ea-af43-9dd114c64e8c",
+      "type": "jsbundle",
+      "filename": "main.jsbundle.tgz",
+      "upload_url": "http://localhost:9119/msr-symbols-sandbox/incoming/e2bbcad8-0566-44ea-af43-9dd114c64e8c.tgz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20250813%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250813T005945Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host%3Bx-amz-meta-mapping_id%3Bx-amz-meta-original_file_name&x-id=PutObject&X-Amz-Signature=bc45a536a1660de12cb9056d6b6c978289e49b53fe6807b81662cd61c195caa1",
+      "expires_at": "2025-08-13T01:59:45.577889184Z",
+      "headers": {
+        "x-amz-meta-mapping_id": "e2bbcad8-0566-44ea-af43-9dd114c64e8c",
+        "x-amz-meta-original_file_name": "main.jsbundle.tgz"
+      },
+      "patch_id": "codepush-v1.0.0-patch-3"
+    },
+    {
+      "id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
+      "type": "jsbundle",
+      "filename": "main.jsbundle.map.tgz",
+      "upload_url": "http://localhost:9119/msr-symbols-sandbox/incoming/77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc.tgz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20250813%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250813T005945Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host%3Bx-amz-meta-mapping_id%3Bx-amz-meta-original_file_name&x-id=PutObject&X-Amz-Signature=7e2e47a5598d0fe9facf6a3fbf7da5cf93a36866b19d1ff236603015529b0bc7",
+      "expires_at": "2025-08-13T01:59:45.577980476Z",
+      "headers": {
+        "x-amz-meta-mapping_id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
+        "x-amz-meta-original_file_name": "main.jsbundle.map.tgz"
+      },
+      "patch_id": "codepush-v1.0.0-patch-3"
+    }
+  ]
+}
+```
+
+#### Request Body
+
+Payload must contain the `patch_id` and at least one mapping.
+
+**Example payload**
+
+<details>
+<summary>Expand</summary>
+
+```json
+{
+  "patch_id": "codepush-v1.0.0-patch-3",
+  "mappings": [
+    {
+      "type": "jsbundle",
+      "filename": "main.jsbundle.tgz"
+    },
+    {
+      "type": "jsbundle",
+      "filename": "main.jsbundle.map.tgz"
+    }
+  ]
+}
+```
+
+| Field      | Type   | Optional | Comment                                                                                                     |
+| ---------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `patch_id` | string | No       | Identifier for the OTA patch.                                                                               |
+| `mappings` | array  | No       | List of mapping file objects (at least one). Same shape as [`PUT /builds` mappings](#mappings).             |
+
+</details>
+
+#### Status Codes \& Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+<summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | OTA mappings accepted; pre-signed upload URLs returned.                                                                 |
+| `400 Bad Request`           | Request body is malformed or is missing `patch_id`/`mappings`. Check the `"error"` field for more details.              |
+| `401 Unauthorized`          | Either the Measure API key is not present or has expired.                                                               |
+| `413 Content Too Large`     | Mapping file size exceeded maximum allowed limit.                                                                       |
 | `429 Too Many Requests`     | Rate limit has exceeded. Retry request respecting `Retry-After` response header.                                        |
 | `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                              |
 | `503 Service Unavailable`   | Measure server is temporarily unavailable. Retry request respecting `Retry-After` response header.                      |
@@ -573,6 +688,7 @@ Events can contain the following attributes, some of which are mandatory.
 | `app_version`                       | string  | No       | App version identifier                                                      |
 | `app_build`                         | string  | No       | App build identifier                                                        |
 | `app_unique_id`                     | string  | No       | App bundle identifier                                                       |
+| `patch_id`                          | string  | Yes      | Identifier of the Over-The-Air patch the app is running, if any. See [`PUT /builds/ota`](#put-buildsota).    |
 | `platform`                          | string  | No       | One of:<br>- android<br>- ios<br>- flutter                                  |
 | `measure_sdk_version`               | string  | No       | Measure SDK version identifier                                              |
 | `thread_name`                       | string  | Yes      | The thread on which the event was captured                                  |

--- a/self-host/clickhouse/20260619060106_alter_events_table.sql
+++ b/self-host/clickhouse/20260619060106_alter_events_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table events
+  add column if not exists `attribute.patch_id` LowCardinality(String) COMMENT 'OTA patch identifier (CodePush/Shorebird)' CODEC(ZSTD(3)) after `attribute.app_build`;
+
+-- migrate:down
+alter table events
+  drop column if exists `attribute.patch_id`;

--- a/self-host/clickhouse/20260619061050_alter_spans_table.sql
+++ b/self-host/clickhouse/20260619061050_alter_spans_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table spans
+  add column if not exists `attribute.patch_id` LowCardinality(String) COMMENT 'OTA patch identifier (CodePush/Shorebird)' CODEC(ZSTD(3)) after `attribute.app_version`;
+
+-- migrate:down
+alter table spans
+  drop column if exists `attribute.patch_id`;

--- a/self-host/postgres/20260619055626_alter_build_mappings_table.sql
+++ b/self-host/postgres/20260619055626_alter_build_mappings_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table "measure"."build_mappings"
+  alter column patch_id type text using coalesce(patch_id::text, ''),
+  alter column patch_id set default '',
+  alter column patch_id set not null;
+
+-- migrate:down
+alter table "measure"."build_mappings"
+  alter column patch_id drop not null,
+  alter column patch_id drop default,
+  alter column patch_id type uuid using nullif(patch_id, '')::uuid;


### PR DESCRIPTION
## Summary

This PR adds Over-The-Air (OTA) symbolication support keyed by a free-form `patch_id`, covering both React Native (JS/Hermes) & Flutter (Dart) patches shipped via CodePush, Shorebird, etc. When a `patch_id` is present on an event or span, symbolication resolves mappings by `patch_id` instead of app version/build. A new `PUT /builds/ota` endpoint uploads patch mappings without any version or build size.

## Tasks

- [x] add `PUT /builds/ota` endpoint for OTA patch mappings
- [x] thread free-form `patch_id` through event & span attributes
- [x] persist `patch_id` to ClickHouse `events` & `spans` tables
- [x] look up mappings by `patch_id` at symbolication for RN & Flutter
- [x] emit JS `debug_id` modules for OTA sourcemap lookup
- [x] scope `/symbols/js` patch lookup by `app_id`
- [x] migrate `build_mappings.patch_id` to `text` `not null`
- [x] update SDK REST API docs

## See also

- fixes #3937