### PR TITLE
feat(backend): ask for content on slack file attachments

### DIFF
--- a/backend/agent/agent/edge_cases_test.go
+++ b/backend/agent/agent/edge_cases_test.go
@@ -322,6 +322,38 @@ func TestSlackQuestionNotMember(t *testing.T) {
 	}
 }
 
+// TestSlackQuestionWithFiles checks a message carrying attachments is answered
+// with the paste-the-contents reply instead of running a turn, including a
+// bare file drop with no text, which must not get the greeting.
+func TestSlackQuestionWithFiles(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	teamID, _, _ := seedTeamUserApp(ctx, t)
+	seedTeamSlack(ctx, t, teamID, []string{"C1"})
+
+	slacktest.MockUserEmail(t, func(context.Context, string, string) (string, error) { return "", nil })
+	delivered := captureSlackDelivery(t)
+	c, stub := newTestAgent(t)
+
+	ev := slackQuestionEvent(teamID, slack.SurfaceAssistant, "what does this crash log say?", "Ev-files")
+	ev.HasFiles = true
+	handleSlackQuestion(t, c, ev)
+	if !strings.Contains(*delivered, "can't read file attachments") {
+		t.Errorf("delivered = %q, want the paste-the-contents reply", *delivered)
+	}
+
+	bare := slackQuestionEvent(teamID, slack.SurfaceAssistant, "", "Ev-files-bare")
+	bare.HasFiles = true
+	handleSlackQuestion(t, c, bare)
+	if !strings.Contains(*delivered, "can't read file attachments") {
+		t.Errorf("delivered = %q, want the paste-the-contents reply for a bare file drop", *delivered)
+	}
+
+	if stub.callCount() != 0 {
+		t.Errorf("llm called %d times for file-carrying messages, want 0", stub.callCount())
+	}
+}
+
 // TestSlackQuestionEmpty checks a mention with no question text gets the
 // greeting rather than running a turn.
 func TestSlackQuestionEmpty(t *testing.T) {

--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -35,6 +35,11 @@ const slackTurnTimeout = 15 * time.Minute
 // somethingWentWrong is the reply for failures the asker can't act on.
 const somethingWentWrong = "Something went wrong on my side. Please try again."
 
+// fileAttachmentsReply is the reply when the triggering message carries file
+// attachments. The agent can't read files yet, so asking for the contents as
+// text beats answering with the attachment silently ignored.
+const fileAttachmentsReply = "I can't read file attachments yet. Please paste the relevant contents directly as text in your message and ask again."
+
 // slackDisabledNotice is the reply when a team has paused its Slack
 // integration: the agent stops answering and points the asker at the switch.
 // dashboard is the word "dashboard", linked to the team page holding the
@@ -270,6 +275,15 @@ func channelUnreachable(err error) bool {
 // runs the turn, and returns the text to post: the answer or a message the
 // asker can act on.
 func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uuid.UUID, botToken, botUserID string) string {
+	// Attachments never make it past the edge, only the typed text does, so
+	// answering the text alone could silently miss the point of the question.
+	// Checked before the empty-question greeting: a bare file drop should ask
+	// for its contents, not say hello.
+	if ev.HasFiles {
+		log.Printf("agent: slack question rejected event=%s reason=file_attachments", ev.EventID)
+		return fileAttachmentsReply
+	}
+
 	question := strings.TrimSpace(slackMentionRE.ReplaceAllString(ev.Text, ""))
 	question = slackUnescaper.Replace(question)
 	if question == "" {

--- a/backend/api/slackwebhook/slackwebhook.go
+++ b/backend/api/slackwebhook/slackwebhook.go
@@ -192,6 +192,9 @@ type slackInnerEvent struct {
 	ThreadTS    string `json:"thread_ts"`
 	Channel     string `json:"channel"`
 	ChannelType string `json:"channel_type"`
+	// Files is the message's file attachments. Only their presence matters
+	// here, so the entries stay unparsed.
+	Files []json.RawMessage `json:"files"`
 	// Tab is set on app_home_opened: "messages" when the user opens the
 	// agent's DM (the greeting trigger in Agent view), or "home" for the App
 	// Home tab, which we ignore.
@@ -324,6 +327,9 @@ func normalizeSlackAgentEvent(envelope slackEventEnvelope, inner slackInnerEvent
 		Channel:     inner.Channel,
 		EventTS:     inner.TS,
 		ThreadTS:    inner.ThreadTS,
+		// The files array and the file_share subtype both mark attachments;
+		// DM messages carry both, mentions only the array.
+		HasFiles: len(inner.Files) > 0 || inner.Subtype == "file_share",
 	}
 	if event.ThreadTS == "" {
 		// A message outside a thread roots its own; replies target it.
@@ -349,7 +355,10 @@ func normalizeSlackAgentEvent(envelope slackEventEnvelope, inner slackInnerEvent
 		return event, false
 	}
 
-	if event.Kind == slack.KindQuestion && strings.TrimSpace(event.Text) == "" {
+	// A question needs text to answer, so textless messages are dropped,
+	// except ones carrying files: those get a reply asking for the contents
+	// as text, where silence would read as the agent ignoring the file.
+	if event.Kind == slack.KindQuestion && strings.TrimSpace(event.Text) == "" && !event.HasFiles {
 		return event, false
 	}
 	return event, true

--- a/backend/api/slackwebhook/slackwebhook_test.go
+++ b/backend/api/slackwebhook/slackwebhook_test.go
@@ -180,12 +180,51 @@ func TestNormalizeSlackAgentEvent(t *testing.T) {
 			Text:        "what does this crash mean?",
 			TS:          "1718000555.000500",
 			Channel:     "D123",
+			Files:       []json.RawMessage{json.RawMessage(`{"id":"F1"}`)},
 		})
 		if !ok {
 			t.Fatal("expected a file_share message with text to normalize")
 		}
 		if event.Kind != slack.KindQuestion {
 			t.Fatalf("got kind=%q", event.Kind)
+		}
+		if !event.HasFiles {
+			t.Fatal("expected the attachment to be flagged on the event")
+		}
+	})
+
+	t.Run("file-only message survives the empty-text drop", func(t *testing.T) {
+		event, ok := normalizeSlackAgentEvent(envelope, slackInnerEvent{
+			Type:        "message",
+			ChannelType: "im",
+			Subtype:     "file_share",
+			User:        "U111",
+			TS:          "1718000556.000500",
+			Channel:     "D123",
+			Files:       []json.RawMessage{json.RawMessage(`{"id":"F1"}`)},
+		})
+		if !ok {
+			t.Fatal("expected a textless file message to normalize; the agent asks for the contents")
+		}
+		if !event.HasFiles {
+			t.Fatal("expected the attachment to be flagged on the event")
+		}
+	})
+
+	t.Run("mention with files sets the flag without a subtype", func(t *testing.T) {
+		event, ok := normalizeSlackAgentEvent(envelope, slackInnerEvent{
+			Type:    "app_mention",
+			User:    "U111",
+			Text:    "<@U999> what does this log say?",
+			TS:      "1718000557.000500",
+			Channel: "C123",
+			Files:   []json.RawMessage{json.RawMessage(`{"id":"F1"}`)},
+		})
+		if !ok {
+			t.Fatal("expected mention with files to normalize")
+		}
+		if !event.HasFiles {
+			t.Fatal("expected the attachment to be flagged on the event")
 		}
 	})
 

--- a/backend/libs/slack/agentevent.go
+++ b/backend/libs/slack/agentevent.go
@@ -41,6 +41,9 @@ type AgentEvent struct {
 	SlackUserID string `json:"slack_user_id"`
 	Text        string `json:"text"`
 	EventID     string `json:"event_id"`
+	// HasFiles marks a message that carried file attachments. Only the typed
+	// text rides on the event; the files themselves are never fetched.
+	HasFiles bool `json:"has_files,omitempty"`
 	// Traceparent carries the W3C trace context of the HTTP request that
 	// received the event, so the consumer's spans join the same trace.
 	Traceparent string `json:"traceparent,omitempty"`


### PR DESCRIPTION
# Description

Slack agent does not support file attachment handling yet. If users attach files to bot message, reply with a message asking them to provide the content directly. File attachments are also ignored when parsing surrounding message context and the bot does not reply to those.



