### PR TITLE
feat(frontend): add KMP onboarding

### DIFF
--- a/.github/workflows/kmp-prepare-release.yml
+++ b/.github/workflows/kmp-prepare-release.yml
@@ -69,6 +69,14 @@ jobs:
           sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=${{ inputs.android_version }}/" kmp/measure-kmp/gradle.properties
           sed -i "s/MEASURE_IOS_VERSION=.*/MEASURE_IOS_VERSION=${{ inputs.ios_version }}/" kmp/measure-kmp/gradle.properties
 
+      - name: Update version in integration guide
+        run: |
+          # The onboarding snippet in the dashboard reads this version at build
+          # time (scripts/extract_sdk_versions.js), so keep it in sync here.
+          KOTLIN_PATTERN='implementation("sh.measure:measure-kmp:.*")'
+          KOTLIN_REPLACEMENT='implementation("sh.measure:measure-kmp:${{ inputs.version }}")'
+          sed -i "s/$KOTLIN_PATTERN/$KOTLIN_REPLACEMENT/" docs/sdk-integration-guide.md
+
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:
@@ -90,6 +98,7 @@ jobs:
             - Updated version to ${{ inputs.version }} in gradle.properties
             - Pinned native Android SDK version to ${{ inputs.android_version }} (android-v${{ inputs.android_version }})
             - Pinned native iOS SDK version to ${{ inputs.ios_version }} (ios-v${{ inputs.ios_version }})
+            - Updated measure-kmp version in docs/sdk-integration-guide.md
             - Generated changelog for version ${{ inputs.version }}
 
             <!-- release-meta

