### PR TITLE
fix(backend): rename ios related typo

### DIFF
--- a/backend/libs/event/event.go
+++ b/backend/libs/event/event.go
@@ -135,7 +135,7 @@ const LifecycleViewControllerTypeViewDidAppear = "viewDidAppear"
 const LifecycleViewControllerTypeViewWillDisappear = "viewWillDisappear"
 const LifecycleViewControllerTypeViewDidDisappear = "viewDidDisappear"
 const LifecycleViewControllerTypeDidReceiveMemoryWarning = "didReceiveMemoryWarning"
-const LifecycleViewControllerTypeInitWithDbName = "initWithDbName"
+const LifecycleViewControllerTypeInitWithNibName = "initWithNibName"
 const LifecycleViewControllerTypeInitWithCoder = "initWithCoder"
 const LifecycleViewControllerTypeVCDeinit = "vcDeinit"
 
@@ -221,7 +221,7 @@ var ValidLifecycleViewControllerTypes = []string{
 	LifecycleViewControllerTypeViewWillDisappear,
 	LifecycleViewControllerTypeViewDidDisappear,
 	LifecycleViewControllerTypeDidReceiveMemoryWarning,
-	LifecycleViewControllerTypeInitWithDbName,
+	LifecycleViewControllerTypeInitWithNibName,
 	LifecycleViewControllerTypeInitWithCoder,
 	LifecycleViewControllerTypeVCDeinit,
 }


### PR DESCRIPTION
## Summary

This PR fixes an iOS related constant name.

## Tasks

- [x] Fix typo in lifecycle view controller constant - should have been initWithNibName

## See also

fixes #4022
