### PR TITLE
chore(android): remove layout snapshot API

### DIFF
--- a/android/measure-android/measure/api/measure.api
+++ b/android/measure-android/measure/api/measure.api
@@ -9,8 +9,6 @@ public final class sh/measure/android/BuildConfig {
 public final class sh/measure/android/Measure {
 	public static final field $stable I
 	public static final field INSTANCE Lsh/measure/android/Measure;
-	public final fun captureLayoutSnapshot (Landroid/app/Activity;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun captureLayoutSnapshot$default (Lsh/measure/android/Measure;Landroid/app/Activity;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun captureScreenshot (Landroid/app/Activity;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun captureScreenshot$default (Lsh/measure/android/Measure;Landroid/app/Activity;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun clearUserId ()V

--- a/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import org.jetbrains.annotations.TestOnly
-import sh.measure.android.Measure.captureLayoutSnapshot
 import sh.measure.android.Measure.captureScreenshot
 import sh.measure.android.Measure.clearUserId
 import sh.measure.android.Measure.createSpanBuilder
@@ -389,7 +388,6 @@ object Measure {
      * following APIs to create an attachment:
      *
      * @see [captureScreenshot] For capturing screen images
-     * @see [captureLayoutSnapshot] For capturing view hierarchy information
      * @see [imageUriToAttachment] For converting image URIs to attachments
      *
      * @param description Description of the bug. Max characters 4000.
@@ -426,31 +424,6 @@ object Measure {
     ) {
         if (isInitialized.get()) {
             return measure.captureScreenshot(activity, onComplete, onError)
-        }
-    }
-
-    /**
-     * Takes a snapshot of the current activity's view hierarchy layout. This method must be called
-     * from the main thread.
-     *
-     * The snapshot captures information about visible elements including their position and
-     * dimensions. It works with both traditional Android Views and Jetpack Compose hierarchies.
-     * These are cheaper to capture and take less storage than screenshots.
-     *
-     * See [docs/android/features/feature_layout_snapshots.md] for more details on layout snapshots.
-     *
-     * @param activity The activity to capture
-     * @param onComplete Callback invoked with the layout snapshot attachment when successful
-     * @param onError Callback invoked if snapshot capture fails
-     */
-    @MainThread
-    fun captureLayoutSnapshot(
-        activity: Activity,
-        onComplete: (attachment: MsrAttachment) -> Unit,
-        onError: (() -> Unit)? = null,
-    ) {
-        if (isInitialized.get()) {
-            return measure.takeLayoutSnapshot(activity, onComplete, onError)
         }
     }
 

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -217,18 +217,6 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         ).captureScreenshot(activity, onComplete, onError)
     }
 
-    fun takeLayoutSnapshot(
-        activity: Activity,
-        onComplete: (attachment: MsrAttachment) -> Unit,
-        onError: (() -> Unit)?,
-    ) {
-        AttachmentHelper(
-            measure.logger,
-            measure.executorServiceRegistry.ioExecutor(),
-            measure.configProvider,
-        ).captureLayoutSnapshot(activity, onComplete, onError)
-    }
-
     fun imageUriToAttachment(
         context: Context,
         uri: Uri,

--- a/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutInspector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutInspector.kt
@@ -34,9 +34,7 @@ import kotlinx.serialization.serializer
 import okio.Buffer
 import okio.GzipSink
 import okio.buffer
-import sh.measure.android.MsrAttachment
 import sh.measure.android.events.Attachment
-import sh.measure.android.events.AttachmentType
 import sh.measure.android.gestures.DetectedGesture
 import sh.measure.android.serialization.jsonSerializer
 import sh.measure.android.utils.ComposeHelper
@@ -254,25 +252,6 @@ internal data class LayoutSnapshot(
             bytes = bytes,
             path = null,
             type = attachmentType,
-        )
-    }
-
-    /**
-     * Converts a layout snapshot to a [MsrAttachment].
-     */
-    @OptIn(ExperimentalSerializationApi::class)
-    fun compressToMsrAttachment(): MsrAttachment {
-        val bytes = Buffer().use { buffer ->
-            GzipSink(buffer).buffer().use { gzip ->
-                jsonSerializer.encodeToStream(root, gzip.outputStream())
-            }
-            buffer.readByteArray()
-        }
-        return MsrAttachment(
-            name = "snapshot.json.gz",
-            bytes = bytes,
-            path = null,
-            type = AttachmentType.LAYOUT_SNAPSHOT,
         )
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/utils/AttachmentHelper.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/utils/AttachmentHelper.kt
@@ -10,7 +10,6 @@ import sh.measure.android.bugreport.BugReportCollector.Companion.MAX_OUTPUT_IMAG
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.events.AttachmentType
 import sh.measure.android.executors.MeasureExecutorService
-import sh.measure.android.layoutinspector.LayoutInspector
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.mainHandler
@@ -78,41 +77,6 @@ internal class AttachmentHelper(
         } catch (_: RejectedExecutionException) {
             onError?.invoke()
         }
-    }
-
-    @MainThread
-    fun captureLayoutSnapshot(
-        activity: Activity,
-        onComplete: (attachment: MsrAttachment) -> Unit,
-        onError: (() -> Unit)?,
-    ) {
-        val window = activity.window ?: run {
-            logger.log(LogLevel.Debug, "Failed to take screenshot, window is null")
-            onError?.invoke()
-            return
-        }
-
-        val decorView = window.peekDecorView() ?: run {
-            logger.log(LogLevel.Debug, "Failed to take screenshot, decor view is null")
-            onError?.invoke()
-            return
-        }
-
-        val view = decorView.rootView ?: run {
-            logger.log(LogLevel.Debug, "Failed to take screenshot, root view is null")
-            onError?.invoke()
-            return
-        }
-
-        val width = view.width
-        val height = view.height
-        if (width <= 0 || height <= 0) {
-            logger.log(LogLevel.Debug, "Failed to take screenshot, invalid view bounds")
-            onError?.invoke()
-            return
-        }
-        val snapshot = LayoutInspector.capture(view)
-        onComplete(snapshot.compressToMsrAttachment())
     }
 
     fun imageUriToAttachment(

--- a/android/measure-android/measure/src/test/java/sh/measure/android/utils/AttachmentHelperTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/utils/AttachmentHelperTest.kt
@@ -53,26 +53,6 @@ class AttachmentHelperTest {
     }
 
     @Test
-    fun `captureLayoutSnapshot triggers onComplete on successful capture`() {
-        var attachment: MsrAttachment? = null
-        controller.setup()
-        attachmentHelper.captureLayoutSnapshot(controller.get(), { a ->
-            attachment = a
-        }, {})
-        Assert.assertNotNull(attachment)
-    }
-
-    @Test
-    fun `captureLayoutSnapshot triggers onError on unsuccessful capture`() {
-        var onErrorCalled = false
-        // Do not launch the activity, thereby failing to capture a snapshot
-        attachmentHelper.captureLayoutSnapshot(controller.get(), {}, {
-            onErrorCalled = true
-        })
-        Assert.assertEquals(true, onErrorCalled)
-    }
-
-    @Test
     fun `imageUriToAttachment triggers onComplete on successful conversion`() {
         val uri = Uri.fromFile(createTestImage())
         var attachment: MsrAttachment? = null

--- a/docs/features/feature-bug-report-android.md
+++ b/docs/features/feature-bug-report-android.md
@@ -1,6 +1,6 @@
 ---
 title: "In-App Bug Reports - Android SDK"
-description: "Let users report bugs from inside your Android app. Built-in or custom UI, screenshots, layout snapshots and shake to report."
+description: "Let users report bugs from inside your Android app. Built-in or custom UI, screenshots and shake to report."
 ---
 
 # Bug Reports - Android
@@ -14,7 +14,6 @@ Bug reports enable users to report issues directly from the app. Measure SDK pro
 * [Custom Experience](#custom-experience)
     * [Attachments](#attachments)
       * [Capture Screenshot](#capture-screenshot)
-      * [Capture Layout Snapshot](#capture-layout-snapshot)
     * [Add Image from Gallery](#add-image-from-gallery)
     * [Limits](#limits)
 * [Add Attributes](#add-attributes)
@@ -86,7 +85,6 @@ Bug reports can be enhanced with attachments. A maximum of `5` attachments can b
 You can add attachments to bug reports in the following ways:
 
 * [Capture Screenshot](#capture-screenshot)
-* [Capture Layout Snapshot](#capture-layout-snapshot)
 * [Add Image from Gallery](#add-image-from-gallery)
 
 
@@ -109,23 +107,6 @@ Measure.trackBugReport(
 
 > [!IMPORTANT]
 > For privacy, screenshots can be masked with the same configuration provided during SDK initialization. See all the configuration options [here](configuration-options.md#screenshot-mask-level).
-
-#### Capture Layout Snapshot
-
-Capture a layout snapshot using `captureLayoutSnapshot`. This function must be called from the main thread.
-
-```kotlin
-private val attachments = mutableListOf<MsrAttachment>()
-
-Measure.captureLayoutSnapshot(activity, onComplete = { attachment ->
-    attachments.add(attachment)
-})
-
-Measure.trackBugReport(
-    description = "Items from cart disappear after reopening the app",
-    attachments = attachments
-)
-```
 
 #### Add Image from Gallery
 

--- a/samples/frank/android/app/src/main/java/sh/frankenstein/android/NativeAndroidScreen.kt
+++ b/samples/frank/android/app/src/main/java/sh/frankenstein/android/NativeAndroidScreen.kt
@@ -105,13 +105,13 @@ fun NativeAndroidScreen() {
         ),
         DemoItem(
             title = "Submit Bug Report",
-            description = "Captures layout snapshot and submits report",
+            description = "Captures screenshot and submits report",
             category = DemoCategory.BUG_REPORTS,
             action = {
-                Measure.captureLayoutSnapshot(context as Activity, onComplete = { snapshot ->
+                Measure.captureScreenshot(context as Activity, onComplete = { screenshot ->
                     Measure.trackBugReport(
                         "Custom bug report",
-                        attachments = listOf(snapshot),
+                        attachments = listOf(screenshot),
                         attributes = AttributesBuilder().put("is_premium", true).build(),
                     )
                     Toast.makeText(context, "Bug report submitted", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
# Description

Removes the public captureLayoutSnapshot API and its internal delegates. Layout snapshots remain supported only for gestures.

Closes #3713

