### PR TITLE
ci(android): bump rn and flutter snapshot deps on prepare-next

### DIFF
--- a/.github/workflows/android-prepare-next.yml
+++ b/.github/workflows/android-prepare-next.yml
@@ -54,6 +54,15 @@ jobs:
           REPLACEMENT="measure-android = \"${{ inputs.version }}\""
           sed -i "s/$PATTERN/$REPLACEMENT/" ../measure-gradle-plugin/gradle/libs.versions.toml
 
+      - name: Update measure-android version in React Native SDK
+        run: |
+          sed -i "s|compileOnly(\"sh.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../react-native/android/build.gradle.kts
+          sed -i "s|implementation(\"sh.measure:measure-android:[^\"]*\")|implementation(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../react-native/example/rnExample/android/app/build.gradle
+
+      - name: Update measure-android version in Flutter SDK
+        run: |
+          sed -i "s|api(\"sh.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../flutter/packages/measure_flutter/android/build.gradle
+
       - name: Verify changes
         run: |
           echo "Changes made:"
@@ -74,6 +83,8 @@ jobs:
             **Changes:**
             - Updated version to `${{ inputs.version }}` in gradle.properties
             - Updated version to `${{ inputs.version }}` in libs.versions.toml
+            - Updated measure-android to `${{ inputs.version }}` in React Native SDK (android/build.gradle.kts and example app)
+            - Updated measure-android to `${{ inputs.version }}` in Flutter SDK (measure_flutter/android/build.gradle)
 
             **Version:** ${{ inputs.version }}
           base: main
@@ -82,3 +93,6 @@ jobs:
           add-paths: |
             android/measure-android/gradle.properties
             android/measure-gradle-plugin/gradle/libs.versions.toml
+            react-native/android/build.gradle.kts
+            react-native/example/rnExample/android/app/build.gradle
+            flutter/packages/measure_flutter/android/build.gradle


### PR DESCRIPTION
# Description

On `main`, the React Native and Flutter SDKs reference the Android SDK via direct, resolvable snapshot versions:

- `react-native/android/build.gradle.kts` (`compileOnly`)
- `react-native/example/rnExample/android/app/build.gradle` (`implementation`)
- `flutter/packages/measure_flutter/android/build.gradle` (`api`)

`android-prepare-next` now bumps all three references to the new `-SNAPSHOT` alongside `gradle.properties` and the plugin `libs.versions.toml`.

Closes #4012