### PR TITLE
feat(backend): link dashboard mentions in agent replies

### DIFF
--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -156,6 +156,19 @@ func NewConfig() *Config {
 	return cfg
 }
 
+// dashboardLink returns the word "dashboard" as a markdown link to one of the
+// team's dashboard pages ("team", "apps", "usage"). Slack replies convert it
+// to mrkdwn via toMrkdwn; MCP clients render the markdown as is. Without a
+// configured site origin there is no address to point at, so it degrades to
+// the plain word.
+func (c *Config) dashboardLink(teamID uuid.UUID, page string) string {
+	origin := strings.TrimSuffix(c.Deps.Config.SiteOrigin, "/")
+	if origin == "" {
+		return "dashboard"
+	}
+	return fmt.Sprintf("[dashboard](%s/%s/%s)", origin, teamID, page)
+}
+
 type askQuestionInput struct {
 	AppID          string `json:"app_id" jsonschema:"UUID of the app to query"`
 	Question       string `json:"question" jsonschema:"Natural-language question about the app's telemetry"`
@@ -281,7 +294,7 @@ func (c *Config) askQuestion(ctx context.Context, in askQuestionInput) (out askQ
 	)
 
 	if err := c.checkAgentAllowed(ctx, customerID); err != nil {
-		return out, err
+		return out, errors.New(agentNotAllowedReply(c.dashboardLink(teamID, "usage")))
 	}
 
 	var conv *conversation

--- a/backend/agent/agent/billing.go
+++ b/backend/agent/agent/billing.go
@@ -17,13 +17,17 @@ import (
 )
 
 // agentNotAllowedReply is shown on both surfaces (Slack and MCP) when the team
-// has reached its agent usage allowance.
-const agentNotAllowedReply = "Your team has reached its agent usage limit. Please go to the Measure dashboard to see plan upgrade options."
+// has reached its agent usage allowance. dashboard is the word "dashboard",
+// linked to the team's usage page (dashboardLink).
+func agentNotAllowedReply(dashboard string) string {
+	return fmt.Sprintf("Your team has reached its agent usage limit. Please go to the Measure %s to see plan upgrade options.", dashboard)
+}
 
 // checkAgentAllowed asks Autumn whether the team is allowed to use the agent.
 // Returns nil if allowed; fail-open on any dependency error so a transient
-// Autumn outage does not block customers. The verdict is cached
-// (autumn.CheckCached).
+// Autumn outage does not block customers. A non-nil return always means the
+// limit is reached; surfaces answer it with agentNotAllowedReply. The verdict
+// is cached (autumn.CheckCached).
 func (c *Config) checkAgentAllowed(ctx context.Context, customerID string) error {
 	deps := c.Deps
 	if !deps.Config.IsBillingEnabled() || customerID == "" {
@@ -41,7 +45,7 @@ func (c *Config) checkAgentAllowed(ctx context.Context, customerID string) error
 	}
 	if !allowed {
 		log.Printf("agent: usage blocked, plan limit reached (customer=%s)", customerID)
-		return errors.New(agentNotAllowedReply)
+		return errors.New("agent usage limit reached")
 	}
 	return nil
 }

--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -37,7 +37,11 @@ const somethingWentWrong = "Something went wrong on my side. Please try again."
 
 // slackDisabledNotice is the reply when a team has paused its Slack
 // integration: the agent stops answering and points the asker at the switch.
-const slackDisabledNotice = "Slack integration is disabled for this workspace. An admin can re-enable it in the Measure dashboard -> Team settings."
+// dashboard is the word "dashboard", linked to the team page holding the
+// switch (dashboardLink).
+func slackDisabledNotice(dashboard string) string {
+	return fmt.Sprintf("Slack integration is disabled for this workspace. An admin can re-enable it under Team settings in the Measure %s.", dashboard)
+}
 
 // HandleSlackEvent consumes one normalized Slack event from the bus.
 // Questions run inline: the event is acked only when its turn has fully run
@@ -179,7 +183,8 @@ func (c *Config) answerSlackQuestion(ctx context.Context, ev slack.AgentEvent) {
 		// why and how to re-enable it. Mark it answered so Slack retries don't
 		// repost the notice.
 		outcome = "integration_disabled"
-		if _, err := slack.PostMessage(ctx, token, ev.Channel, ev.ThreadTS, slackDisabledNotice); err != nil {
+		notice := toMrkdwn(slackDisabledNotice(c.dashboardLink(teamID, "team")))
+		if _, err := slack.PostMessage(ctx, token, ev.Channel, ev.ThreadTS, notice); err != nil {
 			log.Printf("agent: failed to post slack disabled notice: %v", err)
 		}
 		c.markSlackEventAnswered(ctx, ev.EventID)
@@ -282,12 +287,13 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 	}
 	if userID == uuid.Nil {
 		log.Printf("agent: slack question rejected event=%s reason=not_team_member", ev.EventID)
+		dashboard := c.dashboardLink(teamID, "team")
 		// Name the email only in the user's own assistant pane; in a channel
 		// it would disclose a possibly hidden profile email to everyone.
 		if ev.Surface == slack.SurfaceAssistant {
-			return fmt.Sprintf("I couldn't find a Measure team member with the email %s. Please ask your Measure admin to add you to the team with that email and try again.", email)
+			return fmt.Sprintf("I couldn't find a Measure team member with the email %s. Please ask your Measure admin to add you to the team in the %s with that email and try again.", email, dashboard)
 		}
-		return "I couldn't find a Measure team member matching your Slack profile email. Please ask your Measure admin to add you to the team with your Slack profile email and try again."
+		return fmt.Sprintf("I couldn't find a Measure team member matching your Slack profile email. Please ask your Measure admin to add you to the team in the %s with your Slack profile email and try again.", dashboard)
 	}
 
 	conv, err := c.findSlackConversation(ctx, ev.Channel, ev.ThreadTS)
@@ -313,6 +319,10 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 		if err != nil {
 			log.Printf("agent: failed to list team apps: %v", err)
 			return somethingWentWrong
+		}
+		if len(apps) == 0 {
+			log.Printf("agent: slack question from team with no apps event=%s", ev.EventID)
+			return noAppsReply(c.dashboardLink(teamID, "apps"))
 		}
 		app, clarify := pickMeasureApp(apps, question)
 		if clarify != "" {
@@ -343,7 +353,7 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 	trackAgentTokens(c.Deps, customerID, c.ModelSmall, callUsage(resolveUsage))
 	if err := c.checkAgentAllowed(ctx, customerID); err != nil {
 		log.Printf("agent: slack question rejected event=%s reason=usage_blocked", ev.EventID)
-		return agentNotAllowedReply
+		return agentNotAllowedReply(c.dashboardLink(turnTeamID, "usage"))
 	}
 
 	if conv == nil {
@@ -582,12 +592,9 @@ var internalBuildMarkers = []string{".dev", ".debug", ".staging", ".qa", ".test"
 // pickMeasureApp chooses which of a team's apps a question is about: an app
 // named in the question wins, a lone app is it, and internal builds lose to
 // the production one. When it can't choose, it returns a clarifying reply
-// instead.
+// instead. Callers guarantee apps is non-empty; a team with no apps at all is
+// answered with noAppsReply before app picking begins.
 func pickMeasureApp(apps []slackApp, question string) (slackApp, string) {
-	if len(apps) == 0 {
-		return slackApp{}, noAppsLeads[rand.IntN(len(noAppsLeads))]
-	}
-
 	q := strings.ToLower(question)
 	var named []slackApp
 	for _, app := range apps {
@@ -844,22 +851,31 @@ var clarifyLeads = []string{
 // Measure at all. Like clarifyLeads they stay neutral so any mention, greeting
 // or off-topic, reads correctly, but instead of asking which app they point at
 // the dashboard to set one up; one is picked at random. No app list follows.
+// Each lead carries exactly one %s slot where noAppsReply splices the word
+// "dashboard", linked to the team's apps page.
 var noAppsLeads = []string{
-	"Hi! I can help you debug your app's crashes, errors and sessions. Your team doesn't have any apps in Measure yet, so set one up in the dashboard and I'll be ready to help.",
-	"Hey there! I'm the Measure bot, here to help you debug your app's crashes, errors and slow sessions. There are no apps set up for your team yet. Add one in the dashboard and mention me again.",
-	"Hello! I help you dig into how your apps are doing. It looks like your team hasn't set up an app in Measure yet. Create one in the dashboard and I can take it from there.",
-	"Hi there! I help you debug your app, from crashes to slow sessions. Your team has no apps in Measure so far. Set one up in the dashboard whenever you're ready.",
-	"Hey! I'm your Measure helper for app telemetry. There aren't any apps under your team yet, so head to the dashboard to add one and I'll be glad to dig in.",
-	"Hi! I can look into errors, crashes and sessions for your apps. Your team doesn't have any apps in Measure yet. Set one up in the dashboard and mention me again.",
-	"Hello! I'm here to help you debug your app. It seems your team hasn't added an app to Measure yet. Create one in the dashboard and I'll be ready.",
-	"Hey there! I can tell you how your apps are doing once they're in Measure. Your team has no apps set up yet, so add one in the dashboard to get started.",
-	"Hi! I can help you debug app crashes, errors and sessions. There are no apps under your team in Measure yet. Set one up in the dashboard and I'll dig in.",
-	"Hello! I'm the Measure bot for debugging your apps. Your team hasn't set up an app yet. Add one in the dashboard and I can start helping.",
-	"Hey! I can help you keep an eye on crashes, errors and session trends. Your team doesn't have any apps in Measure yet, so set one up in the dashboard first.",
-	"Hi there! I cover crashes, errors and sessions for your apps. It looks like there are no apps set up for your team yet. Create one in the dashboard and mention me again.",
-	"Hello! I'm here to help with your app's health. Your team has no apps in Measure at the moment. Set one up in the dashboard and I'll be ready to dig in.",
-	"Hey there! I help you debug your apps. There aren't any apps under your team yet, so add one in the dashboard to begin.",
-	"Hi! I can dig into crashes, errors and sessions for your apps. Your team hasn't set up an app in Measure yet. Create one in the dashboard whenever you're ready.",
+	"Hi! I can help you debug your app's crashes, errors and sessions. Your team doesn't have any apps in Measure yet, so set one up in the %s and I'll be ready to help.",
+	"Hey there! I'm the Measure bot, here to help you debug your app's crashes, errors and slow sessions. There are no apps set up for your team yet. Add one in the %s and mention me again.",
+	"Hello! I help you dig into how your apps are doing. It looks like your team hasn't set up an app in Measure yet. Create one in the %s and I can take it from there.",
+	"Hi there! I help you debug your app, from crashes to slow sessions. Your team has no apps in Measure so far. Set one up in the %s whenever you're ready.",
+	"Hey! I'm your Measure helper for app telemetry. There aren't any apps under your team yet, so head to the %s to add one and I'll be glad to dig in.",
+	"Hi! I can look into errors, crashes and sessions for your apps. Your team doesn't have any apps in Measure yet. Set one up in the %s and mention me again.",
+	"Hello! I'm here to help you debug your app. It seems your team hasn't added an app to Measure yet. Create one in the %s and I'll be ready.",
+	"Hey there! I can tell you how your apps are doing once they're in Measure. Your team has no apps set up yet, so add one in the %s to get started.",
+	"Hi! I can help you debug app crashes, errors and sessions. There are no apps under your team in Measure yet. Set one up in the %s and I'll dig in.",
+	"Hello! I'm the Measure bot for debugging your apps. Your team hasn't set up an app yet. Add one in the %s and I can start helping.",
+	"Hey! I can help you keep an eye on crashes, errors and session trends. Your team doesn't have any apps in Measure yet, so set one up in the %s first.",
+	"Hi there! I cover crashes, errors and sessions for your apps. It looks like there are no apps set up for your team yet. Create one in the %s and mention me again.",
+	"Hello! I'm here to help with your app's health. Your team has no apps in Measure at the moment. Set one up in the %s and I'll be ready to dig in.",
+	"Hey there! I help you debug your apps. There aren't any apps under your team yet, so add one in the %s to begin.",
+	"Hi! I can dig into crashes, errors and sessions for your apps. Your team hasn't set up an app in Measure yet. Create one in the %s whenever you're ready.",
+}
+
+// noAppsReply picks a no-apps lead and fills its slot with dashboard, the
+// word "dashboard" linked to the team's apps page (dashboardLink), where an
+// app can be created.
+func noAppsReply(dashboard string) string {
+	return fmt.Sprintf(noAppsLeads[rand.IntN(len(noAppsLeads))], dashboard)
 }
 
 // clarifyApps asks which app the question meant, opening with a random

--- a/backend/agent/agent/slack_branches_test.go
+++ b/backend/agent/agent/slack_branches_test.go
@@ -120,7 +120,9 @@ func TestSlackDisabledIntegrationPostsNotice(t *testing.T) {
 	if len(posts) != 1 {
 		t.Fatalf("PostMessage calls = %d, want 1 (the disabled notice): %v", len(posts), posts)
 	}
-	if posts[0] != slackDisabledNotice {
+	// The shared test deps configure no site origin, so the notice carries
+	// the plain word rather than a dashboard link.
+	if posts[0] != slackDisabledNotice("dashboard") {
 		t.Errorf("notice = %q, want the disabled notice", posts[0])
 	}
 

--- a/backend/agent/agent/slack_test.go
+++ b/backend/agent/agent/slack_test.go
@@ -2,10 +2,10 @@ package agent
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"testing"
 
+	"backend/agent/server"
 	"backend/libs/slack"
 
 	"github.com/google/uuid"
@@ -20,13 +20,6 @@ func slackTestApps(names ...[2]string) []slackApp {
 }
 
 func TestPickMeasureApp(t *testing.T) {
-	t.Run("no apps", func(t *testing.T) {
-		_, clarify := pickMeasureApp(nil, "any crashes?")
-		if clarify == "" {
-			t.Fatal("expected a clarifying reply for a team without apps")
-		}
-	})
-
 	t.Run("single app wins by default", func(t *testing.T) {
 		apps := slackTestApps([2]string{"Wikipedia", "org.wikipedia"})
 		app, clarify := pickMeasureApp(apps, "any crashes?")
@@ -190,7 +183,9 @@ func TestClarifyLeads(t *testing.T) {
 func TestNoAppsLeads(t *testing.T) {
 	// The zero-apps leads greet a mention from a team with nothing set up.
 	// They must point at the dashboard, the one action that unblocks the user,
-	// and never ask which app, since there are none.
+	// and never ask which app, since there are none. Each lead carries exactly
+	// one %s slot for the dashboard link and no stray %, so the Sprintf in
+	// noAppsReply can't misfire.
 	if len(noAppsLeads) < 10 {
 		t.Fatalf("expected a healthy set of no-apps leads, got %d", len(noAppsLeads))
 	}
@@ -198,15 +193,51 @@ func TestNoAppsLeads(t *testing.T) {
 		if strings.TrimSpace(lead) == "" {
 			t.Fatalf("no-apps lead %d is empty", i)
 		}
-		if !strings.Contains(lead, "dashboard") {
-			t.Fatalf("no-apps lead %d should point at the dashboard, got %q", i, lead)
+		if strings.Count(lead, "%") != 1 || !strings.Contains(lead, "%s") {
+			t.Fatalf("no-apps lead %d should carry exactly one dashboard %%s slot, got %q", i, lead)
 		}
 	}
 
-	// A team with no apps gets one of these leads back, with no app list.
-	_, clarify := pickMeasureApp(nil, "hey there")
-	if !slices.Contains(noAppsLeads, clarify) {
-		t.Fatalf("a team with no apps should get a no-apps lead, got %q", clarify)
+	// A team with no apps gets one of these leads back with the dashboard
+	// link spliced in.
+	link := "[dashboard](https://app.example.com/9db1a316-6bb2-4bd7-9088-8f5a97966373/apps)"
+	reply := noAppsReply(link)
+	if !strings.Contains(reply, link) {
+		t.Fatalf("noAppsReply should splice the dashboard link, got %q", reply)
+	}
+	if strings.Contains(reply, "%") {
+		t.Fatalf("noAppsReply left format residue, got %q", reply)
+	}
+}
+
+func TestDashboardLink(t *testing.T) {
+	teamID := uuid.MustParse("9db1a316-6bb2-4bd7-9088-8f5a97966373")
+
+	c := &Config{Deps: &server.Deps{Config: &server.Config{SiteOrigin: "https://app.example.com"}}}
+	want := "[dashboard](https://app.example.com/9db1a316-6bb2-4bd7-9088-8f5a97966373/team)"
+	if got := c.dashboardLink(teamID, "team"); got != want {
+		t.Errorf("dashboardLink = %q, want %q", got, want)
+	}
+
+	// A trailing slash on the configured origin must not double up.
+	c = &Config{Deps: &server.Deps{Config: &server.Config{SiteOrigin: "https://app.example.com/"}}}
+	if got := c.dashboardLink(teamID, "team"); got != want {
+		t.Errorf("dashboardLink with trailing slash = %q, want %q", got, want)
+	}
+
+	// Without a site origin there is nothing to point at: degrade to the
+	// plain word so replies still read correctly.
+	c = &Config{Deps: &server.Deps{Config: &server.Config{}}}
+	if got := c.dashboardLink(teamID, "team"); got != "dashboard" {
+		t.Errorf("dashboardLink without origin = %q, want plain word", got)
+	}
+
+	// The link must survive the Slack conversion as a clickable mrkdwn link.
+	c = &Config{Deps: &server.Deps{Config: &server.Config{SiteOrigin: "https://app.example.com"}}}
+	got := toMrkdwn(noAppsReply(c.dashboardLink(teamID, "apps")))
+	wantLink := "<https://app.example.com/9db1a316-6bb2-4bd7-9088-8f5a97966373/apps|dashboard>"
+	if !strings.Contains(got, wantLink) {
+		t.Errorf("slack reply should carry the mrkdwn link %q, got %q", wantLink, got)
 	}
 }
 


### PR DESCRIPTION
# Description

Agent replies that point users at the dashboard now carry a markdown link to the right page of the team's dashboard. Slack replies convert it to a clickable mrkdwn link via toMrkdwn, and MCP clients render the markdown as is.

- not-a-member replies link to /{teamId}/team, where admins invite members
- the disabled Slack integration notice links to /{teamId}/team, where the switch lives
- no-apps replies link to /{teamId}/apps, where apps are created
- the usage limit reply links to /{teamId}/usage on both surfaces



