### PR TITLE
feat(frontend): update docs ui

### DIFF
--- a/docs/features/feature-performance-tracing.md
+++ b/docs/features/feature-performance-tracing.md
@@ -804,7 +804,7 @@ class TracingInterceptor: NSObject, URLSessionTaskDelegate {
 let session = URLSession(configuration: .default, delegate: TracingInterceptor(), delegateQueue: nil)
 ```
 
-h3: ### Distributed Tracing with Dio Interceptor
+### Distributed Tracing with Dio Interceptor
 
 ```dart
 class TraceHeaderInterceptor extends Interceptor {

--- a/frontend/dashboard/__tests__/docs/code_tabs_test.tsx
+++ b/frontend/dashboard/__tests__/docs/code_tabs_test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/docs/features/feature-performance-tracing",
+}));
+
+jest.mock("@/app/utils/analytics/track", () => ({
+  track: jest.fn(),
+}));
+
+jest.mock("@/app/components/code_block", () => ({
+  __esModule: true,
+  default: ({ code }: any) => <pre data-testid="panel-code">{code}</pre>,
+  CopyCodeButton: ({ onCopy }: any) => (
+    <button aria-label="Copy code" onClick={onCopy} />
+  ),
+  CODE_FRAME_CLASS: "",
+  CODE_FRAME_HEADER_CLASS: "",
+  CODE_FRAME_PANEL_CLASS: "",
+}));
+
+import CodeTabs from "@/app/docs/components/code_tabs";
+
+const TABS = JSON.stringify([
+  { label: "Android", code: "kotlin code", className: "language-kotlin" },
+  { label: "iOS", code: "swift code", className: "language-swift" },
+]);
+
+function panelFor(code: string): HTMLElement {
+  const panel = screen
+    .getByText(code)
+    .closest("[aria-hidden]") as HTMLElement | null;
+  expect(panel).not.toBeNull();
+  return panel!;
+}
+
+describe("CodeTabs", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders all panels stacked with only the first visible", () => {
+    render(<CodeTabs tabs={TABS} />);
+    expect(screen.getByRole("tab", { name: "Android" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(panelFor("kotlin code")).toHaveAttribute("aria-hidden", "false");
+    expect(panelFor("swift code")).toHaveAttribute("aria-hidden", "true");
+    expect(panelFor("swift code")).toHaveClass("invisible");
+  });
+
+  it("switches the visible panel on tab click", () => {
+    render(<CodeTabs tabs={TABS} />);
+    fireEvent.click(screen.getByRole("tab", { name: "iOS" }));
+    expect(screen.getByRole("tab", { name: "iOS" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(panelFor("swift code")).toHaveAttribute("aria-hidden", "false");
+    expect(panelFor("kotlin code")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("syncs the selected label across groups on the page", () => {
+    render(
+      <>
+        <CodeTabs tabs={TABS} />
+        <CodeTabs tabs={TABS} />
+      </>,
+    );
+    const iosTabs = screen.getAllByRole("tab", { name: "iOS" });
+    fireEvent.click(iosTabs[0]);
+    expect(iosTabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("remembers the selection and adopts it on mount", () => {
+    window.localStorage.setItem("docs-code-tab", "iOS");
+    render(<CodeTabs tabs={TABS} />);
+    expect(screen.getByRole("tab", { name: "iOS" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("stores the selection on click", () => {
+    render(<CodeTabs tabs={TABS} />);
+    fireEvent.click(screen.getByRole("tab", { name: "iOS" }));
+    expect(window.localStorage.getItem("docs-code-tab")).toBe("iOS");
+  });
+
+  it("renders nothing for invalid tab data", () => {
+    const { container } = render(<CodeTabs tabs="not json" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the first tab active for sync labels it does not have", () => {
+    render(<CodeTabs tabs={TABS} />);
+    act(() => {
+      window.localStorage.setItem("docs-code-tab", "Rust");
+      window.dispatchEvent(new Event("docs-code-tab-select"));
+    });
+    expect(screen.getByRole("tab", { name: "Android" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});

--- a/frontend/dashboard/__tests__/docs/docs_layout_test.tsx
+++ b/frontend/dashboard/__tests__/docs/docs_layout_test.tsx
@@ -119,20 +119,20 @@ describe("DocsLayout", () => {
       </DocsLayout>,
     );
 
-    const contentDiv = container.querySelector(".max-w-6xl");
+    const contentDiv = container.querySelector(".pt-6");
     expect(contentDiv).toBeInTheDocument();
-    expect(contentDiv).toHaveClass("px-4", "sm:px-8", "md:px-16");
+    expect(contentDiv).toHaveClass("px-4", "sm:px-6", "pb-16");
   });
 
-  it("renders content wrapper centered with mx-auto", () => {
+  it("renders content wrapper at full width", () => {
     const { container } = render(
       <DocsLayout>
         <p>Content</p>
       </DocsLayout>,
     );
 
-    const contentDiv = container.querySelector(".max-w-6xl");
-    expect(contentDiv).toHaveClass("mx-auto", "w-full");
+    const contentDiv = container.querySelector(".pt-6");
+    expect(contentDiv).toHaveClass("flex", "w-full");
   });
 
   it("wraps everything in SidebarProvider", () => {

--- a/frontend/dashboard/__tests__/docs/docs_nav_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_nav_test.ts
@@ -1,5 +1,71 @@
-import { docsNav, getFlatNavSlugs, type NavItem } from "@/app/docs/docs_nav";
+import {
+  buildClusters,
+  docsNav,
+  findSectionTitle,
+  getFlatNavSlugs,
+  type NavItem,
+} from "@/app/docs/docs_nav";
 import { describe, expect, it } from "@jest/globals";
+
+describe("buildClusters", () => {
+  it("labels group clusters and merges leading leaves into an unlabeled cluster", () => {
+    const clusters = buildClusters([
+      { title: "Overview", slug: "/docs" },
+      { title: "Getting Started", slug: "/docs/start" },
+      { title: "Features", children: [{ title: "A", slug: "/docs/f/a" }] },
+    ]);
+    expect(clusters.length).toBe(2);
+    expect(clusters[0].label).toBeUndefined();
+    expect(clusters[0].items.map((i) => i.title)).toEqual([
+      "Overview",
+      "Getting Started",
+    ]);
+    expect(clusters[1].label).toBe("Features");
+  });
+
+  it("merges trailing leaves into the previous labeled cluster", () => {
+    const clusters = buildClusters([
+      { title: "Features", children: [{ title: "A", slug: "/docs/f/a" }] },
+      { title: "Configuration Options", slug: "/docs/f/config" },
+    ]);
+    expect(clusters.length).toBe(1);
+    expect(clusters[0].label).toBe("Features");
+    expect(clusters[0].items.map((i) => i.title)).toEqual([
+      "A",
+      "Configuration Options",
+    ]);
+  });
+});
+
+describe("findSectionTitle", () => {
+  it("returns the cluster label for pages inside a labeled cluster", () => {
+    expect(findSectionTitle("/docs/features/feature-crash-reporting")).toBe(
+      "Features",
+    );
+  });
+
+  it("returns the label for trailing leaves merged into the previous cluster", () => {
+    expect(findSectionTitle("/docs/features/configuration-options")).toBe(
+      "Features",
+    );
+    expect(findSectionTitle("/docs/features/performance-impact")).toBe(
+      "Features",
+    );
+  });
+
+  it("returns the label for nested group children", () => {
+    const title = findSectionTitle("/docs/features/feature-bug-report-android");
+    expect(title).toBe("Features");
+  });
+
+  it("returns null for pages in the unlabeled lead cluster", () => {
+    expect(findSectionTitle("/docs/sdk-integration-guide")).toBeNull();
+  });
+
+  it("returns null for slugs missing from the nav", () => {
+    expect(findSectionTitle("/docs/not-a-real-page")).toBeNull();
+  });
+});
 
 describe("docsNav", () => {
   it("is a non-empty array", () => {

--- a/frontend/dashboard/__tests__/docs/docs_sidebar_test.tsx
+++ b/frontend/dashboard/__tests__/docs/docs_sidebar_test.tsx
@@ -10,8 +10,8 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, className }: any) => (
-    <a href={href} className={className}>
+  default: ({ href, children, className, ...props }: any) => (
+    <a href={href} className={className} {...props}>
       {children}
     </a>
   ),
@@ -46,37 +46,9 @@ jest.mock("@/app/components/theme_toggle", () => ({
 jest.mock("@/app/components/sidebar", () => ({
   Sidebar: ({ children }: any) => <div data-testid="sidebar">{children}</div>,
   SidebarContent: ({ children }: any) => <div>{children}</div>,
-  SidebarGroup: ({ children }: any) => <div>{children}</div>,
   SidebarHeader: ({ children }: any) => (
     <div data-testid="sidebar-header">{children}</div>
   ),
-  SidebarMenu: ({ children }: any) => <ul>{children}</ul>,
-  SidebarMenuButton: ({
-    children,
-    onClick,
-    isActive,
-    asChild,
-    ...props
-  }: any) => (
-    <div
-      data-testid="menu-button"
-      data-active={isActive}
-      onClick={onClick}
-      {...props}
-    >
-      {children}
-    </div>
-  ),
-  SidebarMenuItem: ({ children }: any) => <li>{children}</li>,
-  SidebarMenuSub: ({ children }: any) => (
-    <ul data-testid="menu-sub">{children}</ul>
-  ),
-  SidebarMenuSubButton: ({ children, isActive, asChild, ...props }: any) => (
-    <div data-testid="menu-sub-button" data-active={isActive} {...props}>
-      {children}
-    </div>
-  ),
-  SidebarMenuSubItem: ({ children }: any) => <li>{children}</li>,
 }));
 
 jest.mock("@/app/docs/components/docs_search", () => ({
@@ -85,19 +57,20 @@ jest.mock("@/app/docs/components/docs_search", () => ({
     open ? <div data-testid="docs-search-open" /> : null,
 }));
 
-// Mock docsNav with test data that covers all branching: leaf, parent with children, nested children
+// Mock docsNav with test data that covers all branching: top-level leaf,
+// top-level group (always open), nested collapsible group. buildClusters
+// stays real so the sidebar clusters the mock data exactly like production.
 jest.mock("@/app/docs/docs_nav", () => ({
+  ...jest.requireActual("@/app/docs/docs_nav"),
   docsNav: [
     { title: "Getting Started", slug: "/docs/getting-started" },
     {
       title: "Features",
-      slug: "/docs/features",
       children: [
         { title: "Crash Reporting", slug: "/docs/features/crash-reporting" },
         { title: "Performance", slug: "/docs/features/performance" },
         {
           title: "Advanced",
-          slug: "/docs/features/advanced",
           children: [
             {
               title: "Custom Events",
@@ -148,9 +121,16 @@ describe("DocsAppSidebar", () => {
       );
     });
 
-    it("renders parent nav items with chevron", () => {
+    it("renders top-level groups as labels with children visible", () => {
       render(<DocsAppSidebar />);
       expect(screen.getByText("Features")).toBeInTheDocument();
+      expect(screen.getByText("Crash Reporting")).toBeInTheDocument();
+      expect(screen.getByText("Performance")).toBeInTheDocument();
+    });
+
+    it("does not render top-level group labels as links", () => {
+      render(<DocsAppSidebar />);
+      expect(screen.getByText("Features").closest("a")).toBeNull();
     });
   });
 
@@ -158,99 +138,48 @@ describe("DocsAppSidebar", () => {
     it("marks Overview as active when on /docs", () => {
       mockPathname = "/docs";
       render(<DocsAppSidebar />);
-      const overviewButton = screen
-        .getByText("Overview")
-        .closest('[data-testid="menu-button"]');
-      expect(overviewButton).toHaveAttribute("data-active", "true");
+      const overviewLink = screen.getByText("Overview").closest("a");
+      expect(overviewLink).toHaveAttribute("aria-current", "page");
     });
 
     it("does not mark Overview as active on other pages", () => {
       mockPathname = "/docs/getting-started";
       render(<DocsAppSidebar />);
-      const overviewButton = screen
-        .getByText("Overview")
-        .closest('[data-testid="menu-button"]');
-      expect(overviewButton).toHaveAttribute("data-active", "false");
+      const overviewLink = screen.getByText("Overview").closest("a");
+      expect(overviewLink).not.toHaveAttribute("aria-current");
     });
   });
 
-  describe("Collapsible nav items", () => {
-    it("expands parent item on click to show children", () => {
-      render(<DocsAppSidebar />);
-      // Features should be collapsed initially (no child active)
-      expect(screen.queryByText("Crash Reporting")).not.toBeInTheDocument();
-
-      // Click to expand
-      fireEvent.click(screen.getByText("Features"));
-      expect(screen.getByText("Crash Reporting")).toBeInTheDocument();
-      expect(screen.getByText("Performance")).toBeInTheDocument();
-    });
-
-    it("collapses parent item on second click", () => {
-      render(<DocsAppSidebar />);
-      fireEvent.click(screen.getByText("Features"));
-      expect(screen.getByText("Crash Reporting")).toBeInTheDocument();
-
-      fireEvent.click(screen.getByText("Features"));
-      expect(screen.queryByText("Crash Reporting")).not.toBeInTheDocument();
-    });
-
-    it("auto-expands parent when child is active", () => {
+  describe("Active page highlighting", () => {
+    it("marks the active page link", () => {
       mockPathname = "/docs/features/crash-reporting";
       render(<DocsAppSidebar />);
-      // Features should be auto-expanded because a child is active
-      expect(screen.getByText("Crash Reporting")).toBeInTheDocument();
+      const link = screen.getByText("Crash Reporting").closest("a");
+      expect(link).toHaveAttribute("aria-current", "page");
     });
 
-    it("expands a collapsed parent when navigation activates a child", () => {
-      mockPathname = "/docs";
-      const { rerender } = render(<DocsAppSidebar />);
-      // Features starts collapsed — nothing under it is active
-      expect(screen.queryByText("Crash Reporting")).not.toBeInTheDocument();
-
-      // Client-side navigation: pathname changes, sidebar does not remount
-      mockPathname = "/docs/features/crash-reporting";
-      rerender(<DocsAppSidebar />);
-      expect(screen.getByText("Crash Reporting")).toBeInTheDocument();
-    });
-
-    it("marks active child link", () => {
+    it("does not mark inactive page links", () => {
       mockPathname = "/docs/features/crash-reporting";
       render(<DocsAppSidebar />);
-      const subButton = screen
-        .getByText("Crash Reporting")
-        .closest('[data-testid="menu-sub-button"]');
-      expect(subButton).toHaveAttribute("data-active", "true");
-    });
-
-    it("does not mark inactive child link", () => {
-      mockPathname = "/docs/features/crash-reporting";
-      render(<DocsAppSidebar />);
-      const subButton = screen
-        .getByText("Performance")
-        .closest('[data-testid="menu-sub-button"]');
-      expect(subButton).toHaveAttribute("data-active", "false");
+      const link = screen.getByText("Performance").closest("a");
+      expect(link).not.toHaveAttribute("aria-current");
     });
   });
 
-  describe("Nested collapsible sub-items", () => {
-    it("renders nested parent with chevron", () => {
-      mockPathname = "/docs/features/crash-reporting";
+  describe("Nested collapsible groups", () => {
+    it("renders nested group collapsed when no child is active", () => {
       render(<DocsAppSidebar />);
-      // Features is expanded, Advanced should be visible but collapsed
       expect(screen.getByText("Advanced")).toBeInTheDocument();
       expect(screen.queryByText("Custom Events")).not.toBeInTheDocument();
     });
 
-    it("expands nested sub-item on click", () => {
-      mockPathname = "/docs/features/crash-reporting";
+    it("expands nested group on click", () => {
       render(<DocsAppSidebar />);
       fireEvent.click(screen.getByText("Advanced"));
       expect(screen.getByText("Custom Events")).toBeInTheDocument();
     });
 
-    it("collapses nested sub-item on second click", () => {
-      mockPathname = "/docs/features/crash-reporting";
+    it("collapses nested group on second click", () => {
       render(<DocsAppSidebar />);
       fireEvent.click(screen.getByText("Advanced"));
       expect(screen.getByText("Custom Events")).toBeInTheDocument();
@@ -259,12 +188,36 @@ describe("DocsAppSidebar", () => {
       expect(screen.queryByText("Custom Events")).not.toBeInTheDocument();
     });
 
-    it("auto-expands nested parent when deep child is active", () => {
+    it("auto-expands nested group when a child is active", () => {
       mockPathname = "/docs/features/advanced/custom-events";
       render(<DocsAppSidebar />);
-      // Both Features and Advanced should be auto-expanded
-      expect(screen.getByText("Advanced")).toBeInTheDocument();
       expect(screen.getByText("Custom Events")).toBeInTheDocument();
+    });
+
+    it("expands a collapsed group when navigation activates a child", () => {
+      mockPathname = "/docs";
+      const { rerender } = render(<DocsAppSidebar />);
+      expect(screen.queryByText("Custom Events")).not.toBeInTheDocument();
+
+      // Client-side navigation: pathname changes, sidebar does not remount
+      mockPathname = "/docs/features/advanced/custom-events";
+      rerender(<DocsAppSidebar />);
+      expect(screen.getByText("Custom Events")).toBeInTheDocument();
+    });
+  });
+
+  describe("Active row visibility", () => {
+    it("scrolls the row that becomes active into view on navigation", () => {
+      const scrollSpy = jest.fn();
+      window.HTMLElement.prototype.scrollIntoView = scrollSpy;
+
+      mockPathname = "/docs";
+      const { rerender } = render(<DocsAppSidebar />);
+      scrollSpy.mockClear();
+
+      mockPathname = "/docs/features/crash-reporting";
+      rerender(<DocsAppSidebar />);
+      expect(scrollSpy).toHaveBeenCalledWith({ block: "nearest" });
     });
   });
 

--- a/frontend/dashboard/__tests__/docs/docs_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_test.ts
@@ -3,9 +3,83 @@ import {
   extractDescription,
   extractTitle,
   parseFrontmatter,
+  splitLeadingHeading,
+  stripAnchorOutline,
   stripSearchContent,
 } from "@/app/docs/docs";
 import { describe, expect, it } from "@jest/globals";
+
+describe("splitLeadingHeading", () => {
+  it("splits a leading H1 from the body", () => {
+    const { heading, body } = splitLeadingHeading(
+      "# Crash Reporting\n\nIntro paragraph.",
+    );
+    expect(heading).toBe("Crash Reporting");
+    expect(body).toBe("\nIntro paragraph.");
+  });
+
+  it("tolerates blank lines before the heading", () => {
+    const { heading } = splitLeadingHeading("\n\n# Title\nBody");
+    expect(heading).toBe("Title");
+  });
+
+  it("returns null heading when content does not start with an H1", () => {
+    const { heading, body } = splitLeadingHeading("Paragraph first\n\n# Later");
+    expect(heading).toBeNull();
+    expect(body).toBe("Paragraph first\n\n# Later");
+  });
+});
+
+describe("stripAnchorOutline", () => {
+  it("removes a leading list of same-page anchor links", () => {
+    const md = [
+      "Intro paragraph.",
+      "",
+      "- [Metrics](#metrics)",
+      "  - [Crash-Free Rate](#crash-free-rate)",
+      "- [How It Works](#how-it-works)",
+      "",
+      "## Metrics",
+      "Body.",
+    ].join("\n");
+    const out = stripAnchorOutline(md);
+    expect(out).not.toContain("(#metrics)");
+    expect(out).toContain("Intro paragraph.");
+    expect(out).toContain("## Metrics");
+  });
+
+  it("removes a Table of Contents heading together with its list", () => {
+    const md = [
+      "### Table of Contents",
+      "",
+      "- [Features](#features)",
+      "",
+      "# Features",
+      "Body.",
+    ].join("\n");
+    const out = stripAnchorOutline(md);
+    expect(out).not.toContain("Table of Contents");
+    expect(out).not.toContain("(#features)");
+    expect(out).toContain("# Features");
+  });
+
+  it("keeps lists that link to other pages", () => {
+    const md = [
+      "- [Android](feature-bug-report-android.md)",
+      "- [iOS](feature-bug-report-ios.md)",
+      "",
+      "## Section",
+    ].join("\n");
+    expect(stripAnchorOutline(md)).toContain("feature-bug-report-android.md");
+  });
+
+  it("keeps anchor-link lists after the first section heading", () => {
+    const md = ["Intro.", "", "## Section", "", "- [Jump](#somewhere)"].join(
+      "\n",
+    );
+    expect(stripAnchorOutline(md)).toContain("(#somewhere)");
+  });
+});
 
 describe("cleanContent", () => {
   it("strips single-line HTML comments", () => {

--- a/frontend/dashboard/__tests__/docs/md_components_test.tsx
+++ b/frontend/dashboard/__tests__/docs/md_components_test.tsx
@@ -284,7 +284,6 @@ describe("createMarkdownComponents", () => {
       "pre",
       "code",
       "table",
-      "thead",
       "th",
       "td",
       "hr",
@@ -452,17 +451,85 @@ describe("createMarkdownComponents", () => {
       expect(container.querySelector("blockquote")).toBeInTheDocument();
     });
 
-    it("renders a NOTE admonition", () => {
+    it("renders a NOTE admonition as a callout with the marker stripped", () => {
       const components = createMarkdownComponents([]);
       const BlockquoteComponent = components.blockquote as React.FC<{
         children?: React.ReactNode;
       }>;
 
-      render(
+      const { container } = render(
         <BlockquoteComponent>[!NOTE] This is important</BlockquoteComponent>,
       );
 
-      expect(screen.getByText("Note")).toBeInTheDocument();
+      expect(screen.getByText("This is important")).toBeInTheDocument();
+      expect(container.textContent).not.toContain("[!NOTE]");
+      expect(container.firstElementChild).toHaveClass("border-blue-500/20");
+    });
+
+    it("detects the marker behind layout whitespace and drops its hard break", () => {
+      const components = createMarkdownComponents([]);
+      const BlockquoteComponent = components.blockquote as React.FC<{
+        children?: React.ReactNode;
+      }>;
+
+      // Mirrors react-markdown's children shape for "> [!NOTE]  \n> text":
+      // newline text nodes around the paragraph, marker followed by a <br>.
+      const { container } = render(
+        <BlockquoteComponent>
+          {"\n"}
+          <p>
+            {"[!NOTE]"}
+            <br />
+            {"\nActual content"}
+          </p>
+          {"\n"}
+        </BlockquoteComponent>,
+      );
+
+      expect(container.firstElementChild).toHaveClass("border-blue-500/20");
+      expect(container.textContent).not.toContain("[!NOTE]");
+      expect(container.querySelector("br")).toBeNull();
+      expect(container.textContent).toContain("Actual content");
+    });
+
+    it("drops the paragraph when the marker was its only content", () => {
+      const components = createMarkdownComponents([]);
+      const BlockquoteComponent = components.blockquote as React.FC<{
+        children?: React.ReactNode;
+      }>;
+
+      // Mirrors "> [!NOTE]" on its own line followed by a blank "> " line:
+      // the marker gets a paragraph of its own before the real content.
+      const { container } = render(
+        <BlockquoteComponent>
+          {"\n"}
+          <p>{"[!NOTE]"}</p>
+          {"\n"}
+          <p>Real content</p>
+          {"\n"}
+        </BlockquoteComponent>,
+      );
+
+      const paragraphs = container.querySelectorAll("p");
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].textContent).toBe("Real content");
+      expect(container.firstElementChild).toHaveClass("border-blue-500/20");
+    });
+
+    it("strips the marker inside nested paragraph children", () => {
+      const components = createMarkdownComponents([]);
+      const BlockquoteComponent = components.blockquote as React.FC<{
+        children?: React.ReactNode;
+      }>;
+
+      const { container } = render(
+        <BlockquoteComponent>
+          <p>{"[!NOTE]\nWrapped content"}</p>
+        </BlockquoteComponent>,
+      );
+
+      expect(container.textContent).not.toContain("[!NOTE]");
+      expect(container.textContent).toContain("Wrapped content");
     });
 
     it("renders a WARNING admonition", () => {
@@ -471,9 +538,12 @@ describe("createMarkdownComponents", () => {
         children?: React.ReactNode;
       }>;
 
-      render(<BlockquoteComponent>[!WARNING] Be careful</BlockquoteComponent>);
+      const { container } = render(
+        <BlockquoteComponent>[!WARNING] Be careful</BlockquoteComponent>,
+      );
 
-      expect(screen.getByText("Warning")).toBeInTheDocument();
+      expect(screen.getByText("Be careful")).toBeInTheDocument();
+      expect(container.firstElementChild).toHaveClass("border-yellow-500/20");
     });
 
     it("renders a TIP admonition", () => {
@@ -482,9 +552,12 @@ describe("createMarkdownComponents", () => {
         children?: React.ReactNode;
       }>;
 
-      render(<BlockquoteComponent>[!TIP] Helpful tip</BlockquoteComponent>);
+      const { container } = render(
+        <BlockquoteComponent>[!TIP] Helpful tip</BlockquoteComponent>,
+      );
 
-      expect(screen.getByText("Tip")).toBeInTheDocument();
+      expect(screen.getByText("Helpful tip")).toBeInTheDocument();
+      expect(container.firstElementChild).toHaveClass("border-green-500/20");
     });
 
     it("renders an IMPORTANT admonition", () => {
@@ -493,9 +566,12 @@ describe("createMarkdownComponents", () => {
         children?: React.ReactNode;
       }>;
 
-      render(<BlockquoteComponent>[!IMPORTANT] Do this</BlockquoteComponent>);
+      const { container } = render(
+        <BlockquoteComponent>[!IMPORTANT] Do this</BlockquoteComponent>,
+      );
 
-      expect(screen.getByText("Important")).toBeInTheDocument();
+      expect(screen.getByText("Do this")).toBeInTheDocument();
+      expect(container.firstElementChild).toHaveClass("border-purple-500/20");
     });
 
     it("renders a CAUTION admonition", () => {
@@ -504,9 +580,12 @@ describe("createMarkdownComponents", () => {
         children?: React.ReactNode;
       }>;
 
-      render(<BlockquoteComponent>[!CAUTION] Danger zone</BlockquoteComponent>);
+      const { container } = render(
+        <BlockquoteComponent>[!CAUTION] Danger zone</BlockquoteComponent>,
+      );
 
-      expect(screen.getByText("Caution")).toBeInTheDocument();
+      expect(screen.getByText("Danger zone")).toBeInTheDocument();
+      expect(container.firstElementChild).toHaveClass("border-red-500/20");
     });
   });
 
@@ -521,7 +600,7 @@ describe("createMarkdownComponents", () => {
       const { container } = render(<CodeComponent>inline</CodeComponent>);
 
       const code = container.querySelector("code");
-      expect(code).toHaveClass("font-code", "bg-muted");
+      expect(code).toHaveClass("font-code", "bg-muted/50", "border-border");
     });
 
     it("renders code block with language className", () => {

--- a/frontend/dashboard/__tests__/docs/rehype_code_tabs_test.ts
+++ b/frontend/dashboard/__tests__/docs/rehype_code_tabs_test.ts
@@ -1,0 +1,128 @@
+import rehypeCodeTabs from "@/app/docs/rehype_code_tabs";
+import { describe, expect, it } from "@jest/globals";
+import type {
+  Element,
+  ElementContent,
+  Properties,
+  Root,
+  RootContent,
+} from "hast";
+
+function text(value: string): ElementContent {
+  return { type: "text", value };
+}
+
+function el(
+  tagName: string,
+  children: ElementContent[],
+  properties: Properties = {},
+): Element {
+  return { type: "element", tagName, properties, children };
+}
+
+function codeDetails(label: string, code: string, lang?: string): Element {
+  return el("details", [
+    text("\n"),
+    el("summary", [text(label)]),
+    text("\n"),
+    el("pre", [
+      el("code", [text(code)], lang ? { className: [`language-${lang}`] } : {}),
+    ]),
+    text("\n"),
+  ]);
+}
+
+function proseDetails(label: string): Element {
+  return el("details", [
+    el("summary", [text(label)]),
+    el("p", [text("Some prose.")]),
+    el("pre", [el("code", [text("x")])]),
+  ]);
+}
+
+function run(tree: Root): Root {
+  rehypeCodeTabs()(tree);
+  return tree;
+}
+
+function tags(children: RootContent[]): string[] {
+  return children
+    .filter((c): c is Element => c.type === "element")
+    .map((c) => c.tagName);
+}
+
+describe("rehypeCodeTabs", () => {
+  it("merges a run of single-fence details into one code-tabs element", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        codeDetails("Android", "kotlin code\n", "kotlin"),
+        text("\n"),
+        codeDetails("iOS", "swift code", "swift"),
+        text("\n"),
+        codeDetails("Flutter", "dart code", "dart"),
+      ],
+    };
+    run(tree);
+
+    expect(tags(tree.children)).toEqual(["code-tabs"]);
+    const tabs = JSON.parse(
+      (tree.children[0] as Element).properties?.tabs as string,
+    );
+    expect(tabs).toEqual([
+      { label: "Android", code: "kotlin code", className: "language-kotlin" },
+      { label: "iOS", code: "swift code", className: "language-swift" },
+      { label: "Flutter", code: "dart code", className: "language-dart" },
+    ]);
+  });
+
+  it("leaves a single code details block as an accordion", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        codeDetails("Using ObjC", "objc code", "objc"),
+        el("p", [text("After")]),
+      ],
+    };
+    run(tree);
+    expect(tags(tree.children)).toEqual(["details", "p"]);
+  });
+
+  it("does not group details containing prose", () => {
+    const tree: Root = {
+      type: "root",
+      children: [proseDetails("Android"), proseDetails("iOS")],
+    };
+    run(tree);
+    expect(tags(tree.children)).toEqual(["details", "details"]);
+  });
+
+  it("a prose details block splits two runs", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        codeDetails("Android", "a", "kotlin"),
+        codeDetails("iOS", "b", "swift"),
+        proseDetails("Minimum Requirements"),
+        codeDetails("Flutter", "c", "dart"),
+        codeDetails("React Native", "d", "typescript"),
+      ],
+    };
+    run(tree);
+    expect(tags(tree.children)).toEqual(["code-tabs", "details", "code-tabs"]);
+  });
+
+  it("keeps content after the run and recurses into wrappers", () => {
+    const wrapper = el("div", [
+      codeDetails("Android", "a", "kotlin") as ElementContent,
+      codeDetails("iOS", "b", "swift") as ElementContent,
+    ]);
+    const tree: Root = {
+      type: "root",
+      children: [wrapper, el("p", [text("tail")])],
+    };
+    run(tree);
+    expect(tags(tree.children)).toEqual(["div", "p"]);
+    expect(tags(wrapper.children as RootContent[])).toEqual(["code-tabs"]);
+  });
+});

--- a/frontend/dashboard/app/components/analytics/trackable_code_block.tsx
+++ b/frontend/dashboard/app/components/analytics/trackable_code_block.tsx
@@ -16,9 +16,20 @@ interface TrackableCodeBlockProps {
   section?: string;
   /** Optional override for source_page. Defaults to the current pathname. */
   sourcePage?: string;
+  /** Passed through to CodeBlock. */
+  variant?: "plain" | "framed";
+  /** Passed through to CodeBlock; header text for the framed variant. */
+  label?: string;
 }
 
-function defaultSection(pathname: string, language: string): string {
+/**
+ * Section identifier sent with code_copied events. Also used by CodeTabs,
+ * which tracks copies itself.
+ */
+export function defaultCodeCopySection(
+  pathname: string,
+  language: string,
+): string {
   const trimmed = pathname.replace(/^\/+/, "").replace(/\/+$/, "");
   const segments = trimmed.split("/").filter(Boolean);
   // For docs pages, skip the leading "docs" segment so sections track per topic
@@ -34,6 +45,8 @@ export default function TrackableCodeBlock({
   className,
   section,
   sourcePage,
+  variant,
+  label,
 }: TrackableCodeBlockProps) {
   const pathname = usePathname() ?? "";
   return (
@@ -41,11 +54,13 @@ export default function TrackableCodeBlock({
       code={code}
       language={language}
       className={className}
+      variant={variant}
+      label={label}
       showCopyButton
       onCopy={() => {
         track("code_copied", {
           source_page: sourcePage ?? pathname,
-          section: section ?? defaultSection(pathname, language),
+          section: section ?? defaultCodeCopySection(pathname, language),
         });
       }}
     />

--- a/frontend/dashboard/app/components/code_block.tsx
+++ b/frontend/dashboard/app/components/code_block.tsx
@@ -12,14 +12,87 @@ import {
 } from "../utils/highlighter";
 import { cn } from "../utils/shadcn_utils";
 
+// Framed code block pieces, shared with docs CodeTabs which builds the same
+// frame around multiple stacked panels.
+export const CODE_FRAME_CLASS =
+  "code-frame rounded-2xl border border-border bg-muted/40 p-0.5";
+export const CODE_FRAME_HEADER_CLASS =
+  "flex min-h-8 items-center justify-between gap-2 py-0.5 pl-3.5 pr-1";
+export const CODE_FRAME_PANEL_CLASS =
+  "overflow-hidden rounded-xl bg-background font-code text-sm leading-6 [&_pre]:overflow-x-auto [&_pre]:px-4 [&_pre]:py-3.5";
+
+export function CopyCodeButton({
+  code,
+  onCopy,
+  className,
+}: {
+  code: string;
+  /** Fired after a successful copy; used by call sites for tracking. */
+  onCopy?: () => void;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timer = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+    navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        if (onCopy) {
+          onCopy();
+        }
+      })
+      .catch(() => {
+        // Silently ignore — the user can still select and copy manually.
+      });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy code"}
+      className={cn(
+        "inline-flex items-center justify-center rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+        className,
+      )}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
 interface CodeBlockProps {
   code: string;
   language: CodeBlockLanguage;
   className?: string;
-  /** Render a copy-to-clipboard button overlaid on the code block. */
+  /** Render a copy-to-clipboard button on the code block. */
   showCopyButton?: boolean;
   /** Fired after a successful copy; used by call sites for tracking. */
   onCopy?: () => void;
+  /**
+   * "plain" renders the highlighted block as-is. "framed" wraps it in a
+   * bordered container with a header row holding `label` and an
+   * always-visible copy button.
+   */
+  variant?: "plain" | "framed";
+  /** Header text for the framed variant, e.g. the language name. */
+  label?: string;
 }
 
 function highlightSync(
@@ -48,6 +121,8 @@ export default function CodeBlock({
   className,
   showCopyButton = false,
   onCopy,
+  variant = "plain",
+  label,
 }: CodeBlockProps) {
   const { resolvedTheme } = useTheme();
   const theme =
@@ -61,7 +136,6 @@ export default function CodeBlock({
   const [html, setHtml] = useState<string | null>(() =>
     highlightSync(code, language, theme),
   );
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -82,51 +156,64 @@ export default function CodeBlock({
     };
   }, [code, language, theme]);
 
-  useEffect(() => {
-    if (!copied) {
-      return;
-    }
-    const timer = setTimeout(() => setCopied(false), 1500);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
-  const handleCopy = () => {
-    if (typeof navigator === "undefined" || !navigator.clipboard) {
-      return;
-    }
-    navigator.clipboard
-      .writeText(code)
-      .then(() => {
-        setCopied(true);
-        if (onCopy) {
-          onCopy();
-        }
-      })
-      .catch(() => {
-        // Silently ignore — the user can still select and copy manually.
-      });
-  };
-
-  const copyButton = showCopyButton ? (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : "Copy code"}
-      className="absolute top-2 right-2 z-10 inline-flex items-center justify-center rounded-md border border-border bg-background/80 p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-    </button>
+  const overlayCopyButton = showCopyButton ? (
+    <CopyCodeButton
+      code={code}
+      onCopy={onCopy}
+      className="absolute top-2 right-2 z-10 rounded-md border border-border bg-background/80 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+    />
   ) : null;
+
+  if (variant === "framed") {
+    const content =
+      html === null ? (
+        <pre>
+          <code>{code}</code>
+        </pre>
+      ) : (
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      );
+    // Without a label there is nothing to put in a header bar, so the block
+    // is a single bordered panel with the copy button floating over the
+    // code's top-right corner.
+    if (label === undefined || label === "") {
+      return (
+        <div
+          className={cn(
+            CODE_FRAME_PANEL_CLASS,
+            "code-frame relative rounded-2xl border border-border",
+            className,
+          )}
+        >
+          {showCopyButton && (
+            <CopyCodeButton
+              code={code}
+              onCopy={onCopy}
+              className="absolute top-1.5 right-1.5 z-10"
+            />
+          )}
+          {content}
+        </div>
+      );
+    }
+    return (
+      <div className={cn(CODE_FRAME_CLASS, className)}>
+        <div className={CODE_FRAME_HEADER_CLASS}>
+          <span className="font-code text-xs text-muted-foreground">
+            {label}
+          </span>
+          {showCopyButton && <CopyCodeButton code={code} onCopy={onCopy} />}
+        </div>
+        <div className={CODE_FRAME_PANEL_CLASS}>{content}</div>
+      </div>
+    );
+  }
 
   if (html === null) {
     if (showCopyButton) {
       return (
         <div className={cn("group relative", className)}>
-          {copyButton}
+          {overlayCopyButton}
           <pre>
             <code>{code}</code>
           </pre>
@@ -143,7 +230,7 @@ export default function CodeBlock({
   if (showCopyButton) {
     return (
       <div className={cn("group relative", className)}>
-        {copyButton}
+        {overlayCopyButton}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </div>
     );

--- a/frontend/dashboard/app/docs/[...slug]/page.tsx
+++ b/frontend/dashboard/app/docs/[...slug]/page.tsx
@@ -1,4 +1,6 @@
 import { getAllDocSlugs, getDocBySlug } from "@/app/docs/docs";
+import { findSectionTitle } from "@/app/docs/docs_nav";
+import rehypeCodeTabs from "@/app/docs/rehype_code_tabs";
 import { sharedOpenGraph } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -7,6 +9,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import DocsNavLinks from "../components/docs_nav_links";
+import DocsPageHeader from "../components/docs_page_header";
 import DocsToc from "../components/docs_toc";
 import { createMarkdownComponents } from "../components/md_components";
 
@@ -52,17 +55,30 @@ export default async function DocPage({ params }: PageProps) {
     notFound();
   }
 
+  const currentSlug = `/docs/${slug.join("/")}`;
+
   return (
     <>
       <article className="min-w-0 flex-1">
-        <Markdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRaw, rehypeSlug]}
-          components={createMarkdownComponents(slug, doc.isIndex)}
-        >
-          {doc.content}
-        </Markdown>
-        <DocsNavLinks currentSlug={`/docs/${slug.join("/")}`} />
+        <div className="mx-auto w-full max-w-[43.5rem]">
+          <DocsPageHeader
+            eyebrow={findSectionTitle(currentSlug)}
+            heading={doc.heading}
+            description={doc.description}
+          />
+          {/* Anything directly after a heading or rule hugs it: the heading's
+              bottom margin alone sets that gap, like prose's h2+* rules. */}
+          <div className="mt-8 font-body text-gray-700 dark:text-gray-400 [&>:first-child]:mt-0 [&>h1+*]:mt-0 [&>h2+*]:mt-0 [&>h3+*]:mt-0 [&>h4+*]:mt-0 [&>hr+*]:mt-0">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw, rehypeCodeTabs, rehypeSlug]}
+              components={createMarkdownComponents(slug, doc.isIndex)}
+            >
+              {doc.content}
+            </Markdown>
+          </div>
+          <DocsNavLinks currentSlug={currentSlug} />
+        </div>
       </article>
       <DocsToc />
     </>

--- a/frontend/dashboard/app/docs/components/code_tabs.tsx
+++ b/frontend/dashboard/app/docs/components/code_tabs.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { defaultCodeCopySection } from "@/app/components/analytics/trackable_code_block";
+import CodeBlock, {
+  CODE_FRAME_CLASS,
+  CODE_FRAME_HEADER_CLASS,
+  CODE_FRAME_PANEL_CLASS,
+  CopyCodeButton,
+} from "@/app/components/code_block";
+import { track } from "@/app/utils/analytics/track";
+import { PLAINTEXT_LANGUAGE, resolveLanguage } from "@/app/utils/highlighter";
+import { cn } from "@/app/utils/shadcn_utils";
+import { accentGreenTextStyle } from "@/app/utils/shared_styles";
+import { usePathname } from "next/navigation";
+import { useState, useSyncExternalStore } from "react";
+
+// Tab selections sync across every CodeTabs on the page: picking "Android"
+// in one group switches all groups that have an "Android" tab, and the
+// choice is remembered for future pages. The selected label lives in
+// localStorage (module memory when storage is unavailable) and components
+// subscribe to it as an external store.
+const SYNC_EVENT = "docs-code-tab-select";
+const STORAGE_KEY = "docs-code-tab";
+
+let memoryLabel: string | null = null;
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener(SYNC_EVENT, callback);
+  return () => window.removeEventListener(SYNC_EVENT, callback);
+}
+
+function getSnapshot(): string | null {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return memoryLabel;
+  }
+}
+
+function getServerSnapshot(): string | null {
+  return null;
+}
+
+function selectLabel(label: string): void {
+  memoryLabel = label;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, label);
+  } catch {
+    // Storage can be unavailable (private mode); the module variable still
+    // syncs groups within this page.
+  }
+  window.dispatchEvent(new Event(SYNC_EVENT));
+}
+
+export interface CodeTabData {
+  label: string;
+  code: string;
+  className?: string;
+}
+
+function parseTabs(tabsJson: string | undefined): CodeTabData[] | null {
+  if (!tabsJson) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(tabsJson);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return null;
+    }
+    return parsed.filter(
+      (tab): tab is CodeTabData =>
+        typeof tab === "object" &&
+        tab !== null &&
+        typeof tab.label === "string" &&
+        typeof tab.code === "string",
+    );
+  } catch {
+    return null;
+  }
+}
+
+export default function CodeTabs({ tabs: tabsJson }: { tabs?: string }) {
+  const [tabs] = useState(() => parseTabs(tabsJson));
+  const pathname = usePathname() ?? "";
+  const selectedLabel = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  if (!tabs || tabs.length === 0) {
+    return null;
+  }
+
+  const syncedIndex =
+    selectedLabel === null
+      ? -1
+      : tabs.findIndex((tab) => tab.label === selectedLabel);
+  const active = syncedIndex >= 0 ? syncedIndex : 0;
+  const current = tabs[active];
+  const currentLanguage =
+    resolveLanguage(current.className) ?? PLAINTEXT_LANGUAGE;
+
+  return (
+    <div className={cn(CODE_FRAME_CLASS, "mt-5 mb-8")}>
+      <div className={CODE_FRAME_HEADER_CLASS}>
+        <div role="tablist" className="flex items-center gap-3 overflow-x-auto">
+          {tabs.map((tab, index) => (
+            <button
+              key={tab.label + index}
+              type="button"
+              role="tab"
+              aria-selected={index === active}
+              onClick={() => selectLabel(tab.label)}
+              className={cn(
+                "whitespace-nowrap py-1 font-body text-xs font-medium transition-colors",
+                index === active
+                  ? accentGreenTextStyle
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <CopyCodeButton
+          code={current.code}
+          onCopy={() => {
+            track("code_copied", {
+              source_page: pathname,
+              section: defaultCodeCopySection(pathname, currentLanguage),
+            });
+          }}
+        />
+      </div>
+      {/* All panels render stacked in one grid cell, so the frame always has
+          the height of the tallest tab and switching never reflows the page
+          (which matters doubly because tab selection syncs page-wide). */}
+      <div className={cn(CODE_FRAME_PANEL_CLASS, "grid grid-cols-1")}>
+        {tabs.map((tab, index) => (
+          <div
+            key={tab.label + index}
+            className={cn(
+              "col-start-1 row-start-1 min-w-0",
+              index !== active && "invisible",
+            )}
+            aria-hidden={index !== active}
+          >
+            <CodeBlock
+              code={tab.code}
+              language={resolveLanguage(tab.className) ?? PLAINTEXT_LANGUAGE}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/dashboard/app/docs/components/docs_nav_links.tsx
+++ b/frontend/dashboard/app/docs/components/docs_nav_links.tsx
@@ -1,4 +1,5 @@
 import { docsNav, getFlatNavSlugs, type NavItem } from "@/app/docs/docs_nav";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 
 function findTitle(slug: string): string {
@@ -37,17 +38,18 @@ export default function DocsNavLinks({ currentSlug }: { currentSlug: string }) {
     currentIndex < flatSlugs.length - 1 ? flatSlugs[currentIndex + 1] : null;
 
   return (
-    <div className="grid grid-cols-1 gap-4 mt-16 pt-6 border-t border-border sm:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 mt-16 sm:grid-cols-2">
       {prevSlug ? (
         <Link
           href={prevSlug}
-          className="flex flex-col rounded-lg border border-border px-4 py-3 transition-colors hover:border-primary"
+          className="group flex flex-col gap-1 rounded-xl border border-border px-4 py-3 transition-colors hover:border-muted-foreground/40"
         >
-          <span className="font-body text-xs font-medium text-muted-foreground">
-            Previous
-          </span>
-          <span className="font-body text-sm font-medium text-foreground">
+          <span className="font-body font-medium text-foreground">
             {findTitle(prevSlug)}
+          </span>
+          <span className="flex items-center gap-1 font-body text-sm text-muted-foreground transition-colors group-hover:text-foreground">
+            <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+            Previous
           </span>
         </Link>
       ) : (
@@ -56,13 +58,14 @@ export default function DocsNavLinks({ currentSlug }: { currentSlug: string }) {
       {nextSlug ? (
         <Link
           href={nextSlug}
-          className="flex flex-col items-end rounded-lg border border-border px-4 py-3 text-right transition-colors hover:border-primary sm:col-start-2"
+          className="group flex flex-col items-end gap-1 rounded-xl border border-border px-4 py-3 text-right transition-colors hover:border-muted-foreground/40 sm:col-start-2"
         >
-          <span className="font-body text-xs font-medium text-muted-foreground">
-            Next
-          </span>
-          <span className="font-body text-sm font-medium text-foreground">
+          <span className="font-body font-medium text-foreground">
             {findTitle(nextSlug)}
+          </span>
+          <span className="flex items-center gap-1 font-body text-sm text-muted-foreground transition-colors group-hover:text-foreground">
+            Next
+            <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
           </span>
         </Link>
       ) : (

--- a/frontend/dashboard/app/docs/components/docs_page_header.tsx
+++ b/frontend/dashboard/app/docs/components/docs_page_header.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/app/utils/shadcn_utils";
+import { accentGreenTextStyle } from "@/app/utils/shared_styles";
+
+interface DocsPageHeaderProps {
+  /** Sidebar cluster label; null for pages outside any labeled cluster. */
+  eyebrow: string | null;
+  heading: string;
+  description: string;
+}
+
+// Header block above the markdown body: section eyebrow, page title and
+// description lead. The eyebrow is dropped when it would repeat the title
+// (e.g. the hosting overview, whose title is the cluster label).
+export default function DocsPageHeader({
+  eyebrow,
+  heading,
+  description,
+}: DocsPageHeaderProps) {
+  const showEyebrow =
+    eyebrow !== null &&
+    eyebrow !== "" &&
+    eyebrow.toLowerCase() !== heading.toLowerCase();
+
+  return (
+    <header className="space-y-2.5">
+      {showEyebrow && (
+        <p
+          className={cn("font-body text-xs font-medium", accentGreenTextStyle)}
+        >
+          {eyebrow}
+        </p>
+      )}
+      <h1 className="font-display text-3xl font-semibold leading-9 tracking-[-0.03125rem] text-foreground">
+        {heading}
+      </h1>
+      {description !== "" && (
+        <p className="font-body leading-7 text-muted-foreground">
+          {description}
+        </p>
+      )}
+    </header>
+  );
+}

--- a/frontend/dashboard/app/docs/components/docs_sidebar.tsx
+++ b/frontend/dashboard/app/docs/components/docs_sidebar.tsx
@@ -5,175 +5,131 @@ import { Input } from "@/app/components/input";
 import {
   Sidebar,
   SidebarContent,
-  SidebarGroup,
   SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
 } from "@/app/components/sidebar";
 import { ThemeToggle } from "@/app/components/theme_toggle";
-import { docsNav, type NavItem } from "@/app/docs/docs_nav";
+import { buildClusters, docsNav, type NavItem } from "@/app/docs/docs_nav";
 import { cn } from "@/app/utils/shadcn_utils";
+import { accentGreenTextStyle } from "@/app/utils/shared_styles";
 import { ChevronRight, Search } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import DocsSearch from "./docs_search";
 
-// Mute the nested sidebar items by default, like the "On this page" outline.
-// Hover and selected states keep the default shadcn pill. Top-level section
-// headers keep their full-strength default styling.
-const navItemClass = "text-muted-foreground";
+// Rows are plain text: muted by default, full-strength on hover, and the
+// active page in brand green. The text-shadow fakes a bolder weight without
+// changing glyph widths, so rows don't reflow when the active page changes.
+const activeRowClass = cn(
+  accentGreenTextStyle,
+  "[text-shadow:-0.2px_0_0_currentColor,0.2px_0_0_currentColor]",
+);
+const idleRowClass = "text-muted-foreground hover:text-foreground";
 
-function NavSection({ item }: { item: NavItem }) {
-  const pathname = usePathname();
-  const hasChildren = item.children && item.children.length > 0;
-  const isChildActive = hasChildren && hasChildActive(item, pathname);
-
-  if (!hasChildren) {
-    return (
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          asChild
-          isActive={item.slug === pathname}
-          className="h-auto py-2"
-        >
-          <Link
-            href={item.slug || "/docs"}
-            className="font-body font-semibold whitespace-normal"
-          >
-            {item.title}
-          </Link>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-    );
+// Nested rows indent one step per level below a group's children.
+function depthClass(depth: number): string | undefined {
+  if (depth === 1) {
+    return "pl-3";
   }
+  if (depth >= 2) {
+    return "pl-6";
+  }
+  return undefined;
+}
+
+function NavLeafRow({ item, depth }: { item: NavItem; depth: number }) {
+  const pathname = usePathname();
+  const isActive = item.slug === pathname;
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  // The sidebar doesn't scroll on its own when navigation comes from
+  // elsewhere (prev/next links, search, deep links), so the row that just
+  // became active brings itself into view.
+  useEffect(() => {
+    if (isActive) {
+      linkRef.current?.scrollIntoView?.({ block: "nearest" });
+    }
+  }, [isActive]);
 
   return (
-    <CollapsibleNavItem item={item} defaultOpen={isChildActive || false} />
+    <Link
+      ref={linkRef}
+      href={item.slug || "/docs"}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "flex items-start break-words py-1.5 leading-snug transition-colors",
+        depthClass(depth),
+        isActive ? activeRowClass : idleRowClass,
+      )}
+    >
+      {item.title}
+    </Link>
   );
 }
 
-function CollapsibleNavItem({
+function CollapsibleNavGroup({
   item,
-  defaultOpen,
+  depth,
 }: {
   item: NavItem;
-  defaultOpen: boolean;
+  depth: number;
 }) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const pathname = usePathname();
+  const isChildActive = hasChildActive(item, pathname);
+  const [isOpen, setIsOpen] = useState(isChildActive);
 
   // Re-expand when client-side navigation makes a child the active page — the
   // sidebar persists across docs routes, so the useState seed alone would stay
   // stale.
-  const [prevDefaultOpen, setPrevDefaultOpen] = useState(defaultOpen);
-  if (defaultOpen !== prevDefaultOpen) {
-    setPrevDefaultOpen(defaultOpen);
-    if (defaultOpen) {
+  const [prevChildActive, setPrevChildActive] = useState(isChildActive);
+  if (isChildActive !== prevChildActive) {
+    setPrevChildActive(isChildActive);
+    if (isChildActive) {
       setIsOpen(true);
     }
   }
 
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
+    <div>
+      <button
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="font-body font-semibold h-auto py-2 whitespace-normal"
+        className={cn(
+          "flex w-full items-center gap-1 py-1.5 text-left leading-snug transition-colors",
+          depthClass(depth),
+          idleRowClass,
+        )}
       >
-        {item.title}
+        <span className="flex-1 break-words">{item.title}</span>
         <ChevronRight
-          className={cn("ml-auto transition-transform", isOpen && "rotate-90")}
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-transform",
+            isOpen && "rotate-90",
+          )}
+          aria-hidden="true"
         />
-      </SidebarMenuButton>
+      </button>
       {isOpen && (
-        <SidebarMenuSub className="mx-2 px-2">
+        <div className="flex flex-col">
           {item.children!.map((child) => (
-            <NavSubItem key={child.slug || child.title} item={child} />
+            <NavNode
+              key={child.slug || child.title}
+              item={child}
+              depth={depth + 1}
+            />
           ))}
-        </SidebarMenuSub>
+        </div>
       )}
-    </SidebarMenuItem>
+    </div>
   );
 }
 
-function NavSubItem({ item }: { item: NavItem }) {
-  const pathname = usePathname();
-  const hasChildren = item.children && item.children.length > 0;
-
-  if (hasChildren) {
-    const isChildActive = hasChildActive(item, pathname);
-    return (
-      <CollapsibleSubItem item={item} defaultOpen={isChildActive || false} />
-    );
+function NavNode({ item, depth }: { item: NavItem; depth: number }) {
+  if (item.children && item.children.length > 0) {
+    return <CollapsibleNavGroup item={item} depth={depth} />;
   }
-
-  return (
-    <SidebarMenuSubItem>
-      <SidebarMenuSubButton
-        asChild
-        isActive={item.slug === pathname}
-        className={cn("h-auto py-1", navItemClass)}
-      >
-        <Link
-          href={item.slug || "/docs"}
-          className="font-body whitespace-normal"
-        >
-          {item.title}
-        </Link>
-      </SidebarMenuSubButton>
-    </SidebarMenuSubItem>
-  );
-}
-
-function CollapsibleSubItem({
-  item,
-  defaultOpen,
-}: {
-  item: NavItem;
-  defaultOpen: boolean;
-}) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-
-  // Re-expand when client-side navigation makes a child the active page — the
-  // sidebar persists across docs routes, so the useState seed alone would stay
-  // stale.
-  const [prevDefaultOpen, setPrevDefaultOpen] = useState(defaultOpen);
-  if (defaultOpen !== prevDefaultOpen) {
-    setPrevDefaultOpen(defaultOpen);
-    if (defaultOpen) {
-      setIsOpen(true);
-    }
-  }
-
-  return (
-    <SidebarMenuSubItem>
-      <SidebarMenuSubButton asChild className={cn("h-auto py-1", navItemClass)}>
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className="font-body whitespace-normal"
-        >
-          {item.title}
-          <ChevronRight
-            className={cn(
-              "ml-auto transition-transform",
-              isOpen && "rotate-90",
-            )}
-          />
-        </button>
-      </SidebarMenuSubButton>
-      {isOpen && (
-        <SidebarMenuSub className="mx-2 px-2">
-          {item.children!.map((child) => (
-            <NavSubItem key={child.slug || child.title} item={child} />
-          ))}
-        </SidebarMenuSub>
-      )}
-    </SidebarMenuSubItem>
-  );
+  return <NavLeafRow item={item} depth={depth} />;
 }
 
 function hasChildActive(item: NavItem, pathname: string): boolean {
@@ -187,83 +143,91 @@ function hasChildActive(item: NavItem, pathname: string): boolean {
 }
 
 export default function DocsAppSidebar() {
-  const pathname = usePathname();
-  const isDocsIndex = pathname === "/docs";
   const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   return (
     <>
-      <Sidebar variant="sidebar" className="select-none">
+      {/* border-sidebar-border lightens the divider in light mode
+          (#e7e7e7 vs the default #d8d8d8); dark keeps the regular border. */}
+      <Sidebar
+        variant="sidebar"
+        className="select-none border-sidebar-border dark:border-border"
+      >
         <SidebarHeader className="px-4">
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <div className="flex items-center justify-between my-2">
-                <Link
-                  className={cn(
-                    buttonVariants({ variant: "ghost" }),
-                    "group/logo py-2 px-0 pr-1",
-                  )}
-                  href="/"
-                >
-                  <Image
-                    src="/images/measure_logo_horizontal_black.svg"
-                    width={120}
-                    height={40}
-                    alt="Measure logo"
-                    className="dark:hidden"
-                  />
-                  <Image
-                    src="/images/measure_logo_horizontal_white.svg"
-                    width={120}
-                    height={40}
-                    alt="Measure logo"
-                    className="hidden dark:block"
-                  />
-                </Link>
-                <ThemeToggle />
-              </div>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <div
-                className="relative cursor-pointer"
-                onClick={() => setIsSearchOpen(true)}
-              >
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-                <Input
-                  readOnly
-                  placeholder="Search docs..."
-                  className="pl-9 pr-12 cursor-pointer font-body border-0 shadow-none focus-visible:ring-0"
-                  onFocus={(e) => {
-                    e.target.blur();
-                    setIsSearchOpen(true);
-                  }}
-                />
-                <kbd className="absolute right-3 top-1/2 -translate-y-1/2 font-sans text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded pointer-events-none">
-                  &#8984;K
-                </kbd>
-              </div>
-            </SidebarMenuItem>
-          </SidebarMenu>
+          <div className="flex items-center justify-between my-2">
+            <Link
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "group/logo py-2 px-0 pr-1",
+              )}
+              href="/"
+            >
+              <Image
+                src="/images/measure_logo_horizontal_black.svg"
+                width={120}
+                height={40}
+                alt="Measure logo"
+                className="dark:hidden"
+              />
+              <Image
+                src="/images/measure_logo_horizontal_white.svg"
+                width={120}
+                height={40}
+                alt="Measure logo"
+                className="hidden dark:block"
+              />
+            </Link>
+            <ThemeToggle />
+          </div>
+          <div
+            className="relative cursor-pointer"
+            onClick={() => setIsSearchOpen(true)}
+          >
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <Input
+              readOnly
+              placeholder="Search docs..."
+              className="h-8 cursor-pointer rounded-lg pl-9 pr-12 font-body text-sm focus-visible:ring-0"
+              onFocus={(e) => {
+                e.target.blur();
+                setIsSearchOpen(true);
+              }}
+            />
+            <kbd className="absolute right-3 top-1/2 -translate-y-1/2 font-sans text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded pointer-events-none">
+              &#8984;K
+            </kbd>
+          </div>
         </SidebarHeader>
         <SidebarContent>
-          <SidebarGroup className="px-4">
-            <SidebarMenu className="gap-4">
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isDocsIndex}
-                  className="h-auto py-2"
-                >
-                  <Link href="/docs" className="font-body font-semibold">
-                    Overview
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              {docsNav.map((item) => (
-                <NavSection key={item.slug || item.title} item={item} />
-              ))}
-            </SidebarMenu>
-          </SidebarGroup>
+          <nav
+            aria-label="Docs"
+            className="flex flex-col px-4 pb-8 pt-2 font-body text-sm"
+          >
+            {buildClusters([
+              { title: "Overview", slug: "/docs" },
+              ...docsNav,
+            ]).map((cluster, i) => (
+              <div
+                key={cluster.label ?? `pages-${i}`}
+                className={i > 0 ? "mt-7" : undefined}
+              >
+                {cluster.label !== undefined && (
+                  <p className="mb-2 text-xs font-semibold text-foreground">
+                    {cluster.label}
+                  </p>
+                )}
+                <div className="flex flex-col">
+                  {cluster.items.map((item) => (
+                    <NavNode
+                      key={item.slug || item.title}
+                      item={item}
+                      depth={0}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </nav>
         </SidebarContent>
       </Sidebar>
 

--- a/frontend/dashboard/app/docs/components/docs_toc.tsx
+++ b/frontend/dashboard/app/docs/components/docs_toc.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/app/utils/shadcn_utils";
+import { accentGreenTextStyle } from "@/app/utils/shared_styles";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
@@ -156,34 +157,37 @@ export default function DocsToc() {
     // page has none) so the article width never shifts as the outline loads.
     <aside className="hidden xl:block w-56 shrink-0 ml-auto">
       {items.length > 0 && (
-        // Align the outline with the page <h1>: container py-8 (2rem) + h1 mt-12 (3rem).
+        // Align the outline with the page header: container pt-6 (1.5rem).
+        // The list scrolls internally on long pages; its scrollbar is hidden
+        // so it doesn't stack next to the window's.
         <div
           ref={scrollRef}
-          className="fixed top-20 right-8 w-56 overflow-y-auto max-h-[calc(100vh-7rem)]"
+          className="fixed top-6 right-6 w-56 overflow-y-auto max-h-[calc(100vh-3rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
-          <div className="border-l border-border">
-            <p className="text-sm font-body font-medium text-foreground mb-3 pl-4">
-              On this page
-            </p>
-            <nav className="flex flex-col">
-              {items.map((item) => (
-                <a
-                  key={item.id}
-                  data-toc-id={item.id}
-                  href={`#${item.id}`}
-                  className={cn(
-                    "-ml-px border-l-2 py-1.5 pl-4 text-sm font-body leading-snug transition-colors",
-                    item.level === 3 && "pl-8",
-                    activeId === item.id
-                      ? "border-primary text-foreground font-medium"
-                      : "border-transparent text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {item.text}
-                </a>
-              ))}
-            </nav>
-          </div>
+          <p className="text-sm font-body font-medium text-foreground mb-2">
+            On this page
+          </p>
+          <nav className="flex flex-col">
+            {items.map((item) => (
+              <a
+                key={item.id}
+                data-toc-id={item.id}
+                href={`#${item.id}`}
+                className={cn(
+                  "py-1 text-sm font-body leading-6 transition-colors",
+                  item.level === 3 && "pl-4",
+                  activeId === item.id
+                    ? cn(
+                        accentGreenTextStyle,
+                        "[text-shadow:-0.2px_0_0_currentColor,0.2px_0_0_currentColor]",
+                      )
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {item.text}
+              </a>
+            ))}
+          </nav>
         </div>
       )}
     </aside>

--- a/frontend/dashboard/app/docs/components/md_components.tsx
+++ b/frontend/dashboard/app/docs/components/md_components.tsx
@@ -1,45 +1,154 @@
 import TrackableCodeBlock from "@/app/components/analytics/trackable_code_block";
 import TrackGithubLink from "@/app/components/analytics/track_github_link";
-import {
-  CODE_BLOCK_LANGUAGES,
-  type CodeBlockLanguage,
-  PLAINTEXT_LANGUAGE,
-} from "@/app/utils/highlighter";
+import CodeTabs from "@/app/docs/components/code_tabs";
+import { PLAINTEXT_LANGUAGE, resolveLanguage } from "@/app/utils/highlighter";
 import { cn } from "@/app/utils/shadcn_utils";
 import { underlineLinkStyle } from "@/app/utils/shared_styles";
-import { ChevronRight } from "lucide-react";
+import {
+  ChevronRight,
+  CircleAlert,
+  Info,
+  Lightbulb,
+  type LucideIcon,
+  OctagonAlert,
+  TriangleAlert,
+} from "lucide-react";
 import Link from "next/link";
 import React from "react";
 import type { Components } from "react-markdown";
 
 const MEASURE_REPO_URL = "https://github.com/measure-sh/measure";
 
-// Map markdown fence aliases to the Shiki language names we load in highlighter.ts.
-const LANG_ALIASES: Record<string, CodeBlockLanguage> = {
-  sh: "shellscript",
-  shell: "shellscript",
-  bash: "shellscript",
-  objc: "objective-c",
-  ts: "typescript",
+// Content links sit in dimmed body copy, so they get full-strength text like
+// headings and bold text do.
+const contentLinkStyle = cn(underlineLinkStyle, "font-medium text-foreground");
+
+// Display names for the code block header. Plaintext gets no label; the
+// header still renders to hold the copy button.
+const LANG_LABELS: Record<string, string> = {
+  kotlin: "Kotlin",
+  xml: "XML",
+  swift: "Swift",
+  dart: "Dart",
+  yaml: "YAML",
+  ruby: "Ruby",
+  groovy: "Groovy",
+  json: "JSON",
+  jsonc: "JSON",
+  "objective-c": "Objective-C",
+  shellscript: "Shell",
+  java: "Java",
+  typescript: "TypeScript",
+  c: "C",
+  plaintext: "",
 };
 
-const SUPPORTED_LANGUAGES: ReadonlySet<CodeBlockLanguage> = new Set(
-  CODE_BLOCK_LANGUAGES,
-);
+interface CalloutConfig {
+  icon: LucideIcon;
+  boxClassName: string;
+  iconClassName: string;
+}
 
-function resolveLanguage(
-  className: string | undefined,
-): CodeBlockLanguage | null {
-  if (!className) {
-    return null;
+const CALLOUTS: Record<string, CalloutConfig> = {
+  note: {
+    icon: Info,
+    boxClassName: "border-blue-500/20 bg-blue-500/5",
+    iconClassName: "text-blue-500",
+  },
+  tip: {
+    icon: Lightbulb,
+    boxClassName: "border-green-500/20 bg-green-500/5",
+    iconClassName: "text-green-600 dark:text-green-400",
+  },
+  important: {
+    icon: CircleAlert,
+    boxClassName: "border-purple-500/20 bg-purple-500/5",
+    iconClassName: "text-purple-500",
+  },
+  warning: {
+    icon: TriangleAlert,
+    boxClassName: "border-yellow-500/20 bg-yellow-500/5",
+    iconClassName: "text-yellow-600 dark:text-yellow-500",
+  },
+  caution: {
+    icon: OctagonAlert,
+    boxClassName: "border-red-500/20 bg-red-500/5",
+    iconClassName: "text-red-500",
+  },
+};
+
+function isEmptyContent(node: React.ReactNode): boolean {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return true;
   }
-  const match = className.match(/(?:^|\s)language-(\S+)/);
-  if (!match) {
-    return null;
+  if (typeof node === "string") {
+    return node.trim() === "";
   }
-  const raw = match[1].toLowerCase();
-  const mapped = (LANG_ALIASES[raw] ?? raw) as CodeBlockLanguage;
-  return SUPPORTED_LANGUAGES.has(mapped) ? mapped : null;
+  if (Array.isArray(node)) {
+    return node.every(isEmptyContent);
+  }
+  return false;
+}
+
+/**
+ * Remove the leading "[!NOTE]"-style marker from a callout's children so it
+ * doesn't render as literal text. Only the first matching text node is
+ * touched; everything after it is returned unchanged. The marker's leftovers
+ * are dropped with it: a <br> from a marker line ending in a hard break, and
+ * the paragraph itself when the marker was its only content (a marker
+ * written as its own blockquote line) — an empty <p> would otherwise render
+ * as a blank first line that the icon aligns against.
+ */
+function stripAdmonitionMarker(children: React.ReactNode): React.ReactNode {
+  let stripped = false;
+
+  function transform(node: React.ReactNode): React.ReactNode {
+    if (stripped) {
+      return node;
+    }
+    if (typeof node === "string") {
+      const replaced = node.replace(
+        /^\s*\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*/,
+        "",
+      );
+      if (replaced !== node) {
+        stripped = true;
+      }
+      return replaced;
+    }
+    if (Array.isArray(node)) {
+      const out: React.ReactNode[] = [];
+      for (let i = 0; i < node.length; i++) {
+        const wasStripped = stripped;
+        const transformed = transform(node[i]);
+        const strippedHere = !wasStripped && stripped;
+        if (strippedHere && transformed === "") {
+          const next = node[i + 1];
+          if (React.isValidElement(next) && next.type === "br") {
+            i++;
+          }
+          continue;
+        }
+        out.push(transformed);
+      }
+      return out;
+    }
+    if (React.isValidElement(node)) {
+      const props = node.props as { children?: React.ReactNode };
+      if (props.children === undefined) {
+        return node;
+      }
+      const wasStripped = stripped;
+      const transformedChildren = transform(props.children);
+      if (!wasStripped && stripped && isEmptyContent(transformedChildren)) {
+        return null;
+      }
+      return React.cloneElement(node, undefined, transformedChildren);
+    }
+    return node;
+  }
+
+  return transform(children);
 }
 
 /**
@@ -160,6 +269,9 @@ export function rewriteImgSrc(src: string): string {
   return src;
 }
 
+// Heading bottom margins (mb-3) run smaller than the body rhythm suggests:
+// Josefin leaves ~12px of empty line-box below its glyphs, so the rendered
+// gap below headings is what lines up with the rest of the spacing scale.
 export function createMarkdownComponents(
   currentSlug: string[],
   isIndex = false,
@@ -168,7 +280,7 @@ export function createMarkdownComponents(
     h1: ({ children, id }) => (
       <h1
         id={id}
-        className="font-display text-3xl font-bold mt-12 mb-6 scroll-mt-24"
+        className="font-display text-3xl font-semibold leading-9 tracking-[-0.03125rem] text-foreground mt-12 mb-3 scroll-mt-8"
       >
         {children}
       </h1>
@@ -176,7 +288,7 @@ export function createMarkdownComponents(
     h2: ({ children, id }) => (
       <h2
         id={id}
-        className="font-display text-2xl font-semibold mt-16 mb-6 pb-2 border-b border-border scroll-mt-24 group"
+        className="font-display text-2xl font-semibold text-foreground mt-12 mb-3 scroll-mt-8 group"
       >
         {children}
         {id && (
@@ -193,7 +305,7 @@ export function createMarkdownComponents(
     h3: ({ children, id }) => (
       <h3
         id={id}
-        className="font-display text-xl font-semibold mt-12 mb-4 scroll-mt-24 group"
+        className="font-display text-xl font-semibold text-foreground mt-8 mb-3 scroll-mt-8 group"
       >
         {children}
         {id && (
@@ -210,14 +322,12 @@ export function createMarkdownComponents(
     h4: ({ children, id }) => (
       <h4
         id={id}
-        className="font-display text-lg font-semibold mt-8 mb-3 scroll-mt-24"
+        className="font-display text-base font-semibold text-foreground mt-6 mb-3 scroll-mt-8"
       >
         {children}
       </h4>
     ),
-    p: ({ children }) => (
-      <p className="font-body leading-relaxed mb-4">{children}</p>
-    ),
+    p: ({ children }) => <p className="font-body leading-7 mb-5">{children}</p>,
     a: ({ href, children, node, ...props }) => {
       const rewritten = rewriteHref(href || "", currentSlug, isIndex);
       const isExternal =
@@ -239,7 +349,7 @@ export function createMarkdownComponents(
               href={rewritten}
               target="_blank"
               rel="noopener noreferrer"
-              className={underlineLinkStyle}
+              className={contentLinkStyle}
             >
               {children}
             </TrackGithubLink>
@@ -250,7 +360,7 @@ export function createMarkdownComponents(
             href={rewritten}
             target="_blank"
             rel="noopener noreferrer"
-            className={underlineLinkStyle}
+            className={contentLinkStyle}
             {...props}
           >
             {children}
@@ -259,7 +369,7 @@ export function createMarkdownComponents(
       }
 
       return (
-        <Link href={rewritten} className={underlineLinkStyle}>
+        <Link href={rewritten} className={contentLinkStyle}>
           {children}
         </Link>
       );
@@ -269,53 +379,61 @@ export function createMarkdownComponents(
       <img
         src={rewriteImgSrc(typeof src === "string" ? src : "")}
         alt={alt || ""}
-        className="rounded-lg border border-border my-4 max-w-full"
+        className="rounded-xl border border-border my-8 max-w-full"
         loading="lazy"
         {...props}
       />
     ),
+    // The descendant [&_ul]/[&_ol] margins hit nested lists only (the
+    // selector needs an ancestor list) and outweigh the direct mb-5 by
+    // specificity, giving nested lists tighter spacing than top-level ones.
     ul: ({ children }) => (
-      <ul className="list-disc pl-6 mb-4 space-y-1 font-body">{children}</ul>
+      <ul className="list-disc pl-6 mb-5 space-y-2 font-body [&_ul]:my-3 [&_ol]:my-3">
+        {children}
+      </ul>
     ),
     ol: ({ children }) => (
-      <ol className="list-decimal pl-6 mb-4 space-y-1 font-body">{children}</ol>
+      <ol className="list-decimal pl-6 mb-5 space-y-2 font-body [&_ul]:my-3 [&_ol]:my-3">
+        {children}
+      </ol>
     ),
-    li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+    li: ({ children }) => <li className="leading-7">{children}</li>,
     blockquote: ({ children }) => {
+      // The blockquote's children start with layout text nodes ("\n"), so the
+      // marker check must tolerate leading whitespace.
       const childText = extractTextContent(children);
       const admonitionMatch = childText.match(
-        /^\[!(NOTE|WARNING|IMPORTANT|CAUTION|TIP)\]\s*/,
+        /^\s*\[!(NOTE|WARNING|IMPORTANT|CAUTION|TIP)\]\s*/,
       );
 
       if (admonitionMatch) {
         const type = admonitionMatch[1].toLowerCase();
-        const styles: Record<string, string> = {
-          note: "border-blue-500 bg-blue-500/10",
-          tip: "border-green-500 bg-green-500/10",
-          important: "border-purple-500 bg-purple-500/10",
-          warning: "border-yellow-500 bg-yellow-500/10",
-          caution: "border-red-500 bg-red-500/10",
-        };
-        const labels: Record<string, string> = {
-          note: "Note",
-          tip: "Tip",
-          important: "Important",
-          warning: "Warning",
-          caution: "Caution",
-        };
+        const callout = CALLOUTS[type];
+        const Icon = callout.icon;
 
         return (
-          <div className={cn("border-l-4 rounded-r-lg p-4 my-4", styles[type])}>
-            <p className="font-display font-semibold text-sm mb-1">
-              {labels[type]}
-            </p>
-            <div className="font-body text-sm [&>p]:mb-0">{children}</div>
+          <div
+            className={cn(
+              "my-4 flex gap-3 rounded-2xl border px-5 py-4",
+              callout.boxClassName,
+            )}
+          >
+            <Icon
+              className={cn("mt-1 h-4 w-4 shrink-0", callout.iconClassName)}
+              aria-hidden="true"
+            />
+            {/* Callout copy is a size down from body copy, so the inherited
+                paragraph/list line heights are normalized to match; without
+                this the icon alignment drifts with the first line's height. */}
+            <div className="min-w-0 flex-1 font-body text-sm leading-6 [&_p]:leading-6 [&_li]:leading-6 [&_p]:mb-2 [&_ul]:mb-2 [&_ol]:mb-2 [&>:last-child]:mb-0">
+              {stripAdmonitionMarker(children)}
+            </div>
           </div>
         );
       }
 
       return (
-        <blockquote className="border-l-4 border-border pl-4 my-4 text-muted-foreground italic">
+        <blockquote className="border-l-4 border-border pl-4 my-6 text-muted-foreground italic">
           {children}
         </blockquote>
       );
@@ -331,18 +449,27 @@ export function createMarkdownComponents(
         : undefined;
       const code = extractTextContent(children).replace(/\n$/, "");
       const language = resolveLanguage(className) ?? PLAINTEXT_LANGUAGE;
+      // Fences naming a language we don't highlight still label the header
+      // with their raw tag; unnamed fences get no label and render headerless.
+      const rawTag = className?.match(/(?:^|\s)language-(\S+)/)?.[1];
+      const label =
+        language === PLAINTEXT_LANGUAGE
+          ? (rawTag ?? "")
+          : (LANG_LABELS[language] ?? language);
       return (
         <TrackableCodeBlock
           code={code}
           language={language}
-          className="font-code text-sm leading-relaxed rounded-lg overflow-hidden my-4 [&_pre]:p-4 [&_pre]:overflow-x-auto"
+          variant="framed"
+          label={label}
+          className="mt-5 mb-8"
         />
       );
     },
     code: ({ children, className }) => {
       if (!className) {
         return (
-          <code className="font-code bg-muted px-1.5 py-0.5 rounded text-sm">
+          <code className="font-code rounded-md border border-border bg-muted/50 px-1 py-0.5 text-[0.875em] text-foreground">
             {children}
           </code>
         );
@@ -350,27 +477,31 @@ export function createMarkdownComponents(
       return <code className={cn("font-code", className)}>{children}</code>;
     },
     table: ({ children }) => (
-      <div className="my-6 overflow-x-auto rounded-lg border border-border">
+      <div className="my-7 overflow-x-auto">
         <table className="w-full text-sm font-body">{children}</table>
       </div>
     ),
-    thead: ({ children }) => <thead className="bg-muted">{children}</thead>,
     th: ({ children }) => (
-      <th className="text-left font-semibold px-4 py-2 border-b border-border">
+      <th className="text-left font-semibold text-foreground px-3 pb-2 first:pl-0 last:pr-0 border-b border-border align-bottom">
         {children}
       </th>
     ),
     td: ({ children }) => (
-      <td className="px-4 py-2 border-b border-border">{children}</td>
+      <td className="px-3 py-2 first:pl-0 last:pr-0 border-b border-border/60 align-top">
+        {children}
+      </td>
     ),
-    hr: () => <hr className="my-10 border-border" />,
+    hr: () => <hr className="my-12 border-border" />,
+    // Code blocks inside an accordion lose their outer frame (border, tinted
+    // rim) so the accordion border is the only box; the header row with the
+    // language label and copy button stays.
     details: ({ children }) => (
-      <details className="group my-4 border border-border rounded-lg [&>*:not(summary)]:px-4 [&>summary+*]:pt-2 [&>*:not(summary):last-child]:mb-0 [&>*:not(summary):last-child]:pb-3">
+      <details className="group my-5 border border-border rounded-xl [&>*:not(summary)]:px-4 [&>summary+*]:pt-2 [&>*:not(summary):last-child]:mb-0 [&>*:not(summary):last-child]:pb-3 [&_.code-frame]:border-0 [&_.code-frame]:bg-transparent [&_.code-frame]:p-0">
         {children}
       </details>
     ),
     summary: ({ children }) => (
-      <summary className="cursor-pointer font-semibold p-4 hover:bg-muted/50 rounded-lg flex items-center gap-2 list-none [&::-webkit-details-marker]:hidden">
+      <summary className="cursor-pointer font-semibold p-4 hover:bg-muted/50 rounded-xl flex items-center gap-2 list-none [&::-webkit-details-marker]:hidden">
         <ChevronRight
           className="w-4 h-4 shrink-0 transition-transform group-open:rotate-90"
           aria-hidden="true"
@@ -379,8 +510,11 @@ export function createMarkdownComponents(
       </summary>
     ),
     strong: ({ children }) => (
-      <strong className="font-semibold">{children}</strong>
+      <strong className="font-semibold text-foreground">{children}</strong>
     ),
+    // Produced by rehypeCodeTabs from runs of single-code-fence <details>
+    // blocks; not a real HTML element, so it needs the cast.
+    ...({ "code-tabs": CodeTabs } as Partial<Components>),
   };
 }
 

--- a/frontend/dashboard/app/docs/docs.ts
+++ b/frontend/dashboard/app/docs/docs.ts
@@ -13,7 +13,11 @@ function getDocsDirectory(): string {
 
 export interface DocPage {
   slug: string[];
+  /** Markdown body without the leading `# ` title; the page header renders it. */
   content: string;
+  /** Visible page title, from the body's leading H1. */
+  heading: string;
+  /** SEO title for metadata, from frontmatter (usually longer than the H1). */
   title: string;
   description: string;
   isIndex: boolean;
@@ -137,6 +141,59 @@ export function stripSearchContent(content: string): string {
 }
 
 /**
+ * Split the body into its leading `# ` title and the remaining markdown.
+ * Only a heading that is the first non-blank content counts; documents
+ * without one keep their body untouched.
+ */
+export function splitLeadingHeading(content: string): {
+  heading: string | null;
+  body: string;
+} {
+  const match = content.match(/^\s*#[ \t]+(.+?)[ \t]*(?:\r?\n|$)/);
+  if (!match) {
+    return { heading: null, body: content };
+  }
+  return { heading: match[1], body: content.slice(match[0].length) };
+}
+
+/**
+ * Remove a page-outline list from the region before the first section
+ * heading: a bullet list whose items are all same-page anchor links, plus a
+ * "Table of Contents" heading introducing one. The rendered page gets its
+ * outline from the "On this page" rail, so these lists only duplicate it.
+ * Lists that link to other pages, and anything after the first section
+ * heading, are kept.
+ */
+export function stripAnchorOutline(content: string): string {
+  const lines = content.split(/\r?\n/);
+  const out: string[] = [];
+  const anchorItem = /^\s*[-*+]\s+\[[^\]]*\]\(#[^)]*\)\s*$/;
+  const tocHeading = /^#{2,6}\s+table of contents\s*$/i;
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^#{1,6}\s/.test(line) && !tocHeading.test(line)) {
+      out.push(...lines.slice(i));
+      break;
+    }
+    if (tocHeading.test(line) || anchorItem.test(line)) {
+      i++;
+      while (
+        i < lines.length &&
+        (anchorItem.test(lines[i]) || lines[i].trim() === "")
+      ) {
+        i++;
+      }
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+  return out.join("\n");
+}
+
+/**
  * Extract title from the first # heading in markdown content
  */
 export function extractTitle(content: string): string {
@@ -206,11 +263,13 @@ export function getDocBySlug(slug: string[]): DocPage | null {
   const raw = fs.readFileSync(filePath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
   const cleaned = cleanContent(body);
+  const { heading, body: content } = splitLeadingHeading(cleaned);
 
   return {
     slug,
-    content: cleaned,
-    title: frontmatter.title || extractTitle(cleaned),
+    content: stripAnchorOutline(content),
+    heading: heading || frontmatter.title || "Documentation",
+    title: frontmatter.title || heading || "Documentation",
     description: frontmatter.description || extractDescription(cleaned),
     isIndex: filePath.endsWith(`${path.sep}README.md`),
   };
@@ -227,11 +286,13 @@ export function getDocIndex(): DocPage | null {
   const raw = fs.readFileSync(filePath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
   const cleaned = cleanContent(body);
+  const { heading, body: content } = splitLeadingHeading(cleaned);
 
   return {
     slug: [],
-    content: cleaned,
-    title: frontmatter.title || extractTitle(cleaned),
+    content: stripAnchorOutline(content),
+    heading: heading || frontmatter.title || "Documentation",
+    title: frontmatter.title || heading || "Documentation",
     description: frontmatter.description || extractDescription(cleaned),
     isIndex: true,
   };

--- a/frontend/dashboard/app/docs/docs_nav.ts
+++ b/frontend/dashboard/app/docs/docs_nav.ts
@@ -9,6 +9,56 @@ export interface NavItem {
 export const docsNav: NavItem[] = navData;
 
 /**
+ * The sidebar renders the nav as clusters: each top-level group is a cluster
+ * with a label, and top-level leaf pages join the cluster before them (the
+ * first ones form an unlabeled lead cluster). The page-header eyebrow uses
+ * the same clustering, so a page's eyebrow always matches the sidebar
+ * section it appears under.
+ */
+export interface NavCluster {
+  label?: string;
+  items: NavItem[];
+}
+
+export function buildClusters(items: NavItem[]): NavCluster[] {
+  const clusters: NavCluster[] = [];
+  for (const item of items) {
+    if (item.children !== undefined && item.children.length > 0) {
+      clusters.push({ label: item.title, items: [...item.children] });
+      continue;
+    }
+    const last = clusters[clusters.length - 1];
+    if (last !== undefined) {
+      last.items.push(item);
+    } else {
+      clusters.push({ items: [item] });
+    }
+  }
+  return clusters;
+}
+
+/**
+ * Label of the sidebar cluster a page belongs to, shown as the page-header
+ * eyebrow. Pages in the unlabeled lead cluster and pages missing from the
+ * nav have none.
+ */
+export function findSectionTitle(slug: string): string | null {
+  function contains(item: NavItem): boolean {
+    if (item.slug === slug) {
+      return true;
+    }
+    return item.children?.some(contains) ?? false;
+  }
+
+  for (const cluster of buildClusters(docsNav)) {
+    if (cluster.items.some(contains)) {
+      return cluster.label ?? null;
+    }
+  }
+  return null;
+}
+
+/**
  * Flatten the nav tree into an ordered list of slugs for prev/next navigation.
  */
 export function getFlatNavSlugs(): string[] {

--- a/frontend/dashboard/app/docs/layout.tsx
+++ b/frontend/dashboard/app/docs/layout.tsx
@@ -41,7 +41,7 @@ export default function DocsLayout({
     <SidebarProvider
       style={
         {
-          "--sidebar-width": "17rem",
+          "--sidebar-width": "14rem",
         } as React.CSSProperties
       }
     >
@@ -73,9 +73,7 @@ export default function DocsLayout({
           </Link>
           <SidebarTrigger />
         </header>
-        <div className="flex py-8 px-4 sm:px-8 md:px-16 max-w-6xl mx-auto w-full">
-          {children}
-        </div>
+        <div className="flex w-full px-4 pt-6 pb-16 sm:px-6">{children}</div>
       </SidebarInset>
     </SidebarProvider>
   );

--- a/frontend/dashboard/app/docs/page.tsx
+++ b/frontend/dashboard/app/docs/page.tsx
@@ -6,6 +6,7 @@ import Markdown from "react-markdown";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import DocsNavLinks from "./components/docs_nav_links";
+import DocsPageHeader from "./components/docs_page_header";
 import DocsToc from "./components/docs_toc";
 import { createMarkdownComponents } from "./components/md_components";
 
@@ -37,14 +38,23 @@ export default function DocsIndexPage() {
   return (
     <>
       <article className="min-w-0 flex-1">
-        <Markdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeSlug]}
-          components={createMarkdownComponents([], true)}
-        >
-          {doc.content}
-        </Markdown>
-        <DocsNavLinks currentSlug="/docs" />
+        <div className="mx-auto w-full max-w-[43.5rem]">
+          <DocsPageHeader
+            eyebrow={null}
+            heading={doc.heading}
+            description={doc.description}
+          />
+          <div className="mt-8 font-body text-gray-700 dark:text-gray-400 [&>:first-child]:mt-0 [&>h1+*]:mt-0 [&>h2+*]:mt-0 [&>h3+*]:mt-0 [&>h4+*]:mt-0 [&>hr+*]:mt-0">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeSlug]}
+              components={createMarkdownComponents([], true)}
+            >
+              {doc.content}
+            </Markdown>
+          </div>
+          <DocsNavLinks currentSlug="/docs" />
+        </div>
       </article>
       <DocsToc />
     </>

--- a/frontend/dashboard/app/docs/rehype_code_tabs.ts
+++ b/frontend/dashboard/app/docs/rehype_code_tabs.ts
@@ -1,0 +1,124 @@
+import type { ElementContent, Root, RootContent } from "hast";
+
+// Docs markdown expresses per-platform code variants as sibling
+// <details><summary>Android</summary> ```kotlin ...``` </details> blocks so
+// they stay readable on GitHub. On the site, a run of those renders as one
+// tabbed code block instead of a stack of accordions each framing a code
+// block. This plugin replaces each run of MIN_RUN+ consecutive details
+// blocks that hold exactly one fenced code block (and nothing else) with a
+// <code-tabs> element carrying the tab data; md_components maps that tag to
+// the CodeTabs component. Details blocks with prose or several fences are
+// real accordions and stay untouched.
+const MIN_RUN = 2;
+
+interface CodeTab {
+  label: string;
+  code: string;
+  className: string;
+}
+
+function isWhitespace(node: RootContent | ElementContent): boolean {
+  return node.type === "text" && node.value.trim() === "";
+}
+
+function textOf(node: RootContent | ElementContent): string {
+  if (node.type === "text") {
+    return node.value;
+  }
+  if (node.type === "element") {
+    return node.children.map(textOf).join("");
+  }
+  return "";
+}
+
+// A details element groupable into tabs: children are exactly a <summary>
+// and a <pre><code> block.
+function asCodeTab(node: RootContent | ElementContent): CodeTab | null {
+  if (node.type !== "element" || node.tagName !== "details") {
+    return null;
+  }
+  const kids = node.children.filter((child) => !isWhitespace(child));
+  if (kids.length !== 2) {
+    return null;
+  }
+  const [summary, pre] = kids;
+  if (summary.type !== "element" || summary.tagName !== "summary") {
+    return null;
+  }
+  if (pre.type !== "element" || pre.tagName !== "pre") {
+    return null;
+  }
+  const preKids = pre.children.filter((child) => !isWhitespace(child));
+  const code = preKids[0];
+  if (
+    preKids.length !== 1 ||
+    code.type !== "element" ||
+    code.tagName !== "code"
+  ) {
+    return null;
+  }
+  const className = Array.isArray(code.properties?.className)
+    ? code.properties.className.join(" ")
+    : "";
+  const label = textOf(summary).trim();
+  if (label === "") {
+    return null;
+  }
+  return { label, code: textOf(code).replace(/\n$/, ""), className };
+}
+
+function transformChildren(
+  children: (RootContent | ElementContent)[],
+): (RootContent | ElementContent)[] {
+  const out: (RootContent | ElementContent)[] = [];
+  let i = 0;
+
+  while (i < children.length) {
+    const run: CodeTab[] = [];
+    let j = i;
+    // Collect a run of groupable details, allowing whitespace text between
+    // them. `j` only advances past whitespace that precedes another match,
+    // so trailing whitespace after the run is kept.
+    while (j < children.length) {
+      let k = j;
+      while (k < children.length && isWhitespace(children[k])) {
+        k++;
+      }
+      if (k >= children.length) {
+        break;
+      }
+      const tab = asCodeTab(children[k]);
+      if (tab === null) {
+        break;
+      }
+      run.push(tab);
+      j = k + 1;
+    }
+
+    if (run.length >= MIN_RUN) {
+      out.push({
+        type: "element",
+        tagName: "code-tabs",
+        properties: { tabs: JSON.stringify(run) },
+        children: [],
+      });
+      i = j;
+      continue;
+    }
+
+    const node = children[i];
+    if (node.type === "element") {
+      node.children = transformChildren(node.children) as ElementContent[];
+    }
+    out.push(node);
+    i++;
+  }
+
+  return out;
+}
+
+export default function rehypeCodeTabs() {
+  return (tree: Root) => {
+    tree.children = transformChildren(tree.children) as RootContent[];
+  };
+}

--- a/frontend/dashboard/app/utils/highlighter.ts
+++ b/frontend/dashboard/app/utils/highlighter.ts
@@ -43,6 +43,38 @@ export const CODE_BLOCK_LANGUAGES = Object.keys(
 export const CODE_BLOCK_THEME_LIGHT = "vitesse-light";
 export const CODE_BLOCK_THEME_DARK = "vitesse-dark";
 
+// Map markdown fence aliases to the Shiki language names we load grammars for.
+const LANG_ALIASES: Record<string, CodeBlockLanguage> = {
+  sh: "shellscript",
+  shell: "shellscript",
+  bash: "shellscript",
+  objc: "objective-c",
+  ts: "typescript",
+};
+
+const SUPPORTED_LANGUAGES: ReadonlySet<CodeBlockLanguage> = new Set(
+  CODE_BLOCK_LANGUAGES,
+);
+
+/**
+ * Resolve a fenced block's `language-*` class to a supported highlight
+ * language, or null when we don't load a grammar for it.
+ */
+export function resolveLanguage(
+  className: string | undefined,
+): CodeBlockLanguage | null {
+  if (!className) {
+    return null;
+  }
+  const match = className.match(/(?:^|\s)language-(\S+)/);
+  if (!match) {
+    return null;
+  }
+  const raw = match[1].toLowerCase();
+  const mapped = (LANG_ALIASES[raw] ?? raw) as CodeBlockLanguage;
+  return SUPPORTED_LANGUAGES.has(mapped) ? mapped : null;
+}
+
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 let resolvedHighlighter: HighlighterCore | null = null;
 

--- a/frontend/dashboard/app/utils/shared_styles.tsx
+++ b/frontend/dashboard/app/utils/shared_styles.tsx
@@ -1,6 +1,12 @@
 export const underlineLinkStyle =
   "underline decoration-2 underline-offset-2 decoration-green-400 hover:decoration-green-500 dark:decoration-green-300 dark:hover:decoration-green-400";
 
+// Green for active/accent text (docs sidebar, TOC, code tabs, eyebrow).
+// Same pair the landing uses for green text on the page background (pricing
+// checkmarks, MCP demo): decoration greens like the link underline are too
+// light to read as text on white, so light mode gets the deeper shade.
+export const accentGreenTextStyle = "text-green-700 dark:text-green-400";
+
 // Amber warning callout for inline notices, such as the cross-platform note in
 // onboarding and the Slack reconnect prompt. Callers add their own layout
 // classes (flex, spacing) alongside it.


### PR DESCRIPTION
# Description

- add page header with section eyebrow, title and description lead
- cap content width and dim body copy for clearer hierarchy
- frame code blocks with language labels and a visible copy button
- merge per-platform code accordions into page-synced tabbed blocks
- render callouts as icon boxes and stop admonition markers leaking as text
- rework sidebar into labeled sections that track the active page
- drop in-page outline lists that duplicate the on-page TOC
- update type scale and spacing


