### PR TITLE
chore(ios): collect http body only for json content type

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Config/ConfigProvider.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ConfigProvider.swift
@@ -170,9 +170,16 @@ final class BaseConfigProvider: ConfigProvider {
     }
 
     func shouldTrackHttpBody(url: String, contentType: String?) -> Bool {
+        // Only collect JSON bodies. Non-JSON bodies (images, protobuf, gzip, etc.)
+        // are binary and render as garbled text in the timeline.
+        guard let contentType = contentType,
+              contentType.lowercased().hasPrefix("application/json") else {
+            return false
+        }
+
         let state = httpPatternState
         let range = NSRange(location: 0, length: url.utf16.count)
-        
+
         return state.trackRequestPatterns.contains {
             $0.firstMatch(in: url, options: [], range: range) != nil
         } || state.trackResponsePatterns.contains {

--- a/ios/Tests/MeasureSDKTests/Config/BaseConfigProviderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/BaseConfigProviderTests.swift
@@ -84,22 +84,31 @@ final class ConfigProviderTests: XCTestCase {
         XCTAssertTrue(provider.shouldTrackHttpUrl(url: "https://api.example.com/data"))
     }
 
-    func testShouldTrackHttpBody_returnsFalseWhenEmpty() {
-        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://api.example.com/data", contentType: nil))
+    func testShouldTrackHttpBody_returnsFalseWhenContentTypeMissing() {
+        provider.setDynamicConfig(copy(BaseDynamicConfig(), request: ["https://api.example.com/*"]))
+
+        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: nil))
+    }
+
+    func testShouldTrackHttpBody_returnsFalseWhenContentTypeNotJson() {
+        provider.setDynamicConfig(copy(BaseDynamicConfig(), request: ["https://api.example.com/*"]))
+
+        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: "image/png"))
     }
 
     func testRequestBodyMatch() {
         provider.setDynamicConfig(copy(BaseDynamicConfig(), request: ["https://api.example.com/*"]))
 
-        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: nil))
-        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: nil))
+        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: "application/json"))
+        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: "application/json; charset=utf-8"))
+        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: "application/json"))
     }
 
     func testResponseBodyMatch() {
         provider.setDynamicConfig(copy(BaseDynamicConfig(), response: ["https://api.example.com/*"]))
 
-        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: nil))
-        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: nil))
+        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://api.example.com/users", contentType: "application/json"))
+        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: "application/json"))
     }
 
     func testRequestAndResponseIndependent() {
@@ -107,8 +116,8 @@ final class ConfigProviderTests: XCTestCase {
                                        request: ["https://request.example.com/*"],
                                        response: ["https://response.example.com/*"]))
 
-        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://request.example.com/data", contentType: nil))
-        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: nil))
+        XCTAssertTrue(provider.shouldTrackHttpBody(url: "https://request.example.com/data", contentType: "application/json"))
+        XCTAssertFalse(provider.shouldTrackHttpBody(url: "https://other.example.com/data", contentType: "application/json"))
     }
 
     func testDefaultBlockedHeaders() {


### PR DESCRIPTION
# Description

shouldTrackHttpBody received the request/response Content-Type but ignored it, so non-JSON bodies (images, protobuf, gzip) were captured and rendered as garbled text in the session timeline. Require the content type to be application/json.

## Related issue
Closes #3961 


