### PR TITLE
chore(frontend): throw when required env vars are missing

### DIFF
--- a/frontend/dashboard/__tests__/pages/login/login_page_test.tsx
+++ b/frontend/dashboard/__tests__/pages/login/login_page_test.tsx
@@ -132,6 +132,44 @@ describe("Login Page", () => {
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
   });
 
+  it("throws in MCP mode when NEXT_PUBLIC_AGENT_BASE_URL is missing", () => {
+    process.env.NEXT_PUBLIC_AGENT_BASE_URL = "";
+
+    // Silence React's console.error report of the uncaught render error
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      expect(() =>
+        render(
+          <Login
+            searchParams={promiseParams({
+              mcp: "1",
+              response_type: "code",
+              client_id: "test_client",
+              redirect_uri: "http://localhost/cb",
+              state: "s",
+              code_challenge: "ch",
+            })}
+          />,
+        ),
+      ).toThrow("NEXT_PUBLIC_AGENT_BASE_URL is not set");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("normal sign-in is unaffected by a missing NEXT_PUBLIC_AGENT_BASE_URL", async () => {
+    process.env.NEXT_PUBLIC_AGENT_BASE_URL = "";
+
+    await act(async () => {
+      render(<Login searchParams={promiseParams({})} />);
+    });
+
+    expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
+  });
+
   it("constructs correct GitHub authorize URL in MCP mode", () => {
     render(
       <Login

--- a/frontend/dashboard/__tests__/proxy_test.ts
+++ b/frontend/dashboard/__tests__/proxy_test.ts
@@ -36,7 +36,7 @@ describe("proxy", () => {
   const originalPosthog = process.env.POSTHOG_HOST;
 
   beforeEach(() => {
-    delete process.env.API_BASE_URL;
+    process.env.API_BASE_URL = "http://api:8080";
     delete process.env.POSTHOG_HOST;
   });
 
@@ -54,7 +54,7 @@ describe("proxy", () => {
   });
 
   describe("/api proxy", () => {
-    it("rewrites /api/foo to the default API origin", () => {
+    it("rewrites /api/foo to the API origin", () => {
       const result: any = proxy(makeRequest("/api/foo"));
       expect(result.type).toBe("rewrite");
       expect(result.url).toBe("http://api:8080/foo");
@@ -92,10 +92,18 @@ describe("proxy", () => {
       expect(result.url).toBe("http://api:8080/teams/abc/apps/xyz/sessions");
     });
 
-    it("falls back to http://api:8080 when API_BASE_URL is empty string", () => {
+    it("throws when API_BASE_URL is unset", () => {
+      delete process.env.API_BASE_URL;
+      expect(() => proxy(makeRequest("/api/foo"))).toThrow(
+        "API_BASE_URL is not set",
+      );
+    });
+
+    it("throws when API_BASE_URL is an empty string", () => {
       process.env.API_BASE_URL = "";
-      const result: any = proxy(makeRequest("/api/foo"));
-      expect(result.url).toBe("http://api:8080/foo");
+      expect(() => proxy(makeRequest("/api/foo"))).toThrow(
+        "API_BASE_URL is not set",
+      );
     });
   });
 

--- a/frontend/dashboard/app/auth/callback/github/route.ts
+++ b/frontend/dashboard/app/auth/callback/github/route.ts
@@ -41,6 +41,9 @@ export async function GET(request: Request) {
 
   // MCP flow: state starts with "mcp_" — forward to the MCP callback endpoint
   if (state.startsWith("mcp_")) {
+    if (!agentOrigin) {
+      throw new Error("AGENT_BASE_URL is not set");
+    }
     const mcpRes = await fetch(`${agentOrigin}/mcp/auth/callback`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -58,6 +61,9 @@ export async function GET(request: Request) {
     return NextResponse.redirect(mcpData.redirect_url, { status: 302 });
   }
 
+  if (!apiOrigin) {
+    throw new Error("API_BASE_URL is not set");
+  }
   const cookieHeader = request.headers.get("cookie");
   const gaClientId = parseGAClientID(parseCookieValue(cookieHeader, "_ga"));
   const gclid = parseCookieValue(cookieHeader, "gclid");

--- a/frontend/dashboard/app/auth/callback/google/route.ts
+++ b/frontend/dashboard/app/auth/callback/google/route.ts
@@ -41,6 +41,9 @@ export async function GET(request: Request) {
 
   // MCP flow: state starts with "mcp_" — forward to the MCP callback endpoint
   if (state.startsWith("mcp_")) {
+    if (!agentOrigin) {
+      throw new Error("AGENT_BASE_URL is not set");
+    }
     const mcpRes = await fetch(`${agentOrigin}/mcp/auth/callback`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -59,6 +62,9 @@ export async function GET(request: Request) {
   }
 
   // Dashboard flow: exchange code via the backend
+  if (!apiOrigin) {
+    throw new Error("API_BASE_URL is not set");
+  }
   const cookieHeader = request.headers.get("cookie");
   const gaClientId = parseGAClientID(parseCookieValue(cookieHeader, "_ga"));
   const gclid = parseCookieValue(cookieHeader, "gclid");

--- a/frontend/dashboard/app/auth/callback/slack/route.ts
+++ b/frontend/dashboard/app/auth/callback/slack/route.ts
@@ -51,6 +51,12 @@ function verifyTimeBasedState(state: string) {
 }
 
 export async function GET(request: Request) {
+  // Checked outside the try below so a missing variable surfaces as a
+  // named 500 instead of the "Invalid or expired OAuth state" redirect.
+  if (!SALT) {
+    throw new Error("SLACK_OAUTH_STATE_SALT is not set");
+  }
+
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
   const state = searchParams.get("state");
@@ -115,6 +121,9 @@ export async function GET(request: Request) {
   }
 
   // Exchange code for Slack installation
+  if (!apiOrigin) {
+    throw new Error("API_BASE_URL is not set");
+  }
   const res = await fetch(`${apiOrigin}/slack/connect`, {
     method: "POST",
     headers: {

--- a/frontend/dashboard/app/auth/login/page.tsx
+++ b/frontend/dashboard/app/auth/login/page.tsx
@@ -23,7 +23,10 @@ function buildMcpAuthorizeUrl(
   searchParams: { [key: string]: string | string[] | undefined },
   provider: string,
 ): string {
-  const agentBaseUrl = process.env.NEXT_PUBLIC_AGENT_BASE_URL || "";
+  const agentBaseUrl = process.env.NEXT_PUBLIC_AGENT_BASE_URL;
+  if (!agentBaseUrl) {
+    throw new Error("NEXT_PUBLIC_AGENT_BASE_URL is not set");
+  }
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(searchParams)) {
     if (key === "mcp" || value === undefined) {

--- a/frontend/dashboard/app/auth/logout/route.ts
+++ b/frontend/dashboard/app/auth/logout/route.ts
@@ -9,6 +9,9 @@ const apiOrigin = process.env.API_BASE_URL;
 const posthog = getPosthogServer();
 
 export async function DELETE(request: Request) {
+  if (!apiOrigin) {
+    throw new Error("API_BASE_URL is not set");
+  }
   const cookies = request.headers.get("cookie");
   const headers = new Headers(request.headers);
   headers.set("cookie", cookies || "");

--- a/frontend/dashboard/app/auth/refresh/route.ts
+++ b/frontend/dashboard/app/auth/refresh/route.ts
@@ -12,6 +12,9 @@ const posthog = getPosthogServer();
 const errRedirectUrl = `${origin}/auth/login`;
 
 export async function POST(request: Request) {
+  if (!apiOrigin) {
+    throw new Error("API_BASE_URL is not set");
+  }
   const cookies = request.headers.get("cookie");
   const headers = new Headers(request.headers);
   headers.set("cookie", cookies || "");

--- a/frontend/dashboard/app/auth/slack/url/route.ts
+++ b/frontend/dashboard/app/auth/slack/url/route.ts
@@ -27,6 +27,15 @@ function createTimeBasedState(userData: any): string {
 }
 
 export async function POST(req: NextRequest) {
+  // Checked outside the try below so a missing variable surfaces as a
+  // named 500, not the catch-all 400 "Invalid request body".
+  if (!process.env.SLACK_CLIENT_ID) {
+    throw new Error("SLACK_CLIENT_ID is not set");
+  }
+  if (!SALT) {
+    throw new Error("SLACK_OAUTH_STATE_SALT is not set");
+  }
+
   let err = "";
   try {
     const { userId, teamId, redirectUrl } = await req.json();

--- a/frontend/dashboard/proxy.ts
+++ b/frontend/dashboard/proxy.ts
@@ -40,7 +40,10 @@ export function proxy(request: NextRequest) {
 
   if (pathname.startsWith("/api")) {
     // reverse proxy all API requests
-    const apiOrigin = process.env.API_BASE_URL || "http://api:8080";
+    const apiOrigin = process.env.API_BASE_URL;
+    if (!apiOrigin) {
+      throw new Error("API_BASE_URL is not set");
+    }
     const apiOriginUrl = new URL(apiOrigin);
 
     const url = request.nextUrl.clone();


### PR DESCRIPTION
# Description

Missing required env vars failed silently: the API proxy fell back to http://api:8080, MCP sign-in built a broken relative URL, and Slack OAuth signed state with an empty salt.

Check each required variable just before use and throw "<name> is not set": API_BASE_URL, AGENT_BASE_URL, SLACK_CLIENT_ID, SLACK_OAUTH_STATE_SALT, and NEXT_PUBLIC_AGENT_BASE_URL in the MCP login flow.



