### PR TITLE
chore(android): use throwable in trackHttpEvent API

### DIFF
--- a/android/measure-android/measure/api/measure.api
+++ b/android/measure-android/measure/api/measure.api
@@ -44,8 +44,8 @@ public final class sh/measure/android/Measure {
 	public static synthetic fun trackEvent$default (Lsh/measure/android/Measure;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)V
 	public static final fun trackHandledException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public static synthetic fun trackHandledException$default (Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
-	public final fun trackHttpEvent (Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Integer;Ljava/lang/Exception;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun trackHttpEvent$default (Lsh/measure/android/Measure;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Integer;Ljava/lang/Exception;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun trackHttpEvent (Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Integer;Ljava/lang/Throwable;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun trackHttpEvent$default (Lsh/measure/android/Measure;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Integer;Ljava/lang/Throwable;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun trackScreenView (Ljava/lang/String;Ljava/util/Map;)V
 	public static synthetic fun trackScreenView$default (Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -497,7 +497,7 @@ object Measure {
      * @param endTime The time when the HTTP request ended, it is recommended to use `SystemClock.elapsedRealtime()`
      * @param client The name of the HTTP client used, optional
      * @param statusCode The HTTP status code of the response received
-     * @param error The exception if the request fails.
+     * @param error The throwable if the request fails.
      * @param requestHeaders The HTTP headers in the request
      * @param responseHeaders The HTTP headers in the response
      * @param requestBody An optional request body
@@ -509,7 +509,7 @@ object Measure {
         startTime: Long,
         endTime: Long,
         statusCode: Int? = null,
-        error: Exception? = null,
+        error: Throwable? = null,
         requestHeaders: MutableMap<String, String>? = null,
         responseHeaders: MutableMap<String, String>? = null,
         requestBody: String? = null,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -335,7 +335,7 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         startTime: Long,
         endTime: Long,
         statusCode: Int?,
-        error: Exception?,
+        error: Throwable?,
         requestHeaders: MutableMap<String, String>?,
         responseHeaders: MutableMap<String, String>?,
         requestBody: String?,


### PR DESCRIPTION
# Description

Change the `error` parameter of `Measure.trackHttpEvent` from `Exception?` to `Throwable?` so callers can report any throwable, and refresh the public API dump.

This is a breaking change in the public API, however, anyone using it should not get any compilation errors.

Closes #3966