### PR TITLE
refactor(android): move session ANR marking to SessionManager

### DIFF
--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -281,8 +281,6 @@ internal class TestMeasureInitializer(
         processInfo = processInfoProvider,
         signalProcessor = signalProcessor,
         nativeBridge = nativeBridgeImpl,
-        database = database,
-        sessionManager = sessionManager,
     ),
     private val appExitProvider: AppExitProvider = AppExitProviderImpl(
         logger = logger,
@@ -291,7 +289,6 @@ internal class TestMeasureInitializer(
     override val appExitCollector: AppExitCollector = AppExitCollector(
         appExitProvider = appExitProvider,
         signalProcessor = signalProcessor,
-        database = database,
         sessionManager = sessionManager,
     ),
     override val cpuUsageCollector: CpuUsageCollector = CpuUsageCollector(
@@ -376,7 +373,6 @@ internal class TestMeasureInitializer(
         timeProvider = timeProvider,
         ioExecutor = executorServiceRegistry.ioExecutor(),
         sampler = sampler,
-        database = database,
         sessionManager = sessionManager,
     ),
     override val networkChangesCollector: NetworkChangesCollector = NetworkChangesCollector(

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -331,7 +331,6 @@ internal class MeasureInitializerImpl(
     override val appExitCollector: AppExitCollector = AppExitCollector(
         appExitProvider = appExitProvider,
         signalProcessor = signalProcessor,
-        database = database,
         sessionManager = sessionManager,
     ),
     override val cpuUsageCollector: CpuUsageCollector = CpuUsageCollector(
@@ -428,7 +427,6 @@ internal class MeasureInitializerImpl(
         timeProvider = timeProvider,
         ioExecutor = executorServiceRegistry.ioExecutor(),
         sampler = sampler,
-        database = database,
         sessionManager = sessionManager,
     ),
     override val networkChangesCollector: NetworkChangesCollector = NetworkChangesCollector(

--- a/android/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/SessionManager.kt
@@ -8,6 +8,7 @@ import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.storage.Database
 import sh.measure.android.storage.SessionEntity
+import sh.measure.android.storage.SessionRecord
 import sh.measure.android.tracing.InternalTrace
 import sh.measure.android.utils.IdProvider
 import sh.measure.android.utils.PackageInfoProvider
@@ -63,6 +64,52 @@ internal interface SessionManager {
      * Called when config is loaded.
      */
     fun onConfigLoaded()
+
+    /**
+     * Records that [sessionId] experienced an ANR at [anrTimeMs], so that signals delivered
+     * later (e.g. profiles finalized after a relaunch) can be attributed to the session that
+     * was live when the ANR occurred. Runs synchronously as it is called on the ANR'd thread,
+     * which may not survive.
+     */
+    fun markSessionWithAnr(sessionId: String, anrTimeMs: Long)
+
+    /**
+     * Returns the session to attribute an app exit to, given the process ID the
+     * exit was reported for. Sessions already marked by [markSessionsAppExitTracked]
+     * are ignored.
+     *
+     * @param pid The process ID the app exit was reported for.
+     * @return Session data if found, `null` otherwise.
+     */
+    fun getSessionForAppExit(pid: Int): SessionRecord?
+
+    /**
+     * Marks all sessions except the current one as having had their app exit
+     * tracked, hiding them from [getSessionForAppExit] so an app exit is never
+     * reported twice.
+     */
+    fun markSessionsAppExitTracked()
+
+    /**
+     * Returns the session that was active at the given time, based on session
+     * start times.
+     *
+     * @param timeMs Time in milliseconds since epoch.
+     * @return Session data if a session started at or before [timeMs], `null` otherwise.
+     */
+    fun getSessionForTime(timeMs: Long): SessionRecord?
+
+    /**
+     * Returns the most recent session that had an ANR at or before [timeMs] and
+     * within [maxGapMs] of it. Used to attribute an ANR profile back to the
+     * session where the ANR happened, even after a relaunch. The gap bounds the
+     * lookup so a profile is never attributed to a stale, unrelated ANR.
+     *
+     * @param timeMs The profile's capture time in milliseconds since epoch.
+     * @param maxGapMs The maximum allowed gap between the ANR and [timeMs].
+     * @return Session data if a matching ANR session is found, `null` otherwise.
+     */
+    fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord?
 
     /**
      * Sets a listener to be called when a new session is created.
@@ -161,6 +208,20 @@ internal class SessionManagerImpl(
             }
         }
     }
+
+    override fun markSessionWithAnr(sessionId: String, anrTimeMs: Long) {
+        database.setSessionAnrTime(sessionId, anrTimeMs)
+    }
+
+    override fun getSessionForAppExit(pid: Int): SessionRecord? = database.getSessionForAppExit(pid)
+
+    override fun markSessionsAppExitTracked() {
+        database.markSessionsAppExitTracked(excludeSessionId = getSessionId())
+    }
+
+    override fun getSessionForTime(timeMs: Long): SessionRecord? = database.getSessionForTime(timeMs)
+
+    override fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord? = database.getSessionForAnr(timeMs, maxGapMs)
 
     override fun setSessionStartListener(listener: SessionStartListener) {
         this.sessionStartListener = listener

--- a/android/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/appexit/AppExitCollector.kt
@@ -5,11 +5,9 @@ import androidx.annotation.RequiresApi
 import sh.measure.android.SessionManager
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
-import sh.measure.android.storage.Database
 
 internal class AppExitCollector(
     private val appExitProvider: AppExitProvider,
-    private val database: Database,
     private val signalProcessor: SignalProcessor,
     private val sessionManager: SessionManager,
 ) {
@@ -25,7 +23,7 @@ internal class AppExitCollector(
         appExitsMap.forEach {
             val pid = it.key
             val appExit = it.value
-            val session = database.getSessionForAppExit(pid)
+            val session = sessionManager.getSessionForAppExit(pid)
             // Limiting tracking of app exit events to just
             // ANRs for now.
             if (session != null && appExit.isANR()) {
@@ -44,9 +42,9 @@ internal class AppExitCollector(
                 )
                 // backfills the ANR time for a session where the real-time
                 // detector's write may have been lost to a fast kill.
-                database.setSessionAnrTime(session.id, appExit.app_exit_time_ms)
+                sessionManager.markSessionWithAnr(session.id, appExit.app_exit_time_ms)
             }
         }
-        database.markSessionsAppExitTracked(excludeSessionId = sessionManager.getSessionId())
+        sessionManager.markSessionsAppExitTracked()
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/SignalProcessor.kt
@@ -312,10 +312,12 @@ internal class SignalProcessorImpl(
         }
 
         applyAttributes(event, thread)
-        signalStore.store(
-            event,
-            sessionAnrTimeMs = if (event.type == EventType.ANR) timestamp else null,
-        )
+        if (event.type == EventType.ANR) {
+            // Stamped before the store so a profile can be attributed to this session even
+            // if the event insert fails or the process dies mid-store.
+            sessionManager.markSessionWithAnr(event.sessionId, timestamp)
+        }
+        signalStore.store(event)
         onEventTracked(event)
         exporter.export()
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/profiling/ProfileCollector.kt
@@ -13,7 +13,6 @@ import sh.measure.android.events.SignalProcessor
 import sh.measure.android.executors.MeasureExecutorService
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
-import sh.measure.android.storage.Database
 import sh.measure.android.utils.Sampler
 import sh.measure.android.utils.SystemServiceProvider
 import sh.measure.android.utils.TimeProvider
@@ -37,7 +36,6 @@ internal class ProfileCollector(
     private val timeProvider: TimeProvider,
     private val ioExecutor: MeasureExecutorService,
     private val sampler: Sampler,
-    private val database: Database,
     private val sessionManager: SessionManager,
 ) {
     private var resultCallback: Consumer<ProfilingResult>? = null
@@ -98,6 +96,7 @@ internal class ProfileCollector(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     private fun triggerTypes(): IntArray = intArrayOf(
         ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN,
         ProfilingTrigger.TRIGGER_TYPE_ANR,
@@ -141,17 +140,25 @@ internal class ProfileCollector(
             return
         }
         val profileTimeMs = profileTimeFor(file)
-        // An ANR profile's file time is the trace finalization time, which can drift
-        // past a relaunch, so attribute it to the session that actually had an ANR near
-        // that time, and stamp it with the ANR time so it lands in that session's window.
-        // Other profiles are captured while the app is alive, so the session active at
-        // the profile time is correct.
+        // Matching a received profile to the correct session is based on
+        // the following heuristics. This applies to ANRs as the profiles
+        // for an ANR may arrive in the next app launch.
+        //
+        // 1. When an ANR happens the time is written to the sessions table.
+        // 2. When an ANR profile is received, the session with the most recent
+        //    ANR marked in the sessions table (including the current session)
+        //    is returned, provided that ANR happened at most
+        //    MAX_ANR_TO_PROFILE_GAP_MS before the profile time — a profile is
+        //    created within seconds of its ANR, so an older match would be a
+        //    stale, unrelated ANR.
+        // 3. Otherwise, and for all other profile types, the profile is
+        //    attributed to the active session.
         val anrSession = if (reason == REASON_ANR) {
-            database.getSessionForAnr(profileTimeMs, MAX_ANR_TO_PROFILE_GAP_MS)
+            sessionManager.getSessionForAnr(profileTimeMs, MAX_ANR_TO_PROFILE_GAP_MS)
         } else {
             null
         }
-        val session = anrSession ?: database.getSessionForTime(profileTimeMs)
+        val session = anrSession ?: sessionManager.getSessionForTime(profileTimeMs)
         signalProcessor.trackProfile(
             data = ProfileData(reason = reason, format = format),
             timestamp = anrSession?.lastAnrTime ?: profileTimeMs,
@@ -166,24 +173,19 @@ internal class ProfileCollector(
         )
     }
 
+    // the platform stamps the file name with device-local wall clock time.
+    // e.g. profile_trigger-type-2_2026-07-13-18-52-49.perfetto-trace.
     private fun profileTimeFor(file: File): Long {
-        parseProfileTimestamp(file.name)?.let { return it }
-        val lastModified = file.lastModified()
-        if (lastModified > 0) {
-            return lastModified
+        val timestamp = TIMESTAMP_REGEX.find(file.name)?.value?.let {
+            try {
+                SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US).parse(it)?.time
+            } catch (_: ParseException) {
+                null
+            }
         }
-        return timeProvider.now()
-    }
-
-    // the platform stamps the file name with device-local wall clock time,
-    // e.g. profile_trigger-type-2_2026-07-05-17-51-56-124_uid-10229.perfetto-trace
-    private fun parseProfileTimestamp(fileName: String): Long? {
-        val timestamp = TIMESTAMP_REGEX.find(fileName)?.value ?: return null
-        return try {
-            SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US).parse(timestamp)?.time
-        } catch (e: ParseException) {
-            null
-        }
+        return timestamp
+            ?: file.lastModified().takeIf { it > 0 }
+            ?: timeProvider.now()
     }
 
     private fun formatFor(fileName: String): String? = when {
@@ -204,13 +206,10 @@ internal class ProfileCollector(
         private const val PERFETTO_TRACE_EXTENSION = ".perfetto-trace"
         private const val HEAP_DUMP_EXTENSION = ".hprof"
         private const val HEAP_PROFILE_EXTENSION = ".heapprofd"
-        private const val TIMESTAMP_PATTERN = "yyyy-MM-dd-HH-mm-ss-SSS"
-        private val TIMESTAMP_REGEX = Regex("\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}")
+        private const val TIMESTAMP_PATTERN = "yyyy-MM-dd-HH-mm-ss"
+        private val TIMESTAMP_REGEX = Regex("\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}")
         private const val REASON_APP_FULLY_DRAWN = "app_fully_drawn"
         private const val REASON_ANR = "anr"
-
-        // Bounds how far before a profile's capture time an ANR may have occurred
-        // to be considered its origin, so a stale, unrelated ANR is never matched.
         private const val MAX_ANR_TO_PROFILE_GAP_MS = 3 * 60 * 1000L
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -88,11 +88,9 @@ internal interface Database : Closeable {
      * Inserts an event and its associated attachments in a single transaction.
      *
      * @param event The event entity to insert.
-     * @param sessionAnrTimeMs When non-null, records this ANR time against the event's
-     * session in the same transaction. See [setSessionAnrTime].
      * @return `true` if successful, `false` otherwise.
      */
-    fun insertEvent(event: EventEntity, sessionAnrTimeMs: Long? = null): Boolean
+    fun insertEvent(event: EventEntity): Boolean
 
     /**
      * Retrieves event packets for the given event IDs.
@@ -525,7 +523,7 @@ internal class DatabaseImpl(
     // ========================================================================================
 
     @SuppressLint("UseKtx")
-    override fun insertEvent(event: EventEntity, sessionAnrTimeMs: Long?): Boolean {
+    override fun insertEvent(event: EventEntity): Boolean {
         writableDatabase.beginTransaction()
         try {
             val values = ContentValues().apply {
@@ -571,11 +569,6 @@ internal class DatabaseImpl(
                     )
                     return false
                 }
-            }
-            if (sessionAnrTimeMs != null) {
-                writableDatabase
-                    .compileStatement(Sql.setSessionAnrTime(event.sessionId, sessionAnrTimeMs))
-                    .use { it.executeUpdateDelete() }
             }
             writableDatabase.setTransactionSuccessful()
             return true

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/SignalStore.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface SignalStore {
-    fun <T> store(event: Event<T>, sessionAnrTimeMs: Long? = null)
+    fun <T> store(event: Event<T>)
     fun store(spanData: SpanData)
     fun flush()
 }
@@ -66,7 +66,7 @@ internal class SignalStoreImpl(
         }
     }
 
-    override fun <T> store(event: Event<T>, sessionAnrTimeMs: Long?) {
+    override fun <T> store(event: Event<T>) {
         try {
             val eventEntity = event.toEventEntity()
             if (eventEntity == null) {
@@ -88,7 +88,7 @@ internal class SignalStoreImpl(
 
             when {
                 collectTimeline -> {
-                    val success = database.insertEvent(eventEntity, sessionAnrTimeMs)
+                    val success = database.insertEvent(eventEntity)
                     flush()
                     if (!success) {
                         handleEventInsertionFailure(eventEntity)

--- a/android/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/SessionManagerTest.kt
@@ -243,4 +243,13 @@ class SessionManagerTest {
         assertEquals(updatedSessionId, callbackSessionId)
         assertEquals(sessionManager.getSessionStartTime(), callbackSessionTime)
     }
+
+    @Test
+    fun `markSessionsAppExitTracked marks all sessions except the current one`() {
+        val sessionId = sessionManager.init()
+
+        sessionManager.markSessionsAppExitTracked()
+
+        verify(database).markSessionsAppExitTracked(excludeSessionId = sessionId)
+    }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/appexit/AppExitCollectorTest.kt
@@ -1,9 +1,9 @@
 package sh.measure.android.appexit
 
 import android.app.ApplicationExitInfo
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -13,18 +13,15 @@ import sh.measure.android.events.SignalProcessor
 import sh.measure.android.fakes.FakeAppExitProvider
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.TestData
-import sh.measure.android.storage.Database
 import sh.measure.android.storage.SessionRecord
 
 class AppExitCollectorTest {
     private val appExitProvider = FakeAppExitProvider()
-    private val database = mock<Database>()
     private val signalProcessor = mock<SignalProcessor>()
     private val sessionManager = FakeSessionManager()
 
     private val appExitCollector = AppExitCollector(
         appExitProvider,
-        database,
         signalProcessor,
         sessionManager,
     )
@@ -38,7 +35,7 @@ class AppExitCollectorTest {
         val appExits = mapOf(pidToAppExit)
         appExitProvider.appExits = appExits
         val session = getSession(pid)
-        `when`(database.getSessionForAppExit(pid)).thenReturn(session)
+        sessionManager.appExitSessions[pid] = session
 
         // When
         appExitCollector.collect()
@@ -55,7 +52,10 @@ class AppExitCollectorTest {
             appBuild = eq("1000"),
             isSampled = any(),
         )
-        verify(database).setSessionAnrTime(session.id, appExit.app_exit_time_ms)
+        assertEquals(
+            session.id to appExit.app_exit_time_ms,
+            sessionManager.markedAnrSessions.single(),
+        )
     }
 
     @Test
@@ -69,8 +69,8 @@ class AppExitCollectorTest {
             getSession(sessionId = "session-2", pid = 2, appVersion = "1.1.2", appBuild = "112")
 
         appExitProvider.appExits = mapOf(1 to appExit1, 2 to appExit2)
-        `when`(database.getSessionForAppExit(1)).thenReturn(session1)
-        `when`(database.getSessionForAppExit(2)).thenReturn(session2)
+        sessionManager.appExitSessions[1] = session1
+        sessionManager.appExitSessions[2] = session2
 
         // When
         appExitCollector.collect()
@@ -105,7 +105,6 @@ class AppExitCollectorTest {
         // Given
         val appExit = TestData.getAppExit(reasonId = ApplicationExitInfo.REASON_ANR)
         appExitProvider.appExits = mapOf(1 to appExit)
-        `when`(database.getSessionForAppExit(1)).thenReturn(null)
 
         // When
         appExitCollector.collect()
@@ -125,7 +124,7 @@ class AppExitCollectorTest {
     }
 
     @Test
-    fun `marks all sessions except the current one as app exit tracked`() {
+    fun `marks sessions as app exit tracked after collection`() {
         // Given
         val appExit1 = TestData.getAppExit(reasonId = ApplicationExitInfo.REASON_ANR)
         val session1 = getSession(sessionId = "session-1", pid = 1, createdAt = 1000)
@@ -133,14 +132,14 @@ class AppExitCollectorTest {
         val session2 = getSession(sessionId = "session-2", pid = 2, createdAt = 2000)
 
         appExitProvider.appExits = mapOf(1 to appExit1, 2 to appExit2)
-        `when`(database.getSessionForAppExit(1)).thenReturn(session1)
-        `when`(database.getSessionForAppExit(2)).thenReturn(session2)
+        sessionManager.appExitSessions[1] = session1
+        sessionManager.appExitSessions[2] = session2
 
         // When
         appExitCollector.collect()
 
         // Then
-        verify(database).markSessionsAppExitTracked(sessionManager.getSessionId())
+        assertEquals(1, sessionManager.appExitTrackedCount)
     }
 
     private fun getSession(

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/SignalProcessorTest.kt
@@ -292,7 +292,7 @@ internal class SignalProcessorTest {
         )
 
         assertEquals(1, signalStore.trackedEvents.size)
-        assertEquals(null, signalStore.trackedSessionAnrTimes.first())
+        assertEquals(0, sessionManager.markedAnrSessions.size)
         verify(exporter).export()
     }
 
@@ -310,7 +310,12 @@ internal class SignalProcessorTest {
         )
 
         assertEquals(1, signalStore.trackedEvents.size)
-        assertEquals(timestamp, signalStore.trackedSessionAnrTimes.first())
+        // The session is marked with the ANR time so late-delivered profiles can be
+        // attributed to it.
+        assertEquals(
+            sessionManager.getSessionId() to timestamp,
+            sessionManager.markedAnrSessions.single(),
+        )
         verify(exporter).export()
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSessionManager.kt
@@ -2,11 +2,19 @@ package sh.measure.android.fakes
 
 import sh.measure.android.SessionManager
 import sh.measure.android.SessionStartListener
+import sh.measure.android.storage.SessionRecord
 
 internal class FakeSessionManager : SessionManager {
     var id = "fake-session-id"
     var startTime: Long = 0L
     var onSessionStartListener: SessionStartListener? = null
+    val markedAnrSessions = mutableListOf<Pair<String, Long>>()
+    val appExitSessions = mutableMapOf<Int, SessionRecord>()
+    var appExitTrackedCount = 0
+    var sessionForTime: SessionRecord? = null
+    var sessionForAnr: SessionRecord? = null
+    val sessionForTimeCalls = mutableListOf<Long>()
+    val sessionForAnrCalls = mutableListOf<Pair<Long, Long>>()
 
     override fun init(): String = id
 
@@ -24,6 +32,26 @@ internal class FakeSessionManager : SessionManager {
 
     override fun onConfigLoaded() {
         // no-op
+    }
+
+    override fun markSessionWithAnr(sessionId: String, anrTimeMs: Long) {
+        markedAnrSessions.add(sessionId to anrTimeMs)
+    }
+
+    override fun getSessionForAppExit(pid: Int): SessionRecord? = appExitSessions[pid]
+
+    override fun markSessionsAppExitTracked() {
+        appExitTrackedCount++
+    }
+
+    override fun getSessionForTime(timeMs: Long): SessionRecord? {
+        sessionForTimeCalls.add(timeMs)
+        return sessionForTime
+    }
+
+    override fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord? {
+        sessionForAnrCalls.add(timeMs to maxGapMs)
+        return sessionForAnr
     }
 
     override fun setSessionStartListener(listener: SessionStartListener) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeSignalStore.kt
@@ -7,11 +7,9 @@ import sh.measure.android.tracing.SpanData
 internal class FakeSignalStore : SignalStore {
     val trackedEvents = mutableListOf<Event<*>>()
     val trackedSpans = mutableListOf<SpanData>()
-    val trackedSessionAnrTimes = mutableListOf<Long?>()
 
-    override fun <T> store(event: Event<T>, sessionAnrTimeMs: Long?) {
+    override fun <T> store(event: Event<T>) {
         trackedEvents.add(event)
-        trackedSessionAnrTimes.add(sessionAnrTimeMs)
     }
 
     override fun store(spanData: SpanData) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/profiling/ProfileCollectorTest.kt
@@ -4,14 +4,14 @@ import android.os.ProfilingTrigger
 import androidx.concurrent.futures.ResolvableFuture
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import sh.measure.android.events.EventType
@@ -20,7 +20,6 @@ import sh.measure.android.fakes.FakeSampler
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.ImmediateExecutorService
 import sh.measure.android.fakes.NoopLogger
-import sh.measure.android.storage.Database
 import sh.measure.android.storage.SessionRecord
 import sh.measure.android.utils.AndroidTimeProvider
 import sh.measure.android.utils.SystemServiceProvider
@@ -38,7 +37,6 @@ class ProfileCollectorTest {
     private val timeProvider = AndroidTimeProvider(TestClock.create())
     private val ioExecutor = ImmediateExecutorService(ResolvableFuture.create<Any>())
     private val sampler = FakeSampler()
-    private val database = mock<Database>()
     private val sessionManager = FakeSessionManager()
 
     private val profileCollector = ProfileCollector(
@@ -48,7 +46,6 @@ class ProfileCollectorTest {
         timeProvider = timeProvider,
         ioExecutor = ioExecutor,
         sampler = sampler,
-        database = database,
         sessionManager = sessionManager,
     )
 
@@ -59,11 +56,12 @@ class ProfileCollectorTest {
         tempDir.deleteRecursively()
     }
 
+    private fun parseFileTimestamp(timestamp: String): Long = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).parse(timestamp)!!.time
+
     @Test
     fun `attributes an anr profile to the session that had the anr, using the anr time`() {
         val fileTimestamp = "2026-07-05-17-51-56-124"
-        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
-            .parse(fileTimestamp)!!.time
+        val profileTime = parseFileTimestamp(fileTimestamp)
         val file = File(tempDir, "profile_trigger-type-2_${fileTimestamp}_uid-10229.perfetto-trace")
         file.writeText("trace")
         val anrTime = profileTime - 15_000
@@ -74,11 +72,11 @@ class ProfileCollectorTest {
             appBuild = "100",
             lastAnrTime = anrTime,
         )
-        // the trace finalized after a relaunch, so resolving purely by time would
+        // the profile time falls after a relaunch, so resolving purely by time would
         // pick the relaunch session, but the ANR match wins.
         val relaunchSession = SessionRecord("relaunch-session", profileTime - 5_000, "1.0.0", "100")
-        `when`(database.getSessionForAnr(eq(profileTime), any())).thenReturn(anrSession)
-        `when`(database.getSessionForTime(profileTime)).thenReturn(relaunchSession)
+        sessionManager.sessionForAnr = anrSession
+        sessionManager.sessionForTime = relaunchSession
 
         profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
 
@@ -98,13 +96,11 @@ class ProfileCollectorTest {
     @Test
     fun `attributes an anr profile by time when no session had a matching anr`() {
         val fileTimestamp = "2026-07-05-17-51-56-124"
-        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
-            .parse(fileTimestamp)!!.time
+        val profileTime = parseFileTimestamp(fileTimestamp)
         val file = File(tempDir, "profile_trigger-type-2_${fileTimestamp}_uid-10229.perfetto-trace")
         file.writeText("trace")
         val timeSession = SessionRecord("time-session", profileTime - 5_000, "1.0.0", "100")
-        `when`(database.getSessionForAnr(any(), any())).thenReturn(null)
-        `when`(database.getSessionForTime(profileTime)).thenReturn(timeSession)
+        sessionManager.sessionForTime = timeSession
 
         profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
 
@@ -124,16 +120,15 @@ class ProfileCollectorTest {
     @Test
     fun `attributes an app launch profile to the session active at the profile time`() {
         val fileTimestamp = "2026-07-05-17-51-56-124"
-        val profileTime = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.US)
-            .parse(fileTimestamp)!!.time
+        val profileTime = parseFileTimestamp(fileTimestamp)
         val file = File(tempDir, "profile_trigger-type-1_${fileTimestamp}_uid-10229.perfetto-trace")
         file.writeText("trace")
         val session = SessionRecord("launch-session", profileTime - 2_000, "1.0.0", "100")
-        `when`(database.getSessionForTime(profileTime)).thenReturn(session)
+        sessionManager.sessionForTime = session
 
         profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN)
 
-        verify(database, never()).getSessionForAnr(any(), any())
+        assertTrue(sessionManager.sessionForAnrCalls.isEmpty())
         verify(signalProcessor).trackProfile(
             data = eq(ProfileData(reason = "app_fully_drawn", format = "perfetto_trace")),
             timestamp = eq(profileTime),
@@ -151,8 +146,6 @@ class ProfileCollectorTest {
     fun `tracks profile against the current session when no session matches`() {
         val file = File(tempDir, "profile_trigger-type-2_2026-07-05-17-51-56-124_uid-10229.perfetto-trace")
         file.writeText("trace")
-        `when`(database.getSessionForAnr(any(), any())).thenReturn(null)
-        `when`(database.getSessionForTime(any())).thenReturn(null)
 
         profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_ANR)
 
@@ -170,6 +163,33 @@ class ProfileCollectorTest {
     }
 
     @Test
+    fun `parses file timestamps without milliseconds`() {
+        val fileTimestamp = "2026-07-05-17-51-56"
+        val profileTime = parseFileTimestamp(fileTimestamp)
+        // older profiling module versions name files without millis or a uid suffix
+        val file = File(tempDir, "profile_trigger_1_$fileTimestamp.perfetto-trace")
+        file.writeText("trace")
+        file.setLastModified(1751700000000L)
+        val session = SessionRecord("launch-session", profileTime - 2_000, "1.0.0", "100")
+        sessionManager.sessionForTime = session
+
+        profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN)
+
+        assertEquals(listOf(profileTime), sessionManager.sessionForTimeCalls)
+        verify(signalProcessor).trackProfile(
+            data = any(),
+            timestamp = eq(profileTime),
+            type = any(),
+            attachments = any(),
+            sessionId = eq("launch-session"),
+            sessionStartTime = eq(profileTime - 2_000),
+            appVersion = eq("1.0.0"),
+            appBuild = eq("100"),
+            isSampled = eq(true),
+        )
+    }
+
+    @Test
     fun `uses the file modified time when the file name has no timestamp`() {
         val file = File(tempDir, "profile.perfetto-trace")
         file.writeText("trace")
@@ -178,7 +198,7 @@ class ProfileCollectorTest {
 
         profileCollector.handleProfilingResult(file.absolutePath, ProfilingTrigger.TRIGGER_TYPE_APP_FULLY_DRAWN)
 
-        verify(database).getSessionForTime(lastModified)
+        assertEquals(listOf(lastModified), sessionManager.sessionForTimeCalls)
         verify(signalProcessor).trackProfile(
             data = any(),
             timestamp = eq(lastModified),

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/DatabaseTest.kt
@@ -2521,29 +2521,13 @@ class DatabaseTest {
     }
 
     @Test
-    fun `insertEvent records the session ANR time when sessionAnrTimeMs is set`() {
+    fun `insertEvent does not record a session ANR time`() {
         // given
         database.insertSession(TestData.getSessionEntity(id = "anr-session", createdAt = 1000L))
         val event = TestData.getEventEntity(type = EventType.ANR, sessionId = "anr-session")
 
         // when
-        database.insertEvent(event, sessionAnrTimeMs = 5000L)
-
-        // then
-        val session = database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L)
-        assertNotNull(session)
-        assertEquals("anr-session", session!!.id)
-        assertEquals(5000L, session.lastAnrTime)
-    }
-
-    @Test
-    fun `insertEvent does not record a session ANR time when sessionAnrTimeMs is null`() {
-        // given
-        database.insertSession(TestData.getSessionEntity(id = "anr-session", createdAt = 1000L))
-        val event = TestData.getEventEntity(type = EventType.ANR, sessionId = "anr-session")
-
-        // when
-        database.insertEvent(event, sessionAnrTimeMs = null)
+        database.insertEvent(event)
 
         // then
         assertNull(database.getSessionForAnr(timeMs = 8000L, maxGapMs = 60_000L))

--- a/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/storage/SignalStoreTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -57,7 +56,7 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
+        verify(database).insertEvent(eventsCaptor.capture())
         val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
     }
@@ -78,21 +77,9 @@ internal class SignalStoreTest {
             event.id,
             event.serializeDataToString(),
         )
-        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
+        verify(database).insertEvent(eventsCaptor.capture())
         val eventEntity = eventsCaptor.firstValue
         assertEquals("fake-file-path", eventEntity.filePath)
-    }
-
-    @Test
-    fun `forwards session ANR time to insertEvent`() {
-        val exceptionData = TestData.getExceptionData()
-        val event = exceptionData.toEvent(type = EventType.ANR)
-        val anrTimeMs = 987654321L
-        `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-
-        signalStore.store(event, sessionAnrTimeMs = anrTimeMs)
-
-        verify(database).insertEvent(any(), eq(anrTimeMs))
     }
 
     @Test
@@ -101,14 +88,14 @@ internal class SignalStoreTest {
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
         val eventsCaptor = argumentCaptor<EventEntity>()
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then
         verify(fileStorage, never()).writeEventData(any(), any())
-        verify(database).insertEvent(eventsCaptor.capture(), anyOrNull())
+        verify(database).insertEvent(eventsCaptor.capture())
         val eventEntity = eventsCaptor.firstValue
         assertNull(eventEntity.filePath)
         assertNotNull(eventEntity.serializedData)
@@ -476,7 +463,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -497,7 +484,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -518,7 +505,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.ANR)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -538,7 +525,7 @@ internal class SignalStoreTest {
         configProvider.bugReportTimelineDurationSeconds = bugReportTimelineDuration
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -589,7 +576,7 @@ internal class SignalStoreTest {
         // then
         val eventsCaptor = argumentCaptor<List<EventEntity>>()
         val spansCaptor = argumentCaptor<List<SpanEntity>>()
-        verify(database, times(1)).insertEvent(any(), anyOrNull())
+        verify(database, times(1)).insertEvent(any())
         verify(database, times(1)).insertSignals(eventsCaptor.capture(), spansCaptor.capture())
         assertEquals(1, eventsCaptor.firstValue.size)
         assertEquals(1, spansCaptor.firstValue.size)
@@ -629,7 +616,7 @@ internal class SignalStoreTest {
             ),
         )
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(false)
+        `when`(database.insertEvent(any())).thenReturn(false)
 
         // when
         signalStore.store(event)
@@ -656,7 +643,7 @@ internal class SignalStoreTest {
         signalStore.flush()
 
         // then
-        verify(database, never()).insertEvent(any(), anyOrNull())
+        verify(database, never()).insertEvent(any())
         verify(database, never()).insertSignals(any(), any())
     }
 
@@ -688,7 +675,7 @@ internal class SignalStoreTest {
         signalStore.store(event)
 
         // then - event should be queued, not immediately inserted
-        verify(database, never()).insertEvent(any(), anyOrNull())
+        verify(database, never()).insertEvent(any())
 
         // when flushed
         signalStore.flush()
@@ -703,13 +690,13 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then - event should be immediately inserted
-        verify(database).insertEvent(any(), anyOrNull())
+        verify(database).insertEvent(any())
     }
 
     @Test
@@ -718,13 +705,13 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Unhandled)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
 
         // then - event should be immediately inserted
-        verify(database).insertEvent(any(), anyOrNull())
+        verify(database).insertEvent(any())
     }
 
     @Test
@@ -734,7 +721,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData(severity = ExceptionSeverity.Fatal)
         val event = exceptionData.toEvent(type = EventType.EXCEPTION)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -750,7 +737,7 @@ internal class SignalStoreTest {
         val exceptionData = TestData.getExceptionData()
         val event = exceptionData.toEvent(type = EventType.ANR)
         `when`(fileStorage.writeEventData(any(), any())).thenReturn("fake-file-path")
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)
@@ -768,7 +755,7 @@ internal class SignalStoreTest {
         configProvider.bugReportTimelineDurationSeconds = bugReportTimelineDuration
         val bugReportData = TestData.getBugReportData()
         val event = bugReportData.toEvent(type = EventType.BUG_REPORT)
-        `when`(database.insertEvent(any(), anyOrNull())).thenReturn(true)
+        `when`(database.insertEvent(any())).thenReturn(true)
 
         // when
         signalStore.store(event)


### PR DESCRIPTION
# Description

The ANR time used for profile attribution introduced an optional param to `SignalProcessor` and `SignalStore`, leaking a session/profiling concern into those APIs. Introduce `SessionManager.markSessionWithAnr` as the single API for recording a session's ANR time.

## Related issue
References #3970 



