### PR TITLE
chore(backend): make agent service deploy ready

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -112,7 +112,6 @@ jobs:
           file: backend/agent/dockerfile
           build-contexts: |
             libs=backend/libs
-            testinfra=backend/testinfra
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: |

--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -14,6 +14,7 @@ import (
 
 	"backend/agent/server"
 	"backend/libs/opsys"
+	"backend/libs/secret"
 
 	"github.com/google/uuid"
 	"github.com/leporo/sqlf"
@@ -112,7 +113,10 @@ func NewConfig() *Config {
 	}
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	apiKey, err := secret.FromEnvOrFile("OPENROUTER_API_KEY")
+	if err != nil {
+		log.Printf("failed to read OPENROUTER_API_KEY: %v", err)
+	}
 	if apiKey == "" {
 		log.Println("OPENROUTER_API_KEY env var not set, the ask_question tool will return errors")
 	}

--- a/backend/agent/dockerfile
+++ b/backend/agent/dockerfile
@@ -7,14 +7,12 @@ WORKDIR /go/src
 
 # Copy dependency modules first for caching
 COPY --from=libs go.mod go.sum ../libs/
-COPY --from=testinfra go.mod go.sum ../testinfra/
 COPY ["go.mod", "go.sum", "./"]
 
 RUN go mod download
 
 # Copy source
 COPY --from=libs . ../libs/
-COPY --from=testinfra . ../testinfra/
 COPY . .
 
 # Build statically linked binary

--- a/backend/agent/go.mod
+++ b/backend/agent/go.mod
@@ -4,7 +4,6 @@ go 1.25.8
 
 require (
 	backend/libs v0.0.0
-	backend/testinfra v0.0.0-00010101000000-000000000000
 	cloud.google.com/go/pubsub/v2 v2.5.1
 	github.com/ClickHouse/clickhouse-go/v2 v2.44.0
 	github.com/gin-gonic/gin v1.12.0
@@ -184,5 +183,4 @@ require (
 
 replace (
 	backend/libs => ../libs
-	backend/testinfra => ../testinfra
 )

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -72,6 +72,18 @@ target "cleanup" {
   platforms = ["linux/amd64"]
 }
 
+target "agent" {
+  inherits = ["docker-metadata-action"]
+  context = "backend/agent"
+  contexts = {
+    libs = "backend/libs"
+  }
+  dockerfile = "dockerfile"
+  cache-from = ["type=gha"]
+  cache-to = ["type=gha,mode=max"]
+  platforms = ["linux/amd64"]
+}
+
 target "dashboard" {
   inherits = ["docker-metadata-action"]
   context = "frontend/dashboard"

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -186,17 +186,26 @@ services:
       context: ../backend/agent
       additional_contexts:
         libs: ../backend/libs
-        testinfra: ../backend/testinfra
       args:
         TARGETTYPE: debug
     ports:
       - "8084:8084"
+    secrets:
+      - postgres-dsn
+      - clickhouse-dsn
+      - clickhouse-reader-dsn
+      - attachments-secret-access-key
+      - smtp-password
+      - autumn-secret-key
+      - oauth-google-secret
+      - oauth-github-secret
+      - openrouter-api-key
     environment:
       - BILLING_ENABLED=${BILLING_ENABLED}
-      - AUTUMN_SECRET_KEY=${AUTUMN_SECRET_KEY}
-      - POSTGRES_DSN=${POSTGRES_DSN}
-      - CLICKHOUSE_DSN=${CLICKHOUSE_DSN}
-      - CLICKHOUSE_READER_DSN=${CLICKHOUSE_READER_DSN}
+      - AUTUMN_SECRET_KEY_FILE=/run/secrets/autumn-secret-key
+      - POSTGRES_DSN_FILE=/run/secrets/postgres-dsn
+      - CLICKHOUSE_DSN_FILE=/run/secrets/clickhouse-dsn
+      - CLICKHOUSE_READER_DSN_FILE=/run/secrets/clickhouse-reader-dsn
       - REDIS_PORT=${REDIS_PORT}
       - REDIS_HOST=${REDIS_HOST}
       - IGGY_ADDR=${IGGY_ADDR}
@@ -207,24 +216,24 @@ services:
       - ATTACHMENTS_S3_BUCKET=${ATTACHMENTS_S3_BUCKET}
       - ATTACHMENTS_S3_BUCKET_REGION=${ATTACHMENTS_S3_BUCKET_REGION}
       - ATTACHMENTS_ACCESS_KEY=${ATTACHMENTS_ACCESS_KEY}
-      - ATTACHMENTS_SECRET_ACCESS_KEY=${ATTACHMENTS_SECRET_ACCESS_KEY}
+      - ATTACHMENTS_SECRET_ACCESS_KEY_FILE=/run/secrets/attachments-secret-access-key
       - SITE_ORIGIN=${NEXT_PUBLIC_SITE_URL}
       - API_ORIGIN=${NEXT_PUBLIC_AGENT_BASE_URL}
       - OAUTH_GOOGLE_KEY=${OAUTH_GOOGLE_KEY}
-      - OAUTH_GOOGLE_SECRET=${OAUTH_GOOGLE_SECRET}
+      - OAUTH_GOOGLE_SECRET_FILE=/run/secrets/oauth-google-secret
       - OAUTH_GITHUB_KEY=${OAUTH_GITHUB_KEY}
-      - OAUTH_GITHUB_SECRET=${OAUTH_GITHUB_SECRET}
+      - OAUTH_GITHUB_SECRET_FILE=/run/secrets/oauth-github-secret
       - SMTP_HOST=${SMTP_HOST}
       - SMTP_PORT=${SMTP_PORT}
       - SMTP_USER=${SMTP_USER}
-      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - SMTP_PASSWORD_FILE=/run/secrets/smtp-password
       - EMAIL_DOMAIN=${EMAIL_DOMAIN}
       - POSTHOG_API_KEY=${POSTHOG_API_KEY:-}
       - POSTHOG_HOST=${POSTHOG_HOST:-}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}
       - OTEL_INSECURE_MODE=${OTEL_INSECURE_MODE}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
-      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENROUTER_API_KEY_FILE=/run/secrets/openrouter-api-key
       - OPENROUTER_MODEL_SMALL=${OPENROUTER_MODEL_SMALL:-}
       - OPENROUTER_MODEL_MEDIUM=${OPENROUTER_MODEL_MEDIUM:-}
       - OPENROUTER_MODEL_LARGE=${OPENROUTER_MODEL_LARGE:-}
@@ -875,3 +884,5 @@ secrets:
     environment: "OAUTH_GOOGLE_SECRET"
   oauth-github-secret:
     environment: "OAUTH_GITHUB_SECRET"
+  openrouter-api-key:
+    environment: "OPENROUTER_API_KEY"


### PR DESCRIPTION
## Summary

This PR makes the `agent` service deploy ready by moving all its secrets to Docker secrets (`_FILE` via `secret.FromEnvOrFile`), dropping the unused `testinfra` build dependency & adding an `agent` target to `docker-bake.hcl` for cloud deploys.

## Tasks

- [x] Route agent secrets via `_FILE` using `secret.FromEnvOrFile`
- [x] Read `OPENROUTER_API_KEY` from Docker secret
- [x] Add `openrouter-api-key` secret
- [x] Remove `testinfra` from agent `dockerfile`, `go.mod` & CI
- [x] Add `agent` target to `docker-bake.hcl`
