### PR TITLE
fix(backend): route network queries through row-policy reader pool

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -2195,7 +2195,7 @@ func (c *Config) mcpGetUniqueDomains(ctx context.Context, in mcpGetUniqueDomains
 		return nil, nil, err
 	}
 
-	domains, err := network.FetchDomains(ctx, deps.ChPool, appID, teamID, from, to)
+	domains, err := network.FetchDomains(ctx, deps.RchPool, appID, teamID, from, to)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network domains: %v", err)
 	}
@@ -2222,7 +2222,7 @@ func (c *Config) mcpGetPathsForDomain(ctx context.Context, in mcpGetPathsForDoma
 		return nil, nil, err
 	}
 
-	paths, err := network.FetchPaths(ctx, deps.ChPool, appID, teamID, in.Domain, in.Search, from, to)
+	paths, err := network.FetchPaths(ctx, deps.RchPool, appID, teamID, in.Domain, in.Search, from, to)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network paths: %v", err)
 	}
@@ -2253,7 +2253,7 @@ func (c *Config) mcpGetNetworkTrends(ctx context.Context, in mcpGetNetworkTrends
 		limit = 50
 	}
 
-	result, err := network.FetchTrends(ctx, deps.ChPool, appID, teamID, af, limit)
+	result, err := network.FetchTrends(ctx, deps.RchPool, appID, teamID, af, limit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network trends: %v", err)
 	}
