### PR TITLE
chore(backend): add ota builds support in sessionator

### DIFF
--- a/self-host/sessionator/app/app.go
+++ b/self-host/sessionator/app/app.go
@@ -22,6 +22,9 @@ type Build struct {
 	MappingTypes []string
 	MappingFiles []string
 	BuildInfo    BuildInfo
+	// PatchID identifies an OTA patch. Set only for OTA builds
+	// (replayed to /builds/ota); empty for regular builds.
+	PatchID string
 }
 
 // App represents each combination of app and version
@@ -30,6 +33,10 @@ type App struct {
 	Name              string
 	VersionName       string
 	Builds            map[string]*Build
+	// OTABuilds holds OTA patches keyed by patch_id, replayed to
+	// /builds/ota. Kept separate from Builds so the two replay paths
+	// stay self-documenting.
+	OTABuilds         map[string]*Build
 	EventAndSpanFiles []string
 	BlobFiles         []string
 }
@@ -164,6 +171,7 @@ func (apps *Apps) Add(name, version string) {
 		Name:        name,
 		VersionName: version,
 		Builds:      make(map[string]*Build),
+		OTABuilds:   make(map[string]*Build),
 	}
 
 	if apps.index == nil {

--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -214,6 +214,36 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				app.Builds[jsCode].MappingTypes = append(app.Builds[jsCode].MappingTypes, symbol.TypeJsBundle.String())
 			}
 