--- a/frontend/dashboard/__tests__/components/onboarding_test.tsx
+++ b/frontend/dashboard/__tests__/components/onboarding_test.tsx
@@ -641,13 +641,16 @@ describe("Onboarding — Step 2: Integrate", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("renders Android, iOS, Flutter, React Native, and React Native (Expo) tabs", () => {
+    it("renders Android, iOS, Flutter, React Native, React Native (Expo), and Kotlin Multiplatform tabs", () => {
       renderOnboarding();
       expect(screen.getByTestId("tab-Android")).toBeInTheDocument();
       expect(screen.getByTestId("tab-iOS")).toBeInTheDocument();
       expect(screen.getByTestId("tab-Flutter")).toBeInTheDocument();
       expect(screen.getByTestId("tab-React Native")).toBeInTheDocument();
       expect(screen.getByTestId("tab-React Native (Expo)")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("tab-Kotlin Multiplatform"),
+      ).toBeInTheDocument();
     });
 
     it("selects Android by default", () => {
@@ -1111,6 +1114,133 @@ describe("Onboarding — Step 2: Integrate", () => {
       fireEvent.click(screen.getByTestId("tab-React Native"));
       expect(
         screen.getByTestId("onboarding-react-native-native-target-iOS"),
+      ).toHaveAttribute("data-selected", "true");
+    });
+  });
+
+  describe("Kotlin Multiplatform sub-platform selector", () => {
+    it("does not render the sub-selector on Android, iOS or Flutter tabs", () => {
+      renderOnboarding();
+      expect(
+        screen.queryByTestId(
+          "onboarding-kotlin-multiplatform-native-target-select",
+        ),
+      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByTestId("tab-iOS"));
+      expect(
+        screen.queryByTestId(
+          "onboarding-kotlin-multiplatform-native-target-select",
+        ),
+      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByTestId("tab-Flutter"));
+      expect(
+        screen.queryByTestId(
+          "onboarding-kotlin-multiplatform-native-target-select",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the sub-selector when Kotlin Multiplatform is the active tab", () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      expect(
+        screen.getByTestId(
+          "onboarding-kotlin-multiplatform-native-target-Android",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("onboarding-kotlin-multiplatform-native-target-iOS"),
+      ).toBeInTheDocument();
+    });
+
+    it("selects Android as the default sub-platform", () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      expect(
+        screen.getByTestId(
+          "onboarding-kotlin-multiplatform-native-target-Android",
+        ),
+      ).toHaveAttribute("data-selected", "true");
+      expect(
+        screen.getByTestId("onboarding-kotlin-multiplatform-native-target-iOS"),
+      ).toHaveAttribute("data-selected", "false");
+    });
+
+    it("updates the selected sub-platform indicator on click", () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      fireEvent.click(
+        screen.getByTestId("onboarding-kotlin-multiplatform-native-target-iOS"),
+      );
+      expect(
+        screen.getByTestId("onboarding-kotlin-multiplatform-native-target-iOS"),
+      ).toHaveAttribute("data-selected", "true");
+      expect(
+        screen.getByTestId(
+          "onboarding-kotlin-multiplatform-native-target-Android",
+        ),
+      ).toHaveAttribute("data-selected", "false");
+    });
+
+    it("Android sub-platform shows commonMain dep, manifest, native init, and crash", () => {
+      mockSelectedApp = makeApp({ api_key: { key: "msr_kmp_key" } });
+      mockApps = [mockSelectedApp];
+      renderOnboarding();
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      expect(screen.getByTestId("snippet-dependency")).toHaveTextContent(
+        "measure-kmp",
+      );
+      expect(screen.getByTestId("snippet-manifest")).toHaveTextContent(
+        "msr_kmp_key",
+      );
+      expect(screen.getByTestId("snippet-android-init")).toBeInTheDocument();
+      expect(screen.getByTestId("snippet-crash")).toBeInTheDocument();
+      // measure-android comes in transitively via the KMP dep, so there's no
+      // separate Gradle dependency step on this target.
+      expect(
+        screen.queryByTestId("snippet-android-gradle"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("iOS sub-platform shows commonMain dep, SPM dep, native init, and crash", () => {
+      mockSelectedApp = makeApp({ api_key: { key: "msr_kmp_key" } });
+      mockApps = [mockSelectedApp];
+      renderOnboarding();
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      fireEvent.click(
+        screen.getByTestId("onboarding-kotlin-multiplatform-native-target-iOS"),
+      );
+      expect(screen.getByTestId("snippet-dependency")).toHaveTextContent(
+        "measure-kmp",
+      );
+      expect(screen.getByTestId("snippet-ios-dependency")).toHaveTextContent(
+        "Package.swift",
+      );
+      expect(screen.getByTestId("snippet-ios-init")).toHaveTextContent(
+        "msr_kmp_key",
+      );
+      expect(screen.getByTestId("snippet-crash")).toBeInTheDocument();
+      expect(screen.queryByTestId("snippet-manifest")).not.toBeInTheDocument();
+    });
+
+    it("keeps Flutter and Kotlin Multiplatform sub-selections independent", () => {
+      renderOnboarding();
+      // Set Flutter to iOS.
+      fireEvent.click(screen.getByTestId("tab-Flutter"));
+      fireEvent.click(
+        screen.getByTestId("onboarding-flutter-native-target-iOS"),
+      );
+      // Switch to Kotlin Multiplatform — should still default to Android.
+      fireEvent.click(screen.getByTestId("tab-Kotlin Multiplatform"));
+      expect(
+        screen.getByTestId(
+          "onboarding-kotlin-multiplatform-native-target-Android",
+        ),
+      ).toHaveAttribute("data-selected", "true");
+      // Switch back to Flutter — its iOS selection survived.
+      fireEvent.click(screen.getByTestId("tab-Flutter"));
+      expect(
+        screen.getByTestId("onboarding-flutter-native-target-iOS"),
       ).toHaveAttribute("data-selected", "true");
     });
   });

--- a/frontend/dashboard/app/components/onboarding.tsx
+++ b/frontend/dashboard/app/components/onboarding.tsx
@@ -126,9 +126,9 @@ Handler(Looper.getMainLooper()).postDelayed({
   };
 }
 
-function iosSpmDepSnippet(): Snippet {
+function iosSpmDepSnippet(testId: string): Snippet {
   return {
-    testId: "snippet-dependency",
+    testId,
     language: "swift",
     code: `// In Package.swift
 .package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v${SDK_VERSIONS.iosSdk}")`,
@@ -306,6 +306,21 @@ npx expo prebuild`,
   };
 }
 
+function kmpDepSnippet(): Snippet {
+  return {
+    testId: "snippet-dependency",
+    language: "kotlin",
+    code: `// In your shared module's build.gradle.kts
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("sh.measure:measure-kmp:${SDK_VERSIONS.kmp}")
+        }
+    }
+}`,
+  };
+}
+
 // --- Per-platform step lists. Each factory bakes the app's API key/URL into
 // its snippets. Cross-platform factories share the dep/init/crash steps across
 // both native targets and only vary the middle (the part that carries the key).
@@ -330,7 +345,10 @@ function androidSteps(apiKey: string, apiUrl: string): OnboardingStep[] {
 
 function iosSteps(apiKey: string, apiUrl: string): OnboardingStep[] {
   return [
-    { title: "Add the dependency", snippet: iosSpmDepSnippet() },
+    {
+      title: "Add the dependency",
+      snippet: iosSpmDepSnippet("snippet-dependency"),
+    },
     {
       title: "Initialize the SDK",
       snippet: iosInitSnippet(apiKey, apiUrl, "snippet-init"),
@@ -467,6 +485,45 @@ function expoSteps(
   };
 }
 
+// The KMP SDK has no init API of its own, so each native SDK is initialized in
+// its own target. Compose Multiplatform integrates the same way and shares
+// this tab.
+function kmpSteps(
+  apiKey: string,
+  apiUrl: string,
+): Record<NativeTarget, OnboardingStep[]> {
+  const dep = {
+    title: "Add the KMP dependency to commonMain",
+    snippet: kmpDepSnippet(),
+  };
+  return {
+    Android: [
+      dep,
+      {
+        title: "Add API key to AndroidManifest.xml",
+        snippet: androidManifestSnippet(apiKey, apiUrl),
+      },
+      {
+        title: "Initialize the Android native SDK",
+        snippet: androidInitSnippet("snippet-android-init"),
+      },
+      { title: "Trigger a test crash", snippet: androidCrashSnippet() },
+    ],
+    iOS: [
+      dep,
+      {
+        title: "Add the iOS dependency",
+        snippet: iosSpmDepSnippet("snippet-ios-dependency"),
+      },
+      {
+        title: "Initialize the iOS native SDK",
+        snippet: iosInitSnippet(apiKey, apiUrl, "snippet-ios-init"),
+      },
+      { title: "Trigger a test crash", snippet: iosCrashSnippet() },
+    ],
+  };
+}
+
 function buildPlatforms(apiKey: string, apiUrl: string): Platform[] {
   return [
     {
@@ -489,6 +546,11 @@ function buildPlatforms(apiKey: string, apiUrl: string): Platform[] {
       name: "React Native (Expo)",
       crossPlatform: true,
       steps: expoSteps(apiKey, apiUrl),
+    },
+    {
+      name: "Kotlin Multiplatform",
+      crossPlatform: true,
+      steps: kmpSteps(apiKey, apiUrl),
     },
   ];
 }

--- a/frontend/dashboard/app/stores/onboarding_store.ts
+++ b/frontend/dashboard/app/stores/onboarding_store.ts
@@ -10,6 +10,7 @@ export const PLATFORM_NAMES = [
   "Flutter",
   "React Native",
   "React Native (Expo)",
+  "Kotlin Multiplatform",
 ] as const;
 export type PlatformName = (typeof PLATFORM_NAMES)[number];
 

--- a/frontend/dashboard/scripts/extract_sdk_versions.js
+++ b/frontend/dashboard/scripts/extract_sdk_versions.js
@@ -33,6 +33,7 @@ const PATTERNS = {
   iosSdk: /branch:\s*["']ios-v(\d+\.\d+\.\d+)["']/,
   flutter: /measure_flutter:\s*\^(\d+\.\d+\.\d+)/,
   reactNative: /@measuresh\/react-native@(\d+\.\d+\.\d+)/,
+  kmp: /measure-kmp:(\d+\.\d+\.\d+)/,
 };
 
 function findSource() {
@@ -72,6 +73,7 @@ export const SDK_VERSIONS = {
   iosSdk: ${JSON.stringify(versions.iosSdk)},
   flutter: ${JSON.stringify(versions.flutter)},
   reactNative: ${JSON.stringify(versions.reactNative)},
+  kmp: ${JSON.stringify(versions.kmp)},
 } as const
 `;
 }


### PR DESCRIPTION
# Description

Adds a **Kotlin Multiplatform** onboarding tab to the dashboard.

## Related issue
Closes #3949


<img width="1507" height="1885" alt="image" src="https://github.com/user-attachments/assets/f9c35f6b-03d4-4e9c-a35b-1f0249798bd0" />
