### PR TITLE
chore(android): collect http body only for json content type

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/HttpUrlConnectionRecorder.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/HttpUrlConnectionRecorder.kt
@@ -5,6 +5,7 @@ import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.okhttp.HttpClientName
 import sh.measure.android.okhttp.HttpData
+import sh.measure.android.okhttp.isJsonContentType
 import sh.measure.android.utils.TimeProvider
 import java.net.HttpURLConnection
 import java.util.concurrent.atomic.AtomicBoolean
@@ -34,17 +35,24 @@ internal class HttpUrlConnectionRecorder(
     private val responseHeadersCaptured = AtomicBoolean(false)
     private val shipped = AtomicBoolean(false)
 
+    @Volatile
+    private var requestContentType: String? = null
+
+    @Volatile
+    private var responseContentType: String? = null
+
     fun isTracked(): Boolean = tracked && collector.isEnabled()
 
-    fun shouldCaptureRequestBody(): Boolean = isTracked() && configProvider.shouldTrackHttpRequestBody(url)
+    fun shouldCaptureRequestBody(): Boolean = isTracked() && configProvider.shouldTrackHttpRequestBody(url) && isJsonContentType(requestContentType)
 
-    fun shouldCaptureResponseBody(): Boolean = isTracked() && configProvider.shouldTrackHttpResponseBody(url)
+    fun shouldCaptureResponseBody(): Boolean = isTracked() && configProvider.shouldTrackHttpResponseBody(url) && isJsonContentType(responseContentType)
 
-    fun onRequestStart(method: String) {
+    fun onRequestStart(connection: HttpURLConnection) {
         if (!isTracked()) return
         if (started.compareAndSet(false, true)) {
+            requestContentType = readRequestContentTypeOrNull(connection)
             builder
-                .method(method.lowercase())
+                .method((connection.requestMethod ?: "").lowercase())
                 .startTime(timeProvider.elapsedRealtime)
         }
     }
@@ -53,7 +61,9 @@ internal class HttpUrlConnectionRecorder(
         if (!isTracked()) return
         if (!responseHeadersCaptured.compareAndSet(false, true)) return
 
-        val statusCode = readResponseCodeQuietly(connection)
+        responseContentType = readResponseContentTypeOrNull(connection)
+
+        val statusCode = readResponseCodeOrNull(connection)
         if (statusCode != null) {
             builder.statusCode(statusCode)
         }
@@ -133,9 +143,22 @@ internal class HttpUrlConnectionRecorder(
         emptyMap()
     }
 
-    private fun readResponseCodeQuietly(connection: HttpURLConnection): Int? = try {
+    private fun readResponseCodeOrNull(connection: HttpURLConnection): Int? = try {
         val code = connection.responseCode
         if (code <= 0) null else code
+    } catch (e: Throwable) {
+        null
+    }
+
+    private fun readRequestContentTypeOrNull(connection: HttpURLConnection): String? = try {
+        connection.getRequestProperty("Content-Type")
+    } catch (e: Throwable) {
+        // Already connected and the impl forbids requestProperties access in this state.
+        null
+    }
+
+    private fun readResponseContentTypeOrNull(connection: HttpURLConnection): String? = try {
+        connection.contentType
     } catch (e: Throwable) {
         null
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/MsrHttpURLConnection.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/MsrHttpURLConnection.kt
@@ -26,7 +26,7 @@ internal open class MsrHttpURLConnection(
     @Volatile private var wrappedErrorStream: ResponseInputStream? = null
 
     private fun startRecording() {
-        recorder.onRequestStart(delegate.requestMethod ?: "")
+        recorder.onRequestStart(delegate)
     }
 
     // ----- HttpURLConnection-specific -----

--- a/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/MsrHttpsURLConnection.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/httpurl/MsrHttpsURLConnection.kt
@@ -31,7 +31,7 @@ internal class MsrHttpsURLConnection(
     @Volatile private var wrappedErrorStream: ResponseInputStream? = null
 
     private fun startRecording() {
-        recorder.onRequestStart(delegate.requestMethod ?: "")
+        recorder.onRequestStart(delegate)
     }
 
     override fun getCipherSuite(): String = delegate.cipherSuite

--- a/android/measure-android/measure/src/main/java/sh/measure/android/okhttp/HttpContentType.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/okhttp/HttpContentType.kt
@@ -1,0 +1,7 @@
+package sh.measure.android.okhttp
+
+/**
+ * HTTP bodies are only collected for JSON content. Non-JSON bodies (images,
+ * protobuf, gzip, etc.) are binary and render as garbled text in the timeline.
+ */
+internal fun isJsonContentType(contentType: String?): Boolean = contentType?.startsWith("application/json", ignoreCase = true) == true

--- a/android/measure-android/measure/src/main/java/sh/measure/android/okhttp/OkHttpEventCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/okhttp/OkHttpEventCollector.kt
@@ -122,7 +122,10 @@ internal class OkHttpEventCollectorImpl(
     }
 
     override fun request(call: Call, request: Request) {
-        if (configProvider.shouldTrackHttpRequestBody(request.url.toString())) {
+        val contentType = request.header("Content-Type") ?: request.body?.contentType()?.toString()
+        if (configProvider.shouldTrackHttpRequestBody(request.url.toString()) &&
+            isJsonContentType(contentType)
+        ) {
             val key = getIdentityHash(call)
             val builder = httpDataBuilders[key]
             val requestBody = getRequestBodyByteArray(request)
@@ -132,7 +135,9 @@ internal class OkHttpEventCollectorImpl(
     }
 
     override fun response(call: Call, request: Request, response: Response) {
-        if (configProvider.shouldTrackHttpResponseBody(request.url.toString())) {
+        if (configProvider.shouldTrackHttpResponseBody(request.url.toString()) &&
+            isJsonContentType(response.header("Content-Type"))
+        ) {
             val key = getIdentityHash(call)
             val builder = httpDataBuilders[key]
             val responseBody = getResponseBodyByteString(response)

--- a/android/measure-android/measure/src/test/java/sh/measure/android/httpurl/HttpUrlConnectionEventCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/httpurl/HttpUrlConnectionEventCollectorTest.kt
@@ -46,6 +46,9 @@ class HttpUrlConnectionEventCollectorTest {
         server.shutdown()
     }
 
+    private fun jsonResponse(code: Int, body: String): MockResponse = MockResponse().setResponseCode(code).setBody(body)
+        .addHeader("Content-Type", "application/json")
+
     private fun open(path: String = "/"): HttpURLConnection {
         val url = URL(server.url(path).toString())
         val raw = url.openConnection() as HttpURLConnection
@@ -91,7 +94,7 @@ class HttpUrlConnectionEventCollectorTest {
 
     @Test
     fun `captures method url status timings client and ships event on stream close`() {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        server.enqueue(jsonResponse(200, "ok"))
 
         val conn = open("/path")
         conn.responseCode
@@ -107,11 +110,12 @@ class HttpUrlConnectionEventCollectorTest {
 
     @Test
     fun `captures request body when POST`() {
-        server.enqueue(MockResponse().setResponseCode(201).setBody("created"))
+        server.enqueue(jsonResponse(201, "created"))
 
         val conn = open("/post")
         conn.requestMethod = "POST"
         conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/json")
         conn.outputStream.use { os: OutputStream ->
             os.write("hello".toByteArray())
         }
@@ -125,7 +129,7 @@ class HttpUrlConnectionEventCollectorTest {
 
     @Test
     fun `captures status and error body on 4xx`() {
-        server.enqueue(MockResponse().setResponseCode(404).setBody("not found"))
+        server.enqueue(jsonResponse(404, "not found"))
 
         val conn = open("/missing")
         conn.responseCode
@@ -168,11 +172,12 @@ class HttpUrlConnectionEventCollectorTest {
     @Test
     fun `request body capture disabled by config`() {
         configProvider.shouldTrackHttpRequestBodyResult = false
-        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        server.enqueue(jsonResponse(200, "ok"))
 
         val conn = open("/post")
         conn.requestMethod = "POST"
         conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/json")
         conn.outputStream.use { it.write("body".toByteArray()) }
         conn.inputStream.use { it.readBytes() }
 
@@ -183,7 +188,37 @@ class HttpUrlConnectionEventCollectorTest {
     @Test
     fun `response body capture disabled by config`() {
         configProvider.shouldTrackHttpResponseBodyResult = false
-        server.enqueue(MockResponse().setResponseCode(200).setBody("hidden"))
+        server.enqueue(jsonResponse(200, "hidden"))
+
+        val conn = open("/x")
+        conn.responseCode
+        conn.inputStream.use { it.readBytes() }
+
+        val data = verifyTracked()
+        assertNull(data.response_body)
+    }
+
+    @Test
+    fun `does not capture request body when content type is not json`() {
+        server.enqueue(jsonResponse(200, "ok"))
+
+        val conn = open("/post")
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/octet-stream")
+        conn.outputStream.use { it.write("hello".toByteArray()) }
+        conn.inputStream.use { it.readBytes() }
+
+        val data = verifyTracked()
+        assertNull(data.request_body)
+    }
+
+    @Test
+    fun `does not capture response body when content type is not json`() {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody("binary")
+                .addHeader("Content-Type", "image/png"),
+        )
 
         val conn = open("/x")
         conn.responseCode
@@ -208,7 +243,10 @@ class HttpUrlConnectionEventCollectorTest {
     @Test
     fun `truncates oversized response body and appends marker`() {
         val big = ByteArray((MAX_BODY_SIZE_BYTES + 10).toInt()) { 'a'.code.toByte() }
-        server.enqueue(MockResponse().setResponseCode(200).setBody(okio.Buffer().write(big)))
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(okio.Buffer().write(big))
+                .addHeader("Content-Type", "application/json"),
+        )
 
         val conn = open("/big")
         conn.responseCode

--- a/android/measure-android/measure/src/test/java/sh/measure/android/okhttp/OkHttpEventCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/okhttp/OkHttpEventCollectorTest.kt
@@ -581,6 +581,54 @@ class OkHttpEventCollectorTest {
         Assert.assertNull(actualData.response_body)
     }
 
+    @Test
+    fun `does not track request body if content type is not json`() {
+        val captor = argumentCaptor<HttpData>()
+        okHttpEventCollector.register()
+
+        // When
+        simulateSuccessfulPostRequest(requestContentType = "application/octet-stream")
+
+        // Then
+        verify(signalProcessor).track(
+            data = captor.capture(),
+            timestamp = any(),
+            type = any(),
+            attributes = eq(mutableMapOf()),
+            userDefinedAttributes = eq(emptyMap()),
+            attachments = eq(mutableListOf()),
+            threadName = eq(null),
+            sessionId = eq(null),
+            userTriggered = eq(false),
+            isSampled = any(),
+        )
+        Assert.assertNull(captor.firstValue.request_body)
+    }
+
+    @Test
+    fun `does not track response body if content type is not json`() {
+        val captor = argumentCaptor<HttpData>()
+        okHttpEventCollector.register()
+
+        // When
+        simulateSuccessfulPostRequest(responseContentType = "image/png")
+
+        // Then
+        verify(signalProcessor).track(
+            data = captor.capture(),
+            timestamp = any(),
+            type = any(),
+            attributes = eq(mutableMapOf()),
+            userDefinedAttributes = eq(emptyMap()),
+            attachments = eq(mutableListOf()),
+            threadName = eq(null),
+            sessionId = eq(null),
+            userTriggered = eq(false),
+            isSampled = any(),
+        )
+        Assert.assertNull(captor.firstValue.response_body)
+    }
+
     /**
      * Creates a mock server and enqueues a successful response for a POST request.
      * Then consumes the response to ensure all events for EventFactory are triggered.
@@ -599,18 +647,20 @@ class OkHttpEventCollectorTest {
         url: String = "http://localhost:8080/",
         requestBody: String = "{ \"key\": \"value\" }",
         responseBody: String = "{ \"key\": \"value\" }",
+        requestContentType: String = "application/json",
+        responseContentType: String = "application/json",
     ) {
         mockWebServer.let {
             it.enqueue(
                 MockResponse().setResponseCode(statusCode).setBody(responseBody)
-                    .setHeader("Content-Type", "application/json")
+                    .setHeader("Content-Type", responseContentType)
                     .setHeader(responseHeader.first, responseHeader.second),
             )
             it.start(8080)
         }
         val response = client.newCall(
             Request.Builder().url(url)
-                .header("Content-Type", "application/json")
+                .header("Content-Type", requestContentType)
                 .header(requestHeader.first, requestHeader.second)
                 .post(requestBody.toRequestBody()).build(),
         ).execute()


### PR DESCRIPTION
# Description

Request/response bodies were captured based on URL patterns alone, so non-JSON bodies (images, protobuf, gzip) were stored and rendered as garbled text in the session timeline. Gate OkHttp and HttpURLConnection body capture on the request and response Content-Type, collecting only application/json.

## Related issue
Closes #3961 


