### PR TITLE
feat(frontend): add manual input to pricing calculator

### DIFF
--- a/frontend/dashboard/__tests__/components/synced_input_slider_test.tsx
+++ b/frontend/dashboard/__tests__/components/synced_input_slider_test.tsx
@@ -1,0 +1,250 @@
+import { SyncedInputSlider } from "@/app/components/synced_input_slider";
+import { describe, expect, it, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+// Radix Slider measures its track via ResizeObserver, absent in jsdom.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+}
+
+type Props = ComponentProps<typeof SyncedInputSlider>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const onChange = jest.fn();
+  const props: Props = {
+    label: "Daily users",
+    description: "How many users",
+    value: 50,
+    onChange,
+    min: 0,
+    max: 100,
+    step: 1,
+    rangeStartLabel: "0",
+    rangeEndLabel: "100",
+    ...overrides,
+  };
+  const utils = render(<SyncedInputSlider {...props} />);
+  return { onChange, props, ...utils };
+}
+
+const input = () => screen.getByRole("textbox") as HTMLInputElement;
+
+describe("SyncedInputSlider", () => {
+  describe("rendering", () => {
+    it("renders the label, description and value", () => {
+      setup();
+      expect(screen.getByText("Daily users")).toBeInTheDocument();
+      expect(screen.getByText("How many users")).toBeInTheDocument();
+      expect(input()).toHaveValue("50");
+    });
+
+    it("associates the label with the input", () => {
+      setup();
+      // The slider also carries the label as its aria-label, so scope to the
+      // textbox role to confirm the <label> names the input.
+      expect(screen.getByRole("textbox", { name: "Daily users" })).toBe(
+        input(),
+      );
+    });
+
+    it("groups large values with thousands separators", () => {
+      setup({ value: 1000, max: 10_000_000, integer: true });
+      expect(input()).toHaveValue("1,000");
+    });
+
+    it("renders the suffix when provided", () => {
+      setup({ suffix: "users" });
+      expect(screen.getByText("users")).toBeInTheDocument();
+    });
+
+    it("renders the range start and end labels", () => {
+      setup({ rangeStartLabel: "0%", rangeEndLabel: "100%" });
+      expect(screen.getByText("0%")).toBeInTheDocument();
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("exposes the value, min and max on the slider", () => {
+      setup({ value: 42 });
+      const slider = screen.getByRole("slider");
+      expect(slider).toHaveAttribute("aria-valuenow", "42");
+      expect(slider).toHaveAttribute("aria-valuemin", "0");
+      expect(slider).toHaveAttribute("aria-valuemax", "100");
+    });
+
+    it("computes the slider step from a step function", () => {
+      const step = jest.fn((v: number) => (v < 50 ? 1 : 10));
+      setup({ value: 50, step });
+      expect(step).toHaveBeenCalledWith(50);
+    });
+
+    it("renders larger styling for the primary field", () => {
+      setup({ large: true });
+      expect(screen.getByText("Daily users")).toHaveClass("text-2xl");
+    });
+  });
+
+  describe("manual entry — integer field", () => {
+    it("calls onChange with the typed number", () => {
+      const { onChange } = setup({ integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "75" } }));
+      expect(input()).toHaveValue("75");
+      expect(onChange).toHaveBeenCalledWith(75);
+    });
+
+    it("clamps to max when the entry exceeds it", () => {
+      const { onChange } = setup({ integer: true, max: 100 });
+      act(() => fireEvent.change(input(), { target: { value: "150" } }));
+      expect(onChange).toHaveBeenCalledWith(100);
+    });
+
+    it("clamps to min when the entry is below it", () => {
+      const { onChange } = setup({ integer: true, min: 10, max: 100 });
+      act(() => fireEvent.change(input(), { target: { value: "5" } }));
+      expect(onChange).toHaveBeenCalledWith(10);
+    });
+
+    it("clamps a negative entry to the default min of 0", () => {
+      const { onChange } = setup({ integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "-10" } }));
+      expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it("keeps integer fields whole", () => {
+      const { onChange } = setup({ integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "33.7" } }));
+      expect(onChange).toHaveBeenCalledWith(33);
+    });
+  });
+
+  describe("manual entry — decimal field", () => {
+    const decimal = { value: 0.5, min: 0, max: 1, step: 0.01, precision: 2 };
+
+    it("calls onChange with the typed float", () => {
+      const { onChange } = setup(decimal);
+      act(() => fireEvent.change(input(), { target: { value: "0.75" } }));
+      expect(onChange).toHaveBeenCalledWith(0.75);
+    });
+
+    it("clamps a float above max", () => {
+      const { onChange } = setup(decimal);
+      act(() => fireEvent.change(input(), { target: { value: "1.5" } }));
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("clamps a float below min", () => {
+      const { onChange } = setup(decimal);
+      act(() => fireEvent.change(input(), { target: { value: "-0.5" } }));
+      expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it("rounds to the configured precision", () => {
+      const { onChange } = setup(decimal);
+      act(() => fireEvent.change(input(), { target: { value: "0.129" } }));
+      expect(onChange).toHaveBeenCalledWith(0.13);
+    });
+  });
+
+  describe("blur", () => {
+    it("reverts to the last value when left empty", () => {
+      setup({ integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "" } }));
+      expect(input()).toHaveValue("");
+      act(() => fireEvent.blur(input()));
+      expect(input()).toHaveValue("50");
+    });
+
+    it("reverts to the last value when the text is invalid", () => {
+      setup({ integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "abc" } }));
+      act(() => fireEvent.blur(input()));
+      expect(input()).toHaveValue("50");
+    });
+
+    it("clamps and reformats an out-of-range entry", () => {
+      setup({ integer: true, max: 100 });
+      act(() => fireEvent.change(input(), { target: { value: "150" } }));
+      act(() => fireEvent.blur(input()));
+      expect(input()).toHaveValue("100");
+    });
+
+    it("regroups a large entry with separators", () => {
+      setup({ value: 1000, max: 10_000_000, integer: true });
+      act(() => fireEvent.change(input(), { target: { value: "1500000" } }));
+      act(() => fireEvent.blur(input()));
+      expect(input()).toHaveValue("1,500,000");
+    });
+  });
+
+  describe("focus formatting", () => {
+    it("drops separators while editing and restores them on blur", () => {
+      setup({ value: 1000, max: 10_000_000, integer: true });
+      expect(input()).toHaveValue("1,000");
+
+      act(() => fireEvent.focus(input()));
+      expect(input()).toHaveValue("1000");
+
+      act(() => fireEvent.blur(input()));
+      expect(input()).toHaveValue("1,000");
+    });
+  });
+
+  describe("external value changes", () => {
+    it("syncs the input when the value prop changes (e.g. slider drag)", () => {
+      const { props, rerender } = setup({ value: 50 });
+      expect(input()).toHaveValue("50");
+
+      rerender(<SyncedInputSlider {...props} value={75} />);
+      expect(input()).toHaveValue("75");
+    });
+
+    it("updates the slider position when the value prop changes", () => {
+      const { props, rerender } = setup({ value: 50 });
+      expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "50");
+
+      rerender(<SyncedInputSlider {...props} value={75} />);
+      expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "75");
+    });
+
+    it("keeps in-progress text when the value changes mid-edit", () => {
+      const { props, rerender } = setup({ value: 50, integer: true });
+      act(() => fireEvent.focus(input()));
+      act(() => fireEvent.change(input(), { target: { value: "7" } }));
+
+      // A slider-driven value change while the field is focused must not
+      // overwrite what the user is typing.
+      rerender(<SyncedInputSlider {...props} value={90} />);
+      expect(input()).toHaveValue("7");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("does not call onChange for an empty entry", () => {
+      const { onChange } = setup();
+      act(() => fireEvent.change(input(), { target: { value: "" } }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("does not call onChange for whitespace", () => {
+      const { onChange } = setup();
+      act(() => fireEvent.change(input(), { target: { value: "   " } }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("handles min equal to max", () => {
+      const { onChange } = setup({ min: 50, max: 50, value: 50 });
+      act(() => fireEvent.change(input(), { target: { value: "100" } }));
+      expect(onChange).toHaveBeenCalledWith(50);
+    });
+
+    it("renders a zero value", () => {
+      setup({ value: 0, integer: true });
+      expect(input()).toHaveValue("0");
+    });
+  });
+});

--- a/frontend/dashboard/__tests__/pricing/pricing_page_test.tsx
+++ b/frontend/dashboard/__tests__/pricing/pricing_page_test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+// Radix Slider (inside the calculator) measures its track via ResizeObserver.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+}
+
+// Analytics is fire-and-forget; stub it so PricingViewed / CTA links don't run it.
+jest.mock("@/app/utils/analytics/track", () => ({ track: jest.fn() }));
+
+// Landing chrome pulls in next/image, theme and the c15t consent stack (which
+// imports next server internals jest can't transform) — none of it is under test.
+jest.mock("@/app/components/landing_header", () => ({
+  __esModule: true,
+  default: () => <div data-testid="landing-header" />,
+}));
+jest.mock("@/app/components/landing_footer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="landing-footer" />,
+}));
+
+// Imported after the mocks so they take effect (next/jest only applies
+// jest.mock to modules imported below the mock calls).
+import Pricing from "@/app/pricing/page";
+import {
+  FREE_GB,
+  FREE_RETENTION_DAYS,
+  INCLUDED_PRO_GB,
+  MINIMUM_PRICE_AFTER_FREE_TIER,
+  PRO_RETENTION_DAYS,
+} from "@/app/utils/pricing_constants";
+
+const dailyUsers = () =>
+  screen.getByRole("textbox", { name: "Daily app users" }) as HTMLInputElement;
+
+describe("Pricing page", () => {
+  describe("marketing content", () => {
+    it("renders the heading and landing chrome", () => {
+      render(<Pricing />);
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pricing" }),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("landing-header")).toBeInTheDocument();
+      expect(screen.getByTestId("landing-footer")).toBeInTheDocument();
+    });
+
+    it("renders the free plan", () => {
+      render(<Pricing />);
+      expect(screen.getByText("FREE")).toBeInTheDocument();
+      expect(screen.getByText("$0 per month")).toBeInTheDocument();
+      expect(screen.getByText(`${FREE_GB} GB per month`)).toBeInTheDocument();
+      expect(
+        screen.getByText(`${FREE_RETENTION_DAYS} days retention`),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the pro plan", () => {
+      render(<Pricing />);
+      expect(screen.getByText("PRO")).toBeInTheDocument();
+      expect(
+        screen.getByText(`$${MINIMUM_PRICE_AFTER_FREE_TIER} per month`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`${INCLUDED_PRO_GB} GB per month included`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`${PRO_RETENTION_DAYS} days retention`),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the differentiators", () => {
+      render(<Pricing />);
+      expect(screen.getByText("No Seat Limits")).toBeInTheDocument();
+      expect(screen.getByText("No Artificial Bundles")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Adaptive Capture" }),
+      ).toHaveAttribute("href", "/product/adaptive-capture");
+    });
+  });
+
+  describe("cost estimator", () => {
+    it("renders the calculator", () => {
+      render(<Pricing />);
+      expect(
+        screen.getByText("Estimate Your Monthly Cost"),
+      ).toBeInTheDocument();
+      expect(dailyUsers()).toBeInTheDocument();
+    });
+
+    it("starts on the free tier for low usage", () => {
+      render(<Pricing />);
+      expect(screen.getByText("Free Tier")).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Estimated monthly cost/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows a paid estimate once usage grows", () => {
+      render(<Pricing />);
+      act(() =>
+        fireEvent.change(dailyUsers(), { target: { value: "10000000" } }),
+      );
+      expect(screen.getByText(/Estimated monthly cost/)).toBeInTheDocument();
+      expect(screen.queryByText("Free Tier")).not.toBeInTheDocument();
+    });
+
+    it("reveals advanced settings on demand", () => {
+      render(<Pricing />);
+      expect(
+        screen.queryByRole("textbox", { name: /Average app opens/ }),
+      ).not.toBeInTheDocument();
+
+      act(() =>
+        fireEvent.click(
+          screen.getByRole("button", { name: /Advanced Settings/ }),
+        ),
+      );
+
+      expect(
+        screen.getByRole("textbox", { name: /Average app opens/ }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/dashboard/app/components/synced_input_slider.tsx
+++ b/frontend/dashboard/app/components/synced_input_slider.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Slider } from "./slider";
+import { cn } from "../utils/shadcn_utils";
+
+type SyncedInputSliderProps = {
+  label: string;
+  description: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  // A number, or a function of the current value (for value-dependent steps).
+  step: number | ((value: number) => number);
+  integer?: boolean;
+  // Decimal places kept for non-integer fields.
+  precision?: number;
+  // Unit shown after the value, e.g. "%" or "users".
+  suffix?: string;
+  rangeStartLabel: string;
+  rangeEndLabel: string;
+  large?: boolean;
+  className?: string;
+};
+
+export function SyncedInputSlider({
+  label,
+  description,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  integer = false,
+  precision = 4,
+  suffix,
+  rangeStartLabel,
+  rangeEndLabel,
+  large = false,
+  className,
+}: SyncedInputSliderProps) {
+  const inputId = useId();
+
+  const clamp = (n: number) => Math.min(max, Math.max(min, n));
+
+  const round = (n: number) => {
+    if (integer) {
+      return Math.round(n);
+    }
+    const factor = Math.pow(10, precision);
+    return Math.round(n * factor) / factor;
+  };
+
+  // Clamp to [min, max] and snap to the field's numeric type. Both the slider
+  // and the input route every value through here, so they can't disagree.
+  const normalize = (n: number) => clamp(round(n));
+
+  const parse = (str: string) =>
+    integer ? parseInt(str, 10) : parseFloat(str.replace(/,/g, ""));
+
+  // Grouped form shown when the field isn't being edited, e.g. "1,000".
+  const formatIdle = (n: number) =>
+    integer
+      ? n.toLocaleString("en-US")
+      : n.toLocaleString("en-US", { maximumFractionDigits: precision });
+
+  // Separator-free form that's easy to edit.
+  const formatEditing = (n: number) => n.toString();
+
+  const [text, setText] = useState(() => formatIdle(value));
+  const [focused, setFocused] = useState(false);
+
+  // Sync outside changes (e.g. dragging the slider) into the input, unless the
+  // user is mid-edit.
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (!focused) {
+      setText(formatIdle(value));
+    }
+  }
+
+  const handleChange = (raw: string) => {
+    setText(raw);
+    const parsed = parse(raw);
+    if (raw.trim() !== "" && !Number.isNaN(parsed)) {
+      onChange(normalize(parsed));
+    }
+  };
+
+  const handleFocus = () => {
+    setFocused(true);
+    setText(formatEditing(value));
+  };
+
+  const handleBlur = () => {
+    setFocused(false);
+    const parsed = parse(text);
+    if (text.trim() === "" || Number.isNaN(parsed)) {
+      // Nothing usable entered, so keep the last good value.
+      setText(formatIdle(value));
+      return;
+    }
+    const next = normalize(parsed);
+    onChange(next);
+    setText(formatIdle(next));
+  };
+
+  const sliderStep = typeof step === "function" ? step(value) : step;
+  const textSize = large ? "text-2xl" : "text-xl";
+  // Size to the current text (plus slack for the caret) so the box grows with
+  // the value rather than reserving room for the largest possible one.
+  const inputWidth = Math.max(text.length + 1, 3);
+
+  return (
+    <div className={className}>
+      <div className="flex justify-between items-center mb-4 gap-2">
+        <div>
+          <label htmlFor={inputId} className={cn(textSize, "font-display")}>
+            {label}
+          </label>
+          <p className="text-sm py-2 text-muted-foreground font-body">
+            {description}
+          </p>
+        </div>
+        <div
+          className={cn("flex items-baseline gap-1.5 font-display", textSize)}
+        >
+          <input
+            id={inputId}
+            type="text"
+            inputMode={integer ? "numeric" : "decimal"}
+            value={text}
+            onChange={(e) => handleChange(e.target.value)}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            // `ch` ≈ one digit, so the box width tracks the digit count. content-box
+            // makes that width the digits' space; the default border-box would split
+            // it between digits and padding, clipping the number.
+            style={{ width: `${inputWidth}ch` }}
+            className={cn(
+              "box-content rounded-md border border-input bg-transparent px-2.5 py-1 text-right outline-none",
+              "transition-[color,box-shadow,width]",
+              "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+            )}
+          />
+          {suffix && <span>{suffix}</span>}
+        </div>
+      </div>
+      <Slider
+        value={[value]}
+        onValueChange={(v) => onChange(normalize(v[0]))}
+        min={min}
+        max={max}
+        step={sliderStep}
+        aria-label={label}
+        className="mb-2"
+      />
+      <div className="flex justify-between text-sm text-muted-foreground font-body">
+        <span>{rangeStartLabel}</span>
+        <span>{rangeEndLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/dashboard/app/pricing/pricing_calculator.tsx
+++ b/frontend/dashboard/app/pricing/pricing_calculator.tsx
@@ -9,7 +9,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../components/collapsible";
-import { Slider } from "../components/slider";
+import { SyncedInputSlider } from "../components/synced_input_slider";
 import TrackCtaLink from "../components/analytics/track_cta_link";
 import { calculate } from "../utils/pricing_calculator";
 import {
@@ -71,11 +71,6 @@ export default function PricingCalculator() {
     return compactFormatter.format(num);
   };
 
-  const formatPercent = (rate: number) => {
-    const pct = rate * 100;
-    return Number.isInteger(pct) ? `${pct}%` : `${parseFloat(pct.toFixed(2))}%`;
-  };
-
   const percentStep = (value: number) => {
     if (value < 1) {
       return 0.01;
@@ -94,36 +89,22 @@ export default function PricingCalculator() {
         </h3>
         <div className="py-6" />
 
-        {/* Daily users slider (single input) */}
-        <div className="mb-10">
-          <div className="flex justify-between items-center mb-4">
-            <div>
-              <label className="text-2xl font-display">Daily app users</label>
-              <p className="text-sm py-2 text-muted-foreground font-body">
-                Number of users who open your app per day
-              </p>
-            </div>
-            <span className="text-2xl font-display">
-              {formatNumber(dailyUsers)}
-            </span>
-          </div>
-          <Slider
-            value={[dailyUsers]}
-            onValueChange={(value) => setDailyUsers(value[0])}
-            min={0}
-            max={10000000}
-            step={
-              dailyUsers < 10000 ? 1000 : dailyUsers < 100000 ? 10000 : 100000
-            }
-            className="mb-2"
-          />
-          <div className="flex justify-between text-sm text-muted-foreground font-body">
-            <span>0</span>
-            <span>10M+</span>
-          </div>
-        </div>
+        <SyncedInputSlider
+          large
+          className="mb-10"
+          label="Daily app users"
+          description="Number of users who open your app per day"
+          value={dailyUsers}
+          onChange={setDailyUsers}
+          min={0}
+          max={10000000}
+          step={(v) => (v < 10000 ? 1000 : v < 100000 ? 10000 : 100000)}
+          integer
+          suffix="users"
+          rangeStartLabel="0"
+          rangeEndLabel="10M+"
+        />
 
-        {/* Advanced settings dropdown */}
         <Collapsible className="my-8">
           <div className="flex justify-end">
             <CollapsibleTrigger asChild>
@@ -138,184 +119,85 @@ export default function PricingCalculator() {
           </div>
 
           <CollapsibleContent className="mt-8 space-y-8 rounded-lg">
-            {/* App opens per user per day */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    📲 Average app opens by a user per day
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Average number of times a user opens your app per day
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {averageAppOpens} times
-                </span>
-              </div>
-              <Slider
-                value={[averageAppOpens]}
-                onValueChange={(v) => setAverageAppOpens(v[0])}
-                min={0}
-                max={50}
-                step={1}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0</span>
-                <span>50</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="📲 Average app opens by a user per day"
+              description="Average number of times a user opens your app per day"
+              value={averageAppOpens}
+              onChange={setAverageAppOpens}
+              min={0}
+              max={50}
+              step={1}
+              integer
+              suffix="times"
+              rangeStartLabel="0"
+              rangeEndLabel="50"
+            />
 
-            {/* Launch sample rate */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    🚀 Launch time metrics collection rate
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Percentage of app opens for which we collect launch timing
-                    metrics
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {formatPercent(launchSamplePercent / 100)}
-                </span>
-              </div>
-              <Slider
-                value={[launchSamplePercent]}
-                onValueChange={(v) => setLaunchSamplePercent(v[0])}
-                min={0}
-                max={100}
-                step={percentStep(launchSamplePercent)}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0%</span>
-                <span>100%</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="🚀 Launch time metrics collection rate"
+              description="Percentage of app opens for which we collect launch timing metrics"
+              value={launchSamplePercent}
+              onChange={setLaunchSamplePercent}
+              min={0}
+              max={100}
+              step={percentStep}
+              suffix="%"
+              rangeStartLabel="0%"
+              rangeEndLabel="100%"
+            />
 
-            {/* Error rate */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    🐞 Error rate (Crashes, ANRs & Bug reports)
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Percentage of app opens which have Crashes, ANRs & Bug
-                    reports
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {formatPercent(errorRatePercent / 100)}
-                </span>
-              </div>
-              <Slider
-                value={[errorRatePercent]}
-                onValueChange={(v) => setErrorRatePercent(v[0])}
-                min={0}
-                max={100}
-                step={percentStep(errorRatePercent)}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0%</span>
-                <span>100%</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="🐞 Error rate (Crashes, ANRs & Bug reports)"
+              description="Percentage of app opens which have Crashes, ANRs & Bug reports"
+              value={errorRatePercent}
+              onChange={setErrorRatePercent}
+              min={0}
+              max={100}
+              step={percentStep}
+              suffix="%"
+              rangeStartLabel="0%"
+              rangeEndLabel="100%"
+            />
 
-            {/* Performance spans collection rate */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    ⚡️ Performance Spans collection rate
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Percentage of performance spans collected per session when
-                    sampled (a Trace can have multiple child spans)
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {formatNumber(perfSpanSamplePercent)}%
-                </span>
-              </div>
-              <Slider
-                value={[perfSpanSamplePercent]}
-                onValueChange={(v) => setPerfSpanSamplePercent(v[0])}
-                min={0}
-                max={100}
-                step={percentStep(perfSpanSamplePercent)}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0%</span>
-                <span>100%</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="⚡️ Performance Spans collection rate"
+              description="Percentage of performance spans collected per session when sampled (a Trace can have multiple child spans)"
+              value={perfSpanSamplePercent}
+              onChange={setPerfSpanSamplePercent}
+              min={0}
+              max={100}
+              step={percentStep}
+              suffix="%"
+              rangeStartLabel="0%"
+              rangeEndLabel="100%"
+            />
 
-            {/* Performance spans count */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    ⚡️ Number of Performance Spans in app
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Number of performance spans collected per session when
-                    sampled (a Trace can have multiple child spans)
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {formatNumber(perfSpanCount)}
-                </span>
-              </div>
-              <Slider
-                value={[perfSpanCount]}
-                onValueChange={(v) => setPerfSpanCount(Math.round(v[0]))}
-                min={0}
-                max={100}
-                step={1}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0</span>
-                <span>100</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="⚡️ Number of Performance Spans in app"
+              description="Number of performance spans collected per session when sampled (a Trace can have multiple child spans)"
+              value={perfSpanCount}
+              onChange={setPerfSpanCount}
+              min={0}
+              max={100}
+              step={1}
+              integer
+              suffix="spans"
+              rangeStartLabel="0"
+              rangeEndLabel="100"
+            />
 
-            {/* User Journey events collection rate */}
-            <div>
-              <div className="flex justify-between items-center mb-4 gap-2">
-                <div>
-                  <label className="text-xl font-display">
-                    🚕 User Journey events collection rate
-                  </label>
-                  <p className="text-sm py-2 text-muted-foreground font-body">
-                    Percentage of user journey events collected per session when
-                    sampled
-                  </p>
-                </div>
-                <span className="text-xl font-display">
-                  {formatNumber(journeySamplePercent)}%
-                </span>
-              </div>
-              <Slider
-                value={[journeySamplePercent]}
-                onValueChange={(v) => setJourneySamplePercent(v[0])}
-                min={0}
-                max={100}
-                step={percentStep(journeySamplePercent)}
-                className="mb-2"
-              />
-              <div className="flex justify-between text-sm text-muted-foreground font-body">
-                <span>0%</span>
-                <span>100%</span>
-              </div>
-            </div>
+            <SyncedInputSlider
+              label="🚕 User Journey events collection rate"
+              description="Percentage of user journey events collected per session when sampled"
+              value={journeySamplePercent}
+              onChange={setJourneySamplePercent}
+              min={0}
+              max={100}
+              step={percentStep}
+              suffix="%"
+              rangeStartLabel="0%"
+              rangeEndLabel="100%"
+            />
           </CollapsibleContent>
         </Collapsible>
 


### PR DESCRIPTION
# Description

Pricing calculator only allowed slider dragging which is hard to do precision edits with. This commit adds manual input fields with a new component so users can enter exact values.

Also add tests for pricing page and new component.



