### PR TITLE
chore(backend): rename agent LLM env vars

### DIFF
--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -153,36 +153,30 @@ type Config struct {
 
 // NewConfig reads the agent configuration from the environment.
 func NewConfig() *Config {
-	baseURL := os.Getenv("OPENROUTER_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://openrouter.ai/api/v1"
-	}
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
-	apiKey, err := secret.FromEnvOrFile("OPENROUTER_API_KEY")
+	apiKey, err := secret.FromEnvOrFile("LLM_AGENT_KEY")
 	if err != nil {
-		log.Printf("failed to read OPENROUTER_API_KEY: %v", err)
+		log.Printf("failed to read LLM_AGENT_KEY: %v", err)
 	}
 	if apiKey == "" {
-		log.Println("OPENROUTER_API_KEY env var not set, the ask_question tool will return errors")
+		log.Println("LLM_AGENT_KEY env var not set, the ask_question tool will return errors")
 	}
 
-	modelSmall := os.Getenv("OPENROUTER_MODEL_SMALL")
+	modelSmall := os.Getenv("LLM_AGENT_MODEL_SMALL")
 	if modelSmall == "" {
-		log.Println("OPENROUTER_MODEL_SMALL env var not set, conversation compaction will return errors")
+		log.Println("LLM_AGENT_MODEL_SMALL env var not set, conversation compaction will return errors")
 	}
 
-	modelMedium := os.Getenv("OPENROUTER_MODEL_MEDIUM")
+	modelMedium := os.Getenv("LLM_AGENT_MODEL_MEDIUM")
 	if modelMedium == "" {
-		log.Println("OPENROUTER_MODEL_MEDIUM env var not set, the ask_question tool will return errors")
+		log.Println("LLM_AGENT_MODEL_MEDIUM env var not set, the ask_question tool will return errors")
 	}
 
 	cfg := &Config{
-		BaseURL:     baseURL,
+		BaseURL:     "https://openrouter.ai/api/v1",
 		APIKey:      apiKey,
 		ModelSmall:  modelSmall,
 		ModelMedium: modelMedium,
-		ModelLarge:  os.Getenv("OPENROUTER_MODEL_LARGE"),
+		ModelLarge:  os.Getenv("LLM_AGENT_MODEL_LARGE"),
 	}
 
 	cfg.initTools()

--- a/backend/agent/agent/chat.go
+++ b/backend/agent/agent/chat.go
@@ -14,9 +14,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// Small hand-written client for the OpenAI-compatible chat completions API.
-// OpenRouter is the default; OPENROUTER_BASE_URL can point it at any
-// compatible endpoint. Hand-written so we don't depend on a vendor SDK.
+// Small client for the OpenAI-compatible chat completions API,
+// served through OpenRouter.
 
 type chatToolCallFunction struct {
 	Name      string `json:"name"`
@@ -149,10 +148,10 @@ func (c *Config) chat(ctx context.Context, model string, messages []chatMessage,
 	}()
 
 	if c.APIKey == "" {
-		return nil, fmt.Errorf("agent is not configured: OPENROUTER_API_KEY is not set")
+		return nil, fmt.Errorf("agent is not configured: LLM_AGENT_KEY is not set")
 	}
 	if model == "" {
-		return nil, fmt.Errorf("agent is not configured: the OPENROUTER_MODEL_* env var for this task is not set")
+		return nil, fmt.Errorf("agent is not configured: the LLM_AGENT_MODEL_* env var for this task is not set")
 	}
 
 	conversationID, _ := conversationIDFromContext(ctx)

--- a/frontend/dashboard/app/docs/chat/route.ts
+++ b/frontend/dashboard/app/docs/chat/route.ts
@@ -71,7 +71,7 @@ async function chunkedAll<O>(promises: Promise<O>[]): Promise<O[]> {
 }
 
 // ── Per-IP rate limiting ────────────────────────────────────────────────
-// In-memory sliding window; bounds OpenRouter spend from a public
+// In-memory sliding window; bounds LLM spend from a public
 // endpoint. Resets on process restart.
 
 const RATE_LIMIT = 20;
@@ -154,11 +154,11 @@ export async function POST(request: Request) {
     });
   }
 
-  const openrouter = createOpenRouter({ apiKey: config.apiKey });
+  const provider = createOpenRouter({ apiKey: config.apiKey });
   const reqJson = await request.json();
 
   const result = streamText({
-    model: openrouter.chat(config.model),
+    model: provider.chat(config.model),
     // ai v7 rejects system-role entries inside `messages`; the system
     // prompt goes through `instructions` instead.
     instructions: systemPrompt,

--- a/frontend/dashboard/app/docs/components/ai/ask_ai.tsx
+++ b/frontend/dashboard/app/docs/components/ai/ask_ai.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { AISearch, AISearchPanel, AISearchTrigger } from "./search";
 
 /**
- * Mounts the Ask AI chat only when the server has an OpenRouter key
+ * Mounts the Ask AI chat only when the server has an LLM key
  * configured: the /docs/chat GET probe answers 204 when enabled and 404
  * otherwise, so unconfigured self-hosted deployments never show the button.
  */

--- a/frontend/dashboard/content/docs/hosting/agent.mdx
+++ b/frontend/dashboard/content/docs/hosting/agent.mdx
@@ -12,15 +12,15 @@ The agent runs as a separate `agent` service and sends prompts to a language mod
 
 1. Create an account at [openrouter.ai](https://openrouter.ai).
 2. Add credits to your account on the [Credits](https://openrouter.ai/credits) page. OpenRouter bills the agent's usage per token, so the account needs a positive balance for the agent to answer questions.
-3. Create an API key on the [Keys](https://openrouter.ai/keys) page and copy it. You will set it as `OPENROUTER_API_KEY`.
+3. Create an API key on the [Keys](https://openrouter.ai/keys) page and copy it. You will set it as `LLM_AGENT_KEY`.
 4. Optionally, create a second key for the Ask AI chat on the docs pages. You will set it as `LLM_DOCS_CHAT_KEY`. Give this key a credit limit, so traffic from the public docs pages cannot spend the agent's credits. Skip it to keep the docs chat off.
 
 ## Choose the models
 
 The agent uses two models:
 
-- **Small model** (`OPENROUTER_MODEL_SMALL`) handles light work: summarizing long conversations and working out which app a Slack question is about. It does not call tools, so any capable chat model works. Pick a fast, inexpensive one.
-- **Medium model** (`OPENROUTER_MODEL_MEDIUM`) answers the questions by calling Measure's tools, so it **must support tool (function) calling**. Pick a stronger model, since this is where most of the answer quality comes from.
+- **Small model** (`LLM_AGENT_MODEL_SMALL`) handles light work: summarizing long conversations and working out which app a Slack question is about. It does not call tools, so any capable chat model works. Pick a fast, inexpensive one.
+- **Medium model** (`LLM_AGENT_MODEL_MEDIUM`) answers the questions by calling Measure's tools, so it **must support tool (function) calling**. Pick a stronger model, since this is where most of the answer quality comes from.
 
 Both models should have a context window of at least 64k tokens so they can hold a long conversation comfortably.
 
@@ -28,13 +28,13 @@ You can use the same model for both, as long as it supports tool calling. Browse
 
 <Callout type="info">
 
-`OPENROUTER_MODEL_LARGE` is accepted for forward compatibility but is not used yet. You can leave it empty.
+`LLM_AGENT_MODEL_LARGE` is accepted for forward compatibility but is not used yet. You can leave it empty.
 
 </Callout>
 
 ## Configure for a new installation
 
-During installation, the configuration wizard prompts for the agent settings. At the **OpenRouter credentials and models** prompts, paste your API key and the small and medium model ids. The wizard writes `AGENT_ENABLED=false`, so once installation finishes, turn the agent on as described in [Turn the agent on](#turn-the-agent-on).
+During installation, the configuration wizard prompts for the agent settings. At the **agent LLM credentials and models** prompts, paste your API key and the small and medium model ids. The wizard writes `AGENT_ENABLED=false`, so once installation finishes, turn the agent on as described in [Turn the agent on](#turn-the-agent-on).
 
 The wizard also asks for the **Measure Agent service URL**, for example `https://measure-agent.yourcompany.com`. This is the public address coding agents use to reach the MCP endpoint. See [Make the agent reachable over MCP](#make-the-agent-reachable-over-mcp).
 
@@ -46,10 +46,10 @@ If your instance is already running and you want to enable or change the agent, 
 
     ```sh
     AGENT_ENABLED=true
-    OPENROUTER_API_KEY=your-openrouter-api-key        # change this
-    OPENROUTER_MODEL_SMALL=deepseek/deepseek-v4-pro   # change this
-    OPENROUTER_MODEL_MEDIUM=deepseek/deepseek-v4-pro  # change this
-    LLM_DOCS_CHAT_KEY=your-docs-chat-api-key          # optional, turns on the docs Ask AI chat
+    LLM_AGENT_KEY=your-openrouter-api-key            # change this
+    LLM_AGENT_MODEL_SMALL=deepseek/deepseek-v4-pro   # change this
+    LLM_AGENT_MODEL_MEDIUM=deepseek/deepseek-v4-pro  # change this
+    LLM_DOCS_CHAT_KEY=your-docs-chat-api-key         # optional, turns on the docs Ask AI chat
     ```
 
 2. **Shutdown**. Run the following command to shutdown all services.

--- a/frontend/dashboard/content/docs/hosting/index.mdx
+++ b/frontend/dashboard/content/docs/hosting/index.mdx
@@ -138,7 +138,7 @@ Optionally, you can set up Measure Agent so you can debug your app from your cod
 
 - [Set up Measure Agent](/docs/hosting/agent)
 
-Once set up, copy the OpenRouter values and enter them in the relevant prompts. If you wish to ignore it, enter empty values and proceed.
+Once set up, copy the API key and model values and enter them in the relevant prompts. If you wish to ignore it, enter empty values and proceed.
 
 Once completed, the install script will attempt to start all the Measure docker compose services.
 

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -57,7 +57,7 @@ services:
       - NEXT_PUBLIC_GTM_ID=${GTM_ID}
       - NEXT_PUBLIC_C15T_BACKEND_URL=${NEXT_PUBLIC_C15T_BACKEND_URL}
       - LLM_DOCS_CHAT_KEY_FILE=/run/secrets/llm-docs-chat-key
-      - LLM_MODEL=${OPENROUTER_MODEL_SMALL:-}
+      - LLM_MODEL=${LLM_AGENT_MODEL_SMALL:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://0.0.0.0:3000"]
       interval: 5s
@@ -200,7 +200,7 @@ services:
       - autumn-secret-key
       - oauth-google-secret
       - oauth-github-secret
-      - openrouter-api-key
+      - llm-agent-key
     environment:
       - AGENT_ENABLED=${AGENT_ENABLED}
       - BILLING_ENABLED=${BILLING_ENABLED}
@@ -231,10 +231,10 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}
       - OTEL_INSECURE_MODE=${OTEL_INSECURE_MODE}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
-      - OPENROUTER_API_KEY_FILE=/run/secrets/openrouter-api-key
-      - OPENROUTER_MODEL_SMALL=${OPENROUTER_MODEL_SMALL:-}
-      - OPENROUTER_MODEL_MEDIUM=${OPENROUTER_MODEL_MEDIUM:-}
-      - OPENROUTER_MODEL_LARGE=${OPENROUTER_MODEL_LARGE:-}
+      - LLM_AGENT_KEY_FILE=/run/secrets/llm-agent-key
+      - LLM_AGENT_MODEL_SMALL=${LLM_AGENT_MODEL_SMALL:-}
+      - LLM_AGENT_MODEL_MEDIUM=${LLM_AGENT_MODEL_MEDIUM:-}
+      - LLM_AGENT_MODEL_LARGE=${LLM_AGENT_MODEL_LARGE:-}
       - PORT=8084
     develop:
       watch:
@@ -884,7 +884,7 @@ secrets:
     environment: "OAUTH_GOOGLE_SECRET"
   oauth-github-secret:
     environment: "OAUTH_GITHUB_SECRET"
-  openrouter-api-key:
-    environment: "OPENROUTER_API_KEY"
+  llm-agent-key:
+    environment: "LLM_AGENT_KEY"
   llm-docs-chat-key:
     environment: "LLM_DOCS_CHAT_KEY"

--- a/self-host/config.sh
+++ b/self-host/config.sh
@@ -315,14 +315,14 @@ GTM_ID=
 
 NEXT_PUBLIC_C15T_BACKEND_URL=
 
-##############
-# OpenRouter #
-##############
+#######
+# LLM #
+#######
 
-OPENROUTER_API_KEY=
-OPENROUTER_MODEL_SMALL=
-OPENROUTER_MODEL_MEDIUM=
-OPENROUTER_MODEL_LARGE=
+LLM_AGENT_KEY=
+LLM_AGENT_MODEL_SMALL=
+LLM_AGENT_MODEL_MEDIUM=
+LLM_AGENT_MODEL_LARGE=
 LLM_DOCS_CHAT_KEY=
 
 #########
@@ -490,14 +490,14 @@ GTM_ID=
 
 NEXT_PUBLIC_C15T_BACKEND_URL=
 
-##############
-# OpenRouter #
-##############
+#######
+# LLM #
+#######
 
-OPENROUTER_API_KEY=$OPENROUTER_API_KEY
-OPENROUTER_MODEL_SMALL=$OPENROUTER_MODEL_SMALL
-OPENROUTER_MODEL_MEDIUM=$OPENROUTER_MODEL_MEDIUM
-OPENROUTER_MODEL_LARGE=$OPENROUTER_MODEL_LARGE
+LLM_AGENT_KEY=$LLM_AGENT_KEY
+LLM_AGENT_MODEL_SMALL=$LLM_AGENT_MODEL_SMALL
+LLM_AGENT_MODEL_MEDIUM=$LLM_AGENT_MODEL_MEDIUM
+LLM_AGENT_MODEL_LARGE=$LLM_AGENT_MODEL_LARGE
 LLM_DOCS_CHAT_KEY=$LLM_DOCS_CHAT_KEY
 
 #########
@@ -684,14 +684,14 @@ END
     echo -e "Generated secure Slack OAuth State Salt"
     SLACK_OAUTH_STATE_SALT=$(generate_password 44)
 
-    echo -e "\nSet OpenRouter credentials and models"
-    echo -e "Used by the Measure agent service to answer natural language questions. See https://measure.sh/docs/hosting/agent for more details. If you wish to ignore this, enter an empty value."
-    OPENROUTER_API_KEY=$(prompt_optional_value_manual "Enter OpenRouter API key (optional): ")
-    OPENROUTER_MODEL_SMALL=$(prompt_optional_value_manual "Enter small model id, used for light tasks like summarization (optional): ")
-    OPENROUTER_MODEL_MEDIUM=$(prompt_optional_value_manual "Enter medium model id, used to answer questions (optional): ")
-    OPENROUTER_MODEL_LARGE=$(prompt_optional_value_manual "Enter large model id, reserved for future heavy tasks (optional): ")
+    echo -e "\nSet agent LLM credentials and models"
+    echo -e "Used by the Measure agent service to answer natural language questions. The agent sends prompts through OpenRouter. See https://measure.sh/docs/hosting/agent for more details. If you wish to ignore this, enter an empty value."
+    LLM_AGENT_KEY=$(prompt_optional_value_manual "Enter OpenRouter API key (optional): ")
+    LLM_AGENT_MODEL_SMALL=$(prompt_optional_value_manual "Enter small model id, used for light tasks like summarization (optional): ")
+    LLM_AGENT_MODEL_MEDIUM=$(prompt_optional_value_manual "Enter medium model id, used to answer questions (optional): ")
+    LLM_AGENT_MODEL_LARGE=$(prompt_optional_value_manual "Enter large model id, reserved for future heavy tasks (optional): ")
 
-    echo -e "\nSet OpenRouter key for the docs site AI chat"
+    echo -e "\nSet LLM key for the docs site AI chat"
     echo -e "Used by the Ask AI chat on the docs pages. Use a separate key with a spend limit, so public docs traffic cannot spend the agent's credits. Skip to keep the docs chat off."
     LLM_DOCS_CHAT_KEY=$(prompt_optional_value_manual "Enter OpenRouter API key for docs chat (optional): ")
 
@@ -1001,20 +1001,20 @@ ensure() {
     add_env_variable "POSTHOG_API_KEY" ""
   fi
 
-  if ! check_env_variable "OPENROUTER_API_KEY"; then
-    add_env_variable "OPENROUTER_API_KEY" ""
+  if ! check_env_variable "LLM_AGENT_KEY"; then
+    add_env_variable "LLM_AGENT_KEY" ""
   fi
 
-  if ! check_env_variable "OPENROUTER_MODEL_SMALL"; then
-    add_env_variable "OPENROUTER_MODEL_SMALL" ""
+  if ! check_env_variable "LLM_AGENT_MODEL_SMALL"; then
+    add_env_variable "LLM_AGENT_MODEL_SMALL" ""
   fi
 
-  if ! check_env_variable "OPENROUTER_MODEL_MEDIUM"; then
-    add_env_variable "OPENROUTER_MODEL_MEDIUM" ""
+  if ! check_env_variable "LLM_AGENT_MODEL_MEDIUM"; then
+    add_env_variable "LLM_AGENT_MODEL_MEDIUM" ""
   fi
 
-  if ! check_env_variable "OPENROUTER_MODEL_LARGE"; then
-    add_env_variable "OPENROUTER_MODEL_LARGE" ""
+  if ! check_env_variable "LLM_AGENT_MODEL_LARGE"; then
+    add_env_variable "LLM_AGENT_MODEL_LARGE" ""
   fi
 
   if ! check_env_variable "LLM_DOCS_CHAT_KEY"; then


### PR DESCRIPTION
# Description

```
OPENROUTER_API_KEY -> LLM_AGENT_KEY
OPENROUTER_MODEL_SMALL -> LLM_AGENT_MODEL_SMALL
OPENROUTER_MODEL_MEDIUM -> LLM_AGENT_MODEL_MEDIUM
OPENROUTER_MODEL_LARGE -> LLM_AGENT_MODEL_LARGE
```

Removes `OPENROUTER_BASE_URL` which was just pointing to a constant OpenRouter url and had no env var setup in compose.



