### PR TITLE
chore(kmp): prepare sdk release 0.1.0

### DIFF
--- a/kmp/CHANGELOG.md
+++ b/kmp/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :hammer: Misc
 
+- (**kmp**): Prepare sdk release 0.1.0-alpha.1 (#3935) by @abhaysood in #3935
 - (**kmp**): Pin native SDK versions and simplify CI/release (#3933) by @abhaysood in #3933
 - (**kmp**): Prepare sdk release 0.1.0-alpha.1 (#3932) by @abhaysood in #3932
 - (**kmp**): Update documentation and improve release workflow (#3930) by @abhaysood in #3930

--- a/kmp/measure-kmp/gradle.properties
+++ b/kmp/measure-kmp/gradle.properties
@@ -9,7 +9,7 @@ kotlin.code.style=official
 kotlin.mpp.enableCInteropCommonization=true
 
 GROUP=sh.measure
-MEASURE_KMP_VERSION_NAME=0.1.0-alpha.1
+MEASURE_KMP_VERSION_NAME=0.1.0
 
 # Version of sh.measure:measure-android resolved when this module is built
 # standalone (e.g. published to Maven Central). For local development the


### PR DESCRIPTION
This PR prepares the KMP SDK for release version 0.1.0.

Changes:
- Updated version to 0.1.0 in gradle.properties
- Pinned native Android SDK version to 0.18.0 (android-v0.18.0)
- Pinned native iOS SDK version to 0.11.0 (ios-v0.11.0)
- Updated measure-kmp version in docs/sdk-integration-guide.md
- Generated changelog for version 0.1.0

<!-- release-meta
NEXT_VERSION=0.2.0-SNAPSHOT
-->