### PR TITLE
chore(backend): do not reply to deleted agent slack msgs

### DIFF
--- a/backend/agent/agent/edge_cases_test.go
+++ b/backend/agent/agent/edge_cases_test.go
@@ -347,6 +347,7 @@ func captureSlackDelivery(t *testing.T) *string {
 	slacktest.MockSetAssistantTitle(t, func(context.Context, string, string, string, string) error { return nil })
 	slacktest.MockConversationHistory(t, func(context.Context, string, string, int) ([]slack.Message, error) { return nil, nil })
 	slacktest.MockConversationReplies(t, func(context.Context, string, string, string, string, int) ([]slack.Message, error) { return nil, nil })
+	slacktest.MockThreadMessageExists(t, func(context.Context, string, string, string, string) (bool, error) { return true, nil })
 	slacktest.MockPostMessage(t, func(_ context.Context, _, _, _, text string) (string, error) { delivered = text; return "ack.1", nil })
 	slacktest.MockUpdateMessage(t, func(_ context.Context, _, _, _, text string) error { delivered = text; return nil })
 	return &delivered

--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -237,6 +237,28 @@ func (c *Config) answerSlackQuestion(ctx context.Context, ev slack.AgentEvent) {
 	deliverCtx, deliverCancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 	defer deliverCancel()
 
+	// The asker may have deleted the question while the turn ran, and the
+	// reply would then be posted with no question above it: inside the thread
+	// when the question was a thread reply, at channel level when the question
+	// rooted its own thread. We drop the reply, clean up the ack, and mark
+	// the event answered. When the check itself fails the answer still goes out.
+	if exists, err := slack.ThreadMessageExists(deliverCtx, token, ev.Channel, ev.ThreadTS, ev.EventTS); err == nil && !exists {
+		outcome = "question_deleted"
+		if ev.Surface == slack.SurfaceMention {
+			if ackTS != "" {
+				if err := slack.DeleteMessage(deliverCtx, token, ev.Channel, ackTS); err != nil {
+					log.Printf("agent: failed to delete slack ack after question deletion: %v", err)
+				}
+			}
+		} else if err := slack.SetAssistantStatus(deliverCtx, token, ev.Channel, ev.ThreadTS, ""); err != nil {
+			// Nothing will be posted, so the status must be cleared
+			// explicitly or it stays visible in the thread.
+			log.Printf("agent: failed to clear assistant status after question deletion: %v", err)
+		}
+		c.markSlackEventAnswered(deliverCtx, ev.EventID)
+		return
+	}
+
 	if err := c.deliverSlackReply(deliverCtx, token, ev, ackTS, reply); err != nil {
 		outcome = "delivery_failed"
 		span.SetStatus(codes.Error, err.Error())

--- a/backend/agent/agent/slack_branches_test.go
+++ b/backend/agent/agent/slack_branches_test.go
@@ -31,6 +31,7 @@ func TestDeliverSlackReplyFallsBackToFreshPost(t *testing.T) {
 	slacktest.MockSetAssistantStatus(t, func(context.Context, string, string, string, string) error { return nil })
 	slacktest.MockConversationHistory(t, func(context.Context, string, string, int) ([]slack.Message, error) { return nil, nil })
 	slacktest.MockConversationReplies(t, func(context.Context, string, string, string, string, int) ([]slack.Message, error) { return nil, nil })
+	slacktest.MockThreadMessageExists(t, func(context.Context, string, string, string, string) (bool, error) { return true, nil })
 
 	var posts []string
 	slacktest.MockPostMessage(t, func(_ context.Context, _, _, _, text string) (string, error) {
@@ -55,6 +56,144 @@ func TestDeliverSlackReplyFallsBackToFreshPost(t *testing.T) {
 	}
 	if !strings.Contains(posts[1], "Fresh answer") {
 		t.Errorf("fresh post = %q, want the answer", posts[1])
+	}
+}
+
+// TestSlackQuestionDeletedStaysSilent checks that a question deleted while
+// the turn ran gets no reply: the ack placeholder is removed, nothing else is
+// posted, and a redelivery of the event posts nothing either. What is checked
+// is the question's own message, so a question inside a thread is dropped
+// only when it is itself deleted, not when the thread's root is.
+func TestSlackQuestionDeletedStaysSilent(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	const email = "deleter@test.dev"
+	teamID, userID, appID := uuid.New(), uuid.New(), uuid.New()
+	seedTeam(ctx, t, teamID, "team")
+	seedUser(ctx, t, userID, email)
+	seedTeamMembership(ctx, t, teamID, userID, "owner")
+	seedApp(ctx, t, appID, teamID, "soleapp", 30)
+	seedTeamSlack(ctx, t, teamID, []string{"C1"})
+
+	slacktest.MockUserEmail(t, func(context.Context, string, string) (string, error) { return email, nil })
+	slacktest.MockConversationHistory(t, func(context.Context, string, string, int) ([]slack.Message, error) { return nil, nil })
+	slacktest.MockConversationReplies(t, func(context.Context, string, string, string, string, int) ([]slack.Message, error) { return nil, nil })
+	var checkedThreadRootTS, checkedMessageTS string
+	slacktest.MockThreadMessageExists(t, func(_ context.Context, _, _, threadRootTS, messageTS string) (bool, error) {
+		checkedThreadRootTS, checkedMessageTS = threadRootTS, messageTS
+		return false, nil
+	})
+
+	var posts []string
+	slacktest.MockPostMessage(t, func(_ context.Context, _, _, _, text string) (string, error) {
+		posts = append(posts, text)
+		return "ack.1", nil
+	})
+	updated := false
+	slacktest.MockUpdateMessage(t, func(context.Context, string, string, string, string) error {
+		updated = true
+		return nil
+	})
+	var deletedTS string
+	slacktest.MockDeleteMessage(t, func(_ context.Context, _, _, ts string) error {
+		deletedTS = ts
+		return nil
+	})
+
+	// A question asked as a reply inside an existing thread: what must be
+	// checked is the question's own message, not the thread's root.
+	ev := slackQuestionEvent(teamID, slack.SurfaceMention, "how is the app?", "Ev-deleted")
+	ev.EventTS = "1700000000.5"
+
+	c, stub := newTestAgent(t, `{"choices":[{"message":{"role":"assistant","content":"Too late."}}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	handleSlackQuestion(t, c, ev)
+
+	if stub.callCount() != 1 {
+		t.Errorf("llm calls = %d, want 1 (the turn still ran)", stub.callCount())
+	}
+	if checkedThreadRootTS != ev.ThreadTS || checkedMessageTS != "1700000000.5" {
+		t.Errorf("checked thread root=%q message=%q, want the question's own message in its thread", checkedThreadRootTS, checkedMessageTS)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("PostMessage calls = %d, want 1 (the ack only): %v", len(posts), posts)
+	}
+	if updated {
+		t.Error("the ack must not be edited into an answer")
+	}
+	if deletedTS != "ack.1" {
+		t.Errorf("deleted message ts = %q, want the ack placeholder", deletedTS)
+	}
+
+	// A redelivery finds the event marked answered and posts nothing.
+	posts = nil
+	handleSlackQuestion(t, c, ev)
+	if stub.callCount() != 1 || len(posts) != 0 {
+		t.Errorf("redelivery ran again: llm calls = %d, posts = %v", stub.callCount(), posts)
+	}
+}
+
+// TestSlackQuestionDeletedClearsAssistantStatus checks the assistant surface
+// counterpart: there is no ack to remove, so the "digging" status is cleared
+// explicitly and nothing is posted.
+func TestSlackQuestionDeletedClearsAssistantStatus(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	const email = "dm-deleter@test.dev"
+	teamID, userID, appID := uuid.New(), uuid.New(), uuid.New()
+	seedTeam(ctx, t, teamID, "team")
+	seedUser(ctx, t, userID, email)
+	seedTeamMembership(ctx, t, teamID, userID, "owner")
+	seedApp(ctx, t, appID, teamID, "soleapp", 30)
+	seedTeamSlack(ctx, t, teamID, []string{"C1"})
+
+	slacktest.MockUserEmail(t, func(context.Context, string, string) (string, error) { return email, nil })
+	delivered := captureSlackDelivery(t)
+	var statuses []string
+	slacktest.MockSetAssistantStatus(t, func(_ context.Context, _, _, _, status string) error {
+		statuses = append(statuses, status)
+		return nil
+	})
+	slacktest.MockThreadMessageExists(t, func(context.Context, string, string, string, string) (bool, error) { return false, nil })
+
+	c, stub := newTestAgent(t, `{"choices":[{"message":{"role":"assistant","content":"Too late."}}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	handleSlackQuestion(t, c, slackQuestionEvent(teamID, slack.SurfaceAssistant, "how is the app?", "Ev-dm-deleted"))
+
+	if stub.callCount() != 1 {
+		t.Errorf("llm calls = %d, want 1 (the turn still ran)", stub.callCount())
+	}
+	if *delivered != "" {
+		t.Errorf("delivered = %q, want nothing", *delivered)
+	}
+	if len(statuses) == 0 || statuses[len(statuses)-1] != "" {
+		t.Errorf("statuses = %v, want a final empty status clearing the thread", statuses)
+	}
+}
+
+// TestSlackQuestionDeletionCheckFailsOpen checks that when the deletion check
+// itself errors, the answer is still delivered; a transient API failure must
+// not drop answers.
+func TestSlackQuestionDeletionCheckFailsOpen(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	const email = "blipped@test.dev"
+	teamID, userID, appID := uuid.New(), uuid.New(), uuid.New()
+	seedTeam(ctx, t, teamID, "team")
+	seedUser(ctx, t, userID, email)
+	seedTeamMembership(ctx, t, teamID, userID, "owner")
+	seedApp(ctx, t, appID, teamID, "soleapp", 30)
+	seedTeamSlack(ctx, t, teamID, []string{"C1"})
+
+	slacktest.MockUserEmail(t, func(context.Context, string, string) (string, error) { return email, nil })
+	delivered := captureSlackDelivery(t)
+	slacktest.MockThreadMessageExists(t, func(context.Context, string, string, string, string) (bool, error) {
+		return false, errors.New("ratelimited")
+	})
+
+	c, _ := newTestAgent(t, `{"choices":[{"message":{"role":"assistant","content":"Still delivered."}}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	handleSlackQuestion(t, c, slackQuestionEvent(teamID, slack.SurfaceAssistant, "how is the app?", "Ev-check-blip"))
+
+	if !strings.Contains(*delivered, "Still delivered") {
+		t.Errorf("delivered = %q, want the answer despite the failed check", *delivered)
 	}
 }
 

--- a/backend/agent/agent/slack_handler_test.go
+++ b/backend/agent/agent/slack_handler_test.go
@@ -67,6 +67,7 @@ func TestAnswerSlackQuestionAssistant(t *testing.T) {
 	slacktest.MockSetAssistantTitle(t, func(context.Context, string, string, string, string) error { return nil })
 	slacktest.MockConversationHistory(t, func(context.Context, string, string, int) ([]slack.Message, error) { return nil, nil })
 	slacktest.MockConversationReplies(t, func(context.Context, string, string, string, string, int) ([]slack.Message, error) { return nil, nil })
+	slacktest.MockThreadMessageExists(t, func(context.Context, string, string, string, string) (bool, error) { return true, nil })
 
 	var delivered string
 	capture := func(text string) { delivered = text }

--- a/backend/libs/slack/slack.go
+++ b/backend/libs/slack/slack.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -150,9 +151,11 @@ func retryAfterDelay(header string) time.Duration {
 var (
 	PostMessage                  = postMessage
 	UpdateMessage                = updateMessage
+	DeleteMessage                = deleteMessage
 	UserEmail                    = userEmail
 	ConversationReplies          = conversationReplies
 	ConversationHistory          = conversationHistory
+	ThreadMessageExists          = threadMessageExists
 	SetAssistantStatus           = setAssistantStatus
 	SetAssistantTitle            = setAssistantTitle
 	SetAssistantSuggestedPrompts = setAssistantSuggestedPrompts
@@ -186,6 +189,15 @@ func updateMessage(ctx context.Context, token, channel, ts, text string) error {
 		"text":    text,
 	}
 	return postJSON(ctx, token, "chat.update", payload, nil)
+}
+
+// DeleteMessage removes a previously posted message.
+func deleteMessage(ctx context.Context, token, channel, ts string) error {
+	payload := map[string]any{
+		"channel": channel,
+		"ts":      ts,
+	}
+	return postJSON(ctx, token, "chat.delete", payload, nil)
 }
 
 // UserEmail returns the email on a Slack user's profile. Workspaces can hide
@@ -265,6 +277,48 @@ func conversationReplies(ctx context.Context, token, channel, threadTS, oldest s
 		}
 	}
 	return tail, nil
+}
+
+// ThreadMessageExists reports whether the message with timestamp messageTS,
+// in the thread whose root message has timestamp threadRootTS, still exists.
+// For a message outside any thread the two timestamps are the same. Callers
+// use it to detect a question that was deleted while its answer was being
+// prepared; only the message is checked, so a thread whose root was
+// deleted still reports true for a surviving reply in it. Slack replaces a
+// deleted root that has replies with a tombstone message, which counts as
+// deleted here. The error is non-nil only when the check itself failed, in
+// which case the boolean is meaningless.
+func threadMessageExists(ctx context.Context, token, channel, threadRootTS, messageTS string) (bool, error) {
+	query := url.Values{}
+	query.Set("channel", channel)
+	query.Set("ts", threadRootTS)
+	query.Set("oldest", messageTS)
+	query.Set("inclusive", "true")
+	// Replies are returned oldest first, so a live message is the first one
+	// at or after its own timestamp, except that Slack can include the
+	// thread's root in front of it even when the oldest filter excludes the
+	// root. A limit of 2 covers both positions; the root's inclusion is
+	// observed rather than documented behavior, and a limit that is too
+	// small reports a live message as deleted, so one extra slot guards a
+	// miscount there.
+	query.Set("limit", "3")
+	var resp struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := getJSON(ctx, token, "conversations.replies", query, &resp); err != nil {
+		if strings.Contains(err.Error(), "thread_not_found") {
+			return false, nil
+		}
+		return false, err
+	}
+	// Matched by timestamp rather than by position, so it does not matter
+	// whether the root was included.
+	for _, m := range resp.Messages {
+		if m.TS == messageTS {
+			return m.Subtype != "tombstone", nil
+		}
+	}
+	return false, nil
 }
 
 // ConversationHistory returns a channel's most recent messages. Slack returns

--- a/backend/libs/slack/slack_test.go
+++ b/backend/libs/slack/slack_test.go
@@ -52,6 +52,74 @@ func TestConversationRepliesPaginatesToNewest(t *testing.T) {
 	}
 }
 
+// TestThreadMessageExists checks the aliveness verdicts: a live message
+// counts wherever it exists in the thread, deletion is recognized both as a
+// missing message and as a root's tombstone, other messages' fates don't
+// matter, and an unrelated API failure is reported as an error rather than a
+// verdict.
+func TestThreadMessageExists(t *testing.T) {
+	orig := httpClient
+	defer func() { httpClient = orig }()
+
+	cases := map[string]struct {
+		threadTS, ts string
+		body         string
+		exists       bool
+		wantsError   bool
+	}{
+		"live root, no thread": {
+			threadTS: "1.0", ts: "1.0",
+			body:   `{"ok":true,"messages":[{"ts":"1.0","text":"the question"}]}`,
+			exists: true,
+		},
+		"root tombstoned by deletion": {
+			threadTS: "1.0", ts: "1.0",
+			body:   `{"ok":true,"messages":[{"ts":"1.0","subtype":"tombstone","text":"This message was deleted."},{"ts":"1.5","text":"the ack"}]}`,
+			exists: false,
+		},
+		"reply alive under deleted root": {
+			threadTS: "1.0", ts: "1.4",
+			body:   `{"ok":true,"messages":[{"ts":"1.0","subtype":"tombstone","text":"This message was deleted."},{"ts":"1.4","text":"the question"},{"ts":"1.6","text":"later chatter"}]}`,
+			exists: true,
+		},
+		"reply deleted": {
+			threadTS: "1.0", ts: "1.4",
+			body:   `{"ok":true,"messages":[{"ts":"1.0","text":"the root"},{"ts":"1.6","text":"later chatter"}]}`,
+			exists: false,
+		},
+		"thread not found": {
+			threadTS: "1.0", ts: "1.0",
+			body:   `{"ok":false,"error":"thread_not_found"}`,
+			exists: false,
+		},
+		"api failure": {
+			threadTS: "1.0", ts: "1.0",
+			body:   `{"ok":false,"error":"fatal_error"}`,
+			exists: false, wantsError: true,
+		},
+	}
+	for name, tc := range cases {
+		httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			q := r.URL.Query()
+			if q.Get("ts") != tc.threadTS || q.Get("oldest") != tc.ts || q.Get("inclusive") != "true" {
+				t.Errorf("%s: query = %s, want ts=%s oldest=%s inclusive=true", name, q.Encode(), tc.threadTS, tc.ts)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+				Header:     make(http.Header),
+			}, nil
+		})}
+		exists, err := ThreadMessageExists(context.Background(), "tok", "C1", tc.threadTS, tc.ts)
+		if tc.wantsError != (err != nil) {
+			t.Errorf("%s: err = %v, wantsError = %v", name, err, tc.wantsError)
+		}
+		if exists != tc.exists {
+			t.Errorf("%s: exists = %v, want %v", name, exists, tc.exists)
+		}
+	}
+}
+
 // TestConversationRepliesStopsWithoutCursor checks the loop ends on a single
 // page that reports no more.
 func TestConversationRepliesStopsWithoutCursor(t *testing.T) {

--- a/backend/libs/slack/testhelpers/testhelpers.go
+++ b/backend/libs/slack/testhelpers/testhelpers.go
@@ -36,6 +36,14 @@ func MockUpdateMessage(t *testing.T, fn func(ctx context.Context, token, channel
 	t.Cleanup(func() { slack.UpdateMessage = orig })
 }
 
+// MockDeleteMessage swaps slack.DeleteMessage for the duration of the test.
+func MockDeleteMessage(t *testing.T, fn func(ctx context.Context, token, channel, ts string) error) {
+	t.Helper()
+	orig := slack.DeleteMessage
+	slack.DeleteMessage = fn
+	t.Cleanup(func() { slack.DeleteMessage = orig })
+}
+
 // MockUserEmail swaps slack.UserEmail for the duration of the test.
 func MockUserEmail(t *testing.T, fn func(ctx context.Context, token, slackUserID string) (string, error)) {
 	t.Helper()
@@ -50,6 +58,14 @@ func MockConversationReplies(t *testing.T, fn func(ctx context.Context, token, c
 	orig := slack.ConversationReplies
 	slack.ConversationReplies = fn
 	t.Cleanup(func() { slack.ConversationReplies = orig })
+}
+
+// MockThreadMessageExists swaps slack.ThreadMessageExists for the duration of the test.
+func MockThreadMessageExists(t *testing.T, fn func(ctx context.Context, token, channel, threadRootTS, messageTS string) (bool, error)) {
+	t.Helper()
+	orig := slack.ThreadMessageExists
+	slack.ThreadMessageExists = fn
+	t.Cleanup(func() { slack.ThreadMessageExists = orig })
 }
 
 // MockConversationHistory swaps slack.ConversationHistory for the duration of the test.


### PR DESCRIPTION
# Description

If user posts a question and then deletes it, we now check whether the message exists before replying to it. This prevents messages from being posted in channel directly if top level message is deleted since it can't post in a thread. In threaded questions also, we check if question exists before posting the reply. Deleted messages are acked and in progress status messages are also cleaned up.



