### PR TITLE
chore(backend): remove platform attribute usage

### DIFF
--- a/self-host/sessionator/app/app.go
+++ b/self-host/sessionator/app/app.go
@@ -74,7 +74,6 @@ func (a *App) Attribute() (attribute *event.Attribute, err error) {
 			AppBuild:           spanAttr.AppBuild,
 			AppUniqueID:        spanAttr.AppUniqueID,
 			MeasureSDKVersion:  spanAttr.MeasureSDKVersion,
-			Platform:           spanAttr.Platform,
 			ThreadName:         spanAttr.ThreadName,
 			UserID:             spanAttr.UserID,
 			DeviceName:         spanAttr.DeviceName,


### PR DESCRIPTION
## Summary

This PR fixes a lone usage of `platform` attribute that was missed to remove from sessionator.

## Tasks

- [x] Remove a lone reference to platform attribute from sessionator

