### PR TITLE
feat: add builds page

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -579,7 +579,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_filters
 		newTool(&mcpsdk.Tool{
 			Name:        "get_filters",
-			Description: "Get available filter options (versions, OS, countries, devices, etc.) for an app. Optionally scope to errors (error_types) or spans (span).",
+			Description: "Get available filter options (versions, OS, countries, devices, etc.) for an app. Events, spans and builds are separate sources: options derive from events by default, from span data with span. The builds source lists versions only, taken from uploaded build mappings. error_types narrows the event-derived options to errors/ANRs.",
 			InputSchema: mcpMustInferErrorFilterSchema[mcpGetFiltersInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFiltersInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetFilters(ctx, in)
@@ -723,7 +723,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_instances
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_instances",
-			Description: "Get span instances for a root span name. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
+			Description: "Get span instances for a root span name. Covers all app versions unless versions/version_codes narrow it; get_filters with span=true lists the versions seen in span data.",
 			InputSchema: mcpMustInferSchema[mcpGetSpanInstancesInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanInstancesInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanInstances(ctx, in)
@@ -732,7 +732,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_metrics_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_metrics_over_time",
-			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
+			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers all app versions unless versions/version_codes narrow it; get_filters with span=true lists the versions seen in span data.",
 			InputSchema: mcpMustInferSchema[mcpGetSpanMetricsOverTimeInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanMetricsOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanMetricsOverTime(ctx, in)
@@ -918,8 +918,9 @@ type mcpErrorFilters struct {
 type mcpListAppsInput struct{}
 type mcpGetFiltersInput struct {
 	AppID      string   `json:"app_id" jsonschema:"UUID of the app to query"`
-	ErrorTypes []string `json:"error_types,omitempty" jsonschema:"Scope filter options to errors of these types: 'error' (exceptions) and/or 'anr'. Mutually exclusive with span. Omit for all data."`
-	Span       bool     `json:"span,omitempty" jsonschema:"Scope filter options to spans"`
+	ErrorTypes []string `json:"error_types,omitempty" jsonschema:"Narrow the event-derived options to errors of these types: 'error' (exceptions) and/or 'anr'. Mutually exclusive with span and builds. Omitted, options cover all events, not only errors"`
+	Span       bool     `json:"span,omitempty" jsonschema:"Scope filter options to span data. Required for span-relevant options; omitted, options derive from event data, not spans. Mutually exclusive with error_types and builds"`
+	Builds     bool     `json:"builds,omitempty" jsonschema:"Scope filter options to uploaded builds. Required for build-relevant versions; omitted, versions derive from event data, not build mappings. Mutually exclusive with span and error_types"`
 }
 type mcpGetMetricsInput struct {
 	mcpCommonFilters
@@ -1362,6 +1363,9 @@ func (c *Config) mcpGetFilters(ctx context.Context, in mcpGetFiltersInput) (*mcp
 	if in.Span && len(in.ErrorTypes) > 0 {
 		return nil, nil, fmt.Errorf("span and error_types are mutually exclusive")
 	}
+	if in.Builds && (in.Span || len(in.ErrorTypes) > 0) {
+		return nil, nil, fmt.Errorf("builds is mutually exclusive with span and error_types")
+	}
 	if in.Span {
 		af.Span = true
 	}
@@ -1376,7 +1380,16 @@ func (c *Config) mcpGetFilters(ctx context.Context, in mcpGetFiltersInput) (*mcp
 	filterCtx := ambient.WithTeamId(ctx, app.TeamId)
 
 	var fl filter.FilterList
-	if err := af.GetGenericFilters(filterCtx, deps.RchPool, &fl, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode); err != nil {
+
+	// The builds scope reads version options from uploaded build mappings;
+	// every other scope derives its options from event data.
+	if in.Builds {
+		err = af.GetBuildFilters(ctx, deps.PgPool, &fl)
+	} else {
+		err = af.GetGenericFilters(filterCtx, deps.RchPool, &fl, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode)
+	}
+
+	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get filters: %v", err)
 	}
 	data, _ := json.Marshal(fl)

--- a/backend/agent/main.go
+++ b/backend/agent/main.go
@@ -170,9 +170,12 @@ func main() {
 		c.String(http.StatusOK, "pong")
 	})
 
-	// Attachment URLs in tool results point at this service's origin, so it
-	// serves the same read proxy as api.
-	r.GET("/proxy/attachments", proxyAttachment(deps))
+	// Attachment URLs in tool results point at this service's origin only
+	// outside cloud; in cloud PreSignURL returns direct GCS signed URLs, so
+	// the read proxy is registered for self-host only.
+	if !config.IsCloud() {
+		r.GET("/proxy/attachments", proxyAttachment(deps))
+	}
 
 	// MCP OAuth 2.0 Authorization Server endpoints
 	r.GET("/.well-known/oauth-authorization-server", mcpH.MCPOAuthMetadata)

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -4,6 +4,7 @@ package mcp
 
 import (
 	"backend/agent/agent"
+	"backend/agent/server"
 	"backend/libs/authsession"
 	"bytes"
 	"context"
@@ -15,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -186,7 +188,9 @@ func TestMCPWithUserIDContext(t *testing.T) {
 // ==========================================================================
 
 func TestMCPOAuthMetadata(t *testing.T) {
-	deps.Config.AgentOrigin = "https://api.example.com"
+	setConfig(t, func(c *server.Config) {
+		c.AgentOrigin = "https://api.example.com"
+	})
 
 	c, w := newTestGinContext("GET", "/.well-known/oauth-authorization-server", nil)
 	h.MCPOAuthMetadata(c)
@@ -396,8 +400,10 @@ func TestMCPAuthorize(t *testing.T) {
 
 	t.Run("missing code_challenge returns 400", func(t *testing.T) {
 		cleanupAll(ctx, t)
-		deps.Config.OAuthGitHubKey = "test_gh_key"
-		deps.Config.AgentOrigin = "https://api.example.com"
+		setConfig(t, func(c *server.Config) {
+			c.OAuthGitHubKey = "test_gh_key"
+			c.AgentOrigin = "https://api.example.com"
+		})
 		seedMCPClient(ctx, t, "client_pkce", "MyApp", []string{"http://localhost:9999/cb"}, "secret")
 
 		params := url.Values{
@@ -417,7 +423,9 @@ func TestMCPAuthorize(t *testing.T) {
 
 	t.Run("no provider redirects to login page", func(t *testing.T) {
 		cleanupAll(ctx, t)
-		deps.Config.SiteOrigin = "https://app.example.com"
+		setConfig(t, func(c *server.Config) {
+			c.SiteOrigin = "https://app.example.com"
+		})
 
 		params := url.Values{
 			"response_type":  {"code"},
@@ -470,9 +478,11 @@ func TestMCPAuthorize(t *testing.T) {
 
 	t.Run("provider=github redirects to GitHub OAuth with unified callback and mcp_ prefix", func(t *testing.T) {
 		cleanupAll(ctx, t)
-		deps.Config.OAuthGitHubKey = "test_gh_key"
-		deps.Config.AgentOrigin = "https://api.example.com"
-		deps.Config.SiteOrigin = "https://app.example.com"
+		setConfig(t, func(c *server.Config) {
+			c.OAuthGitHubKey = "test_gh_key"
+			c.AgentOrigin = "https://api.example.com"
+			c.SiteOrigin = "https://app.example.com"
+		})
 		seedMCPClient(ctx, t, "client2", "MyApp", []string{"http://localhost:9999/cb"}, "secret")
 
 		params := url.Values{
@@ -515,10 +525,12 @@ func TestMCPAuthorize(t *testing.T) {
 
 	t.Run("provider=google redirects to Google OAuth with unified callback and mcp_ prefix", func(t *testing.T) {
 		cleanupAll(ctx, t)
-		deps.Config.OAuthGoogleKey = "test_google_key"
-		deps.Config.OAuthGoogleSecret = "test_google_secret"
-		deps.Config.AgentOrigin = "https://api.example.com"
-		deps.Config.SiteOrigin = "https://app.example.com"
+		setConfig(t, func(c *server.Config) {
+			c.OAuthGoogleKey = "test_google_key"
+			c.OAuthGoogleSecret = "test_google_secret"
+			c.AgentOrigin = "https://api.example.com"
+			c.SiteOrigin = "https://app.example.com"
+		})
 		seedMCPClient(ctx, t, "client_google", "MyApp", []string{"http://localhost:9999/cb"}, "secret")
 
 		params := url.Values{
@@ -1540,9 +1552,9 @@ func TestMCPAskQuestionAgentDisabled(t *testing.T) {
 	rawToken := "msr_agentofftoken"
 	seedMCPAccessToken(ctx, t, rawToken, userID.String(), "client1", time.Now().Add(90*24*time.Hour))
 
-	orig := deps.Config.AgentEnabled
-	deps.Config.AgentEnabled = false
-	t.Cleanup(func() { deps.Config.AgentEnabled = orig })
+	setConfig(t, func(c *server.Config) {
+		c.AgentEnabled = false
+	})
 
 	resp := callMCPTool(t, rawToken, "ask_question", map[string]any{
 		"app_ids":  []string{uuid.New().String()},
@@ -2213,6 +2225,76 @@ func TestMCPGetFilters(t *testing.T) {
 		})
 		if !isToolError(resp) {
 			t.Error("want tool error when span and error_types are both set")
+		}
+	})
+
+	t.Run("builds and span are mutually exclusive", func(t *testing.T) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), "filtbldmutex@mcp.test")
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "filtbldmutex team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_filtbldmutextok"
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+
+		resp := callMCPTool(t, rawToken, "get_filters", map[string]any{
+			"app_id": appID.String(),
+			"builds": true,
+			"span":   true,
+		})
+		if !isToolError(resp) {
+			t.Error("want tool error when builds and span are both set")
+		}
+	})
+
+	t.Run("builds source lists versions from build mappings", func(t *testing.T) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), "filtbld@mcp.test")
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "filtbld team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_filtbldtok"
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+
+		// no event data seeded: build versions must surface regardless
+		now := time.Now().UTC()
+		seedBuildMapping(ctx, t, uuid.New().String(), appID.String(), "1.0.1", "1", "proguard", now.Add(-2*time.Hour))
+		seedBuildMapping(ctx, t, uuid.New().String(), appID.String(), "1.0.1", "1", "elf_debug", now.Add(-2*time.Hour))
+		seedBuildMapping(ctx, t, uuid.New().String(), appID.String(), "1.0.2", "2", "proguard", now.Add(-time.Hour))
+
+		resp := callMCPTool(t, rawToken, "get_filters", map[string]any{
+			"app_id": appID.String(),
+			"builds": true,
+		})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+
+		var fl struct {
+			Versions     []string `json:"versions"`
+			VersionCodes []string `json:"version_codes"`
+			OsNames      []string `json:"os_names"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &fl); err != nil {
+			t.Fatalf("parse filters response: %v", err)
+		}
+
+		wantVersions := []string{"1.0.2", "1.0.1"}
+		wantCodes := []string{"2", "1"}
+		if !reflect.DeepEqual(fl.Versions, wantVersions) {
+			t.Errorf("want versions %v, got %v", wantVersions, fl.Versions)
+		}
+		if !reflect.DeepEqual(fl.VersionCodes, wantCodes) {
+			t.Errorf("want version codes %v, got %v", wantCodes, fl.VersionCodes)
+		}
+		if len(fl.OsNames) != 0 {
+			t.Errorf("want no os_names for builds source, got %v", fl.OsNames)
 		}
 	})
 

--- a/backend/agent/mcp/test_helpers_test.go
+++ b/backend/agent/mcp/test_helpers_test.go
@@ -67,6 +67,17 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// setConfig applies overrides to the shared test config and restores the
+// previous values when the test finishes, so config changes never leak
+// across tests and the suite stays order-independent. Tests must use this
+// instead of assigning deps.Config fields directly.
+func setConfig(t *testing.T, mutate func(c *server.Config)) {
+	t.Helper()
+	orig := *deps.Config
+	mutate(deps.Config)
+	t.Cleanup(func() { *deps.Config = orig })
+}
+
 // --------------------------------------------------------------------------
 // Thin wrappers delegating to testinfra.TestHelper
 // --------------------------------------------------------------------------
@@ -112,6 +123,10 @@ func seedSpan(
 
 func seedEventWithSession(ctx context.Context, t *testing.T, teamID, appID, sessionID string, ts time.Time) {
 	th.SeedEventWithSession(ctx, t, teamID, appID, sessionID, ts)
+}
+
+func seedBuildMapping(ctx context.Context, t *testing.T, mappingID, appID, versionName, versionCode, mappingType string, lastUpdated time.Time) {
+	th.SeedBuildMapping(ctx, t, mappingID, appID, versionName, versionCode, mappingType, lastUpdated)
 }
 
 // --------------------------------------------------------------------------

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -720,7 +720,15 @@ func (h Handlers) GetAppFilters(c *gin.Context) {
 
 	var fl filter.FilterList
 
-	if err := af.GetGenericFilters(ctx, deps.RchPool, &fl, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode); err != nil {
+	// The builds filter source reads version options from uploaded build
+	// mappings; every other source derives its options from event data.
+	if af.Builds {
+		err = af.GetBuildFilters(ctx, deps.PgPool, &fl)
+	} else {
+		err = af.GetGenericFilters(ctx, deps.RchPool, &fl, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode)
+	}
+
+	if err != nil {
 		msg := `failed to query app filters`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/api/handlers/build.go
+++ b/backend/api/handlers/build.go
@@ -1,15 +1,271 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 
+	"backend/api/server"
+	"backend/libs/filter"
+	"backend/libs/measure"
 	"backend/libs/objstore"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
+
+// buildDownloadConfig builds the storage config measure.OpenBuildDownload
+// needs from the process config.
+func buildDownloadConfig(deps *server.Deps) measure.BuildDownloadConfig {
+	return measure.BuildDownloadConfig{
+		IsCloud:                deps.Config.IsCloud(),
+		AWSEndpoint:            deps.Config.AWSEndpoint,
+		SymbolsBucket:          deps.Config.SymbolsBucket,
+		SymbolsBucketRegion:    deps.Config.SymbolsBucketRegion,
+		SymbolsAccessKey:       deps.Config.SymbolsAccessKey,
+		SymbolsSecretAccessKey: deps.Config.SymbolsSecretAccessKey,
+	}
+}
+
+func (h Handlers) GetBuilds(c *gin.Context) {
+	deps := h.Deps
+	ctx := c.Request.Context()
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	af := filter.AppFilter{
+		AppID: id,
+		Limit: filter.DefaultPaginationLimit,
+	}
+
+	if err := c.ShouldBindQuery(&af); err != nil {
+		msg := `failed to parse query parameters`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if err := af.Expand(ctx, deps.PgPool); err != nil {
+		msg := `failed to expand filters`
+		fmt.Println(msg, err)
+		status := http.StatusInternalServerError
+		if errors.Is(err, pgx.ErrNoRows) {
+			status = http.StatusNotFound
+		}
+		c.JSON(status, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	msg := "builds overview request validation failed"
+	if err := af.Validate(); err != nil {
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
+		if err := af.ValidateVersions(); err != nil {
+			fmt.Println(msg, err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   msg,
+				"details": err.Error(),
+			})
+			return
+		}
+	}
+
+	if !af.HasTimeRange() {
+		af.SetDefaultTimeRange()
+	}
+
+	app := measure.App{
+		ID: &id,
+	}
+	team, err := app.GetTeam(ctx, deps.PgPool)
+	if err != nil {
+		msg := "failed to get team from app id"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+	if team == nil {
+		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	userId := c.GetString("userId")
+	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	if !okTeam || !okApp {
+		msg := `you are not authorized to access this app`
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
+	builds, next, previous, err := measure.GetBuildsWithFilter(ctx, deps.PgPool, &af)
+	if err != nil {
+		msg := "failed to get app's builds"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	// Downloads are served by the authenticated download endpoint, which
+	// packages the artifact the way its platform tooling expects.
+	for i := range builds {
+		builds[i].DownloadURL = fmt.Sprintf("/apps/%s/builds/%s/download", id, builds[i].ID)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"results": builds,
+		"meta": gin.H{
+			"next":     next,
+			"previous": previous,
+		},
+	})
+}
+
+func (h Handlers) DownloadBuild(c *gin.Context) {
+	deps := h.Deps
+	ctx := c.Request.Context()
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	buildId, err := uuid.Parse(c.Param("buildId"))
+	if err != nil {
+		msg := `build id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	app := measure.App{
+		ID: &id,
+	}
+	team, err := app.GetTeam(ctx, deps.PgPool)
+	if err != nil {
+		msg := "failed to get team from app id"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+	if team == nil {
+		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	userId := c.GetString("userId")
+	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	if !okTeam || !okApp {
+		msg := `you are not authorized to access this app`
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
+	build, err := measure.GetBuild(ctx, deps.PgPool, id, buildId)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			msg := fmt.Sprintf("no build [%s] exists for app [%s]", buildId, id)
+			c.JSON(http.StatusNotFound, gin.H{"error": msg})
+			return
+		}
+		msg := "failed to get app's build"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	download, err := measure.OpenBuildDownload(ctx, buildDownloadConfig(deps), build)
+	if err != nil {
+		msg := "failed to open build download"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+	defer func() {
+		if err := download.Close(); err != nil {
+			fmt.Println("failed to close build download:", err)
+		}
+	}()
+
+	c.Header("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": download.Filename}))
+	c.Header("Content-Type", download.ContentType)
+	if download.ContentLength >= 0 {
+		c.Header("Content-Length", strconv.FormatInt(download.ContentLength, 10))
+	}
+	c.Status(http.StatusOK)
+
+	// The response is already streaming, so a failure here can no longer
+	// produce an error status. The connection has to die abruptly instead:
+	// a chunked response that returns normally ends with a valid terminator,
+	// so a truncated download would look complete to the client. The stdlib
+	// abort for this is panic(http.ErrAbortHandler), but CapturePanic
+	// recovers every panic and would finish the response cleanly, so the
+	// connection is hijacked and closed directly.
+	if err := download.Stream(c.Writer); err != nil {
+		fmt.Println("failed to stream build download:", err)
+		if hijacker, ok := c.Writer.(http.Hijacker); ok {
+			if conn, _, hijackErr := hijacker.Hijack(); hijackErr == nil {
+				conn.Close()
+			}
+		}
+	}
+}
 
 func (h Handlers) PutBuilds(c *gin.Context) {
 	deps := h.Deps

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -157,6 +157,10 @@ func main() {
 		apps.GET(":id/thresholdPrefs", hdl.GetAppThresholdPrefs)
 		apps.PATCH(":id/thresholdPrefs", hdl.UpdateAppThresholdPrefs)
 
+		// builds
+		apps.GET(":id/builds", hdl.GetBuilds)
+		apps.GET(":id/builds/:buildId/download", hdl.DownloadBuild)
+
 		// app management
 		apps.GET(":id/config", hdl.GetConfig)
 		apps.PATCH(":id/config", hdl.PatchConfig)

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -166,6 +166,11 @@ type AppFilter struct {
 	// consider spans.
 	Span bool `form:"span"`
 
+	// Builds indicates the filter options should
+	// come from build mappings instead of event
+	// data.
+	Builds bool `form:"builds"`
+
 	// SpanStatuses represents the list of status of
 	// a span to be filtered on.
 	SpanStatuses []int8 `form:"span_statuses"`
@@ -883,6 +888,49 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 	if err := filterGroup.Wait(); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// GetBuildFilters finds distinct pairs of app versions & app build
+// no from an app's uploaded build mappings. It backs the builds
+// filter source, which lists versions that have uploaded builds
+// rather than versions seen in event data.
+func (af AppFilter) GetBuildFilters(ctx context.Context, pg *pgxpool.Pool, fl *FilterList) error {
+	stmt := sqlf.PostgreSQL.From("build_mappings").
+		Select("version_name").
+		Select("version_code").
+		Where("app_id = ?", af.AppID).
+		GroupBy("version_name").
+		GroupBy("version_code")
+
+	defer stmt.Close()
+
+	rows, err := pg.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	v := &Versions{}
+
+	for rows.Next() {
+		var name, code string
+		if err := rows.Scan(&name, &code); err != nil {
+			return err
+		}
+		v.Add(name, code)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// intelligently sort versions
+	v.Sort()
+
+	fl.Versions = append(fl.Versions, v.Versions()...)
+	fl.VersionCodes = append(fl.VersionCodes, v.Codes()...)
 
 	return nil
 }

--- a/backend/libs/measure/build.go
+++ b/backend/libs/measure/build.go
@@ -1,0 +1,399 @@
+package measure
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"backend/libs/filter"
+	"backend/libs/objstore"
+	"backend/libs/symbol"
+
+	"cloud.google.com/go/storage"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+// Build represents a single mapping file uploaded
+// for an app version.
+type Build struct {
+	ID          uuid.UUID `json:"id"`
+	VersionName string    `json:"version_name"`
+	VersionCode string    `json:"version_code"`
+	MappingType string    `json:"mapping_type"`
+	Key         string    `json:"-"`
+	DownloadURL string    `json:"download_url"`
+	FileSize    int64     `json:"filesize"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// BuildDownloadConfig is the storage configuration OpenBuildDownload
+// needs to read mapping file artifacts from the symbols bucket.
+type BuildDownloadConfig struct {
+	IsCloud                bool
+	AWSEndpoint            string
+	SymbolsBucket          string
+	SymbolsBucketRegion    string
+	SymbolsAccessKey       string
+	SymbolsSecretAccessKey string
+}
+
+// BuildDownload is the downloadable form of a build's mapping file:
+// the filename and headers a file download response needs, plus a
+// Stream method that writes the body.
+type BuildDownload struct {
+	Filename    string
+	ContentType string
+
+	// ContentLength is -1 when the final size is not known upfront,
+	// e.g. a dSYM bundle zip assembled while streaming.
+	ContentLength int64
+
+	stream func(w io.Writer) error
+	closer func() error
+}
+
+// Stream writes the download body. Call after response
+// headers are set; it must be called at most once.
+func (d *BuildDownload) Stream(w io.Writer) error {
+	return d.stream(w)
+}
+
+// Close releases the underlying object reader.
+func (d *BuildDownload) Close() error {
+	return d.closer()
+}
+
+// openSymbolObject opens the object at key in the symbols bucket and
+// returns its reader, size and object metadata. The reader's Close
+// releases every underlying resource.
+func openSymbolObject(ctx context.Context, config BuildDownloadConfig, key string) (body io.ReadCloser, size int64, metadata map[string]string, err error) {
+	if config.IsCloud {
+		client, errStorage := storage.NewClient(ctx)
+		if errStorage != nil {
+			return nil, 0, nil, errStorage
+		}
+
+		obj := client.Bucket(config.SymbolsBucket).Object(key)
+
+		attrs, errAttrs := obj.Attrs(ctx)
+		if errAttrs != nil {
+			client.Close()
+			return nil, 0, nil, errAttrs
+		}
+
+		reader, errReader := obj.NewReader(ctx)
+		if errReader != nil {
+			client.Close()
+			return nil, 0, nil, errReader
+		}
+
+		return &gcsObjectReader{reader: reader, client: client}, attrs.Size, attrs.Metadata, nil
+	}
+
+	client := objstore.CreateS3Client(ctx, config.SymbolsAccessKey, config.SymbolsSecretAccessKey, config.SymbolsBucketRegion, config.AWSEndpoint)
+
+	out, errGet := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(config.SymbolsBucket),
+		Key:    aws.String(key),
+	})
+	if errGet != nil {
+		return nil, 0, nil, errGet
+	}
+
+	return out.Body, aws.ToInt64(out.ContentLength), out.Metadata, nil
+}
+
+// gcsObjectReader couples a GCS object reader with its client so
+// closing the download releases both.
+type gcsObjectReader struct {
+	reader *storage.Reader
+	client *storage.Client
+}
+
+func (r *gcsObjectReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *gcsObjectReader) Close() error {
+	readerErr := r.reader.Close()
+	if clientErr := r.client.Close(); clientErr != nil && readerErr == nil {
+		readerErr = clientErr
+	}
+	return readerErr
+}
+
+// dsymName reads the binary name from the /meta object stored next to
+// a dsym artifact's /debuginfo object.
+func dsymName(ctx context.Context, config BuildDownloadConfig, debugInfoKey string) (string, error) {
+	body, _, _, err := openSymbolObject(ctx, config, path.Dir(debugInfoKey)+"/meta")
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	var meta struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(body).Decode(&meta); err != nil {
+		return "", err
+	}
+	if meta.Name == "" {
+		return "", fmt.Errorf("dsym meta has no name for key %q", debugInfoKey)
+	}
+
+	return meta.Name, nil
+}
+
+// xmlEscape escapes a string for interpolation into XML text nodes.
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	// EscapeText only errors on writer failures and bytes.Buffer has none.
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
+}
+
+// writeDsymBundleZip writes a zip holding a reconstructed .dSYM bundle:
+// the stored DWARF binary at Contents/Resources/DWARF/<name> plus a
+// minimal Info.plist, which is the shape Xcode produces and symbol
+// tooling expects.
+func writeDsymBundleZip(w io.Writer, name, versionName, versionCode string, dwarf io.Reader) error {
+	// name becomes a path segment in the zip entries below and originates
+	// from an uploaded artifact's tar entry basename, so a crafted name
+	// with a path separator could make an extractor write outside its
+	// target directory. A real Mach-O binary name is a bare filename, so
+	// reject anything that is not.
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("unsafe dsym bundle name %q", name)
+	}
+
+	zw := zip.NewWriter(w)
+
+	plist, err := zw.Create(name + ".dSYM/Contents/Info.plist")
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(plist, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.apple.xcode.dsym.%[1]s</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>dSYM</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%[2]s</string>
+	<key>CFBundleVersion</key>
+	<string>%[3]s</string>
+</dict>
+</plist>
+`, xmlEscape(name), xmlEscape(versionName), xmlEscape(versionCode)); err != nil {
+		return err
+	}
+
+	dw, err := zw.Create(name + ".dSYM/Contents/Resources/DWARF/" + name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(dw, dwarf); err != nil {
+		return err
+	}
+
+	return zw.Close()
+}
+
+// OpenBuildDownload opens the downloadable form of a build's mapping
+// file. The stored artifact already is what developers expect for
+// proguard, elf_debug and jsbundle mappings and streams through as-is;
+// dsym artifacts are stored as the DWARF binary, so the download
+// reconstructs the .dSYM bundle around it as a zip.
+func OpenBuildDownload(ctx context.Context, config BuildDownloadConfig, build Build) (*BuildDownload, error) {
+	body, size, metadata, err := openSymbolObject(ctx, config, build.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	passthrough := func(w io.Writer) error {
+		_, copyErr := io.Copy(w, body)
+		return copyErr
+	}
+
+	switch build.MappingType {
+	case symbol.TypeProguard.String():
+		return &BuildDownload{
+			Filename:      "mapping.txt",
+			ContentType:   "text/plain",
+			ContentLength: size,
+			stream:        passthrough,
+			closer:        body.Close,
+		}, nil
+	case symbol.TypeElfDebug.String():
+		filename := metadata["original_file_name"]
+		if filename == "" {
+			filename = path.Base(build.Key)
+		}
+		return &BuildDownload{
+			Filename:      filename,
+			ContentType:   "application/octet-stream",
+			ContentLength: size,
+			stream:        passthrough,
+			closer:        body.Close,
+		}, nil
+	case symbol.TypeJsBundle.String():
+		return &BuildDownload{
+			Filename:      path.Base(build.Key),
+			ContentType:   "application/octet-stream",
+			ContentLength: size,
+			stream:        passthrough,
+			closer:        body.Close,
+		}, nil
+	case symbol.TypeDsym.String():
+		name, nameErr := dsymName(ctx, config, build.Key)
+		if nameErr != nil {
+			fmt.Println("failed to read dsym meta, falling back to a generic bundle name:", nameErr)
+			name = "debuginfo"
+		}
+		return &BuildDownload{
+			Filename:      name + ".dSYM.zip",
+			ContentType:   "application/zip",
+			ContentLength: -1,
+			stream: func(w io.Writer) error {
+				return writeDsymBundleZip(w, name, build.VersionName, build.VersionCode, body)
+			},
+			closer: body.Close,
+		}, nil
+	}
+
+	if closeErr := body.Close(); closeErr != nil {
+		fmt.Println("failed to close symbol object reader:", closeErr)
+	}
+
+	return nil, fmt.Errorf("failed to recognize mapping type %q", build.MappingType)
+}
+
+// GetBuild reads a single build mapping row of an app.
+func GetBuild(ctx context.Context, pg *pgxpool.Pool, appID, buildID uuid.UUID) (build Build, err error) {
+	stmt := sqlf.PostgreSQL.From("build_mappings").
+		Select("id").
+		Select("version_name").
+		Select("version_code").
+		Select("mapping_type").
+		Select("key").
+		Select("file_size").
+		Select("last_updated").
+		Where("id = ?", buildID).
+		Where("app_id = ?", appID).
+		// an empty key means the mapping file hasn't finished uploading
+		// and processing yet, so there is nothing to download
+		Where("key != ''")
+
+	defer stmt.Close()
+
+	err = pg.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(
+		&build.ID,
+		&build.VersionName,
+		&build.VersionCode,
+		&build.MappingType,
+		&build.Key,
+		&build.FileSize,
+		&build.LastUpdated,
+	)
+
+	return build, err
+}
+
+// GetBuildsWithFilter provides a paginated list of an app's build mapping
+// files matching various filters, ordered by upload time, newest first.
+func GetBuildsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFilter) (builds []Build, next, previous bool, err error) {
+	stmt := sqlf.PostgreSQL.From("build_mappings").
+		Select("id").
+		Select("version_name").
+		Select("version_code").
+		Select("mapping_type").
+		Select("key").
+		Select("file_size").
+		Select("last_updated").
+		Where("app_id = ?", af.AppID).
+		// an empty key means the mapping file hasn't finished uploading
+		// and processing yet, so there is nothing to download
+		Where("key != ''").
+		// id breaks ties in case last_updated is same
+		OrderBy("last_updated desc, id")
+
+	if af.HasTimeRange() {
+		stmt.Where("last_updated >= ?", af.From)
+		stmt.Where("last_updated <= ?", af.To)
+	}
+
+	if af.HasVersions() {
+		stmt.Where("version_name = ANY(?)", af.Versions)
+		stmt.Where("version_code = ANY(?)", af.VersionCodes)
+	}
+
+	if af.Limit > 0 {
+		stmt.Limit(uint64(af.Limit) + 1)
+	}
+
+	if af.Offset >= 0 {
+		stmt.Offset(uint64(af.Offset))
+	}
+
+	defer stmt.Close()
+
+	rows, err := pg.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, false, false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var build Build
+		if err := rows.Scan(
+			&build.ID,
+			&build.VersionName,
+			&build.VersionCode,
+			&build.MappingType,
+			&build.Key,
+			&build.FileSize,
+			&build.LastUpdated,
+		); err != nil {
+			return nil, false, false, err
+		}
+		builds = append(builds, build)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, false, false, err
+	}
+
+	resultLen := len(builds)
+
+	// Set pagination next & previous flags
+	if af.Limit > 0 && resultLen > af.Limit {
+		builds = builds[:resultLen-1]
+		next = true
+	}
+	if af.Offset > 0 {
+		previous = true
+	}
+
+	return builds, next, previous, nil
+}

--- a/backend/libs/measure/build_test.go
+++ b/backend/libs/measure/build_test.go
@@ -1,0 +1,115 @@
+package measure
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWriteDsymBundleZip(t *testing.T) {
+	dwarf := []byte("\xcf\xfa\xed\xfefake mach-o dwarf bytes")
+
+	var buf bytes.Buffer
+	if err := writeDsymBundleZip(&buf, "DemoApp", "1.2.0", "42", bytes.NewReader(dwarf)); err != nil {
+		t.Fatalf("write dsym bundle zip: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+
+	entries := make(map[string][]byte)
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open zip entry %q: %v", f.Name, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read zip entry %q: %v", f.Name, err)
+		}
+		entries[f.Name] = data
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("want 2 zip entries, got %d: %v", len(entries), zr.File)
+	}
+
+	dwarfEntry, ok := entries["DemoApp.dSYM/Contents/Resources/DWARF/DemoApp"]
+	if !ok {
+		t.Fatal("missing DWARF entry at DemoApp.dSYM/Contents/Resources/DWARF/DemoApp")
+	}
+	if !bytes.Equal(dwarfEntry, dwarf) {
+		t.Error("DWARF entry bytes differ from input")
+	}
+
+	plist, ok := entries["DemoApp.dSYM/Contents/Info.plist"]
+	if !ok {
+		t.Fatal("missing Info.plist entry at DemoApp.dSYM/Contents/Info.plist")
+	}
+	for _, want := range []string{
+		"com.apple.xcode.dsym.DemoApp",
+		"<string>dSYM</string>",
+		"<string>1.2.0</string>",
+		"<string>42</string>",
+	} {
+		if !strings.Contains(string(plist), want) {
+			t.Errorf("Info.plist missing %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestWriteDsymBundleZipRejectsUnsafeName(t *testing.T) {
+	for _, name := range []string{
+		"",
+		".",
+		"..",
+		"../evil",
+		`..\..\evil`,
+		"dir/evil",
+		`dir\evil`,
+	} {
+		var buf bytes.Buffer
+		err := writeDsymBundleZip(&buf, name, "1.0", "1", strings.NewReader("d"))
+		if err == nil {
+			t.Errorf("name %q: want error, got nil", name)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("name %q: want no bytes written, got %d", name, buf.Len())
+		}
+	}
+}
+
+func TestWriteDsymBundleZipEscapesXML(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeDsymBundleZip(&buf, "A&B", "1.0<beta>", "1", strings.NewReader("d")); err != nil {
+		t.Fatalf("write dsym bundle zip: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, "Info.plist") {
+			continue
+		}
+		rc, _ := f.Open()
+		data, _ := io.ReadAll(rc)
+		rc.Close()
+		plist := string(data)
+		if !strings.Contains(plist, "com.apple.xcode.dsym.A&amp;B") {
+			t.Errorf("bundle identifier not XML-escaped:\n%s", plist)
+		}
+		if !strings.Contains(plist, "1.0&lt;beta&gt;") {
+			t.Errorf("version not XML-escaped:\n%s", plist)
+		}
+		return
+	}
+	t.Fatal("Info.plist entry not found")
+}

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -150,6 +150,22 @@ func (h *TestHelper) SeedApp(ctx context.Context, t *testing.T, appID, teamID, a
 	}
 }
 
+// SeedBuildMapping inserts a single build mapping file row.
+func (h *TestHelper) SeedBuildMapping(ctx context.Context, t *testing.T, mappingID, appID, versionName, versionCode, mappingType string, lastUpdated time.Time) {
+	t.Helper()
+
+	_, err := h.PgPool.Exec(ctx,
+		`INSERT INTO build_mappings (id, app_id, version_name, version_code, mapping_type, key, location, fnv1_hash, file_size, last_updated)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		mappingID, appID, versionName, versionCode, mappingType,
+		fmt.Sprintf("test/%s", mappingID),
+		fmt.Sprintf("http://minio.test:9000/msr-symbols-test/test/%s", mappingID),
+		"0xtesthash", 100, lastUpdated)
+	if err != nil {
+		t.Fatalf("seed build mapping: %v", err)
+	}
+}
+
 func (h *TestHelper) SeedAPIKey(
 	ctx context.Context,
 	t *testing.T,

--- a/docs/api/dashboard/README.md
+++ b/docs/api/dashboard/README.md
@@ -254,164 +254,174 @@ Find all the endpoints, resources and detailed documentation for Measure Dashboa
     - [Authorization \& Content Type](#authorization--content-type-43)
     - [Response Body](#response-body-46)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-46)
-  - [GET `/apps/:id/config`](#get-appsidconfig)
+  - [GET `/apps/:id/builds`](#get-appsidbuilds)
     - [Usage Notes](#usage-notes-47)
     - [Authorization \& Content Type](#authorization--content-type-44)
     - [Response Body](#response-body-47)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-47)
-  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
+  - [GET `/apps/:id/builds/:buildId/download`](#get-appsidbuildsbuildiddownload)
     - [Usage Notes](#usage-notes-48)
     - [Authorization \& Content Type](#authorization--content-type-45)
     - [Response Body](#response-body-48)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-48)
-  - [GET `/apps/:id/networkRequests/domains`](#get-appsidnetworkrequestsdomains)
+  - [GET `/apps/:id/config`](#get-appsidconfig)
     - [Usage Notes](#usage-notes-49)
     - [Authorization \& Content Type](#authorization--content-type-46)
     - [Response Body](#response-body-49)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-49)
-  - [GET `/apps/:id/networkRequests/paths`](#get-appsidnetworkrequestspaths)
+  - [PATCH `/apps/:id/config`](#patch-appsidconfig)
     - [Usage Notes](#usage-notes-50)
     - [Authorization \& Content Type](#authorization--content-type-47)
     - [Response Body](#response-body-50)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-50)
-  - [GET `/apps/:id/networkRequests/trends`](#get-appsidnetworkrequeststrends)
+  - [GET `/apps/:id/networkRequests/domains`](#get-appsidnetworkrequestsdomains)
     - [Usage Notes](#usage-notes-51)
     - [Authorization \& Content Type](#authorization--content-type-48)
     - [Response Body](#response-body-51)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-51)
-  - [GET `/apps/:id/networkRequests/plots/overviewStatusCodes`](#get-appsidnetworkrequestsplotsoverviewstatuscodes)
+  - [GET `/apps/:id/networkRequests/paths`](#get-appsidnetworkrequestspaths)
     - [Usage Notes](#usage-notes-52)
     - [Authorization \& Content Type](#authorization--content-type-49)
     - [Response Body](#response-body-52)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-52)
-  - [GET `/apps/:id/networkRequests/plots/endpointLatency`](#get-appsidnetworkrequestsplotsendpointlatency)
+  - [GET `/apps/:id/networkRequests/trends`](#get-appsidnetworkrequeststrends)
     - [Usage Notes](#usage-notes-53)
     - [Authorization \& Content Type](#authorization--content-type-50)
     - [Response Body](#response-body-53)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-53)
-  - [GET `/apps/:id/networkRequests/plots/endpointStatusCodes`](#get-appsidnetworkrequestsplotsendpointstatuscodes)
+  - [GET `/apps/:id/networkRequests/plots/overviewStatusCodes`](#get-appsidnetworkrequestsplotsoverviewstatuscodes)
     - [Usage Notes](#usage-notes-54)
     - [Authorization \& Content Type](#authorization--content-type-51)
     - [Response Body](#response-body-54)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-54)
-  - [GET `/apps/:id/networkRequests/plots/overviewTimeline`](#get-appsidnetworkrequestsplotsoverviewtimeline)
+  - [GET `/apps/:id/networkRequests/plots/endpointLatency`](#get-appsidnetworkrequestsplotsendpointlatency)
     - [Usage Notes](#usage-notes-55)
     - [Authorization \& Content Type](#authorization--content-type-52)
     - [Response Body](#response-body-55)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-55)
-  - [GET `/apps/:id/networkRequests/plots/endpointTimeline`](#get-appsidnetworkrequestsplotsendpointtimeline)
+  - [GET `/apps/:id/networkRequests/plots/endpointStatusCodes`](#get-appsidnetworkrequestsplotsendpointstatuscodes)
     - [Usage Notes](#usage-notes-56)
     - [Authorization \& Content Type](#authorization--content-type-53)
     - [Response Body](#response-body-56)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-56)
-- [Teams](#teams)
-  - [POST `/teams`](#post-teams)
-    - [Authorization \& Content Type](#authorization--content-type-54)
-    - [Request Body](#request-body-8)
+  - [GET `/apps/:id/networkRequests/plots/overviewTimeline`](#get-appsidnetworkrequestsplotsoverviewtimeline)
     - [Usage Notes](#usage-notes-57)
+    - [Authorization \& Content Type](#authorization--content-type-54)
     - [Response Body](#response-body-57)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-57)
-  - [GET `/teams`](#get-teams)
+  - [GET `/apps/:id/networkRequests/plots/endpointTimeline`](#get-appsidnetworkrequestsplotsendpointtimeline)
+    - [Usage Notes](#usage-notes-58)
     - [Authorization \& Content Type](#authorization--content-type-55)
     - [Response Body](#response-body-58)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-58)
-  - [GET `/teams/:id/apps`](#get-teamsidapps)
-    - [Usage Notes](#usage-notes-58)
+- [Teams](#teams)
+  - [POST `/teams`](#post-teams)
     - [Authorization \& Content Type](#authorization--content-type-56)
+    - [Request Body](#request-body-8)
+    - [Usage Notes](#usage-notes-59)
     - [Response Body](#response-body-59)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-59)
-  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
-    - [Usage Notes](#usage-notes-59)
+  - [GET `/teams`](#get-teams)
     - [Authorization \& Content Type](#authorization--content-type-57)
     - [Response Body](#response-body-60)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-60)
-  - [POST `/teams/:id/apps`](#post-teamsidapps)
+  - [GET `/teams/:id/apps`](#get-teamsidapps)
     - [Usage Notes](#usage-notes-60)
-    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-58)
     - [Response Body](#response-body-61)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-61)
-  - [GET `/teams/:id/invites`](#get-teamsidinvites)
+  - [GET `/teams/:id/apps/:id`](#get-teamsidappsid)
     - [Usage Notes](#usage-notes-61)
     - [Authorization \& Content Type](#authorization--content-type-59)
     - [Response Body](#response-body-62)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-62)
-  - [POST `/teams/:id/invite`](#post-teamsidinvite)
+  - [POST `/teams/:id/apps`](#post-teamsidapps)
     - [Usage Notes](#usage-notes-62)
-    - [Request body](#request-body-10)
+    - [Request body](#request-body-9)
     - [Authorization \& Content Type](#authorization--content-type-60)
     - [Response Body](#response-body-63)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-63)
-  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
+  - [GET `/teams/:id/invites`](#get-teamsidinvites)
     - [Usage Notes](#usage-notes-63)
     - [Authorization \& Content Type](#authorization--content-type-61)
     - [Response Body](#response-body-64)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-64)
-  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
+  - [POST `/teams/:id/invite`](#post-teamsidinvite)
     - [Usage Notes](#usage-notes-64)
+    - [Request body](#request-body-10)
     - [Authorization \& Content Type](#authorization--content-type-62)
     - [Response Body](#response-body-65)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-65)
-  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
+  - [PATCH `/teams/:id/invite/:id`](#patch-teamsidinviteid)
     - [Usage Notes](#usage-notes-65)
-    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-63)
     - [Response Body](#response-body-66)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-66)
-  - [GET `/teams/:id/members`](#get-teamsidmembers)
+  - [DELETE `/teams/:id/invite/:id`](#delete-teamsidinviteid)
     - [Usage Notes](#usage-notes-66)
     - [Authorization \& Content Type](#authorization--content-type-64)
     - [Response Body](#response-body-67)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-67)
-  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
+  - [PATCH `/teams/:id/rename`](#patch-teamsidrename)
     - [Usage Notes](#usage-notes-67)
+    - [Request body](#request-body-11)
     - [Authorization \& Content Type](#authorization--content-type-65)
     - [Response Body](#response-body-68)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-68)
-  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
+  - [GET `/teams/:id/members`](#get-teamsidmembers)
     - [Usage Notes](#usage-notes-68)
-    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-66)
     - [Response Body](#response-body-69)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-69)
-  - [GET `/teams/:id/authz`](#get-teamsidauthz)
+  - [DELETE `/teams/:id/members/:id`](#delete-teamsidmembersid)
     - [Usage Notes](#usage-notes-69)
     - [Authorization \& Content Type](#authorization--content-type-67)
     - [Response Body](#response-body-70)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-70)
-  - [GET `/teams/:id/usage`](#get-teamsidusage)
+  - [PATCH `/teams/:id/members/:id/role`](#patch-teamsidmembersidrole)
     - [Usage Notes](#usage-notes-70)
+    - [Request body](#request-body-12)
     - [Authorization \& Content Type](#authorization--content-type-68)
     - [Response Body](#response-body-71)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-71)
-  - [GET `/teams/:id/slack`](#get-teamsidslack)
+  - [GET `/teams/:id/authz`](#get-teamsidauthz)
     - [Usage Notes](#usage-notes-71)
     - [Authorization \& Content Type](#authorization--content-type-69)
     - [Response Body](#response-body-72)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-72)
-  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
+  - [GET `/teams/:id/usage`](#get-teamsidusage)
     - [Usage Notes](#usage-notes-72)
-    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-70)
     - [Response Body](#response-body-73)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-73)
-  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
+  - [GET `/teams/:id/slack`](#get-teamsidslack)
     - [Usage Notes](#usage-notes-73)
     - [Authorization \& Content Type](#authorization--content-type-71)
     - [Response Body](#response-body-74)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-74)
-- [Prefs](#prefs)
-  - [GET `/prefs/notifPrefs`](#get-prefsnotifprefs)
+  - [PATCH `/teams/:id/slack/status`](#patch-teamsidslackstatus)
     - [Usage Notes](#usage-notes-74)
+    - [Request body](#request-body-13)
     - [Authorization \& Content Type](#authorization--content-type-72)
     - [Response Body](#response-body-75)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-75)
-  - [PATCH `/prefs/notifPrefs`](#patch-prefsnotifprefs)
+  - [POST `/teams/:id/slack/test`](#post-teamsidslacktest)
     - [Usage Notes](#usage-notes-75)
-    - [Request body](#request-body-14)
     - [Authorization \& Content Type](#authorization--content-type-73)
     - [Response Body](#response-body-76)
     - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-76)
+- [Prefs](#prefs)
+  - [GET `/prefs/notifPrefs`](#get-prefsnotifprefs)
+    - [Usage Notes](#usage-notes-76)
+    - [Authorization \& Content Type](#authorization--content-type-74)
+    - [Response Body](#response-body-77)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-77)
+  - [PATCH `/prefs/notifPrefs`](#patch-prefsnotifprefs)
+    - [Usage Notes](#usage-notes-77)
+    - [Request body](#request-body-14)
+    - [Authorization \& Content Type](#authorization--content-type-75)
+    - [Response Body](#response-body-78)
+    - [Status Codes \& Troubleshooting](#status-codes--troubleshooting-78)
 
 ## Auth
 
@@ -870,7 +880,7 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/anrGroups/:id/plots/instances`**](#get-appsidanrgroupsidplotsinstances) - _(deprecated)_ Fetch an app's ANR detail instances aggregated by date range & version.
 - [**GET `/apps/:id/anrGroups/:id/plots/journey`**](#get-appsidanrgroupsidplotsjourney) - _(deprecated)_ Fetch an app's ANR journey map.
 - [**GET `/apps/:id/errorGroups`**](#get-appsiderrorgroups) - Fetch an app's error overview.
-- [**GET `/apps/:id/errorGroups/plots/instances`**](#get-appsiderrorGroupsplotsinstances) - Fetch an app's error overview instances plot aggregated by date range & version.
+- [**GET `/apps/:id/errorGroups/plots/instances`**](#get-appsiderrorgroupsplotsinstances) - Fetch an app's error overview instances plot aggregated by date range & version.
 - [**GET `/apps/:id/errorGroups/:errorGroupId/errors`**](#get-appsiderrorgroupserrorgroupiderrors) - Fetch an app's error detail.
 - [**GET `/apps/:id/errorGroups/:errorGroupId/path`**](#get-appsiderrorgroupserrorgroupidpath) - Fetch an error group's common path.
 - [**GET `/apps/:id/errorGroups/:errorGroupId/plots/instances`**](#get-appsiderrorgroupserrorgroupidplotsinstances) - Fetch an app's error detail instances aggregated by date range & version.
@@ -892,6 +902,8 @@ List of HTTP status codes for success and failures.
 - [**GET `/apps/:id/bugReports/:bugReportId`**](#get-appsidbugreportsbugreportid) - Fetch a bug report.
 - [**PATCH `/apps/:id/bugReports/:bugReportId`**](#patch-appsidbugreportsbugreportid) - Update a bug report's status.
 - [**GET `/apps/:id/alerts`**](#get-appsidalerts) - Fetch an app's alerts with optional filters.
+- [**GET `/apps/:id/builds`**](#get-appsidbuilds) - Fetch an app's builds with optional filters.
+- [**GET `/apps/:id/builds/:buildId/download`**](#get-appsidbuildsbuildiddownload) - Download a build's mapping file packaged for its platform tooling.
 - [**GET `/apps/:id/config`**](#get-appsidconfig) - Fetch an app's config.
 - [**PATCH `/apps/:id/config`**](#patch-appsidconfig) - Update an app's config.
 - [**GET `/apps/:id/networkRequests/domains`**](#get-appsidnetworkrequestsdomains) - Fetch an app's unique network request domains.
@@ -1284,7 +1296,9 @@ Fetch an app's filters.
 - Pass `type=anr` to only return filters relevant to ANR events
 - Pass `type=error,anr` to return filters relevant to both exceptions and ANRs
 - Pass `ud_attr_keys=1` as query string parameter to return user defined attribute keys
-- If `type` is omitted, filters are computed from all events
+- Pass `span=1` to return filters computed from span data instead of event data
+- Pass `builds=1` to return version filters computed from uploaded build mappings instead of event data
+- If `type`, `span` and `builds` are omitted, filters are computed from all events
 
 #### Authorization & Content Type
 
@@ -1590,7 +1604,7 @@ List of HTTP status codes for success and failures.
 
 Fetch an app's crash overview instances plot aggregated by date range & version.
 
-> **Deprecated:** Use [`GET /apps/:id/errorGroups/plots/instances`](#get-appsiderrorGroupsplotsinstances) instead.
+> **Deprecated:** Use [`GET /apps/:id/errorGroups/plots/instances`](#get-appsiderrorgroupsplotsinstances) instead.
 
 #### Usage Notes
 
@@ -2417,7 +2431,7 @@ List of HTTP status codes for success and failures.
 
 Fetch an app's ANR overview instances plot aggregated by date range & version.
 
-> **Deprecated:** Use [`GET /apps/:id/errorGroups/plots/instances`](#get-appsiderrorGroupsplotsinstances) instead.
+> **Deprecated:** Use [`GET /apps/:id/errorGroups/plots/instances`](#get-appsiderrorgroupsplotsinstances) instead.
 
 #### Usage Notes
 
@@ -6652,6 +6666,187 @@ List of HTTP status codes for success and failures.
 | `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
 | `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
 | `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+
+### GET `/apps/:id/builds`
+
+Fetch an app's builds by applying various optional filters.
+
+#### Usage Notes
+
+- App's UUID must be passed in the URI
+- Accepted query parameters
+  - `from` (_optional_) - ISO8601 timestamp to include builds uploaded after this time.
+  - `to` (_optional_) - ISO8601 timestamp to include builds uploaded before this time.
+  - `versions` (_optional_) - List of comma separated version identifier strings to return only matching builds.
+  - `version_codes` (_optional_) - List of comma separated version codes to return only matching builds.
+  - `offset` (_optional_) - Number of items to skip when paginating. Use with `limit` parameter to control amount of items fetched.
+  - `limit` (_optional_) - Number of items to return. Used for pagination. Should be used along with `offset`.
+  - `filter_short_code` (_optional_) - Code representing combination of filters.
+- Both `versions` &amp; `version_codes` should be present if any one of them is present.
+- Number of items in `versions` &amp; `version_codes` must be same.
+- Builds are ordered by upload time, newest first.
+- Each build's `download_url` is the path of the [download endpoint](#get-appsidbuildsbuildiddownload) serving the build's mapping file.
+- For multiple comma separated fields, make sure no whitespace characters exist before or after comma.
+- Pass `limit` and `offset` values to paginate results
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Response
+
+  <details>
+    <summary>Click to expand</summary>
+
+  ```json
+  {
+    "meta": {
+        "next": true,
+        "previous": false
+    },
+    "results": [
+        {
+            "id": "8bd23e1c-71f0-4a94-9c9c-d5b9b1f27b30",
+            "version_name": "1.2.0",
+            "version_code": "1200",
+            "mapping_type": "proguard",
+            "download_url": "/apps/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/builds/8bd23e1c-71f0-4a94-9c9c-d5b9b1f27b30/download",
+            "filesize": 8712174,
+            "last_updated": "2025-07-08T09:14:33.712Z"
+        },
+        {
+            "id": "38c4d1a9-9153-4f81-b2e8-63f4a1c05d9b",
+            "version_name": "1.2.0",
+            "version_code": "1200",
+            "mapping_type": "elf_debug",
+            "download_url": "/apps/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/builds/38c4d1a9-9153-4f81-b2e8-63f4a1c05d9b/download",
+            "filesize": 24509831,
+            "last_updated": "2025-07-08T09:14:32.409Z"
+        },
+        {
+            "id": "f3b7c2e5-0d64-4a1f-9c3a-7e85d20b41ac",
+            "version_name": "1.1.0",
+            "version_code": "1100",
+            "mapping_type": "proguard",
+            "download_url": "/apps/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/builds/f3b7c2e5-0d64-4a1f-9c3a-7e85d20b41ac/download",
+            "filesize": 8532117,
+            "last_updated": "2025-06-24T14:02:11.108Z"
+        }
+    ]
+  }
+  ```
+
+  </details>
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
+| `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
+
+</details>
+
+
+### GET `/apps/:id/builds/:buildId/download`
+
+Download a build's mapping file, packaged the way its platform tooling expects.
+
+#### Usage Notes
+
+- App's UUID and the build's UUID must be passed in the URI
+- The response is the mapping file itself with a `Content-Disposition` filename, not JSON
+- Packaging depends on the build's `mapping_type`
+  - `proguard` - the mapping file as stored, named `mapping.txt`
+  - `elf_debug` - the debug file as stored, named with its uploaded filename
+  - `jsbundle` - the bundle or sourcemap file as stored, named with its uploaded filename
+  - `dsym` - a zip of the `.dSYM` bundle reconstructed around the stored DWARF binary, named `<binary>.dSYM.zip`
+
+#### Authorization & Content Type
+
+1. (Optional) Set the sessions's access token in `Authorization: Bearer <access-token>` format unless you are using cookies to send access tokens.
+
+2. Set content type as `Content-Type: application/json; charset=utf-8`
+
+The required headers must be present in each request.
+
+<details>
+  <summary>Request Headers - Click to expand</summary>
+
+| **Name**        | **Value**                        |
+| --------------- | -------------------------------- |
+| `Authorization` | Bearer &lt;user-access-token&gt; |
+| `Content-Type`  | application/json; charset=utf-8  |
+</details>
+
+#### Response Body
+
+- Successful responses stream the file's bytes with download headers, for example
+
+  ```
+  Content-Disposition: attachment; filename="mapping.txt"
+  Content-Type: text/plain
+  ```
+
+- Failed requests have the following response shape
+
+  ```json
+  {
+    "error": "Error message"
+  }
+  ```
+
+#### Status Codes &amp; Troubleshooting
+
+List of HTTP status codes for success and failures.
+
+<details>
+  <summary>Status Codes - Click to expand</summary>
+
+| **Status**                  | **Meaning**                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `200 Ok`                    | Successful response, no errors.                                                                                        |
+| `400 Bad Request`           | Request URI is malformed or does not meet one or more acceptance criteria. Check the `"error"` field for more details. |
+| `401 Unauthorized`          | Either the user's access token is invalid or has expired.                                                              |
+| `403 Forbidden`             | Requester does not have access to this resource.                                                                       |
+| `404 Not Found`             | No build with this id exists for this app.                                                                             |
 | `429 Too Many Requests`     | Rate limit of the requester has crossed maximum limits.                                                                |
 | `500 Internal Server Error` | Measure server encountered an unfortunate error. Report this to your server administrator.                             |
 

--- a/docs/features/feature-mcp.md
+++ b/docs/features/feature-mcp.md
@@ -72,7 +72,7 @@ List all apps the authenticated user has access to.
 
 ### `get_filters`
 
-Get available filter options (versions, OS, countries, devices, etc.) for an app.
+Get available filter options (versions, OS, countries, devices, etc.) for an app. 
 
 ### `get_metrics`
 

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -27,6 +27,7 @@ import {
   BugReportsOverviewApiStatus,
   BugReportsOverviewPlotApiStatus,
   BugReportStatus,
+  BuildsApiStatus,
   buildShortFiltersPostBody,
   changeAppApiKeyFromServer,
   changeAppNameFromServer,
@@ -37,6 +38,7 @@ import {
   defaultFilters,
   DowngradeToFreeApiStatus,
   downgradeToFreeFromServer,
+  downloadBuild,
   UndoDowngradeApiStatus,
   undoDowngradeFromServer,
   fetchAlertsOverviewFromServer,
@@ -51,6 +53,7 @@ import {
   fetchBugReportFromServer,
   fetchBugReportsOverviewFromServer,
   fetchBugReportsOverviewPlotFromServer,
+  fetchBuildsFromServer,
   fetchErrorGroupCommonPathFromServer,
   fetchErrorsDetailsFromServer,
   fetchErrorsDetailsPlotFromServer,
@@ -459,6 +462,17 @@ describe("fetchFiltersFromServer", () => {
     expect(result.status).toBe(FiltersApiStatus.Success);
   });
 
+  it("returns NoBuilds for the Builds source when the app has no builds", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(
+      successResponse({ versions: null }),
+    );
+    const result = await fetchFiltersFromServer(
+      onboardedApp,
+      FilterSource.Builds,
+    );
+    expect(result.status).toBe(FiltersApiStatus.NoBuilds);
+  });
+
   it("returns NoData when the app is onboarded but has no versions", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ versions: null }),
@@ -856,6 +870,83 @@ describe("sessions, bug reports, alerts", () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
     await fetchAlertsOverviewFromServer(makeFilters(), 20, 0);
     expect(lastFetchUrl()).toContain("/api/apps/app-a/alerts");
+  });
+
+  it("fetchBuildsFromServer hits /builds with filters and pagination", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await fetchBuildsFromServer(makeFilters(), 10, 20);
+    const url = lastFetchUrl();
+    expect(url).toContain("/api/apps/app-a/builds");
+    expect(url).toContain("filter_short_code=code-123");
+    expect(url).toContain("from=");
+    expect(url).toContain("to=");
+    expect(url).toContain("limit=10");
+    expect(url).toContain("offset=20");
+  });
+
+  it("fetchBuildsFromServer returns Error on a non-ok response", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    const result = await fetchBuildsFromServer(makeFilters(), 10, 0);
+    expect(result.status).toBe(BuildsApiStatus.Error);
+  });
+
+  it("fetchBuildsFromServer returns Error when the request throws", async () => {
+    mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
+    const result = await fetchBuildsFromServer(makeFilters(), 10, 0);
+    expect(result.status).toBe(BuildsApiStatus.Error);
+  });
+});
+
+// ========================================================================
+// downloadBuild
+// ========================================================================
+describe("downloadBuild", () => {
+  const originalLocation = window.location;
+  const assignMock = jest.fn();
+
+  beforeAll(() => {
+    delete (window as any).location;
+    (window as any).location = {
+      origin: originalLocation.origin,
+      href: originalLocation.href,
+      assign: assignMock,
+    };
+  });
+
+  afterAll(() => {
+    (window as any).location = originalLocation;
+  });
+
+  it("refreshes the session through apiClient before navigating", async () => {
+    assignMock.mockClear();
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
+    await downloadBuild("/api/apps/app-a/builds/b-1/download");
+    expect(lastFetchUrl()).toBe("/api/auth/session");
+    expect(assignMock).toHaveBeenCalledWith(
+      "/api/apps/app-a/builds/b-1/download",
+    );
+  });
+
+  it("navigates even when the session touch fails", async () => {
+    // A thrown probe is a network failure, not an auth failure: the
+    // session state is unknown rather than known-dead, so the download
+    // is still attempted; the worst case is a retryable failure.
+    assignMock.mockClear();
+    mockApiClientFetch.mockRejectedValueOnce(new Error("offline"));
+    await downloadBuild("/api/apps/app-a/builds/b-1/download");
+    expect(assignMock).toHaveBeenCalledWith(
+      "/api/apps/app-a/builds/b-1/download",
+    );
+  });
+
+  it("does not navigate when the session is dead", async () => {
+    // A non-ok probe means the refresh failed too: apiClient has already
+    // started the redirect to login, and a hard navigation would override
+    // it and land the browser on the api's raw 401 body.
+    assignMock.mockClear();
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse(401));
+    await downloadBuild("/api/apps/app-a/builds/b-1/download");
+    expect(assignMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -144,6 +144,7 @@ function defaultProps(overrides: Record<string, any> = {}) {
     appVersionsInitialSelectionType: AppVersionsInitialSelectionType.Latest,
     showNoData: false,
     showNotOnboarded: false,
+    showNoBuilds: false,
     showAppSelector: true,
     showDates: true,
     showAppVersions: true,
@@ -217,6 +218,12 @@ function setFiltersNoData() {
   filterOptionsQueryState = {
     status: "success",
     data: { status: FiltersApiStatus.NoData, data: null },
+  };
+}
+function setFiltersNoBuilds() {
+  filterOptionsQueryState = {
+    status: "success",
+    data: { status: FiltersApiStatus.NoBuilds, data: null },
   };
 }
 function setFiltersNotOnboarded() {
@@ -355,6 +362,16 @@ describe("Filters — filter options states", () => {
     await waitFor(() => {
       expect(
         screen.getByText(/No .* received for this app yet/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders the "no builds" message when showNoBuilds is true and status is NoBuilds', async () => {
+    setFiltersNoBuilds();
+    await renderFilters({ showNoBuilds: true });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No builds uploaded for this app yet/),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -1,0 +1,464 @@
+import { promiseParams } from "@/__tests__/helpers/promise_params";
+import Builds from "@/app/[teamId]/builds/page";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+// Global replace mock for router.replace
+const replaceMock = jest.fn();
+const pushMock = jest.fn();
+
+// Mock next/navigation hooks
+let mockSearchParams = new URLSearchParams();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    push: pushMock,
+  }),
+  // By default, return empty search params.
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Mock API calls and constants
+const downloadBuildMock = jest.fn();
+jest.mock("@/app/api/api_calls", () => ({
+  __esModule: true,
+  emptyBuildsResponse: {
+    meta: { next: false, previous: false },
+    results: [],
+  },
+  FilterSource: { Builds: "builds" },
+  downloadBuild: (url: string) => downloadBuildMock(url),
+}));
+
+jest.mock("@/app/stores/provider", () => {
+  const { create } = jest.requireActual("zustand");
+  const filtersStore = create(() => ({
+    filters: { ready: false, serialisedFilters: "" },
+  }));
+  return { __esModule: true, useFiltersStore: filtersStore };
+});
+
+const mockUseBuildsQuery = jest.fn(() => ({
+  data: undefined as any,
+  status: "pending" as string,
+  isFetching: true,
+  error: null as Error | null,
+}));
+
+jest.mock("@/app/query/hooks", () => ({
+  __esModule: true,
+  useBuildsQuery: () => mockUseBuildsQuery(),
+  paginationOffsetUrlKey: "po",
+}));
+
+jest.mock("@/app/components/filters", () => ({
+  __esModule: true,
+  default: () => <div data-testid="filters-mock" />,
+  AppVersionsInitialSelectionType: { All: "all" },
+}));
+
+// Updated Paginator mock renders Next and Prev buttons.
+jest.mock("@/app/components/paginator", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="paginator-mock">
+      <button
+        data-testid="prev-button"
+        onClick={props.onPrev}
+        disabled={!props.prevEnabled}
+      >
+        Prev
+      </button>
+      <button
+        data-testid="next-button"
+        onClick={props.onNext}
+        disabled={!props.nextEnabled}
+      >
+        Next
+      </button>
+      <span>{props.displayText}</span>
+    </div>
+  ),
+}));
+
+// Mock LoadingBar component.
+jest.mock("@/app/components/loading_bar", () => () => (
+  <div data-testid="loading-bar-mock">LoadingBar Rendered</div>
+));
+
+// Mock time utils
+jest.mock("@/app/utils/time_utils", () => ({
+  formatDateToHumanReadableDateTime: jest.fn(() => "1 Jan, 2020, 12:00:00 AM"),
+}));
+
+const { useFiltersStore } = require("@/app/stores/provider") as any;
+
+const mockBuildResult = {
+  id: "mapping-1",
+  version_name: "1.0.2",
+  version_code: "2",
+  mapping_type: "dsym",
+  download_url: "/apps/app1/builds/mapping-1/download",
+  filesize: 100,
+  last_updated: "2020-01-01T00:00:00Z",
+};
+
+const mockBuildsData = {
+  results: [mockBuildResult],
+  meta: { previous: true, next: true },
+};
+
+describe("Builds Component", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    pushMock.mockClear();
+    downloadBuildMock.mockClear();
+    mockSearchParams = new URLSearchParams();
+    mockUseBuildsQuery.mockReset();
+    mockUseBuildsQuery.mockReturnValue({
+      data: undefined,
+      status: "pending" as string,
+      isFetching: true,
+      error: null,
+    });
+    useFiltersStore.setState({
+      filters: { ready: false, serialisedFilters: "" },
+    });
+  });
+
+  it("renders the Filters component", () => {
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
+  });
+
+  it("does not render main builds UI when filters are not ready", () => {
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    expect(screen.queryByTestId("paginator-mock")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-bar-mock")).not.toBeInTheDocument();
+    expect(screen.queryByText("Build")).not.toBeInTheDocument();
+  });
+
+  it("renders main builds UI, updates URL when filters become ready, and renders table headers", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: mockBuildsData,
+      status: "success",
+      isFetching: false,
+      error: null,
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    // Check URL update.
+    expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
+      scroll: false,
+    });
+
+    // Verify main UI components are rendered.
+    expect(await screen.findByTestId("paginator-mock")).toBeInTheDocument();
+    // Check that the table header cells are rendered.
+    expect(
+      screen.getByRole("columnheader", { name: "Build" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Download" }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays build data correctly when API returns results", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: mockBuildsData,
+      status: "success",
+      isFetching: false,
+      error: null,
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    // Main line is the mapping id, second line is version (code), type, datetime.
+    expect(screen.getByText("mapping-1")).toBeInTheDocument();
+    expect(
+      screen.getByText("1.0.2 (2), dsym, 1 Jan, 2020, 12:00:00 AM"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a download link per build pointing at the download endpoint", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: mockBuildsData,
+      status: "success",
+      isFetching: false,
+      error: null,
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    const link = screen.getByRole("link", { name: "Download" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      "href",
+      "/api/apps/app1/builds/mapping-1/download",
+    );
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("downloads through the session-refreshing helper on click", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: mockBuildsData,
+      status: "success",
+      isFetching: false,
+      error: null,
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    const link = screen.getByRole("link", { name: "Download" });
+    await act(async () => {
+      fireEvent.click(link);
+    });
+
+    expect(downloadBuildMock).toHaveBeenCalledWith(
+      "/api/apps/app1/builds/mapping-1/download",
+    );
+  });
+
+  it("shows error message when API returns error status", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: undefined,
+      status: "error",
+      isFetching: false,
+      error: new Error("fail"),
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    // Check that error message is displayed
+    expect(
+      screen.getByText(/Error fetching list of builds/),
+    ).toBeInTheDocument();
+  });
+
+  describe("Pagination offset handling", () => {
+    it("initializes pagination offset to 0 when no offset is provided", async () => {
+      mockUseBuildsQuery.mockReturnValue({
+        data: mockBuildsData,
+        status: "success",
+        isFetching: false,
+        error: null,
+      });
+      render(<Builds params={promiseParams({ teamId: "123" })} />);
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            serialisedFilters: "updated",
+            app: { id: "app1" },
+          },
+        });
+      });
+      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
+        scroll: false,
+      });
+    });
+
+    it("increments pagination offset when Next is clicked", async () => {
+      mockUseBuildsQuery.mockReturnValue({
+        data: mockBuildsData,
+        status: "success",
+        isFetching: false,
+        error: null,
+      });
+      render(<Builds params={promiseParams({ teamId: "123" })} />);
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            serialisedFilters: "updated",
+            app: { id: "app1" },
+          },
+        });
+      });
+      const nextButton = await screen.findByTestId("next-button");
+      await act(async () => {
+        fireEvent.click(nextButton);
+      });
+      // The pagination limit is 10 so offset should be 10.
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=10&updated", {
+        scroll: false,
+      });
+    });
+
+    it("decrements pagination offset when Prev is clicked, but not below 0", async () => {
+      mockUseBuildsQuery.mockReturnValue({
+        data: mockBuildsData,
+        status: "success",
+        isFetching: false,
+        error: null,
+      });
+      render(<Builds params={promiseParams({ teamId: "123" })} />);
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            serialisedFilters: "updated",
+            app: { id: "app1" },
+          },
+        });
+      });
+      const nextButton = await screen.findByTestId("next-button");
+      await act(async () => {
+        fireEvent.click(nextButton);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=10&updated", {
+        scroll: false,
+      });
+      const prevButton = await screen.findByTestId("prev-button");
+      await act(async () => {
+        fireEvent.click(prevButton);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
+        scroll: false,
+      });
+      await act(async () => {
+        fireEvent.click(prevButton);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
+        scroll: false,
+      });
+    });
+
+    it("resets pagination offset to 0 when filters change (if previous filters were non-default)", async () => {
+      mockUseBuildsQuery.mockReturnValue({
+        data: mockBuildsData,
+        status: "success",
+        isFetching: false,
+        error: null,
+      });
+
+      render(<Builds params={promiseParams({ teamId: "123" })} />);
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            serialisedFilters: "updated",
+            app: { id: "app1" },
+          },
+        });
+      });
+      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
+        scroll: false,
+      });
+
+      const nextButton = await screen.findByTestId("next-button");
+      await act(async () => {
+        fireEvent.click(nextButton);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=10&updated", {
+        scroll: false,
+      });
+
+      // Now simulate a filter change with a different value.
+      await act(async () => {
+        useFiltersStore.setState({
+          filters: {
+            ready: true,
+            serialisedFilters: "updated2",
+            app: { id: "app1" },
+          },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated2", {
+        scroll: false,
+      });
+    });
+  });
+
+  it("correctly toggles loading bar visibility based on API status", async () => {
+    mockUseBuildsQuery.mockReturnValue({
+      data: undefined,
+      status: "pending" as string,
+      isFetching: true,
+      error: null,
+    });
+    render(<Builds params={promiseParams({ teamId: "123" })} />);
+
+    // Set loading state
+    await act(async () => {
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    // Test the loading state - loading bar should be visible
+    const loadingBarContainer =
+      screen.getByTestId("loading-bar-mock").parentElement;
+    expect(loadingBarContainer).toHaveClass("visible");
+    expect(loadingBarContainer).not.toHaveClass("invisible");
+
+    // Set success state
+    await act(async () => {
+      mockUseBuildsQuery.mockReturnValue({
+        data: mockBuildsData,
+        status: "success",
+        isFetching: false,
+        error: null,
+      });
+      useFiltersStore.setState({
+        filters: {
+          ready: true,
+          serialisedFilters: "updated",
+          app: { id: "app1" },
+        },
+      });
+    });
+
+    // After loading, the loading bar should be invisible
+    await screen.findByText("mapping-1");
+    expect(loadingBarContainer).not.toHaveClass("visible");
+    expect(loadingBarContainer).toHaveClass("invisible");
+  });
+});

--- a/frontend/dashboard/__tests__/query/hooks_test.tsx
+++ b/frontend/dashboard/__tests__/query/hooks_test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import {
   AppsApiStatus,
+  BuildsApiStatus,
   ErrorGroupCommonPathApiStatus,
   ErrorsDetailsApiStatus,
   ErrorsDetailsPlotApiStatus,
@@ -21,6 +22,7 @@ jest.mock("@/app/api/api_calls", () => {
   return {
     ...actual,
     fetchAppsFromServer: jest.fn(),
+    fetchBuildsFromServer: jest.fn(),
     fetchFiltersFromServer: jest.fn(),
     fetchRootSpanNamesFromServer: jest.fn(),
     fetchErrorsOverviewFromServer: jest.fn(),
@@ -54,6 +56,7 @@ jest.mock("@/app/api/api_client", () => ({
 
 import {
   fetchAppsFromServer,
+  fetchBuildsFromServer,
   fetchErrorGroupCommonPathFromServer,
   fetchErrorsDetailsFromServer,
   fetchErrorsDetailsPlotFromServer,
@@ -68,6 +71,7 @@ import {
   fetchCurrentSession,
   signOut,
   useAppsQuery,
+  useBuildsQuery,
   useErrorGroupCommonPathQuery,
   useErrorsDetailsPlotQuery,
   useErrorsDetailsQuery,
@@ -80,6 +84,7 @@ import {
 } from "@/app/query/hooks";
 
 const mockFetchApps = fetchAppsFromServer as jest.Mock;
+const mockFetchBuilds = fetchBuildsFromServer as jest.Mock;
 const mockFetchFilters = fetchFiltersFromServer as jest.Mock;
 const mockFetchRootSpanNames = fetchRootSpanNamesFromServer as jest.Mock;
 const mockFetchErrorsOverview = fetchErrorsOverviewFromServer as jest.Mock;
@@ -209,6 +214,39 @@ describe("useFilterOptionsQuery", () => {
       data: null,
     });
     expect(mockFetchFilters).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the Builds source even when the app is never onboarded", async () => {
+    mockFetchFilters.mockResolvedValueOnce({
+      status: FiltersApiStatus.Success,
+      data: {
+        versions: [{ name: "1.0.2", code: "2" }],
+        os_versions: null,
+        countries: null,
+        network_providers: null,
+        network_types: null,
+        network_generations: null,
+        locales: null,
+        device_manufacturers: null,
+        device_names: null,
+        ud_attrs: null,
+      },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useFilterOptionsQuery(notOnboardedApp, FilterSource.Builds),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchFilters).toHaveBeenCalledWith(
+      notOnboardedApp,
+      FilterSource.Builds,
+    );
+    expect(result.current.data?.status).toBe(FiltersApiStatus.Success);
+    expect(result.current.data?.data?.versions).toHaveLength(1);
   });
 
   it("fetches and parses on Success when app is onboarded", async () => {
@@ -527,6 +565,52 @@ describe("useErrorsOverviewQuery", () => {
     await waitFor(() => expect(result.current.status).toBe("error"));
     expect((result.current.error as Error).message).toMatch(
       /Failed to fetch errors overview/,
+    );
+  });
+});
+
+describe("useBuildsQuery", () => {
+  it("is disabled when filters.ready is false", () => {
+    mockFiltersState = { ready: false };
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useBuildsQuery(0), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchBuilds).not.toHaveBeenCalled();
+  });
+
+  it("returns success with data once the fetch resolves", async () => {
+    mockFiltersState = readyFilters();
+    mockFetchBuilds.mockResolvedValueOnce({
+      status: BuildsApiStatus.Success,
+      data: {
+        results: [{ id: "b1" }],
+        meta: { next: false, previous: false },
+      },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useBuildsQuery(20), { wrapper });
+
+    expect(result.current.status).toBe("pending");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchBuilds).toHaveBeenCalledWith(mockFiltersState, 10, 20);
+    expect((result.current.data as any).results[0].id).toBe("b1");
+  });
+
+  it("throws on Error status", async () => {
+    mockFiltersState = readyFilters();
+    mockFetchBuilds.mockResolvedValueOnce({
+      status: BuildsApiStatus.Error,
+      data: null,
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useBuildsQuery(0), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect((result.current.error as Error).message).toMatch(
+      /Failed to fetch builds/,
     );
   });
 });

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -56,6 +56,7 @@ const baseConfig = {
   filterSource: FilterSource.Errors,
   showNoData: false,
   showNotOnboarded: false,
+  showNoBuilds: false,
   showAppSelector: true,
   showDates: true,
   showAppVersions: true,
@@ -714,6 +715,24 @@ describe("computed filters object", () => {
     store.getState().setSelectedApp(makeApp("a"));
     store.getState().setFilterOptions(null, FiltersApiStatus.NoData);
     expect(store.getState().filters.ready).toBe(false);
+  });
+
+  it("filters.ready is false on NoBuilds when showNoBuilds is set (filters component renders the NoBuilds UI)", () => {
+    const store = createFiltersStore();
+    store.getState().setConfig({ ...baseConfig, showNoBuilds: true });
+    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setSelectedApp(makeApp("a"));
+    store.getState().setFilterOptions(null, FiltersApiStatus.NoBuilds);
+    expect(store.getState().filters.ready).toBe(false);
+  });
+
+  it("filters.ready is true on NoBuilds when showNoBuilds is not set", () => {
+    const store = createFiltersStore();
+    store.getState().setConfig(baseConfig);
+    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setSelectedApp(makeApp("a"));
+    store.getState().setFilterOptions(null, FiltersApiStatus.NoBuilds);
+    expect(store.getState().filters.ready).toBe(true);
   });
 
   it("filters.ready is false on NoData when showNoData is set (filters component renders the NoData UI)", () => {

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+import { useFiltersStore } from "@/app/stores/provider";
+
+import {
+  downloadBuild,
+  emptyBuildsResponse,
+  FilterSource,
+} from "@/app/api/api_calls";
+import { Button } from "@/app/components/button";
+import Filters, {
+  AppVersionsInitialSelectionType,
+} from "@/app/components/filters";
+import LoadingBar from "@/app/components/loading_bar";
+import Paginator from "@/app/components/paginator";
+import { SkeletonListPage } from "@/app/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/app/components/table";
+import { paginationOffsetUrlKey, useBuildsQuery } from "@/app/query/hooks";
+import { formatDateToHumanReadableDateTime } from "@/app/utils/time_utils";
+import { useRouter, useSearchParams } from "next/navigation";
+import { use, useEffect, useRef, useState } from "react";
+
+const PAGINATION_LIMIT = 10;
+
+export default function Builds(props: { params: Promise<{ teamId: string }> }) {
+  const params = use(props.params);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const filters = useFiltersStore((state) => state.filters);
+
+  // Pagination is component-local state, initialized from URL
+  const [paginationOffset, setPaginationOffset] = useState(() => {
+    const po = searchParams.get(paginationOffsetUrlKey);
+    return po ? parseInt(po) : 0;
+  });
+
+  // Reset pagination when filters change (skip pre-ready transitions)
+  const prevFiltersRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!filters.ready) {
+      return;
+    }
+    if (
+      prevFiltersRef.current !== null &&
+      prevFiltersRef.current !== filters.serialisedFilters
+    ) {
+      setPaginationOffset(0);
+    }
+    prevFiltersRef.current = filters.serialisedFilters;
+  }, [filters.ready, filters.serialisedFilters]);
+
+  // URL sync
+  useEffect(() => {
+    if (!filters.ready) {
+      return;
+    }
+    router.replace(
+      `?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`,
+      { scroll: false },
+    );
+  }, [paginationOffset, filters.ready, filters.serialisedFilters]);
+
+  const {
+    data: builds = emptyBuildsResponse,
+    status,
+    isFetching,
+  } = useBuildsQuery(paginationOffset);
+
+  const nextPage = () => setPaginationOffset((o) => o + PAGINATION_LIMIT);
+  const prevPage = () =>
+    setPaginationOffset((o) => Math.max(0, o - PAGINATION_LIMIT));
+
+  return (
+    <div className="flex flex-col items-start">
+      <div className="py-4" />
+
+      <Filters
+        teamId={params.teamId}
+        filterSource={FilterSource.Builds}
+        appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
+        showNoData={false}
+        showNotOnboarded={false}
+        showNoBuilds={true}
+        showAppSelector={true}
+        showAppVersions={true}
+        showDates={true}
+        showSessionTypes={false}
+        showOsVersions={false}
+        showCountries={false}
+        showNetworkTypes={false}
+        showNetworkProviders={false}
+        showNetworkGenerations={false}
+        showLocales={false}
+        showDeviceManufacturers={false}
+        showDeviceNames={false}
+        showBugReportStatus={false}
+        showHttpMethods={false}
+        showUdAttrs={false}
+        showFreeText={false}
+      />
+      <div className="py-4" />
+
+      {filters.loading && <SkeletonListPage />}
+
+      {/* Error state for builds fetch */}
+      {filters.ready && status === "error" && (
+        <p className="text-lg font-display">
+          Error fetching list of builds, please change filters, refresh page or
+          select a different app to try again
+        </p>
+      )}
+
+      {/* Main builds list UI */}
+      {filters.ready && (status === "success" || status === "pending") && (
+        <div className="flex flex-col items-center w-full">
+          <div className="self-end">
+            <Paginator
+              prevEnabled={isFetching ? false : builds.meta.previous}
+              nextEnabled={isFetching ? false : builds.meta.next}
+              displayText=""
+              onNext={nextPage}
+              onPrev={prevPage}
+            />
+          </div>
+          <div
+            className={`py-1 w-full ${isFetching ? "visible" : "invisible"}`}
+          >
+            <LoadingBar />
+          </div>
+          <div className="py-4" />
+          <Table className="font-display select-none">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[80%]">Build</TableHead>
+                <TableHead className="w-[20%] text-center">Download</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {builds.results?.map(
+                ({
+                  id,
+                  version_name,
+                  version_code,
+                  mapping_type,
+                  download_url,
+                  last_updated,
+                }: any) => (
+                  <TableRow
+                    key={id}
+                    data-testid="build-row"
+                    className="font-body"
+                  >
+                    <TableCell className="w-[80%]">
+                      <p className="truncate select-none">{id}</p>
+                      <div className="py-1" />
+                      <p className="text-xs truncate text-muted-foreground select-none">
+                        {version_name +
+                          " (" +
+                          version_code +
+                          "), " +
+                          mapping_type +
+                          ", " +
+                          formatDateToHumanReadableDateTime(last_updated)}
+                      </p>
+                    </TableCell>
+                    <TableCell className="w-[20%] text-center">
+                      <Button variant="outline" asChild>
+                        <a
+                          href={`/api${download_url}`}
+                          download
+                          onClick={(e) => {
+                            e.preventDefault();
+                            downloadBuild(`/api${download_url}`);
+                          }}
+                        >
+                          Download
+                        </a>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -107,6 +107,12 @@ function buildInitNavData() {
             external: false,
           },
           {
+            title: "Builds",
+            url: "builds",
+            isActive: false,
+            external: false,
+          },
+          {
             title: "Team",
             url: "team",
             isActive: false,

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -69,6 +69,7 @@ export enum FiltersApiStatus {
   Error,
   NotOnboarded,
   NoData,
+  NoBuilds,
   Cancelled,
 }
 export enum SaveFiltersApiStatus {
@@ -82,6 +83,7 @@ export enum FilterSource {
   Events,
   Spans,
   Errors,
+  Builds,
 }
 
 export enum AppHealthPlotApiStatus {
@@ -417,6 +419,11 @@ export enum UpdateBugReportStatusApiStatus {
   Success,
   Error,
   Cancelled,
+}
+
+export enum BuildsApiStatus {
+  Success,
+  Error,
 }
 
 export enum AlertsOverviewApiStatus {
@@ -1087,6 +1094,22 @@ export const emptyBugReportsOverviewResponse = {
   }[],
 };
 
+export const emptyBuildsResponse = {
+  meta: {
+    next: false,
+    previous: false,
+  },
+  results: [] as {
+    id: string;
+    version_name: string;
+    version_code: string;
+    mapping_type: string;
+    download_url: string;
+    filesize: number;
+    last_updated: string;
+  }[],
+};
+
 export const emptyBugReport = {
   session_id: "",
   app_id: "",
@@ -1728,11 +1751,14 @@ export const fetchFiltersFromServer = async (
   // fetch the user defined attributes
   url += "?ud_attr_keys=1";
 
-  // if filter is for Spans or Errors we append a query param indicating it
+  // if filter is for Spans, Errors or Builds we append a query param
+  // indicating it
   if (filterSource === FilterSource.Spans) {
     url += "&span=1";
   } else if (filterSource === FilterSource.Errors) {
     url += "&type=error,anr";
+  } else if (filterSource === FilterSource.Builds) {
+    url += "&builds=1";
   }
 
   try {
@@ -1745,6 +1771,12 @@ export const fetchFiltersFromServer = async (
     const data = await res.json();
 
     if (data.versions === null) {
+      // Builds are uploaded independently of event data, so an empty
+      // builds source means no builds; the event-derived NoData and
+      // NotOnboarded split does not apply to it.
+      if (filterSource === FilterSource.Builds) {
+        return { status: FiltersApiStatus.NoBuilds, data: null };
+      }
       if (!selectedApp.onboarded) {
         return { status: FiltersApiStatus.NotOnboarded, data: null };
       } else {
@@ -2860,6 +2892,54 @@ export const updateBugReportStatusFromServer = async (
     return { status: UpdateBugReportStatusApiStatus.Success };
   } catch {
     return { status: UpdateBugReportStatusApiStatus.Cancelled };
+  }
+};
+
+// downloadBuild triggers a build mapping download. The download is a plain
+// browser navigation, which bypasses apiClient's 401 refresh interceptor, so
+// an authenticated endpoint is touched through apiClient first: an expired
+// access token gets refreshed before the navigation instead of failing it.
+export const downloadBuild = async (downloadUrl: string) => {
+  try {
+    const res = await apiClient.fetch(`/api/auth/session`);
+    if (!res.ok) {
+      // A non-ok probe means the refresh failed too: the session is dead
+      // and apiClient has already started the redirect to login. A hard
+      // navigation now would override that redirect and land the browser
+      // on the api's raw 401 body instead of the login page.
+      return;
+    }
+  } catch {
+    // A thrown probe is a network failure, not an auth failure. The
+    // session state is unknown rather than known-dead, so attempt the
+    // navigation anyway; the worst case is a failed download the user
+    // can retry.
+  }
+
+  window.location.assign(downloadUrl);
+};
+
+export const fetchBuildsFromServer = async (
+  filters: Filters,
+  limit: number,
+  offset: number,
+) => {
+  var url = `/api/apps/${filters.app!.id}/builds?`;
+
+  url = await applyGenericFiltersToUrl(url, filters, limit, offset);
+
+  try {
+    const res = await apiClient.fetch(url);
+
+    if (!res.ok) {
+      return { status: BuildsApiStatus.Error, data: null };
+    }
+
+    const data = await res.json();
+
+    return { status: BuildsApiStatus.Success, data: data };
+  } catch {
+    return { status: BuildsApiStatus.Error, data: null };
   }
 };
 

--- a/frontend/dashboard/app/components/app_breadcrumbs.tsx
+++ b/frontend/dashboard/app/components/app_breadcrumbs.tsx
@@ -25,6 +25,7 @@ const sectionTitles: Record<string, string> = {
   traces: "Traces",
   network: "Network",
   apps: "Apps",
+  builds: "Builds",
   team: "Team",
   notif_prefs: "Notifications",
   usage: "Usage",

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -87,6 +87,7 @@ interface FiltersProps {
   appVersionsInitialSelectionType: AppVersionsInitialSelectionType;
   showNoData: boolean;
   showNotOnboarded: boolean;
+  showNoBuilds?: boolean;
   showAppSelector: boolean;
   showDates: boolean;
   showAppVersions: boolean;
@@ -505,6 +506,7 @@ const FiltersComponent = forwardRef<
       appVersionsInitialSelectionType,
       showNoData,
       showNotOnboarded,
+      showNoBuilds = false,
       showAppSelector,
       showDates,
       showAppVersions,
@@ -559,6 +561,7 @@ const FiltersComponent = forwardRef<
         filterSource,
         showNoData,
         showNotOnboarded,
+        showNoBuilds,
         showAppSelector,
         showDates,
         showAppVersions,
@@ -580,6 +583,7 @@ const FiltersComponent = forwardRef<
       filterSource,
       showNoData,
       showNotOnboarded,
+      showNoBuilds,
       showAppSelector,
       showDates,
       showAppVersions,
@@ -1422,6 +1426,12 @@ const FiltersComponent = forwardRef<
                     No{" "}
                     {filterSource === FilterSource.Errors ? "errors" : "data"}{" "}
                     received for this app yet
+                  </p>
+                )}
+              {showNoBuilds &&
+                store.filtersApiStatus === FiltersApiStatus.NoBuilds && (
+                  <p className="font-body text-sm">
+                    No builds uploaded for this app yet
                   </p>
                 )}
               {showNotOnboarded &&

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -8,6 +8,7 @@ import {
   BugReportApiStatus,
   BugReportsOverviewApiStatus,
   BugReportsOverviewPlotApiStatus,
+  BuildsApiStatus,
   CreateAppApiStatus,
   CreateTeamApiStatus,
   DowngradeToFreeApiStatus,
@@ -81,6 +82,7 @@ import {
   fetchBugReportFromServer,
   fetchBugReportsOverviewFromServer,
   fetchBugReportsOverviewPlotFromServer,
+  fetchBuildsFromServer,
   fetchCheckoutSessionFromServer,
   fetchCustomerPortalUrlFromServer,
   fetchErrorGroupCommonPathFromServer,
@@ -233,8 +235,10 @@ export function useFilterOptionsQuery(
     ] as const,
     queryFn: async () => {
       // Fast path: never-onboarded apps return NotOnboarded for every
-      // filterSource. Skip the network round-trip.
-      if (!app!.onboarded) {
+      // event-derived filterSource, skipping the network round-trip. Builds
+      // can be uploaded before an app is onboarded, so the Builds source
+      // always asks the server.
+      if (!app!.onboarded && filterSource !== FilterSource.Builds) {
         return { status: FiltersApiStatus.NotOnboarded, data: null };
       }
       const r = await fetchFiltersFromServer(app!, filterSource);
@@ -847,6 +851,30 @@ export function useBugReportsOverviewQuery(paginationOffset: number) {
       );
       if (result.status === BugReportsOverviewApiStatus.Error) {
         throw new Error("Failed to fetch bug reports");
+      }
+      return result.data;
+    },
+    enabled: filters.ready,
+  });
+}
+
+// ─── Paginated: Builds ───────────────────────────────────────────────────
+
+const BUILDS_LIMIT = 10;
+
+export function useBuildsQuery(paginationOffset: number) {
+  const filters = useFiltersStore((s) => s.filters);
+  return useQuery({
+    queryKey: ["builds", filters.serialisedFilters, paginationOffset] as const,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const result = await fetchBuildsFromServer(
+        filters,
+        BUILDS_LIMIT,
+        paginationOffset,
+      );
+      if (result.status === BuildsApiStatus.Error) {
+        throw new Error("Failed to fetch builds");
       }
       return result.data;
     },

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -32,6 +32,7 @@ export type FilterConfig = {
   filterSource: FilterSource;
   showNoData: boolean;
   showNotOnboarded: boolean;
+  showNoBuilds: boolean;
   showAppSelector: boolean;
   showDates: boolean;
   showAppVersions: boolean;
@@ -488,40 +489,25 @@ function computeFilters(state: FiltersStoreState): Filters {
 
   const config = state.config;
 
-  let ready = false;
-  if (config.showNoData && config.showNotOnboarded) {
-    ready =
-      state.appsApiStatus === AppsApiStatus.Success &&
-      ((config.filterSource === FilterSource.Spans &&
-        state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
-        config.filterSource !== FilterSource.Spans) &&
-      state.filtersApiStatus === FiltersApiStatus.Success;
-  } else if (config.showNoData) {
-    ready =
-      state.appsApiStatus === AppsApiStatus.Success &&
-      ((config.filterSource === FilterSource.Spans &&
-        state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
-        config.filterSource !== FilterSource.Spans) &&
-      (state.filtersApiStatus === FiltersApiStatus.Success ||
-        state.filtersApiStatus === FiltersApiStatus.NotOnboarded);
-  } else if (config.showNotOnboarded) {
-    ready =
-      state.appsApiStatus === AppsApiStatus.Success &&
-      ((config.filterSource === FilterSource.Spans &&
-        state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
-        config.filterSource !== FilterSource.Spans) &&
-      (state.filtersApiStatus === FiltersApiStatus.Success ||
-        state.filtersApiStatus === FiltersApiStatus.NoData);
-  } else {
-    ready =
-      state.appsApiStatus === AppsApiStatus.Success &&
-      ((config.filterSource === FilterSource.Spans &&
-        state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
-        config.filterSource !== FilterSource.Spans) &&
-      (state.filtersApiStatus === FiltersApiStatus.Success ||
-        state.filtersApiStatus === FiltersApiStatus.NoData ||
-        state.filtersApiStatus === FiltersApiStatus.NotOnboarded);
-  }
+  // A filter options status counts toward ready when it is Success, or an
+  // empty state the page does not surface (its show* flag is false).
+  // Surfaced empty states hold ready back so the page renders the
+  // explanation instead of an empty view.
+  const filtersReady =
+    state.filtersApiStatus === FiltersApiStatus.Success ||
+    (!config.showNoData &&
+      state.filtersApiStatus === FiltersApiStatus.NoData) ||
+    (!config.showNotOnboarded &&
+      state.filtersApiStatus === FiltersApiStatus.NotOnboarded) ||
+    (!config.showNoBuilds &&
+      state.filtersApiStatus === FiltersApiStatus.NoBuilds);
+
+  const ready =
+    state.appsApiStatus === AppsApiStatus.Success &&
+    ((config.filterSource === FilterSource.Spans &&
+      state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+      config.filterSource !== FilterSource.Spans) &&
+    filtersReady;
 
   const updatedUrlFilters: URLFilters = {
     appId: state.selectedApp.id,

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -147,6 +147,8 @@ services:
       - PORT=8080
     develop:
       watch:
+        - path: ../backend/api
+          action: rebuild
         - path: ../backend/libs
           action: rebuild
     healthcheck:


### PR DESCRIPTION
# Description

- add a Builds page to the dashboard listing an app's uploaded build mappings, with a download button per mapping file and an explicit empty state for apps without builds
- add GET /apps/:id/builds to the api service
- add GET /apps/:id/builds/:buildId/download to the api service: it fetches the stored artifact, packages it the way its platform tooling expects (mapping.txt for proguard, original filenames for elf_debug and jsbundle, a reconstructed .dSYM bundle zip for dsym) and streams the download
- add a builds filter source: /filters?builds=1 derives version options from build_mappings instead of event data
- update mcp tool descriptions with the new filter option for builds.
- document the new endpoints and filter param in the dashboard API reference
- side improvement: serve the agent's attachment read proxy on self-host only. Not needed in cloud.
- side improvement: watch backend/api for rebuilds in compose


