### PR TITLE
Docs fixes

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - .github/workflows/dashboard.yml
       - "frontend/dashboard/**"
+      # The dashboard renders the docs: its prebuild copies docs/ into the
+      # site and several test suites run against that content
+      - "docs/**"
   push:
     branches:
       - "main"
     paths:
       - .github/workflows/dashboard.yml
       - "frontend/dashboard/**"
+      - "docs/**"
     tags:
       - "v*"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ how to leverage different features in your mobile applications. Also, review the
 feature's documentation to understand its underlying mechanism and enhance your ability to use it effectively.
 
 * [**Session Timelines**](features/feature-session-timelines.md) — Find and view session timelines
-* [**Crash Reporting**](features/feature-upload-symbols.md) — Analyze app crashes
+* [**Crash Reporting**](features/feature-crash-reporting.md) — Analyze app crashes
 * [**ANR Reporting**](features/feature-anr-reporting.md) — Analyze Application Not Responding (ANR) issues
 * [**Error Tracking**](features/feature-error-tracking.md) — Track and analyze handled errors in your app
 * [**Gesture Tracking**](features/feature-gesture-tracking.md) — Automatically track user gestures in your app
@@ -58,6 +58,7 @@ feature's documentation to understand its underlying mechanism and enhance your 
 * [**Slack Integration**](features/feature-slack-integration.md) — Connect Slack to receive alert notifications and daily summaries
 * [**MCP Server**](features/feature-mcp.md) — Let AI tools like Claude Code query your app's crash and error data
 * [**Measure Agent**](features/feature-agent.md) — Debug your app with full context, from your coding agent or Slack
+* [**Uploading Symbols**](features/feature-upload-symbols.md) — Symbolicate stack traces from crashes, ANRs and errors
 
 # Configuration Options
 

--- a/docs/features/feature-bug-report-android.md
+++ b/docs/features/feature-bug-report-android.md
@@ -47,7 +47,7 @@ Measure.launchBugReportActivity(takeScreenshot = false)
 
 ### Theming
 
