### PR TITLE
chore(android): remove platform attribute from events and spans

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/attributes/Attribute.kt
@@ -20,7 +20,6 @@ internal object Attribute {
     const val OS_NAME_KEY = "os_name"
     const val OS_VERSION_KEY = "os_version"
     const val OS_PAGE_SIZE = "os_page_size"
-    const val PLATFORM_KEY = "platform"
     const val NETWORK_TYPE_KEY = "network_type"
     const val NETWORK_GENERATION_KEY = "network_generation"
     const val NETWORK_PROVIDER_KEY = "network_provider"

--- a/android/measure-android/measure/src/main/java/sh/measure/android/attributes/SpanDeviceAttributeProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/attributes/SpanDeviceAttributeProcessor.kt
@@ -15,7 +15,6 @@ internal class SpanDeviceAttributeProcessor(
         Attribute.DEVICE_LOCALE_KEY to getDeviceLocale(),
         Attribute.OS_NAME_KEY to "android",
         Attribute.OS_VERSION_KEY to Build.VERSION.SDK_INT.toString(),
-        Attribute.PLATFORM_KEY to "android",
     )
 
     private fun getDeviceLocale(): String = localeProvider.getLocale()

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -174,7 +174,7 @@ internal class SignalProcessorImpl(
                             sessionId = sessionId,
                             isSampled = isSampled,
                         ) ?: return@trace
-                        applyAttributes(attributes, event, resolvedThreadName)
+                        applyAttributes(event, resolvedThreadName)
                         InternalTrace.trace(label = { "msr-store-event" }, block = {
                             signalStore.store(event)
                             onEventTracked(event)
@@ -213,7 +213,7 @@ internal class SignalProcessorImpl(
                     sessionId = sessionId,
                     isSampled = isSampled,
                 ) ?: return@trace
-                applyAttributes(attributes, event, threadName)
+                applyAttributes(event, threadName)
                 event.updateVersionAttribute(appVersion, appBuild)
                 event.updateSessionStartTimeAttribute(sessionStartTime)
                 InternalTrace.trace(label = { "msr-store-event" }, block = {
@@ -255,7 +255,7 @@ internal class SignalProcessorImpl(
             }
         }
 
-        applyAttributes(attributes, event, thread)
+        applyAttributes(event, thread)
         signalStore.store(event)
         onEventTracked(event)
         exporter.export()
@@ -299,7 +299,7 @@ internal class SignalProcessorImpl(
                 userDefinedAttributes = userDefinedAttributes,
                 isSampled = true,
             ) ?: return@submit
-            applyAttributes(attributes, event, thread)
+            applyAttributes(event, thread)
             signalStore.store(event)
             onEventTracked(event)
             exporter.export()
@@ -344,15 +344,11 @@ internal class SignalProcessorImpl(
     }
 
     private fun <T> applyAttributes(
-        attributes: MutableMap<String, Any?>,
         event: Event<T>,
         threadName: String,
     ) {
         InternalTrace.trace(label = { "msr-apply-attributes" }, block = {
             event.appendAttribute(Attribute.THREAD_NAME, threadName)
-            if (!attributes.contains(Attribute.PLATFORM_KEY)) {
-                event.appendAttribute(Attribute.PLATFORM_KEY, "android")
-            }
             event.appendAttributes(attributeProcessors)
         })
     }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
@@ -56,7 +56,7 @@ internal class SignalProcessorTest {
     }
 
     @Test
-    fun `track stores event with session id, event id, thread name and platform attributes`() {
+    fun `track stores event with session id, event id and thread name attributes`() {
         val exceptionData = TestData.getExceptionData()
         val timestamp = 1710746412L
         val type = EventType.EXCEPTION
@@ -74,7 +74,6 @@ internal class SignalProcessorTest {
             sessionId = sessionManager.getSessionId(),
         ).apply {
             appendAttribute(Attribute.THREAD_NAME, Thread.currentThread().name)
-            appendAttribute(Attribute.PLATFORM_KEY, "android")
         }
 
         assertEquals(1, signalStore.trackedEvents.size)
@@ -103,7 +102,6 @@ internal class SignalProcessorTest {
             attachments = attachments,
         ).apply {
             appendAttribute(Attribute.THREAD_NAME, Thread.currentThread().name)
-            appendAttribute(Attribute.PLATFORM_KEY, "android")
         }
 
         assertEquals(1, signalStore.trackedEvents.size)
@@ -191,7 +189,6 @@ internal class SignalProcessorTest {
             attributes = mutableMapOf("key" to "value"),
         ).apply {
             appendAttribute(Attribute.THREAD_NAME, Thread.currentThread().name)
-            appendAttribute(Attribute.PLATFORM_KEY, "android")
         }
 
         assertEquals(1, signalStore.trackedEvents.size)
@@ -268,7 +265,6 @@ internal class SignalProcessorTest {
             isSampled = sampler.trackJourneyForSession,
         ).apply {
             appendAttribute(Attribute.THREAD_NAME, Thread.currentThread().name)
-            appendAttribute(Attribute.PLATFORM_KEY, "android")
         }
 
         signalProcessor.trackUserTriggered(


### PR DESCRIPTION
# Description

Stop sending `platform=android` attribute.

Closes #3836

