### PR TITLE
chore(backend): modify ota symbolication

### DIFF
--- a/backend/api/event/attribute.go
+++ b/backend/api/event/attribute.go
@@ -26,11 +26,15 @@ type Attribute struct {
 	AppUniqueID string `json:"app_unique_id" binding:"required"`
 
 	// PatchID identifies an Over-The-Air patch (e.g. CodePush
-	// for RN, Shorebird for Flutter). Free-form text supplied by
-	// the mobile team. Optional — when present, symbolication
-	// looks up mapping files by patch_id, ignoring the app
-	// version/build.
-	PatchID string `json:"patch_id"`
+	// for RN, Shorebird for Flutter). Optional UUID — when
+	// present (non-nil), symbolication looks up mapping files by
+	// patch_id, ignoring the app version/build.
+	PatchID uuid.UUID `json:"patch_id"`
+
+	// PatchVersion is the human-facing version of the OTA
+	// patch the app is running, if any. Free-form text,
+	// optional. Not used for symbolication.
+	PatchVersion string `json:"patch_version"`
 
 	// MeasureSDKVersion is the measure sdk version
 	// identifier.
@@ -150,7 +154,7 @@ func (a Attribute) Validate() error {
 		maxAppVersionChars         = 128
 		maxAppBuildChars           = 32
 		maxAppUniqueIDChars        = 128
-		maxPatchIDChars            = 1024
+		maxPatchVersionChars       = 256
 		maxMeasureSDKVersion       = 16
 		maxNetworkTypeChars        = 16
 		maxNetworkGenerationChars  = 8
@@ -202,8 +206,8 @@ func (a Attribute) Validate() error {
 	if len(a.AppUniqueID) > maxAppUniqueIDChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
 	}
-	if len(a.PatchID) > maxPatchIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.patch_id`, maxPatchIDChars)
+	if len(a.PatchVersion) > maxPatchVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.patch_version`, maxPatchVersionChars)
 	}
 	if len(a.Platform) > maxPlatformChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.platform`, maxPlatformChars)

--- a/backend/api/span/span.go
+++ b/backend/api/span/span.go
@@ -67,7 +67,7 @@ const (
 	maxAppVersionChars         = 128
 	maxAppBuildChars           = 32
 	maxAppUniqueIDChars        = 128
-	maxPatchIDChars            = 1024
+	maxPatchVersionChars       = 256
 	maxMeasureSDKVersion       = 16
 	maxNetworkTypeChars        = 16
 	maxNetworkGenerationChars  = 8
@@ -83,7 +83,8 @@ type CheckPointField struct {
 type SpanAttributes struct {
 	AppUniqueID              string    `json:"app_unique_id" binding:"required"`
 	InstallationID           uuid.UUID `json:"installation_id" binding:"required"`
-	PatchID                  string    `json:"patch_id"`
+	PatchID                  uuid.UUID `json:"patch_id"`
+	PatchVersion             string    `json:"patch_version"`
 	UserID                   string    `json:"user_id"`
 	MeasureSDKVersion        string    `json:"measure_sdk_version" binding:"required"`
 	AppVersion               string    `json:"app_version" binding:"required"`
@@ -286,8 +287,8 @@ func (s *SpanField) Validate(opts ...ingest.ValidationOptions) error {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.app_unique_id`, maxAppUniqueIDChars)
 	}
 