-You can apply a custom theme by overriding any of the values in the theme: [themes.xml](https://github.com/measure-sh/measure/tree/main/android/measure-android/measure/src/main/res/values/themes.xml).
+You can apply a custom theme by overriding any of the values in the theme: [themes.xml](../../android/measure-android/measure/src/main/res/values/themes.xml).
 
 For more details on customizing themes, refer to the Android documentation on [theming](https://developer.android.com/develop/ui/views/theming/themes#CustomizeTheme).
 

--- a/docs/features/feature-crash-reporting.md
+++ b/docs/features/feature-crash-reporting.md
@@ -1,0 +1,152 @@
+---
+title: "Mobile Crash Reporting (Android, iOS, Flutter, React Native)"
+description: "Track crashes in Android, iOS, Flutter and React Native apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping and symbolicated stack traces."
+---
+
+# Crash Reporting
+
+Crashes are automatically tracked, optionally with a snapshot of the app's UI at the time of the crash. To get
+human-readable stack traces from obfuscated builds, see [Uploading Symbols](feature-upload-symbols.md).
+
+* [**Metrics**](#metrics)
+    * [Crash-Free Rate](#crash-free-rate)
+    * [Perceived Crash Rate](#perceived-crash-rate)
+* [**Get a UI Snapshot**](#get-a-ui-snapshot)
+* [**Crash Grouping**](#crash-grouping)
+* [**How It Works**](#how-it-works)
+
+> [!NOTE]  
+> Crash reporting for native crashes (from C/C++/etc.) is not yet supported. Track the progress [here](https://github.com/measure-sh/measure/issues/103). Upvote and comment on the issue if you are looking forward to this feature.
+
+## Metrics
+
+Metrics related to crashes are automatically computed and shown on the dashboard.
+
+![Crash metrics](../assets/crash-metrics.webp)
+
+### Crash-Free Rate
+
+The crash-free rate indicates the percentage of sessions that did not experience any crashes. It is calculated as follows:
+
+```
+Crash-Free Rate = (Total Sessions - Crashed Sessions) / Total Sessions * 100
+```
+
+Where:
+
+- **Total Sessions**: The total number of sessions recorded.
+- **Crashed Sessions**: The number of sessions that experienced a crash.
+- **Crash-Free Rate**: The percentage of sessions that did not crash.
+
+The crash-free rate is a key metric to monitor the stability of your app. A higher crash-free rate indicates a more stable app, while a lower rate suggests that users are experiencing issues that need to be addressed.
+
+### Perceived Crash Rate
+
+The perceived crash rate indicates the percentage of sessions that experienced a crash when the user was actively using the app. It is calculated as follows:
+
+```
+Perceived Crash Rate = Crashed Sessions When App Is in Foreground / Total Sessions * 100
+```
+
+Where:
+
+- **Crashed Sessions When App Is in Foreground**: The number of sessions that experienced a crash while the app was actively being used by the user.
+- **Total Sessions**: The total number of sessions recorded.
+
+## Get a UI Snapshot
+
+A screenshot of the app is captured when an app crashes. This feature is enabled by default and can be
+remotely configured on the dashboard under the "Apps" section. The following configuration options are available:
+
+- `Capture Screenshot on Crash` — Enables or disables the automatic screenshot capture on crash. It is enabled by default.
+- `Mask Sensitive Information` — Masks sensitive information in the screenshot by blurring text fields and
+  password fields. It is disabled by default.
+
+Note that on iOS a screenshot cannot be captured reliably at the time of crash, it instead captures a layout snapshot.
+
+## Crash Grouping
+
+Crashes are grouped to help you identify the most common issues in your app. Each group represents a unique crash, identified by the exception type and the stack trace. A percentage contribution of each crash group is also shown on the dashboard to get a quick idea about the impact of the issue.
+
+### Android
+
+Exceptions in Android (JVM) are grouped based on the exception type and the stack trace. Crashes with the same type and the same method name and file name from the _first frame_ of the stack trace are grouped together.
+
+For example, for the following crash, the exception type is `java.lang.NullPointerException`, the method name of the first frame is `onCreate` and the file name is `MainActivity.kt`:
+
+```
+java.lang.NullPointerException: Attempt to invoke virtual method 'void com.example.app.MainActivity.onCreate(android.os.Bundle)' on a null object reference
+    at com.example.app.MainActivity.onCreate(MainActivity.kt:10)
+    at android.app.Activity.performCreate(Activity.java:8000)
+    ...
+```
+
+### iOS
+
+Exceptions in iOS (Objective-C/Swift) are grouped based on the exception signal and the stack trace. Crashes with the same signal, for example, `SIGABRT`, the same method name and file name from the _first frame belonging to the application binary_ are grouped together.
+
+For example, for the following crash, the signal is `SIGABRT`, the method name of the first relevant frame is `-viewDidLoad` and the file name is `MainViewController.m`:
+
+```
+Exception Type: EXC_CRASH (SIGABRT)
+Exception Codes: 0x0000000000000000, 0x0000000000000000
+Crashed Thread: 0
+
+Application Specific Information:
+*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MainViewController viewDidLoad]: unrecognized selector sent to instance 0x600000e2c0c0'
+
+First Throw Call Stack:
+(
+    0   CoreFoundation                      0x000000010a2f3b6c __exceptionPreprocess + 220
+    1   libobjc.A.dylib                     0x0000000109d8e5e1 objc_exception_throw + 48
+    2   MainViewController.m                0x000000010a2f3b6c -[MainViewController viewDidLoad] + 0
+    ...
+)
+```
+
+### Flutter
+
+In Flutter, crashes are grouped based on the exception type and the stack trace. Crashes with the same exception type
+and the same method name and file name from the _first frame_ of the stack trace are grouped together.
+
+For example, for the following crash, the exception type is `FlutterError`, the method name of the first frame
+is `_incrementCounter` and the file name is `main.dart`:
+
+```
+FlutterError (setState() called after dispose(): _MyHomePageState#12345(ticker: _TickerModeEnabled))
+  at _MyHomePageState._incrementCounter (package:my_app/main.dart:42:9)
+  at _MyHomePageState.build (package:my_app/main.dart:30:5)
+  at StatelessElement.build (package:flutter/src/widgets/framework.dart:4620:27)
+  ...
+```
+
+### React Native
+
+In React Native, JS exceptions are grouped based on the error message and the stack trace. Crashes with the same
+message and the same function name and file name from the _first frame_ of the stack trace are grouped together.
+
+## How It Works
+
+### Android
+
+When an unhandled exception occurs, it is intercepted by Measure using an `UncaughtExceptionHandler`. The exception is then parsed and sent as an `exception` event. Crashes are attempted to be sent immediately, but if the app is terminated before the event is sent, it is stored locally and sent on the next app launch.
+
+### iOS
+
+We rely on [PLCrashReporter](https://github.com/microsoft/plcrashreporter) to detect crashes. When a crash occurs, a crash report is generated and stored locally on the device. On the next launch, the crash report is prepared and sent to the server.
+
+### Flutter
+
+When the SDK is initialized, it automatically sets up both `FlutterError.onError`
+and `PlatformDispatcher.instance.onError` callbacks. Any errors are forwarded to the server. Internally, we rely
+on [stack_trace](https://pub.dev/packages/stack_trace) to parse the stack trace and send it as an `exception` event. 
+
+All crashes captured by the native Android or iOS SDK are also tracked for Flutter apps.
+
+### React Native
+
+When the SDK is initialized, it automatically installs a global error handler via React Native's `ErrorUtils`
+and sets up an unhandled Promise rejection tracker. Any unhandled JS exceptions and promise rejections are captured
+and sent as `exception` events.
+
+All crashes captured by the underlying native Android or iOS SDKs are also tracked for React Native apps.

--- a/docs/features/feature-screenshot-masking-flutter.md
+++ b/docs/features/feature-screenshot-masking-flutter.md
@@ -4,8 +4,7 @@ description: "Mask sensitive content in Flutter widgets when Measure captures sc
 
 # Screenshot Masking for Flutter
 
-Measure captures screenshots on fatal erros, unhandled errors and bug reports. Before a screenshot leaves the device,
-sensitive content is redacted so it does not leak to the server.
+Measure captures screenshots on fatal errors, unhandled errors and bug reports. Before a screenshot leaves the device, sensitive content is redacted so it does not leak to the server.
 
 On Flutter, masking traverses the widget tree under the `MeasureWidget` and paints over the regions
 that match the configured [screenshot mask level](configuration-options.md#screenshot-mask-level).
@@ -16,7 +15,6 @@ that match the configured [screenshot mask level](configuration-options.md#scree
 * [**Mask Levels**](#mask-levels)
 * [**Manual Masking**](#manual-masking)
     * [**`MsrMask`**](#msrmask)
-* [**Examples**](#examples)
 
 # How Flutter Masking Works
 
@@ -43,11 +41,9 @@ and what each one redacts.
 
 # Manual Masking
 
-## `MsrMask` Widget
+## `MsrMask`
 
-Automatic detection covers standard text, input and image widgets. To always mask anything else,
-wrap it with `MsrMask`. The wrapped widget's area is always redacted, regardless of the configured 
-mask level.
+Automatic detection covers standard text, input and image widgets. To always mask anything else, wrap it with the `MsrMask` widget. The wrapped widget's area is always redacted, regardless of the configured mask level.
 
 ```dart
 MsrMask(

--- a/docs/features/feature-upload-symbols.md
+++ b/docs/features/feature-upload-symbols.md
@@ -1,147 +1,27 @@
 ---
-title: "Mobile Crash Reporting (Android, iOS, Flutter, React Native)"
-description: "Track crashes in Android, iOS, Flutter and React Native apps. Crash-free rate, perceived crash rate, UI snapshots, crash grouping and symbolicated stack traces."
+title: "Uploading Symbols (Android, iOS, Flutter, React Native)"
+description: "Upload ProGuard/R8 mapping files, dSYM files and JavaScript sourcemaps to symbolicate stack traces from crashes, ANRs and errors in Android, iOS, Flutter and React Native apps."
 ---
 
-# Crash Reporting
+# Uploading Symbols
 
-Crashes are automatically tracked, optionally with a snapshot of the app's UI at the time of the crash.
+Stack traces from crashes, ANRs and errors may be obfuscated or contain memory addresses. To convert the stack traces to a human-readable format, you need to upload the mapping or symbol files based on the platform.
 
-* [**Metrics**](#metrics)
-    * [Crash-Free Rate](#crash-free-rate)
-    * [Perceived Crash Rate](#perceived-crash-rate)
-* [**Get a UI Snapshot**](#get-a-ui-snapshot)
-* [**Crash Grouping**](#crash-grouping)
-* [**API Reference**](#api-reference)
-  * [**Symbolicate Stacktrace**](#symbolicate-stacktrace)
-* [**How It Works**](#how-it-works)
+* [**Android**](#android)
+* [**iOS**](#ios)
+* [**React Native**](#react-native)
+  * [Over the Air Update Symbolication](#over-the-air-update-symbolication)
+* [**Flutter**](#flutter)
 
-> [!NOTE]  
-> Crash reporting for native crashes (from C/C++/etc.) is not yet supported. Track the progress [here](https://github.com/measure-sh/measure/issues/103). Upvote and comment on the issue if you are looking forward to this feature.
-
-## Metrics
-
-Metrics related to crashes are automatically computed and shown on the dashboard.
-
-![Crash metrics](../assets/crash-metrics.webp)
-
-### Crash-Free Rate
-
-The crash-free rate indicates the percentage of sessions that did not experience any crashes. It is calculated as follows:
-
-```
-Crash-Free Rate = (Total Sessions - Crashed Sessions) / Total Sessions * 100
-```
-
-Where:
-
-- **Total Sessions**: The total number of sessions recorded.
-- **Crashed Sessions**: The number of sessions that experienced a crash.
-- **Crash-Free Rate**: The percentage of sessions that did not crash.
-
-The crash-free rate is a key metric to monitor the stability of your app. A higher crash-free rate indicates a more stable app, while a lower rate suggests that users are experiencing issues that need to be addressed.
-
-### Perceived Crash Rate
-
-The perceived crash rate indicates the percentage of sessions that experienced a crash when the user was actively using the app. It is calculated as follows:
-
-```
-Perceived Crash Rate = Crashed Sessions When App Is in Foreground / Total Sessions * 100
-```
-
-Where:
-
-- **Crashed Sessions When App Is in Foreground**: The number of sessions that experienced a crash while the app was actively being used by the user.
-- **Total Sessions**: The total number of sessions recorded.
-
-## Get a UI Snapshot
-
-A screenshot of the app is captured when an app crashes. This feature is enabled by default and can be
-remotely configured on the dashboard under the "Apps" section. The following configuration options are available:
-
-- `Capture Screenshot on Crash` — Enables or disables the automatic screenshot capture on crash. It is enabled by default.
-- `Mask Sensitive Information` — Masks sensitive information in the screenshot by blurring text fields and
-  password fields. It is disabled by default.
-
-Note that on iOS a screenshot cannot be captured reliably at the time of crash, it instead captures a layout snapshot.
-
-## Crash Grouping
-
-Crashes are grouped to help you identify the most common issues in your app. Each group represents a unique crash, identified by the exception type and the stack trace. A percentage contribution of each crash group is also shown on the dashboard to get a quick idea about the impact of the issue.
-
-### Android
-
-Exceptions in Android (JVM) are grouped based on the exception type and the stack trace. Crashes with the same type and the same method name and file name from the _first frame_ of the stack trace are grouped together.
-
-For example, for the following crash, the exception type is `java.lang.NullPointerException`, the method name of the first frame is `onCreate` and the file name is `MainActivity.kt`:
-
-```
-java.lang.NullPointerException: Attempt to invoke virtual method 'void com.example.app.MainActivity.onCreate(android.os.Bundle)' on a null object reference
-    at com.example.app.MainActivity.onCreate(MainActivity.kt:10)
-    at android.app.Activity.performCreate(Activity.java:8000)
-    ...
-```
-
-### iOS
-
-Exceptions in iOS (Objective-C/Swift) are grouped based on the exception signal and the stack trace. Crashes with the same signal, for example, `SIGABRT`, the same method name and file name from the _first frame belonging to the application binary_ are grouped together.
-
-For example, for the following crash, the signal is `SIGABRT`, the method name of the first relevant frame is `-viewDidLoad` and the file name is `MainViewController.m`:
-
-```
-Exception Type: EXC_CRASH (SIGABRT)
-Exception Codes: 0x0000000000000000, 0x0000000000000000
-Crashed Thread: 0
-
-Application Specific Information:
-*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MainViewController viewDidLoad]: unrecognized selector sent to instance 0x600000e2c0c0'
-
-First Throw Call Stack:
-(
-    0   CoreFoundation                      0x000000010a2f3b6c __exceptionPreprocess + 220
-    1   libobjc.A.dylib                     0x0000000109d8e5e1 objc_exception_throw + 48
-    2   MainViewController.m                0x000000010a2f3b6c -[MainViewController viewDidLoad] + 0
-    ...
-)
-```
-
-### Flutter
-
-In Flutter, crashes are grouped based on the exception type and the stack trace. Crashes with the same exception type
-and the same method name and file name from the _first frame_ of the stack trace are grouped together.
-
-For example, for the following crash, the exception type is `FlutterError`, the method name of the first frame
-is `_incrementCounter` and the file name is `main.dart`:
-
-```
-FlutterError (setState() called after dispose(): _MyHomePageState#12345(ticker: _TickerModeEnabled))
-  at _MyHomePageState._incrementCounter (package:my_app/main.dart:42:9)
-  at _MyHomePageState.build (package:my_app/main.dart:30:5)
-  at StatelessElement.build (package:flutter/src/widgets/framework.dart:4620:27)
-  ...
-```
-
-### React Native
-
-In React Native, JS exceptions are grouped based on the error message and the stack trace. Crashes with the same
-message and the same function name and file name from the _first frame_ of the stack trace are grouped together.
-
-
-## API Reference
-
-### Symbolicate Stacktrace
-
-Stack traces from crashes may be obfuscated or contain memory addresses. To convert the stack traces to a human-readable format, you need to upload the mapping or symbol files based on the platform.
-
-#### Android
+## Android
 
 If you are using ProGuard or R8 to obfuscate your code, you need to upload the mapping files to de-obfuscate the stack traces. Measure's Android Gradle Plugin automatically uploads the ProGuard/R8 mapping file to the Measure server when you run an `assemble` gradle task.
 
-#### iOS
+## iOS
 
 To symbolicate stack traces for iOS, you need to upload the dSYM files to map the memory addresses to a human-readable format. There are two ways to upload dSYM files:
 
-##### Using Shell Script
+### Using Shell Script
 
 Run the [`upload_dsym_manual.sh`](../../ios/Scripts/upload_dsym_manual.sh) script to manually upload dSYM files after building your app.
 
@@ -149,7 +29,7 @@ Run the [`upload_dsym_manual.sh`](../../ios/Scripts/upload_dsym_manual.sh) scrip
 ./upload_dsym_manual.sh <path_to_dsym_folder> <api_url> <api_key> <version_name> <version_code> <app_unique_id> <build_size> [custom_headers]
 ```
 
-##### Using XCArchive
+### Using XCArchive
 
 Run the [`upload_dsym_xcarchive.sh`](../../ios/Scripts/upload_dsym_xcarchive.sh) script to automatically upload dSYMs using `xcarchive` file. This script automatically extracts all necessary build metadata (version, build size, dSYM paths, etc.) directly from the generated .xcarchive. the `ipa` file is necessary to generate the build size info. If the ipa_path is not provided, the script uses the application binary to generate build size.
 
@@ -160,18 +40,18 @@ Run the [`upload_dsym_xcarchive.sh`](../../ios/Scripts/upload_dsym_xcarchive.sh)
 > [!CAUTION]  
 > If you are using Build Phases to upload DSYMs, make sure to **upload DSYMs only for release builds**.
 
-#### React Native
+## React Native
 
 React Native apps require sourcemaps to symbolicate JavaScript stack traces. The setup differs slightly between Android and iOS.
 
-##### Android
+### Android
 
 The Measure Android Gradle Plugin automatically captures and uploads the composed JavaScript sourcemap when you run `assembleRelease` or `bundleRelease`. No additional steps are required.
 
 > [!IMPORTANT]
 > Always use the sourcemap from the Gradle build output. Generating the sourcemap separately (e.g. via `npx react-native bundle`) produces a different bundle than what is embedded in the APK and will result in incorrect symbolication.
 
-##### iOS
+### iOS
 
 Add the `upload_build_phase.sh` script as a Run Script Build Phase in Xcode. It automatically uploads dSYM files and JavaScript sourcemaps in one step.
 
@@ -206,7 +86,7 @@ Replace the API URL and API key with your values from the Measure dashboard.
 > fi
 > ```
 
-##### Over the Air Update symbolication
+### Over the Air Update Symbolication
 
 Over-The-Air (OTA) updates let you ship JavaScript changes without a full native app release. When a crash occurs in a patched bundle, Measure needs the corresponding sourcemap to symbolicate the JavaScript stack trace.
 
@@ -216,7 +96,7 @@ The patch ID can be set in two ways:
 
 * **Manual** — You generate the patch ID yourself and pass it to `MeasureConfig`.
 
-###### Automated - Metro plugin (Expo)
+#### Automated - Metro Plugin (Expo)
 
 With this approach you only need to update the Metro config, the patch ID is injected into the bundle at build time, with no changes to your SDK initialisation code.
 
@@ -241,7 +121,7 @@ The export produces `.hbc.map` files under `dist/_expo/static/js/ios/` and `dist
 > [!IMPORTANT]
 > Always upload the sourcemaps from the same `expo export` run that produced the bundle. Generating the sourcemap separately produces a different bundle and will result in incorrect symbolication.
 
-###### Manual
+#### Manual
 
 Use this approach when you manage the OTA update yourself and do not use the Expo/Metro build pipeline.
 
@@ -282,7 +162,7 @@ npx react-native bundle \
   --sourcemap-output main.jsbundle.map
 ```
 
-###### Upload the Sourcemap
+#### Upload the Sourcemap
 
 Run `upload_patch.sh` after deploying each OTA update. The script is included with the SDK package.
 
@@ -309,7 +189,7 @@ Use this when you set `patchId` manually in `MeasureConfig`.
   "your-patch-uuid"
 ```
 
-#### Flutter
+## Flutter
 
 When obfuscating your Flutter app using --obfuscate and --split-debug-info options:
 
@@ -317,29 +197,3 @@ When obfuscating your Flutter app using --obfuscate and --split-debug-info optio
 * **iOS** — You need to upload the dSYM files as described in the iOS section above. After building
   with `flutter build ipa`, run the `upload_dsyms.sh` script using the IPA path and the path to the dSYM folder
   (typically under _/build/ios/Release-iphoneos/_)
-
-## How It Works
-
-### Android
-
-When an unhandled exception occurs, it is intercepted by Measure using an `UncaughtExceptionHandler`. The exception is then parsed and sent as an `exception` event. Crashes are attempted to be sent immediately, but if the app is terminated before the event is sent, it is stored locally and sent on the next app launch.
-
-### iOS
-
-We rely on [PLCrashReporter](https://github.com/microsoft/plcrashreporter) to detect crashes. When a crash occurs, a crash report is generated and stored locally on the device. On the next launch, the crash report is prepared and sent to the server.
-
-### Flutter
-
-When the SDK is initialized, it automatically sets up both `FlutterError.onError`
-and `PlatformDispatcher.instance.onError` callbacks. Any errors are forwarded to the server. Internally, we rely
-on [stack_trace](https://pub.dev/packages/stack_trace) to parse the stack trace and send it as an `exception` event. 
-
-All crashes captured by the native Android or iOS SDK are also tracked for Flutter apps.
-
-### React Native
-
-When the SDK is initialized, it automatically installs a global error handler via React Native's `ErrorUtils`
-and sets up an unhandled Promise rejection tracker. Any unhandled JS exceptions and promise rejections are captured
-and sent as `exception` events.
-
-All crashes captured by the underlying native Android or iOS SDKs are also tracked for React Native apps.

--- a/frontend/dashboard/__tests__/docs/docs_links_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_links_test.ts
@@ -1,0 +1,321 @@
+/**
+ * Verifies that internal links resolve across the docs and the app:
+ * relative links between docs pages point at files that exist, anchors
+ * point at real headings, images point at real assets, links that escape
+ * the docs tree point at real repo files, and /docs hrefs hardcoded in app
+ * code target real pages.
+ *
+ * Runs against content/docs, which pretest regenerates from the repo docs,
+ * so a broken link fails here before it ships.
+ */
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const CONTENT_DIR = path.join(ROOT, "content", "docs");
+const APP_DIR = path.join(ROOT, "app");
+const REPO_DOCS_DIR = path.resolve(ROOT, "..", "..", "docs");
+
+const hasContentDocs = fs.existsSync(CONTENT_DIR);
+
+function walkFiles(dir: string, extension: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, extension));
+    } else if (entry.name.endsWith(extension)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Blank out fenced code blocks so their contents are not mistaken for links
+ * or headings, while keeping line numbers intact.
+ */
+function blankFencedCode(markdown: string): string {
+  return markdown.replace(/```[\s\S]*?```/g, (block) =>
+    block.replace(/[^\n]/g, " "),
+  );
+}
+
+/**
+ * Additionally blank inline code spans, for link extraction only: heading
+ * extraction must keep them because code-span text stays in GitHub slugs.
+ */
+function blankOutCode(markdown: string): string {
+  return blankFencedCode(markdown).replace(/`[^`\n]*`/g, (span) =>
+    " ".repeat(span.length),
+  );
+}
+
+/**
+ * GitHub's heading-anchor algorithm, which rehype-slug also uses for the
+ * rendered site: lowercase, drop punctuation except hyphens and
+ * underscores, spaces become hyphens, and repeated slugs get -1, -2...
+ * suffixes in document order. Reimplemented here because github-slugger
+ * ships as ESM only, which jest does not transform.
+ */
+function githubSlugs(headings: string[]): Set<string> {
+  const counts = new Map<string, number>();
+  const slugs = new Set<string>();
+  for (const heading of headings) {
+    const base = heading
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, "")
+      .replace(/ /g, "-");
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+    slugs.add(count === 0 ? base : `${base}-${count}`);
+  }
+  return slugs;
+}
+
+/**
+ * Reduce a heading line to the text GitHub slugs: inline code keeps its
+ * text, links keep their label, emphasis markers and HTML tags drop.
+ */
+function headingText(line: string): string {
+  return line
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\*/g, "")
+    .replace(/\b_+|_+\b/g, "");
+}
+
+const anchorCache = new Map<string, Set<string>>();
+
+function anchorsFor(mdFile: string): Set<string> {
+  const cached = anchorCache.get(mdFile);
+  if (cached) {
+    return cached;
+  }
+  const content = blankFencedCode(fs.readFileSync(mdFile, "utf-8"));
+  const headings: string[] = [];
+  for (const match of content.matchAll(/^#{1,6}\s+(.+)$/gm)) {
+    headings.push(headingText(match[1]));
+  }
+  const anchors = githubSlugs(headings);
+  anchorCache.set(mdFile, anchors);
+  return anchors;
+}
+
+/** Slugs of every page the docs site serves, mirroring copy_docs.js. */
+function validDocsSlugs(): Set<string> {
+  const slugs = new Set<string>(["/docs"]);
+  for (const file of walkFiles(CONTENT_DIR, ".md")) {
+    const relPath = path.relative(CONTENT_DIR, file).replaceAll(path.sep, "/");
+    if (relPath.endsWith("README.md")) {
+      const dir = relPath.replace(/\/?README\.md$/, "");
+      slugs.add(dir === "" ? "/docs" : `/docs/${dir}`);
+    } else {
+      slugs.add(`/docs/${relPath.replace(/\.md$/, "")}`);
+    }
+  }
+  return slugs;
+}
+
+/** The docs page a slug is rendered from, for anchor lookups. */
+function mdFileForSlug(slug: string): string | null {
+  if (slug === "/docs") {
+    return path.join(CONTENT_DIR, "README.md");
+  }
+  const relPath = slug.replace(/^\/docs\//, "");
+  const asFile = path.join(CONTENT_DIR, `${relPath}.md`);
+  if (fs.existsSync(asFile)) {
+    return asFile;
+  }
+  const asDirReadme = path.join(CONTENT_DIR, relPath, "README.md");
+  if (fs.existsSync(asDirReadme)) {
+    return asDirReadme;
+  }
+  return null;
+}
+
+interface DocLink {
+  file: string;
+  line: number;
+  target: string;
+}
+
+function extractLinks(mdFile: string): DocLink[] {
+  const content = blankOutCode(fs.readFileSync(mdFile, "utf-8"));
+  const links: DocLink[] = [];
+  for (const match of content.matchAll(
+    /!?\[[^\]]*\]\(([^()\s]+)(?:\s+"[^"]*")?\)/g,
+  )) {
+    links.push({
+      file: path.relative(CONTENT_DIR, mdFile),
+      line: content.slice(0, match.index).split("\n").length,
+      target: match[1],
+    });
+  }
+  return links;
+}
+
+(hasContentDocs ? describe : describe.skip)("docs internal links", () => {
+  const allLinks = walkFiles(CONTENT_DIR, ".md").flatMap(extractLinks);
+
+  function describeLink(link: DocLink, reason: string): string {
+    return `${link.file}:${link.line} -> ${link.target} (${reason})`;
+  }
+
+  it("has links to check", () => {
+    expect(allLinks.length).toBeGreaterThan(0);
+  });
+
+  it("relative links resolve to existing files", () => {
+    const failures: string[] = [];
+
+    for (const link of allLinks) {
+      if (/^(https?:|mailto:|#|\/)/.test(link.target)) {
+        continue;
+      }
+      const [targetPath] = link.target.split("#");
+      const resolved = path.resolve(
+        CONTENT_DIR,
+        path.dirname(link.file),
+        targetPath,
+      );
+
+      if (resolved.startsWith(CONTENT_DIR + path.sep)) {
+        if (!fs.existsSync(resolved)) {
+          failures.push(describeLink(link, "file not found in docs"));
+        }
+        continue;
+      }
+
+      // Links that escape the docs tree render as GitHub blob URLs, so the
+      // target must exist in the repo. Skipped when the checkout does not
+      // include the repo root (content/docs prebuilt elsewhere).
+      if (fs.existsSync(REPO_DOCS_DIR)) {
+        const resolvedInRepo = path.resolve(
+          REPO_DOCS_DIR,
+          path.dirname(link.file),
+          targetPath,
+        );
+        if (!fs.existsSync(resolvedInRepo)) {
+          failures.push(describeLink(link, "file not found in repo"));
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("absolute /docs links point at real pages", () => {
+    const failures: string[] = [];
+    const slugs = validDocsSlugs();
+
+    for (const link of allLinks) {
+      if (!link.target.startsWith("/docs")) {
+        continue;
+      }
+      const [route] = link.target.split("#");
+      if (!slugs.has(route.replace(/\/$/, "") || "/docs")) {
+        failures.push(describeLink(link, "no docs page for this route"));
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("anchors point at real headings", () => {
+    const failures: string[] = [];
+
+    for (const link of allLinks) {
+      if (/^(https?:|mailto:)/.test(link.target)) {
+        continue;
+      }
+      const [targetPath, anchor] = link.target.split("#");
+      if (anchor === undefined || anchor === "") {
+        continue;
+      }
+
+      let targetFile: string | null;
+      if (targetPath === "") {
+        targetFile = path.join(CONTENT_DIR, link.file);
+      } else if (targetPath.startsWith("/docs")) {
+        targetFile = mdFileForSlug(targetPath.replace(/\/$/, ""));
+      } else {
+        targetFile = path.resolve(
+          CONTENT_DIR,
+          path.dirname(link.file),
+          targetPath,
+        );
+      }
+
+      if (
+        targetFile === null ||
+        !targetFile.endsWith(".md") ||
+        !fs.existsSync(targetFile)
+      ) {
+        // Missing files are reported by the resolution tests above
+        continue;
+      }
+
+      if (!anchorsFor(targetFile).has(anchor)) {
+        failures.push(describeLink(link, "no heading for this anchor"));
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+(hasContentDocs ? describe : describe.skip)("app links to docs", () => {
+  it("every /docs href in app code targets a real page and heading", () => {
+    const failures: string[] = [];
+    const slugs = validDocsSlugs();
+    const files = [...walkFiles(APP_DIR, ".ts"), ...walkFiles(APP_DIR, ".tsx")];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+      for (const match of content.matchAll(
+        /["'`](\/docs(?:\/[\w\-/.]*)?(?:#[\w-]*)?)["'`$]/g,
+      )) {
+        const [route, anchor] = match[1].split("#");
+        // A bare or trailing-slash /docs is a route prefix being
+        // concatenated with a dynamic slug, which cannot be checked here
+        const normalized = route.replace(/\/$/, "");
+        if (normalized === "/docs" && route !== "/docs") {
+          continue;
+        }
+        const line = content.slice(0, match.index).split("\n").length;
+        const lineText = lines[line - 1].trim();
+        if (lineText.startsWith("//") || lineText.startsWith("*")) {
+          continue;
+        }
+        const location = `${path.relative(ROOT, file)}:${line}`;
+
+        // A route with a file extension is a static asset fetch, served
+        // from public/ rather than rendered as a docs page
+        if (/\.\w+$/.test(normalized)) {
+          if (!fs.existsSync(path.join(ROOT, "public", normalized))) {
+            failures.push(`${location} -> ${match[1]} (no public asset)`);
+          }
+          continue;
+        }
+
+        if (!slugs.has(normalized)) {
+          failures.push(`${location} -> ${match[1]} (no docs page)`);
+          continue;
+        }
+        if (anchor) {
+          const targetFile = mdFileForSlug(normalized);
+          if (targetFile === null || !anchorsFor(targetFile).has(anchor)) {
+            failures.push(`${location} -> ${match[1]} (no heading)`);
+          }
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/frontend/dashboard/__tests__/docs/docs_links_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_links_test.ts
@@ -76,14 +76,31 @@ function githubSlugs(headings: string[]): Set<string> {
 }
 
 /**
+ * Strip HTML tags iteratively until the string stops changing, like
+ * stripHtmlTags in scripts/copy_docs.js: a single pass leaves a partial
+ * tag behind for nested input like `<scr<script>ipt>`. The regex always
+ * consumes at least 3 chars per match, so the loop terminates.
+ */
+function stripHtmlTags(input: string): string {
+  let out = input;
+  for (let i = 0; i < 50; i++) {
+    const next = out.replace(/<[^>]+>/g, "");
+    if (next === out) {
+      return next;
+    }
+    out = next;
+  }
+  return out;
+}
+
+/**
  * Reduce a heading line to the text GitHub slugs: inline code keeps its
  * text, links keep their label, emphasis markers and HTML tags drop.
  */
 function headingText(line: string): string {
-  return line
-    .replace(/`([^`]*)`/g, "$1")
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-    .replace(/<[^>]+>/g, "")
+  return stripHtmlTags(
+    line.replace(/`([^`]*)`/g, "$1").replace(/\[([^\]]*)\]\([^)]*\)/g, "$1"),
+  )
     .replace(/\*/g, "")
     .replace(/\b_+|_+\b/g, "");
 }

--- a/frontend/dashboard/__tests__/docs/docs_nav_links_test.tsx
+++ b/frontend/dashboard/__tests__/docs/docs_nav_links_test.tsx
@@ -1,5 +1,5 @@
 import DocsNavLinks from "@/app/docs/components/docs_nav_links";
-import { getFlatNavSlugs } from "@/app/docs/docs_nav";
+import { docsNav, getFlatNavSlugs } from "@/app/docs/docs_nav";
 import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/jest-globals";
@@ -29,9 +29,10 @@ describe("DocsNavLinks", () => {
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(1);
 
-    // Next link should point to Getting Started
-    expect(links[0]).toHaveAttribute("href", "/docs/sdk-integration-guide");
-    expect(links[0]).toHaveTextContent("Getting Started");
+    // Next link should point to the second page in nav order
+    expect(links[0]).toHaveAttribute("href", getFlatNavSlugs()[1]);
+    expect(links[0].textContent).toBeTruthy();
+    expect(links[0].textContent).not.toContain("Documentation");
   });
 
   it("renders only previous link on the last page", () => {
@@ -49,44 +50,52 @@ describe("DocsNavLinks", () => {
   });
 
   it("renders both previous and next links for a middle page", () => {
-    render(
-      <DocsNavLinks currentSlug="/docs/features/feature-crash-reporting" />,
-    );
+    // Any slug that is neither first nor last in the nav order works here
+    const flatSlugs = getFlatNavSlugs();
+    const middleSlug = flatSlugs[Math.floor(flatSlugs.length / 2)];
+    render(<DocsNavLinks currentSlug={middleSlug} />);
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(2);
   });
 
   it("shows correct previous and next titles", () => {
-    render(<DocsNavLinks currentSlug="/docs/sdk-integration-guide" />);
+    // The second page's previous link is the docs root, whose "Overview"
+    // title is a component constant rather than a nav title
+    const flatSlugs = getFlatNavSlugs();
+    render(<DocsNavLinks currentSlug={flatSlugs[1]} />);
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(2);
 
-    // Previous should be Overview (/docs)
     expect(links[0]).toHaveTextContent("Overview");
     expect(links[0]).toHaveAttribute("href", "/docs");
 
-    // Next should be the first Features item
-    expect(links[1]).toHaveTextContent("Session Timeline");
-    expect(links[1]).toHaveAttribute(
-      "href",
-      "/docs/features/feature-session-timelines",
-    );
+    expect(links[1]).toHaveAttribute("href", flatSlugs[2]);
+    expect(links[1].textContent).toBeTruthy();
+    expect(links[1].textContent).not.toContain("Documentation");
   });
 
   it("resolves nested nav item titles correctly", () => {
-    // Bug Reports > Android is a deeply nested item
-    render(
-      <DocsNavLinks currentSlug="/docs/features/feature-bug-report-android" />,
+    // A leaf two levels deep exercises the recursive title lookup
+    const outerGroup = docsNav.find((item) =>
+      (item.children ?? []).some((child) => (child.children ?? []).length > 0),
     );
+    expect(outerGroup).toBeDefined();
+    const nestedGroup = outerGroup!.children!.find(
+      (child) => (child.children ?? []).length > 0,
+    );
+    const nestedLeaf = nestedGroup!.children!.find((child) => child.slug);
+    expect(nestedLeaf).toBeDefined();
+
+    render(<DocsNavLinks currentSlug={nestedLeaf!.slug!} />);
 
     const links = screen.getAllByRole("link");
     expect(links.length).toBeGreaterThanOrEqual(1);
 
     // Verify that link text is a real title, not "Documentation" fallback
     for (const link of links) {
-      expect(link.textContent).not.toBe("Documentation");
+      expect(link.textContent).not.toContain("Documentation");
     }
   });
 });

--- a/frontend/dashboard/__tests__/docs/docs_nav_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_nav_test.ts
@@ -39,27 +39,66 @@ describe("buildClusters", () => {
 
 describe("findSectionTitle", () => {
   it("returns the cluster label for pages inside a labeled cluster", () => {
-    expect(findSectionTitle("/docs/features/feature-crash-reporting")).toBe(
-      "Features",
-    );
+    // Samples are derived from the nav so a doc rename cannot break the test
+    const pairs = docsNav
+      .filter((item) => (item.children ?? []).length > 0)
+      .map((group) => ({
+        label: group.title,
+        leaf: group.children!.find((child) => child.slug),
+      }))
+      .filter((pair) => pair.leaf);
+    expect(pairs.length).toBeGreaterThan(0);
+
+    for (const { label, leaf } of pairs) {
+      expect(findSectionTitle(leaf!.slug!)).toBe(label);
+    }
   });
 
   it("returns the label for trailing leaves merged into the previous cluster", () => {
-    expect(findSectionTitle("/docs/features/configuration-options")).toBe(
-      "Features",
-    );
-    expect(findSectionTitle("/docs/features/performance-impact")).toBe(
-      "Features",
-    );
+    // Top-level leaves that follow a labeled group belong to that group's cluster
+    let lastGroupTitle: string | null = null;
+    const trailing: Array<{ slug: string; label: string }> = [];
+    for (const item of docsNav) {
+      if ((item.children ?? []).length > 0) {
+        lastGroupTitle = item.title;
+      } else if (lastGroupTitle && item.slug) {
+        trailing.push({ slug: item.slug, label: lastGroupTitle });
+      }
+    }
+    expect(trailing.length).toBeGreaterThan(0);
+
+    for (const { slug, label } of trailing) {
+      expect(findSectionTitle(slug)).toBe(label);
+    }
   });
 
   it("returns the label for nested group children", () => {
-    const title = findSectionTitle("/docs/features/feature-bug-report-android");
-    expect(title).toBe("Features");
+    const outerGroup = docsNav.find((item) =>
+      (item.children ?? []).some((child) => (child.children ?? []).length > 0),
+    );
+    expect(outerGroup).toBeDefined();
+    const nestedGroup = outerGroup!.children!.find(
+      (child) => (child.children ?? []).length > 0,
+    );
+    const leaf = nestedGroup!.children!.find((child) => child.slug);
+    expect(leaf).toBeDefined();
+
+    expect(findSectionTitle(leaf!.slug!)).toBe(outerGroup!.title);
   });
 
   it("returns null for pages in the unlabeled lead cluster", () => {
-    expect(findSectionTitle("/docs/sdk-integration-guide")).toBeNull();
+    const firstGroupIndex = docsNav.findIndex(
+      (item) => (item.children ?? []).length > 0,
+    );
+    expect(firstGroupIndex).toBeGreaterThan(0);
+    const leadLeaves = docsNav
+      .slice(0, firstGroupIndex)
+      .filter((item) => item.slug);
+    expect(leadLeaves.length).toBeGreaterThan(0);
+
+    for (const leaf of leadLeaves) {
+      expect(findSectionTitle(leaf.slug!)).toBeNull();
+    }
   });
 
   it("returns null for slugs missing from the nav", () => {
@@ -191,23 +230,21 @@ describe("getFlatNavSlugs", () => {
   });
 
   it("preserves depth-first traversal order", () => {
-    const slugs = getFlatNavSlugs();
+    function collectDfs(items: NavItem[]): string[] {
+      const slugs: string[] = [];
+      for (const item of items) {
+        if (item.slug) {
+          slugs.push(item.slug);
+        }
+        if (item.children) {
+          slugs.push(...collectDfs(item.children));
+        }
+      }
+      return slugs;
+    }
 
-    // Getting Started should come before Features children
-    const gettingStarted = slugs.indexOf("/docs/sdk-integration-guide");
-    const sessionTimelines = slugs.indexOf(
-      "/docs/features/feature-session-timelines",
-    );
-
-    expect(gettingStarted).toBeLessThan(sessionTimelines);
-
-    // SDK Upgrade Guides should come after Performance Impact
-    const performanceImpact = slugs.indexOf(
-      "/docs/features/performance-impact",
-    );
-    const upgradeGuides = slugs.indexOf("/docs/sdk-upgrade-guides");
-
-    expect(performanceImpact).toBeLessThan(upgradeGuides);
+    // The flat list is the docs root followed by a depth-first walk of the tree
+    expect(getFlatNavSlugs()).toEqual(["/docs", ...collectDfs(docsNav)]);
   });
 
   it("contains more entries than top-level nav items due to nested children", () => {

--- a/frontend/dashboard/__tests__/scripts/generate_sitemap_test.ts
+++ b/frontend/dashboard/__tests__/scripts/generate_sitemap_test.ts
@@ -110,7 +110,7 @@ describe("isExcluded", () => {
 
   it("returns false for docs routes", () => {
     expect(isExcluded("/docs")).toBe(false);
-    expect(isExcluded("/docs/features/feature-crash-reporting")).toBe(false);
+    expect(isExcluded("/docs/features/feature-example")).toBe(false);
   });
 });
 
@@ -180,22 +180,54 @@ describe("getDocsSlugs", () => {
     });
 
     it("includes subdirectory README.md as directory slug", () => {
+      // A subdirectory README maps to the directory's own slug
+      const dirWithReadme = fs
+        .readdirSync(contentDir, { withFileTypes: true })
+        .find(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== "assets" &&
+            fs.existsSync(path.join(contentDir, e.name, "README.md")),
+        );
+      expect(dirWithReadme).toBeDefined();
+
       const slugs = getDocsSlugs();
 
-      // hosting/README.md should produce /docs/hosting
-      expect(slugs).toContain("/docs/hosting");
+      expect(slugs).toContain(`/docs/${dirWithReadme!.name}`);
     });
 
     it("includes regular .md files as page slugs", () => {
+      const topLevelMd = fs
+        .readdirSync(contentDir)
+        .find((f) => f.endsWith(".md") && f !== "README.md");
+      expect(topLevelMd).toBeDefined();
+
       const slugs = getDocsSlugs();
 
-      expect(slugs).toContain("/docs/sdk-integration-guide");
+      expect(slugs).toContain(`/docs/${topLevelMd!.replace(/\.md$/, "")}`);
     });
 
     it("includes nested .md files with full path", () => {
+      // Derive the expected slug from a real nested .md file so the test
+      // does not depend on a particular doc file existing
+      let expected: string | null = null;
+      const subDirs = fs
+        .readdirSync(contentDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && e.name !== "assets");
+      for (const dir of subDirs) {
+        const mdFile = fs
+          .readdirSync(path.join(contentDir, dir.name))
+          .find((f) => f.endsWith(".md") && f !== "README.md");
+        if (mdFile) {
+          expected = `/docs/${dir.name}/${mdFile.replace(/\.md$/, "")}`;
+          break;
+        }
+      }
+      expect(expected).not.toBeNull();
+
       const slugs = getDocsSlugs();
 
-      expect(slugs).toContain("/docs/features/feature-crash-reporting");
+      expect(slugs).toContain(expected);
     });
 
     it("does not include assets directory contents", () => {
@@ -347,13 +379,13 @@ describe("main", () => {
 
     main();
 
-    expect(writtenContent).toContain(
-      `<loc>${SITE_URL}/docs/sdk-integration-guide</loc>`,
-    );
-    expect(writtenContent).toContain(`<loc>${SITE_URL}/docs/hosting</loc>`);
-    expect(writtenContent).toContain(
-      `<loc>${SITE_URL}/docs/features/feature-crash-reporting</loc>`,
-    );
+    // getDocsSlugs is itself validated against the filesystem above, so
+    // checking every slug it returns keeps this free of hardcoded pages
+    const docSlugs = getDocsSlugs();
+    expect(docSlugs.length).toBeGreaterThan(0);
+    for (const slug of docSlugs) {
+      expect(writtenContent).toContain(`<loc>${SITE_URL}${slug}</loc>`);
+    }
   });
 
   it("produces sorted URLs", () => {

--- a/frontend/dashboard/app/docs/components/md_components.tsx
+++ b/frontend/dashboard/app/docs/components/md_components.tsx
@@ -129,7 +129,15 @@ function stripAdmonitionMarker(children: React.ReactNode): React.ReactNode {
           }
           continue;
         }
-        out.push(transformed);
+        // The rebuilt array renders as dynamic children, so element entries
+        // need keys. react-markdown keys its elements, but children can also
+        // arrive unkeyed. The source index is a stable identity here because
+        // the transform never reorders entries.
+        out.push(
+          React.isValidElement(transformed) && transformed.key === null
+            ? React.cloneElement(transformed, { key: i })
+            : transformed,
+        );
       }
       return out;
     }

--- a/ios/Scripts/upload_dsym_manual.sh
+++ b/ios/Scripts/upload_dsym_manual.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#ios.
-
 if [ "$#" -lt 7 ]; then
   echo "Usage: $0 <path_to_dsym_folder> <api_url> <api_key> <version_name> <version_code> <app_unique_id> <build_size> [options]"
   echo ""

--- a/ios/Scripts/upload_dsym_manual.sh
+++ b/ios/Scripts/upload_dsym_manual.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-crash-reporting.md#ios-1.
+# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#ios.
 
 if [ "$#" -lt 7 ]; then
   echo "Usage: $0 <path_to_dsym_folder> <api_url> <api_key> <version_name> <version_code> <app_unique_id> <build_size> [options]"

--- a/ios/Scripts/upload_dsym_xcarchive.sh
+++ b/ios/Scripts/upload_dsym_xcarchive.sh
@@ -4,7 +4,6 @@
 #   ./upload_dsym.sh <path_to_xcarchive> <api_url> <api_key> [custom_headers] [ipa_path]
 # Example:
 #   ./upload_dsym.sh MyApp.xcarchive https://api.example.com abc123 'X-Custom-1: val1|X-Custom-2: val2' ./MyApp.ipa
-# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#ios.
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <path_to_xcarchive> <api_url> <api_key> [custom_headers] [ipa_path]"

--- a/ios/Scripts/upload_dsym_xcarchive.sh
+++ b/ios/Scripts/upload_dsym_xcarchive.sh
@@ -4,7 +4,7 @@
 #   ./upload_dsym.sh <path_to_xcarchive> <api_url> <api_key> [custom_headers] [ipa_path]
 # Example:
 #   ./upload_dsym.sh MyApp.xcarchive https://api.example.com abc123 'X-Custom-1: val1|X-Custom-2: val2' ./MyApp.ipa
-# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-crash-reporting.md#ios-1.
+# Checkout the documentation for more details https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#ios.
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <path_to_xcarchive> <api_url> <api_key> [custom_headers] [ipa_path]"

--- a/react-native/scripts/upload_build_phase.sh
+++ b/react-native/scripts/upload_build_phase.sh
@@ -15,7 +15,7 @@
 # code and images" build phase:
 #   export SOURCEMAP_FILE="$(pwd)/main.jsbundle.map"
 #
-# See https://github.com/measure-sh/measure/blob/main/docs/features/feature-crash-reporting.md
+# See https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#react-native
 
 if [ "$#" -lt 2 ]; then
   echo "Usage: $0 <api_url> <api_key>"


### PR DESCRIPTION
# Description

- Restored the crash reporting doc at its original URL, undoing the rename from #4005 that broke four dashboard tests and killed an SEO-indexed page
- Extracted the symbol upload instructions into a new Uploading Symbols page covering crashes, ANRs and errors, placed in the sidebar after Measure Agent, with the crash doc, integration guide and upload scripts pointing at it
- Rewrote the docs test suites to derive their sample pages from the nav and filesystem, so no doc rename can break them again
- Fixed a React missing-key warning by keying the children that the docs callout transform rebuilds
- Added a broken-links test suite that validates every internal docs link, anchor, image and app-code /docs href, which caught and fixed two dead links in the Flutter screenshot masking doc
- Made dashboard CI run on docs changes, closing the gap that let #4005 land with broken tests
- Converted the one absolute repo link in docs to relative so the link test covers it, and removed docs backlinks from the iOS upload scripts so docs restructures can't strand them



