### PR TITLE
Deliver slack agent events in per-thread order

### DIFF
--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -52,9 +52,11 @@ func slackDisabledNotice(dashboard string) string {
 // Questions run inline: the event is acked only when its turn has fully run
 // (the nil return), so a crash or shutdown mid-turn leaves it on the bus to
 // re-run after restart. The consumer sets the concurrency: Iggy delivers
-// strictly one at a time, Pub/Sub a bounded handful. A turn that ran but
-// failed answers with an error message in the thread rather than nacking;
-// redelivery would only repeat the failure.
+// strictly one at a time, Pub/Sub a bounded handful. Events are published
+// with a per-thread ordering key, so what runs concurrently is always
+// different threads; one thread's events arrive one at a time, in order. A
+// turn that ran but failed answers with an error message in the thread
+// rather than nacking; redelivery would only repeat the failure.
 func (c *Config) HandleSlackEvent(ctx context.Context, data []byte) error {
 	var ev slack.AgentEvent
 	if err := json.Unmarshal(data, &ev); err != nil {
@@ -319,7 +321,7 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 	continued := conv != nil
 	var appID uuid.UUID
 	var resolveUsage chatUsage
-	if conv != nil {
+	if continued {
 		// Assistant threads stay private to whoever started them. Channel
 		// threads are open to the whole team; resolveSlackUser already
 		// required team membership.
@@ -370,7 +372,7 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 		return agentNotAllowedReply(c.dashboardLink(turnTeamID, "usage"))
 	}
 
-	if conv == nil {
+	if !continued {
 		conv = &conversation{
 			UserID:         userID,
 			AppID:          appID,
@@ -381,23 +383,8 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 			SlackUserID:    ev.SlackUserID,
 		}
 		if err := c.createConversation(ctx, conv, conversationTitle(question)); err != nil {
-			// Two near-simultaneous messages in one thread can race on the
-			// unique index; the loser continues the winner's conversation,
-			// including the winner's app choice.
-			existing, ferr := c.findSlackConversation(ctx, ev.Channel, ev.ThreadTS)
-			if ferr != nil || existing == nil {
-				log.Printf("agent: failed to create slack conversation: %v", err)
-				return somethingWentWrong
-			}
-			conv, continued = existing, true
-			if conv.AppID != appID {
-				appID = conv.AppID
-				turnTeamID, customerID, err = c.resolveAppAccess(ctx, userID, appID)
-				if err != nil {
-					log.Printf("agent: slack app access check failed: %v", err)
-					return somethingWentWrong
-				}
-			}
+			log.Printf("agent: failed to create slack conversation: %v", err)
+			return somethingWentWrong
 		}
 		if ev.Surface == slack.SurfaceAssistant {
 			if err := slack.SetAssistantTitle(ctx, botToken, ev.Channel, ev.ThreadTS, conversationTitle(question)); err != nil {

--- a/backend/agent/main.go
+++ b/backend/agent/main.go
@@ -26,8 +26,11 @@ import (
 )
 
 // maxConcurrentSlackTurns caps how many questions Pub/Sub hands the agent at
-// once; each one runs a full LLM turn in its handler. Iggy (self-host)
-// delivers strictly one at a time, so no cap is needed there.
+// once; each one runs a full LLM turn in its handler. Events carry per-thread
+// ordering keys, so the concurrent questions are always from different
+// threads; this needs the subscription created with message ordering
+// enabled. Iggy (self-host) delivers strictly one at a time, so no cap is
+// needed there.
 const maxConcurrentSlackTurns = 4
 
 // newSlackConsumer builds the bus consumer carrying Slack events published

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -793,13 +793,23 @@ type agentEventsProducer struct {
 }
 
 func (a *agentEventsProducer) Publish(ctx context.Context, data []byte) error {
+	return a.publish(func(p bus.Producer) error { return p.Publish(ctx, data) })
+}
+
+func (a *agentEventsProducer) PublishOrdered(ctx context.Context, orderingKey string, data []byte) error {
+	return a.publish(func(p bus.Producer) error { return p.PublishOrdered(ctx, orderingKey, data) })
+}
+
+// publish runs send through the current producer, rebuilding it and retrying
+// once when the attempt fails.
+func (a *agentEventsProducer) publish(send func(bus.Producer) error) error {
 	a.mu.Lock()
 	p := a.p
 	a.mu.Unlock()
 
 	var firstErr error
 	if p != nil {
-		if firstErr = p.Publish(ctx, data); firstErr == nil {
+		if firstErr = send(p); firstErr == nil {
 			return nil
 		}
 		log.Printf("agent events producer publish failed, rebuilding: %v\n", firstErr)
@@ -813,7 +823,7 @@ func (a *agentEventsProducer) Publish(ctx context.Context, data []byte) error {
 		}
 		return err
 	}
-	return p.Publish(ctx, data)
+	return send(p)
 }
 
 // swap replaces a broken producer with a freshly built one, unless another

--- a/backend/api/slackwebhook/slackwebhook.go
+++ b/backend/api/slackwebhook/slackwebhook.go
@@ -296,7 +296,10 @@ func (s *Webhook) handleSlackEventsAPI(c *gin.Context, body []byte) {
 		return
 	}
 
-	if err := s.producer.Publish(ctx, data); err != nil {
+	// Key delivery by thread: the agent then receives one thread's events one
+	// at a time, in order, while different threads still run in parallel.
+	orderingKey := event.Channel + ":" + event.ThreadTS
+	if err := s.producer.PublishOrdered(ctx, orderingKey, data); err != nil {
 		fmt.Println("slack events: failed to publish agent event:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process event"})
 		return

--- a/backend/api/slackwebhook/slackwebhook_test.go
+++ b/backend/api/slackwebhook/slackwebhook_test.go
@@ -393,6 +393,10 @@ func TestHandleSlackEventsPublishesMention(t *testing.T) {
 	if ev.EventID != "Ev-mention" || ev.SlackUserID != "U1" || ev.Channel != "C1" {
 		t.Errorf("event fields not carried over: %+v", ev)
 	}
+	// Same thread → same key, so the agent consumes a thread's events in order.
+	if want := "C1:1718000000.000100"; fp.keys[0] != want {
+		t.Errorf("ordering key = %q, want %q", fp.keys[0], want)
+	}
 }
 
 // TestHandleSlackEventsGreetsOnMessagesTabOpen checks that opening the DM's

--- a/backend/api/slackwebhook/test_helpers_test.go
+++ b/backend/api/slackwebhook/test_helpers_test.go
@@ -88,7 +88,10 @@ func slackTeamIDFor(teamID uuid.UUID) string {
 // can assert what would reach the agent.
 type fakeProducer struct {
 	published [][]byte
-	err       error
+	// keys[i] is the ordering key published[i] was sent with, "" for a plain
+	// publish.
+	keys []string
+	err  error
 }
 
 func (f *fakeProducer) Publish(_ context.Context, data []byte) error {
@@ -96,6 +99,16 @@ func (f *fakeProducer) Publish(_ context.Context, data []byte) error {
 		return f.err
 	}
 	f.published = append(f.published, data)
+	f.keys = append(f.keys, "")
+	return nil
+}
+
+func (f *fakeProducer) PublishOrdered(_ context.Context, orderingKey string, data []byte) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.published = append(f.published, data)
+	f.keys = append(f.keys, orderingKey)
 	return nil
 }
 

--- a/backend/libs/bus/bus.go
+++ b/backend/libs/bus/bus.go
@@ -16,6 +16,13 @@ type Producer interface {
 	// Publish sends data to the configured topic/stream. Blocks until the
 	// backend confirms delivery or ctx is cancelled.
 	Publish(ctx context.Context, data []byte) error
+	// PublishOrdered sends data like Publish, additionally asking the backend
+	// to deliver messages sharing an orderingKey one at a time, in publish
+	// order. On Pub/Sub the guarantee also needs the subscription created
+	// with message ordering enabled; a subscription without it accepts the
+	// key but delivers unordered. Iggy delivers to its consumers serially
+	// already, so there the key is ignored.
+	PublishOrdered(ctx context.Context, orderingKey string, data []byte) error
 	// Close flushes any pending messages and releases backend resources.
 	Close() error
 }

--- a/backend/libs/bus/bus_test.go
+++ b/backend/libs/bus/bus_test.go
@@ -586,6 +586,26 @@ func TestIggyProducerPublish(t *testing.T) {
 	})
 }
 
+// TestIggyProducerPublishOrdered checks the ordering key is ignored on Iggy:
+// the message goes out like a plain publish.
+func TestIggyProducerPublishOrdered(t *testing.T) {
+	mock := &mockIggyClient{}
+	p := newTestProducer(mock)
+
+	if err := p.PublishOrdered(context.Background(), "C1:1718000000.1", []byte("hello")); err != nil {
+		t.Fatalf("PublishOrdered() error = %v", err)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.sentMessages) != 1 {
+		t.Fatalf("sentMessages = %d, want 1", len(mock.sentMessages))
+	}
+	if !bytes.Equal(mock.sentMessages[0].Messages[0].Payload, []byte("hello")) {
+		t.Errorf("payload = %q, want %q", mock.sentMessages[0].Messages[0].Payload, "hello")
+	}
+}
+
 func TestIggyProducerClose(t *testing.T) {
 	mock := &mockIggyClient{}
 	p := newTestProducer(mock)

--- a/backend/libs/bus/iggy_producer.go
+++ b/backend/libs/bus/iggy_producer.go
@@ -86,6 +86,13 @@ func (p *iggyProducer) Publish(_ context.Context, data []byte) error {
 	return nil
 }
 
+// PublishOrdered ignores the ordering key: Iggy's ordering comes from the
+// topic's partitioning and its serial consumers, not from a per-message key,
+// so a plain publish already carries the guarantee the key asks for.
+func (p *iggyProducer) PublishOrdered(ctx context.Context, _ string, data []byte) error {
+	return p.Publish(ctx, data)
+}
+
 func (p *iggyProducer) Close() error {
 	return p.client.Close()
 }

--- a/backend/libs/bus/pubsub_producer.go
+++ b/backend/libs/bus/pubsub_producer.go
@@ -46,6 +46,10 @@ func NewPubSubProducer(ctx context.Context, topic string, opts ...PubSubOption) 
 	if cfg.publishSettings != nil {
 		publisher.PublishSettings = *cfg.publishSettings
 	}
+	// The client rejects keyed messages (PublishOrdered) unless ordering is
+	// enabled up front; keyless publishes are unaffected by the flag, so it
+	// is always on rather than another option.
+	publisher.EnableMessageOrdering = true
 
 	return &pubSubProducer{client: client, publisher: publisher}, nil
 }
@@ -54,6 +58,19 @@ func (p *pubSubProducer) Publish(ctx context.Context, data []byte) error {
 	result := p.publisher.Publish(ctx, &pubsub.Message{Data: data})
 	if _, err := result.Get(ctx); err != nil {
 		return fmt.Errorf("bus: pubsub publish failed: %w", err)
+	}
+	return nil
+}
+
+func (p *pubSubProducer) PublishOrdered(ctx context.Context, orderingKey string, data []byte) error {
+	result := p.publisher.Publish(ctx, &pubsub.Message{Data: data, OrderingKey: orderingKey})
+	if _, err := result.Get(ctx); err != nil {
+		// After a failed keyed publish the client fails every later
+		// message on the same key until told to resume. The bus contract is
+		// per-message error reporting with the caller owning retries, so
+		// resume immediately or one failure would wedge the key for good.
+		p.publisher.ResumePublish(orderingKey)
+		return fmt.Errorf("bus: pubsub ordered publish failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Slack agent events were published unordered, so on Pub/Sub two messages in one thread could run turns concurrently, racing the conversation create and replying out of order. Events now carry a per-thread ordering key: one thread's events arrive one at a time in publish order, different threads still run in parallel.

- bus.Producer gains PublishOrdered. Pub/Sub sets the key and enables ordered publishing (keyless publishes unaffected); on failure it calls ResumePublish so one error can't block the key. Iggy ignores the key, already ordered.
- The api edge keys agent events by channel and thread ts
- The create-race recovery in slackReply is removed: same-thread delivery is now serial.



