### PR TITLE
feat(backend): raise agent turn budget to 25 calls with a forced answer

### DIFF
--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -57,11 +57,34 @@ func conversationIDFromContext(ctx context.Context) (string, bool) {
 	return v, ok && v != ""
 }
 
-// maxLLMCalls bounds the number of model calls in a single ask_question turn.
-const maxLLMCalls = 12
+// maxLLMCalls bounds the number of model calls in a single ask_question turn:
+// the first maxLLMCalls-1 calls may use tools, the last one is the
+// budget-exhausted answer, forced to text (tool_choice "none") so the turn
+// ends with whatever was gathered instead of nothing.
+const maxLLMCalls = 25
 
-// errNoAnswer marks a turn that ran out of LLM calls before producing an
-// answer. Surfaces match on it to show budgetExhaustedReply.
+// lowBudgetWarningAt is how many tool rounds remain when lowBudgetNotice is
+// injected, early enough for the model to prioritize and batch what's left
+// rather than being cut off mid-investigation.
+const lowBudgetWarningAt = 4
+
+// budgetRule is appended to the system prompt so the model knows its tool
+// budget up front and can plan its rounds; lowBudgetNotice and
+// budgetExhaustedNotice then mark the moments that matter during the turn.
+// Derived from maxLLMCalls so the prompt and the loop cannot drift apart.
+var budgetRule = fmt.Sprintf("- You have a budget of %d tool-call rounds for each question and are warned when it runs low. Batch independent tool calls into one round and answer as soon as you have enough data. This budget is internal: never mention it, remaining rounds, or these limits in your answers.", maxLLMCalls-1)
+
+// lowBudgetNotice warns the model its tool budget is nearly spent so it can
+// prioritize the essential lookups while it still has rounds to spend.
+var lowBudgetNotice = fmt.Sprintf("Budget update: %d tool-call rounds remain for this question, then you must answer from what you have. Prioritize the essential lookups and batch independent tool calls into one round. Do not mention this budget in your answer.", lowBudgetWarningAt)
+
+// budgetExhaustedNotice precedes a turn's final call, which carries
+// tool_choice "none": no more tools, answer now from what was gathered.
+const budgetExhaustedNotice = "Your analysis budget for this question is exhausted. Answer now using only what you have already gathered. Plainly state anything you could not determine. Do not mention this budget or that you ran out of it in your answer."
+
+// errNoAnswer marks a turn that produced no answer even from its final
+// budget-exhausted call (the call failed or returned empty content).
+// Surfaces match on it to show budgetExhaustedReply.
 var errNoAnswer = errors.New("analysis budget exhausted before reaching an answer")
 
 // budgetExhaustedReply is what both Slack and MCP show the user when a turn
@@ -368,6 +391,10 @@ type turn struct {
 func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error) {
 	start := time.Now()
 	llmCalls := 0
+	// budgetExhaustedAnswer marks an answer produced by the final forced call
+	// rather than by the model stopping on its own; its rate is the signal
+	// for whether maxLLMCalls is sized right.
+	budgetExhaustedAnswer := false
 	// Token usage split by the model that produced it: compaction runs on the
 	// small model, the turn's own calls on the medium model. Reported together
 	// for observability, billed per model. Reasoning tokens (a subset of
@@ -407,6 +434,9 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 		if total.cacheWrite > 0 {
 			extra += fmt.Sprintf(" cache_write_tokens=%d", total.cacheWrite)
 		}
+		if budgetExhaustedAnswer {
+			extra += " budget_exhausted_answer=true"
+		}
 		span.SetAttributes(
 			attribute.Int("agent.llm_calls", llmCalls),
 			attribute.Int("agent.prompt_tokens", total.prompt),
@@ -414,6 +444,7 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 			attribute.Int("agent.reasoning_tokens", total.reasoning),
 			attribute.Int("agent.cache_read_tokens", total.cacheRead),
 			attribute.Int("agent.cache_write_tokens", total.cacheWrite),
+			attribute.Bool("agent.budget_exhausted_answer", budgetExhaustedAnswer),
 		)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
@@ -421,19 +452,20 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 		log.Printf("agent: turn entry_point=%s conversation=%q llm_calls=%d prompt_tokens=%d completion_tokens=%d%s duration=%s err=%v",
 			t.entryPoint, convID, llmCalls, total.prompt, total.completion, extra, time.Since(start).Round(time.Millisecond), err)
 		fireAgentQueryEvent(t.userID.String(), agentQueryEvent{
-			appID:            t.appID.String(),
-			teamID:           t.teamID.String(),
-			conversationID:   convID,
-			continued:        t.continued,
-			entryPoint:       t.entryPoint,
-			llmCalls:         llmCalls,
-			promptTokens:     total.prompt,
-			completionTokens: total.completion,
-			reasoningTokens:  total.reasoning,
-			cacheReadTokens:  total.cacheRead,
-			cacheWriteTokens: total.cacheWrite,
-			duration:         time.Since(start),
-			success:          err == nil,
+			appID:                 t.appID.String(),
+			teamID:                t.teamID.String(),
+			conversationID:        convID,
+			continued:             t.continued,
+			entryPoint:            t.entryPoint,
+			llmCalls:              llmCalls,
+			promptTokens:          total.prompt,
+			completionTokens:      total.completion,
+			reasoningTokens:       total.reasoning,
+			cacheReadTokens:       total.cacheRead,
+			cacheWriteTokens:      total.cacheWrite,
+			budgetExhaustedAnswer: budgetExhaustedAnswer,
+			duration:              time.Since(start),
+			success:               err == nil,
 		})
 	}()
 
