### PR TITLE
chore(flutter): collect http body only for json content type

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/http/http_collector.dart
@@ -61,11 +61,13 @@ class HttpCollector {
         );
     }
 
-    if (!configProvider.shouldTrackHttpRequestBody(url)) {
+    if (!configProvider.shouldTrackHttpRequestBody(url) ||
+        !_isJsonContentType(requestHeaders)) {
       requestBody = null;
     }
 
-    if (!configProvider.shouldTrackHttpResponseBody(url)) {
+    if (!configProvider.shouldTrackHttpResponseBody(url) ||
+        !_isJsonContentType(responseHeaders)) {
       responseBody = null;
     }
 
@@ -90,5 +92,19 @@ class HttpCollector {
       userDefinedAttrs: {},
       userTriggered: false,
     );
+  }
+
+  // Only collect JSON bodies. Non-JSON bodies (images, protobuf, gzip, etc.)
+  // are binary and render as garbled text in the timeline.
+  bool _isJsonContentType(Map<String, String>? headers) {
+    if (headers == null) {
+      return false;
+    }
+    for (final entry in headers.entries) {
+      if (entry.key.toLowerCase() == 'content-type') {
+        return entry.value.toLowerCase().startsWith('application/json');
+      }
+    }
+    return false;
   }
 }

--- a/flutter/packages/measure_flutter/test/http/http_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/http/http_collector_test.dart
@@ -346,6 +346,59 @@ void main() {
         // Response body kept
         expect(httpData.responseBody, '{"id": 1}');
       });
+
+      test('removes request body when content type is not json', () {
+        configProvider.shouldTrackHttpRequestBodyResult = true;
+        collector.register();
+
+        collector.trackHttpEvent(
+          url: 'https://api.example.com/users',
+          method: HttpMethod.post,
+          requestHeaders: {'content-type': 'application/octet-stream'},
+          startTime: 1234567890,
+          statusCode: 201,
+          requestBody: 'binary-blob',
+        );
+
+        final httpData = signalProcessor.trackedEvents.first.data as HttpData;
+        expect(httpData.requestBody, null);
+      });
+
+      test('removes response body when content type is not json', () {
+        configProvider.shouldTrackHttpResponseBodyResult = true;
+        collector.register();
+
+        collector.trackHttpEvent(
+          url: 'https://api.example.com/users',
+          method: HttpMethod.get,
+          responseHeaders: {'content-type': 'image/png'},
+          startTime: 1234567890,
+          statusCode: 200,
+          responseBody: 'binary-blob',
+        );
+
+        final httpData = signalProcessor.trackedEvents.first.data as HttpData;
+        expect(httpData.responseBody, null);
+      });
+
+      test('removes bodies when content type header is absent', () {
+        configProvider.shouldTrackHttpRequestBodyResult = true;
+        configProvider.shouldTrackHttpResponseBodyResult = true;
+        collector.register();
+
+        collector.trackHttpEvent(
+          url: 'https://api.example.com/users',
+          method: HttpMethod.post,
+          startTime: 1234567890,
+          statusCode: 201,
+          requestBody: '{"name": "John"}',
+          responseBody: '{"id": 1}',
+        );
+
+        final httpData = signalProcessor.trackedEvents.first.data as HttpData;
+        expect(httpData.requestBody, null);
+        expect(httpData.responseBody, null);
+      });
     });
 
     group('registration state', () {


### PR DESCRIPTION
# Description

Request/response bodies were captured based on URL patterns alone, so non-JSON bodies (images, protobuf, gzip) were stored and rendered as garbled text in the session timeline. Drop bodies unless the request or response headers declare application/json.

## Related issue
Closes #3961 


