### PR TITLE
chore(backend): add AGENT_ENABLED flag

### DIFF
--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -27,6 +27,10 @@ import (
 
 var tracer = otel.Tracer("agent")
 
+// UnavailableReply is the canned reply every surface returns while the agent
+// is disabled (AGENT_ENABLED is not "true").
+const UnavailableReply = "Measure Agent is unavailable at the moment. Please try again later."
+
 // userIDKey carries the authenticated user id in a context.
 type userIDKey struct{}
 

--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -66,6 +66,16 @@ func (c *Config) HandleSlackEvent(ctx context.Context, data []byte) error {
 
 	log.Printf("agent: slack event received id=%s kind=%s surface=%s", ev.EventID, ev.Kind, ev.Surface)
 
+	// The one gate for the whole Slack surface: with the agent disabled,
+	// questions get the canned notice and greetings are dropped.
+	if !c.Deps.Config.IsAgentEnabled() {
+		if ev.Kind == slack.KindQuestion {
+			c.answerSlackUnavailable(ctx, ev)
+			return ctx.Err()
+		}
+		return nil
+	}
+
 	switch ev.Kind {
 	case slack.KindGreeting:
 		// Greeting is cheap and touches no transcript; keep the queue
@@ -138,6 +148,33 @@ func (c *Config) greetAssistantThread(ctx context.Context, ev slack.AgentEvent) 
 	if err := slack.SetAssistantSuggestedPrompts(ctx, token, ev.Channel, prompts); err != nil {
 		log.Printf("agent: failed to set suggested prompts: %v", err)
 	}
+}
+
+// answerSlackUnavailable replies to a question with the canned notice while
+// the agent is disabled; no turn runs. The event is marked answered so Slack
+// retries don't repost the notice.
+func (c *Config) answerSlackUnavailable(ctx context.Context, ev slack.AgentEvent) {
+	defer recoverSlackPanic("unavailable notice")
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	teamID, err := uuid.Parse(ev.TeamID)
+	if err != nil {
+		log.Printf("agent: slack event with invalid team id %q", ev.TeamID)
+		return
+	}
+	if c.slackEventAnswered(ctx, ev.EventID) {
+		return
+	}
+	token, _, _, err := c.getSlackIntegration(ctx, teamID)
+	if err != nil || token == "" {
+		log.Printf("agent: no usable slack integration for team %s: %v", teamID, err)
+		return
+	}
+	if _, err := slack.PostMessage(ctx, token, ev.Channel, ev.ThreadTS, UnavailableReply); err != nil {
+		log.Printf("agent: failed to post agent unavailable notice: %v", err)
+	}
+	c.markSlackEventAnswered(ctx, ev.EventID)
 }
 
 // answerSlackQuestion runs one Slack question end to end: skip it if a

--- a/backend/agent/agent/slack_branches_test.go
+++ b/backend/agent/agent/slack_branches_test.go
@@ -273,6 +273,46 @@ func TestSlackDisabledIntegrationPostsNotice(t *testing.T) {
 	}
 }
 
+// TestSlackAgentDisabledPostsNotice checks that with the agent disabled, a
+// question gets the unavailability notice instead of a turn, and a redelivery
+// of the same event doesn't repost it.
+func TestSlackAgentDisabledPostsNotice(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	teamID, _, _ := seedTeamUserApp(ctx, t)
+	seedTeamSlack(ctx, t, teamID, []string{"C1"})
+
+	orig := deps.Config.AgentEnabled
+	deps.Config.AgentEnabled = false
+	t.Cleanup(func() { deps.Config.AgentEnabled = orig })
+
+	var posts []string
+	slacktest.MockPostMessage(t, func(_ context.Context, _, _, _, text string) (string, error) {
+		posts = append(posts, text)
+		return "notice.1", nil
+	})
+
+	c, stub := newTestAgent(t) // no scripted responses; the turn must not start
+	handleSlackQuestion(t, c, slackQuestionEvent(teamID, slack.SurfaceMention, "how is the app?", "Ev-agentoff"))
+
+	if stub.callCount() != 0 {
+		t.Errorf("llm called %d times, want 0 (turn must not run when the agent is off)", stub.callCount())
+	}
+	if len(posts) != 1 {
+		t.Fatalf("PostMessage calls = %d, want 1 (the unavailability notice): %v", len(posts), posts)
+	}
+	if posts[0] != UnavailableReply {
+		t.Errorf("notice = %q, want %q", posts[0], UnavailableReply)
+	}
+
+	// Redelivery of the same event is deduped: no second notice.
+	posts = nil
+	handleSlackQuestion(t, c, slackQuestionEvent(teamID, slack.SurfaceMention, "how is the app?", "Ev-agentoff"))
+	if len(posts) != 0 {
+		t.Errorf("redelivery posted %v, want nothing (deduped)", posts)
+	}
+}
+
 // TestResolveAppFromContextUsesModel checks the LLM-driven app resolution: when
 // the team has several apps and the discussion describes one only loosely, the
 // small model picks it from the surrounding context.

--- a/backend/agent/agent/slack_handler_test.go
+++ b/backend/agent/agent/slack_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"backend/libs/concur"
 	"backend/libs/slack"
 	slacktest "backend/libs/slack/testhelpers"
 
@@ -41,6 +42,41 @@ func TestGreetAssistantThread(t *testing.T) {
 	}
 	if len(gotPrompts) == 0 {
 		t.Error("expected starter prompts to be set")
+	}
+}
+
+// TestGreetAssistantThreadAgentDisabled checks that with the agent disabled,
+// a greeting event is dropped and no starter prompts are set.
+func TestGreetAssistantThreadAgentDisabled(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	teamID, _, _ := seedTeamUserApp(ctx, t)
+	seedTeamSlack(ctx, t, teamID, []string{"C123"})
+
+	orig := deps.Config.AgentEnabled
+	deps.Config.AgentEnabled = false
+	t.Cleanup(func() { deps.Config.AgentEnabled = orig })
+
+	promptCalls := 0
+	slacktest.MockSetAssistantSuggestedPrompts(t, func(context.Context, string, string, []slack.SuggestedPrompt) error {
+		promptCalls++
+		return nil
+	})
+
+	c := &Config{Deps: deps}
+	data, _ := json.Marshal(slack.AgentEvent{
+		Kind: slack.KindGreeting, Surface: slack.SurfaceAssistant,
+		TeamID: teamID.String(), Channel: "C123", EventID: "Ev-greetoff",
+	})
+	if err := c.HandleSlackEvent(ctx, data); err != nil {
+		t.Fatalf("HandleSlackEvent: %v", err)
+	}
+	// Greetings run on a background goroutine when dispatched; wait so a
+	// wrongly dispatched one is caught rather than racing the assertion.
+	concur.GlobalWg.Wait()
+
+	if promptCalls != 0 {
+		t.Errorf("suggested prompts set %d times, want 0 when the agent is off", promptCalls)
 	}
 }
 

