### PR TITLE
refactor(backend): remove unused code & streamline sessionator

### DIFF
--- a/backend/libs/symbol/symbol.go
+++ b/backend/libs/symbol/symbol.go
@@ -22,6 +22,17 @@ const (
 // type for internal computational use.
 type MappingType int
 
+// MappingTypes returns all known mapping types,
+// excluding the unknown type.
+func MappingTypes() []MappingType {
+	return []MappingType{
+		TypeProguard,
+		TypeDsym,
+		TypeElfDebug,
+		TypeJsBundle,
+	}
+}
+
 // String provides the human recognizable
 // mapping type.
 func (m MappingType) String() string {

--- a/self-host/sessionator/app/resource.go
+++ b/self-host/sessionator/app/resource.go
@@ -1,9 +1,0 @@
-package app
-
-// Resource represents the required fields used by the
-// program for sending build info with the request.
-type Resource struct {
-	AppVersion  string `json:"app_version" binding:"required"`
-	AppBuild    string `json:"app_build" binding:"required"`
-	AppUniqueID string `json:"app_unique_id" binding:"required"`
-}

--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"backend/libs/symbol"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -134,7 +135,7 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 
 				app.Builds[code].MappingFiles = append(app.Builds[code].MappingFiles, path)
-				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, "proguard")
+				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, symbol.TypeProguard.String())
 			}
 
 			dSYMMapping, err := filepath.Match("*/*/*/*.tgz", rel)
@@ -158,7 +159,7 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 
 				app.Builds[code].MappingFiles = append(app.Builds[code].MappingFiles, path)
-				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, "dsym")
+				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, symbol.TypeDsym.String())
 			}
 
 			elfDebugInfo, err := filepath.Match("*/*/*/*.symbols", rel)
@@ -182,7 +183,7 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 
 				app.Builds[code].MappingFiles = append(app.Builds[code].MappingFiles, path)
-				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, "elf_debug")
+				app.Builds[code].MappingTypes = append(app.Builds[code].MappingTypes, symbol.TypeElfDebug.String())
 			}
 
 			// jsbundle mappings (.tgz) are nested under a jsbundle/ subdir
@@ -210,7 +211,7 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				}
 
 				app.Builds[jsCode].MappingFiles = append(app.Builds[jsCode].MappingFiles, path)
-				app.Builds[jsCode].MappingTypes = append(app.Builds[jsCode].MappingTypes, "jsbundle")
+				app.Builds[jsCode].MappingTypes = append(app.Builds[jsCode].MappingTypes, symbol.TypeJsBundle.String())
 			}
 
 			blob, err := filepath.Match("*/*/blobs/*", rel)

--- a/self-host/sessionator/app/session.go
+++ b/self-host/sessionator/app/session.go
@@ -1,8 +1,0 @@
-package app
-
-// Session represents the session for parsing and reading
-// certain resource fields.
-type Session struct {
-	SessionID string   `json:"session_id" binding:"required"`
-	Resource  Resource `json:"resource" binding:"required"`
-}

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -4,6 +4,7 @@ import (
 	"backend/libs/codec"
 	"backend/libs/event"
 	"backend/libs/span"
+	"backend/libs/symbol"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"sessionator/app"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -411,9 +413,9 @@ func writeBuildMultipart(c *gin.Context) {
 	}
 
 	for i := range mappingTypes {
-		if mappingTypes[i] != "proguard" && mappingTypes[i] != "dsym" && mappingTypes[i] != "elf_debug" {
+		if mappingTypes[i] != symbol.TypeProguard.String() && mappingTypes[i] != symbol.TypeDsym.String() && mappingTypes[i] != symbol.TypeElfDebug.String() {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": fmt.Errorf(`"mapping_file" should be either %q, %q or %q`, "proguard", "dsym", "elf_debug"),
+				"error": fmt.Errorf(`"mapping_file" should be either %q, %q or %q`, symbol.TypeProguard.String(), symbol.TypeDsym.String(), symbol.TypeElfDebug.String()),
 			})
 			return
 		}
@@ -448,9 +450,9 @@ func writeBuildMultipart(c *gin.Context) {
 		var filename string
 
 		switch mappingType {
-		case "proguard":
+		case symbol.TypeProguard.String():
 			filename = "mapping.txt"
-		case "dsym":
+		case symbol.TypeDsym.String():
 			if err := codec.IsTarGz(file); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{
 					"error":   fmt.Errorf("mapping file %q is not a gzipped tarball", header.Filename),
@@ -461,7 +463,7 @@ func writeBuildMultipart(c *gin.Context) {
 
 			filename = header.Filename
 			filename = strings.ReplaceAll(filename, " ", "")
-		case "elf_debug":
+		case symbol.TypeElfDebug.String():
 			filename = header.Filename
 			filename = strings.ReplaceAll(filename, " ", "")
 		}
@@ -693,13 +695,13 @@ func writeBuildJSON(c *gin.Context) {
 	}
 
 	for _, m := range req.Mappings {
-		if m.Type != "proguard" && m.Type != "dsym" && m.Type != "elf_debug" && m.Type != "jsbundle" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(`"type" should be one of %q, %q, %q or %q`, "proguard", "dsym", "elf_debug", "jsbundle")})
+		if !slices.Contains(symbol.MappingTypes(), symbol.ParseMappingType(m.Type)) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(`"type" should be one of %q, %q, %q or %q`, symbol.TypeProguard.String(), symbol.TypeDsym.String(), symbol.TypeElfDebug.String(), symbol.TypeJsBundle.String())})
 			return
 		}
 
 		filename := strings.ReplaceAll(m.Filename, " ", "")
