### PR TITLE
feat(android): integrate android profiling results

### DIFF
--- a/android/measure-android/gradle/libs.versions.toml
+++ b/android/measure-android/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-lifecycle = "2.9.4"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"
 androidx-core-ktx = "1.16.0"
+androidx-work = "2.9.1"
 androidx-compose-ui = "1.9.4"
 androidx-compose-material3 = "1.4.0"
 androidx-runtime-android = "1.9.4"
@@ -50,6 +51,8 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-j
 androidx-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-junit" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
+androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
+androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }

--- a/android/measure-android/measure/build.gradle.kts
+++ b/android/measure-android/measure/build.gradle.kts
@@ -162,6 +162,11 @@ dependencies {
     compileOnly(libs.androidx.navigation.fragment)
     compileOnly(libs.squareup.okhttp)
 
+    // Compile only, so consumers who do not need ProfilingManager uploads are not forced to
+    // pull WorkManager (and its transitive Room dependency). Profiling is enabled only when the
+    // consumer adds androidx.work themselves; see WorkManagerAvailability.
+    compileOnly(libs.androidx.work.runtime)
+
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.androidx.annotation)
@@ -180,6 +185,8 @@ dependencies {
     testImplementation(libs.androidx.compose.ui)
     testImplementation(libs.androidx.material3)
     testImplementation(libs.squareup.okhttp.mockwebserver)
+    testImplementation(libs.androidx.work.runtime)
+    testImplementation(libs.androidx.work.testing)
 
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.3") {
         isTransitive = false

--- a/android/measure-android/measure/consumer-rules.pro
+++ b/android/measure-android/measure/consumer-rules.pro
@@ -10,3 +10,8 @@
 # Required to find gesture targe for composables
 -keepnames class androidx.compose.ui.platform.AndroidComposeView
 
+# WorkManager is an optional dependency, only present when the consumer enables ProfilingManager
+# uploads. Used to check for its presence in the runtime classpath; silence references when absent.
+-keepnames class androidx.work.WorkManager
+-dontwarn androidx.work.**
+

--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/FakeConfigProvider.kt
@@ -58,6 +58,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override val launchSamplingRate: Float = 1f
     override val gestureClickTakeSnapshot: Boolean = true
     override val httpSamplingRate: Float = 1f
+    override val profileSamplingRate: Float = 100f
     override val httpDisableEventForUrls: List<String> = emptyList()
     override val httpTrackRequestForUrls: List<String> = emptyList()
     override val httpTrackResponseForUrls: List<String> = emptyList()

--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -56,6 +56,7 @@ import sh.measure.android.performance.CpuUsageCollector
 import sh.measure.android.performance.DefaultMemoryReader
 import sh.measure.android.performance.MemoryReader
 import sh.measure.android.performance.MemoryUsageCollector
+import sh.measure.android.profiling.ProfileCollector
 import sh.measure.android.screenshot.ScreenshotCollector
 import sh.measure.android.screenshot.ScreenshotCollectorImpl
 import sh.measure.android.storage.DataCleanupService
@@ -237,6 +238,7 @@ internal class TestMeasureInitializer(
         lowMemoryCheck = lowMemoryCheck,
         config = configProvider,
     ),
+    override val workManagerAvailable: Boolean = false,
     override val exporter: Exporter = ExporterImpl(
         logger = logger,
         database = database,
@@ -279,6 +281,8 @@ internal class TestMeasureInitializer(
         processInfo = processInfoProvider,
         signalProcessor = signalProcessor,
         nativeBridge = nativeBridgeImpl,
+        database = database,
+        sessionManager = sessionManager,
     ),
     private val appExitProvider: AppExitProvider = AppExitProviderImpl(
         logger = logger,
@@ -364,6 +368,16 @@ internal class TestMeasureInitializer(
         timeProvider = timeProvider,
         launchTracker = launchTracker,
         sampler = sampler,
+    ),
+    override val profileCollector: ProfileCollector = ProfileCollector(
+        logger = logger,
+        systemServiceProvider = systemServiceProvider,
+        signalProcessor = signalProcessor,
+        timeProvider = timeProvider,
+        ioExecutor = executorServiceRegistry.ioExecutor(),
+        sampler = sampler,
+        database = database,
+        sessionManager = sessionManager,
     ),
     override val networkChangesCollector: NetworkChangesCollector = NetworkChangesCollector(
         context = application,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -323,8 +323,6 @@ internal class MeasureInitializerImpl(
         processInfo = processInfoProvider,
         signalProcessor = signalProcessor,
         nativeBridge = nativeBridgeImpl,
-        database = database,
-        sessionManager = sessionManager,
     ),
     private val appExitProvider: AppExitProvider = AppExitProviderImpl(
         logger = logger,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -63,6 +63,8 @@ import sh.measure.android.performance.CpuUsageCollector
 import sh.measure.android.performance.DefaultMemoryReader
 import sh.measure.android.performance.MemoryReader
 import sh.measure.android.performance.MemoryUsageCollector
+import sh.measure.android.profiling.ProfileCollector
+import sh.measure.android.profiling.ProfileUploadScheduler
 import sh.measure.android.screenshot.ScreenshotCollector
 import sh.measure.android.screenshot.ScreenshotCollectorImpl
 import sh.measure.android.storage.DataCleanupService
@@ -110,6 +112,7 @@ import sh.measure.android.utils.SamplerImpl
 import sh.measure.android.utils.SystemServiceProvider
 import sh.measure.android.utils.SystemServiceProviderImpl
 import sh.measure.android.utils.TimeProvider
+import sh.measure.android.utils.isClassAvailable
 
 internal class MeasureInitializerImpl(
     private val application: Application,
@@ -252,6 +255,9 @@ internal class MeasureInitializerImpl(
         config = configProvider,
     ),
     private val httpClient: HttpClient = HttpUrlConnectionClient(logger),
+    override val workManagerAvailable: Boolean = isClassAvailable("androidx.work.WorkManager"),
+    private val profileUploadScheduler: ProfileUploadScheduler? =
+        if (workManagerAvailable) ProfileUploadScheduler(application, logger) else null,
     override val dataCleanupService: DataCleanupService = DataCleanupServiceImpl(
         logger = logger,
         fileStorage = fileStorage,
@@ -271,6 +277,7 @@ internal class MeasureInitializerImpl(
         httpClient = httpClient,
         configProvider = configProvider,
         eventExportService = executorServiceRegistry.eventExportExecutor(),
+        profileUploadScheduler = profileUploadScheduler,
     ),
     override val signalProcessor: SignalProcessor = SignalProcessorImpl(
         logger = logger,
@@ -316,6 +323,8 @@ internal class MeasureInitializerImpl(
         processInfo = processInfoProvider,
         signalProcessor = signalProcessor,
         nativeBridge = nativeBridgeImpl,
+        database = database,
+        sessionManager = sessionManager,
     ),
     private val appExitProvider: AppExitProvider = AppExitProviderImpl(
         logger = logger,
@@ -414,6 +423,16 @@ internal class MeasureInitializerImpl(
         launchTracker = launchTracker,
         sampler = sampler,
     ),
+    override val profileCollector: ProfileCollector = ProfileCollector(
+        logger = logger,
+        systemServiceProvider = systemServiceProvider,
+        signalProcessor = signalProcessor,
+        timeProvider = timeProvider,
+        ioExecutor = executorServiceRegistry.ioExecutor(),
+        sampler = sampler,
+        database = database,
+        sessionManager = sessionManager,
+    ),
     override val networkChangesCollector: NetworkChangesCollector = NetworkChangesCollector(
         context = application,
         signalProcessor = signalProcessor,
@@ -487,8 +506,10 @@ internal interface MeasureInitializer {
     val appLifecycleCollector: AppLifecycleCollector
     val gestureCollector: GestureCollector
     val appLaunchCollector: AppLaunchCollector
+    val profileCollector: ProfileCollector
     val networkChangesCollector: NetworkChangesCollector
     val exporter: Exporter
+    val workManagerAvailable: Boolean
     val userAttributeProcessor: UserAttributeProcessor
     val screenshotCollector: ScreenshotCollector
     val dataCleanupService: DataCleanupService

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -392,6 +392,11 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         measure.spanCollector.register()
         measure.customEventCollector.register()
         measure.periodicSignalStoreScheduler.register()
+        // Profiling relies on WorkManager to upload its results durably, so it is enabled only when
+        // the consumer has added WorkManager to the classpath.
+        if (measure.workManagerAvailable) {
+            measure.profileCollector.register()
+        }
     }
 
     private fun unregisterCollectors() {
@@ -409,6 +414,9 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         measure.spanCollector.unregister()
         measure.customEventCollector.unregister()
         measure.periodicSignalStoreScheduler.unregister()
+        if (measure.workManagerAvailable) {
+            measure.profileCollector.unregister()
+        }
     }
 
     private fun pauseCollectorsOnBackground() {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -1,6 +1,5 @@
 package sh.measure.android
 
-import android.os.Build
 import androidx.annotation.VisibleForTesting
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.config.DefaultConfig
@@ -189,7 +188,6 @@ internal class SessionManagerImpl(
                                 id,
                                 pid,
                                 startTime,
-                                supportsAppExit = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R,
                                 appVersion = packageInfoProvider.appVersion,
                                 appBuild = packageInfoProvider.getVersionCode(),
                             ),

--- a/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -3,17 +3,21 @@ package sh.measure.android.anr
 import android.os.Looper
 import sh.measure.android.AnrListener
 import sh.measure.android.NativeBridge
+import sh.measure.android.SessionManager
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
 import sh.measure.android.mainHandler
+import sh.measure.android.storage.Database
 import sh.measure.android.utils.ProcessInfoProvider
 
 internal class AnrCollector(
     private val processInfo: ProcessInfoProvider,
     private val signalProcessor: SignalProcessor,
     private val nativeBridge: NativeBridge,
+    private val database: Database,
+    private val sessionManager: SessionManager,
     private val mainLooper: Looper = mainHandler.looper,
 ) : AnrListener {
 
@@ -43,6 +47,9 @@ internal class AnrCollector(
             type = EventType.ANR,
             takeScreenshot = true,
         )
+        // record the ANR against its session so a late-delivered ANR profile
+        // can be attributed back to it even after the process is relaunched.
+        database.setSessionAnrTime(sessionManager.getSessionId(), anrError.timestamp)
     }
 
     private fun toMeasureException(anr: AnrError): ExceptionData = ExceptionFactory.createMeasureException(

--- a/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -3,21 +3,17 @@ package sh.measure.android.anr
 import android.os.Looper
 import sh.measure.android.AnrListener
 import sh.measure.android.NativeBridge
-import sh.measure.android.SessionManager
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.exceptions.ExceptionFactory
 import sh.measure.android.mainHandler
-import sh.measure.android.storage.Database
 import sh.measure.android.utils.ProcessInfoProvider
 
 internal class AnrCollector(
     private val processInfo: ProcessInfoProvider,
     private val signalProcessor: SignalProcessor,
     private val nativeBridge: NativeBridge,
-    private val database: Database,
-    private val sessionManager: SessionManager,
     private val mainLooper: Looper = mainHandler.looper,
 ) : AnrListener {
 
@@ -47,9 +43,6 @@ internal class AnrCollector(
             type = EventType.ANR,
             takeScreenshot = true,
         )
-        // record the ANR against its session so a late-delivered ANR profile
-        // can be attributed back to it even after the process is relaunched.
-        database.setSessionAnrTime(sessionManager.getSessionId(), anrError.timestamp)
     }
 
     private fun toMeasureException(anr: AnrError): ExceptionData = ExceptionFactory.createMeasureException(

--- a/android/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
@@ -22,11 +22,10 @@ internal class AppExitCollector(
     @RequiresApi(Build.VERSION_CODES.R)
     private fun trackANRFromAppExit() {
         val appExitsMap: Map<Int, AppExit> = appExitProvider.get() ?: return
-        val trackedSessions = mutableListOf<Session>()
         appExitsMap.forEach {
             val pid = it.key
             val appExit = it.value
-            val session = getSessionForAppExit(pid)
+            val session = database.getSessionForAppExit(pid)
             // Limiting tracking of app exit events to just
             // ANRs for now.
             if (session != null && appExit.isANR()) {
@@ -43,19 +42,11 @@ internal class AppExitCollector(
                     threadName = Thread.currentThread().name,
                     isSampled = true,
                 )
-                trackedSessions.add(session)
+                // backfills the ANR time for a session where the real-time
+                // detector's write may have been lost to a fast kill.
+                database.setSessionAnrTime(session.id, appExit.app_exit_time_ms)
             }
         }
-        database.clearAppExitRecords(excludeSessionId = sessionManager.getSessionId())
+        database.markSessionsAppExitTracked(excludeSessionId = sessionManager.getSessionId())
     }
-
-    private fun getSessionForAppExit(pid: Int): Session? = database.getSessionForAppExit(pid)
-
-    internal data class Session(
-        val id: String,
-        val pid: Int,
-        val createdAt: Long,
-        val appVersion: String?,
-        val appBuild: String?,
-    )
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigProvider.kt
@@ -136,6 +136,8 @@ internal class ConfigProviderImpl(defaultConfig: Config) : ConfigProvider {
         get() = dynamicConfig.httpTrackResponseForUrls.toList()
     override val httpBlockedHeaders: List<String>
         get() = dynamicConfig.httpBlockedHeaders.toList()
+    override val profileSamplingRate: Float
+        get() = dynamicConfig.profileSamplingRate
 
     override fun shouldTrackHttpEvent(url: String): Boolean {
         val state = httpPatternState

--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/DynamicConfig.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/DynamicConfig.kt
@@ -110,6 +110,13 @@ internal interface IDynamicConfig {
      * * X-Api-Key
      */
     val httpBlockedHeaders: List<String>
+
+    /**
+     * Sampling rate in percentage for profile events. Defaults to 100%, i.e. every profile that
+     * survives the system's own throttling is collected. The OS already rate limits these, so this
+     * is an additional, remotely tunable cap on top of that.
+     */
+    val profileSamplingRate: Float
 }
 
 @Serializable
@@ -175,4 +182,7 @@ internal data class DynamicConfig(
         "WWW-Authenticate",
         "X-Api-Key",
     ),
+
+    @SerialName("profile_sampling_rate")
+    override val profileSamplingRate: Float = 100f,
 ) : IDynamicConfig

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/AttachmentType.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/AttachmentType.kt
@@ -4,6 +4,9 @@ internal object AttachmentType {
     const val SCREENSHOT = "screenshot"
     const val LAYOUT_SNAPSHOT = "layout_snapshot"
     const val LAYOUT_SNAPSHOT_JSON = "layout_snapshot_json"
+    const val PERFETTO_TRACE = "perfetto_trace"
+    const val HEAP_DUMP = "heap_dump"
+    const val HEAP_PROFILE = "heap_profile"
 
     val VALID_TYPES = listOf(SCREENSHOT, LAYOUT_SNAPSHOT, LAYOUT_SNAPSHOT_JSON)
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/EventType.kt
@@ -23,6 +23,7 @@ internal enum class EventType(val value: String) {
     CUSTOM("custom"),
     BUG_REPORT("bug_report"),
     SESSION_START("session_start"),
+    PROFILE("profile"),
     ;
 
     companion object {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -312,7 +312,10 @@ internal class SignalProcessorImpl(
         }
 
         applyAttributes(event, thread)
-        signalStore.store(event)
+        signalStore.store(
+            event,
+            sessionAnrTimeMs = if (event.type == EventType.ANR) timestamp else null,
+        )
         onEventTracked(event)
         exporter.export()
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -17,6 +17,7 @@ import sh.measure.android.executors.MeasureExecutorService
 import sh.measure.android.exporter.Exporter
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.profiling.ProfileData
 import sh.measure.android.screenshot.ScreenshotCollector
 import sh.measure.android.storage.SignalStore
 import sh.measure.android.tracing.InternalTrace
@@ -68,6 +69,23 @@ internal interface SignalProcessor {
         threadName: String,
         sessionId: String,
         sessionStartTime: Long,
+        appVersion: String?,
+        appBuild: String?,
+        isSampled: Boolean = true,
+    )
+
+    /**
+     * Profile events can be delivered by the OS after the session they were captured in has
+     * ended. This method is used to track profile events for a specific session with the
+     * attributes provided. The session attributes are left untouched when they are unknown.
+     */
+    fun trackProfile(
+        data: ProfileData,
+        timestamp: Long,
+        type: EventType,
+        attachments: MutableList<Attachment>,
+        sessionId: String,
+        sessionStartTime: Long?,
         appVersion: String?,
         appBuild: String?,
         isSampled: Boolean = true,
@@ -223,6 +241,44 @@ internal class SignalProcessorImpl(
         )
     }
 
+    override fun trackProfile(
+        data: ProfileData,
+        timestamp: Long,
+        type: EventType,
+        attachments: MutableList<Attachment>,
+        sessionId: String,
+        sessionStartTime: Long?,
+        appVersion: String?,
+        appBuild: String?,
+        isSampled: Boolean,
+    ) {
+        InternalTrace.trace(
+            label = { "msr-trackEvent" },
+            block = {
+                val event = createEvent(
+                    data = data,
+                    timestamp = timestamp,
+                    type = type,
+                    attachments = attachments,
+                    attributes = mutableMapOf(),
+                    userTriggered = false,
+                    userDefinedAttributes = mutableMapOf(),
+                    sessionId = sessionId,
+                    isSampled = isSampled,
+                ) ?: return@trace
+                applyAttributes(event, Thread.currentThread().name)
+                event.updateVersionAttribute(appVersion, appBuild)
+                if (sessionStartTime != null) {
+                    event.updateSessionStartTimeAttribute(sessionStartTime)
+                }
+                InternalTrace.trace(label = { "msr-store-event" }, block = {
+                    signalStore.store(event)
+                    onEventTracked(event)
+                })
+            },
+        )
+    }
+
     override fun trackCrash(
         data: ExceptionData,
         timestamp: Long,
@@ -368,11 +424,11 @@ internal class SignalProcessorImpl(
         })
     }
 
-    // This is a quick way to update the version attributes for app exit events.
-    // AppExit events are tracked for older sessions, and the version attributes are not
-    // available at that time. Instead of changing the flow of tracking events, we apply the
+    // This is a quick way to update the session attributes for events tracked against an
+    // older session, like app exits and profiles. The attribute processors only know the
+    // current session, so instead of changing the flow of tracking events, we apply the
     // attributes as is and then mutate them here.
-    private fun Event<AppExit>.updateVersionAttribute(appVersion: String?, appBuild: String?) {
+    private fun Event<*>.updateVersionAttribute(appVersion: String?, appBuild: String?) {
         if (appVersion != null) {
             attributes[Attribute.APP_VERSION_KEY] = appVersion
         }
@@ -381,7 +437,7 @@ internal class SignalProcessorImpl(
         }
     }
 
-    private fun Event<AppExit>.updateSessionStartTimeAttribute(sessionStartTime: Long) {
+    private fun Event<*>.updateSessionStartTimeAttribute(sessionStartTime: Long) {
         attributes[Attribute.SESSION_START_TIME_KEY] = sessionStartTime.iso8601Timestamp()
     }
 

--- a/android/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/executors/MeasureExecutorService.kt
@@ -2,6 +2,7 @@ package sh.measure.android.executors
 
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.Callable
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
@@ -9,7 +10,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 
-internal interface MeasureExecutorService {
+internal interface MeasureExecutorService : Executor {
     @Throws(RejectedExecutionException::class)
     fun <T> submit(callable: Callable<T>): Future<T>
 
@@ -32,6 +33,8 @@ internal class MeasureExecutorServiceImpl @TestOnly constructor(private val exec
     constructor(threadFactory: ThreadFactory) : this(
         Executors.newSingleThreadScheduledExecutor(threadFactory),
     )
+
+    override fun execute(command: Runnable) = executorService.execute(command)
 
     override fun <T> submit(callable: Callable<T>): Future<T> = executorService.submit(callable)
 

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -7,6 +7,8 @@ import sh.measure.android.config.ConfigProvider
 import sh.measure.android.executors.MeasureExecutorService
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.profiling.EnqueueResult
+import sh.measure.android.profiling.ProfileUploadScheduler
 import sh.measure.android.serialization.jsonSerializer
 import sh.measure.android.storage.Database
 import sh.measure.android.storage.FileStorage
@@ -43,6 +45,7 @@ internal class ExporterImpl(
     private val httpClient: HttpClient,
     private val configProvider: ConfigProvider,
     private val eventExportService: MeasureExecutorService,
+    private val profileUploadScheduler: ProfileUploadScheduler? = null,
 ) : Exporter {
     @VisibleForTesting
     internal val isExporting = AtomicBoolean(false)
@@ -56,6 +59,8 @@ internal class ExporterImpl(
         // Rough estimate of a single signal's (event or span) serialized size, used to
         // convert the payload size limit into a maximum number of signals per batch.
         private const val ESTIMATED_SIGNAL_SIZE_BYTES = 1024
+
+        private const val MAX_PROFILE_UPLOADS_PER_BATCH = 5
     }
 
     override fun export() {
@@ -65,6 +70,7 @@ internal class ExporterImpl(
                     try {
                         exportEvents()
                         exportAttachments()
+                        handoffProfileUploads()
                     } finally {
                         isExporting.set(false)
                     }
@@ -84,6 +90,7 @@ internal class ExporterImpl(
                     try {
                         exportExistingBatches()
                         exportAttachments()
+                        handoffProfileUploads()
                     } finally {
                         isExporting.set(false)
                     }
@@ -236,6 +243,40 @@ internal class ExporterImpl(
                 if (index < attachments.size - 1) {
                     sleeper.sleep(configProvider.attachmentExportIntervalMs)
                 }
+            }
+        }
+    }
+
+    /**
+     * Hands every signed profile attachment to the WorkManager and removes its row
+     * from the database.
+     */
+    private fun handoffProfileUploads() {
+        val scheduler = profileUploadScheduler ?: return
+        while (true) {
+            val profiles = database.getProfileAttachmentsToUpload(MAX_PROFILE_UPLOADS_PER_BATCH)
+            if (profiles.isEmpty()) {
+                return
+            }
+            var madeProgress = false
+            for (attachment in profiles) {
+                when (scheduler.enqueue(attachment)) {
+                    EnqueueResult.ENQUEUED -> {
+                        database.deleteAttachment(attachment.id)
+                        madeProgress = true
+                    }
+
+                    EnqueueResult.DROP -> {
+                        fileStorage.deleteFilePaths(listOf(attachment.path))
+                        database.deleteAttachment(attachment.id)
+                        madeProgress = true
+                    }
+
+                    EnqueueResult.RETRY -> Unit
+                }
+            }
+            if (!madeProgress) {
+                return
             }
         }
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
@@ -194,7 +194,7 @@ internal class ProfileCollector(
     }
 
     private fun reasonFor(triggerType: Int): String? = when (triggerType) {
-        ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN -> REASON_APP_LAUNCH
+        ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN -> REASON_APP_FULLY_DRAWN
         ProfilingTrigger.TRIGGER_TYPE_ANR -> REASON_ANR
         else -> null
     }
@@ -206,7 +206,7 @@ internal class ProfileCollector(
         private const val HEAP_PROFILE_EXTENSION = ".heapprofd"
         private const val TIMESTAMP_PATTERN = "yyyy-MM-dd-HH-mm-ss-SSS"
         private val TIMESTAMP_REGEX = Regex("\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}")
-        private const val REASON_APP_LAUNCH = "app_launch"
+        private const val REASON_APP_FULLY_DRAWN = "app_fully_drawn"
         private const val REASON_ANR = "anr"
 
         // Bounds how far before a profile's capture time an ANR may have occurred

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
@@ -1,0 +1,216 @@
+package sh.measure.android.profiling
+
+import android.os.Build
+import android.os.ProfilingResult
+import android.os.ProfilingTrigger
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import sh.measure.android.SessionManager
+import sh.measure.android.events.Attachment
+import sh.measure.android.events.AttachmentType
+import sh.measure.android.events.EventType
+import sh.measure.android.events.SignalProcessor
+import sh.measure.android.executors.MeasureExecutorService
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import sh.measure.android.storage.Database
+import sh.measure.android.utils.Sampler
+import sh.measure.android.utils.SystemServiceProvider
+import sh.measure.android.utils.TimeProvider
+import java.io.File
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.function.Consumer
+
+/**
+ * Reports each trigger based profiling result from [android.os.ProfilingManager] as a
+ * [EventType.PROFILE] event, attaching the output file in place at the path the platform wrote it
+ * to.
+ *
+ * Requires Android 16 (API 36); [register] and [unregister] are no-ops on older versions.
+ */
+internal class ProfileCollector(
+    private val logger: Logger,
+    private val systemServiceProvider: SystemServiceProvider,
+    private val signalProcessor: SignalProcessor,
+    private val timeProvider: TimeProvider,
+    private val ioExecutor: MeasureExecutorService,
+    private val sampler: Sampler,
+    private val database: Database,
+    private val sessionManager: SessionManager,
+) {
+    private var resultCallback: Consumer<ProfilingResult>? = null
+
+    fun register() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) {
+            return
+        }
+        registerTriggers()
+    }
+
+    fun unregister() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) {
+            return
+        }
+        unregisterTriggers()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun registerTriggers() {
+        if (resultCallback != null) {
+            return
+        }
+        val profilingManager = systemServiceProvider.profilingManager
+        if (profilingManager == null) {
+            logger.log(LogLevel.Debug, "ProfilingManager unavailable, skipping profiling")
+            return
+        }
+        val callback = Consumer<ProfilingResult> { result -> onProfilingResult(result) }
+        try {
+            profilingManager.registerForAllProfilingResults(ioExecutor, callback)
+            resultCallback = callback
+            val triggers = triggerTypes().map { type ->
+                ProfilingTrigger.Builder(type)
+                    .setRateLimitingPeriodHours(RATE_LIMITING_PERIOD_HOURS)
+                    .build()
+            }
+            profilingManager.addProfilingTriggers(triggers)
+            logger.log(LogLevel.Debug, "Registered ${triggers.size} profiling triggers")
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Failed to register profiling triggers", e)
+            resultCallback = null
+            runCatching { profilingManager.unregisterForAllProfilingResults(callback) }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun unregisterTriggers() {
+        val callback = resultCallback ?: return
+        val profilingManager = systemServiceProvider.profilingManager ?: return
+        try {
+            profilingManager.removeProfilingTriggersByType(triggerTypes())
+            profilingManager.unregisterForAllProfilingResults(callback)
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Failed to remove profiling triggers", e)
+        } finally {
+            resultCallback = null
+        }
+    }
+
+    private fun triggerTypes(): IntArray = intArrayOf(
+        ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN,
+        ProfilingTrigger.TRIGGER_TYPE_ANR,
+    )
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun onProfilingResult(result: ProfilingResult) {
+        if (result.errorCode != ProfilingResult.ERROR_NONE) {
+            logger.log(
+                LogLevel.Debug,
+                "Profiling result error ${result.errorCode}: ${result.errorMessage}",
+            )
+            return
+        }
+        handleProfilingResult(result.resultFilePath, result.triggerType)
+    }
+
+    @VisibleForTesting
+    internal fun handleProfilingResult(filePath: String?, triggerType: Int) {
+        if (filePath.isNullOrEmpty()) {
+            return
+        }
+        val file = File(filePath)
+        if (!file.exists()) {
+            return
+        }
+        val format = formatFor(file.name)
+        if (format == null) {
+            logger.log(LogLevel.Debug, "Discarding profile with unrecognized format: ${file.name}")
+            return
+        }
+        val reason = reasonFor(triggerType)
+        if (reason == null) {
+            logger.log(
+                LogLevel.Debug,
+                "Discarding profile with unrecognized trigger: $triggerType",
+            )
+            return
+        }
+        if (!sampler.shouldSampleProfile()) {
+            return
+        }
+        val profileTimeMs = profileTimeFor(file)
+        // An ANR profile's file time is the trace finalization time, which can drift
+        // past a relaunch, so attribute it to the session that actually had an ANR near
+        // that time, and stamp it with the ANR time so it lands in that session's window.
+        // Other profiles are captured while the app is alive, so the session active at
+        // the profile time is correct.
+        val anrSession = if (reason == REASON_ANR) {
+            database.getSessionForAnr(profileTimeMs, MAX_ANR_TO_PROFILE_GAP_MS)
+        } else {
+            null
+        }
+        val session = anrSession ?: database.getSessionForTime(profileTimeMs)
+        signalProcessor.trackProfile(
+            data = ProfileData(reason = reason, format = format),
+            timestamp = anrSession?.lastAnrTime ?: profileTimeMs,
+            type = EventType.PROFILE,
+            attachments = mutableListOf(
+                Attachment(name = file.name, type = format, path = filePath),
+            ),
+            sessionId = session?.id ?: sessionManager.getSessionId(),
+            sessionStartTime = session?.createdAt,
+            appVersion = session?.appVersion,
+            appBuild = session?.appBuild,
+        )
+    }
+
+    private fun profileTimeFor(file: File): Long {
+        parseProfileTimestamp(file.name)?.let { return it }
+        val lastModified = file.lastModified()
+        if (lastModified > 0) {
+            return lastModified
+        }
+        return timeProvider.now()
+    }
+
+    // the platform stamps the file name with device-local wall clock time,
+    // e.g. profile_trigger-type-2_2026-07-05-17-51-56-124_uid-10229.perfetto-trace
+    private fun parseProfileTimestamp(fileName: String): Long? {
+        val timestamp = TIMESTAMP_REGEX.find(fileName)?.value ?: return null
+        return try {
+            SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US).parse(timestamp)?.time
+        } catch (e: ParseException) {
+            null
+        }
+    }
+
+    private fun formatFor(fileName: String): String? = when {
+        fileName.endsWith(PERFETTO_TRACE_EXTENSION) -> AttachmentType.PERFETTO_TRACE
+        fileName.endsWith(HEAP_DUMP_EXTENSION) -> AttachmentType.HEAP_DUMP
+        fileName.endsWith(HEAP_PROFILE_EXTENSION) -> AttachmentType.HEAP_PROFILE
+        else -> null
+    }
+
+    private fun reasonFor(triggerType: Int): String? = when (triggerType) {
+        ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN -> REASON_APP_LAUNCH
+        ProfilingTrigger.TRIGGER_TYPE_ANR -> REASON_ANR
+        else -> null
+    }
+
+    companion object {
+        private const val RATE_LIMITING_PERIOD_HOURS = 1
+        private const val PERFETTO_TRACE_EXTENSION = ".perfetto-trace"
+        private const val HEAP_DUMP_EXTENSION = ".hprof"
+        private const val HEAP_PROFILE_EXTENSION = ".heapprofd"
+        private const val TIMESTAMP_PATTERN = "yyyy-MM-dd-HH-mm-ss-SSS"
+        private val TIMESTAMP_REGEX = Regex("\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}")
+        private const val REASON_APP_LAUNCH = "app_launch"
+        private const val REASON_ANR = "anr"
+
+        // Bounds how far before a profile's capture time an ANR may have occurred
+        // to be considered its origin, so a stale, unrelated ANR is never matched.
+        private const val MAX_ANR_TO_PROFILE_GAP_MS = 3 * 60 * 1000L
+    }
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileData.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileData.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class ProfileData(
     /**
-     * The occasion that produced the profile, e.g. "app_launch" or "anr". For profiles captured by
+     * The occasion that produced the profile, e.g. "app_fully_drawn" or "anr". For profiles captured by
      * the platform [android.os.ProfilingManager] this is derived from the trigger that fired.
      */
     val reason: String,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileData.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileData.kt
@@ -1,0 +1,24 @@
+package sh.measure.android.profiling
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Data for a [sh.measure.android.events.EventType.PROFILE] event. The profile output file (a
+ * Perfetto trace or heap dump) is attached to the event separately, with the same [format].
+ */
+@Serializable
+internal data class ProfileData(
+    /**
+     * The occasion that produced the profile, e.g. "app_launch" or "anr". For profiles captured by
+     * the platform [android.os.ProfilingManager] this is derived from the trigger that fired.
+     */
+    val reason: String,
+
+    /**
+     * The format of the attached profile artifact, mirroring the attachment's type. One of
+     * [sh.measure.android.events.AttachmentType.PERFETTO_TRACE],
+     * [sh.measure.android.events.AttachmentType.HEAP_DUMP], or
+     * [sh.measure.android.events.AttachmentType.HEAP_PROFILE].
+     */
+    val format: String,
+)

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileUploadScheduler.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileUploadScheduler.kt
@@ -1,0 +1,98 @@
+package sh.measure.android.profiling
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import sh.measure.android.exporter.AttachmentPacket
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import java.util.concurrent.TimeUnit
+
+/**
+ * Outcome of trying to enqueue a profile upload, telling the caller what to do with the attachment
+ * row and file.
+ */
+internal enum class EnqueueResult {
+    /** Work enqueued. Remove the attachment row; leave the file for the worker. */
+    ENQUEUED,
+
+    /** Transient failure (e.g. WorkManager unavailable). Keep the row and retry on the next export. */
+    RETRY,
+
+    /** The descriptor cannot be carried as input data. Remove the row and the file; give up. */
+    DROP,
+}
+
+/**
+ * Enqueues a durable WorkManager job to upload a single profile artifact. The whole upload
+ * descriptor (file path, signed URL, content type, headers) is passed through the work's input data,
+ * so the worker never reads the SDK database.
+ *
+ * References `androidx.work` types directly; only instantiate when WorkManager is on the classpath.
+ */
+internal class ProfileUploadScheduler(
+    private val context: Context,
+    private val logger: Logger,
+) {
+    fun enqueue(attachment: AttachmentPacket): EnqueueResult {
+        val headersJson = Json.encodeToString(
+            MapSerializer(String.serializer(), String.serializer()),
+            attachment.headers,
+        )
+        val descriptorBytes = attachment.path.length + attachment.url.length + headersJson.length +
+            attachment.contentType.length + (attachment.contentEncoding?.length ?: 0) +
+            DESCRIPTOR_OVERHEAD_BYTES
+        if (descriptorBytes > MAX_DESCRIPTOR_BYTES) {
+            logger.log(
+                LogLevel.Error,
+                "Profile upload descriptor too large (${descriptorBytes}B) for ${attachment.id}",
+            )
+            return EnqueueResult.DROP
+        }
+
+        val data = Data.Builder()
+            .putString(ProfileUploadWorker.KEY_FILE_PATH, attachment.path)
+            .putString(ProfileUploadWorker.KEY_UPLOAD_URL, attachment.url)
+            .putString(ProfileUploadWorker.KEY_CONTENT_TYPE, attachment.contentType)
+            .putString(ProfileUploadWorker.KEY_CONTENT_ENCODING, attachment.contentEncoding)
+            .putString(ProfileUploadWorker.KEY_HEADERS, headersJson)
+            .build()
+        val request = OneTimeWorkRequest.Builder(ProfileUploadWorker::class.java)
+            .setInputData(data)
+            .setConstraints(
+                Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build(),
+            )
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_SECONDS, TimeUnit.SECONDS)
+            .build()
+        return try {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "$UNIQUE_WORK_PREFIX${attachment.id}",
+                ExistingWorkPolicy.KEEP,
+                request,
+            )
+            EnqueueResult.ENQUEUED
+        } catch (e: Exception) {
+            // WorkManager.getInstance throws if the host disabled its default initializer without
+            // providing a Configuration.Provider. Degrade rather than crash.
+            logger.log(LogLevel.Error, "Failed to enqueue profile upload for ${attachment.id}", e)
+            EnqueueResult.RETRY
+        }
+    }
+
+    companion object {
+        private const val UNIQUE_WORK_PREFIX = "sh.measure.android.profile-upload-"
+        private const val BACKOFF_SECONDS = 30L
+
+        // WorkManager caps input data at 10 KB; stay under it with room for serialization overhead.
+        private const val MAX_DESCRIPTOR_BYTES = 8 * 1024
+        private const val DESCRIPTOR_OVERHEAD_BYTES = 256
+    }
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileUploadWorker.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileUploadWorker.kt
@@ -1,0 +1,102 @@
+package sh.measure.android.profiling
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import okio.IOException
+import okio.source
+import sh.measure.android.exporter.HttpResponse
+import sh.measure.android.exporter.HttpUrlConnectionClient
+import sh.measure.android.logger.AndroidLogger
+import sh.measure.android.logger.LogLevel
+import java.io.File
+
+/**
+ * Uploads a single profile artifact described entirely by the worker's input data: the file path,
+ * signed URL, content type and headers. The worker is self-contained, it never opens the SDK
+ * database, so it cannot contend with the in-process exporter or cleanup, and it does not depend on
+ * the SDK being initialized in this process.
+ *
+ * Retries with WorkManager backoff only on transient or server errors. A client error (including an
+ * expired signed URL, which the server rejects with a 4xx) or a missing file is terminal: the file
+ * is removed and the work ends without rescheduling.
+ *
+ * References `androidx.work` types directly and is only loaded when WorkManager is on the classpath.
+ */
+internal class ProfileUploadWorker(
+    context: Context,
+    params: WorkerParameters,
+) : Worker(context, params) {
+    override fun doWork(): Result {
+        val logger = AndroidLogger(enabled = false)
+        val path = inputData.getString(KEY_FILE_PATH) ?: return Result.failure()
+        val url = inputData.getString(KEY_UPLOAD_URL) ?: return Result.failure()
+        val contentType = inputData.getString(KEY_CONTENT_TYPE) ?: DEFAULT_CONTENT_TYPE
+        val contentEncoding = inputData.getString(KEY_CONTENT_ENCODING)
+        val headers = decodeHeaders(inputData.getString(KEY_HEADERS))
+
+        val file = File(path)
+        if (!file.exists() || !file.canRead()) {
+            // The file was already removed; nothing left to upload.
+            return Result.success()
+        }
+
+        val httpClient = HttpUrlConnectionClient(logger)
+        return try {
+            val response = httpClient.uploadFile(
+                url = url,
+                contentType = contentType,
+                contentEncoding = contentEncoding,
+                headers = headers,
+                fileSize = file.length(),
+            ) { sink ->
+                sink.writeAll(file.source())
+            }
+            when (response) {
+                is HttpResponse.Success -> {
+                    file.delete()
+                    Result.success()
+                }
+
+                is HttpResponse.Error.ClientError -> {
+                    logger.log(
+                        LogLevel.Error,
+                        "ProfileUpload: ${response.code} for upload, dropping profile",
+                    )
+                    file.delete()
+                    Result.failure()
+                }
+
+                else -> Result.retry()
+            }
+        } catch (_: IOException) {
+            Result.retry()
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "ProfileUpload: failed to upload profile", e)
+            Result.failure()
+        }
+    }
+
+    private fun decodeHeaders(json: String?): Map<String, String> {
+        if (json.isNullOrEmpty()) {
+            return emptyMap()
+        }
+        return try {
+            Json.decodeFromString(MapSerializer(String.serializer(), String.serializer()), json)
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+
+    companion object {
+        const val KEY_FILE_PATH = "file_path"
+        const val KEY_UPLOAD_URL = "upload_url"
+        const val KEY_CONTENT_TYPE = "content_type"
+        const val KEY_CONTENT_ENCODING = "content_encoding"
+        const val KEY_HEADERS = "headers"
+        private const val DEFAULT_CONTENT_TYPE = "application/octet-stream"
+    }
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/DataCleanupService.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/DataCleanupService.kt
@@ -15,13 +15,16 @@ internal interface DataCleanupService {
 
 private const val DB_DELETION_BATCH_SIZE = 1000
 private const val MAX_SDK_DEBUG_LOG_FILES = 5
+private const val MAX_SESSIONS_TO_RETAIN = 5
 
 /**
  * Cleans up stale data from the database and file storage.
  *
  * This service deletes all events, attachments, and sessions that
  * are not marked for reporting. It also deletes events for the oldest session if
- * the total number of events in database exceeds the maximum allowed.
+ * the total number of events in database exceeds the maximum allowed. The rows of
+ * the most recently created sessions are always retained, so late-delivered
+ * signals can be attributed to the session they occurred in.
  */
 internal class DataCleanupServiceImpl(
     private val logger: Logger,
@@ -151,7 +154,9 @@ internal class DataCleanupServiceImpl(
         InternalTrace.trace(
             { "msr-deleteEmptySessions" },
             {
+                val retainedSessionIds = database.getRecentSessionIds(MAX_SESSIONS_TO_RETAIN).toSet()
                 val sessionIds = database.getSessionIds(excludeSessionId = currentSessionId)
+                    .filterNot { it in retainedSessionIds }
                 val sessionsToDelete = mutableListOf<String>()
                 for (sessionId in sessionIds) {
                     val events = database.getEventsCount(sessionId)
@@ -203,19 +208,19 @@ internal class DataCleanupServiceImpl(
         if (estimatedSizeInMb <= configProvider.maxDiskUsageInMb.coerceIn(20, 1500)) {
             return
         }
-        database.getOldestSession()?.let {
+        database.getOldestSessionWithSignals()?.let {
             if (it != currentSessionId) {
                 val eventIds = database.getEventsForSession(it)
                 fileStorage.deleteEventsIfExist(eventIds)
                 val attachmentIds = database.getAttachmentsForEvents(eventIds)
                 fileStorage.deleteAttachmentsIfExist(attachmentIds)
 
-                // deleting sessions from db will also delete events, spans and attachments for the session
-                // as they are cascaded deletes.
-                database.deleteSession(it)
+                // the session row is kept so late-delivered signals can still be
+                // attributed to it, deleteEmptySessions prunes it eventually.
+                database.deleteSessionData(it)
                 logger.log(
                     LogLevel.Debug,
-                    "DataCleanup: deleted session $it estimated storage: $estimatedSizeInMb, maxAllowed: ${configProvider.maxDiskUsageInMb}",
+                    "DataCleanup: deleted data for session $it estimated storage: $estimatedSizeInMb, maxAllowed: ${configProvider.maxDiskUsageInMb}",
                 )
             }
         }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -9,7 +9,6 @@ import android.database.sqlite.SQLiteDatabase.CONFLICT_IGNORE
 import android.database.sqlite.SQLiteException
 import android.database.sqlite.SQLiteOpenHelper
 import kotlinx.serialization.encodeToString
-import sh.measure.android.appexit.AppExitCollector
 import sh.measure.android.events.EventType
 import sh.measure.android.exporter.AttachmentPacket
 import sh.measure.android.exporter.Batch
@@ -58,9 +57,23 @@ internal interface Database : Closeable {
     fun getSessionIds(excludeSessionId: String): List<String>
 
     /**
-     * Returns the session ID of the oldest session, or `null` if no sessions exist.
+     * Returns session IDs of the [count] most recently created sessions.
      */
-    fun getOldestSession(): String?
+    fun getRecentSessionIds(count: Int): List<String>
+
+    /**
+     * Returns the session ID of the oldest session which still has events or
+     * spans, or `null` if no such session exists.
+     */
+    fun getOldestSessionWithSignals(): String?
+
+    /**
+     * Deletes all events, spans and attachments for a session while keeping the
+     * session row, so late-delivered signals can still be attributed to it.
+     *
+     * @param sessionId The session ID whose data should be deleted.
+     */
+    fun deleteSessionData(sessionId: String)
 
     /**
      * Updates all journey events for a given session as sampled.
@@ -190,11 +203,21 @@ internal interface Database : Closeable {
     fun getAttachmentsForEvents(events: List<String>): List<String>
 
     /**
-     * Returns attachments ready for upload (have signed URLs that haven't expired).
+     * Returns non-profile attachments ready for upload (have a signed URL). Profiles are excluded
+     * because they are uploaded by their own WorkManager worker; see [getProfileAttachmentsToUpload].
      *
      * @param maxCount Maximum number of attachments to return.
      */
     fun getAttachmentsToUpload(maxCount: Int): List<AttachmentPacket>
+
+    /**
+     * Returns profile attachments ready for upload (have a signed URL). Counterpart to
+     * [getAttachmentsToUpload]; the exporter drains these, handing each to the WorkManager-based
+     * profile upload subsystem and then deleting the row.
+     *
+     * @param maxCount Maximum number of attachments to return.
+     */
+    fun getProfileAttachmentsToUpload(maxCount: Int): List<AttachmentPacket>
 
     /**
      * Updates attachment records with signed upload URLs and expiration timestamps.
@@ -283,20 +306,53 @@ internal interface Database : Closeable {
 
     /**
      * Returns session data for app exit attribution based on process ID.
+     * Sessions already marked by [markSessionsAppExitTracked] are ignored.
      * If multiple sessions share the same PID, returns the most recent one.
      *
      * @param pid The process ID to look up.
      * @return Session data if found, `null` otherwise.
      */
-    fun getSessionForAppExit(pid: Int): AppExitCollector.Session?
+    fun getSessionForAppExit(pid: Int): SessionRecord?
 
     /**
-     * Deletes all app exit records in AppExit table except for the
-     * provided [excludeSessionId].
+     * Returns the session that was active at the given time, based on session
+     * start times.
      *
-     * @param excludeSessionId The session ID to exclude from deletion.
+     * @param timeMs Time in milliseconds since epoch.
+     * @return Session data if a session started at or before [timeMs], `null` otherwise.
      */
-    fun clearAppExitRecords(excludeSessionId: String)
+    fun getSessionForTime(timeMs: Long): SessionRecord?
+
+    /**
+     * Records that an ANR occurred in the given session, for attributing
+     * late-delivered ANR profiles. Keeps the latest ANR time if called
+     * multiple times for a session.
+     *
+     * @param sessionId The session the ANR occurred in.
+     * @param anrTimeMs The ANR time in milliseconds since epoch.
+     */
+    fun setSessionAnrTime(sessionId: String, anrTimeMs: Long)
+
+    /**
+     * Returns the most recent session that had an ANR at or before [timeMs] and
+     * within [maxGapMs] of it. Used to attribute an ANR profile back to the
+     * session where the ANR happened, even after a relaunch. The gap bounds the
+     * lookup so a profile is never attributed to a stale, unrelated ANR.
+     *
+     * @param timeMs The profile's capture time in milliseconds since epoch.
+     * @param maxGapMs The maximum allowed gap between the ANR and [timeMs].
+     * @return Session data if a matching ANR session is found, `null` otherwise.
+     */
+    fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord?
+
+    /**
+     * Marks all sessions except the provided [excludeSessionId] as having had
+     * their app exit tracked, hiding them from [getSessionForAppExit] so an
+     * app exit is never reported twice.
+     *
+     * @param excludeSessionId The session ID to exclude from marking.
+     */
+    fun markSessionsAppExitTracked(excludeSessionId: String)
 }
 
 /**
@@ -318,7 +374,6 @@ internal class DatabaseImpl(
             db.execSQL(Sql.CREATE_ATTACHMENTS_V1_TABLE)
             db.execSQL(Sql.CREATE_BATCHES_TABLE)
             db.execSQL(Sql.CREATE_EVENTS_BATCH_TABLE)
-            db.execSQL(Sql.CREATE_APP_EXIT_TABLE)
             db.execSQL(Sql.CREATE_SPANS_TABLE)
             db.execSQL(Sql.CREATE_SPANS_BATCH_TABLE)
             db.execSQL(Sql.CREATE_EVENTS_TIMESTAMP_INDEX)
@@ -327,7 +382,7 @@ internal class DatabaseImpl(
             db.execSQL(Sql.CREATE_SESSIONS_CREATED_AT_INDEX)
             db.execSQL(Sql.CREATE_SPANS_SESSION_SAMPLED_INDEX)
             db.execSQL(Sql.CREATE_SPANS_BATCH_SPAN_ID_INDEX)
-            db.execSQL(Sql.CREATE_APP_EXIT_PID_INDEX)
+            db.execSQL(Sql.CREATE_SESSIONS_PID_INDEX)
         } catch (e: SQLiteException) {
             logger.log(LogLevel.Debug, "Failed to create database", e)
         }
@@ -348,45 +403,27 @@ internal class DatabaseImpl(
 
     @SuppressLint("UseKtx")
     override fun insertSession(session: SessionEntity): Boolean {
-        writableDatabase.beginTransaction()
         try {
             val sessionValues = ContentValues().apply {
                 put(SessionsTable.COL_SESSION_ID, session.sessionId)
-                put(SessionsTable.COL_PID, 0)
+                put(SessionsTable.COL_PID, session.pid)
                 put(SessionsTable.COL_CREATED_AT, session.createdAt)
                 put(SessionsTable.COL_PRIORITY_SESSION, session.prioritySession)
                 put(SessionsTable.COL_CRASHED, false)
                 put(SessionsTable.COL_TRACK_JOURNEY, session.trackJourney)
+                put(SessionsTable.COL_APP_VERSION, session.appVersion)
+                put(SessionsTable.COL_APP_BUILD, session.appBuild)
             }
-            if (session.supportsAppExit) {
-                val appExitValues = ContentValues().apply {
-                    put(AppExitTable.COL_SESSION_ID, session.sessionId)
-                    put(AppExitTable.COL_PID, session.pid)
-                    put(AppExitTable.COL_CREATED_AT, session.createdAt)
-                    put(AppExitTable.COL_APP_VERSION, session.appVersion)
-                    put(AppExitTable.COL_APP_BUILD, session.appBuild)
-                }
-                writableDatabase.insertWithOnConflict(
-                    AppExitTable.TABLE_NAME,
-                    null,
-                    appExitValues,
-                    CONFLICT_IGNORE,
-                )
-            }
-
             val sessionsResult =
                 writableDatabase.insert(SessionsTable.TABLE_NAME, null, sessionValues)
             if (sessionsResult == -1L) {
                 logger.log(LogLevel.Debug, "Failed to insert session(${session.sessionId})")
                 return false
             }
-            writableDatabase.setTransactionSuccessful()
             return true
         } catch (e: Exception) {
             logger.log(LogLevel.Debug, "Failed to insert session(${session.sessionId})", e)
             return false
-        } finally {
-            writableDatabase.endTransaction()
         }
     }
 
@@ -415,9 +452,20 @@ internal class DatabaseImpl(
         return sessionIds
     }
 
-    override fun getOldestSession(): String? {
+    override fun getRecentSessionIds(count: Int): List<String> {
+        val sessionIds = mutableListOf<String>()
+        readableDatabase.rawQuery(Sql.getRecentSessionIds(count), null).use {
+            while (it.moveToNext()) {
+                val sessionIdIndex = it.getColumnIndex(SessionsTable.COL_SESSION_ID)
+                sessionIds.add(it.getString(sessionIdIndex))
+            }
+        }
+        return sessionIds
+    }
+
+    override fun getOldestSessionWithSignals(): String? {
         val sessionId: String
-        readableDatabase.rawQuery(Sql.getOldestSession(), null).use {
+        readableDatabase.rawQuery(Sql.getOldestSessionWithSignals(), null).use {
             if (it.count == 0) {
                 return null
             }
@@ -426,6 +474,32 @@ internal class DatabaseImpl(
             sessionId = it.getString(sessionIdIndex)
         }
         return sessionId
+    }
+
+    override fun deleteSessionData(sessionId: String) {
+        writableDatabase.beginTransaction()
+        try {
+            writableDatabase.delete(
+                EventTable.TABLE_NAME,
+                "${EventTable.COL_SESSION_ID} = ?",
+                arrayOf(sessionId),
+            )
+            writableDatabase.delete(
+                SpansTable.TABLE_NAME,
+                "${SpansTable.COL_SESSION_ID} = ?",
+                arrayOf(sessionId),
+            )
+            writableDatabase.delete(
+                AttachmentV1Table.TABLE_NAME,
+                "${AttachmentV1Table.COL_SESSION_ID} = ?",
+                arrayOf(sessionId),
+            )
+            writableDatabase.setTransactionSuccessful()
+        } catch (e: Exception) {
+            logger.log(LogLevel.Debug, "Failed to delete data for session($sessionId)", e)
+        } finally {
+            writableDatabase.endTransaction()
+        }
     }
 
     override fun sampleJourneyEvents(sessionId: String, journeyEventTypes: List<EventType>) {
@@ -894,10 +968,14 @@ internal class DatabaseImpl(
         return attachmentIds
     }
 
-    override fun getAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> {
+    override fun getAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getAttachmentsToUpload(maxCount))
+
+    override fun getProfileAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getProfileAttachmentsToUpload(maxCount))
+
+    private fun queryAttachmentsToUpload(sql: String): List<AttachmentPacket> {
         val attachments = mutableListOf<AttachmentPacket>()
         try {
-            readableDatabase.rawQuery(Sql.getAttachmentsToUpload(maxCount), null).use {
+            readableDatabase.rawQuery(sql, null).use {
                 while (it.moveToNext()) {
                     val idIndex = it.getColumnIndex(AttachmentV1Table.COL_ID)
                     val urlIndex = it.getColumnIndex(AttachmentV1Table.COL_UPLOAD_URL)
@@ -1212,36 +1290,42 @@ internal class DatabaseImpl(
     // App Exit Tracking
     // ========================================================================================
 
-    override fun getSessionForAppExit(pid: Int): AppExitCollector.Session? {
-        readableDatabase.rawQuery(Sql.getSessionForAppExit(pid), null).use {
-            if (it.count == 0) {
+    override fun getSessionForAppExit(pid: Int): SessionRecord? = querySessionRecord(Sql.getSessionForAppExit(pid))
+
+    override fun getSessionForTime(timeMs: Long): SessionRecord? = querySessionRecord(Sql.getSessionForTime(timeMs))
+
+    override fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord? = querySessionRecord(Sql.getSessionForAnr(timeMs, maxGapMs))
+
+    private fun querySessionRecord(query: String): SessionRecord? {
+        readableDatabase.rawQuery(query, null).use {
+            if (!it.moveToFirst()) {
                 return null
             }
-            it.moveToFirst()
-            val sessionIdIndex = it.getColumnIndex(AppExitTable.COL_SESSION_ID)
-            val createdAtIndex = it.getColumnIndex(AppExitTable.COL_CREATED_AT)
-            val appVersionIndex = it.getColumnIndex(AppExitTable.COL_APP_VERSION)
-            val appBuildIndex = it.getColumnIndex(AppExitTable.COL_APP_BUILD)
-
-            val sessionId = it.getString(sessionIdIndex)
-            val createdAt = it.getLong(createdAtIndex)
-            val appVersion: String? = it.getString(appVersionIndex)
-            val appBuild: String? = it.getString(appBuildIndex)
-
-            return AppExitCollector.Session(
-                id = sessionId,
-                createdAt = createdAt,
-                pid = pid,
-                appVersion = appVersion,
-                appBuild = appBuild,
+            val lastAnrTimeIndex = it.getColumnIndexOrThrow(SessionsTable.COL_LAST_ANR_TIME)
+            return SessionRecord(
+                id = it.getString(it.getColumnIndexOrThrow(SessionsTable.COL_SESSION_ID)),
+                createdAt = it.getLong(it.getColumnIndexOrThrow(SessionsTable.COL_CREATED_AT)),
+                appVersion = it.getString(it.getColumnIndexOrThrow(SessionsTable.COL_APP_VERSION)),
+                appBuild = it.getString(it.getColumnIndexOrThrow(SessionsTable.COL_APP_BUILD)),
+                lastAnrTime = if (it.isNull(lastAnrTimeIndex)) null else it.getLong(lastAnrTimeIndex),
             )
         }
     }
 
-    override fun clearAppExitRecords(excludeSessionId: String) {
-        writableDatabase.delete(
-            AppExitTable.TABLE_NAME,
-            "${AppExitTable.COL_SESSION_ID} != ?",
+    override fun setSessionAnrTime(sessionId: String, anrTimeMs: Long) {
+        writableDatabase.compileStatement(Sql.setSessionAnrTime(sessionId, anrTimeMs)).use {
+            it.executeUpdateDelete()
+        }
+    }
+
+    override fun markSessionsAppExitTracked(excludeSessionId: String) {
+        val values = ContentValues().apply {
+            put(SessionsTable.COL_APP_EXIT_TRACKED, 1)
+        }
+        writableDatabase.update(
+            SessionsTable.TABLE_NAME,
+            values,
+            "${SessionsTable.COL_SESSION_ID} != ?",
             arrayOf(excludeSessionId),
         )
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -88,9 +88,11 @@ internal interface Database : Closeable {
      * Inserts an event and its associated attachments in a single transaction.
      *
      * @param event The event entity to insert.
+     * @param sessionAnrTimeMs When non-null, records this ANR time against the event's
+     * session in the same transaction. See [setSessionAnrTime].
      * @return `true` if successful, `false` otherwise.
      */
-    fun insertEvent(event: EventEntity): Boolean
+    fun insertEvent(event: EventEntity, sessionAnrTimeMs: Long? = null): Boolean
 
     /**
      * Retrieves event packets for the given event IDs.
@@ -523,7 +525,7 @@ internal class DatabaseImpl(
     // ========================================================================================
 
     @SuppressLint("UseKtx")
-    override fun insertEvent(event: EventEntity): Boolean {
+    override fun insertEvent(event: EventEntity, sessionAnrTimeMs: Long?): Boolean {
         writableDatabase.beginTransaction()
         try {
             val values = ContentValues().apply {
@@ -569,6 +571,11 @@ internal class DatabaseImpl(
                     )
                     return false
                 }
+            }
+            if (sessionAnrTimeMs != null) {
+                writableDatabase
+                    .compileStatement(Sql.setSessionAnrTime(event.sessionId, sessionAnrTimeMs))
+                    .use { it.executeUpdateDelete() }
             }
             writableDatabase.setTransactionSuccessful()
             return true

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
@@ -1,10 +1,11 @@
 package sh.measure.android.storage
 
+import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
 
 internal object DbConstants {
     const val DATABASE_NAME = "measure.db"
-    const val DATABASE_VERSION = DbVersion.V7
+    const val DATABASE_VERSION = DbVersion.V9
 }
 
 internal object DbVersion {
@@ -15,6 +16,8 @@ internal object DbVersion {
     const val V5 = 5
     const val V6 = 6
     const val V7 = 7
+    const val V8 = 8
+    const val V9 = 9
 }
 
 internal object EventTable {
@@ -81,14 +84,13 @@ internal object SpansBatchTable {
 internal object SessionsTable {
     const val TABLE_NAME = "sessions"
     const val COL_SESSION_ID = "session_id"
-
-    @Deprecated("Use AppExitTable instead")
     const val COL_PID = "pid"
     const val COL_CREATED_AT = "created_at"
-
-    @Deprecated("Use AppExitTable instead")
     const val COL_APP_EXIT_TRACKED = "app_exit_tracked"
     const val COL_PRIORITY_SESSION = "needs_reporting"
+    const val COL_APP_VERSION = "app_version"
+    const val COL_APP_BUILD = "app_build"
+    const val COL_LAST_ANR_TIME = "last_anr_time"
 
     @Deprecated("No longer used")
     const val COL_CRASHED = "crashed"
@@ -97,6 +99,9 @@ internal object SessionsTable {
     const val COL_TRACK_JOURNEY = "track_journey"
 }
 
+/**
+ * Dropped in [DbVersion.V8]; referenced only by migrations.
+ */
 internal object AppExitTable {
     const val TABLE_NAME = "app_exit"
     const val COL_SESSION_ID = "session_id"
@@ -199,7 +204,10 @@ internal object Sql {
             ${SessionsTable.COL_APP_EXIT_TRACKED} INTEGER DEFAULT 0,
             ${SessionsTable.COL_PRIORITY_SESSION} INTEGER DEFAULT 0,
             ${SessionsTable.COL_CRASHED} INTEGER DEFAULT 0,
-            ${SessionsTable.COL_TRACK_JOURNEY} INTEGER DEFAULT 0
+            ${SessionsTable.COL_TRACK_JOURNEY} INTEGER DEFAULT 0,
+            ${SessionsTable.COL_APP_VERSION} TEXT DEFAULT NULL,
+            ${SessionsTable.COL_APP_BUILD} TEXT DEFAULT NULL,
+            ${SessionsTable.COL_LAST_ANR_TIME} INTEGER DEFAULT NULL
         )
     """
 
@@ -259,9 +267,9 @@ internal object Sql {
         ON ${SpansBatchTable.TABLE_NAME}(${SpansBatchTable.COL_SPAN_ID})
     """
 
-    const val CREATE_APP_EXIT_PID_INDEX = """
-        CREATE INDEX IF NOT EXISTS idx_app_exit_pid_created 
-        ON ${AppExitTable.TABLE_NAME}(${AppExitTable.COL_PID}, ${AppExitTable.COL_CREATED_AT} DESC)
+    const val CREATE_SESSIONS_PID_INDEX = """
+        CREATE INDEX IF NOT EXISTS sessions_pid_created_at_index
+        ON ${SessionsTable.TABLE_NAME}(${SessionsTable.COL_PID}, ${SessionsTable.COL_CREATED_AT} DESC)
     """
 
     fun getEventsForIds(eventIds: List<String>): String = """
@@ -310,9 +318,23 @@ internal object Sql {
             WHERE ${AttachmentV1Table.COL_EVENT_ID} IN (${events.joinToString(", ") { "\'$it\'" }})
     """.trimIndent()
 
-    fun getOldestSession(): String = """
+    fun getRecentSessionIds(count: Int): String = """
             SELECT ${SessionsTable.COL_SESSION_ID}
             FROM ${SessionsTable.TABLE_NAME}
+            ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
+            LIMIT $count
+    """.trimIndent()
+
+    fun getOldestSessionWithSignals(): String = """
+            SELECT ${SessionsTable.COL_SESSION_ID}
+            FROM ${SessionsTable.TABLE_NAME}
+            WHERE EXISTS (
+                SELECT 1 FROM ${EventTable.TABLE_NAME}
+                WHERE ${EventTable.TABLE_NAME}.${EventTable.COL_SESSION_ID} = ${SessionsTable.TABLE_NAME}.${SessionsTable.COL_SESSION_ID}
+            ) OR EXISTS (
+                SELECT 1 FROM ${SpansTable.TABLE_NAME}
+                WHERE ${SpansTable.TABLE_NAME}.${SpansTable.COL_SESSION_ID} = ${SessionsTable.TABLE_NAME}.${SessionsTable.COL_SESSION_ID}
+            )
             ORDER BY ${SessionsTable.COL_CREATED_AT} ASC
             LIMIT 1
     """.trimIndent()
@@ -339,16 +361,46 @@ internal object Sql {
             FROM ${SpansTable.TABLE_NAME}
     """.trimIndent()
 
+    // Columns read into a SessionRecord; all getSessionFor* queries select these.
+    private val SESSION_RECORD_COLUMNS = listOf(
+        SessionsTable.COL_SESSION_ID,
+        SessionsTable.COL_CREATED_AT,
+        SessionsTable.COL_APP_VERSION,
+        SessionsTable.COL_APP_BUILD,
+        SessionsTable.COL_LAST_ANR_TIME,
+    ).joinToString(", ")
+
     fun getSessionForAppExit(pid: Int): String = """
-            SELECT
-                ${AppExitTable.COL_SESSION_ID},
-                ${AppExitTable.COL_CREATED_AT},
-                ${AppExitTable.COL_APP_VERSION},
-                ${AppExitTable.COL_APP_BUILD}
-            FROM ${AppExitTable.TABLE_NAME}
-            WHERE ${AppExitTable.COL_PID} = $pid 
-            ORDER BY ${AppExitTable.COL_CREATED_AT} DESC
+            SELECT $SESSION_RECORD_COLUMNS
+            FROM ${SessionsTable.TABLE_NAME}
+            WHERE ${SessionsTable.COL_PID} = $pid AND ${SessionsTable.COL_APP_EXIT_TRACKED} = 0
+            ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
             LIMIT 1
+    """.trimIndent()
+
+    fun getSessionForTime(timeMs: Long): String = """
+            SELECT $SESSION_RECORD_COLUMNS
+            FROM ${SessionsTable.TABLE_NAME}
+            WHERE ${SessionsTable.COL_CREATED_AT} <= $timeMs
+            ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
+            LIMIT 1
+    """.trimIndent()
+
+    fun getSessionForAnr(timeMs: Long, maxGapMs: Long): String = """
+            SELECT $SESSION_RECORD_COLUMNS
+            FROM ${SessionsTable.TABLE_NAME}
+            WHERE ${SessionsTable.COL_LAST_ANR_TIME} IS NOT NULL
+                AND ${SessionsTable.COL_LAST_ANR_TIME} <= $timeMs
+                AND $timeMs - ${SessionsTable.COL_LAST_ANR_TIME} <= $maxGapMs
+            ORDER BY ${SessionsTable.COL_LAST_ANR_TIME} DESC
+            LIMIT 1
+    """.trimIndent()
+
+    fun setSessionAnrTime(sessionId: String, anrTimeMs: Long): String = """
+            UPDATE ${SessionsTable.TABLE_NAME}
+            SET ${SessionsTable.COL_LAST_ANR_TIME} = $anrTimeMs
+            WHERE ${SessionsTable.COL_SESSION_ID} = '$sessionId'
+                AND (${SessionsTable.COL_LAST_ANR_TIME} IS NULL OR ${SessionsTable.COL_LAST_ANR_TIME} < $anrTimeMs)
     """.trimIndent()
 
     fun getBatchedEventIds(batchIds: List<String>): String = """
@@ -373,6 +425,13 @@ internal object Sql {
                 IN (${batchIds.joinToString(", ") { "'$it'" }})
     """.trimIndent()
 
+    // Profiles are uploaded by their own WorkManager worker, not the in-process drain.
+    private val profileTypesList = listOf(
+        AttachmentType.PERFETTO_TRACE,
+        AttachmentType.HEAP_DUMP,
+        AttachmentType.HEAP_PROFILE,
+    ).joinToString(", ") { "'$it'" }
+
     fun getAttachmentsToUpload(maxCount: Int): String = """
             SELECT
                 ${AttachmentV1Table.COL_ID},
@@ -389,6 +448,28 @@ internal object Sql {
                 ${AttachmentV1Table.TABLE_NAME}
             WHERE
                 ${AttachmentV1Table.COL_UPLOAD_URL} IS NOT NULL
+                AND ${AttachmentV1Table.COL_TYPE} NOT IN ($profileTypesList)
+            LIMIT
+                $maxCount
+    """.trimIndent()
+
+    fun getProfileAttachmentsToUpload(maxCount: Int): String = """
+            SELECT
+                ${AttachmentV1Table.COL_ID},
+                ${AttachmentV1Table.COL_EVENT_ID},
+                ${AttachmentV1Table.COL_SESSION_ID},
+                ${AttachmentV1Table.COL_TIMESTAMP},
+                ${AttachmentV1Table.COL_TYPE},
+                ${AttachmentV1Table.COL_FILE_PATH},
+                ${AttachmentV1Table.COL_NAME},
+                ${AttachmentV1Table.COL_UPLOAD_URL},
+                ${AttachmentV1Table.COL_URL_EXPIRES_AT},
+                ${AttachmentV1Table.COL_URL_HEADERS}
+            FROM
+                ${AttachmentV1Table.TABLE_NAME}
+            WHERE
+                ${AttachmentV1Table.COL_UPLOAD_URL} IS NOT NULL
+                AND ${AttachmentV1Table.COL_TYPE} IN ($profileTypesList)
             LIMIT
                 $maxCount
     """.trimIndent()

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbMigrations.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbMigrations.kt
@@ -19,6 +19,8 @@ internal object DbMigrations {
                             DbVersion.V5 -> migrateToV5(this)
                             DbVersion.V6 -> migrateToV6(this)
                             DbVersion.V7 -> migrateToV7(this)
+                            DbVersion.V8 -> migrateToV8(this)
+                            DbVersion.V9 -> migrateToV9(this)
                             else -> logger.log(
                                 LogLevel.Debug,
                                 "Db migration failed: $version not found ",
@@ -106,5 +108,45 @@ internal object DbMigrations {
     private fun migrateToV7(db: SQLiteDatabase) {
         db.execSQL("ALTER TABLE ${EventTable.TABLE_NAME} ADD COLUMN ${EventTable.COL_SAMPLED} INTEGER DEFAULT 0;")
         db.execSQL("DROP INDEX IF EXISTS sessions_needs_reporting_index")
+    }
+
+    private fun migrateToV8(db: SQLiteDatabase) {
+        db.execSQL("ALTER TABLE ${SessionsTable.TABLE_NAME} ADD COLUMN ${SessionsTable.COL_APP_VERSION} TEXT DEFAULT NULL;")
+        db.execSQL("ALTER TABLE ${SessionsTable.TABLE_NAME} ADD COLUMN ${SessionsTable.COL_APP_BUILD} TEXT DEFAULT NULL;")
+        db.execSQL(
+            """
+            UPDATE ${SessionsTable.TABLE_NAME}
+            SET ${SessionsTable.COL_PID} = (
+                    SELECT ${AppExitTable.COL_PID} FROM ${AppExitTable.TABLE_NAME}
+                    WHERE ${AppExitTable.TABLE_NAME}.${AppExitTable.COL_SESSION_ID} = ${SessionsTable.TABLE_NAME}.${SessionsTable.COL_SESSION_ID}
+                ),
+                ${SessionsTable.COL_APP_VERSION} = (
+                    SELECT ${AppExitTable.COL_APP_VERSION} FROM ${AppExitTable.TABLE_NAME}
+                    WHERE ${AppExitTable.TABLE_NAME}.${AppExitTable.COL_SESSION_ID} = ${SessionsTable.TABLE_NAME}.${SessionsTable.COL_SESSION_ID}
+                ),
+                ${SessionsTable.COL_APP_BUILD} = (
+                    SELECT ${AppExitTable.COL_APP_BUILD} FROM ${AppExitTable.TABLE_NAME}
+                    WHERE ${AppExitTable.TABLE_NAME}.${AppExitTable.COL_SESSION_ID} = ${SessionsTable.TABLE_NAME}.${SessionsTable.COL_SESSION_ID}
+                )
+            WHERE ${SessionsTable.COL_SESSION_ID} IN (
+                SELECT ${AppExitTable.COL_SESSION_ID} FROM ${AppExitTable.TABLE_NAME}
+            );
+            """.trimIndent(),
+        )
+        db.execSQL(
+            """
+            UPDATE ${SessionsTable.TABLE_NAME}
+            SET ${SessionsTable.COL_APP_EXIT_TRACKED} = 1
+            WHERE ${SessionsTable.COL_SESSION_ID} NOT IN (
+                SELECT ${AppExitTable.COL_SESSION_ID} FROM ${AppExitTable.TABLE_NAME}
+            );
+            """.trimIndent(),
+        )
+        db.execSQL(Sql.CREATE_SESSIONS_PID_INDEX)
+        db.execSQL("DROP TABLE IF EXISTS ${AppExitTable.TABLE_NAME}")
+    }
+
+    private fun migrateToV9(db: SQLiteDatabase) {
+        db.execSQL("ALTER TABLE ${SessionsTable.TABLE_NAME} ADD COLUMN ${SessionsTable.COL_LAST_ANR_TIME} INTEGER DEFAULT NULL;")
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/Entities.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/Entities.kt
@@ -113,11 +113,22 @@ internal data class SessionEntity(
     val prioritySession: Boolean = false,
     @Deprecated("No longer used")
     val crashed: Boolean = false,
-    val supportsAppExit: Boolean,
     val appVersion: String?,
     val appBuild: String?,
     @Deprecated("No longer used")
     val trackJourney: Boolean = false,
+)
+
+/**
+ * A session row read back from the sessions table, used to attribute
+ * late-delivered signals to the session active when they originated.
+ */
+internal data class SessionRecord(
+    val id: String,
+    val createdAt: Long,
+    val appVersion: String?,
+    val appBuild: String?,
+    val lastAnrTime: Long? = null,
 )
 
 internal data class BatchEntity(

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/EventExtensions.kt
@@ -30,6 +30,7 @@ import sh.measure.android.okhttp.HttpData
 import sh.measure.android.performance.CpuUsageData
 import sh.measure.android.performance.MemoryUsageData
 import sh.measure.android.performance.TrimMemoryData
+import sh.measure.android.profiling.ProfileData
 import sh.measure.android.utils.toJsonElement
 
 private val json by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
@@ -167,5 +168,12 @@ internal fun <T> Event<T>.serializeDataToString(): String = when (type) {
 
     EventType.SESSION_START -> {
         json.encodeToString(SessionStartData.serializer(), data as SessionStartData)
+    }
+
+    EventType.PROFILE -> {
+        json.encodeToString(
+            ProfileData.serializer(),
+            data as ProfileData,
+        )
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface SignalStore {
-    fun <T> store(event: Event<T>)
+    fun <T> store(event: Event<T>, sessionAnrTimeMs: Long? = null)
     fun store(spanData: SpanData)
     fun flush()
 }
@@ -66,7 +66,7 @@ internal class SignalStoreImpl(
         }
     }
 
-    override fun <T> store(event: Event<T>) {
+    override fun <T> store(event: Event<T>, sessionAnrTimeMs: Long?) {
         try {
             val eventEntity = event.toEventEntity()
             if (eventEntity == null) {
@@ -88,7 +88,7 @@ internal class SignalStoreImpl(
 
             when {
                 collectTimeline -> {
-                    val success = database.insertEvent(eventEntity)
+                    val success = database.insertEvent(eventEntity, sessionAnrTimeMs)
                     flush()
                     if (!success) {
                         handleEventInsertionFailure(eventEntity)

--- a/android/measure-android/measure/src/main/java/sh/measure/android/utils/Sampler.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/utils/Sampler.kt
@@ -7,6 +7,7 @@ internal interface Sampler {
     fun shouldSampleLaunchEvent(): Boolean
     fun shouldTrackJourneyForSession(sessionId: String): Boolean
     fun shouldSampleHttpEvent(): Boolean
+    fun shouldSampleProfile(): Boolean
 }
 
 internal class SamplerImpl(
@@ -63,6 +64,17 @@ internal class SamplerImpl(
         }
 
         return randomizer.random() < (configProvider.httpSamplingRate / 100)
+    }
+
+    override fun shouldSampleProfile(): Boolean {
+        if (configProvider.profileSamplingRate == 0.0f) {
+            return false
+        }
+        if (configProvider.profileSamplingRate == 100f) {
+            return true
+        }
+
+        return randomizer.random() < (configProvider.profileSamplingRate / 100)
     }
 
     /**

--- a/android/measure-android/measure/src/main/java/sh/measure/android/utils/SystemServiceProvider.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/utils/SystemServiceProvider.kt
@@ -4,8 +4,11 @@ import android.app.ActivityManager
 import android.content.Context
 import android.hardware.SensorManager
 import android.net.ConnectivityManager
+import android.os.Build
 import android.os.PowerManager
+import android.os.ProfilingManager
 import android.telephony.TelephonyManager
+import androidx.annotation.RequiresApi
 
 internal interface SystemServiceProvider {
     val powerManager: PowerManager?
@@ -13,6 +16,9 @@ internal interface SystemServiceProvider {
     val telephonyManager: TelephonyManager?
     val activityManager: ActivityManager?
     val sensorManager: SensorManager?
+
+    @get:RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    val profilingManager: ProfilingManager?
 }
 
 internal class SystemServiceProviderImpl(private val context: Context) : SystemServiceProvider {
@@ -34,5 +40,14 @@ internal class SystemServiceProviderImpl(private val context: Context) : SystemS
 
     override val sensorManager: SensorManager? by lazy(mode = LazyThreadSafetyMode.NONE) {
         runCatching { context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager }.getOrNull()
+    }
+
+    @get:RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    override val profilingManager: ProfilingManager? by lazy(mode = LazyThreadSafetyMode.NONE) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) {
+            null
+        } else {
+            runCatching { context.getSystemService(ProfilingManager::class.java) }.getOrNull()
+        }
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/MeasureInternalTest.kt
@@ -49,6 +49,7 @@ class MeasureInternalTest {
         `when`(initializer.appLifecycleCollector).thenReturn(mock())
         `when`(initializer.gestureCollector).thenReturn(mock())
         `when`(initializer.appLaunchCollector).thenReturn(mock())
+        `when`(initializer.profileCollector).thenReturn(mock())
         `when`(initializer.networkChangesCollector).thenReturn(mock())
         `when`(initializer.appExitCollector).thenReturn(mock())
         `when`(initializer.userAttributeProcessor).thenReturn(mock())

--- a/android/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -1,6 +1,5 @@
 package sh.measure.android
 
-import android.os.Build
 import androidx.concurrent.futures.ResolvableFuture
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -103,7 +102,6 @@ class SessionManagerTest {
             createdAt = timeProvider.now(),
             prioritySession = false,
             crashed = false,
-            supportsAppExit = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R,
             trackJourney = false,
             appBuild = packageInfoProvider.getVersionCode(),
             appVersion = packageInfoProvider.appVersion,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -16,16 +16,20 @@ import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.fakes.FakeProcessInfoProvider
+import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.storage.Database
 
 class AnrCollectorTest {
     private val logger = NoopLogger()
     private val processInfo = FakeProcessInfoProvider()
     private val signalProcessor = mock<SignalProcessor>()
     private val nativeBridge = mock<NativeBridge>()
+    private val database = mock<Database>()
+    private val sessionManager = FakeSessionManager()
     private val looper = mock<Looper>()
     private val anrCollector =
-        AnrCollector(processInfo, signalProcessor, nativeBridge, looper)
+        AnrCollector(processInfo, signalProcessor, nativeBridge, database, sessionManager, looper)
 
     @Test
     fun `register enables anr reporting and registers itself as listener`() {
@@ -77,5 +81,16 @@ class AnrCollectorTest {
         assertEquals(expectedAnrError.timestamp, timestampCaptor.firstValue)
         assertEquals(null, dataCaptor.firstValue.severity)
         assertEquals(processInfo.isForegroundProcess(), dataCaptor.firstValue.foreground)
+    }
+
+    @Test
+    fun `records the ANR time against the current session`() {
+        val thread = Thread.currentThread()
+        `when`(looper.thread).thenReturn(thread)
+        val timestamp = 876544454L
+
+        anrCollector.onAnrDetected(timestamp)
+
+        verify(database).setSessionAnrTime(sessionManager.getSessionId(), timestamp)
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -16,20 +16,16 @@ import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.fakes.FakeProcessInfoProvider
-import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.NoopLogger
-import sh.measure.android.storage.Database
 
 class AnrCollectorTest {
     private val logger = NoopLogger()
     private val processInfo = FakeProcessInfoProvider()
     private val signalProcessor = mock<SignalProcessor>()
     private val nativeBridge = mock<NativeBridge>()
-    private val database = mock<Database>()
-    private val sessionManager = FakeSessionManager()
     private val looper = mock<Looper>()
     private val anrCollector =
-        AnrCollector(processInfo, signalProcessor, nativeBridge, database, sessionManager, looper)
+        AnrCollector(processInfo, signalProcessor, nativeBridge, looper)
 
     @Test
     fun `register enables anr reporting and registers itself as listener`() {
@@ -81,16 +77,5 @@ class AnrCollectorTest {
         assertEquals(expectedAnrError.timestamp, timestampCaptor.firstValue)
         assertEquals(null, dataCaptor.firstValue.severity)
         assertEquals(processInfo.isForegroundProcess(), dataCaptor.firstValue.foreground)
-    }
-
-    @Test
-    fun `records the ANR time against the current session`() {
-        val thread = Thread.currentThread()
-        `when`(looper.thread).thenReturn(thread)
-        val timestamp = 876544454L
-
-        anrCollector.onAnrDetected(timestamp)
-
-        verify(database).setSessionAnrTime(sessionManager.getSessionId(), timestamp)
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
@@ -6,6 +6,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
@@ -13,6 +14,7 @@ import sh.measure.android.fakes.FakeAppExitProvider
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.TestData
 import sh.measure.android.storage.Database
+import sh.measure.android.storage.SessionRecord
 
 class AppExitCollectorTest {
     private val appExitProvider = FakeAppExitProvider()
@@ -53,6 +55,7 @@ class AppExitCollectorTest {
             appBuild = eq("1000"),
             isSampled = any(),
         )
+        verify(database).setSessionAnrTime(session.id, appExit.app_exit_time_ms)
     }
 
     @Test
@@ -98,7 +101,31 @@ class AppExitCollectorTest {
     }
 
     @Test
-    fun `clears sessions that happened before the latest app exit`() {
+    fun `given no session is available for given pid, does not track app exit event`() {
+        // Given
+        val appExit = TestData.getAppExit(reasonId = ApplicationExitInfo.REASON_ANR)
+        appExitProvider.appExits = mapOf(1 to appExit)
+        `when`(database.getSessionForAppExit(1)).thenReturn(null)
+
+        // When
+        appExitCollector.collect()
+
+        // Then
+        verify(signalProcessor, never()).trackAppExit(
+            any(),
+            any(),
+            any(),
+            threadName = any(),
+            sessionId = any(),
+            sessionStartTime = any(),
+            appVersion = any(),
+            appBuild = any(),
+            isSampled = any(),
+        )
+    }
+
+    @Test
+    fun `marks all sessions except the current one as app exit tracked`() {
         // Given
         val appExit1 = TestData.getAppExit(reasonId = ApplicationExitInfo.REASON_ANR)
         val session1 = getSession(sessionId = "session-1", pid = 1, createdAt = 1000)
@@ -113,7 +140,7 @@ class AppExitCollectorTest {
         appExitCollector.collect()
 
         // Then
-        verify(database).clearAppExitRecords(sessionManager.getSessionId())
+        verify(database).markSessionsAppExitTracked(sessionManager.getSessionId())
     }
 
     private fun getSession(
@@ -122,9 +149,8 @@ class AppExitCollectorTest {
         createdAt: Long = 98765,
         appVersion: String = "1.0.0",
         appBuild: String = "1000",
-    ) = AppExitCollector.Session(
+    ) = SessionRecord(
         id = sessionId,
-        pid = pid,
         createdAt = createdAt,
         appVersion = appVersion,
         appBuild = appBuild,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
@@ -292,6 +292,7 @@ internal class SignalProcessorTest {
         )
 
         assertEquals(1, signalStore.trackedEvents.size)
+        assertEquals(null, signalStore.trackedSessionAnrTimes.first())
         verify(exporter).export()
     }
 
@@ -309,6 +310,7 @@ internal class SignalProcessorTest {
         )
 
         assertEquals(1, signalStore.trackedEvents.size)
+        assertEquals(timestamp, signalStore.trackedSessionAnrTimes.first())
         verify(exporter).export()
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
@@ -21,6 +21,7 @@ import sh.measure.android.fakes.ImmediateExecutorService
 import sh.measure.android.fakes.NoopLogger
 import sh.measure.android.fakes.TestData
 import sh.measure.android.fakes.TestData.toEvent
+import sh.measure.android.profiling.ProfileData
 import sh.measure.android.screenshot.Screenshot
 import sh.measure.android.screenshot.ScreenshotCollector
 import sh.measure.android.utils.iso8601Timestamp
@@ -440,6 +441,62 @@ internal class SignalProcessorTest {
         )
         assertEquals(appVersion, event.attributes[Attribute.APP_VERSION_KEY])
         assertEquals(appBuild, event.attributes[Attribute.APP_BUILD_KEY])
+    }
+
+    @Test
+    fun `trackProfile stores event with provided sessionId, session start time and version attributes`() {
+        val profileData = ProfileData(reason = "anr", format = "perfetto_trace")
+        val timestamp = 1710746412L
+        val sessionId = "session-id-profile"
+        val sessionStartTime = 1710746000L
+
+        signalProcessor.trackProfile(
+            data = profileData,
+            timestamp = timestamp,
+            type = EventType.PROFILE,
+            attachments = mutableListOf(),
+            sessionId = sessionId,
+            sessionStartTime = sessionStartTime,
+            appVersion = "app-version",
+            appBuild = "1000",
+            isSampled = true,
+        )
+
+        assertEquals(1, signalStore.trackedEvents.size)
+        val event = signalStore.trackedEvents.first()
+        assertEquals(EventType.PROFILE, event.type)
+        assertEquals(sessionId, event.sessionId)
+        assertEquals(timestamp.iso8601Timestamp(), event.timestamp)
+        assertEquals(
+            sessionStartTime.iso8601Timestamp(),
+            event.attributes[Attribute.SESSION_START_TIME_KEY],
+        )
+        assertEquals("app-version", event.attributes[Attribute.APP_VERSION_KEY])
+        assertEquals("1000", event.attributes[Attribute.APP_BUILD_KEY])
+    }
+
+    @Test
+    fun `trackProfile leaves session attributes untouched when they are unknown`() {
+        val profileData = ProfileData(reason = "anr", format = "perfetto_trace")
+
+        signalProcessor.trackProfile(
+            data = profileData,
+            timestamp = 1710746412L,
+            type = EventType.PROFILE,
+            attachments = mutableListOf(),
+            sessionId = "session-id-profile",
+            sessionStartTime = null,
+            appVersion = null,
+            appBuild = null,
+            isSampled = true,
+        )
+
+        assertEquals(1, signalStore.trackedEvents.size)
+        val event = signalStore.trackedEvents.first()
+        assertEquals("session-id-profile", event.sessionId)
+        assertEquals(null, event.attributes[Attribute.SESSION_START_TIME_KEY])
+        assertEquals(null, event.attributes[Attribute.APP_VERSION_KEY])
+        assertEquals(null, event.attributes[Attribute.APP_BUILD_KEY])
     }
 
     @Test

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -2,7 +2,6 @@
 
 package sh.measure.android.exporter
 
-import android.os.Build
 import androidx.concurrent.futures.ResolvableFuture
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -808,7 +807,6 @@ internal class ExporterTest {
                 pid = 12345,
                 createdAt = 12345,
                 prioritySession = prioritySession,
-                supportsAppExit = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R,
                 appVersion = "1.0.0",
                 appBuild = "100",
                 trackJourney = false,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeConfigProvider.kt
@@ -52,6 +52,7 @@ internal class FakeConfigProvider : ConfigProvider {
     override var launchSamplingRate: Float = 1f
     override var gestureClickTakeSnapshot: Boolean = true
     override var httpSamplingRate: Float = 1f
+    override var profileSamplingRate: Float = 100f
     override var httpDisableEventForUrls: List<String> = emptyList()
     override var httpTrackRequestForUrls: List<String> = emptyList()
     override var httpTrackResponseForUrls: List<String> = emptyList()

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSampler.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSampler.kt
@@ -9,11 +9,13 @@ internal class FakeSampler : Sampler {
     var isCrashTimelineSampled: Boolean = true
     var trackJourneyForSession: Boolean = true
     var isHttpEventSampled: Boolean = true
+    var isProfileSampled: Boolean = true
 
     override fun shouldSampleTrace(traceId: String): Boolean = isTraceSampled
     override fun shouldSampleLaunchEvent(): Boolean = isLaunchEventSampled
     override fun shouldTrackJourneyForSession(sessionId: String): Boolean = trackJourneyForSession
     override fun shouldSampleHttpEvent(): Boolean = isHttpEventSampled
+    override fun shouldSampleProfile(): Boolean = isProfileSampled
 
     fun setSampled(isSampled: Boolean) {
         this.isTraceSampled = isSampled

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
@@ -7,9 +7,11 @@ import sh.measure.android.tracing.SpanData
 internal class FakeSignalStore : SignalStore {
     val trackedEvents = mutableListOf<Event<*>>()
     val trackedSpans = mutableListOf<SpanData>()
+    val trackedSessionAnrTimes = mutableListOf<Long?>()
 
-    override fun <T> store(event: Event<T>) {
+    override fun <T> store(event: Event<T>, sessionAnrTimeMs: Long?) {
         trackedEvents.add(event)
+        trackedSessionAnrTimes.add(sessionAnrTimeMs)
     }
 
     override fun store(spanData: SpanData) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/ImmediateExecutorService.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/ImmediateExecutorService.kt
@@ -12,6 +12,10 @@ import java.util.concurrent.TimeUnit
  */
 internal class ImmediateExecutorService(private val resolvableFuture: ResolvableFuture<Any?>) : MeasureExecutorService {
 
+    override fun execute(command: Runnable) {
+        command.run()
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun <T> submit(callable: Callable<T>): Future<T> {
         val future = ResolvableFuture.create<T>()

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -35,6 +35,7 @@ import sh.measure.android.okhttp.HttpData
 import sh.measure.android.performance.CpuUsageData
 import sh.measure.android.performance.MemoryUsageData
 import sh.measure.android.performance.TrimMemoryData
+import sh.measure.android.profiling.ProfileData
 import sh.measure.android.storage.AttachmentEntity
 import sh.measure.android.storage.EventEntity
 import sh.measure.android.storage.SessionEntity
@@ -265,6 +266,14 @@ internal object TestData {
         intentData,
     )
 
+    fun getProfileData(
+        reason: String = "app_launch",
+        format: String = AttachmentType.PERFETTO_TRACE,
+    ): ProfileData = ProfileData(
+        reason = reason,
+        format = format,
+    )
+
     fun getNetworkChangeData(
         previousNetworkType: String = "cellular",
         networkType: String = "wifi",
@@ -415,7 +424,6 @@ internal object TestData {
         createdAt: Long = 987654321L,
         prioritySession: Boolean = false,
         crashed: Boolean = false,
-        supportsAppExit: Boolean = false,
         appVersion: String? = "1.0.0",
         appBuild: String? = "100",
         trackJourney: Boolean = false,
@@ -425,7 +433,6 @@ internal object TestData {
         createdAt = createdAt,
         prioritySession = prioritySession,
         crashed = crashed,
-        supportsAppExit = supportsAppExit,
         appVersion = appVersion,
         appBuild = appBuild,
         trackJourney = trackJourney,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/TestData.kt
@@ -267,7 +267,7 @@ internal object TestData {
     )
 
     fun getProfileData(
-        reason: String = "app_launch",
+        reason: String = "app_fully_drawn",
         format: String = AttachmentType.PERFETTO_TRACE,
     ): ProfileData = ProfileData(
         reason = reason,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
@@ -1,0 +1,205 @@
+package sh.measure.android.profiling
+
+import android.os.ProfilingTrigger
+import androidx.concurrent.futures.ResolvableFuture
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import sh.measure.android.events.EventType
+import sh.measure.android.events.SignalProcessor
+import sh.measure.android.fakes.FakeSampler
+import sh.measure.android.fakes.FakeSessionManager
+import sh.measure.android.fakes.ImmediateExecutorService
+import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.storage.Database
+import sh.measure.android.storage.SessionRecord
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.SystemServiceProvider
+import sh.measure.android.utils.TestClock
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+import kotlin.io.path.createTempDirectory
+
+@RunWith(AndroidJUnit4::class)
+class ProfileCollectorTest {
+    private val logger = NoopLogger()
+    private val systemServiceProvider = mock<SystemServiceProvider>()
+    private val signalProcessor = mock<SignalProcessor>()
+    private val timeProvider = AndroidTimeProvider(TestClock.create())
+    private val ioExecutor = ImmediateExecutorService(ResolvableFuture.create<Any>())
+    private val sampler = FakeSampler()
+    private val database = mock<Database>()
+    private val sessionManager = FakeSessionManager()
+
+    private val profileCollector = ProfileCollector(
+        logger = logger,
+        systemServiceProvider = systemServiceProvider,
+        signalProcessor = signalProcessor,
+        timeProvider = timeProvider,
+        ioExecutor = ioExecutor,
+        sampler = sampler,
+        database = database,
+        sessionManager = sessionManager,
+    )
+
+    private val tempDir = createTempDirectory("profiling-test").toFile()
+
+    @After
+    fun tearDown() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `attributes an anr profile to the session that had the anr, using the anr time`() {
+        val fileTimestamp = "2026-07-05-17-51-56-124"
+        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
+            .parse(fileTimestamp)!!.time
+        val file = File(tempDir, "profile_trigger-type-2_${fileTimestamp}_uid-10229.perfetto-trace")
+        file.writeText("trace")
+        val anrTime = profileTime - 15_000
+        val anrSession = SessionRecord(
+            id = "anr-session",
+            createdAt = profileTime - 60_000,
+            appVersion = "1.0.0",
+            appBuild = "100",
+            lastAnrTime = anrTime,
+        )
+        // the trace finalized after a relaunch, so resolving purely by time would
+        // pick the relaunch session, but the ANR match wins.
+        val relaunchSession = SessionRecord("relaunch-session", profileTime - 5_000, "1.0.0", "100")
+        `when`(database.getSessionForAnr(eq(profileTime), any())).thenReturn(anrSession)
+        `when`(database.getSessionForTime(profileTime)).thenReturn(relaunchSession)
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
+
+        verify(signalProcessor).trackProfile(
+            data = eq(ProfileData(reason = "anr", format = "perfetto_trace")),
+            timestamp = eq(anrTime),
+            type = eq(EventType.PROFILE),
+            attachments = any(),
+            sessionId = eq("anr-session"),
+            sessionStartTime = eq(profileTime - 60_000),
+            appVersion = eq("1.0.0"),
+            appBuild = eq("100"),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
+    fun `attributes an anr profile by time when no session had a matching anr`() {
+        val fileTimestamp = "2026-07-05-17-51-56-124"
+        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
+            .parse(fileTimestamp)!!.time
+        val file = File(tempDir, "profile_trigger-type-2_${fileTimestamp}_uid-10229.perfetto-trace")
+        file.writeText("trace")
+        val timeSession = SessionRecord("time-session", profileTime - 5_000, "1.0.0", "100")
+        `when`(database.getSessionForAnr(any(), any())).thenReturn(null)
+        `when`(database.getSessionForTime(profileTime)).thenReturn(timeSession)
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
+
+        verify(signalProcessor).trackProfile(
+            data = eq(ProfileData(reason = "anr", format = "perfetto_trace")),
+            timestamp = eq(profileTime),
+            type = eq(EventType.PROFILE),
+            attachments = any(),
+            sessionId = eq("time-session"),
+            sessionStartTime = eq(profileTime - 5_000),
+            appVersion = eq("1.0.0"),
+            appBuild = eq("100"),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
+    fun `attributes an app launch profile to the session active at the profile time`() {
+        val fileTimestamp = "2026-07-05-17-51-56-124"
+        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
+            .parse(fileTimestamp)!!.time
+        val file = File(tempDir, "profile_trigger-type-1_${fileTimestamp}_uid-10229.perfetto-trace")
+        file.writeText("trace")
+        val session = SessionRecord("launch-session", profileTime - 2_000, "1.0.0", "100")
+        `when`(database.getSessionForTime(profileTime)).thenReturn(session)
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN)
+
+        verify(database, never()).getSessionForAnr(any(), any())
+        verify(signalProcessor).trackProfile(
+            data = eq(ProfileData(reason = "app_launch", format = "perfetto_trace")),
+            timestamp = eq(profileTime),
+            type = eq(EventType.PROFILE),
+            attachments = any(),
+            sessionId = eq("launch-session"),
+            sessionStartTime = eq(profileTime - 2_000),
+            appVersion = eq("1.0.0"),
+            appBuild = eq("100"),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
+    fun `tracks profile against the current session when no session matches`() {
+        val file = File(tempDir, "profile_trigger-type-2_2026-07-05-17-51-56-124_uid-10229.perfetto-trace")
+        file.writeText("trace")
+        `when`(database.getSessionForAnr(any(), any())).thenReturn(null)
+        `when`(database.getSessionForTime(any())).thenReturn(null)
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
+
+        verify(signalProcessor).trackProfile(
+            data = eq(ProfileData(reason = "anr", format = "perfetto_trace")),
+            timestamp = any(),
+            type = eq(EventType.PROFILE),
+            attachments = any(),
+            sessionId = eq(sessionManager.getSessionId()),
+            sessionStartTime = isNull(),
+            appVersion = isNull(),
+            appBuild = isNull(),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
+    fun `uses the file modified time when the file name has no timestamp`() {
+        val file = File(tempDir, "profile.perfetto-trace")
+        file.writeText("trace")
+        val lastModified = 1751700000000L
+        file.setLastModified(lastModified)
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN)
+
+        verify(database).getSessionForTime(lastModified)
+        verify(signalProcessor).trackProfile(
+            data = any(),
+            timestamp = eq(lastModified),
+            type = any(),
+            attachments = any(),
+            sessionId = any(),
+            sessionStartTime = isNull(),
+            appVersion = isNull(),
+            appBuild = isNull(),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
+    fun `does not track profile when not sampled`() {
+        val file = File(tempDir, "profile_trigger-type-2_2026-07-05-17-51-56-124_uid-10229.perfetto-trace")
+        file.writeText("trace")
+        sampler.isProfileSampled = false
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
+
+        verifyNoInteractions(signalProcessor)
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
@@ -135,7 +135,7 @@ class ProfileCollectorTest {
 
         verify(database, never()).getSessionForAnr(any(), any())
         verify(signalProcessor).trackProfile(
-            data = eq(ProfileData(reason = "app_launch", format = "perfetto_trace")),
+            data = eq(ProfileData(reason = "app_fully_drawn", format = "perfetto_trace")),
             timestamp = eq(profileTime),
             type = eq(EventType.PROFILE),
             attachments = any(),

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/DataCleanupServiceTest.kt
@@ -141,13 +141,28 @@ class DataCleanupServiceTest {
     }
 
     @Test
-    fun `trimMemoryUsage deletes oldest session when disk usage exceeds limit`() {
+    fun `deleteEmptySessions does not delete recently created sessions`() {
+        setupDefaultMocks()
+        `when`(database.getSessionIds(sessionManager.getSessionId()))
+            .thenReturn(listOf("empty-session", "recent-empty-session"))
+        `when`(database.getRecentSessionIds(5)).thenReturn(listOf("recent-empty-session"))
+        `when`(database.getEventsCount("empty-session")).thenReturn(0)
+        `when`(database.getSpansCount("empty-session")).thenReturn(0)
+
+        dataCleanupService.cleanup()
+
+        verify(database, times(1)).deleteSession("empty-session")
+        verify(database, never()).deleteSession("recent-empty-session")
+    }
+
+    @Test
+    fun `trimMemoryUsage deletes data of the oldest session with signals when disk usage exceeds limit`() {
         setupDefaultMocks()
         `when`(database.getEventsCount()).thenReturn(100)
         `when`(database.getSpansCount()).thenReturn(0)
         configProvider.estimatedEventSizeInKb = 1024
         configProvider.maxDiskUsageInMb = 50
-        `when`(database.getOldestSession()).thenReturn("oldest-session")
+        `when`(database.getOldestSessionWithSignals()).thenReturn("oldest-session")
         `when`(database.getEventsForSession("oldest-session")).thenReturn(listOf("event1", "event2"))
         `when`(database.getAttachmentsForEvents(listOf("event1", "event2"))).thenReturn(listOf("attachment1"))
 
@@ -155,11 +170,12 @@ class DataCleanupServiceTest {
 
         verify(fileStorage, times(1)).deleteEventsIfExist(listOf("event1", "event2"))
         verify(fileStorage, times(1)).deleteAttachmentsIfExist(listOf("attachment1"))
-        verify(database, times(1)).deleteSession("oldest-session")
+        verify(database, times(1)).deleteSessionData("oldest-session")
+        verify(database, never()).deleteSession("oldest-session")
     }
 
     @Test
-    fun `trimMemoryUsage does not delete session when disk usage is within limit`() {
+    fun `trimMemoryUsage does not delete data when disk usage is within limit`() {
         // (100 * 15) / 1024 ≈ 1.5MB < 50MB limit
         setupDefaultMocks()
         `when`(database.getEventsCount()).thenReturn(100)
@@ -167,19 +183,19 @@ class DataCleanupServiceTest {
 
         dataCleanupService.cleanup()
 
-        verify(database, never()).getOldestSession()
+        verify(database, never()).getOldestSessionWithSignals()
     }
 
     @Test
-    fun `trimMemoryUsage does not delete current session even if it is oldest`() {
+    fun `trimMemoryUsage does not delete data of the current session even if it is oldest`() {
         setupDefaultMocks()
         `when`(database.getEventsCount()).thenReturn(3500)
         `when`(database.getSpansCount()).thenReturn(0)
-        `when`(database.getOldestSession()).thenReturn(sessionManager.getSessionId())
+        `when`(database.getOldestSessionWithSignals()).thenReturn(sessionManager.getSessionId())
 
         dataCleanupService.cleanup()
 
-        verify(database, never()).deleteSession(sessionManager.getSessionId())
+        verify(database, never()).deleteSessionData(sessionManager.getSessionId())
     }
 
     @Test
@@ -274,6 +290,7 @@ class DataCleanupServiceTest {
 
         // Default mocks for deleteEmptySessions
         `when`(database.getSessionIds(any())).thenReturn(emptyList())
+        `when`(database.getRecentSessionIds(any())).thenReturn(emptyList())
 
         // Default mocks for trimMemoryUsage
         `when`(database.getEventsCount()).thenReturn(100)

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
@@ -2521,6 +2521,35 @@ class DatabaseTest {
     }
 
     @Test
+    fun `insertEvent records the session ANR time when sessionAnrTimeMs is set`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "anr-session", createdAt = 1000L))
+        val event = TestData.getEventEntity(type = EventType.ANR, sessionId = "anr-session")
+
+        // when
+        database.insertEvent(event, sessionAnrTimeMs = 5000L)
+
+        // then
+        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
+        assertNotNull(session)
+        assertEquals("anr-session", session!!.id)
+        assertEquals(5000L, session.lastAnrTime)
+    }
+
+    @Test
+    fun `insertEvent does not record a session ANR time when sessionAnrTimeMs is null`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "anr-session", createdAt = 1000L))
+        val event = TestData.getEventEntity(type = EventType.ANR, sessionId = "anr-session")
+
+        // when
+        database.insertEvent(event, sessionAnrTimeMs = null)
+
+        // then
+        assertNull(database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L))
+    }
+
+    @Test
     fun `markSessionsAppExitTracked does not mark the excluded session`() {
         // given
         database.insertSession(

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import sh.measure.android.config.DefaultConfig
+import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
 import sh.measure.android.exporter.EventPacket
 import sh.measure.android.exporter.SignedAttachment
@@ -57,8 +58,6 @@ class DatabaseTest {
             assertEquals(BatchesTable.TABLE_NAME, it.getString(it.getColumnIndex("name")))
             it.moveToNext()
             assertEquals(EventsBatchTable.TABLE_NAME, it.getString(it.getColumnIndex("name")))
-            it.moveToNext()
-            assertEquals(AppExitTable.TABLE_NAME, it.getString(it.getColumnIndex("name")))
             it.moveToNext()
             assertEquals(SpansTable.TABLE_NAME, it.getString(it.getColumnIndex("name")))
             it.moveToNext()
@@ -1274,12 +1273,80 @@ class DatabaseTest {
     }
 
     @Test
-    fun `getOldestSession returns null when no sessions exist`() {
+    fun `getRecentSessionIds returns the most recently created sessions`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-2", createdAt = 2000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-3", createdAt = 3000L))
+
         // when
-        val sessionId = database.getOldestSession()
+        val sessionIds = database.getRecentSessionIds(2)
+
+        // then
+        assertEquals(listOf("session-3", "session-2"), sessionIds)
+    }
+
+    @Test
+    fun `getOldestSessionWithSignals returns the oldest session with events or spans`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "empty-session", createdAt = 1000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-with-event", createdAt = 2000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-with-span", createdAt = 3000L))
+        database.insertEvent(
+            TestData.getEventEntity(eventId = "event-1", sessionId = "session-with-event"),
+        )
+        database.insertSpan(
+            TestData.getSpanEntity(spanId = "span-1", sessionId = "session-with-span"),
+        )
+
+        // when
+        val sessionId = database.getOldestSessionWithSignals()
+
+        // then
+        assertEquals("session-with-event", sessionId)
+    }
+
+    @Test
+    fun `getOldestSessionWithSignals returns null when no session has events or spans`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "empty-session", createdAt = 1000L))
+
+        // when
+        val sessionId = database.getOldestSessionWithSignals()
 
         // then
         assertNull(sessionId)
+    }
+
+    @Test
+    fun `deleteSessionData deletes events, spans and attachments but keeps the session`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-2", createdAt = 2000L))
+        database.insertEvent(
+            TestData.getEventEntity(
+                eventId = "event-1",
+                sessionId = "session-1",
+                attachmentEntities = listOf(TestData.getAttachmentEntity(id = "attachment-1")),
+            ),
+        )
+        database.insertSpan(TestData.getSpanEntity(spanId = "span-1", sessionId = "session-1"))
+        database.insertEvent(
+            TestData.getEventEntity(eventId = "event-2", sessionId = "session-2"),
+        )
+
+        // when
+        database.deleteSessionData("session-1")
+
+        // then
+        assertEquals(0, database.getEventsCount("session-1"))
+        assertEquals(0, database.getSpansCount("session-1"))
+        database.readableDatabase.rawQuery(
+            "SELECT * FROM ${AttachmentV1Table.TABLE_NAME} WHERE ${AttachmentV1Table.COL_SESSION_ID} = 'session-1'",
+            null,
+        ).use { assertEquals(0, it.count) }
+        assertEquals(listOf("session-2", "session-1"), database.getRecentSessionIds(2))
+        assertEquals(1, database.getEventsCount("session-2"))
     }
 
     @Test
@@ -1974,6 +2041,60 @@ class DatabaseTest {
     }
 
     @Test
+    fun `getAttachmentsToUpload excludes profiles, getProfileAttachmentsToUpload returns only them`() {
+        database.insertSession(TestData.getSessionEntity(id = "session-id"))
+        database.insertEvent(
+            TestData.getEventEntity(
+                eventId = "event-1",
+                sessionId = "session-id",
+                attachmentEntities = listOf(
+                    TestData.getAttachmentEntity(id = "screenshot", type = AttachmentType.SCREENSHOT),
+                    TestData.getAttachmentEntity(id = "profile", type = AttachmentType.PERFETTO_TRACE),
+                ),
+            ),
+        )
+        database.updateAttachmentUrls(
+            listOf(
+                SignedAttachment(
+                    id = "screenshot",
+                    type = AttachmentType.SCREENSHOT,
+                    filename = "screenshot.png",
+                    uploadUrl = "https://example.com/screenshot",
+                    expiresAt = "2025-01-15T10:00:00.000Z",
+                    headers = emptyMap(),
+                ),
+                SignedAttachment(
+                    id = "profile",
+                    type = AttachmentType.PERFETTO_TRACE,
+                    filename = "profile.perfetto-trace",
+                    uploadUrl = "https://example.com/profile",
+                    expiresAt = "2025-01-15T10:00:00.000Z",
+                    headers = emptyMap(),
+                ),
+            ),
+        )
+
+        assertEquals(listOf("screenshot"), database.getAttachmentsToUpload(10).map { it.id })
+        assertEquals(listOf("profile"), database.getProfileAttachmentsToUpload(10).map { it.id })
+    }
+
+    @Test
+    fun `getProfileAttachmentsToUpload returns nothing for unsigned profile attachments`() {
+        database.insertSession(TestData.getSessionEntity(id = "session-id"))
+        database.insertEvent(
+            TestData.getEventEntity(
+                eventId = "event-1",
+                sessionId = "session-id",
+                attachmentEntities = listOf(
+                    TestData.getAttachmentEntity(id = "profile", type = AttachmentType.PERFETTO_TRACE),
+                ),
+            ),
+        )
+
+        assertTrue(database.getProfileAttachmentsToUpload(10).isEmpty())
+    }
+
+    @Test
     fun `updateAttachmentUrls returns false when attachment missing`() {
         // given
         database.insertSession(TestData.getSessionEntity(id = "session-id"))
@@ -2189,7 +2310,6 @@ class DatabaseTest {
                 createdAt = 1000L,
                 appVersion = "1.0.0",
                 appBuild = "100",
-                supportsAppExit = true,
             ),
         )
 
@@ -2199,7 +2319,6 @@ class DatabaseTest {
         // then
         assertNotNull(session)
         assertEquals("session-id", session!!.id)
-        assertEquals(pid, session.pid)
         assertEquals(1000L, session.createdAt)
         assertEquals("1.0.0", session.appVersion)
         assertEquals("100", session.appBuild)
@@ -2214,7 +2333,6 @@ class DatabaseTest {
                 id = "older-session",
                 pid = pid,
                 createdAt = 1000L,
-                supportsAppExit = true,
             ),
         )
         database.insertSession(
@@ -2222,7 +2340,6 @@ class DatabaseTest {
                 id = "newer-session",
                 pid = pid,
                 createdAt = 2000L,
-                supportsAppExit = true,
             ),
         )
         database.insertSession(
@@ -2230,7 +2347,6 @@ class DatabaseTest {
                 id = "newest-session",
                 pid = pid,
                 createdAt = 3000L,
-                supportsAppExit = true,
             ),
         )
 
@@ -2250,7 +2366,6 @@ class DatabaseTest {
             TestData.getSessionEntity(
                 id = "session-id",
                 pid = 12345,
-                supportsAppExit = true,
             ),
         )
 
@@ -2262,54 +2377,165 @@ class DatabaseTest {
     }
 
     @Test
-    fun `clearAppExitRecords removes all records except for current session`() {
+    fun `getSessionForAppExit returns null for sessions marked as app exit tracked`() {
         // given
+        val pid = 111
         database.insertSession(
-            TestData.getSessionEntity(
-                id = "old-session",
-                pid = 111,
-                createdAt = 1000L,
-                supportsAppExit = true,
-            ),
+            TestData.getSessionEntity(id = "rotated-1", pid = pid, createdAt = 1000L),
         )
         database.insertSession(
-            TestData.getSessionEntity(
-                id = "boundary-session",
-                pid = 222,
-                createdAt = 2000L,
-                supportsAppExit = true,
-            ),
-        )
-        database.insertSession(
-            TestData.getSessionEntity(
-                id = "current-session",
-                pid = 333,
-                createdAt = 3000L,
-                supportsAppExit = true,
-            ),
+            TestData.getSessionEntity(id = "rotated-2", pid = pid, createdAt = 2000L),
         )
 
         // when
-        database.clearAppExitRecords("current-session")
+        database.markSessionsAppExitTracked(excludeSessionId = "current-session")
 
         // then
-        val db = database.readableDatabase
-        db.query(
-            AppExitTable.TABLE_NAME,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-        ).use { cursor ->
-            assertEquals(1, cursor.count)
-            assertTrue(cursor.moveToFirst())
-            assertEquals(
-                "current-session",
-                cursor.getString(cursor.getColumnIndex(AppExitTable.COL_SESSION_ID)),
-            )
-        }
+        assertNull(database.getSessionForAppExit(pid))
+    }
+
+    @Test
+    fun `getSessionForTime returns the session active at the given time`() {
+        // given
+        database.insertSession(
+            TestData.getSessionEntity(
+                id = "session-1",
+                createdAt = 1000L,
+                appVersion = "1.0.0",
+                appBuild = "100",
+            ),
+        )
+        database.insertSession(TestData.getSessionEntity(id = "session-2", createdAt = 2000L))
+
+        // when
+        val session = database.getSessionForTime(1500L)
+
+        // then
+        assertNotNull(session)
+        assertEquals("session-1", session!!.id)
+        assertEquals(1000L, session.createdAt)
+        assertEquals("1.0.0", session.appVersion)
+        assertEquals("100", session.appBuild)
+    }
+
+    @Test
+    fun `getSessionForTime returns the latest session when the time is after all sessions`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+        database.insertSession(TestData.getSessionEntity(id = "session-2", createdAt = 2000L))
+
+        // when
+        val session = database.getSessionForTime(3000L)
+
+        // then
+        assertEquals("session-2", session!!.id)
+    }
+
+    @Test
+    fun `getSessionForTime returns null when the time is before all sessions`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+
+        // when
+        val session = database.getSessionForTime(500L)
+
+        // then
+        assertNull(session)
+    }
+
+    @Test
+    fun `getSessionForAnr returns the most recent session that had an ANR within the gap`() {
+        // given
+        database.insertSession(
+            TestData.getSessionEntity(
+                id = "anr-session",
+                createdAt = 1000L,
+                appVersion = "1.0.0",
+                appBuild = "100",
+            ),
+        )
+        database.insertSession(TestData.getSessionEntity(id = "relaunch-session", createdAt = 6000L))
+        database.setSessionAnrTime("anr-session", 5000L)
+
+        // when: the profile finalized 3s after the ANR, resolved-by-time would be relaunch-session
+        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
+
+        // then
+        assertNotNull(session)
+        assertEquals("anr-session", session!!.id)
+        assertEquals(5000L, session.lastAnrTime)
+        assertEquals("1.0.0", session.appVersion)
+    }
+
+    @Test
+    fun `getSessionForAnr keeps the latest ANR time when set multiple times`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+        database.setSessionAnrTime("session-1", 5000L)
+        database.setSessionAnrTime("session-1", 2000L) // earlier, must not overwrite
+        database.setSessionAnrTime("session-1", 7000L) // later, must win
+
+        // when
+        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
+
+        // then
+        assertEquals(7000L, session!!.lastAnrTime)
+    }
+
+    @Test
+    fun `getSessionForAnr ignores a stale ANR outside the gap`() {
+        // given a session whose ANR is far in the past
+        database.insertSession(TestData.getSessionEntity(id = "old-anr-session", createdAt = 1000L))
+        database.setSessionAnrTime("old-anr-session", 2000L)
+
+        // when the profile time is well beyond the gap
+        val session = database.getSessionForAnr(timeMs = 200_000L, maxGapMs = 60_000L)
+
+        // then
+        assertNull(session)
+    }
+
+    @Test
+    fun `getSessionForAnr ignores ANRs after the profile time`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+        database.setSessionAnrTime("session-1", 9000L)
+
+        // when the profile time is before the ANR
+        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
+
+        // then
+        assertNull(session)
+    }
+
+    @Test
+    fun `getSessionForAnr returns null when no session had an ANR`() {
+        // given
+        database.insertSession(TestData.getSessionEntity(id = "session-1", createdAt = 1000L))
+
+        // when
+        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
+
+        // then
+        assertNull(session)
+    }
+
+    @Test
+    fun `markSessionsAppExitTracked does not mark the excluded session`() {
+        // given
+        database.insertSession(
+            TestData.getSessionEntity(id = "old-session", pid = 111, createdAt = 1000L),
+        )
+        database.insertSession(
+            TestData.getSessionEntity(id = "current-session", pid = 222, createdAt = 2000L),
+        )
+
+        // when
+        database.markSessionsAppExitTracked(excludeSessionId = "current-session")
+
+        // then
+        assertNull(database.getSessionForAppExit(111))
+        assertEquals("current-session", database.getSessionForAppExit(222)!!.id)
     }
 
     @Test

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/DbMigrationsTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/DbMigrationsTest.kt
@@ -264,4 +264,93 @@ class DbMigrationsTest {
 
         db.close()
     }
+
+    @Test
+    fun `migration v7 to v8 folds app exit data into sessions and drops app exit table`() {
+        val db = TestDatabaseHelper.createDatabase(DbVersion.V7)
+
+        // Insert a session with a pending app_exit row and one without
+        db.execSQL(
+            "INSERT INTO sessions (session_id, pid, created_at) VALUES ('unreported-session', 0, 1000)",
+        )
+        db.execSQL(
+            """
+            INSERT INTO app_exit (session_id, pid, created_at, app_build, app_version)
+            VALUES ('unreported-session', 111, 1000, '100', '1.0.0')
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "INSERT INTO sessions (session_id, pid, created_at) VALUES ('reported-session', 0, 2000)",
+        )
+
+        // Perform migration
+        DbMigrations.apply(logger, db, DbVersion.V7, DbVersion.V8)
+
+        // Verify new columns exist on sessions
+        val tableInfoCursor = db.queryTableInfo("sessions")
+        val columnNames = mutableListOf<String>()
+        if (tableInfoCursor.moveToFirst()) {
+            do {
+                columnNames.add(tableInfoCursor.getString(tableInfoCursor.getColumnIndexOrThrow("name")))
+            } while (tableInfoCursor.moveToNext())
+        }
+        tableInfoCursor.close()
+        assertTrue(columnNames.contains(SessionsTable.COL_APP_VERSION))
+        assertTrue(columnNames.contains(SessionsTable.COL_APP_BUILD))
+
+        // Verify pid and versions backfilled for the session with a pending app_exit row
+        db.rawQuery(
+            "SELECT pid, app_version, app_build, app_exit_tracked FROM sessions WHERE session_id = 'unreported-session'",
+            null,
+        ).use {
+            assertTrue(it.moveToFirst())
+            assertEquals(111, it.getInt(0))
+            assertEquals("1.0.0", it.getString(1))
+            assertEquals("100", it.getString(2))
+            assertEquals(0, it.getInt(3))
+        }
+
+        // Verify the session without an app_exit row is marked tracked
+        db.rawQuery(
+            "SELECT pid, app_version, app_build, app_exit_tracked FROM sessions WHERE session_id = 'reported-session'",
+            null,
+        ).use {
+            assertTrue(it.moveToFirst())
+            assertEquals(0, it.getInt(0))
+            assertEquals(null, it.getString(1))
+            assertEquals(null, it.getString(2))
+            assertEquals(1, it.getInt(3))
+        }
+
+        // Verify app_exit table no longer exists
+        db.rawQuery(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='app_exit'",
+            null,
+        ).use {
+            assertEquals(0, it.count)
+        }
+
+        db.close()
+    }
+
+    @Test
+    fun `migration v8 to v9 adds last_anr_time column to sessions`() {
+        val db = TestDatabaseHelper.createDatabase(DbVersion.V8)
+
+        // Perform migration
+        DbMigrations.apply(logger, db, DbVersion.V8, DbVersion.V9)
+
+        // Verify the new column exists on sessions
+        val tableInfoCursor = db.queryTableInfo("sessions")
+        val columnNames = mutableListOf<String>()
+        if (tableInfoCursor.moveToFirst()) {
+            do {
+                columnNames.add(tableInfoCursor.getString(tableInfoCursor.getColumnIndexOrThrow("name")))
+            } while (tableInfoCursor.moveToNext())
+        }
+        tableInfoCursor.close()
+        assertTrue(columnNames.contains(SessionsTable.COL_LAST_ANR_TIME))
+
+        db.close()
+    }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/EventExtensionsKtTest.kt
@@ -95,6 +95,10 @@ class EventExtensionsKtTest {
 
         val screenViewEvent = TestData.getScreenViewData().toEvent(type = EventType.SCREEN_VIEW)
         assert(screenViewEvent.serializeDataToString().isNotEmpty())
+
+        val profileEvent = TestData.getProfileData()
+            .toEvent(type = EventType.PROFILE)
+        assert(profileEvent.serializeDataToString().isNotEmpty())
     }
 
     @Test

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -56,7 +57,7 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(eventsCaptor.capture())
+        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
         val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
     }
@@ -77,9 +78,21 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(eventsCaptor.capture())
+        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
         val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
+    }
+
+    @Test
+    fun `forwards session ANR time to insertEvent`() {
+        val exceptionData = TestData.getExceptionData()
+        val event = exceptionData.toEvent(type = EventType.ANR)
+        val anrTimeMs = 987654321L
+        `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
+
+        signalStore.store(event, sessionAnrTimeMs = anrTimeMs)
+
+        verify(database).insertEvent(any(), eq(anrTimeMs))
     }
 
     @Test
@@ -88,14 +101,14 @@ internal class SignalStoreTest {
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
         val eventsCaptor = argumentCaptor<EventEntity>()
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then
         verify(fileStorage, never()).writeEventData(any(), any())
-        verify(database).insertEvent(eventsCaptor.capture())
+        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
         val eventEntity = eventsCaptor.firstValue
         assertNull(eventEntity.filePath)
         assertNotNull(eventEntity.serializedData)
@@ -463,7 +476,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -484,7 +497,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -505,7 +518,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.ANR)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -525,7 +538,7 @@ internal class SignalStoreTest {
         configProvider.bugReportTimelineDurationSeconds = bugReportTimelineDuration
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -576,7 +589,7 @@ internal class SignalStoreTest {
         // then
         val eventsCaptor = argumentCaptor<List<EventEntity>>()
         val spansCaptor = argumentCaptor<List<SpanEntity>>()
-        verify(database, times(1)).insertEvent(any())
+        verify(database, times(1)).insertEvent(any(), anyOrNull())
         verify(database, times(1)).insertSignals(eventsCaptor.capture(), spansCaptor.capture())
         assertEquals(1, eventsCaptor.firstValue.size)
         assertEquals(1, spansCaptor.firstValue.size)
@@ -616,7 +629,7 @@ internal class SignalStoreTest {
             ),
         )
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(false)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(false)
 
         // when
         signalStore.store(event)
@@ -643,7 +656,7 @@ internal class SignalStoreTest {
         signalStore.flush()
 
         // then
-        verify(database, never()).insertEvent(any())
+        verify(database, never()).insertEvent(any(), anyOrNull())
         verify(database, never()).insertSignals(any(), any())
     }
 
@@ -675,7 +688,7 @@ internal class SignalStoreTest {
         signalStore.store(event)
 
         // then - event should be queued, not immediately inserted
-        verify(database, never()).insertEvent(any())
+        verify(database, never()).insertEvent(any(), anyOrNull())
 
         // when flushed
         signalStore.flush()
@@ -690,13 +703,13 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then - event should be immediately inserted
-        verify(database).insertEvent(any())
+        verify(database).insertEvent(any(), anyOrNull())
     }
 
     @Test
@@ -705,13 +718,13 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then - event should be immediately inserted
-        verify(database).insertEvent(any())
+        verify(database).insertEvent(any(), anyOrNull())
     }
 
     @Test
@@ -721,7 +734,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -737,7 +750,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.ANR)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -755,7 +768,7 @@ internal class SignalStoreTest {
         configProvider.bugReportTimelineDurationSeconds = bugReportTimelineDuration
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
-        `when`(database.insertEvent(any())).thenReturn(true)
+        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
 
         // when
         signalStore.store(event)

--- a/android/measure-android/measure/src/test/java/sh/measure/android/utils/ClassUtilTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/utils/ClassUtilTest.kt
@@ -1,0 +1,18 @@
+package sh.measure.android.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class ClassUtilTest {
+    @Test
+    fun `reports class available when on the classpath`() {
+        // androidx.work is on the unit test classpath via testImplementation.
+        assertTrue(isClassAvailable("androidx.work.WorkManager"))
+    }
+
+    @Test
+    fun `reports class unavailable when not on the classpath`() {
+        assertFalse(isClassAvailable("com.example.DoesNotExist"))
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/utils/FakeSampler.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/utils/FakeSampler.kt
@@ -5,4 +5,5 @@ class FakeSampler : Sampler {
     override fun shouldSampleLaunchEvent(): Boolean = true
     override fun shouldTrackJourneyForSession(sessionId: String): Boolean = true
     override fun shouldSampleHttpEvent(): Boolean = true
+    override fun shouldSampleProfile(): Boolean = true
 }

--- a/android/measure-android/measure/src/test/resources/schemas/schema_v7.sql
+++ b/android/measure-android/measure/src/test/resources/schemas/schema_v7.sql
@@ -1,0 +1,86 @@
+CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY,
+            pid INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            app_exit_tracked INTEGER DEFAULT 0,
+            needs_reporting INTEGER DEFAULT 0,
+            crashed INTEGER DEFAULT 0,
+            track_journey INTEGER DEFAULT 0
+        );
+CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            user_triggered INTEGER NOT NULL DEFAULT 0,
+            file_path TEXT DEFAULT NULL,
+            serialized_data TEXT DEFAULT NULL,
+            attributes TEXT DEFAULT NULL,
+            user_defined_attributes TEXT DEFAULT NULL,
+            attachments_size INTEGER NOT NULL,
+            attachments TEXT DEFAULT NULL,
+            sampled INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE attachments_v1 (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            file_path TEXT DEFAULT NULL,
+            name TEXT DEFAULT NULL,
+            url TEXT DEFAULT NULL,
+            url_expires_at TEXT DEFAULT NULL,
+            headers TEXT DEFAULT NULL,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE batches (
+            batch_id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL
+        );
+CREATE TABLE events_batch (
+            event_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (event_id, batch_id),
+            FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+        );
+CREATE TABLE app_exit (
+            session_id TEXT NOT NULL,
+            pid INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            app_build TEXT,
+            app_version TEXT,
+            PRIMARY KEY (session_id, pid)
+        );
+CREATE TABLE spans (
+            span_id TEXT NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            trace_id TEXT NOT NULL,
+            parent_id TEXT,
+            start_time INTEGER NOT NULL,
+            end_time INTEGER NOT NULL,
+            duration INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            serialized_attrs TEXT,
+            user_defined_attributes TEXT,
+            serialized_span_events TEXT,
+            sampled INTEGER DEFAULT 0,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE spans_batch (
+            span_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (span_id, batch_id),
+            FOREIGN KEY (span_id) REFERENCES spans(span_id) ON DELETE CASCADE
+        );
+CREATE INDEX events_timestamp_index ON events (timestamp);
+CREATE INDEX events_session_id_index ON events (session_id);
+CREATE INDEX events_batch_event_id_index ON events_batch (event_id);
+CREATE INDEX sessions_created_at_index ON sessions (created_at);
+CREATE INDEX idx_spans_session_sampled_starttime ON spans(session_id, sampled, start_time);
+CREATE INDEX idx_spans_batch_span_id ON spans_batch(span_id);
+CREATE INDEX idx_app_exit_pid_created ON app_exit(pid, created_at DESC);

--- a/android/measure-android/measure/src/test/resources/schemas/schema_v8.sql
+++ b/android/measure-android/measure/src/test/resources/schemas/schema_v8.sql
@@ -1,0 +1,80 @@
+CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY,
+            pid INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            app_exit_tracked INTEGER DEFAULT 0,
+            needs_reporting INTEGER DEFAULT 0,
+            crashed INTEGER DEFAULT 0,
+            track_journey INTEGER DEFAULT 0,
+            app_version TEXT DEFAULT NULL,
+            app_build TEXT DEFAULT NULL
+        );
+CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            user_triggered INTEGER NOT NULL DEFAULT 0,
+            file_path TEXT DEFAULT NULL,
+            serialized_data TEXT DEFAULT NULL,
+            attributes TEXT DEFAULT NULL,
+            user_defined_attributes TEXT DEFAULT NULL,
+            attachments_size INTEGER NOT NULL,
+            attachments TEXT DEFAULT NULL,
+            sampled INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE attachments_v1 (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            file_path TEXT DEFAULT NULL,
+            name TEXT DEFAULT NULL,
+            url TEXT DEFAULT NULL,
+            url_expires_at TEXT DEFAULT NULL,
+            headers TEXT DEFAULT NULL,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE batches (
+            batch_id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL
+        );
+CREATE TABLE events_batch (
+            event_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (event_id, batch_id),
+            FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+        );
+CREATE TABLE spans (
+            span_id TEXT NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            trace_id TEXT NOT NULL,
+            parent_id TEXT,
+            start_time INTEGER NOT NULL,
+            end_time INTEGER NOT NULL,
+            duration INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            serialized_attrs TEXT,
+            user_defined_attributes TEXT,
+            serialized_span_events TEXT,
+            sampled INTEGER DEFAULT 0,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+CREATE TABLE spans_batch (
+            span_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (span_id, batch_id),
+            FOREIGN KEY (span_id) REFERENCES spans(span_id) ON DELETE CASCADE
+        );
+CREATE INDEX events_timestamp_index ON events (timestamp);
+CREATE INDEX events_session_id_index ON events (session_id);
+CREATE INDEX events_batch_event_id_index ON events_batch (event_id);
+CREATE INDEX sessions_created_at_index ON sessions (created_at);
+CREATE INDEX idx_spans_session_sampled_starttime ON spans(session_id, sampled, start_time);
+CREATE INDEX idx_spans_batch_span_id ON spans_batch(span_id);
+CREATE INDEX sessions_pid_created_at_index ON sessions(pid, created_at DESC);

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -3567,6 +3567,7 @@ func (h Handlers) GetSession(c *gin.Context) {
 		event.TypeScreenView,
 		event.TypeBugReport,
 		event.TypeCustom,
+		event.TypeProfile,
 	}
 
 	eventMap := session.EventsOfTypes(typeList...)
@@ -3640,6 +3641,13 @@ func (h Handlers) GetSession(c *gin.Context) {
 		coldLaunches := timeline.ComputeColdLaunches(coldLaunchEvents)
 		threadedColdLaunches := timeline.GroupByThreads(coldLaunches)
 		threads.Organize(event.TypeColdLaunch, threadedColdLaunches)
+	}
+
+	profileEvents := eventMap[event.TypeProfile]
+	if len(profileEvents) > 0 {
+		profiles := timeline.ComputeProfiles(profileEvents)
+		threadedProfiles := timeline.GroupByThreads(profiles)
+		threads.Organize(event.TypeProfile, threadedProfiles)
 	}
 
 	warmLaunchEvents := eventMap[event.TypeWarmLaunch]

--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -98,6 +98,12 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 	if patch.HTTPBlockedHeaders != nil {
 		stmt.Set("http_blocked_headers", *patch.HTTPBlockedHeaders)
 	}
+	if patch.ProfileSamplingRate != nil {
+		if *patch.ProfileSamplingRate < 0 || *patch.ProfileSamplingRate > 100 {
+			return fmt.Errorf("profile_sampling_rate must be between 0-100")
+		}
+		stmt.Set("profile_sampling_rate", *patch.ProfileSamplingRate)
+	}
 	stmt.Set("updated_at", time.Now())
 	stmt.Set("updated_by", &userIdUUID)
 	stmt.Where("app_id = ?", appID)

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -998,6 +998,17 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			row.
 				Set(`custom.name`, nil)
 		}
+
+		// profile
+		if e.events[i].IsProfile() {
+			row.
+				Set(`profile.reason`, e.events[i].Profile.Reason).
+				Set(`profile.format`, e.events[i].Profile.Format)
+		} else {
+			row.
+				Set(`profile.reason`, nil).
+				Set(`profile.format`, nil)
+		}
 	}
 
 	asyncCtx := clickhouse.Context(ctx, clickhouse.WithAsync(true))

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -105,6 +105,10 @@ type eventreq struct {
 	osName string
 	// size keeps track of the ingest payload size
 	size uint64
+	// attachmentsSize is the portion of size that comes
+	// from attachments. It is excluded from the payload
+	// size-limit validation but still counts toward billing.
+	attachmentsSize uint64
 	// events is the list of events in the ingest
 	// batch
 	events []event.EventField
@@ -222,6 +226,14 @@ func (e *eventreq) uploadAttachments() error {
 // events in bytes.
 func (e *eventreq) bumpSize(n uint64) {
 	e.size = e.size + n
+}
+
+// bumpAttachmentSize increases the payload size in bytes
+// and tracks the attachment portion separately so it can
+// be excluded from the payload size-limit validation.
+func (e *eventreq) bumpAttachmentSize(n uint64) {
+	e.size = e.size + n
+	e.attachmentsSize = e.attachmentsSize + n
 }
 
 // estimateAttachmentSize returns an estimated size in bytes
@@ -424,7 +436,7 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 		if header == nil {
 			continue
 		}
-		e.bumpSize(uint64(header.Size))
+		e.bumpAttachmentSize(uint64(header.Size))
 
 		// inject the form field header to
 		// the previously constructed partial
@@ -512,9 +524,9 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 			// by newer SDKs. Fall back to estimates for older
 			// SDKs that don't send size.
 			if attachment.Size > 0 {
-				e.bumpSize(attachment.Size)
+				e.bumpAttachmentSize(attachment.Size)
 			} else {
-				e.bumpSize(estimateAttachmentSize(attachment.Name))
+				e.bumpAttachmentSize(estimateAttachmentSize(attachment.Name))
 			}
 		}
 
@@ -749,7 +761,10 @@ func (e eventreq) validate() error {
 		}
 	}
 
-	if e.size >= uint64(maxBatchSize) {
+	// attachments are excluded from the size limit; they are
+	// uploaded directly to storage and are not part of the
+	// event payload. they only count toward billing.
+	if e.size-e.attachmentsSize >= uint64(maxBatchSize) {
 		return fmt.Errorf(`payload cannot exceed maximum allowed size of %d`, maxBatchSize)
 	}
 

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -103,11 +103,10 @@ type eventreq struct {
 	seen bool
 	// osName is operating system runtime of the SDK
 	osName string
-	// size keeps track of the ingest payload size
-	size uint64
-	// attachmentsSize is the portion of size that comes
-	// from attachments. It is excluded from the payload
-	// size-limit validation but still counts toward billing.
+	// payloadSize is the size in bytes of the event and span
+	// payload.
+	payloadSize uint64
+	// attachmentsSize is the total size in bytes of attachments.
 	attachmentsSize uint64
 	// events is the list of events in the ingest
 	// batch
@@ -222,18 +221,22 @@ func (e *eventreq) uploadAttachments() error {
 	return nil
 }
 
-// bumpSize increases the payload size of
-// events in bytes.
-func (e *eventreq) bumpSize(n uint64) {
-	e.size = e.size + n
+// bumpPayloadSize increases the event and span payload size
+// in bytes.
+func (e *eventreq) bumpPayloadSize(n uint64) {
+	e.payloadSize += n
 }
 
-// bumpAttachmentSize increases the payload size in bytes
-// and tracks the attachment portion separately so it can
-// be excluded from the payload size-limit validation.
-func (e *eventreq) bumpAttachmentSize(n uint64) {
-	e.size = e.size + n
-	e.attachmentsSize = e.attachmentsSize + n
+// bumpAttachmentsSize increases the tracked attachments size
+// in bytes.
+func (e *eventreq) bumpAttachmentsSize(n uint64) {
+	e.attachmentsSize += n
+}
+
+// billableSize is the total size in bytes counted toward billing:
+// the event and span payload plus all attachments.
+func (e *eventreq) billableSize() uint64 {
+	return e.payloadSize + e.attachmentsSize
 }
 
 // estimateAttachmentSize returns an estimated size in bytes
@@ -362,7 +365,7 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 			dupEvent[ev.ID] = struct{}{}
 		}
 
-		e.bumpSize(uint64(len(bytes)))
+		e.bumpPayloadSize(uint64(len(bytes)))
 		ev.AppID = e.appId
 
 		// partially prepare list of attachments
@@ -414,7 +417,7 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 			dupSpan[sp.SpanID] = struct{}{}
 		}
 
-		e.bumpSize(uint64(len(bytes)))
+		e.bumpPayloadSize(uint64(len(bytes)))
 		sp.AppID = e.appId
 
 		e.spans = append(e.spans, sp)
@@ -436,7 +439,7 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 		if header == nil {
 			continue
 		}
-		e.bumpAttachmentSize(uint64(header.Size))
+		e.bumpAttachmentsSize(uint64(header.Size))
 
 		// inject the form field header to
 		// the previously constructed partial
@@ -508,7 +511,7 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 			return err
 		}
 
-		e.bumpSize(uint64(len(bytes)))
+		e.bumpPayloadSize(uint64(len(bytes)))
 		ev.AppID = e.appId
 
 		for _, attachment := range ev.Attachments {
@@ -524,9 +527,9 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 			// by newer SDKs. Fall back to estimates for older
 			// SDKs that don't send size.
 			if attachment.Size > 0 {
-				e.bumpAttachmentSize(attachment.Size)
+				e.bumpAttachmentsSize(attachment.Size)
 			} else {
-				e.bumpAttachmentSize(estimateAttachmentSize(attachment.Name))
+				e.bumpAttachmentsSize(estimateAttachmentSize(attachment.Name))
 			}
 		}
 
@@ -553,7 +556,7 @@ func (e *eventreq) readJsonRequest(payload *IngestRequest) error {
 			return err
 		}
 
-		e.bumpSize(uint64(len(bytes)))
+		e.bumpPayloadSize(uint64(len(bytes)))
 		sp.AppID = e.appId
 
 		e.spans = append(e.spans, sp)
@@ -761,10 +764,10 @@ func (e eventreq) validate() error {
 		}
 	}
 
-	// attachments are excluded from the size limit; they are
-	// uploaded directly to storage and are not part of the
-	// event payload. they only count toward billing.
-	if e.size-e.attachmentsSize >= uint64(maxBatchSize) {
+	// only the event payload counts toward the size limit.
+	// attachments upload directly to storage and are not part
+	// of the payload.
+	if e.payloadSize >= uint64(maxBatchSize) {
 		return fmt.Errorf(`payload cannot exceed maximum allowed size of %d`, maxBatchSize)
 	}
 
@@ -1021,7 +1024,7 @@ func PutEvents(c *gin.Context) {
 		TeamID:   eventReq.teamId.String(),
 		OsName:   eventReq.osName,
 		ClientIP: c.ClientIP(),
-		Size:     eventReq.size,
+		Size:     eventReq.billableSize(),
 		Events:   eventReq.events,
 		Spans:    eventReq.spans,
 	}

--- a/backend/ingest/measure/sdkconfig.go
+++ b/backend/ingest/measure/sdkconfig.go
@@ -62,6 +62,7 @@ type SdkConfig struct {
 	HTTPTrackRequestForURLs   []string            `json:"http_track_request_for_urls"`
 	HTTPTrackResponseForURLs  []string            `json:"http_track_response_for_urls"`
 	HTTPBlockedHeaders        []string            `json:"http_blocked_headers"`
+	ProfileSamplingRate       float64             `json:"profile_sampling_rate"`
 	UpdatedAt                 *time.Time          `json:"-"`
 	UpdatedBy                 *uuid.UUID          `json:"-"`
 }
@@ -129,6 +130,7 @@ func createDefaultConfig() SdkConfig {
 		HTTPTrackRequestForURLs:   []string{},
 		HTTPTrackResponseForURLs:  []string{},
 		HTTPBlockedHeaders:        []string{},
+		ProfileSamplingRate:       100,
 	}
 }
 
@@ -209,6 +211,7 @@ func getConfigFromDb(ctx context.Context, appID uuid.UUID) (*SdkConfig, error) {
 		Select("http_track_request_for_urls").
 		Select("http_track_response_for_urls").
 		Select("http_blocked_headers").
+		Select("profile_sampling_rate").
 		Select("updated_at").
 		Select("updated_by").
 		From("measure.sdk_config").
@@ -236,6 +239,7 @@ func getConfigFromDb(ctx context.Context, appID uuid.UUID) (*SdkConfig, error) {
 		&sdkConfig.HTTPTrackRequestForURLs,
 		&sdkConfig.HTTPTrackResponseForURLs,
 		&sdkConfig.HTTPBlockedHeaders,
+		&sdkConfig.ProfileSamplingRate,
 		&sdkConfig.UpdatedAt,
 		&sdkConfig.UpdatedBy,
 	)

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -51,7 +51,7 @@ type PreSignConfig struct {
 }
 
 // attachmentTypes is a list of all valid attachment types.
-var attachmentTypes = []string{"screenshot", "android_method_trace", "layout_snapshot", "layout_snapshot_json"}
+var attachmentTypes = []string{"screenshot", "android_method_trace", "layout_snapshot", "layout_snapshot_json", "perfetto_trace", "heap_dump", "heap_profile"}
 
 // isNotFound checks if error is a googleapi
 // not found error.

--- a/backend/libs/event/event.go
+++ b/backend/libs/event/event.go
@@ -104,6 +104,7 @@ const TypeNavigation = "navigation"
 const TypeScreenView = "screen_view"
 const TypeBugReport = "bug_report"
 const TypeSessionStart = "session_start"
+const TypeProfile = "profile"
 
 const NetworkGeneration2G = "2g"
 const NetworkGeneration3G = "3g"
@@ -171,6 +172,7 @@ var androidValidTypes = []string{
 	TypeCustom,
 	TypeBugReport,
 	TypeSessionStart,
+	TypeProfile,
 }
 
 // iOSValidTypes defines a whitelist for all
@@ -678,6 +680,11 @@ type SessionStart struct {
 	// No fields are required for this event.
 }
 
+type Profile struct {
+	Reason string `json:"reason" binding:"required"`
+	Format string `json:"format" binding:"required"`
+}
+
 type EventField struct {
 	ID                      uuid.UUID                `json:"id"`
 	IPv4                    net.IP                   `json:"inet_ipv4"`
@@ -718,6 +725,7 @@ type EventField struct {
 	BugReport               *BugReport               `json:"bug_report,omitempty"`
 	Custom                  *Custom                  `json:"custom,omitempty"`
 	SessionStart            *SessionStart            `json:"session_start,omitempty"`
+	Profile                 *Profile                 `json:"profile,omitempty"`
 }
 
 // Validate validates the event for data
@@ -783,6 +791,10 @@ func (e *EventField) Validate(opts ...ingest.ValidationOptions) error {
 		if len(e.ANR.Exceptions) < 1 || len(e.ANR.Threads) < 1 {
 			return fmt.Errorf(`%q must contain at least one anr & thread`, `anr`)
 		}
+	}
+
+	if e.IsProfile() && e.Profile == nil {
+		return fmt.Errorf(`%q must not be empty`, TypeProfile)
 	}
 
 	if e.IsException() {
@@ -1327,6 +1339,11 @@ func (e EventField) IsLifecycleApp() bool {
 // launch event.
 func (e EventField) IsColdLaunch() bool {
 	return e.Type == TypeColdLaunch
+}
+
+// IsProfile returns true for profile event.
+func (e EventField) IsProfile() bool {
+	return e.Type == TypeProfile
 }
 
 // IsWarmLaunch returns true for warm

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -4919,6 +4919,8 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			`navigation.to`,
 			`navigation.from`,
 			`navigation.source`,
+			`profile.reason`,
+			`profile.format`,
 		}...)
 	case opsys.AppleFamily:
 		cols = append(cols, []string{
@@ -4996,6 +4998,7 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 		var userDefAttr map[string][]any
 		var bugReport event.BugReport
 		var custom event.Custom
+		var profile event.Profile
 
 		var coldLaunchDuration uint32
 		var warmLaunchDuration uint32
@@ -5231,6 +5234,10 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 				&navigation.To,
 				&navigation.From,
 				&navigation.Source,
+
+				// profile
+				&profile.Reason,
+				&profile.Format,
 			}...)
 		case opsys.AppleFamily:
 			dest = append(dest, []any{
@@ -5414,6 +5421,15 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			session.Events = append(session.Events, ev)
 		case event.TypeMemoryUsageAbs:
 			ev.MemoryUsageAbs = &memoryUsageAbs
+			session.Events = append(session.Events, ev)
+		case event.TypeProfile:
+			// only unmarshal attachments if more than 8 characters
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
+			ev.Profile = &profile
 			session.Events = append(session.Events, ev)
 		default:
 			continue

--- a/backend/libs/measure/sdkconfig.go
+++ b/backend/libs/measure/sdkconfig.go
@@ -44,6 +44,7 @@ type SdkConfig struct {
 	HTTPTrackRequestForURLs   []string            `json:"http_track_request_for_urls"`
 	HTTPTrackResponseForURLs  []string            `json:"http_track_response_for_urls"`
 	HTTPBlockedHeaders        []string            `json:"http_blocked_headers"`
+	ProfileSamplingRate       float64             `json:"profile_sampling_rate"`
 	UpdatedAt                 *time.Time          `json:"-"`
 	UpdatedBy                 *uuid.UUID          `json:"-"`
 }
@@ -67,6 +68,7 @@ type ConfigPatch struct {
 	HTTPTrackRequestForURLs   *[]string            `json:"http_track_request_for_urls,omitempty"`
 	HTTPTrackResponseForURLs  *[]string            `json:"http_track_response_for_urls,omitempty"`
 	HTTPBlockedHeaders        *[]string            `json:"http_blocked_headers,omitempty"`
+	ProfileSamplingRate       *float64             `json:"profile_sampling_rate,omitempty"`
 }
 
 func (s ScreenshotMaskLevel) IsValid() bool {
@@ -100,6 +102,7 @@ func createDefaultConfig() SdkConfig {
 		HTTPTrackRequestForURLs:   []string{},
 		HTTPTrackResponseForURLs:  []string{},
 		HTTPBlockedHeaders:        []string{},
+		ProfileSamplingRate:       100,
 	}
 }
 
@@ -127,6 +130,7 @@ func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*S
 		Select("http_track_request_for_urls").
 		Select("http_track_response_for_urls").
 		Select("http_blocked_headers").
+		Select("profile_sampling_rate").
 		Select("updated_at").
 		Select("updated_by").
 		From("measure.sdk_config").
@@ -155,6 +159,7 @@ func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*S
 		&sdkConfig.HTTPTrackRequestForURLs,
 		&sdkConfig.HTTPTrackResponseForURLs,
 		&sdkConfig.HTTPBlockedHeaders,
+		&sdkConfig.ProfileSamplingRate,
 		&sdkConfig.UpdatedAt,
 		&sdkConfig.UpdatedBy,
 	)
@@ -205,6 +210,7 @@ func CreateConfig(ctx context.Context, tx pgx.Tx, teamID, appID uuid.UUID, creat
 		Set("http_track_request_for_urls", config.HTTPTrackRequestForURLs).
 		Set("http_track_response_for_urls", config.HTTPTrackResponseForURLs).
 		Set("http_blocked_headers", config.HTTPBlockedHeaders).
+		Set("profile_sampling_rate", config.ProfileSamplingRate).
 		Set("updated_at", time.Now()).
 		Set("updated_by", createdBy)
 

--- a/backend/libs/timeline/profiling.go
+++ b/backend/libs/timeline/profiling.go
@@ -1,0 +1,49 @@
+package timeline
+
+import (
+	"time"
+
+	"backend/libs/event"
+	"backend/libs/udattr"
+)
+
+// Profile represents a profile event
+// suitable for session timeline.
+type Profile struct {
+	EventType   string              `json:"event_type"`
+	UDAttribute *udattr.UDAttribute `json:"user_defined_attribute"`
+	ThreadName  string              `json:"thread_name"`
+	*event.Profile
+	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
+}
+
+// GetThreadName provides the name of the thread
+// where the profile was delivered.
+func (pr Profile) GetThreadName() string {
+	return pr.ThreadName
+}
+
+// GetTimestamp provides the timestamp of the
+// profile event.
+func (pr Profile) GetTimestamp() time.Time {
+	return pr.Timestamp
+}
+
+// ComputeProfiles computes profile events
+// for session timeline.
+func ComputeProfiles(events []event.EventField) (result []ThreadGrouper) {
+	for _, ev := range events {
+		profile := Profile{
+			ev.Type,
+			&ev.UserDefinedAttribute,
+			ev.Attribute.ThreadName,
+			ev.Profile,
+			ev.Timestamp,
+			ev.Attachments,
+		}
+		result = append(result, profile)
+	}
+
+	return
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ feature's documentation to understand its underlying mechanism and enhance your 
   lifecycle events
 * [**CPU Monitoring**](features/feature-cpu-monitoring.md) — Monitor CPU usage for every session
 * [**Memory Monitoring**](features/feature-memory-monitoring.md) — Monitor memory usage for every session
+* [**Profiling**](features/feature-profiling.md) — Capture system traces and heap dumps on Android
 * [**Identify Users**](features/feature-identify-users.md) — Correlate sessions with a user ID
 * [**Manually Start or Stop the SDK**](features/feature-manually-start-stop-sdk.md) — Control when data collection
   happens

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -73,6 +73,7 @@ Find all the endpoints, resources and detailed documentation for Measure SDK RES
     - [**`screen_view`**](#screen_view)
     - [**`custom`**](#custom)
     - [**`session_start`**](#session_start)
+    - [**`profile`**](#profile)
   - [Traces](#traces)
 
 ## Resources
@@ -753,7 +754,7 @@ Attachments are arbitrary files associated with the session each having the foll
 | ------ | ------ | -------- | ------------------------------------------------------------------------------------------------ |
 | `id`   | string | No       | id of the attachment                                                                             |
 | `name` | string | No       | name of the attachment                                                                           |
-| `type` | string | No       | One of the following:<br />- `screenshot`<br />- `android_method_trace`<br />- `layout_snapshot` |
+| `type` | string | No       | One of the following:<br />- `screenshot`<br />- `android_method_trace`<br />- `layout_snapshot`<br />- `perfetto_trace`<br />- `heap_dump`<br />- `heap_profile` |
 
 ### Events
 
@@ -1300,6 +1301,15 @@ Use the `custom` type for custom events.
 Use the `session_start` type to mark begining of a new session. This must be the first _event_ by time in a session.
 
 This event has no additional fields.
+
+#### **`profile`**
+
+Use the `profile` type for a performance profile captured by the SDK, such as a [Perfetto](https://perfetto.dev/) trace or heap dump. The profile artifact itself is sent as an [attachment](#attachments) on the event whose `type` matches the event's `format`.
+
+| Field    | Type   | Optional | Comment                                                                                                                            |
+| -------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `reason` | string | No       | The occasion that produced the profile. One of:<br />- `app_launch`<br />- `anr`                                                   |
+| `format` | string | No       | Format of the attached profile artifact, mirroring the attachment `type`. One of:<br />- `perfetto_trace`<br />- `heap_dump`<br />- `heap_profile` |
 
 ### Traces
 

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -1308,7 +1308,7 @@ Use the `profile` type for a performance profile captured by the SDK, such as a 
 
 | Field    | Type   | Optional | Comment                                                                                                                            |
 | -------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `reason` | string | No       | The occasion that produced the profile. One of:<br />- `app_launch`<br />- `anr`                                                   |
+| `reason` | string | No       | The occasion that produced the profile. One of:<br />- `app_fully_drawn`<br />- `anr`                                                   |
 | `format` | string | No       | Format of the attached profile artifact, mirroring the attachment `type`. One of:<br />- `perfetto_trace`<br />- `heap_dump`<br />- `heap_profile` |
 
 ### Traces

--- a/docs/features/feature-profiling.md
+++ b/docs/features/feature-profiling.md
@@ -27,13 +27,7 @@ in the background.
 To avoid pulling WorkManager and its transitive dependencies into apps that don't need profiling,
 Measure does not bundle it. Profiling is enabled only when WorkManager is present as a dependency.
 
-To enable profiling, add the WorkManager dependency to your app's `build.gradle.kts` (use the latest available version):
-
-```kotlin
-dependencies {
-    implementation("androidx.work:work-runtime:2.10.0")
-}
-```
+To enable profiling, add the [WorkManager dependency](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started) to your app's `build.gradle.kts`.
 
 When WorkManager is not present, the profiling collector is never registered and no profiling data is collected.
 
@@ -42,7 +36,7 @@ When WorkManager is not present, the profiling collector is never registered and
 A trigger describes an occasion on which the operating system may capture a profile. Measure currently registers two.
 
 > [!NOTE]  
-> Android 17 (API level 37) adds further profiling triggers, such as out-of-memory, cold start and excessive CPU usage.
+> Android 17 (API level 37) adds more profiling triggers like out-of-memory, cold start and excessive CPU usage.
 > Registering these requires compiling against the Android 17 SDK (`compileSdk 37`); support is coming soon.
 
 ### App fully drawn (`app_launch`)

--- a/docs/features/feature-profiling.md
+++ b/docs/features/feature-profiling.md
@@ -1,0 +1,93 @@
+---
+title: "Mobile App Profiling"
+description: "Auto-capture heap dumps and perfetto traces from Android apps using the platform's trigger-based profiling APIs."
+---
+
+# Profiling
+
+- [Introduction](#introduction)
+- [Enable profiling](#enable-profiling)
+- [Triggers](#triggers)
+- [Sampling](#sampling)
+- [How It Works](#how-it-works)
+
+## Introduction
+
+Measure can capture Perfetto system traces and heap dumps and attaches them to your session timeline. They let you dig into exactly what the app was doing at a specific moment, for example when it finished launching or became unresponsive.
+
+> [!NOTE]  
+> Profiling is currently available on Android only. It requires Android 16 (API level 36) or higher and is a no-op on older versions.
+
+## Enable profiling
+
+Profiling is off by default. It relies on [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager)
+to upload its results, because a system trace or heap dump can be large (often over 10 MB) and must be uploaded durably
+in the background. 
+
+To avoid pulling WorkManager and its transitive dependencies into apps that don't need profiling,
+Measure does not bundle it. Profiling is enabled only when WorkManager is present as a dependency.
+
+To enable profiling, add the WorkManager dependency to your app's `build.gradle.kts` (use the latest available version):
+
+```kotlin
+dependencies {
+    implementation("androidx.work:work-runtime:2.10.0")
+}
+```
+
+When WorkManager is not present, the profiling collector is never registered and no profiling data is collected.
+
+## Triggers
+
+A trigger describes an occasion on which the operating system may capture a profile. Measure currently registers two.
+
+> [!NOTE]  
+> Android 17 (API level 37) adds further profiling triggers, such as out-of-memory, cold start and excessive CPU usage.
+> Registering these requires compiling against the Android 17 SDK (`compileSdk 37`); support is coming soon.
+
+### App fully drawn (`app_launch`)
+
+Captured once the app reports that it has finished drawing its first meaningful content. This is not automatic: your app
+must signal the moment by calling [`Activity.reportFullyDrawn()`](https://developer.android.com/reference/android/app/Activity#reportFullyDrawn()).
+Call it once the first screen's meaningful content is on screen, including any data loaded asynchronously:
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.loadHome()
+    }
+
+    // Call once the first meaningful content has finished rendering.
+    private fun onHomeContentReady() {
+        reportFullyDrawn()
+    }
+}
+```
+
+### ANR (`anr`)
+
+Captured when the app becomes unresponsive (an Application Not Responding event). The operating system detects ANRs on its own, so no app-side setup is required.
+
+Each trigger is rate-limited by the operating system. Measure sets a rate-limiting period of one hour per trigger type, so the same trigger will not produce more than one profile per hour.
+
+## Sampling
+
+Profiling results are sampled independently of session sampling. The sampling rate is a value between 0 and 100 and
+defaults to 100, meaning every result the operating system produces is collected. The default is kept high because the
+OS already rate-limits how often each trigger can fire, so an aggressive client-side rate would collect almost nothing. So keep this sampling rate higher than other sampling rates you may have configured.
+
+## How It Works
+
+Measure uses [`android.os.ProfilingManager`](https://developer.android.com/reference/android/os/ProfilingManager), the
+platform's trigger-based profiling API introduced in Android 16. The SDK registers the triggers above with the operating
+system along with a callback to receive results. From then on the OS decides when to run a profiling
+session, writes the result to a file and hands it back. Measure attaches that file to a `profile` event tagged with the trigger that produced it.
+
+Because profiling artifacts can be large, they are uploaded in the background by a dedicated WorkManager worker once the device is connected to a network, rather than in-process with other events. Once uploaded, a result can be downloaded from the session timeline in the dashboard.
+
+## Further reading
+
+* [Android ProfilingManager](https://developer.android.com/reference/android/os/ProfilingManager)
+* [Android ProfilingTrigger](https://developer.android.com/reference/android/os/ProfilingTrigger)
+* [Perfetto](https://perfetto.dev/)

--- a/docs/features/feature-profiling.md
+++ b/docs/features/feature-profiling.md
@@ -39,7 +39,7 @@ A trigger describes an occasion on which the operating system may capture a prof
 > Android 17 (API level 37) adds more profiling triggers like out-of-memory, cold start and excessive CPU usage.
 > Registering these requires compiling against the Android 17 SDK (`compileSdk 37`); support is coming soon.
 
-### App fully drawn (`app_launch`)
+### App fully drawn (`app_fully_drawn`)
 
 Captured once the app reports that it has finished drawing its first meaningful content. This is not automatic: your app
 must signal the moment by calling [`Activity.reportFullyDrawn()`](https://developer.android.com/reference/android/app/Activity#reportFullyDrawn()).

--- a/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
+++ b/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
@@ -120,6 +120,7 @@ const mockInitialConfig = {
   http_track_response_for_urls: [],
   http_blocked_headers: [],
   screenshot_mask_level: "sensitive_fields_only",
+  profile_sampling_rate: 100,
 };
 
 // Helper: simulate the mutation.mutate call succeeding
@@ -165,6 +166,7 @@ describe("SdkConfigurator Component", () => {
     expect(screen.getByText("Bug Reports")).toBeInTheDocument();
     expect(screen.getByText("Traces")).toBeInTheDocument();
     expect(screen.getByText("Launch Metrics")).toBeInTheDocument();
+    expect(screen.getByText("Profiling")).toBeInTheDocument();
     expect(screen.getByText("User Journeys")).toBeInTheDocument();
     expect(screen.getByText("HTTP")).toBeInTheDocument();
     expect(screen.getByText("Screenshot Masking")).toBeInTheDocument();

--- a/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
@@ -128,6 +128,11 @@ describe("SessionTimelineEventCell", () => {
         "SwiftUI",
       ],
       ["string", { string: "a log line" }, "Log"],
+      [
+        "profile",
+        { reason: "app_launch", format: "perfetto_trace" },
+        "Profile",
+      ],
       ["unknown_event_type", {}, "unknown_event_type"],
     ])("shows %s pill label", (eventType, eventDetails, expectedLabel) => {
       renderCell({ eventType, eventDetails });
@@ -182,6 +187,11 @@ describe("SessionTimelineEventCell", () => {
       ["trace", { trace_name: "checkout" }, "bg-pink-100"],
       ["custom", { name: "event" }, "bg-purple-100"],
       ["string", { string: "a log line" }, "bg-indigo-100"],
+      [
+        "profile",
+        { reason: "app_launch", format: "perfetto_trace" },
+        "bg-teal-100",
+      ],
       ["unknown_event_type", {}, "bg-indigo-100"],
     ])("applies %s pill bg", (eventType, eventDetails, expectedClass) => {
       const { container } = renderCell({ eventType, eventDetails });

--- a/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_cell_test.tsx
@@ -130,7 +130,7 @@ describe("SessionTimelineEventCell", () => {
       ["string", { string: "a log line" }, "Log"],
       [
         "profile",
-        { reason: "app_launch", format: "perfetto_trace" },
+        { reason: "app_fully_drawn", format: "perfetto_trace" },
         "Profile",
       ],
       ["unknown_event_type", {}, "unknown_event_type"],
@@ -189,7 +189,7 @@ describe("SessionTimelineEventCell", () => {
       ["string", { string: "a log line" }, "bg-indigo-100"],
       [
         "profile",
-        { reason: "app_launch", format: "perfetto_trace" },
+        { reason: "app_fully_drawn", format: "perfetto_trace" },
         "bg-teal-100",
       ],
       ["unknown_event_type", {}, "bg-indigo-100"],

--- a/frontend/dashboard/__tests__/components/session_timeline_event_details_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_timeline_event_details_test.tsx
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockOpenTraceInPerfetto = jest.fn(
+  (_url: string, _title: string): Promise<void> => Promise.resolve(),
+);
+jest.mock("@/app/utils/perfetto_utils", () => ({
+  openTraceInPerfetto: (url: string, title: string) =>
+    mockOpenTraceInPerfetto(url, title),
+}));
 
 jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableDateTime: (ts: string) => `formatted:${ts}`,
@@ -440,6 +448,72 @@ describe("SessionTimelineEventDetails", () => {
         },
       });
       expect(screen.getByTestId("layout-snapshot")).toBeInTheDocument();
+    });
+  });
+
+  describe("Profile attachments", () => {
+    const traceEventDetails = {
+      format: "perfetto_trace",
+      attachments: [
+        {
+          key: "trace-1",
+          name: "profile.perfetto-trace",
+          location: "https://example.com/profile.perfetto-trace",
+          type: "perfetto_trace",
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      mockOpenTraceInPerfetto.mockClear();
+    });
+
+    it("renders a download link for profile attachments", () => {
+      renderDetails({ eventType: "profile", eventDetails: traceEventDetails });
+      expect(screen.getByText("Download").closest("a")).toHaveAttribute(
+        "href",
+        "https://example.com/profile.perfetto-trace",
+      );
+    });
+
+    it("opens perfetto traces in the Perfetto UI on click", () => {
+      renderDetails({ eventType: "profile", eventDetails: traceEventDetails });
+      fireEvent.click(screen.getByText("Open in Perfetto"));
+      expect(mockOpenTraceInPerfetto).toHaveBeenCalledWith(
+        "https://example.com/profile.perfetto-trace",
+        "profile.perfetto-trace",
+      );
+    });
+
+    it("does not show the Perfetto button for non-trace attachments", () => {
+      renderDetails({
+        eventType: "profile",
+        eventDetails: {
+          format: "heap_profile",
+          attachments: [
+            {
+              key: "heap-1",
+              name: "profile.heapprofd",
+              location: "https://example.com/profile.heapprofd",
+              type: "heap_profile",
+            },
+          ],
+        },
+      });
+      expect(screen.getByText("Download")).toBeInTheDocument();
+      expect(screen.queryByText("Open in Perfetto")).not.toBeInTheDocument();
+    });
+
+    it("renders a non-clickable Perfetto label in demo mode", () => {
+      renderDetails({
+        demo: true,
+        eventType: "profile",
+        eventDetails: traceEventDetails,
+      });
+      const perfetto = screen.getByText("Open in Perfetto");
+      expect(perfetto.tagName).toBe("DIV");
+      fireEvent.click(perfetto);
+      expect(mockOpenTraceInPerfetto).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1169,6 +1169,7 @@ export type SdkConfig = {
   http_track_response_for_urls: string[];
   http_blocked_headers: string[];
   screenshot_mask_level: string;
+  profile_sampling_rate: number;
 };
 export class AppVersion {
   name: string;

--- a/frontend/dashboard/app/components/pill.tsx
+++ b/frontend/dashboard/app/components/pill.tsx
@@ -53,6 +53,7 @@ export enum PillType {
   SessionEventTrace = "session_event_trace",
   SessionEventCustom = "session_event_custom",
   SessionEventLog = "session_event_log",
+  SessionEventProfile = "session_event_profile",
   SessionEventDefault = "session_event_default",
 }
 
@@ -97,6 +98,8 @@ const sessionPink =
   "rounded-sm border-pink-400 text-pink-700 bg-pink-100 dark:border-pink-400 dark:text-pink-400 dark:bg-pink-950/40";
 const sessionPurple =
   "rounded-sm border-purple-400 text-purple-700 bg-purple-100 dark:border-purple-400 dark:text-purple-400 dark:bg-purple-950/40";
+const sessionTeal =
+  "rounded-sm border-teal-400 text-teal-700 bg-teal-100 dark:border-teal-400 dark:text-teal-400 dark:bg-teal-950/40";
 // Indigo is the catch-all for lifecycle, launches, memory, logs and any
 // otherwise-unmapped event.
 const sessionIndigo =
@@ -214,6 +217,10 @@ const pillDefaults: Record<PillType, { label?: string; tint: string }> = {
   [PillType.SessionEventTrace]: { label: "Trace", tint: sessionPink },
   [PillType.SessionEventCustom]: { label: "Custom", tint: sessionPurple },
   [PillType.SessionEventLog]: { label: "Log", tint: sessionIndigo },
+  [PillType.SessionEventProfile]: {
+    label: "Profile",
+    tint: sessionTeal,
+  },
   // No label: the cell passes the raw event type as children for unknown
   // events, mirroring the old `return eventType` fallback.
   [PillType.SessionEventDefault]: { tint: sessionIndigo },

--- a/frontend/dashboard/app/components/sdk_configurator.tsx
+++ b/frontend/dashboard/app/components/sdk_configurator.tsx
@@ -60,6 +60,7 @@ export default function SdkConfigurator({
     bugReports: "idle",
     traces: "idle",
     launch: "idle",
+    profiling: "idle",
     journey: "idle",
     http: "idle",
     masking: "idle",
@@ -75,6 +76,7 @@ export default function SdkConfigurator({
   const [bugReportsConfirmOpen, setBugReportsConfirmOpen] = useState(false);
   const [tracesConfirmOpen, setTracesConfirmOpen] = useState(false);
   const [launchConfirmOpen, setLaunchConfirmOpen] = useState(false);
+  const [profilingConfirmOpen, setProfilingConfirmOpen] = useState(false);
   const [journeyConfirmOpen, setJourneyConfirmOpen] = useState(false);
   const [httpConfirmOpen, setHttpConfirmOpen] = useState(false);
   const [maskingConfirmOpen, setMaskingConfirmOpen] = useState(false);
@@ -121,6 +123,10 @@ export default function SdkConfigurator({
     !!sdkConfig &&
     !!originalSdkConfig &&
     sdkConfig.launch_sampling_rate !== originalSdkConfig.launch_sampling_rate;
+  const profilingChanged =
+    !!sdkConfig &&
+    !!originalSdkConfig &&
+    sdkConfig.profile_sampling_rate !== originalSdkConfig.profile_sampling_rate;
   const journeyChanged =
     !!sdkConfig &&
     !!originalSdkConfig &&
@@ -206,6 +212,11 @@ export default function SdkConfigurator({
   const handleSaveLaunch = () => {
     saveSection("launch", {
       launch_sampling_rate: sdkConfig.launch_sampling_rate,
+    });
+  };
+  const handleSaveProfiling = () => {
+    saveSection("profiling", {
+      profile_sampling_rate: sdkConfig.profile_sampling_rate,
     });
   };
   const handleSaveJourney = () => {
@@ -435,6 +446,34 @@ export default function SdkConfigurator({
           </li>
         </ul>
         <p className="mt-4">These changes will apply to all new launches.</p>
+      </div>
+    );
+  };
+
+  const getProfilingConfirmBody = () => {
+    return (
+      <div className="font-body">
+        <p>
+          Are you sure you want to update{" "}
+          <span className="font-display font-bold">Profiling settings</span> for
+          app <span className="font-display font-bold">{appName}</span>?
+        </p>
+        <p className="mt-4">The following changes will be applied:</p>
+        <ul className="mt-2 space-y-1 list-disc list-inside">
+          <li>
+            Sampling rate:{" "}
+            <span className="font-display font-bold">
+              {originalSdkConfig.profile_sampling_rate}%
+            </span>{" "}
+            →{" "}
+            <span className="font-display font-bold">
+              {sdkConfig.profile_sampling_rate}%
+            </span>
+          </li>
+        </ul>
+        <p className="mt-4">
+          These changes will apply to all new profiling results.
+        </p>
       </div>
     );
   };
@@ -806,6 +845,50 @@ export default function SdkConfigurator({
             </AccordionContent>
           </AccordionItem>
 
+          {/* Profiling Accordion */}
+          <AccordionItem value="profiling" className="mt-2">
+            <AccordionTrigger className="font-body text-base">
+              Profiling
+            </AccordionTrigger>
+            <AccordionContent className={accordionContentStyle}>
+              <div className="mt-2 space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-body text-sm">
+                    Collect profiling traces at
+                  </span>
+                  <SdkConfigNumericInput
+                    testId="profiling-sampling-rate-input"
+                    value={sdkConfig.profile_sampling_rate}
+                    minValue={0}
+                    maxValue={100}
+                    step={0.01}
+                    type="float"
+                    onChange={(value) =>
+                      updateSdkConfig({
+                        profile_sampling_rate: value,
+                      })
+                    }
+                    disabled={!currentUserCanChangeAppSettings}
+                  />
+                  <span className="font-body text-sm">% sampling rate</span>
+                </div>
+                <div className="flex justify-end mt-2">
+                  <Button
+                    data-testid="profiling-save-button"
+                    variant="outline"
+                    disabled={
+                      !currentUserCanChangeAppSettings || !profilingChanged
+                    }
+                    loading={sectionStatuses.profiling === "saving"}
+                    onClick={() => setProfilingConfirmOpen(true)}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
           {/* User Journeys Accordion */}
           <AccordionItem value="journeys" className="mt-2">
             <AccordionTrigger className="font-body text-base">
@@ -1126,6 +1209,18 @@ export default function SdkConfigurator({
           handleSaveLaunch();
         }}
         onCancelAction={() => setLaunchConfirmOpen(false)}
+      />
+
+      <DangerConfirmationDialog
+        body={getProfilingConfirmBody()}
+        open={profilingConfirmOpen}
+        affirmativeText="Yes, I'm sure"
+        cancelText="Cancel"
+        onAffirmativeAction={() => {
+          setProfilingConfirmOpen(false);
+          handleSaveProfiling();
+        }}
+        onCancelAction={() => setProfilingConfirmOpen(false)}
       />
 
       <DangerConfirmationDialog

--- a/frontend/dashboard/app/components/session_timeline_event_cell.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_cell.tsx
@@ -32,6 +32,7 @@ const eventPillTypes: Record<string, PillType> = {
   trace: PillType.SessionEventTrace,
   custom: PillType.SessionEventCustom,
   string: PillType.SessionEventLog,
+  profile: PillType.SessionEventProfile,
 };
 
 function pillTypeForEvent(eventType: string, eventDetails: any): PillType {
@@ -136,6 +137,9 @@ export default function SessionTimelineEventCell({
     }
     if (eventType === "custom") {
       return eventDetails.name;
+    }
+    if (eventType === "profile") {
+      return String(eventDetails.reason);
     }
     return "";
   }

--- a/frontend/dashboard/app/components/session_timeline_event_details.tsx
+++ b/frontend/dashboard/app/components/session_timeline_event_details.tsx
@@ -8,6 +8,8 @@ import {
   formatDateToHumanReadableDateTime,
   formatMillisToHumanReadable,
 } from "../utils/time_utils";
+import { openTraceInPerfetto } from "../utils/perfetto_utils";
+import { toastNegative } from "../utils/use_toast";
 import { buttonVariants } from "./button_variants";
 import CodeBlock from "./code_block";
 import LayoutSnapshot from "./layout_snapshot";
@@ -283,12 +285,82 @@ export default function SessionTimelineEventDetails({
     }
   }
 
+  function getDownloadFromEventDetails(): ReactNode {
+    if (eventType !== "profile") {
+      return null;
+    }
+    if (
+      eventDetails.attachments === undefined ||
+      eventDetails.attachments === null ||
+      eventDetails.attachments.length === 0
+    ) {
+      return null;
+    }
+    const linkStyle = cn(
+      buttonVariants({ variant: "secondary" }),
+      "justify-center w-fit",
+    );
+    return (
+      <div className="flex flex-wrap gap-3">
+        {eventDetails.attachments.map(
+          (attachment: {
+            key: string;
+            name: string;
+            location: string;
+            type: string;
+          }) => (
+            <div key={attachment.key} className="flex flex-wrap gap-3">
+              {attachment.type === "perfetto_trace" &&
+                (demo ? (
+                  <div className={linkStyle}>Open in Perfetto</div>
+                ) : (
+                  <button
+                    type="button"
+                    className={linkStyle}
+                    onClick={() =>
+                      openTraceInPerfetto(
+                        attachment.location,
+                        attachment.name,
+                      ).catch((error) =>
+                        toastNegative(
+                          "Failed to open trace in Perfetto",
+                          error instanceof Error
+                            ? error.message
+                            : String(error),
+                        ),
+                      )
+                    }
+                  >
+                    Open in Perfetto
+                  </button>
+                ))}
+              {demo ? (
+                <div className={linkStyle}>Download</div>
+              ) : (
+                <a
+                  href={attachment.location}
+                  download={attachment.name}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkStyle}
+                >
+                  Download
+                </a>
+              )}
+            </div>
+          ),
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-3 font-display break-words">
       {getJsonLayoutSnapshotsFromEventDetails()}
       {getImageLayoutSnapshotsFromEventDetails()}
       {getBodyFromEventDetails()}
       {getDetailsLinkFromEventDetails()}
+      {getDownloadFromEventDetails()}
     </div>
   );
 }

--- a/frontend/dashboard/app/utils/perfetto_utils.ts
+++ b/frontend/dashboard/app/utils/perfetto_utils.ts
@@ -15,23 +15,22 @@ export async function openTraceInPerfetto(
     throw new Error("could not open Perfetto UI, check your popup blocker");
   }
 
-  let buffer: ArrayBuffer;
   try {
     const response = await fetch(traceUrl);
     if (!response.ok) {
       throw new Error(`fetching trace failed with status ${response.status}`);
     }
-    buffer = await response.arrayBuffer();
+    const buffer = await response.arrayBuffer();
+
+    await waitForPerfettoReady(perfettoWindow);
+    perfettoWindow.postMessage(
+      { perfetto: { buffer, title } },
+      PERFETTO_UI_ORIGIN,
+    );
   } catch (error) {
     perfettoWindow.close();
     throw error;
   }
-
-  await waitForPerfettoReady(perfettoWindow);
-  perfettoWindow.postMessage(
-    { perfetto: { buffer, title } },
-    PERFETTO_UI_ORIGIN,
-  );
 }
 
 // Perfetto's message channel is not buffered, so we PING until the UI answers
@@ -39,7 +38,11 @@ export async function openTraceInPerfetto(
 function waitForPerfettoReady(perfettoWindow: Window): Promise<void> {
   return new Promise((resolve, reject) => {
     const onMessage = (event: MessageEvent) => {
-      if (event.origin === PERFETTO_UI_ORIGIN && event.data === "PONG") {
+      if (
+        event.source === perfettoWindow &&
+        event.origin === PERFETTO_UI_ORIGIN &&
+        event.data === "PONG"
+      ) {
         cleanup();
         resolve();
       }
@@ -53,6 +56,11 @@ function waitForPerfettoReady(perfettoWindow: Window): Promise<void> {
 
     window.addEventListener("message", onMessage);
     const pingInterval = window.setInterval(() => {
+      if (perfettoWindow.closed) {
+        cleanup();
+        reject(new Error("Perfetto UI was closed before the trace loaded"));
+        return;
+      }
       perfettoWindow.postMessage("PING", PERFETTO_UI_ORIGIN);
     }, 100);
     const timeout = window.setTimeout(() => {

--- a/frontend/dashboard/app/utils/perfetto_utils.ts
+++ b/frontend/dashboard/app/utils/perfetto_utils.ts
@@ -1,0 +1,63 @@
+const PERFETTO_UI_ORIGIN = "https://ui.perfetto.dev";
+
+// Opens a trace in the Perfetto UI. The dashboard fetches the trace bytes and
+// hands them to Perfetto over postMessage, so presigned (non-public) trace URLs
+// work without being exposed to Perfetto or needing CORS on Perfetto's origin.
+// See https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui
+export async function openTraceInPerfetto(
+  traceUrl: string,
+  title: string,
+): Promise<void> {
+  // window.open must run synchronously within the click gesture, before the
+  // await below, or the popup blocker will reject it.
+  const perfettoWindow = window.open(PERFETTO_UI_ORIGIN);
+  if (perfettoWindow === null) {
+    throw new Error("could not open Perfetto UI, check your popup blocker");
+  }
+
+  let buffer: ArrayBuffer;
+  try {
+    const response = await fetch(traceUrl);
+    if (!response.ok) {
+      throw new Error(`fetching trace failed with status ${response.status}`);
+    }
+    buffer = await response.arrayBuffer();
+  } catch (error) {
+    perfettoWindow.close();
+    throw error;
+  }
+
+  await waitForPerfettoReady(perfettoWindow);
+  perfettoWindow.postMessage(
+    { perfetto: { buffer, title } },
+    PERFETTO_UI_ORIGIN,
+  );
+}
+
+// Perfetto's message channel is not buffered, so we PING until the UI answers
+// with PONG before posting the trace.
+function waitForPerfettoReady(perfettoWindow: Window): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin === PERFETTO_UI_ORIGIN && event.data === "PONG") {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const cleanup = () => {
+      window.clearInterval(pingInterval);
+      window.clearTimeout(timeout);
+      window.removeEventListener("message", onMessage);
+    };
+
+    window.addEventListener("message", onMessage);
+    const pingInterval = window.setInterval(() => {
+      perfettoWindow.postMessage("PING", PERFETTO_UI_ORIGIN);
+    }, 100);
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("timed out waiting for Perfetto UI to load"));
+    }, 15000);
+  });
+}

--- a/samples/frank/android/app/build.gradle.kts
+++ b/samples/frank/android/app/build.gradle.kts
@@ -129,6 +129,9 @@ afterEvaluate {
 
 dependencies {
     implementation("sh.measure:measure-android:0.18.0-SNAPSHOT")
+    // Opt into ProfilingManager uploads: the Measure SDK keeps WorkManager as a compileOnly
+    // dependency, so the app must add it to enable the profiling feature.
+    implementation("androidx.work:work-runtime:2.9.1")
     implementation(project(":kmp"))
     implementation(project(":flutter"))
     implementation(libs.androidx.activity.compose)

--- a/samples/frank/android/app/src/main/java/sh/frankenstein/android/MainActivity.kt
+++ b/samples/frank/android/app/src/main/java/sh/frankenstein/android/MainActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.ReportDrawn
 import androidx.activity.compose.setContent
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -66,6 +67,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             MeasureTheme {
+                ReportDrawn()
                 AppNavigation()
             }
         }

--- a/self-host/clickhouse/20260705120455_alter_events_table.sql
+++ b/self-host/clickhouse/20260705120455_alter_events_table.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 alter table events
-  add column if not exists `profile.reason` LowCardinality(String) comment 'occasion the profile was captured: app_launch, anr, error, manual or interval' CODEC(ZSTD(3)),
-  add column if not exists `profile.format` LowCardinality(String) comment 'profile artifact format, matches attachment type: perfetto_trace, heap_dump or heap_profile' CODEC(ZSTD(3));
+  add column if not exists `profile.reason` LowCardinality(String) comment 'occasion the profile was captured, eg. app_fully_drawn, anr' CODEC(ZSTD(3)),
+  add column if not exists `profile.format` LowCardinality(String) comment 'profile artifact format, matches attachment type, eg. perfetto_trace or heap_dump' CODEC(ZSTD(3));
 
 -- migrate:down
 alter table events

--- a/self-host/clickhouse/20260705120455_alter_events_table.sql
+++ b/self-host/clickhouse/20260705120455_alter_events_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+alter table events
+  add column if not exists `profile.reason` LowCardinality(String) comment 'occasion the profile was captured: app_launch, anr, error, manual or interval' CODEC(ZSTD(3)),
+  add column if not exists `profile.format` LowCardinality(String) comment 'profile artifact format, matches attachment type: perfetto_trace, heap_dump or heap_profile' CODEC(ZSTD(3));
+
+-- migrate:down
+alter table events
+  drop column if exists `profile.reason`,
+  drop column if exists `profile.format`;

--- a/self-host/postgres/20260705120456_alter_sdk_config_table.sql
+++ b/self-host/postgres/20260705120456_alter_sdk_config_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE sdk_config
+ADD COLUMN profile_sampling_rate float8 not null default 100;
+
+COMMENT ON COLUMN sdk_config.profile_sampling_rate IS 'sampling rate for profile events';
+
+-- migrate:down
+ALTER TABLE sdk_config
+DROP COLUMN profile_sampling_rate;


### PR DESCRIPTION
# Description

- Gate profiling event features on availability of work manager.
- Implement work manager based uploads for profile attachments.
- Standardize the session attribution for app exit and profile events using the existing sessions table.
- Register triggers for app fully drawn and ANRs.
- Ingest a new event type called `profile`.

| Property | Type | Description | Possible values |
| --- | --- | --- | --- |
| `reason` | string | The occasion that produced the profile. | `app_launch`, `anr` |
| `format` | string | Format of the attached profile artifact, mirroring the attachment's type. | `perfetto_trace`, `heap_dump`, `heap_profile` |

- Handle the new event in session timeline.
- Add a dynamic config to control `profiling` sampling rate.
- Create a new feature doc.
- Ignore attachment size to validate max batch size of 10MB. Refactor the relevant code to make it easier to follow.