### PR TITLE
fix(backend): record stored object size for build mappings

### DIFF
--- a/backend/symboloader/process.go
+++ b/backend/symboloader/process.go
@@ -236,6 +236,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 
 				b.Mappings[index].Key = dif.Key
 				b.Mappings[index].Location = buildLocation(dif.Key)
+				b.Mappings[index].Size = int64(len(dif.Data))
 				b.Mappings[index].UploadComplete = true
 			}
 		case symbol.TypeDsym.String():
@@ -278,6 +279,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 
 					b.Mappings[index].Key = dif.Key
 					b.Mappings[index].Location = buildLocation(dif.Key)
+					b.Mappings[index].Size = int64(len(dif.Data))
 					b.Mappings[index].UploadComplete = true
 				}
 
@@ -350,6 +352,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 
 					b.Mappings[index].Key = dif.Key
 					b.Mappings[index].Location = buildLocation(dif.Key)
+					b.Mappings[index].Size = int64(len(dif.Data))
 					b.Mappings[index].UploadComplete = true
 				}
 
@@ -421,6 +424,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 
 				b.Mappings[index].Key = dif.Key
 				b.Mappings[index].Location = buildLocation(dif.Key)
+				b.Mappings[index].Size = int64(len(dif.Data))
 				b.Mappings[index].UploadComplete = true
 			}
 		}


### PR DESCRIPTION
## Summary

This PR fixes `build_mappings.file_size` recording the originally uploaded file's size instead of the extracted debug-info object that `key` points at. For `dsym` mappings the uploaded archive is replaced by the extracted debug info under a rewritten key, so the row paired the extracted object's key with the archive's size. The size is now taken from the stored object's bytes when `key` is rewritten.

## Tasks

- [x] Set `file_size` from extracted `dif` bytes in `Build.upload`
- [x] Apply across `proguard`, `dsym`, `elf_debug` & `jsbundle` mappings

## See also

- fixes #4014