### PR TITLE
chore(backend): support JSON ingest APIs in record

### DIFF
--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -185,6 +185,34 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, "elf_debug")
 			}
 
+			// jsbundle mappings (.tgz) are nested under a jsbundle/ subdir
+			// so their type is recoverable structurally — the .tgz extension
+			// alone is ambiguous with dsym. code is two levels up here.
+			jsBundle, err := filepath.Match("*/*/*/jsbundle/*", rel)
+			if err != nil {
+				return err
+			}
+			if jsBundle {
+				app := apps.Lookup(parts[0], parts[1])
+				info, err := d.Info()
+				if err != nil {
+					return err
+				}
+				if info.Size() < 1 {
+					return fmt.Errorf(`%q has empty jsbundle mapping file. check %q`, app.FullName(), rel)
+				}
+
+				jsCode := filepath.Base(filepath.Dir(filepath.Dir(rel)))
+				if _, ok := app.Builds[jsCode]; !ok {
+					app.Builds[jsCode] = &Build{
+						VersionCode: jsCode,
+					}
+				}
+
+				app.Builds[jsCode].MappingFiles = append(app.Builds[jsCode].MappingFiles, path)
+				app.Builds[jsCode].MappingTypes = append(app.Builds[jsCode].MappingTypes, "jsbundle")
+			}
+
 			blob, err := filepath.Match("*/*/blobs/*", rel)
 			if err != nil {
 				return err

--- a/self-host/sessionator/cmd/help.go
+++ b/self-host/sessionator/cmd/help.go
@@ -13,7 +13,10 @@ func DirTree() string {
 │     ├── 203334e1-2a7a-466b-b968-506ec3e23615.json
 │     └── 1000/
 │     	 ├── build.toml
-│        ├── mapping.txt`
+│        ├── mapping.txt
+│        └── jsbundle/
+│           ├── main.jsbundle.tgz
+│           └── main.jsbundle.map.tgz`
 }
 
 // ValidNote provides note about validity of files

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -245,12 +245,19 @@ func writeEventMultipart(c *gin.Context, reqId string) {
 		return
 	}
 
-	var appDir string
+	var appUniqueID, appVersion string
 	if len(events) > 0 {
-		appDir = filepath.Join(rootDir, events[0].Attribute.AppUniqueID, events[0].Attribute.AppVersion)
+		appUniqueID = events[0].Attribute.AppUniqueID
+		appVersion = events[0].Attribute.AppVersion
 	} else {
-		appDir = filepath.Join(rootDir, spans[0].Attributes.AppUniqueID, spans[0].Attributes.AppVersion)
+		appUniqueID = spans[0].Attributes.AppUniqueID
+		appVersion = spans[0].Attributes.AppVersion
 	}
+	if !safePathComponent(appUniqueID) || !safePathComponent(appVersion) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid app_unique_id or app_version"})
+		return
+	}
+	appDir := filepath.Join(rootDir, appUniqueID, appVersion)
 	batchFile := filepath.Join(appDir, reqId+".json")
 	blobsDir := filepath.Join(appDir, "blobs")
 
@@ -396,6 +403,12 @@ func writeBuildMultipart(c *gin.Context) {
 		})
 		return
 	}
+	if !safePathComponent(appUniqueID) || !safePathComponent(versionName) || !safePathComponent(versionCode) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid app_unique_id, version_name or version_code",
+		})
+		return
+	}
 
 	for i := range mappingTypes {
 		if mappingTypes[i] != "proguard" && mappingTypes[i] != "dsym" && mappingTypes[i] != "elf_debug" {
@@ -451,6 +464,15 @@ func writeBuildMultipart(c *gin.Context) {
 		case "elf_debug":
 			filename = header.Filename
 			filename = strings.ReplaceAll(filename, " ", "")
+		}
+
+		// header.Filename is attacker-controlled; reject any value that
+		// would escape the version directory.
+		if !safePathComponent(filename) {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": fmt.Sprintf("invalid mapping filename %q", header.Filename),
+			})
+			return
 		}
 
 		mappingFilePath := filepath.Join(outputDir, appUniqueID, versionName, versionCode, filename)