-	if len(s.Attributes.PatchID) > maxPatchIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.patch_id`, maxPatchIDChars)
+	if len(s.Attributes.PatchVersion) > maxPatchVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.patch_version`, maxPatchVersionChars)
 	}
 
 	if len(s.Attributes.UserID) > maxUserIDChars {

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -500,6 +500,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			Set(`attribute.app_build`, e.events[i].Attribute.AppBuild).
 			Set(`attribute.app_unique_id`, e.events[i].Attribute.AppUniqueID).
 			Set(`attribute.patch_id`, e.events[i].Attribute.PatchID).
+			Set(`attribute.patch_version`, strings.TrimSpace(e.events[i].Attribute.PatchVersion)).
 			Set(`attribute.platform`, e.events[i].Attribute.Platform).
 			Set(`attribute.measure_sdk_version`, e.events[i].Attribute.MeasureSDKVersion).
 			Set(`attribute.thread_name`, e.events[i].Attribute.ThreadName).
@@ -1043,6 +1044,7 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 			Set(`checkpoints`, formattedCheckpoints).
 			Set(`attribute.app_unique_id`, e.spans[i].Attributes.AppUniqueID).
 			Set(`attribute.patch_id`, e.spans[i].Attributes.PatchID).
+			Set(`attribute.patch_version`, strings.TrimSpace(e.spans[i].Attributes.PatchVersion)).
 			Set(`attribute.installation_id`, e.spans[i].Attributes.InstallationID).
 			Set(`attribute.user_id`, e.spans[i].Attributes.UserID).
 			Set(`attribute.measure_sdk_version`, e.spans[i].Attributes.MeasureSDKVersion).

--- a/backend/ingest-worker/symbolicator/symbolicator.go
+++ b/backend/ingest-worker/symbolicator/symbolicator.go
@@ -219,22 +219,22 @@ func New(origin, operatingSys string, sources []Source, sentrySources []SentrySo
 }
 
 // resolveBatchPatchID returns the batch's effective Over-The-Air
-// patch_id. If any event or span attribute carries a non-empty
-// patch_id, the first such value is used for the whole batch. An
-// empty string means no patch_id is in play and version-based
+// patch_id. If any event or span attribute carries a non-nil
+// patch_id, the first such value is used for the whole batch. A
+// nil UUID means no patch_id is in play and version-based
 // mapping lookup applies.
-func resolveBatchPatchID(events []event.EventField, spans []span.SpanField) string {
+func resolveBatchPatchID(events []event.EventField, spans []span.SpanField) uuid.UUID {
 	for i := range events {
-		if events[i].Attribute.PatchID != "" {
+		if events[i].Attribute.PatchID != uuid.Nil {
 			return events[i].Attribute.PatchID
 		}
 	}
 	for i := range spans {
-		if spans[i].Attributes.PatchID != "" {
+		if spans[i].Attributes.PatchID != uuid.Nil {
 			return spans[i].Attributes.PatchID
 		}
 	}
-	return ""
+	return uuid.Nil
 }
 
 // Symbolicate performs symbolication by retrieving
@@ -242,7 +242,7 @@ func resolveBatchPatchID(events []event.EventField, spans []span.SpanField) stri
 // request to response cycle.
 func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appId uuid.UUID, events []event.EventField, spans []span.SpanField) (err error) {
 	// Resolve the batch's effective Over-The-Air patch_id. When any
-	// event or span attribute carries a non-empty patch_id, the whole
+	// event or span attribute carries a non-nil patch_id, the whole
 	// batch symbolicates by patch_id (ignoring app version/build).
 	patchID := resolveBatchPatchID(events, spans)
 
@@ -250,7 +250,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 	// the batch, so fetch it once. On error, leave it empty and let
 	// the per-event gate skip symbolication (frames stay raw).
 	var patchMappings map[string]symbol.MappingType
-	if patchID != "" {
+	if patchID != uuid.Nil {
 		if patchMappings, err = symbol.GetMappingsByPatchID(ctx, conn, appId, patchID); err != nil {
 			fmt.Printf("Error fetching mapping keys for appId %s, patch_id %s: %v\n", appId, patchID, err)
 			err = nil
@@ -278,7 +278,7 @@ func (s *Symbolicator) Symbolicate(ctx context.Context, conn *pgxpool.Pool, appI
 		// in play, use the patch_id-scoped set; otherwise fall back to
 		// the (app_id, version_name, version_code) lookup.
 		var mappings map[string]symbol.MappingType
-		if patchID != "" {
+		if patchID != uuid.Nil {
 			mappings = patchMappings
 		} else {
 			name := ev.Attribute.AppVersion
@@ -1091,11 +1091,11 @@ func (js *jsSymbolicator) configureSource(symboloaderOrigin, token string, appID
 // these entries to resolve sourcemaps by debug id — the patch_id
 // path on the /symbols/js endpoint.
 //
-// When patchID is empty (non-OTA build), no modules are emitted
+// When patchID is nil (non-OTA build), no modules are emitted
 // and Symbolicator's URL-fallback path runs, scoped by the
 // app_id + version params on the source URL.
-func (js *jsSymbolicator) populateModules(ev event.EventField, patchID string) {
-	if patchID == "" {
+func (js *jsSymbolicator) populateModules(ev event.EventField, patchID uuid.UUID) {
+	if patchID == uuid.Nil {
 		return
 	}
 	for _, excep := range ev.Exception.Exceptions {
@@ -1103,7 +1103,7 @@ func (js *jsSymbolicator) populateModules(ev event.EventField, patchID string) {
 			if frame.FileName == "" {
 				continue
 			}
-			js.request.AddModule(frame.FileName, patchID)
+			js.request.AddModule(frame.FileName, patchID.String())
 		}
 	}
 }

--- a/backend/ingest/measure/build.go
+++ b/backend/ingest/measure/build.go
@@ -38,7 +38,7 @@ type Mapping struct {
 	// PatchID echoes the build's optional patch_id back to the
 	// caller so the build script can confirm the value persisted
 	// against this mapping row.
-	PatchID string `json:"patch_id,omitempty"`
+	PatchID uuid.UUID `json:"patch_id,omitempty"`
 }
 
 type Build struct {
@@ -52,7 +52,7 @@ type Build struct {
 	// PatchID identifies an Over-The-Air patch. It is set only by
 	// the OTA handler (PutOTABuilds); PUT /builds neither accepts
 	// nor returns it.
-	PatchID string `json:"-"`
+	PatchID uuid.UUID `json:"-"`
 }
 
 type BuildResponse struct {
@@ -60,11 +60,11 @@ type BuildResponse struct {
 }
 
 // OTABuild is the request body for PUT /builds/ota. It carries
-// only a free-form patch_id and the mapping files — no app
-// version, build number or build size. The app is resolved from
-// the request's API key (like PutBuilds), never from the body.
+// only a patch_id (UUID) and the mapping files — no app version,
+// build number or build size. The app is resolved from the
+// request's API key (like PutBuilds), never from the body.
 type OTABuild struct {
-	PatchID  string     `json:"patch_id" binding:"required"`
+	PatchID  uuid.UUID  `json:"patch_id" binding:"required"`
 	Mappings []*Mapping `json:"mappings" binding:"required,dive,required"`
 }
 
@@ -325,7 +325,7 @@ func PutBuilds(c *gin.Context) {
 
 // PutOTABuilds handles uploads of Over-The-Air patch mapping
 // files (CodePush / Shorebird). Unlike PutBuilds it is driven
-// solely by a free-form patch_id — it accepts no app version,
+// solely by a patch_id (UUID) — it accepts no app version,
 // build number or build size. The mapping rows are stored with
 // empty version columns and the supplied patch_id, which is the
 // sole key for patch_id-based symbolication lookups.

--- a/backend/libs/symbol/dif.go
+++ b/backend/libs/symbol/dif.go
@@ -305,7 +305,7 @@ func GetMappingsByPatchID(
 	ctx context.Context,
 	db *pgxpool.Pool,
 	appId uuid.UUID,
-	patchID string,
+	patchID uuid.UUID,
 ) (keyMap map[string]MappingType, err error) {
 	stmt := sqlf.PostgreSQL.
 		From("build_mappings").

--- a/backend/symboloader/symbolsjs.go
+++ b/backend/symboloader/symbolsjs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/leporo/sqlf"
 )
 
@@ -55,7 +56,7 @@ type lookupFile struct {
 // the handler boundary.
 type jsbundleRow struct {
 	Key     string
-	PatchID string
+	PatchID uuid.UUID
 }
 
 // filename returns the inner filename embedded in the row's
@@ -167,7 +168,7 @@ func resolveByPatchID(ctx context.Context, appID string, patchIDs []string) (pai
 		return
 	}
 
-	byPatchID := make(map[string][]jsbundleRow)
+	byPatchID := make(map[uuid.UUID][]jsbundleRow)
 	for _, r := range rows {
 		byPatchID[r.PatchID] = append(byPatchID[r.PatchID], r)
 	}
@@ -356,16 +357,27 @@ func classifyRows(rows []jsbundleRow) (bundle, sourcemap *jsbundleRow) {
 // the given app_id and patch_ids whose mapping_type is "jsbundle",
 // ordered most-recent first so re-uploads dedupe to the latest.
 //
-// patch_ids are free-form developer-supplied text, so the app_id
-// filter is required to avoid cross-app collisions. The app_id
-// reaches this path via the source URL the ingest-worker sets on
-// the Sentry source (configureSource).
+// patch_ids are UUIDs; the app_id filter is still required to
+// avoid cross-app collisions. The app_id reaches this path via
+// the source URL the ingest-worker sets on the Sentry source
+// (configureSource). Inbound ?debug_id= values arrive as strings
+// and are parsed to UUIDs here; non-UUID values are skipped so a
+// malformed query param can't error the whole lookup at the DB.
 func queryJsBundleRowsByPatchID(ctx context.Context, appID string, patchIDs []string) (rows []jsbundleRow, err error) {
-	placeholders := make([]string, len(patchIDs))
-	args := make([]any, len(patchIDs))
-	for i, d := range patchIDs {
-		placeholders[i] = "?"
-		args[i] = d
+	placeholders := make([]string, 0, len(patchIDs))
+	args := make([]any, 0, len(patchIDs))
+	for _, d := range patchIDs {
+		id, parseErr := uuid.Parse(d)
+		if parseErr != nil {
+			continue
+		}
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+
+	// No valid UUID patch_ids to look up.
+	if len(args) == 0 {
+		return
 	}
 
 	stmt := sqlf.PostgreSQL.

--- a/docs/api/sdk/README.md
+++ b/docs/api/sdk/README.md
@@ -462,13 +462,13 @@ List of HTTP status codes for success and failures.
 
 ### PUT `/builds/ota`
 
-Uploads mapping files for an Over-The-Air (OTA) patch — a remote update that ships new code without a new store build (e.g. CodePush for React Native, Shorebird for Flutter). It is driven by a `patch_id` and takes no app version, build number or build size.
+Uploads mapping files for an Over-The-Air (OTA) patch — a remote update that ships new code without a new store build (e.g. CodePush for React Native, Shorebird for Flutter). It is driven by a `patch_id` (a UUID) and takes no app version, build number or build size.
 
 Like `PUT /builds`, this API accepts metadata and returns pre-signed URLs for uploading the mapping files directly. Upload each file with a standard HTTP **PUT** using the returned `upload_url` and `headers`.
 
 #### Usage Notes
 
-- `patch_id` is **required**. Tag your OTA patch with any identifier; it is echoed back on each mapping in the response.
+- `patch_id` is **required** and must be a **UUID**. Tag your OTA patch with a UUID; it is echoed back on each mapping in the response.
 - The app is determined from your API key — do **not** send an app identifier in the body.
 - `mappings` is **required** and must contain at least one mapping. `mapping_type` can be `proguard`, `dsym`, `elf_debug`, or `jsbundle` (React Native).
 - For React Native, upload the JS bundle and its sourcemap as **two separate `jsbundle` mappings in the same request** (same tarball and `<bundle>` / `<bundle>.map` conventions as [`PUT /builds`](#usage-notes-1)).
@@ -499,7 +499,7 @@ The response contains a `mappings` array with the pre-signed upload URL for each
         "x-amz-meta-mapping_id": "e2bbcad8-0566-44ea-af43-9dd114c64e8c",
         "x-amz-meta-original_file_name": "main.jsbundle.tgz"
       },
-      "patch_id": "codepush-v1.0.0-patch-3"
+      "patch_id": "550e8400-e29b-41d4-a716-446655440000"
     },
     {
       "id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
@@ -511,7 +511,7 @@ The response contains a `mappings` array with the pre-signed upload URL for each
         "x-amz-meta-mapping_id": "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc",
         "x-amz-meta-original_file_name": "main.jsbundle.map.tgz"
       },
-      "patch_id": "codepush-v1.0.0-patch-3"
+      "patch_id": "550e8400-e29b-41d4-a716-446655440000"
     }
   ]
 }
@@ -528,7 +528,7 @@ Payload must contain the `patch_id` and at least one mapping.
 
 ```json
 {
-  "patch_id": "codepush-v1.0.0-patch-3",
+  "patch_id": "550e8400-e29b-41d4-a716-446655440000",
   "mappings": [
     {
       "type": "jsbundle",
@@ -544,7 +544,7 @@ Payload must contain the `patch_id` and at least one mapping.
 
 | Field      | Type   | Optional | Comment                                                                                                     |
 | ---------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `patch_id` | string | No       | Identifier for the OTA patch.                                                                               |
+| `patch_id` | string (UUID) | No       | UUID identifier for the OTA patch.                                                                   |
 | `mappings` | array  | No       | List of mapping file objects (at least one). Same shape as [`PUT /builds` mappings](#mappings).             |
 
 </details>
@@ -682,7 +682,8 @@ Events can contain the following attributes, some of which are mandatory.
 | `app_version`                       | string  | No       | App version identifier                                                      |
 | `app_build`                         | string  | No       | App build identifier                                                        |
 | `app_unique_id`                     | string  | No       | App bundle identifier                                                       |
-| `patch_id`                          | string  | Yes      | Identifier of the Over-The-Air patch the app is running, if any. See [`PUT /builds/ota`](#put-buildsota).    |
+| `patch_id`                          | string (UUID) | Yes      | UUID of the Over-The-Air patch the app is running, if any. See [`PUT /builds/ota`](#put-buildsota).    |
+| `patch_version`                     | string  | Yes      | Human-facing version of the Over-The-Air patch the app is running, if any.  |
 | `platform`                          | string  | No       | One of:<br>- android<br>- ios<br>- flutter                                  |
 | `measure_sdk_version`               | string  | No       | Measure SDK version identifier                                              |
 | `thread_name`                       | string  | Yes      | The thread on which the event was captured                                  |

--- a/self-host/clickhouse/20260702080925_alter_events_table.sql
+++ b/self-host/clickhouse/20260702080925_alter_events_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table events
+  add column if not exists `attribute.patch_version` LowCardinality(String) COMMENT 'OTA patch version (free-form)' CODEC(ZSTD(3)) after `attribute.patch_id`;
+
+-- migrate:down
+alter table events
+  drop column if exists `attribute.patch_version`;

--- a/self-host/clickhouse/20260702080930_alter_spans_table.sql
+++ b/self-host/clickhouse/20260702080930_alter_spans_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table spans
+  add column if not exists `attribute.patch_version` LowCardinality(String) COMMENT 'OTA patch version (free-form)' CODEC(ZSTD(3)) after `attribute.patch_id`;
+
+-- migrate:down
+alter table spans
+  drop column if exists `attribute.patch_version`;

--- a/self-host/clickhouse/20260702091814_alter_app_filters_table.sql
+++ b/self-host/clickhouse/20260702091814_alter_app_filters_table.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+alter table app_filters
+  add column if not exists `patch_version` LowCardinality(String) comment 'OTA patch version' CODEC(ZSTD(3)),
+  modify order by (team_id, app_id, end_of_month, exception, anr, network_type, network_generation, os_version, app_version, country_code, device_manufacturer, device_locale, network_provider, device_name, patch_version);
+
+-- migrate:down
+alter table app_filters
+  modify order by (team_id, app_id, end_of_month, exception, anr, network_type, network_generation, os_version, app_version, country_code, device_manufacturer, device_locale, network_provider, device_name);
+
+-- migrate:up
+select 1;
+
+-- migrate:down
+alter table app_filters
+  drop column if exists `patch_version`;

--- a/self-host/clickhouse/20260702091821_alter_span_filters_table.sql
+++ b/self-host/clickhouse/20260702091821_alter_span_filters_table.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+alter table span_filters
+  add column if not exists `patch_version` LowCardinality(String) comment 'OTA patch version' CODEC(ZSTD(3)),
+  modify order by (team_id, app_id, end_of_month, app_version, os_version, country_code, network_provider, network_type, network_generation, device_locale, device_manufacturer, device_name, patch_version);
+
+-- migrate:down
+alter table span_filters
+  modify order by (team_id, app_id, end_of_month, app_version, os_version, country_code, network_provider, network_type, network_generation, device_locale, device_manufacturer, device_name);
+
+-- migrate:up
+select 1;
+
+-- migrate:down
+alter table span_filters
+  drop column if exists `patch_version`;

--- a/self-host/clickhouse/20260702104539_alter_app_filters_mv.sql
+++ b/self-host/clickhouse/20260702104539_alter_app_filters_mv.sql
@@ -1,0 +1,83 @@
+-- migrate:up
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max((type = 'exception') and (exception.handled = 0)) as exception,
+    max(type = 'anr')                                     as anr,
+    attribute.patch_version                               as patch_version
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    patch_version;
+
+-- migrate:down
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max((type = 'exception') and (exception.handled = 0)) as exception,
+    max(type = 'anr')                                     as anr
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name;

--- a/self-host/clickhouse/20260702104548_alter_span_filters_mv.sql
+++ b/self-host/clickhouse/20260702104548_alter_span_filters_mv.sql
@@ -1,0 +1,77 @@
+-- migrate:up
+alter table span_filters_mv modify query
+select distinct
+    team_id,
+    app_id,
+    toLastDayOfMonth(start_time)   as end_of_month,
+    attribute.app_version          as app_version,
+    attribute.os_version           as os_version,
+    attribute.country_code         as country_code,
+    attribute.network_provider     as network_provider,
+    attribute.network_type         as network_type,
+    attribute.network_generation   as network_generation,
+    attribute.device_locale        as device_locale,
+    attribute.device_manufacturer  as device_manufacturer,
+    attribute.device_name          as device_name,
+    attribute.patch_version        as patch_version
+from spans
+where toString(attribute.os_version) != ''
+  and toString(attribute.country_code) != ''
+  and toString(attribute.network_provider) != ''
+  and toString(attribute.network_type) != ''
+  and toString(attribute.network_generation) != ''
+  and toString(attribute.device_locale) != ''
+  and toString(attribute.device_manufacturer) != ''
+  and toString(attribute.device_name) != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    attribute.app_version,
+    attribute.os_version,
+    attribute.country_code,
+    attribute.network_provider,
+    attribute.network_type,
+    attribute.network_generation,
+    attribute.device_locale,
+    attribute.device_manufacturer,
+    attribute.device_name,
+    attribute.patch_version;
+
+-- migrate:down
+alter table span_filters_mv modify query
+select distinct
+    team_id,
+    app_id,
+    toLastDayOfMonth(start_time)   as end_of_month,
+    attribute.app_version          as app_version,
+    attribute.os_version           as os_version,
+    attribute.country_code         as country_code,
+    attribute.network_provider     as network_provider,
+    attribute.network_type         as network_type,
+    attribute.network_generation   as network_generation,
+    attribute.device_locale        as device_locale,
+    attribute.device_manufacturer  as device_manufacturer,
+    attribute.device_name          as device_name
+from spans
+where toString(attribute.os_version) != ''
+  and toString(attribute.country_code) != ''
+  and toString(attribute.network_provider) != ''
+  and toString(attribute.network_type) != ''
+  and toString(attribute.network_generation) != ''
+  and toString(attribute.device_locale) != ''
+  and toString(attribute.device_manufacturer) != ''
+  and toString(attribute.device_name) != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    attribute.app_version,
+    attribute.os_version,
+    attribute.country_code,
+    attribute.network_provider,
+    attribute.network_type,
+    attribute.network_generation,
+    attribute.device_locale,
+    attribute.device_manufacturer,
+    attribute.device_name;

--- a/self-host/clickhouse/20260702120126_alter_events_table.sql
+++ b/self-host/clickhouse/20260702120126_alter_events_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table events drop column if exists `attribute.patch_id`;
+
+-- migrate:down
+alter table events drop column if exists `attribute.patch_id`;
+
+-- migrate:up
+alter table events add column if not exists `attribute.patch_id` UUID comment 'OTA patch identifier' CODEC(ZSTD(3)) after `attribute.app_build`;
+
+-- migrate:down
+alter table events add column if not exists `attribute.patch_id` LowCardinality(String) comment 'OTA patch identifier (CodePush/Shorebird)' CODEC(ZSTD(3)) after `attribute.app_build`;

--- a/self-host/clickhouse/20260702120153_alter_spans_table.sql
+++ b/self-host/clickhouse/20260702120153_alter_spans_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table spans drop column if exists `attribute.patch_id`;
+
+-- migrate:down
+alter table spans drop column if exists `attribute.patch_id`;
+
+-- migrate:up
+alter table spans add column if not exists `attribute.patch_id` UUID comment 'OTA patch identifier' CODEC(ZSTD(3)) after `attribute.app_version`;
+
+-- migrate:down
+alter table spans add column if not exists `attribute.patch_id` LowCardinality(String) comment 'OTA patch identifier (CodePush/Shorebird)' CODEC(ZSTD(3)) after `attribute.app_version`;

--- a/self-host/postgres/20260702115931_alter_build_mappings_table.sql
+++ b/self-host/postgres/20260702115931_alter_build_mappings_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+alter table "measure"."build_mappings" drop column if exists patch_id;
+alter table "measure"."build_mappings" add column patch_id uuid not null default '00000000-0000-0000-0000-000000000000';
+
+-- migrate:down
+alter table "measure"."build_mappings" drop column if exists patch_id;
+alter table "measure"."build_mappings" add column patch_id text not null default '';


### PR DESCRIPTION
## Summary

This PR adds an optional free-form `patch_version` attribute on events & spans (persisted to the `events`/`spans` tables & surfaced as a filter dimension in `app_filters`/`span_filters`) to carry the human-facing OTA patch version. With that field taking over the free-form role, `patch_id` reverts to a strict `uuid` across Postgres, ClickHouse & Go, tightening OTA symbolication lookups. SDK ingestion docs are updated to match.

## Tasks

- [x] Add optional free-form `patch_version` to event & span attributes
- [x] Persist `patch_version` to `events` & `spans` tables
- [x] Populate `patch_version` into `app_filters` & `span_filters`
- [x] Change `patch_id` to `uuid` across Postgres, ClickHouse & Go
- [x] Update SDK ingestion docs