+			// OTA jsbundle mappings nest one level deeper, under a
+			// patch_id dir: jsbundle/<patch_id>/<file>. Disjoint from the
+			// regular jsbundle pattern above since "*" never crosses "/".
+			otaBundle, err := filepath.Match("*/*/*/jsbundle/*/*", rel)
+			if err != nil {
+				return err
+			}
+			if otaBundle {
+				app := apps.Lookup(parts[0], parts[1])
+				info, err := d.Info()
+				if err != nil {
+					return err
+				}
+				if info.Size() < 1 {
+					return fmt.Errorf(`%q has empty OTA jsbundle mapping file. check %q`, app.FullName(), rel)
+				}
+
+				patchID := filepath.Base(filepath.Dir(rel))
+				otaCode := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(rel))))
+				if _, ok := app.OTABuilds[patchID]; !ok {
+					app.OTABuilds[patchID] = &Build{
+						VersionCode: otaCode,
+						PatchID:     patchID,
+					}
+				}
+
+				app.OTABuilds[patchID].MappingFiles = append(app.OTABuilds[patchID].MappingFiles, path)
+				app.OTABuilds[patchID].MappingTypes = append(app.OTABuilds[patchID].MappingTypes, symbol.TypeJsBundle.String())
+			}
+
 			blob, err := filepath.Match("*/*/blobs/*", rel)
 			if err != nil {
 				return err

--- a/self-host/sessionator/app/scan_test.go
+++ b/self-host/sessionator/app/scan_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanOTADiscovery checks that an OTA jsbundle (nested under a patch_id
+// dir) lands in OTABuilds while a regular jsbundle (directly under jsbundle/)
+// still lands in Builds. The two scan patterns must stay disjoint.
+func TestScanOTADiscovery(t *testing.T) {
+	root := t.TempDir()
+
+	patchID := "3f2b8c1a-0000-4000-8000-000000000000"
+	regular := filepath.Join(root, "foo-app", "1.2.3", "1000", "jsbundle", "main.jsbundle.tgz")
+	ota := filepath.Join(root, "foo-app", "1.2.3", "1000", "jsbundle", patchID, "main.jsbundle.tgz")
+
+	for _, p := range []string{regular, ota} {
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	apps, err := Scan(root, &ScanOpts{})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	app := apps.Lookup("foo-app", "1.2.3")
+
+	if len(app.OTABuilds) != 1 {
+		t.Fatalf("expected 1 OTA build, got %d", len(app.OTABuilds))
+	}
+	otaBuild, ok := app.OTABuilds[patchID]
+	if !ok {
+		t.Fatalf("OTA build for patch %q not found", patchID)
+	}
+	if otaBuild.VersionCode != "1000" {
+		t.Errorf("expected OTA version code 1000, got %q", otaBuild.VersionCode)
+	}
+	if len(otaBuild.MappingFiles) != 1 {
+		t.Errorf("expected 1 OTA mapping file, got %d", len(otaBuild.MappingFiles))
+	}
+
+	// regular jsbundle must not leak into OTABuilds nor be missed by Builds
+	build, ok := app.Builds["1000"]
+	if !ok {
+		t.Fatal("regular build 1000 not found")
+	}
+	if len(build.MappingFiles) != 1 {
+		t.Errorf("expected 1 regular jsbundle mapping, got %d", len(build.MappingFiles))
+	}
+}

--- a/self-host/sessionator/cmd/help.go
+++ b/self-host/sessionator/cmd/help.go
@@ -16,7 +16,9 @@ func DirTree() string {
 │        ├── mapping.txt
 │        └── jsbundle/
 │           ├── main.jsbundle.tgz
-│           └── main.jsbundle.map.tgz`
+│           ├── main.jsbundle.map.tgz
+│           └── 3f2b8c1a-.../          (OTA patch_id)
+│              └── main.jsbundle.tgz`
 }
 
 // ValidNote provides note about validity of files

--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -151,6 +151,7 @@ func IngestSerial(apps *app.Apps, origin string) {
 	startTime := time.Now()
 	eventURL := fmt.Sprintf("%s/events", origin)
 	buildURL := fmt.Sprintf("%s/builds", origin)
+	otaBuildURL := fmt.Sprintf("%s/builds/ota", origin)
 	virtualizer := NewVirtualizer()
 
 	for _, app := range apps.Items {
@@ -175,6 +176,19 @@ func IngestSerial(apps *app.Apps, origin string) {
 
 		fmt.Printf("🟢 %s \n", status)
 		metrics.bumpBuild()
+
+		if len(app.OTABuilds) > 0 {
+			fmt.Printf("Uploading OTA build info...")
+			status, err := UploadOTABuilds(otaBuildURL, apiKey, app)
+			if err != nil {
+				if status == "" {
+					status = err.Error()
+				}
+				fmt.Printf("🔴 %s \n", status)
+				log.Fatal(err)
+			}
+			fmt.Printf("🟢 %s \n", status)
+		}
 
 		// wait for some duration for builds to process
 		fmt.Printf("Waiting %v for builds to process...\n", buildProcessDelay)
@@ -216,6 +230,7 @@ func IngestParallel(apps *app.Apps, origin string) {
 	startTime := time.Now()
 	eventURL := fmt.Sprintf("%s/events", origin)
 	buildURL := fmt.Sprintf("%s/builds", origin)
+	otaBuildURL := fmt.Sprintf("%s/builds/ota", origin)
 
 	var logResults = func(results *[]string) {
 		for _, result := range *results {
@@ -246,6 +261,19 @@ func IngestParallel(apps *app.Apps, origin string) {
 
 		fmt.Printf("🟢 %s \n", status)
 		metrics.bumpBuild()
+
+		if len(app.OTABuilds) > 0 {
+			fmt.Printf("Uploading OTA build info...")
+			status, err := UploadOTABuilds(otaBuildURL, apiKey, app)
+			if err != nil {
+				if status == "" {
+					status = err.Error()
+				}
+				fmt.Printf("🔴 %s \n", status)
+				log.Fatal(err)
+			}
+			fmt.Printf("🟢 %s \n", status)
+		}
 
 		// wait for some duration for builds to process
 		fmt.Printf("Waiting %v for builds to process...\n", buildProcessDelay)
@@ -309,6 +337,96 @@ func IngestParallel(apps *app.Apps, origin string) {
 	}
 
 	metrics.setIngestDuration(time.Since(startTime))
+}
+
+// UploadOTABuilds prepares & sends the request to upload OTA jsbundle
+// mappings, keyed by patch_id, to /builds/ota.
+func UploadOTABuilds(url, apiKey string, app app.App) (status string, err error) {
+	status = http.StatusText(http.StatusOK)
+
+	if dryRun {
+		return
+	}
+
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	for _, otaBuild := range app.OTABuilds {
+		patchID, err := uuid.Parse(otaBuild.PatchID)
+		if err != nil {
+			return http.StatusText(http.StatusInternalServerError), err
+		}
+
+		build := measure.OTABuild{PatchID: patchID}
+		mappingFilesMap := make(map[string]string)
+
+		for index, mappingType := range otaBuild.MappingTypes {
+			filename := filepath.Base(otaBuild.MappingFiles[index])
+			mappingFilesMap[filename] = otaBuild.MappingFiles[index]
+
+			build.Mappings = append(build.Mappings, &measure.Mapping{
+				Type:     mappingType,
+				Filename: filename,
+			})
+		}
+
+		data, err := json.Marshal(build)
+		if err != nil {
+			return http.StatusText(http.StatusInternalServerError), err
+		}
+
+		status, bodyBytes, err := sendRequest(url, apiKey, headers, data)
+		if err != nil {
+			return status, err
+		}
+
+		buildres := measure.BuildResponse{}
+		if err := json.Unmarshal(bodyBytes, &buildres); err != nil {
+			return http.StatusText(http.StatusInternalServerError), err
+		}
+
+		for _, mapping := range buildres.Mappings {
+			mappingFilePath := mappingFilesMap[mapping.Filename]
+
+			file, err := os.Open(mappingFilePath)
+			if err != nil {
+				return http.StatusText(http.StatusInternalServerError), err
+			}
+			defer file.Close()
+
+			fileInfo, err := file.Stat()
+			if err != nil {
+				return http.StatusText(http.StatusInternalServerError), err
+			}
+
+			req, err := http.NewRequest("PUT", mapping.UploadURL, file)
+			if err != nil {
+				return http.StatusText(http.StatusInternalServerError), err
+			}
+
+			// set metadata headers
+			for key, val := range mapping.Headers {
+				req.Header.Set(key, val)
+			}
+
+			// some S3 backends may reject the upload
+			// if content-length header is not set.
+			req.ContentLength = fileInfo.Size()
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return http.StatusText(http.StatusInternalServerError), err
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				return http.StatusText(http.StatusInternalServerError), fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			}
+		}
+	}
+
+	return
 }
 
 // UploadBuilds prepares & sends the request to

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -108,6 +108,7 @@ Structue of "session-data" directory once written:` + "\n" + DirTree() + "\n" + 
 		r := gin.Default()
 
 		r.PUT("/builds", writeBuild)
+		r.PUT("/builds/ota", writeOTABuild)
 		r.PUT("/events", writeEvent)
 		r.PUT("/upload", writeUpload)
 
@@ -719,6 +720,59 @@ func writeBuildJSON(c *gin.Context) {
 		m.ExpiresAt = time.Now().Add(uploadExpiry)
 	}
 	fmt.Printf("returning %d mapping upload url(s)\n", len(req.Mappings))
+
+	c.JSON(http.StatusOK, gin.H{"mappings": req.Mappings})
+}
+
+// writeOTABuild handles PUT /builds/ota. OTA patches carry a patch_id and
+// jsbundle mappings but no version/size, so no build.toml is written. Mapping
+// files nest under jsbundle/<patch_id>/ so scan.go recovers the patch_id.
+// ponytail: JSON-only; OTA has no legacy multipart path to mirror.
+func writeOTABuild(c *gin.Context) {
+	var req buildRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse json payload: " + err.Error()})
+		return
+	}
+	if req.AppUniqueID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "app_unique_id is required"})
+		return
+	}
+	if req.VersionName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `"version_name" is required`})
+		return
+	}
+	if req.VersionCode == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `"version_code" is required`})
+		return
+	}
+	if err := uuid.Validate(req.PatchID); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `"patch_id" must be a valid UUID`})
+		return
+	}
+	if !safePathComponent(req.AppUniqueID) || !safePathComponent(req.VersionName) || !safePathComponent(req.VersionCode) || !safePathComponent(req.PatchID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid app_unique_id, version_name, version_code or patch_id"})
+		return
+	}
+	if len(req.Mappings) < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least 1 mapping is required"})
+		return
+	}
+
+	for _, m := range req.Mappings {
+		if m.Type != symbol.TypeJsBundle.String() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(`OTA "type" must be %q`, symbol.TypeJsBundle.String())})
+			return
+		}
+
+		filename := strings.ReplaceAll(m.Filename, " ", "")
+		relPath := filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", req.PatchID, filename)
+		m.ID = uuid.NewString()
+		m.PatchID = req.PatchID
+		m.UploadURL = uploadURL(c, relPath)
+		m.ExpiresAt = time.Now().Add(uploadExpiry)
+	}
+	fmt.Printf("returning %d OTA mapping upload url(s)\n", len(req.Mappings))
 
 	c.JSON(http.StatusOK, gin.H{"mappings": req.Mappings})
 }


### PR DESCRIPTION
## Summary

This PR adds support for OTA builds in sessionator record & ingest commands.

## Tasks

- [x] Support OTA builds in sessionator record & ingest

## See also

- fixes #4032