--- a/backend/agent/agent/test_helpers_test.go
+++ b/backend/agent/agent/test_helpers_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 		ChPool:  chConn,
 		RchPool: chConn,
 		VK:      vk,
-		Config:  &server.Config{BillingEnabled: true},
+		Config:  &server.Config{BillingEnabled: true, AgentEnabled: true},
 	}
 
 	// Background token tracking must never reach the network in tests. Tests

--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -529,6 +529,12 @@ func askQuestionTool(cfg *Config) Tool {
 			"Use list_apps to discover app ids. Pass conversation_id from a previous answer to continue that conversation.",
 		InputSchema: mcpMustInferSchema[askQuestionInput](),
 	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in askQuestionInput) (*mcpsdk.CallToolResult, any, error) {
+		// The one agent-backed tool: while the agent is disabled it returns
+		// the unavailability notice. The plain data tools are not
+		// agent-dependent and keep working.
+		if !cfg.Deps.Config.IsAgentEnabled() {
+			return mcpTextResult(UnavailableReply), nil, nil
+		}
 		out, err := cfg.askQuestion(ctx, in)
 		if err != nil {
 			return nil, nil, err

--- a/backend/agent/mcp/auth.go
+++ b/backend/agent/mcp/auth.go
@@ -805,9 +805,7 @@ func (h Handlers) ValidateMCPToken() gin.HandlerFunc {
 				}
 				providerToken := *info.ProviderToken
 				tokenID := info.TokenID
-				concur.GlobalWg.Add(1)
-				go func() {
-					defer concur.GlobalWg.Done()
+				concur.GlobalWg.Go(func() {
 					if valErr := mcpValidateProviderTokenFn(provider, providerToken, deps.Config.OAuthGoogleKey, deps.Config.OAuthGoogleSecret); valErr != nil {
 						fmt.Printf("mcp: revoking token %s, provider token check failed: %v\n", tokenID, valErr)
 						if revokeErr := mcpRevokeToken(context.Background(), deps, tokenID); revokeErr != nil {
@@ -818,7 +816,7 @@ func (h Handlers) ValidateMCPToken() gin.HandlerFunc {
 							fmt.Println("mcp: failed to update provider_token_checked_at:", updErr)
 						}
 					}
-				}()
+				})
 			}
 		}
 

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -1528,6 +1528,42 @@ func TestMCPToolsList(t *testing.T) {
 	}
 }
 