@@ -463,8 +495,8 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 	} else {
 		platform = platformNote(osNames)
 	}
-	sysMsg := fmt.Sprintf("%s\n\nThe question is about the app with app_id %s; pass it to tools that take an app_id.%s",
-		systemPrompt, t.appID, platform)
+	sysMsg := fmt.Sprintf("%s\n%s\n\nThe question is about the app with app_id %s; pass it to tools that take an app_id.%s",
+		systemPrompt, budgetRule, t.appID, platform)
 	messages = append(messages, chatMessage{Role: "system", Content: sysMsg})
 	for _, m := range history {
 		messages = append(messages, m.msg)
@@ -477,9 +509,33 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 	messages = append(messages, userMsg)
 	newMessages := []storedMessage{{msg: userMsg}}
 
-	for range maxLLMCalls {
+	for i := range maxLLMCalls {
+		// The last call is the budget-exhausted answer: the model is told the
+		// budget is spent and, via tool_choice "none", can only answer in
+		// text. The warning lands a few rounds earlier so the model can wind
+		// the investigation down instead of being cut off mid-plan. Both
+		// notices are persisted like everything else, keeping the stored
+		// transcript identical to what the model saw.
+		final := i == maxLLMCalls-1
+		notice := ""
+		switch {
+		case final:
+			notice = budgetExhaustedNotice
+		case maxLLMCalls-1-i == lowBudgetWarningAt:
+			notice = lowBudgetNotice
+		}
+		if notice != "" {
+			msg := chatMessage{Role: "system", Content: notice}
+			messages = append(messages, msg)
+			newMessages = append(newMessages, storedMessage{msg: msg})
+		}
+		toolChoice := ""
+		if final {
+			toolChoice = "none"
+		}
+
 		llmCalls++
-		resp, err := c.chat(ctx, c.ModelMedium, messages, c.modelTools)
+		resp, err := c.chat(ctx, c.ModelMedium, messages, c.modelTools, toolChoice)
 		if err != nil {
 			// Cap the failed turn with a neutral assistant note so a later
 			// retry has a well-formed turn to answer against. The question is
@@ -506,6 +562,15 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, err error)
 
 		if len(assistant.ToolCalls) == 0 {
 			answer = assistant.Content
+			budgetExhaustedAnswer = final && answer != ""
+			break
+		}
+		if final {
+			// tool_choice "none" makes tool calls here unexpected, but a
+			// provider may ignore it. Execute nothing, no later call would
+			// read the results, and salvage any text sent alongside.
+			answer = assistant.Content
+			budgetExhaustedAnswer = answer != ""
 			break
 		}
 

--- a/backend/agent/agent/analytics.go
+++ b/backend/agent/agent/analytics.go
@@ -19,8 +19,11 @@ type agentQueryEvent struct {
 	reasoningTokens  int
 	cacheReadTokens  int
 	cacheWriteTokens int
-	duration         time.Duration
-	success          bool
+	// budgetExhaustedAnswer marks a turn answered by the forced final call;
+	// its rate says whether the LLM-call budget is sized right.
+	budgetExhaustedAnswer bool
+	duration              time.Duration
+	success               bool
 }
 
 // fireAgentQueryEvent fires the PostHog `agent_query_made` event for one
@@ -28,20 +31,21 @@ type agentQueryEvent struct {
 // success tells them apart.
 func fireAgentQueryEvent(userID string, e agentQueryEvent) {
 	posthog.Capture(userID, "agent_query_made", map[string]any{
-		"schema_version":         "v1",
-		"app_id":                 e.appID,
-		"team_id":                e.teamID,
-		"conversation_id":        e.conversationID,
-		"conversation_continued": e.continued,
-		"llm_calls":              e.llmCalls,
-		"prompt_tokens":          e.promptTokens,
-		"completion_tokens":      e.completionTokens,
-		"reasoning_tokens":       e.reasoningTokens,
-		"cache_read_tokens":      e.cacheReadTokens,
-		"cache_write_tokens":     e.cacheWriteTokens,
-		"duration_ms":            e.duration.Milliseconds(),
-		"success":                e.success,
-		"feature_area":           "agent",
-		"entry_point":            e.entryPoint,
+		"schema_version":          "v1",
+		"app_id":                  e.appID,
+		"team_id":                 e.teamID,
+		"conversation_id":         e.conversationID,
+		"conversation_continued":  e.continued,
+		"llm_calls":               e.llmCalls,
+		"prompt_tokens":           e.promptTokens,
+		"completion_tokens":       e.completionTokens,
+		"reasoning_tokens":        e.reasoningTokens,
+		"cache_read_tokens":       e.cacheReadTokens,
+		"cache_write_tokens":      e.cacheWriteTokens,
+		"budget_exhausted_answer": e.budgetExhaustedAnswer,
+		"duration_ms":             e.duration.Milliseconds(),
+		"success":                 e.success,
+		"feature_area":            "agent",
+		"entry_point":             e.entryPoint,
 	}, nil)
 }

--- a/backend/agent/agent/chat.go
+++ b/backend/agent/agent/chat.go
@@ -51,6 +51,10 @@ type chatRequest struct {
 	Model    string        `json:"model"`
 	Messages []chatMessage `json:"messages"`
 	Tools    []chatTool    `json:"tools,omitempty"`
+	// ToolChoice steers tool use; "none" forbids tool calls while the tool
+	// definitions stay in the prompt, keeping the cached prefix intact.
+	// Empty means the provider default (auto when tools are present).
+	ToolChoice string `json:"tool_choice,omitempty"`
 	// SessionID is OpenRouter's sticky-routing key: requests sharing it route to
 	// the same provider, keeping that provider's prompt cache warm across a
 	// conversation's turns. We pass the conversation id.
@@ -130,8 +134,10 @@ type chatResponse struct {
 
 var chatHTTPClient = &http.Client{Timeout: 180 * time.Second}
 
-// chat makes one chat-completions call with the given model.
-func (c *Config) chat(ctx context.Context, model string, messages []chatMessage, tools []chatTool) (_ *chatResponse, err error) {
+// chat makes one chat-completions call with the given model. toolChoice
+// steers tool use: "none" forces a text answer while the tool definitions
+// stay in the prompt; empty leaves it to the provider default.
+func (c *Config) chat(ctx context.Context, model string, messages []chatMessage, tools []chatTool, toolChoice string) (_ *chatResponse, err error) {
 	start := time.Now()
 	ctx, span := tracer.Start(ctx, "agent.llm_call")
 	defer span.End()
@@ -151,10 +157,11 @@ func (c *Config) chat(ctx context.Context, model string, messages []chatMessage,
 
 	conversationID, _ := conversationIDFromContext(ctx)
 	body, err := json.Marshal(chatRequest{
-		Model:     model,
-		Messages:  messages,
-		Tools:     tools,
-		SessionID: conversationID,
+		Model:      model,
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: toolChoice,
+		SessionID:  conversationID,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/agent/agent/chat_test.go
+++ b/backend/agent/agent/chat_test.go
@@ -27,7 +27,7 @@ func TestChatRateLimited(t *testing.T) {
 	t.Run("429 with provider message", func(t *testing.T) {
 		c := chatTestConfig(t, http.StatusTooManyRequests,
 			`{"error":{"message":"Provider returned error"}}`)
-		_, err := c.chat(context.Background(), "test-model", nil, nil)
+		_, err := c.chat(context.Background(), "test-model", nil, nil, "")
 		if !errors.Is(err, errLLMRateLimited) {
 			t.Fatalf("expected errLLMRateLimited, got %v", err)
 		}
@@ -39,7 +39,7 @@ func TestChatRateLimited(t *testing.T) {
 	t.Run("429 with unparseable body", func(t *testing.T) {
 		// Proxies can answer 429 with HTML; the sentinel must still fire.
 		c := chatTestConfig(t, http.StatusTooManyRequests, "<html>slow down</html>")
-		_, err := c.chat(context.Background(), "test-model", nil, nil)
+		_, err := c.chat(context.Background(), "test-model", nil, nil, "")
 		if !errors.Is(err, errLLMRateLimited) {
 			t.Fatalf("expected errLLMRateLimited, got %v", err)
 		}
@@ -48,7 +48,7 @@ func TestChatRateLimited(t *testing.T) {
 	t.Run("other provider errors are not rate limits", func(t *testing.T) {
 		c := chatTestConfig(t, http.StatusInternalServerError,
 			`{"error":{"message":"upstream exploded"}}`)
-		_, err := c.chat(context.Background(), "test-model", nil, nil)
+		_, err := c.chat(context.Background(), "test-model", nil, nil, "")
 		if err == nil || errors.Is(err, errLLMRateLimited) {
 			t.Fatalf("expected a plain llm error, got %v", err)
 		}
@@ -57,7 +57,7 @@ func TestChatRateLimited(t *testing.T) {
 	t.Run("success decodes", func(t *testing.T) {
 		c := chatTestConfig(t, http.StatusOK,
 			`{"choices":[{"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`)
-		resp, err := c.chat(context.Background(), "test-model", nil, nil)
+		resp, err := c.chat(context.Background(), "test-model", nil, nil, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -79,7 +79,7 @@ func TestChatParsesCacheAndReasoningTokens(t *testing.T) {
 			"completion_tokens_details":{"reasoning_tokens":5}
 		}
 	}`)
-	resp, err := c.chat(context.Background(), "test-model", nil, nil)
+	resp, err := c.chat(context.Background(), "test-model", nil, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestChatSendsSessionID(t *testing.T) {
 
 	t.Run("sent from context", func(t *testing.T) {
 		ctx := withConversationID(context.Background(), "conv-123")
-		if _, err := c.chat(ctx, "test-model", nil, nil); err != nil {
+		if _, err := c.chat(ctx, "test-model", nil, nil, ""); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := decode(t)["session_id"]; got != "conv-123" {
@@ -162,7 +162,7 @@ func TestChatSendsSessionID(t *testing.T) {
 	})
 
 	t.Run("omitted when absent", func(t *testing.T) {
-		if _, err := c.chat(context.Background(), "test-model", nil, nil); err != nil {
+		if _, err := c.chat(context.Background(), "test-model", nil, nil, ""); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if _, present := decode(t)["session_id"]; present {

--- a/backend/agent/agent/compact.go
+++ b/backend/agent/agent/compact.go
@@ -111,7 +111,7 @@ func (c *Config) compactIfNeeded(ctx context.Context, conversationID uuid.UUID, 
 	resp, err := c.chat(ctx, c.ModelSmall, []chatMessage{
 		{Role: "system", Content: compactionPrompt},
 		{Role: "user", Content: renderTranscript(head)},
-	}, nil)
+	}, nil, "")
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		log.Printf("agent: compaction failed for conversation %s: %v", conversationID, err)

--- a/backend/agent/agent/edge_cases_test.go
+++ b/backend/agent/agent/edge_cases_test.go
@@ -125,7 +125,9 @@ func TestRunTurnLLMFailure(t *testing.T) {
 }
 
 // TestRunTurnBudgetExhausted checks a model that keeps calling a tool runs out
-// of the LLM-call budget and returns errNoAnswer.
+// of the LLM-call budget: the low-budget warning and the exhausted notice are
+// injected on the right calls, the final call forbids tools, and a model that
+// still returns only tool calls there yields errNoAnswer.
 func TestRunTurnBudgetExhausted(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
@@ -151,6 +153,85 @@ func TestRunTurnBudgetExhausted(t *testing.T) {
 	}
 	if stub.callCount() != maxLLMCalls {
 		t.Errorf("llm calls = %d, want maxLLMCalls=%d", stub.callCount(), maxLLMCalls)
+	}
+
+	stub.mu.Lock()
+	warnReq, finalReq := stub.requests[maxLLMCalls-1-lowBudgetWarningAt], stub.requests[maxLLMCalls-1]
+	stub.mu.Unlock()
+
+	var warn chatRequest
+	if err := json.Unmarshal(warnReq, &warn); err != nil {
+		t.Fatalf("decode warning request: %v", err)
+	}
+	if last := warn.Messages[len(warn.Messages)-1]; last.Role != "system" || last.Content != lowBudgetNotice {
+		t.Errorf("warning call should end with the low-budget notice, got role=%q content=%q", last.Role, last.Content)
+	}
+
+	var final chatRequest
+	if err := json.Unmarshal(finalReq, &final); err != nil {
+		t.Fatalf("decode final request: %v", err)
+	}
+	if final.ToolChoice != "none" {
+		t.Errorf("final call tool_choice = %q, want none", final.ToolChoice)
+	}
+	if last := final.Messages[len(final.Messages)-1]; last.Role != "system" || last.Content != budgetExhaustedNotice {
+		t.Errorf("final call should end with the exhausted notice, got role=%q content=%q", last.Role, last.Content)
+	}
+}
+
+// TestRunTurnBudgetExhaustedAnswer checks the final forced call turns a
+// budget-exhausted turn into an answer: 24 tool rounds, then the model
+// answers in text and the turn succeeds with the notices persisted.
+func TestRunTurnBudgetExhaustedAnswer(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	teamID, userID, appID := seedTeamUserApp(ctx, t)
+	now := time.Now().UTC()
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.EventRow{Timestamp: now})
+
+	args := fmt.Sprintf(`{"query":"select count(*) as n from {{events}}","from":"%s","to":"%s"}`,
+		now.Add(-time.Hour).Format(time.RFC3339), now.Add(time.Hour).Format(time.RFC3339))
+	toolCall := fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"c","type":"function","function":{"name":"run_sql","arguments":%s}}]}}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`,
+		strconv.Quote(args))
+	responses := make([]string, 0, maxLLMCalls)
+	for range maxLLMCalls - 1 {
+		responses = append(responses, toolCall)
+	}
+	responses = append(responses, `{"choices":[{"message":{"role":"assistant","content":"Partial: found the top error."}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`)
+	c, stub := newTestAgent(t, responses...)
+
+	conv := &conversation{UserID: userID, AppID: appID, TeamID: teamID, Surface: "mcp"}
+	if err := c.createConversation(ctx, conv, "q"); err != nil {
+		t.Fatalf("createConversation: %v", err)
+	}
+
+	answer, err := c.runTurn(ctx, turn{userID: userID, appID: appID, teamID: teamID, conv: conv, question: "loop", entryPoint: "mcp"})
+	if err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	if answer != "Partial: found the top error." {
+		t.Errorf("answer = %q, want the forced final answer", answer)
+	}
+	if stub.callCount() != maxLLMCalls {
+		t.Errorf("llm calls = %d, want maxLLMCalls=%d", stub.callCount(), maxLLMCalls)
+	}
+
+	// Both notices are part of the turn and must be stored with it, so the
+	// next turn's replayed transcript matches what the model saw.
+	loaded, err := c.loadMessages(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("loadMessages: %v", err)
+	}
+	var sawWarning, sawExhausted bool
+	for _, m := range loaded {
+		if m.msg.Role != "system" {
+			continue
+		}
+		sawWarning = sawWarning || m.msg.Content == lowBudgetNotice
+		sawExhausted = sawExhausted || m.msg.Content == budgetExhaustedNotice
+	}
+	if !sawWarning || !sawExhausted {
+		t.Errorf("persisted transcript missing notices: warning=%v exhausted=%v", sawWarning, sawExhausted)
 	}
 }
 

--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -721,7 +721,7 @@ func (c *Config) approximateAppFromMessages(ctx context.Context, msgs []slack.Me
 	resp, err := c.chat(ctx, c.ModelSmall, []chatMessage{
 		{Role: "system", Content: appResolutionPrompt},
 		{Role: "user", Content: prompt},
-	}, nil)
+	}, nil, "")
 	if err != nil {
 		log.Printf("agent: slack app approximation failed: %v", err)
 		return slackApp{}, chatUsage{}, false
@@ -1337,7 +1337,7 @@ func (c *Config) summarizeSlackContext(ctx context.Context, msgs []slack.Message
 	resp, err := c.chat(ctx, c.ModelSmall, []chatMessage{
 		{Role: "system", Content: slackContextSummaryPrompt},
 		{Role: "user", Content: rendered},
-	}, nil)
+	}, nil, "")
 	if err != nil {
 		return "", "", chatUsage{}, err
 	}


### PR DESCRIPTION
# Description

The turn budget was 12 LLM calls and exhausting it discarded all the gathered data, with an apologetic response. Now 24 calls may use tools and the 25th is the budget-exhausted answer: a persisted notice tells the model the budget is spent and tool_choice "none" forces a text answer from what it has, with tool definitions kept in the prompt so the cached prefix survives. If a provider ignores tool_choice, no tools run and any text alongside is salvaged.

The model is told the budget up front in the system prompt and warned when 4 rounds remain, so it can batch and prioritize; all notices instruct it never to reveal the budget in answers.



