### PR TITLE
chore(android): limit batch size to max 10MB

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -47,6 +47,17 @@ internal class ExporterImpl(
     @VisibleForTesting
     internal val isExporting = AtomicBoolean(false)
 
+    companion object {
+        // Upper bound on the serialized size of a single batch's upload payload.
+        // Batches are split so that no batch exceeds this size, keeping each export
+        // request small enough to upload reliably.
+        private const val MAX_BATCH_PAYLOAD_SIZE_BYTES = 10 * 1024 * 1024
+
+        // Rough estimate of a single signal's (event or span) serialized size, used to
+        // convert the payload size limit into a maximum number of signals per batch.
+        private const val ESTIMATED_SIGNAL_SIZE_BYTES = 1024
+    }
+
     override fun export() {
         if (isExporting.compareAndSet(false, true)) {
             try {
@@ -90,11 +101,17 @@ internal class ExporterImpl(
             // First export existing batches
             if (exportExistingBatches()) return
 
-            // Then create new batches and export
+            // Create new batches and export them. The number of signals (events and
+            // spans) per batch is capped by both the configured limit and a limit
+            // derived from the max payload size, so a single batch never exceeds
+            // MAX_BATCH_PAYLOAD_SIZE_BYTES. Sessions larger than the cap are split
+            // across multiple batches.
+            val payloadSignalLimit = MAX_BATCH_PAYLOAD_SIZE_BYTES / ESTIMATED_SIGNAL_SIZE_BYTES
+            val maxSignalsPerBatch = minOf(configProvider.maxEventsInBatch, payloadSignalLimit)
             val batchesCreatedCount = database.batchSessions(
                 idProvider,
                 timeProvider,
-                configProvider.maxEventsInBatch,
+                maxSignalsPerBatch,
                 1000,
             )
             if (batchesCreatedCount > 0) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -17,8 +17,10 @@ import org.mockito.Mockito.never
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -44,7 +46,7 @@ internal class ExporterTest {
     private val logger = NoopLogger()
     private val attachmentExecutorService = ImmediateExecutorService(ResolvableFuture.create<Any>())
     private val eventExecutorService = ImmediateExecutorService(ResolvableFuture.create<Any>())
-    private val idProvider = FakeIdProvider()
+    private val idProvider = FakeIdProvider(autoIncrement = true)
     private val context =
         InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     private val database = DatabaseImpl(context, logger)
@@ -195,6 +197,43 @@ internal class ExporterTest {
             any(),
             any(),
         )
+    }
+
+    @Test
+    fun `caps batch size at payload limit when config limit is larger`() {
+        whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
+        // Payload limit: 10 MB / 1 KB estimated per signal = 10_240 signals per batch.
+        // The config limit is set higher, so the payload limit should take effect.
+        configProvider.maxEventsInBatch = 20_000
+
+        insertSessionInDb("session1")
+        insertEventsInDb("session1", count = 10_241)
+
+        exporter.export()
+
+        // 10_241 events split into batches of 10_240 and 1.
+        val eventsCaptor = argumentCaptor<List<EventPacket>>()
+        verify(networkClient, times(2)).execute(any(), eventsCaptor.capture(), any())
+        val batchSizes = eventsCaptor.allValues.map { it.size }.sortedDescending()
+        assertEquals(listOf(10_240, 1), batchSizes)
+    }
+
+    @Test
+    fun `uses config limit when smaller than payload limit`() {
+        whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
+        // Config limit (5) is smaller than the payload limit (10_240), so it wins.
+        configProvider.maxEventsInBatch = 5
+
+        insertSessionInDb("session1")
+        insertEventsInDb("session1", count = 6)
+
+        exporter.export()
+
+        // 6 events split into batches of 5 and 1.
+        val eventsCaptor = argumentCaptor<List<EventPacket>>()
+        verify(networkClient, times(2)).execute(any(), eventsCaptor.capture(), any())
+        val batchSizes = eventsCaptor.allValues.map { it.size }.sortedDescending()
+        assertEquals(listOf(5, 1), batchSizes)
     }
 
     @Test
@@ -805,6 +844,20 @@ internal class ExporterTest {
                 isSampled = sampled,
             ),
         )
+    }
+
+    private fun insertEventsInDb(sessionId: String, count: Int) {
+        // Wrap in a single transaction so bulk inserts stay fast.
+        val db = database.writableDatabase
+        db.beginTransaction()
+        try {
+            for (i in 0 until count) {
+                insertEventInDb(sessionId, "event$i", sampled = true)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
     }
 
     private fun insertBatchInDb(


### PR DESCRIPTION
# Description

Limits batch size to be max 10MB

Closes #3380 

