### PR TITLE
chore(backend): consume slack events via push

### DIFF
--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -28,9 +28,9 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 )
 
-// slackTurnTimeout bounds one Slack-originated turn. Generous because a
-// turn can chain a dozen LLM calls plus tool work.
-const slackTurnTimeout = 15 * time.Minute
+// slackTurnTimeout bounds one Slack turn. A turn chains many LLM & tool
+// calls; keep it modest so a turn completes within a single delivery attempt.
+const slackTurnTimeout = 9 * time.Minute
 
 // somethingWentWrong is the reply for failures the asker can't act on.
 const somethingWentWrong = "Something went wrong on my side. Please try again."

--- a/backend/agent/go.mod
+++ b/backend/agent/go.mod
@@ -136,7 +136,7 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	google.golang.org/api v0.286.0 // indirect
+	google.golang.org/api v0.286.0
 	google.golang.org/genproto v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect

--- a/backend/agent/main.go
+++ b/backend/agent/main.go
@@ -186,13 +186,24 @@ func main() {
 	r.POST("/mcp", mcpH.ValidateMCPToken(), gin.WrapH(mcpHandler))
 	r.GET("/mcp", mcpH.ValidateMCPToken(), gin.WrapH(mcpHandler))
 
+	// Slack events arrive either by push to an HTTP endpoint or by a background
+	// pull consumer. Exactly one is active.
+	pushEnabled := os.Getenv("AGENT_SLACK_PUBSUB_PUSH_ENABLED") == "true"
+
 	// Consume Slack questions the api service publishes to the bus.
 	// runSlackConsumer supervises the consumer, rebuilding it whenever the
 	// connection dies, and runs until consumerCtx is cancelled. stopConsumer is
 	// that cancel, called on shutdown below to bring the supervisor down.
 	consumerCtx, stopConsumer := context.WithCancel(context.Background())
 	defer stopConsumer()
-	go runSlackConsumer(consumerCtx, config, agentConfig.HandleSlackEvent)
+
+	if config.IsCloud() && pushEnabled {
+		// The token audience is this service's origin plus the push path.
+		audience := config.AgentOrigin + "/subscribe/slack"
+		r.POST("/subscribe/slack", slackPushHandler(agentConfig, audience))
+	} else {
+		go runSlackConsumer(consumerCtx, config, agentConfig.HandleSlackEvent)
+	}
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/backend/agent/slackpush.go
+++ b/backend/agent/slackpush.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/base64"
+	"log"
+	"net/http"
+	"strings"
+
+	"backend/agent/agent"
+
+	"github.com/gin-gonic/gin"
+	"google.golang.org/api/idtoken"
+)
+
+// pushEnvelope is the JSON body of a pushed message. Only the base64 data is
+// needed; the event's fields live inside the decoded payload.
+type pushEnvelope struct {
+	Message struct {
+		Data string `json:"data"`
+	} `json:"message"`
+}
+
+// slackPushHandler serves Slack events delivered over HTTP, the counterpart to
+// the pull consumer. It verifies the request token, caps concurrent turns &
+// runs the turn synchronously so the response reflects its outcome. audience is
+// the token audience the caller must present.
+func slackPushHandler(agentConfig *agent.Config, audience string) gin.HandlerFunc {
+	// Counting semaphore: a full channel means the turn cap is reached.
+	sem := make(chan struct{}, maxConcurrentSlackTurns)
+	expectedEmail := agentConfig.Deps.Config.ServiceAccountEmail
+
+	return func(c *gin.Context) {
+		if !verifyPushToken(c, audience, expectedEmail) {
+			return
+		}
+
+		// At capacity: ask the caller to retry later instead of running more
+		// turns than the cap allows.
+		select {
+		case sem <- struct{}{}:
+			defer func() { <-sem }()
+		default:
+			c.Status(http.StatusTooManyRequests)
+			return
+		}
+
+		var env pushEnvelope
+		if err := c.BindJSON(&env); err != nil {
+			// Malformed input never succeeds on retry; drop it with 200.
+			log.Printf("agent: dropping slack push with bad envelope: %v", err)
+			c.Status(http.StatusOK)
+			return
+		}
+
+		data, err := base64.StdEncoding.DecodeString(env.Message.Data)
+		if err != nil {
+			log.Printf("agent: dropping slack push with bad base64: %v", err)
+			c.Status(http.StatusOK)
+			return
+		}
+
+		// Run the turn on the request context. A non-nil error, including a
+		// cancelled request, returns 5xx so the caller retries; nil returns 200.
+		if err := agentConfig.HandleSlackEvent(c.Request.Context(), data); err != nil {
+			log.Printf("agent: slack push turn did not complete: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		c.Status(http.StatusOK)
+	}
+}
+
+// verifyPushToken checks the signed bearer token on the request: signature,
+// the expected audience & when set the expected email claim. It writes
+// 401/403 & returns false on failure.
+func verifyPushToken(c *gin.Context, audience, expectedEmail string) bool {
+	authz := c.GetHeader("Authorization")
+	token, ok := strings.CutPrefix(authz, "Bearer ")
+	if !ok || token == "" {
+		c.Status(http.StatusUnauthorized)
+		return false
+	}
+
+	payload, err := idtoken.Validate(c.Request.Context(), token, audience)
+	if err != nil {
+		log.Printf("agent: slack push token rejected: %v", err)
+		c.Status(http.StatusUnauthorized)
+		return false
+	}
+
+	if expectedEmail != "" {
+		if email, _ := payload.Claims["email"].(string); email != expectedEmail {
+			log.Printf("agent: slack push token from unexpected principal %q", email)
+			c.Status(http.StatusForbidden)
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary

This PR lets the agent consume Slack events by push in addition to the existing pull consumer. On cloud it serves a `/subscribe/slack` HTTP endpoint that verifies the request's signed token, caps concurrent turns with a semaphore & runs the turn synchronously so the response reflects the outcome; self-host keeps the pull consumer. `slackTurnTimeout` drops to 9m so a turn completes within a single delivery attempt.

## Tasks

- [x] Add push delivery of Slack events at `/subscribe/slack`
- [x] Verify the request's signed token before running a turn
- [x] Serve push on cloud & keep the pull consumer otherwise
- [x] Cap concurrent turns with a semaphore
- [x] Lower `slackTurnTimeout` to 9m
- [x] Promote `idtoken` to a direct dependency