@@ -569,6 +591,11 @@ func writeEventJSON(c *gin.Context, reqId string) {
 		appVersion = s.Attributes.AppVersion
 	}
 
+	if !safePathComponent(appUniqueID) || !safePathComponent(appVersion) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid app_unique_id or app_version"})
+		return
+	}
+
 	rootDir, err := filepath.Abs(outputDir)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to acquire directory: %q", rootDir)})
@@ -635,6 +662,10 @@ func writeBuildJSON(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": `"version_code" is required`})
 		return
 	}
+	if !safePathComponent(req.AppUniqueID) || !safePathComponent(req.VersionName) || !safePathComponent(req.VersionCode) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid app_unique_id, version_name or version_code"})
+		return
+	}
 
 	versionDir := filepath.Join(outputDir, req.AppUniqueID, req.VersionName, req.VersionCode)
 	buildFilePath := filepath.Join(versionDir, "build.toml")
@@ -688,6 +719,16 @@ func writeBuildJSON(c *gin.Context) {
 	fmt.Printf("returning %d mapping upload url(s)\n", len(req.Mappings))
 
 	c.JSON(http.StatusOK, gin.H{"mappings": req.Mappings})
+}
+
+// safePathComponent reports whether v is safe to use as a single path
+// segment built from untrusted request data (app_unique_id, version names,
+// etc.) — it must be non-empty and free of separators or ".." traversal.
+func safePathComponent(v string) bool {
+	if v == "" {
+		return false
+	}
+	return !strings.ContainsAny(v, `/\`) && !strings.Contains(v, "..")
 }
 
 // resolveUploadPath joins dst onto rootDir, rejecting any path that would

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -10,11 +10,13 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sessionator/app"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -31,6 +33,55 @@ type Batch struct {
 type ErrorResponse struct {
 	Error   string `json:"error"`
 	Message string `json:"message"`
+}
+
+// uploadInfo mirrors the ingest service's attachment upload descriptor: the
+// SDK uploads the file with a plain PUT to UploadURL after the events request
+// returns. See backend/ingest/measure/event.go (AttachmentUploadInfo).
+type uploadInfo struct {
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	Filename  string            `json:"filename"`
+	UploadURL string            `json:"upload_url"`
+	ExpiresAt time.Time         `json:"expires_at"`
+	Headers   map[string]string `json:"headers,omitempty"`
+}
+
+// mapping mirrors the ingest service's build mapping descriptor, used in both
+// the PUT /builds request and response. See backend/ingest/measure/build.go.
+type mapping struct {
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	Filename  string            `json:"filename"`
+	Key       string            `json:"key,omitempty"`
+	Checksum  string            `json:"checksum,omitempty"`
+	Size      int64             `json:"size,omitempty"`
+	UploadURL string            `json:"upload_url,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	PatchID   string            `json:"patch_id,omitempty"`
+}
+
+// buildRequest is the JSON payload PUT /builds accepts from newer SDKs.
+type buildRequest struct {
+	AppUniqueID string     `json:"app_unique_id"`
+	VersionName string     `json:"version_name"`
+	VersionCode string     `json:"version_code"`
+	Type        string     `json:"build_type"`
+	Size        uint       `json:"build_size"`
+	PatchID     string     `json:"patch_id"`
+	Mappings    []*mapping `json:"mappings"`
+}
+
+// uploadExpiry is a cosmetic expiry stamped on the upload URLs we return.
+// record never enforces it — the SDK uploads immediately after the request.
+const uploadExpiry = time.Hour * 24 * 7
+
+// uploadURL builds a presigned-style URL pointing back at this recorder. The
+// destination path (relative to outputDir) is encoded so writeUpload can land
+// the bytes on disk where app/scan.go expects them.
+func uploadURL(c *gin.Context, relPath string) string {
+	return fmt.Sprintf("http://%s/upload?dst=%s", c.Request.Host, url.QueryEscape(relPath))
 }
 
 // The path to output directory
@@ -56,6 +107,7 @@ Structue of "session-data" directory once written:` + "\n" + DirTree() + "\n" + 
 
 		r.PUT("/builds", writeBuild)
 		r.PUT("/events", writeEvent)
+		r.PUT("/upload", writeUpload)
 
 		r.Run(":" + port)
 	},
@@ -78,6 +130,17 @@ func writeEvent(c *gin.Context) {
 		return
 	}
 
+	// newer SDKs send a JSON payload and upload attachments out-of-band via
+	// the presigned URLs we return; older SDKs send everything as multipart.
+	if strings.HasPrefix(c.ContentType(), "application/json") {
+		writeEventJSON(c, reqId)
+		return
+	}
+
+	writeEventMultipart(c, reqId)
+}
+
+func writeEventMultipart(c *gin.Context, reqId string) {
 	pathErr := func(dir string) error {
 		return fmt.Errorf(`failed to acquire directory: %q`, dir)
 	}
@@ -292,6 +355,17 @@ func writeEvent(c *gin.Context) {
 }
 
 func writeBuild(c *gin.Context) {
+	// newer SDKs send a JSON payload and upload mapping files out-of-band via
+	// the presigned URLs we return; older SDKs send everything as multipart.
+	if strings.HasPrefix(c.ContentType(), "application/json") {
+		writeBuildJSON(c)
+		return
+	}
+
+	writeBuildMultipart(c)
+}
+
+func writeBuildMultipart(c *gin.Context) {
 	if err := c.Request.ParseMultipartForm(100 << 20); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "unable to parse multipart form: " + err.Error(),
@@ -444,6 +518,232 @@ func writeBuild(c *gin.Context) {
 		})
 		return
 	}
+
+	c.Status(http.StatusOK)
+}
+
+// writeEventJSON handles the JSON variant of PUT /events. It writes the batch
+// file in the same on-disk format as the multipart path, then returns presigned
+// upload URLs for each attachment. Attachment bytes arrive later via writeUpload.
+func writeEventJSON(c *gin.Context, reqId string) {
+	var req struct {
+		Events []json.RawMessage `json:"events"`
+		Spans  []json.RawMessage `json:"spans"`
+	}
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read request body"})
+		return
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse json payload: " + err.Error()})
+		return
+	}
+	if len(req.Events) < 1 && len(req.Spans) < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "payload should contain at least 1 event or span"})
+		return
+	}
+
+	// parse events for app coordinates and attachment metadata
+	events := make([]event.EventField, 0, len(req.Events))
+	for i := range req.Events {
+		var e event.EventField
+		if err := json.Unmarshal(req.Events[i], &e); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse event json: " + err.Error()})
+			return
+		}
+		events = append(events, e)
+	}
+
+	var appUniqueID, appVersion string
+	if len(events) > 0 {
+		appUniqueID = events[0].Attribute.AppUniqueID
+		appVersion = events[0].Attribute.AppVersion
+	} else {
+		var s span.SpanField
+		if err := json.Unmarshal(req.Spans[0], &s); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse span json: " + err.Error()})
+			return
+		}
+		appUniqueID = s.Attributes.AppUniqueID
+		appVersion = s.Attributes.AppVersion
+	}
+
+	rootDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to acquire directory: %q", rootDir)})
+		return
+	}
+
+	appDir := filepath.Join(rootDir, appUniqueID, appVersion)
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to acquire directory: %q", appDir)})
+		return
+	}
+
+	batchFile := filepath.Join(appDir, reqId+".json")
+	jsonBytes, err := json.Marshal(Batch{Events: req.Events, Spans: req.Spans})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode event file content as json"})
+		return
+	}
+	if err := os.WriteFile(batchFile, jsonBytes, 0644); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Errorf("failed to write to %q", batchFile).Error()})
+		return
+	}
+	fmt.Printf("written %d event(s) and %d span(s) to %q\n", len(req.Events), len(req.Spans), batchFile)
+
+	// hand out an upload URL per attachment. blobs land at blobs/{id} (no
+	// extension) to match app/scan.go's expectations.
+	attachments := []uploadInfo{}
+	for i := range events {
+		for j := range events[i].Attachments {
+			id := events[i].Attachments[j].ID.String()
+			relPath := filepath.Join(appUniqueID, appVersion, "blobs", id)
+			attachments = append(attachments, uploadInfo{
+				ID:        id,
+				Type:      events[i].Attachments[j].Type,
+				Filename:  events[i].Attachments[j].Name,
+				UploadURL: uploadURL(c, relPath),
+				ExpiresAt: time.Now().Add(uploadExpiry),
+			})
+		}
+	}
+	fmt.Printf("returning %d attachment upload url(s)\n", len(attachments))
+
+	c.JSON(http.StatusAccepted, gin.H{"attachments": attachments})
+}
+
+// writeBuildJSON handles the JSON variant of PUT /builds. It writes build.toml
+// and returns presigned upload URLs for each mapping file. Mapping bytes arrive
+// later via writeUpload.
+func writeBuildJSON(c *gin.Context) {
+	var req buildRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse json payload: " + err.Error()})
+		return
+	}
+	if req.AppUniqueID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "app_unique_id is required"})
+		return
+	}
+	if req.VersionName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `"version_name" is required`})
+		return
+	}
+	if req.VersionCode == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `"version_code" is required`})
+		return
+	}
+
+	versionDir := filepath.Join(outputDir, req.AppUniqueID, req.VersionName, req.VersionCode)
+	buildFilePath := filepath.Join(versionDir, "build.toml")
+	if err := os.MkdirAll(filepath.Dir(buildFilePath), 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf(`failed to create directory for build file %q: `, err.Error())})
+		return
+	}
+
+	out, err := os.Create(buildFilePath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf(`failed to create build.toml file %q: %v`, buildFilePath, err.Error())})
+		return
+	}
+	defer out.Close()
+
+	if err := toml.NewEncoder(out).Encode(app.BuildInfo{Size: req.Size, Type: req.Type}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create build.toml file: " + err.Error()})
+		return
+	}
+	fmt.Printf("written build.toml to %q\n", buildFilePath)
+
+	if len(req.Mappings) < 1 {
+		c.JSON(http.StatusOK, gin.H{"ok": "build info updated"})
+		return
+	}
+
+	for _, m := range req.Mappings {
+		if m.Type != "proguard" && m.Type != "dsym" && m.Type != "elf_debug" && m.Type != "jsbundle" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(`"type" should be one of %q, %q, %q or %q`, "proguard", "dsym", "elf_debug", "jsbundle")})
+			return
+		}
+
+		filename := strings.ReplaceAll(m.Filename, " ", "")
+		if m.Type == "proguard" {
+			filename = "mapping.txt"
+		}
+
+		// jsbundle archives are .tgz, same as dsym, and their filenames
+		// differ across platforms (main.jsbundle*.tgz on iOS,
+		// index.android.bundle*.tgz on Android) — so the type can't be
+		// recovered from the extension on replay. Nest them under jsbundle/
+		// so app/scan.go recognizes the type structurally.
+		relPath := filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, filename)
+		if m.Type == "jsbundle" {
+			relPath = filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", filename)
+		}
+		m.ID = uuid.NewString()
+		m.UploadURL = uploadURL(c, relPath)
+		m.ExpiresAt = time.Now().Add(uploadExpiry)
+	}
+	fmt.Printf("returning %d mapping upload url(s)\n", len(req.Mappings))
+
+	c.JSON(http.StatusOK, gin.H{"mappings": req.Mappings})
+}
+
+// resolveUploadPath joins dst onto rootDir, rejecting any path that would
+// escape rootDir (absolute paths, traversal via "..").
+func resolveUploadPath(rootDir, dst string) (full string, err error) {
+	clean := filepath.Clean(dst)
+	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
+		return "", fmt.Errorf("invalid dst path: %q", dst)
+	}
+	full = filepath.Join(rootDir, clean)
+	if !strings.HasPrefix(full, rootDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("dst path escapes output directory: %q", dst)
+	}
+	return full, nil
+}
+
+// writeUpload is the sink for presigned-style uploads handed out by the JSON
+// event/build handlers. The destination path (relative to outputDir) is taken
+// from the "dst" query param and sanitized to prevent path traversal.
+func writeUpload(c *gin.Context) {
+	dst := c.Query("dst")
+	if dst == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing dst query param"})
+		return
+	}
+
+	rootDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve output directory"})
+		return
+	}
+
+	full, err := resolveUploadPath(rootDir, dst)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create directory for upload"})
+		return
+	}
+
+	file, err := os.Create(full)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create file %q", full)})
+		return
+	}
+	defer file.Close()
+
+	written, err := io.Copy(file, c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to write %q to disk", full)})
+		return
+	}
+	fmt.Printf("written %d bytes to %q\n", written, full)
 
 	c.Status(http.StatusOK)
 }

--- a/self-host/sessionator/cmd/record_test.go
+++ b/self-host/sessionator/cmd/record_test.go
@@ -18,3 +18,19 @@ func TestResolveUploadPath(t *testing.T) {
 		}
 	}
 }
+
+func TestSafePathComponent(t *testing.T) {
+	// legit app ids & versions pass
+	for _, ok := range []string{"sh.measure.sample", "1.0.0", "100", "com.example"} {
+		if !safePathComponent(ok) {
+			t.Fatalf("expected %q to be accepted", ok)
+		}
+	}
+
+	// separators, traversal & empty are rejected
+	for _, bad := range []string{"", "..", "../etc", "a/b", `a\b`, "..\\x"} {
+		if safePathComponent(bad) {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}

--- a/self-host/sessionator/cmd/record_test.go
+++ b/self-host/sessionator/cmd/record_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "testing"
+
+func TestResolveUploadPath(t *testing.T) {
+	root := "/tmp/session-data"
+
+	// valid relative paths resolve under root
+	got, err := resolveUploadPath(root, "app/1.0/blobs/abc")
+	if err != nil || got != "/tmp/session-data/app/1.0/blobs/abc" {
+		t.Fatalf("valid path: got %q, err %v", got, err)
+	}
+
+	// traversal and absolute paths are rejected
+	for _, bad := range []string{"../etc/passwd", "/etc/passwd", "app/../../etc"} {
+		if _, err := resolveUploadPath(root, bad); err == nil {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}

--- a/self-host/sessionator/cmd/remove.go
+++ b/self-host/sessionator/cmd/remove.go
@@ -104,7 +104,7 @@ func newRemoveAppsCmd() *cobra.Command {
 				return
 			}
 
-			if err = j.rmIssueGroups(ctx); err != nil {
+			if err = j.rmErrorGroups(ctx); err != nil {
 				return
 			}
 

--- a/self-host/sessionator/cmd/rm.go
+++ b/self-host/sessionator/cmd/rm.go
@@ -230,7 +230,7 @@ func rmAppResources(ctx context.Context, c *config.Config) (err error) {
 		return
 	}
 
-	if err = j.rmIssueGroups(ctx); err != nil {
+	if err = j.rmErrorGroups(ctx); err != nil {
 		return
 	}
 
@@ -479,8 +479,8 @@ func (j *janitor) resolveAppIds(ctx context.Context, conn *pgx.Conn, apps []stri
 	return
 }
 
-// rmIssueGroups removes exception and ANR groups for apps in config.
-func (j *janitor) rmIssueGroups(ctx context.Context) (err error) {
+// rmErrorGroups removes error and ANR groups for apps in config.
+func (j *janitor) rmErrorGroups(ctx context.Context) (err error) {
 	deleteFatalExceptionGroups := `delete from fatal_exception_groups where app_id = @app_id;`
 	deleteNonFatalExceptionGroups := `delete from nonfatal_exception_groups where app_id = @app_id;`
 	deleteAnrGroups := `delete from anr_groups where app_id = @app_id;`


### PR DESCRIPTION
## Summary

This PR brings `sessionator record` on par with the ingest service's APIs so maintainers can record sessions locally during development. `PUT /events` & `PUT /builds` now accept the newer JSON payloads, returning presigned-style upload URLs that point back at `record`; a new `PUT /upload` endpoint sinks those files to disk. It also adds `jsbundle` mapping support, nesting them under `jsbundle/` so `app/scan.go` can recover the type structurally on replay.

## Tasks

- [x] Branch `PUT /events` & `PUT /builds` on `application/json`
- [x] Return presigned-style upload URLs pointing back at `record`
- [x] Add `PUT /upload` sink writing files to disk, with path-traversal guard
- [x] Support `jsbundle` mapping type, nested under `jsbundle/` for scan recovery
- [x] Recognize `jsbundle` mappings in `app/scan.go`
- [x] Rename `rmIssueGroups` to `rmErrorGroups`

## See also

- fixes #3947