-		if m.Type == "proguard" {
+		if m.Type == symbol.TypeProguard.String() {
 			filename = "mapping.txt"
 		}
 
@@ -709,7 +711,7 @@ func writeBuildJSON(c *gin.Context) {
 		// recovered from the extension on replay. Nest them under jsbundle/
 		// so app/scan.go recognizes the type structurally.
 		relPath := filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, filename)
-		if m.Type == "jsbundle" {
+		if m.Type == symbol.TypeJsBundle.String() {
 			relPath = filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", filename)
 		}
 		m.ID = uuid.NewString()

--- a/self-host/sessionator/cmd/rm.go
+++ b/self-host/sessionator/cmd/rm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"backend/libs/objstore"
 	"bytes"
 	"context"
 	"crypto/md5"
@@ -28,8 +29,10 @@ type janitor struct {
 	appIds []uuid.UUID
 }
 
-type S3Options struct {
-	MiddlewareStackFuncs []func(stack *middleware.Stack) error
+// withContentMd5 applies the Content-Md5 delete middleware as a
+// per-request option. Needed only on DeleteObjects calls.
+func withContentMd5(o *s3.Options) {
+	o.APIOptions = append(o.APIOptions, stackFunc)
 }
 
 // stackFunc is the common stack middleware creation function
@@ -114,7 +117,7 @@ func deleteAllObjects(ctx context.Context, bucket *string, client *s3.Client) (e
 				Objects: objectIdentifiers,
 				Quiet:   aws.Bool(true),
 			},
-		})
+		}, withContentMd5)
 
 		if err != nil {
 			return fmt.Errorf("failed to delete objects: %w", err)
@@ -304,15 +307,9 @@ func rmAll(ctx context.Context, c *config.Config) (err error) {
 		config: c,
 	}
 
-	options := []S3Options{
-		{
-			MiddlewareStackFuncs: []func(stack *middleware.Stack) error{stackFunc},
-		},
-	}
-
-	symbolsClient := j.getSymbolsClient(options...)
+	symbolsClient := j.getSymbolsClient()
 	symbolsBucket := aws.String(j.config.Storage["symbols_s3_bucket"])
-	attachmentsClient := j.getAttachmentsClient(options...)
+	attachmentsClient := j.getAttachmentsClient()
 	attachmentsBucket := aws.String(j.config.Storage["attachments_s3_bucket"])
 
 	fmt.Println("removing all app resources")
@@ -438,66 +435,26 @@ func rmAll(ctx context.Context, c *config.Config) (err error) {
 
 // getSymbolsClient creates an S3 client for operating
 // on symbols S3 bucket.
-func (j *janitor) getSymbolsClient(options ...S3Options) (client *s3.Client) {
-	var credentialsProvider aws.CredentialsProviderFunc = func(ctx context.Context) (aws.Credentials, error) {
-		return aws.Credentials{
-			AccessKeyID:     j.config.Storage["symbols_access_key"],
-			SecretAccessKey: j.config.Storage["symbols_secret_access_key"],
-		}, nil
-	}
-
-	awsConfig := &aws.Config{
-		Region:      j.config.Storage["symbols_s3_bucket_region"],
-		Credentials: credentialsProvider,
-	}
-
-	return s3.NewFromConfig(*awsConfig, func(o *s3.Options) {
-		endpoint := j.config.Storage["aws_endpoint_url"]
-		if endpoint != "" {
-			o.BaseEndpoint = aws.String(endpoint)
-			o.UsePathStyle = *aws.Bool(true)
-		}
-
-		if len(options) > 0 {
-			for _, opt := range options {
-				for _, stackFunc := range opt.MiddlewareStackFuncs {
-					o.APIOptions = append(o.APIOptions, stackFunc)
-				}
-			}
-		}
-	})
+func (j *janitor) getSymbolsClient() (client *s3.Client) {
+	return objstore.CreateS3Client(
+		context.Background(),
+		j.config.Storage["symbols_access_key"],
+		j.config.Storage["symbols_secret_access_key"],
+		j.config.Storage["symbols_s3_bucket_region"],
+		j.config.Storage["aws_endpoint_url"],
+	)
 }
 
 // getAttachmentsClient creates an S3 client for operating
 // on attachments S3 bucket.
-func (j *janitor) getAttachmentsClient(options ...S3Options) (client *s3.Client) {
-	var credentialsProvider aws.CredentialsProviderFunc = func(ctx context.Context) (aws.Credentials, error) {
-		return aws.Credentials{
-			AccessKeyID:     j.config.Storage["attachments_access_key"],
-			SecretAccessKey: j.config.Storage["attachments_secret_access_key"],
-		}, nil
-	}
-
-	awsConfig := &aws.Config{
-		Region:      j.config.Storage["attachments_s3_bucket_region"],
-		Credentials: credentialsProvider,
-	}
-
-	return s3.NewFromConfig(*awsConfig, func(o *s3.Options) {
-		endpoint := j.config.Storage["aws_endpoint_url"]
-		if endpoint != "" {
-			o.BaseEndpoint = aws.String(endpoint)
-			o.UsePathStyle = *aws.Bool(true)
-		}
-
-		if len(options) > 0 {
-			for _, opt := range options {
-				for _, stackFunc := range opt.MiddlewareStackFuncs {
-					o.APIOptions = append(o.APIOptions, stackFunc)
-				}
-			}
-		}
-	})
+func (j *janitor) getAttachmentsClient() (client *s3.Client) {
+	return objstore.CreateS3Client(
+		context.Background(),
+		j.config.Storage["attachments_access_key"],
+		j.config.Storage["attachments_secret_access_key"],
+		j.config.Storage["attachments_s3_bucket_region"],
+		j.config.Storage["aws_endpoint_url"],
+	)
 }
 
 // resolveAppIds resolves app uuids from
@@ -1291,16 +1248,10 @@ func (j *janitor) rmAttachmentObjects(ctx context.Context, objectIds []types.Obj
 		Delete: &types.Delete{Objects: objectIds},
 	}
 
-	options := []S3Options{
-		{
-			MiddlewareStackFuncs: []func(stack *middleware.Stack) error{stackFunc},
-		},
-	}
-
-	client := j.getAttachmentsClient(options...)
+	client := j.getAttachmentsClient()
 
 	// ignoring delete objects output
-	_, err = client.DeleteObjects(ctx, deleteObjectsInput)
+	_, err = client.DeleteObjects(ctx, deleteObjectsInput, withContentMd5)
 	if err != nil {
 		return
 	}
@@ -1319,16 +1270,10 @@ func (j *janitor) rmMappingObjects(ctx context.Context, objectIds []types.Object
 		Delete: &types.Delete{Objects: objectIds},
 	}
 
-	options := []S3Options{
-		{
-			MiddlewareStackFuncs: []func(stack *middleware.Stack) error{stackFunc},
-		},
-	}
-
-	client := j.getSymbolsClient(options...)
+	client := j.getSymbolsClient()
 
 	// ignoring delete objects output
-	_, err = client.DeleteObjects(ctx, deleteObjectsInput)
+	_, err = client.DeleteObjects(ctx, deleteObjectsInput, withContentMd5)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

This PR refactors sessionator to remove unused structs & reuses existing package for setting up object store clients.

## Tasks

- [x] Remove unused session & resource structs
- [x] Rewire object storage client setup to reused existing module
- [x] Improve mapping types validation in `sessionator record` command