@@ -2284,7 +2284,7 @@ func (c *Config) mcpGetAppStatusCodesOverTime(ctx context.Context, in mcpGetAppH
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetNetworkOverviewStatusCodesPlot(ctx, deps.ChPool, appID, teamID, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetNetworkOverviewStatusCodesPlot(ctx, deps.RchPool, appID, teamID, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network status overview over time: %v", err)
 	}
@@ -2324,7 +2324,7 @@ func (c *Config) mcpGetHttpEndpointLatencyOverTime(ctx context.Context, in mcpGe
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetEndpointLatencyPlot(ctx, deps.ChPool, appID, teamID, domain, path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetEndpointLatencyPlot(ctx, deps.RchPool, appID, teamID, domain, path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network latency over time: %v", err)
 	}
@@ -2364,7 +2364,7 @@ func (c *Config) mcpGetHttpEndpointStatusCodesOverTime(ctx context.Context, in m
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.ChPool, appID, teamID, domain, path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, appID, teamID, domain, path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network status distribution over time: %v", err)
 	}
@@ -2384,7 +2384,7 @@ func (c *Config) mcpGetNetworkTimeline(ctx context.Context, in mcpGetNetworkTime
 		return nil, nil, err
 	}
 
-	result, err := network.FetchOverviewTimelinePlot(ctx, deps.ChPool, appID, teamID, af, 0)
+	result, err := network.FetchOverviewTimelinePlot(ctx, deps.RchPool, appID, teamID, af, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network request timeline: %v", err)
 	}
@@ -2414,7 +2414,7 @@ func (c *Config) mcpGetNetworkEndpointTimeline(ctx context.Context, in mcpGetNet
 		return nil, nil, err
 	}
 
-	result, err := network.FetchEndpointTimelinePlot(ctx, deps.ChPool, appID, teamID, domain, path, af)
+	result, err := network.FetchEndpointTimelinePlot(ctx, deps.RchPool, appID, teamID, domain, path, af)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network endpoint timeline: %v", err)
 	}

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -509,7 +509,7 @@ func (h Handlers) GetAppMetrics(c *gin.Context) {
 			"use_query_cache": gin.Mode() == gin.ReleaseMode,
 			"query_cache_ttl": int(config.DefaultQueryCacheTTL.Seconds()),
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "adoption"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "adoption"))
 
 		adoption, err = app.GetAdoptionMetrics(ctx, deps.RchPool, &af)
 		if err != nil {
@@ -529,7 +529,7 @@ func (h Handlers) GetAppMetrics(c *gin.Context) {
 			"use_query_cache": gin.Mode() == gin.ReleaseMode,
 			"query_cache_ttl": int(config.DefaultQueryCacheTTL.Seconds()),
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "issue_free"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "issue_free"))
 
 		crashFree, perceivedCrashFree, anrFree, perceivedANRFree, err = app.GetIssueFreeMetrics(ctx, deps.RchPool, &af, excludedVersions)
 		if err != nil {
@@ -546,7 +546,7 @@ func (h Handlers) GetAppMetrics(c *gin.Context) {
 			"use_query_cache": gin.Mode() == gin.ReleaseMode,
 			"query_cache_ttl": int(config.DefaultQueryCacheTTL.Seconds()),
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "launch"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "launch"))
 
 		launch, err = app.GetLaunchMetrics(ctx, deps.RchPool, &af)
 		if err != nil {
@@ -564,7 +564,7 @@ func (h Handlers) GetAppMetrics(c *gin.Context) {
 				"use_query_cache": gin.Mode() == gin.ReleaseMode,
 				"query_cache_ttl": int(config.DefaultQueryCacheTTL.Seconds()),
 			}
-			ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "sizes"))
+			ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "sizes"))
 
 			sizes, err = app.GetSizeMetrics(ctx, deps.PgPool, &af, excludedVersions)
 			if err != nil {
@@ -5418,7 +5418,7 @@ func (h Handlers) GetNetworkRequestsDomains(c *gin.Context) {
 		return
 	}
 
-	origins, err := network.FetchDomains(ctx, deps.ChPool, *app.ID, *team.ID, af.From, af.To)
+	origins, err := network.FetchDomains(ctx, deps.RchPool, *app.ID, *team.ID, af.From, af.To)
 	if err != nil {
 		msg := "failed to get network domains"
 		fmt.Println(msg, err)
@@ -5508,7 +5508,7 @@ func (h Handlers) GetNetworkRequestsPaths(c *gin.Context) {
 
 	search := c.Query("search")
 
-	paths, err := network.FetchPaths(ctx, deps.ChPool, *app.ID, *team.ID, domain, search, af.From, af.To)
+	paths, err := network.FetchPaths(ctx, deps.RchPool, *app.ID, *team.ID, domain, search, af.From, af.To)
 	if err != nil {
 		msg := "failed to get network paths"
 		fmt.Println(msg, err)
@@ -5649,7 +5649,7 @@ func (h Handlers) GetNetworkEndpointLatencyPlot(c *gin.Context) {
 		return
 	}
 
-	result, err := network.GetEndpointLatencyPlot(ctx, deps.ChPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetEndpointLatencyPlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		msg := "failed to get network latency metrics"
 		fmt.Println(msg, err)
@@ -5788,7 +5788,7 @@ func (h Handlers) GetNetworkEndpointStatusCodesPlot(c *gin.Context) {
 		return
 	}
 
-	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.ChPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		msg := "failed to get network status distribution metrics"
 		fmt.Println(msg, err)
@@ -5911,7 +5911,7 @@ func (h Handlers) GetNetworkRequestsTrends(c *gin.Context) {
 		trendsLimit = 50
 	}
 
-	result, err := network.FetchTrends(ctx, deps.ChPool, *app.ID, *team.ID, &af, trendsLimit)
+	result, err := network.FetchTrends(ctx, deps.RchPool, *app.ID, *team.ID, &af, trendsLimit)
 	if err != nil {
 		msg := "failed to get network overview"
 		fmt.Println(msg, err)
@@ -6028,7 +6028,7 @@ func (h Handlers) GetNetworkOverviewTimelinePlot(c *gin.Context) {
 
 	timelineLimit, _ := strconv.Atoi(c.Query("timeline_limit"))
 
-	result, err := network.FetchOverviewTimelinePlot(ctx, deps.ChPool, *app.ID, *team.ID, &af, timelineLimit)
+	result, err := network.FetchOverviewTimelinePlot(ctx, deps.RchPool, *app.ID, *team.ID, &af, timelineLimit)
 	if err != nil {
 		msg := "failed to get session timeline data"
 		fmt.Println(msg, err)
@@ -6155,7 +6155,7 @@ func (h Handlers) GetNetworkEndpointTimelinePlot(c *gin.Context) {
 		return
 	}
 
-	result, err := network.FetchEndpointTimelinePlot(ctx, deps.ChPool, *app.ID, *team.ID, domain, path, &af)
+	result, err := network.FetchEndpointTimelinePlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af)
 	if err != nil {
 		msg := "failed to get endpoint timeline data"
 		fmt.Println(msg, err)
@@ -6282,7 +6282,7 @@ func (h Handlers) GetNetworkOverviewStatusCodesPlot(c *gin.Context) {
 		return
 	}
 
-	result, err := network.GetNetworkOverviewStatusCodesPlot(ctx, deps.ChPool, *app.ID, *team.ID, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetNetworkOverviewStatusCodesPlot(ctx, deps.RchPool, *app.ID, *team.ID, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		msg := "failed to get network status overview plot"
 		fmt.Println(msg, err)

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -679,8 +679,8 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 
 	var filterGroup errgroup.Group
 
-	// each go routine isolates log comment &
-	// clickhouse settings for safe concurrency
+	// each goroutine derives its own local ctx so
+	// log comment & clickhouse settings don't race
 	filterGroup.Go(func() (err error) {
 		lc := logcomment.New(2)
 		settings := clickhouse.Settings{
@@ -693,7 +693,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"force_primary_key":    debugMode,
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "app_versions"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "app_versions"))
 
 		versions, versionCodes, err := af.getAppVersions(ctx, rch)
 		if err != nil {
@@ -714,7 +714,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "os_versions"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "os_versions"))
 
 		osNames, osVersions, err := af.getOSVersions(ctx, rch)
 		if err != nil {
@@ -735,7 +735,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "countries"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "countries"))
 
 		countries, err := af.getCountries(ctx, rch)
 		if err != nil {
@@ -755,7 +755,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_providers"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_providers"))
 
 		networkProviders, err := af.getNetworkProviders(ctx, rch)
 		if err != nil {
@@ -775,7 +775,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_types"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_types"))
 
 		networkTypes, err := af.getNetworkTypes(ctx, rch)
 		if err != nil {
@@ -795,7 +795,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_generations"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "network_generations"))
 
 		networkGenerations, err := af.getNetworkGenerations(ctx, rch)
 		if err != nil {
@@ -815,7 +815,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_locales"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_locales"))
 
 		deviceLocales, err := af.getDeviceLocales(ctx, rch)
 		if err != nil {
@@ -835,7 +835,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_manufacturers"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_manufacturers"))
 
 		deviceManufacturers, err := af.getDeviceManufacturers(ctx, rch)
 		if err != nil {
@@ -855,7 +855,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 			"query_cache_ttl":      int(config.DefaultQueryCacheTTL.Seconds()),
 			chquery.ReaderScopeKey: clickhouse.CustomSetting{Value: teamId.String()},
 		}
-		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_names"))
+		ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "device_names"))
 
 		deviceNames, err := af.getDeviceNames(ctx, rch)
 		if err != nil {
@@ -888,7 +888,7 @@ func (af AppFilter) GetGenericFilters(ctx context.Context, rch driver.Conn, fl *
 				name = "ud_attr_keys_spans"
 			}
 
-			ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, name))
+			ctx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, name))
 
 			keytypes, err := af.getUDAttrKeys(ctx, rch)
 			if err != nil {

--- a/backend/libs/network/network.go
+++ b/backend/libs/network/network.go
@@ -151,6 +151,7 @@ func applyPathFilter(stmt *sqlf.Stmt, pathPattern string) {
 // patternExists checks if a path pattern exists in
 // the url_patterns table for the given app.
 func patternExists(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, pathPattern string) (bool, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.
 		Select("1").
 		From("url_patterns FINAL").
@@ -179,6 +180,7 @@ func patternExists(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID,
 // fetchTrendsCategory queries a single trends
 // category from http_metrics.
 func fetchTrendsCategory(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, af *filter.AppFilter, orderBy string, limit int) ([]TrendMetric, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.
 		Select("domain").
 		Select("path").
@@ -232,6 +234,7 @@ func fetchTrendsCategory(ctx context.Context, ch driver.Conn, appId, teamId uuid
 // FetchDomains returns list of unique domains for a
 // given app and team within the given time range.
 func FetchDomains(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, from, to time.Time) (domains []string, err error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	// clamp to a minimum of 1 week
 	// as smaller time ranges may not
 	// have enough data available
@@ -279,6 +282,7 @@ func FetchDomains(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, 
 // is used only for the fallback http_events search,
 // clamped to a minimum of 1 week.
 func FetchPaths(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, search string, from, to time.Time) (paths []string, err error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.
 		Select("path").
 		From("url_patterns FINAL").
@@ -395,6 +399,7 @@ func FetchTrends(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, a
 // GetNetworkOverviewStatusCodesPlot returns a distribution
 // of status codes over time.
 func GetNetworkOverviewStatusCodesPlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, af *filter.AppFilter, bucketExpr, datetimeFormat string) (result []MetricsDataPoint, err error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.From("http_events").
 		Select(bucketExpr+" as datetime_bucket", af.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", datetimeFormat).
@@ -445,6 +450,7 @@ func GetNetworkOverviewStatusCodesPlot(ctx context.Context, ch driver.Conn, appI
 // FetchOverviewTimelinePlot returns 5-second average request
 // count buckets (per session) for URL patterns of a given app.
 func FetchOverviewTimelinePlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, af *filter.AppFilter, limit int) (*TimelineResponse, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	if limit <= 0 {
 		limit = defaultOverviewTimelineMax
 	}
@@ -539,6 +545,7 @@ func GetEndpointLatencyPlot(
 	af *filter.AppFilter,
 	bucketExpr, datetimeFormat string,
 ) ([]MetricsDataPoint, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 
 	result := make([]MetricsDataPoint, 0)
 
@@ -602,6 +609,7 @@ func GetEndpointStatusCodesPlot(
 	af *filter.AppFilter,
 	bucketExpr, datetimeFormat string,
 ) (*EndpointStatusCodesPlotResponse, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 
 	stmt := sqlf.From("http_events").
 		Select(bucketExpr+" as datetime_bucket", af.Timezone).
@@ -683,6 +691,7 @@ func GetEndpointStatusCodesPlot(
 // It first checks whether the given path is a known pattern
 // in the url_patterns table; if not, it returns nil.
 func FetchEndpointTimelinePlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, pathPattern string, af *filter.AppFilter) (*TimelineResponse, error) {
+	ctx = chquery.WithTeamScope(ctx, teamId)
 	exists, err := patternExists(ctx, ch, appId, teamId, domain, pathPattern)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

This PR routes the network/HTTP dashboard & agent MCP query functions through the row-policy-guarded reader ClickHouse pool for defense-in-depth team isolation. Each `libs/network` query function now self-scopes via `chquery.WithTeamScope`, & call sites in the API handlers & agent MCP toolbox switch from `deps.ChPool` to `deps.RchPool`. It also fixes ctx data races in errgroup closures inside `GetGenericFilters` & `GetAppMetrics` by shadowing `ctx :=` per goroutine.

## Tasks

- [x] Self-scope network query functions in libs/network via chquery.WithTeamScope
- [x] Switch network call sites from ChPool to RchPool in API handlers
- [x] Switch network call sites from ChPool to RchPool in agent MCP toolbox
- [x] Fix ctx data race in GetGenericFilters errgroup goroutines
- [x] Fix ctx data race in GetAppMetrics errgroup goroutines
- [x] Verify gofmt, build & vet across all backend modules
- [x] Verify go test -race clean on touched packages
