### PR TITLE
chore(backend): format symboloader symsync files

### DIFF
--- a/backend/symboloader/symsync/pipeline/cloner_test.go
+++ b/backend/symboloader/symsync/pipeline/cloner_test.go
@@ -25,8 +25,8 @@ type fakeClonerServer struct {
 
 	// folders maps folderID → mimeType + canAddChildren.
 	folders map[string]struct {
-		mimeType        string
-		canAddChildren  bool
+		mimeType       string
+		canAddChildren bool
 	}
 
 	// listings maps parent folderID → slice of file metadata to return.
@@ -52,8 +52,11 @@ type fakeFile struct {
 func newFakeClonerServer(t *testing.T) *fakeClonerServer {
 	t.Helper()
 	f := &fakeClonerServer{
-		t:            t,
-		folders:      make(map[string]struct{ mimeType string; canAddChildren bool }),
+		t: t,
+		folders: make(map[string]struct {
+			mimeType       string
+			canAddChildren bool
+		}),
 		listings:     make(map[string][]fakeFile),
 		deleteStatus: make(map[string]int),
 	}

--- a/backend/symboloader/symsync/pipeline/fetcher_gdrive.go
+++ b/backend/symboloader/symsync/pipeline/fetcher_gdrive.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"backend/libs/symbol"
+
 	"github.com/bodgit/sevenzip"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/drive/v3"

--- a/backend/symboloader/symsync/pipeline/janitor.go
+++ b/backend/symboloader/symsync/pipeline/janitor.go
@@ -12,10 +12,10 @@ import (
 
 // DeleteResult records the outcome of removing one archive's DIFs.
 type DeleteResult struct {
-	Entry         ArchiveEntry
-	DIFsDeleted   int // debug IDs whose objects were actually removed
-	DIFsRetained  int // debug IDs skipped because they are still referenced by an active archive
-	Err           error
+	Entry        ArchiveEntry
+	DIFsDeleted  int // debug IDs whose objects were actually removed
+	DIFsRetained int // debug IDs skipped because they are still referenced by an active archive
+	Err          error
 }
 
 // StoreJanitor removes DIFs whose archives are no longer in the planner's

--- a/backend/symboloader/symsync/reporter/model.go
+++ b/backend/symboloader/symsync/reporter/model.go
@@ -16,19 +16,22 @@ import (
 
 // --- messages ---
 
-type stageStartedMsg     struct{ name string }
-type stageProgressMsg    struct{ name, detail string }
-type stageFinishedMsg    struct{ name, detail string }
-type stageFailedMsg      struct{ name string; err error }
-type fetchStartedMsg     struct{ total int }
-type fetchProgressMsg    struct{ update pipeline.FetchProgressUpdate }
-type fetchResultMsg      struct{ result pipeline.FetchResult }
-type fetchDoneMsg        struct{}
-type janitorStartedMsg   struct{ total int }
-type deleteResultMsg     struct{ result pipeline.DeleteResult }
-type janitorDoneMsg      struct{}
-type manifestSummaryMsg  struct{ cat ManifestCategorized }
-type doneMsg             struct{ err error }
+type stageStartedMsg struct{ name string }
+type stageProgressMsg struct{ name, detail string }
+type stageFinishedMsg struct{ name, detail string }
+type stageFailedMsg struct {
+	name string
+	err  error
+}
+type fetchStartedMsg struct{ total int }
+type fetchProgressMsg struct{ update pipeline.FetchProgressUpdate }
+type fetchResultMsg struct{ result pipeline.FetchResult }
+type fetchDoneMsg struct{}
+type janitorStartedMsg struct{ total int }
+type deleteResultMsg struct{ result pipeline.DeleteResult }
+type janitorDoneMsg struct{}
+type manifestSummaryMsg struct{ cat ManifestCategorized }
+type doneMsg struct{ err error }
 
 // --- public categorization ---
 

--- a/backend/symboloader/symsync/spot/spot_test.go
+++ b/backend/symboloader/symsync/spot/spot_test.go
@@ -363,9 +363,9 @@ func TestArchiveMatchesSpec(t *testing.T) {
 
 		// Mid-range version that the old code dropped.
 		{"18.3.2", "17.5-18.7", true},
-		{"18.0", "17.5-18.7", true},   // in range
-		{"17.4", "17.5-18.7", false},  // below range
-		{"18.8", "17.5-18.7", false},  // above range
+		{"18.0", "17.5-18.7", true},    // in range
+		{"17.4", "17.5-18.7", false},   // below range
+		{"18.8", "17.5-18.7", false},   // above range
 		{"18.7.6", "17.5-18.7", false}, // 18.7.6 > 18.7 upper bound
 
 		// Wildcard-all bound.
@@ -413,9 +413,9 @@ func TestArchivesPassingSpecsLastN(t *testing.T) {
 func TestArchivesPassingSpecsCombined(t *testing.T) {
 	c := fixtureCatalog()
 	all := []pipeline.Target{
-		{FileName: "26.4.1 (23E254) arm64e.7z"},   // 26 — top major
-		{FileName: "18.5 (22F76) arm64e.7z"},      // 18 — not top, but not 17.x either
-		{FileName: "17.6.1 (21G101) arm64e.7z"},   // 17.x — kept by spec
+		{FileName: "26.4.1 (23E254) arm64e.7z"}, // 26 — top major
+		{FileName: "18.5 (22F76) arm64e.7z"},    // 18 — not top, but not 17.x either
+		{FileName: "17.6.1 (21G101) arm64e.7z"}, // 17.x — kept by spec
 	}
 
 	got := archivesPassingSpecs(all, []string{"last 1 versions", "17.x"}, catalogMajors(c))


### PR DESCRIPTION
## Summary

This PR formats few unformatted go files in `symboloader` service.

## Tasks

- [x] Formats some unformatted go files in `symboloader/symsync`