+// TestMCPAskQuestionAgentDisabled checks that with the agent disabled,
+// ask_question returns the unavailability notice while the plain data tools
+// keep working.
+func TestMCPAskQuestionAgentDisabled(t *testing.T) {
+	ctx := context.Background()
+	cleanupAll(ctx, t)
+
+	userID := uuid.New()
+	seedUser(ctx, t, userID.String(), "agentoff@mcp.test")
+	rawToken := "msr_agentofftoken"
+	seedMCPAccessToken(ctx, t, rawToken, userID.String(), "client1", time.Now().Add(90*24*time.Hour))
+
+	orig := deps.Config.AgentEnabled
+	deps.Config.AgentEnabled = false
+	t.Cleanup(func() { deps.Config.AgentEnabled = orig })
+
+	resp := callMCPTool(t, rawToken, "ask_question", map[string]any{
+		"app_id":   uuid.New().String(),
+		"question": "how is the app?",
+	})
+	if text := extractTextContent(t, resp); text != agent.UnavailableReply {
+		t.Errorf("ask_question text = %q, want %q", text, agent.UnavailableReply)
+	}
+
+	// A data tool is not agent-dependent: list_apps still answers normally.
+	resp = callMCPTool(t, rawToken, "list_apps", nil)
+	content := extractTextContent(t, resp)
+	if content == agent.UnavailableReply {
+		t.Fatalf("list_apps returned the unavailability notice, want a normal answer")
+	}
+	var apps []any
+	if err := json.Unmarshal([]byte(content), &apps); err != nil {
+		t.Errorf("list_apps content = %q, want a JSON app list: %v", content, err)
+	}
+}
+
 func TestMCPListApps(t *testing.T) {
 	ctx := context.Background()
 

--- a/backend/agent/mcp/test_helpers_test.go
+++ b/backend/agent/mcp/test_helpers_test.go
@@ -44,6 +44,7 @@ func TestMain(m *testing.M) {
 		VK:      vk,
 		Config: &server.Config{
 			BillingEnabled: true,
+			AgentEnabled:   true,
 		},
 	}
 	h = NewHandlers(deps)

--- a/backend/agent/server/server.go
+++ b/backend/agent/server/server.go
@@ -104,6 +104,7 @@ type Config struct {
 	CloudEnv                     bool
 	IngestEnforceTimeWindow      bool
 	BillingEnabled               bool
+	AgentEnabled                 bool
 }
 
 // IsCloud is true if the service is
@@ -116,6 +117,12 @@ func (c *Config) IsCloud() bool {
 // billing feature enabled.
 func (c *Config) IsBillingEnabled() bool {
 	return c.BillingEnabled
+}
+
+// IsAgentEnabled is true if the service has
+// the agent feature enabled.
+func (c *Config) IsAgentEnabled() bool {
+	return c.AgentEnabled
 }
 
 // Deps holds the live infrastructure handles the agent uses at runtime. NewConfig +
@@ -144,6 +151,14 @@ func NewConfig() *Config {
 	billingEnabled := false
 	if os.Getenv("BILLING_ENABLED") == "true" {
 		billingEnabled = true
+	}
+
+	agentEnabled := false
+	if os.Getenv("AGENT_ENABLED") == "true" {
+		agentEnabled = true
+	}
+	if !agentEnabled {
+		log.Println("AGENT_ENABLED env var not set to true, agent surfaces reply with an unavailability notice")
 	}
 
 	// capture google service account email when running in
@@ -446,6 +461,7 @@ func NewConfig() *Config {
 		CloudEnv:                     cloudEnv,
 		IngestEnforceTimeWindow:      enforceIngestTimeWindow,
 		BillingEnabled:               billingEnabled,
+		AgentEnabled:                 agentEnabled,
 	}
 }
 

--- a/docs/hosting/agent.md
+++ b/docs/hosting/agent.md
@@ -14,6 +14,7 @@ The agent runs as a separate `agent` service and sends prompts to a language mod
 - [Choose the models](#choose-the-models)
 - [Configure for a new installation](#configure-for-a-new-installation)
 - [Configure for an existing installation](#configure-for-an-existing-installation)
+- [Turn the agent on](#turn-the-agent-on)
 - [Make the agent reachable over MCP](#make-the-agent-reachable-over-mcp)
 
 ## Get an OpenRouter API key
@@ -39,7 +40,7 @@ You can use the same model for both, as long as it supports tool calling. Browse
 
 ## Configure for a new installation
 
-During installation, the configuration wizard prompts for the agent settings. At the **OpenRouter credentials and models** prompts, paste your API key and the small and medium model ids. Leaving them empty disables the agent.
+During installation, the configuration wizard prompts for the agent settings. At the **OpenRouter credentials and models** prompts, paste your API key and the small and medium model ids. The wizard writes `AGENT_ENABLED=false`, so once installation finishes, turn the agent on as described in [Turn the agent on](#turn-the-agent-on).
 
 The wizard also asks for the **Measure Agent service URL**, for example `https://measure-agent.yourcompany.com`. This is the public address coding agents use to reach the MCP endpoint. See [Make the agent reachable over MCP](#make-the-agent-reachable-over-mcp).
 
@@ -47,9 +48,10 @@ The wizard also asks for the **Measure Agent service URL**, for example `https:/
 
 If your instance is already running and you want to enable or change the agent, update the environment variables manually.
 
-1. **Agent Credentials**. Open the `self-host/.env` file & add the following environment variables as obtained from OpenRouter.
+1. **Agent Credentials**. Open the `self-host/.env` file & add the following environment variables. Set the credentials and models as obtained from OpenRouter, and set `AGENT_ENABLED=true` to turn the agent on.
 
     ```sh
+    AGENT_ENABLED=true
     OPENROUTER_API_KEY=your-openrouter-api-key        # change this
     OPENROUTER_MODEL_SMALL=deepseek/deepseek-v4-pro   # change this
     OPENROUTER_MODEL_MEDIUM=deepseek/deepseek-v4-pro  # change this
@@ -66,6 +68,18 @@ If your instance is already running and you want to enable or change the agent, 
     ```sh
     sudo ./install.sh
     ```
+
+## Turn the agent on
+
+The agent is off by default. It answers only when `AGENT_ENABLED` is set to `true` in `self-host/.env`; with any other value, or with the variable missing, Slack questions and the MCP `ask_question` tool receive a short notice that the agent is unavailable instead of an answer. The other MCP tools read data directly without the agent, so they keep working.
+
+To turn the agent on, set the variable and restart the services as described above.
+
+```sh
+AGENT_ENABLED=true
+```
+
+Set it back to `false` and restart to take the agent out of service without removing its configuration.
 
 ## Make the agent reachable over MCP
 

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -200,6 +200,7 @@ services:
       - oauth-github-secret
       - openrouter-api-key
     environment:
+      - AGENT_ENABLED=${AGENT_ENABLED}
       - BILLING_ENABLED=${BILLING_ENABLED}
       - AUTUMN_SECRET_KEY_FILE=/run/secrets/autumn-secret-key
       - POSTGRES_DSN_FILE=/run/secrets/postgres-dsn

--- a/self-host/config.sh
+++ b/self-host/config.sh
@@ -321,6 +321,12 @@ OPENROUTER_MODEL_SMALL=
 OPENROUTER_MODEL_MEDIUM=
 OPENROUTER_MODEL_LARGE=
 
+#########
+# Agent #
+#########
+
+AGENT_ENABLED=false
+
 EOF
 }
 
@@ -479,6 +485,12 @@ OPENROUTER_API_KEY=$OPENROUTER_API_KEY
 OPENROUTER_MODEL_SMALL=$OPENROUTER_MODEL_SMALL
 OPENROUTER_MODEL_MEDIUM=$OPENROUTER_MODEL_MEDIUM
 OPENROUTER_MODEL_LARGE=$OPENROUTER_MODEL_LARGE
+
+#########
+# Agent #
+#########
+
+AGENT_ENABLED=false
 
 EOF
 }
@@ -942,6 +954,10 @@ ensure() {
 
   if ! check_env_variable "OPENROUTER_MODEL_LARGE"; then
     add_env_variable "OPENROUTER_MODEL_LARGE" ""
+  fi
+
+  if ! check_env_variable "AGENT_ENABLED"; then
+    add_env_variable "AGENT_ENABLED" "false"
   fi
 
   if ! check_env_variable "GTM_ID"; then


### PR DESCRIPTION
# Description

If AGENT_ENABLED is not true, agent surfaces like Slack and the mcp ask_question tool return a canned message.



