### PR TITLE
feat(backend): allow removing owners from their default team

### DIFF
--- a/backend/agent/mcp/auth.go
+++ b/backend/agent/mcp/auth.go
@@ -475,24 +475,9 @@ func mcpFindOrCreateUser(ctx context.Context, deps *server.Deps, name, email, pr
 			fmt.Println("mcp: failed to create notif prefs:", err)
 		}
 
-		userName := msrUser.FirstName()
-		teamName := fmt.Sprintf("%s's team", userName)
-		team := &measure.Team{Name: &teamName}
-
-		tx, err := deps.PgPool.Begin(ctx)
-		if err != nil {
+		if _, err := measure.CreatePersonalTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser); err != nil {
 			return mcpUserInfo{}, fmt.Errorf("%s: %w", msg, err)
 		}
-		defer tx.Rollback(ctx)
-
-		if err := team.Create(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser, &tx); err != nil {
-			return mcpUserInfo{}, fmt.Errorf("%s: %w", msg, err)
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return mcpUserInfo{}, fmt.Errorf("%s: %w", msg, err)
-		}
-
-		measure.FireTeamCreatedEvent(ctx, msrUser, team)
 
 		if err := measure.AddNewUserToInvitedTeams(ctx, deps.PgPool, *msrUser.ID, email); err != nil {
 			fmt.Println("mcp: failed to add user to invited teams:", err)
@@ -500,6 +485,10 @@ func mcpFindOrCreateUser(ctx context.Context, deps *server.Deps, name, email, pr
 	} else {
 		if err := msrUser.TouchLastSignInAt(ctx, deps.PgPool); err != nil {
 			fmt.Println("mcp: failed to touch last_sign_in_at:", err)
+		}
+
+		if _, err := measure.EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser); err != nil {
+			return mcpUserInfo{}, fmt.Errorf("%s: %w", msg, err)
 		}
 	}
 

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -3979,7 +3979,10 @@ func (h Handlers) RenameApp(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&app); err != nil {
+	var payload struct {
+		Name string `json:"name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
 		msg := `failed to parse app rename json payload`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -3987,6 +3990,8 @@ func (h Handlers) RenameApp(c *gin.Context) {
 		})
 		return
 	}
+
+	app.AppName = payload.Name
 
 	err = app.Rename(deps.PgPool)
 	if err != nil {

--- a/backend/api/handlers/app_test.go
+++ b/backend/api/handlers/app_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func appNameInDB(ctx context.Context, t *testing.T, appID uuid.UUID) string {
+	t.Helper()
+	var name string
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT app_name FROM apps WHERE id = $1`, appID).Scan(&name); err != nil {
+		t.Fatalf("read app name: %v", err)
+	}
+	return name
+}
+
+func newRenameAppContext(callerID string, appID uuid.UUID, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("PATCH", "/apps/"+appID.String()+"/rename", bytes.NewBufferString(body))
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+	return c, w
+}
+
+func TestRenameApp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can rename an app", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+		seedAPIKey(ctx, t, appID, "msrsh", "key-value", "checksum", false, nil, time.Now())
+
+		c, w := newRenameAppContext(ownerID, appID, `{"name":"renamed-app"}`)
+		h.RenameApp(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if got := appNameInDB(ctx, t, appID); got != "renamed-app" {
+			t.Errorf("app name = %q, want renamed-app", got)
+		}
+	})
+
+	t.Run("missing name gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+
+		c, w := newRenameAppContext(ownerID, appID, `{}`)
+		h.RenameApp(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("a body-supplied id cannot redirect the rename", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+
+		// an app in a team the caller has nothing to do with
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, otherTeamID, "other-team")
+		victimAppID := uuid.New()
+		seedApp(ctx, t, victimAppID, otherTeamID, 90)
+
+		body := fmt.Sprintf(`{"id":%q,"name":"hacked"}`, victimAppID)
+		c, w := newRenameAppContext(ownerID, appID, body)
+		h.RenameApp(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if got := appNameInDB(ctx, t, appID); got != "hacked" {
+			t.Errorf("url app name = %q, want hacked (url id wins)", got)
+		}
+		if got := appNameInDB(ctx, t, victimAppID); got == "hacked" {
+			t.Errorf("victim app was renamed via body id, want untouched")
+		}
+	})
+}

--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -308,6 +308,8 @@ func (h Handlers) SigninGitHub(c *gin.Context) {
 			return
 		}
 
+		var team *measure.Team
+
 		if msrUser == nil {
 			msrUser = measure.NewUser(ghUser.Name, ghUser.Email)
 			if err := msrUser.Save(ctx, deps.PgPool, nil); err != nil {
@@ -328,14 +330,7 @@ func (h Handlers) SigninGitHub(c *gin.Context) {
 				fmt.Println("failed to create notif prefs", err)
 			}
 
-			userName := msrUser.FirstName()
-			teamName := fmt.Sprintf("%s's team", userName)
-
-			team := &measure.Team{
-				Name: &teamName,
-			}
-
-			tx, err := deps.PgPool.Begin(ctx)
+			team, err = measure.CreatePersonalTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser)
 			if err != nil {
 				fmt.Println(msg, err)
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
@@ -343,26 +338,6 @@ func (h Handlers) SigninGitHub(c *gin.Context) {
 				})
 				return
 			}
-
-			defer tx.Rollback(ctx)
-
-			if err := team.Create(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser, &tx); err != nil {
-				fmt.Println(msg, err)
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-					"error": msg,
-				})
-				return
-			}
-
-			if err := tx.Commit(ctx); err != nil {
-				fmt.Println(msg, err)
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-					"error": msg,
-				})
-				return
-			}
-
-			measure.FireTeamCreatedEvent(ctx, msrUser, team)
 
 			if err := measure.AddNewUserToInvitedTeams(ctx, deps.PgPool, *msrUser.ID, ghUser.Email); err != nil {
 				// If there is an error while adding user to invited team,
@@ -379,21 +354,21 @@ func (h Handlers) SigninGitHub(c *gin.Context) {
 				})
 				return
 			}
+
+			team, err = measure.EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser)
+			if err != nil {
+				msg := "failed to lookup user's team"
+				fmt.Println(msg, err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+					"error": msg,
+				})
+				return
+			}
 		}
 
 		// FIXME: Change User struct's ID field to UUID
 		// so that these kinds of convertion is not needed.
 		userId := uuid.MustParse(*msrUser.ID)
-
-		team, err := msrUser.GetOwnTeam(ctx, deps.PgPool)
-		if err != nil {
-			msg := "failed to lookup user's team"
-			fmt.Println(msg, err)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-			return
-		}
 
 		authSess, err := authsession.NewAuthSession(deps.Config.AccessTokenSecret, deps.Config.RefreshTokenSecret, userId, "github", userMeta)
 		if err != nil {
@@ -554,6 +529,8 @@ func (h Handlers) SigninGoogle(c *gin.Context) {
 			return
 		}
 
+		var team *measure.Team
+
 		if msrUser == nil {
 			msrUser = measure.NewUser(googUser.Name, googUser.Email)
 			if err := msrUser.Save(ctx, deps.PgPool, nil); err != nil {
@@ -574,14 +551,7 @@ func (h Handlers) SigninGoogle(c *gin.Context) {
 				fmt.Println("failed to create notif prefs", err)
 			}
 
-			userName := msrUser.FirstName()
-			teamName := fmt.Sprintf("%s's team", userName)
-
-			team := &measure.Team{
-				Name: &teamName,
-			}
-
-			tx, err := deps.PgPool.Begin(ctx)
+			team, err = measure.CreatePersonalTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser)
 			if err != nil {
 				fmt.Println(msg, err)
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
@@ -589,26 +559,6 @@ func (h Handlers) SigninGoogle(c *gin.Context) {
 				})
 				return
 			}
-
-			defer tx.Rollback(ctx)
-
-			if err := team.Create(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser, &tx); err != nil {
-				fmt.Println(msg, err)
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-					"error": msg,
-				})
-				return
-			}
-
-			if err := tx.Commit(ctx); err != nil {
-				fmt.Println(msg, err)
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-					"error": msg,
-				})
-				return
-			}
-
-			measure.FireTeamCreatedEvent(ctx, msrUser, team)
 
 			if err := measure.AddNewUserToInvitedTeams(ctx, deps.PgPool, *msrUser.ID, googUser.Email); err != nil {
 				// If there is an error while adding user to invited team,
@@ -625,21 +575,21 @@ func (h Handlers) SigninGoogle(c *gin.Context) {
 				})
 				return
 			}
+
+			team, err = measure.EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), msrUser)
+			if err != nil {
+				msg := "failed to lookup user's team"
+				fmt.Println(msg, err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+					"error": msg,
+				})
+				return
+			}
 		}
 
 		// FIXME: Change User struct's ID field to UUID
 		// so that these kinds of convertion is not needed.
 		userId := uuid.MustParse(*msrUser.ID)
-
-		team, err := msrUser.GetOwnTeam(ctx, deps.PgPool)
-		if err != nil {
-			msg := "failed to lookup user's team"
-			fmt.Println(msg, err)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": msg,
-			})
-			return
-		}
 
 		authSess, err := authsession.NewAuthSession(deps.Config.AccessTokenSecret, deps.Config.RefreshTokenSecret, userId, "google", userMeta)
 		if err != nil {
@@ -837,17 +787,7 @@ func (h Handlers) GetAuthSession(c *gin.Context) {
 		ID: &userId,
 	}
 
-	ownTeam, err := user.GetOwnTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "Unable to get user's team"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	err = user.GetUserDetails(ctx, deps.PgPool)
+	err := user.GetUserDetails(ctx, deps.PgPool)
 
 	if err != nil {
 		msg := "Unable to get user details"
@@ -873,6 +813,16 @@ func (h Handlers) GetAuthSession(c *gin.Context) {
 		msg := "could not fetch session"
 		fmt.Println(msg, err)
 		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	ownTeam, err := measure.EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), user)
+	if err != nil {
+		msg := "Unable to get user's team"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": msg,
 		})
 		return

--- a/backend/api/handlers/team.go
+++ b/backend/api/handlers/team.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -15,28 +16,22 @@ import (
 
 const maxInvitees = 25
 
+// normalizeTeamName trims a bound team name and reports whether it is usable.
+// A missing field (nil) or a value that is blank after trimming is rejected.
+func normalizeTeamName(name *string) (string, bool) {
+	if name == nil {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(*name)
+	return trimmed, trimmed != ""
+}
+
 func (h Handlers) CreateTeam(c *gin.Context) {
 	deps := h.Deps
 	ctx := c.Request.Context()
 	userId := c.GetString("userId")
 	u := &measure.User{
 		ID: &userId,
-	}
-
-	ownTeam, err := u.GetOwnTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to lookup user's team"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if ownTeam == nil {
-		// use does not have team
-		msg := fmt.Sprintf("no associated team for user %q", *u.ID)
-		fmt.Println(msg)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
 	}
 
 	newTeam := &measure.Team{}
@@ -48,26 +43,12 @@ func (h Handlers) CreateTeam(c *gin.Context) {
 		return
 	}
 
-	// trim team name value
-	*newTeam.Name = strings.Trim(*newTeam.Name, " ")
-
-	if *newTeam.Name == "" {
-		msg := "team name cannot be empty"
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+	name, ok := normalizeTeamName(newTeam.Name)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "team name cannot be empty"})
 		return
 	}
-
-	ok, err := measure.PerformAuthz(deps.PgPool, userId, ownTeam.ID.String(), *measure.ScopeTeamAll)
-	if err != nil {
-		msg := `couldn't perform authorization checks`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	} else if !ok {
-		msg := "you don't have permissions to create new teams"
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
+	*newTeam.Name = name
 
 	msg := "failed to create team"
 	tx, err := deps.PgPool.Begin(ctx)
@@ -823,15 +804,24 @@ func (h Handlers) RenameTeam(c *gin.Context) {
 		return
 	}
 
-	var team = new(measure.Team)
-	team.ID = &teamId
+	var payload struct {
+		Name *string `json:"name"`
+	}
 
-	if err := c.ShouldBindJSON(&team); err != nil {
-		msg := "failed to parse invite payload"
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		msg := "failed to parse rename payload"
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 		return
 	}
+
+	name, ok := normalizeTeamName(payload.Name)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "team name cannot be empty"})
+		return
+	}
+
+	team := &measure.Team{ID: &teamId, Name: &name}
 
 	if err := team.Rename(c.Request.Context(), deps.PgPool); err != nil {
 		msg := "failed to rename team"
@@ -984,23 +974,12 @@ func (h Handlers) RemoveTeamMember(c *gin.Context) {
 		return
 	}
 
-	// check if member is being removed from their default team
-	memberOwnTeam, err := memberUser.GetOwnTeam(c.Request.Context(), deps.PgPool)
-	if err != nil {
-		msg := "couldn't perform authorization checks: failed to lookup member's default team"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if memberOwnTeam.ID != nil && *memberOwnTeam.ID == teamId {
-		msg := fmt.Sprintf("member [%s] cannot be removed from their default team [%s]", memberId, teamId)
-		fmt.Println(msg)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
 	if err = team.RemoveMember(c.Request.Context(), deps.PgPool, &memberId); err != nil {
+		if errors.Is(err, measure.ErrLastOwner) {
+			msg := fmt.Sprintf("cannot remove member [%s]: team [%s] must have at least one owner", memberId, teamId)
+			c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+			return
+		}
 		msg := fmt.Sprintf("couldn't remove member [%s]", memberId)
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
@@ -1025,15 +1004,33 @@ func (h Handlers) RemoveTeamMember(c *gin.Context) {
 		fmt.Println(msg, err)
 	}
 
-	subject, body := email.RemovedFromTeamEmail(*team.Name, *user.Email, deps.Config.SiteOrigin, memberOwnTeam.ID.String())
+	// invoices and dunning notices from Autumn/Stripe go to the customer
+	// email; if it belonged to the removed owner, hand it to a remaining one
+	if memberRole == measure.RoleMap["owner"] && memberUser.Email != nil {
+		if err := measure.SyncBillingEmailOnOwnerExit(c.Request.Context(), deps.PgPool, deps.Config.IsBillingEnabled(), teamId, *memberUser.Email); err != nil {
+			fmt.Println("failed to sync billing email after owner removal:", err)
+		}
+	}
 
-	email.SendEmail(deps.Mail, email.EmailInfo{
-		From:        deps.Config.TxEmailAddress,
-		To:          *memberUser.Email,
-		Subject:     subject,
-		ContentType: "text/html",
-		Body:        body,
-	})
+	// the removed member's dashboard link points at their next default team;
+	// with no team left, empty means the dashboard root, which provisions a
+	// personal team at next sign-in
+	memberTeamId := ""
+	if memberDefaultTeam, err := memberUser.GetDefaultTeam(c.Request.Context(), deps.PgPool); err == nil && memberDefaultTeam.ID != nil {
+		memberTeamId = memberDefaultTeam.ID.String()
+	}
+
+	if team.Name != nil && user.Email != nil && memberUser.Email != nil {
+		subject, body := email.RemovedFromTeamEmail(*team.Name, *user.Email, deps.Config.SiteOrigin, memberTeamId)
+
+		email.SendEmail(deps.Mail, email.EmailInfo{
+			From:        deps.Config.TxEmailAddress,
+			To:          *memberUser.Email,
+			Subject:     subject,
+			ContentType: "text/html",
+			Body:        body,
+		})
+	}
 
 	c.JSON(http.StatusOK, gin.H{"ok": fmt.Sprintf("removed member [%s] from team [%s]", memberId, teamId)})
 }
@@ -1090,20 +1087,36 @@ func (h Handlers) ChangeMemberRole(c *gin.Context) {
 		return
 	}
 
-	member := &measure.Member{
-		ID: &memberId,
+	// bind only the role; the target member comes from the URL param, never
+	// the request body
+	var payload struct {
+		Role *string `json:"role"`
 	}
 
-	if err := c.ShouldBindJSON(&member); err != nil {
+	if err := c.ShouldBindJSON(&payload); err != nil {
 		msg := `failed to parse payload`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 		return
 	}
 
-	if role := measure.RoleMap[*member.Role]; !role.Valid() {
-		msg := fmt.Sprintf("role [%s] is not valid", *member.Role)
+	if payload.Role == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "role is required"})
+		return
+	}
+
+	newRole := measure.RoleMap[*payload.Role]
+	if !newRole.Valid() {
+		msg := fmt.Sprintf("role [%s] is not valid", *payload.Role)
 		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	// a member can only assign roles at or below their own rank
+	if userRole < newRole {
+		msg := fmt.Sprintf("you don't have permissions to assign role [%s] in team [%s]", *payload.Role, teamId)
+		fmt.Println(msg)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
 		return
 	}
 
@@ -1138,23 +1151,12 @@ func (h Handlers) ChangeMemberRole(c *gin.Context) {
 		return
 	}
 
-	// check if member role is being changed in default team
-	memberOwnTeam, err := memberUser.GetOwnTeam(c, deps.PgPool)
-	if err != nil {
-		msg := "couldn't perform authorization checks: failed to lookup member's default team"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if memberOwnTeam.ID != nil && *memberOwnTeam.ID == teamId {
-		msg := fmt.Sprintf("cannot change role of member [%s] in their default team [%s]", memberId, teamId)
-		fmt.Println(msg)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	if err := team.ChangeRole(c.Request.Context(), deps.PgPool, &memberId, measure.RoleMap[*member.Role]); err != nil {
+	if err := team.ChangeRole(c.Request.Context(), deps.PgPool, &memberId, newRole); err != nil {
+		if errors.Is(err, measure.ErrLastOwner) {
+			msg := fmt.Sprintf("cannot change role of member [%s]: team [%s] must have at least one owner", memberId, teamId)
+			c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+			return
+		}
 		msg := `failed to change role`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
@@ -1179,15 +1181,26 @@ func (h Handlers) ChangeMemberRole(c *gin.Context) {
 		fmt.Println(msg, err)
 	}
 
-	subject, body := email.RoleChangedEmail(*member.Role, *user.Email, *team.Name, deps.Config.SiteOrigin, team.ID.String())
+	// invoices and dunning notices from Autumn/Stripe go to the customer
+	// email; a member demoted from owner loses billing access, so hand the
+	// email to a remaining owner if it was theirs
+	if memberRole == measure.RoleMap["owner"] && newRole != measure.RoleMap["owner"] && memberUser.Email != nil {
+		if err := measure.SyncBillingEmailOnOwnerExit(c.Request.Context(), deps.PgPool, deps.Config.IsBillingEnabled(), teamId, *memberUser.Email); err != nil {
+			fmt.Println("failed to sync billing email after owner demotion:", err)
+		}
+	}
 
-	email.SendEmail(deps.Mail, email.EmailInfo{
-		From:        deps.Config.TxEmailAddress,
-		To:          *memberUser.Email,
-		Subject:     subject,
-		ContentType: "text/html",
-		Body:        body,
-	})
+	if team.Name != nil && user.Email != nil && memberUser.Email != nil {
+		subject, body := email.RoleChangedEmail(*payload.Role, *user.Email, *team.Name, deps.Config.SiteOrigin, team.ID.String())
+
+		email.SendEmail(deps.Mail, email.EmailInfo{
+			From:        deps.Config.TxEmailAddress,
+			To:          *memberUser.Email,
+			Subject:     subject,
+			ContentType: "text/html",
+			Body:        body,
+		})
+	}
 
 	c.JSON(http.StatusOK, gin.H{"ok": "done"})
 }

--- a/backend/api/handlers/team_test.go
+++ b/backend/api/handlers/team_test.go
@@ -1,0 +1,1074 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"backend/libs/autumn"
+	autumntest "backend/libs/autumn/testhelpers"
+	"backend/libs/measure"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// getMemberRole returns the member's role in a team, or "" when the
+// membership row does not exist.
+func getMemberRole(ctx context.Context, t *testing.T, teamID uuid.UUID, userID string) string {
+	t.Helper()
+	var role string
+	err := th.PgPool.QueryRow(ctx,
+		`SELECT role FROM team_membership WHERE team_id = $1 AND user_id = $2`, teamID, userID).Scan(&role)
+	if err != nil {
+		return ""
+	}
+	return role
+}
+
+func newRemoveMemberContext(callerID string, teamID uuid.UUID, memberID string) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("DELETE", fmt.Sprintf("/teams/%s/members/%s", teamID, memberID), nil)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "memberId", Value: memberID}}
+	return c, w
+}
+
+func newChangeRoleContext(callerID string, teamID uuid.UUID, memberID, role string) (*gin.Context, *httptest.ResponseRecorder) {
+	body := bytes.NewBufferString(fmt.Sprintf(`{"role":%q}`, role))
+	c, w := newTestGinContext("PATCH", fmt.Sprintf("/teams/%s/members/%s/role", teamID, memberID), body)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "memberId", Value: memberID}}
+	return c, w
+}
+
+func TestRemoveTeamMember(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can remove a co-owner from the co-owner's default team", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		// the original signup owner and their auto-created team
+		originalOwnerID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, originalOwnerID, "original-owner@test.com")
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeamMembership(ctx, t, teamID, originalOwnerID, "owner")
+
+		// a second owner added later
+		newOwnerID := uuid.New().String()
+		seedUser(ctx, t, newOwnerID, "new-owner@test.com")
+		seedTeamMembership(ctx, t, teamID, newOwnerID, "owner")
+
+		c, w := newRemoveMemberContext(newOwnerID, teamID, originalOwnerID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, originalOwnerID); role != "" {
+			t.Errorf("membership still present with role %q, want removed", role)
+		}
+
+		// the removed user has no team left; the sign-in path re-provisions one
+		removedUser := &measure.User{ID: &originalOwnerID}
+		team, err := measure.EnsureDefaultTeam(ctx, th.PgPool, false, removedUser)
+		if err != nil {
+			t.Fatalf("EnsureDefaultTeam after removal: %v", err)
+		}
+		if team.ID == nil || *team.ID == teamID {
+			t.Errorf("EnsureDefaultTeam returned team %v, want a newly created team", team.ID)
+		}
+		if role := getMemberRole(ctx, t, *team.ID, originalOwnerID); role != "owner" {
+			t.Errorf("re-provisioned team role = %q, want owner", role)
+		}
+	})
+
+	t.Run("removing the last owner is rejected", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		adminID := uuid.New().String()
+		seedUser(ctx, t, adminID, "admin@test.com")
+		seedTeamMembership(ctx, t, teamID, adminID, "admin")
+
+		// owners rank equal, so the request passes the rank check and must
+		// be stopped by the last-owner guard
+		c, w := newRemoveMemberContext(ownerID, teamID, ownerID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "at least one owner")
+		if role := getMemberRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("owner membership = %q, want intact", role)
+		}
+	})
+
+	t.Run("owner can remove a non-owner member", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		devID := uuid.New().String()
+		seedUser(ctx, t, devID, "dev@test.com")
+		seedTeamMembership(ctx, t, teamID, devID, "developer")
+
+		c, w := newRemoveMemberContext(ownerID, teamID, devID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, devID); role != "" {
+			t.Errorf("membership still present with role %q, want removed", role)
+		}
+	})
+
+	t.Run("billing email moves to a remaining owner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		originalOwnerID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, originalOwnerID, "original-owner@test.com")
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeamMembership(ctx, t, teamID, originalOwnerID, "owner")
+
+		newOwnerID := uuid.New().String()
+		seedUser(ctx, t, newOwnerID, "new-owner@test.com")
+		seedTeamMembership(ctx, t, teamID, newOwnerID, "owner")
+
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "original-owner@test.com"}, nil
+		})
+		var updatedCustomerID, updatedEmail string
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, customerID, email string) error {
+			updatedCustomerID = customerID
+			updatedEmail = email
+			return nil
+		})
+
+		c, w := newRemoveMemberContext(newOwnerID, teamID, originalOwnerID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if updatedCustomerID != custID {
+			t.Errorf("updated customer = %q, want %q", updatedCustomerID, custID)
+		}
+		if updatedEmail != "new-owner@test.com" {
+			t.Errorf("updated email = %q, want new-owner@test.com", updatedEmail)
+		}
+	})
+
+	t.Run("billing email set to another address is left alone", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		originalOwnerID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, originalOwnerID, "original-owner@test.com")
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeamMembership(ctx, t, teamID, originalOwnerID, "owner")
+
+		newOwnerID := uuid.New().String()
+		seedUser(ctx, t, newOwnerID, "new-owner@test.com")
+		seedTeamMembership(ctx, t, teamID, newOwnerID, "owner")
+
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "finance@test.com"}, nil
+		})
+		updateCalled := false
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, _, _ string) error {
+			updateCalled = true
+			return nil
+		})
+
+		c, w := newRemoveMemberContext(newOwnerID, teamID, originalOwnerID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if updateCalled {
+			t.Error("UpdateCustomer called, want billing email left alone")
+		}
+	})
+}
+
+func TestChangeMemberRole(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can demote a co-owner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		originalOwnerID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, originalOwnerID, "original-owner@test.com")
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeamMembership(ctx, t, teamID, originalOwnerID, "owner")
+
+		newOwnerID := uuid.New().String()
+		seedUser(ctx, t, newOwnerID, "new-owner@test.com")
+		seedTeamMembership(ctx, t, teamID, newOwnerID, "owner")
+
+		c, w := newChangeRoleContext(newOwnerID, teamID, originalOwnerID, "viewer")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, originalOwnerID); role != "viewer" {
+			t.Errorf("role = %q, want viewer", role)
+		}
+	})
+
+	t.Run("demoting the last owner is rejected", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newChangeRoleContext(ownerID, teamID, ownerID, "admin")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "at least one owner")
+		if role := getMemberRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("role = %q, want owner", role)
+		}
+	})
+
+	t.Run("missing role field gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		devID := uuid.New().String()
+		seedUser(ctx, t, devID, "dev@test.com")
+		seedTeamMembership(ctx, t, teamID, devID, "developer")
+
+		body := bytes.NewBufferString(`{}`)
+		c, w := newTestGinContext("PATCH", fmt.Sprintf("/teams/%s/members/%s/role", teamID, devID), body)
+		c.Set("userId", ownerID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "memberId", Value: devID}}
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, devID); role != "developer" {
+			t.Errorf("role = %q, want developer (unchanged)", role)
+		}
+	})
+
+	t.Run("admin cannot assign the owner role", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		_, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		adminID := uuid.New().String()
+		seedUser(ctx, t, adminID, "admin@test.com")
+		seedTeamMembership(ctx, t, teamID, adminID, "admin")
+		devID := uuid.New().String()
+		seedUser(ctx, t, devID, "dev@test.com")
+		seedTeamMembership(ctx, t, teamID, devID, "developer")
+
+		c, w := newChangeRoleContext(adminID, teamID, devID, "owner")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, devID); role != "developer" {
+			t.Errorf("role = %q, want developer", role)
+		}
+	})
+
+	t.Run("billing email moves to a remaining owner on demotion", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		originalOwnerID := uuid.New().String()
+		teamID := uuid.New()
+		seedUser(ctx, t, originalOwnerID, "original-owner@test.com")
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeamMembership(ctx, t, teamID, originalOwnerID, "owner")
+
+		newOwnerID := uuid.New().String()
+		seedUser(ctx, t, newOwnerID, "new-owner@test.com")
+		seedTeamMembership(ctx, t, teamID, newOwnerID, "owner")
+
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "original-owner@test.com"}, nil
+		})
+		var updatedEmail string
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, _, email string) error {
+			updatedEmail = email
+			return nil
+		})
+
+		c, w := newChangeRoleContext(newOwnerID, teamID, originalOwnerID, "viewer")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if updatedEmail != "new-owner@test.com" {
+			t.Errorf("updated email = %q, want new-owner@test.com", updatedEmail)
+		}
+	})
+}
+
+func TestCreateTeam(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("user with no team can create one", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "creator@test.com")
+
+		c, w := newTestGinContext("POST", "/teams", bytes.NewBufferString(`{"name":"fresh-team"}`))
+		c.Set("userId", userID)
+		h.CreateTeam(c)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201, body: %s", w.Code, w.Body.String())
+		}
+		var created measure.Team
+		if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if created.ID == nil {
+			t.Fatal("response team has no id")
+		}
+		if role := getMemberRole(ctx, t, *created.ID, userID); role != "owner" {
+			t.Errorf("creator role = %q, want owner", role)
+		}
+		if id := getTeamAutumnCustomerID(ctx, t, *created.ID); id == nil || *id == "" {
+			t.Error("autumn customer not provisioned for new team")
+		}
+	})
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "creator@test.com")
+
+		c, w := newTestGinContext("POST", "/teams", bytes.NewBufferString(`{"name":"  "}`))
+		c.Set("userId", userID)
+		h.CreateTeam(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing name is rejected", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "creator@test.com")
+
+		c, w := newTestGinContext("POST", "/teams", bytes.NewBufferString(`{}`))
+		c.Set("userId", userID)
+		h.CreateTeam(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// Helpers for invite and team assertions
+// --------------------------------------------------------------------------
+
+// seedInviteRow inserts an invites row with an explicit updated_at so tests
+// can control invite validity (valid = updated_at within TeamInviteValidity).
+func seedInviteRow(ctx context.Context, t *testing.T, inviteID, teamID uuid.UUID, byUserID, role, email string, updatedAt time.Time) {
+	t.Helper()
+	_, err := th.PgPool.Exec(ctx,
+		`INSERT INTO invites (id, invited_by_user_id, invited_to_team_id, invited_as_role, email, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $6)`,
+		inviteID, byUserID, teamID, role, email, updatedAt)
+	if err != nil {
+		t.Fatalf("seed invite: %v", err)
+	}
+}
+
+// confirmUser sets users.confirmed_at, which GetExistingAndNewInvitees
+// requires before treating an email as an existing user.
+func confirmUser(ctx context.Context, t *testing.T, userID string) {
+	t.Helper()
+	if _, err := th.PgPool.Exec(ctx, `UPDATE users SET confirmed_at = now() WHERE id = $1`, userID); err != nil {
+		t.Fatalf("confirm user: %v", err)
+	}
+}
+
+func countInvitesForTeam(ctx context.Context, t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var count int
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT count(*) FROM invites WHERE invited_to_team_id = $1`, teamID).Scan(&count); err != nil {
+		t.Fatalf("count invites: %v", err)
+	}
+	return count
+}
+
+func inviteUpdatedAt(ctx context.Context, t *testing.T, inviteID uuid.UUID) time.Time {
+	t.Helper()
+	var updatedAt time.Time
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT updated_at FROM invites WHERE id = $1`, inviteID).Scan(&updatedAt); err != nil {
+		t.Fatalf("get invite updated_at: %v", err)
+	}
+	return updatedAt
+}
+
+func teamNameInDB(ctx context.Context, t *testing.T, teamID uuid.UUID) string {
+	t.Helper()
+	var name string
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT name FROM teams WHERE id = $1`, teamID).Scan(&name); err != nil {
+		t.Fatalf("read team name: %v", err)
+	}
+	return name
+}
+
+func decodeJSONArray(t *testing.T, w *httptest.ResponseRecorder) []map[string]any {
+	t.Helper()
+	var items []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal response array: %v, body: %s", err, w.Body.String())
+	}
+	return items
+}
+
+// --------------------------------------------------------------------------
+// GetTeams
+// --------------------------------------------------------------------------
+
+func TestGetTeams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns the caller's teams with roles", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, otherTeamID, "second-team")
+		seedTeamMembership(ctx, t, otherTeamID, userID, "viewer")
+
+		c, w := newTestGinContext("GET", "/teams", nil)
+		c.Set("userId", userID)
+		h.GetTeams(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		teams := decodeJSONArray(t, w)
+		if len(teams) != 2 {
+			t.Fatalf("len(teams) = %d, want 2", len(teams))
+		}
+		roleByID := map[string]string{}
+		for _, tm := range teams {
+			roleByID[tm["id"].(string)] = tm["role"].(string)
+		}
+		if roleByID[teamID.String()] != "owner" || roleByID[otherTeamID.String()] != "viewer" {
+			t.Errorf("teams = %v, want owner + viewer roles", roleByID)
+		}
+	})
+
+	t.Run("user with no teams gets 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "orphan@test.com")
+
+		c, w := newTestGinContext("GET", "/teams", nil)
+		c.Set("userId", userID)
+		h.GetTeams(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// GetTeamApps / GetTeamApp
+// --------------------------------------------------------------------------
+
+func TestGetTeamApps(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("member can list the team's apps", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+		seedAPIKey(ctx, t, appID, "msrsh", "key-value", "checksum", false, nil, time.Now())
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/apps", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamApps(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		apps := decodeJSONArray(t, w)
+		if len(apps) != 1 {
+			t.Fatalf("len(apps) = %d, want 1", len(apps))
+		}
+		if apps[0]["id"] != appID.String() {
+			t.Errorf("app id = %v, want %s", apps[0]["id"], appID)
+		}
+	})
+
+	t.Run("team without apps gets 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/apps", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamApps(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("non-member gets an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		_, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/apps", nil)
+		c.Set("userId", outsiderID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamApps(c)
+
+		// PerformAuthz errors on an unknown role, so a non-member gets 500
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestGetTeamApp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("member can fetch a team app", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+		seedAPIKey(ctx, t, appID, "msrsh", "key-value", "checksum", false, nil, time.Now())
+
+		c, w := newTestGinContext("GET", fmt.Sprintf("/teams/%s/apps/%s", teamID, appID), nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "appId", Value: appID.String()}}
+		h.GetTeamApp(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("app of another team gets 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, otherTeamID, "other-team")
+		foreignAppID := uuid.New()
+		seedApp(ctx, t, foreignAppID, otherTeamID, 90)
+		seedAPIKey(ctx, t, foreignAppID, "msrsh", "key-value", "checksum", false, nil, time.Now())
+
+		c, w := newTestGinContext("GET", fmt.Sprintf("/teams/%s/apps/%s", teamID, foreignAppID), nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "appId", Value: foreignAppID.String()}}
+		h.GetTeamApp(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("non-member gets an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		_, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newTestGinContext("GET", fmt.Sprintf("/teams/%s/apps/%s", teamID, appID), nil)
+		c.Set("userId", outsiderID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "appId", Value: appID.String()}}
+		h.GetTeamApp(c)
+
+		// PerformAuthz errors on an unknown role, so a non-member gets 500
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// InviteMembers
+// --------------------------------------------------------------------------
+
+func newInviteContext(callerID string, teamID uuid.UUID, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("POST", "/teams/"+teamID.String()+"/invite", bytes.NewBufferString(body))
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+	return c, w
+}
+
+func TestInviteMembers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("new email gets an invite row", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newInviteContext(ownerID, teamID, `[{"email":"new@test.com","role":"admin"}]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "ok", "Invited new@test.com")
+		if n := countInvitesForTeam(ctx, t, teamID); n != 1 {
+			t.Errorf("invites = %d, want 1", n)
+		}
+	})
+
+	t.Run("existing confirmed user is added as member directly", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		existingID := uuid.New().String()
+		seedUser(ctx, t, existingID, "existing@test.com")
+		confirmUser(ctx, t, existingID)
+
+		c, w := newInviteContext(ownerID, teamID, `[{"email":"existing@test.com","role":"developer"}]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "ok", "Added existing@test.com")
+		if role := getMemberRole(ctx, t, teamID, existingID); role != "developer" {
+			t.Errorf("role = %q, want developer", role)
+		}
+		if n := countInvitesForTeam(ctx, t, teamID); n != 0 {
+			t.Errorf("invites = %d, want 0 (added directly, not invited)", n)
+		}
+	})
+
+	t.Run("viewer cannot invite above their rank", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		viewerID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+
+		c, w := newInviteContext(viewerID, teamID, `[{"email":"new@test.com","role":"admin"}]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("admin cannot invite an owner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		adminID, teamID := seedTeamAndMemberWithRole(t, ctx, "admin")
+
+		c, w := newInviteContext(adminID, teamID, `[{"email":"new@test.com","role":"owner"}]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("inviting an existing member gets 409", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		memberID := uuid.New().String()
+		seedUser(ctx, t, memberID, "member@test.com")
+		seedTeamMembership(ctx, t, teamID, memberID, "viewer")
+
+		c, w := newInviteContext(ownerID, teamID, `[{"email":"member@test.com","role":"viewer"}]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusConflict {
+			t.Fatalf("status = %d, want 409, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("empty invitee list gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newInviteContext(ownerID, teamID, `[]`)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("more than the invitee cap gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		invitees := make([]string, 0, 26)
+		for i := range 26 {
+			invitees = append(invitees, fmt.Sprintf(`{"email":"user%d@test.com","role":"viewer"}`, i))
+		}
+		body := "[" + strings.Join(invitees, ",") + "]"
+
+		c, w := newInviteContext(ownerID, teamID, body)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// GetValidTeamInvites
+// --------------------------------------------------------------------------
+
+func TestGetValidTeamInvites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("member sees valid invites only", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+		seedInviteRow(ctx, t, uuid.New(), teamID, userID, "admin", "fresh@test.com", time.Now())
+		seedInviteRow(ctx, t, uuid.New(), teamID, userID, "viewer", "stale@test.com", time.Now().Add(-8*24*time.Hour))
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/invites", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetValidTeamInvites(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		invites := decodeJSONArray(t, w)
+		if len(invites) != 1 {
+			t.Fatalf("len(invites) = %d, want 1", len(invites))
+		}
+		if invites[0]["email"] != "fresh@test.com" {
+			t.Errorf("invite email = %v, want fresh@test.com", invites[0]["email"])
+		}
+	})
+
+	t.Run("non-member gets an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		_, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/invites", nil)
+		c.Set("userId", outsiderID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetValidTeamInvites(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// ResendInvite / RemoveInvite
+// --------------------------------------------------------------------------
+
+func newInviteActionContext(method string, callerID string, teamID, inviteID uuid.UUID) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext(method, fmt.Sprintf("/teams/%s/invites/%s", teamID, inviteID), nil)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "inviteId", Value: inviteID.String()}}
+	return c, w
+}
+
+func TestResendInvite(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can resend and validity restarts", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		inviteID := uuid.New()
+		seedInviteRow(ctx, t, inviteID, teamID, ownerID, "viewer", "dev@test.com", time.Now().Add(-8*24*time.Hour))
+
+		before := inviteUpdatedAt(ctx, t, inviteID)
+
+		c, w := newInviteActionContext("PATCH", ownerID, teamID, inviteID)
+		h.ResendInvite(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if after := inviteUpdatedAt(ctx, t, inviteID); !after.After(before) {
+			t.Errorf("updated_at not bumped: before %v, after %v", before, after)
+		}
+	})
+
+	t.Run("admin cannot resend an owner invite", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		adminID := uuid.New().String()
+		seedUser(ctx, t, adminID, "admin@test.com")
+		seedTeamMembership(ctx, t, teamID, adminID, "admin")
+
+		inviteID := uuid.New()
+		seedInviteRow(ctx, t, inviteID, teamID, ownerID, "owner", "future-owner@test.com", time.Now())
+
+		c, w := newInviteActionContext("PATCH", adminID, teamID, inviteID)
+		h.ResendInvite(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("unknown invite gets an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newInviteActionContext("PATCH", ownerID, teamID, uuid.New())
+		h.ResendInvite(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 for missing invite, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestRemoveInvite(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can remove an invite", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		inviteID := uuid.New()
+		seedInviteRow(ctx, t, inviteID, teamID, ownerID, "viewer", "dev@test.com", time.Now())
+
+		c, w := newInviteActionContext("DELETE", ownerID, teamID, inviteID)
+		h.RemoveInvite(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if n := countInvitesForTeam(ctx, t, teamID); n != 0 {
+			t.Errorf("invites = %d, want 0", n)
+		}
+	})
+
+	t.Run("admin cannot remove an owner invite", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		adminID := uuid.New().String()
+		seedUser(ctx, t, adminID, "admin@test.com")
+		seedTeamMembership(ctx, t, teamID, adminID, "admin")
+
+		inviteID := uuid.New()
+		seedInviteRow(ctx, t, inviteID, teamID, ownerID, "owner", "future-owner@test.com", time.Now())
+
+		c, w := newInviteActionContext("DELETE", adminID, teamID, inviteID)
+		h.RemoveInvite(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+		if n := countInvitesForTeam(ctx, t, teamID); n != 1 {
+			t.Errorf("invites = %d, want 1 (invite kept)", n)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// RenameTeam
+// --------------------------------------------------------------------------
+
+func newRenameContext(callerID string, teamID uuid.UUID, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/rename", bytes.NewBufferString(body))
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+	return c, w
+}
+
+func TestRenameTeam(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can rename the team", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newRenameContext(ownerID, teamID, `{"name":"  renamed-team  "}`)
+		h.RenameTeam(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if got := teamNameInDB(ctx, t, teamID); got != "renamed-team" {
+			t.Errorf("name = %q, want renamed-team (trimmed)", got)
+		}
+	})
+
+	t.Run("admin cannot rename", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		adminID, teamID := seedTeamAndMemberWithRole(t, ctx, "admin")
+
+		c, w := newRenameContext(adminID, teamID, `{"name":"renamed-team"}`)
+		h.RenameTeam(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+		if got := teamNameInDB(ctx, t, teamID); got != testTeamName {
+			t.Errorf("name = %q, want unchanged %q", got, testTeamName)
+		}
+	})
+
+	t.Run("missing name gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newRenameContext(ownerID, teamID, `{}`)
+		h.RenameTeam(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("blank name gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newRenameContext(ownerID, teamID, `{"name":"   "}`)
+		h.RenameTeam(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("a body-supplied id cannot redirect the rename", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		// a team the caller has nothing to do with
+		victimID := uuid.New()
+		seedTeam(ctx, t, victimID, "victim-team")
+
+		body := fmt.Sprintf(`{"id":%q,"name":"hacked"}`, victimID)
+		c, w := newRenameContext(ownerID, teamID, body)
+		h.RenameTeam(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if got := teamNameInDB(ctx, t, teamID); got != "hacked" {
+			t.Errorf("url team name = %q, want hacked (url id wins)", got)
+		}
+		if got := teamNameInDB(ctx, t, victimID); got != "victim-team" {
+			t.Errorf("victim team name = %q, want unchanged", got)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// GetTeamMembers
+// --------------------------------------------------------------------------
+
+func TestGetTeamMembers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("member can list members with roles", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		viewerID, teamID := seedTeamAndMemberWithRole(t, ctx, "viewer")
+		ownerID := uuid.New().String()
+		seedUser(ctx, t, ownerID, "owner@test.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/members", nil)
+		c.Set("userId", viewerID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamMembers(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		members := decodeJSONArray(t, w)
+		if len(members) != 2 {
+			t.Fatalf("len(members) = %d, want 2", len(members))
+		}
+	})
+
+	t.Run("non-member gets an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		_, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/members", nil)
+		c.Set("userId", outsiderID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamMembers(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/backend/libs/autumn/client.go
+++ b/backend/libs/autumn/client.go
@@ -136,6 +136,7 @@ func do(ctx context.Context, opName, method, path string, body any, out any) (er
 var (
 	GetOrCreateCustomer = getOrCreateCustomer
 	GetCustomer         = getCustomer
+	UpdateCustomer      = updateCustomer
 	Attach              = attach
 	Update              = update
 	OpenCustomerPortal  = openCustomerPortal
@@ -167,6 +168,16 @@ func getCustomer(ctx context.Context, customerID string) (*Customer, error) {
 		return nil, err
 	}
 	return &out, nil
+}
+
+// updateCustomer changes the email on an existing Autumn customer. Invoices,
+// receipts and dunning notifications from Autumn/Stripe go to this address.
+func updateCustomer(ctx context.Context, customerID, email string) error {
+	req := updateCustomerRequest{
+		CustomerID: customerID,
+		Email:      email,
+	}
+	return do(ctx, "autumn-update-customer", http.MethodPost, "/v1/customers.update", req, nil)
 }
 
 // ----------------------------------------------------------------------------

--- a/backend/libs/autumn/client_test.go
+++ b/backend/libs/autumn/client_test.go
@@ -59,6 +59,31 @@ func TestGetOrCreateCustomer(t *testing.T) {
 	}
 }
 
+func TestUpdateCustomer(t *testing.T) {
+	var gotBody updateCustomerRequest
+	cleanup := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/customers.update" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer cleanup()
+
+	if err := updateCustomer(context.Background(), "cust_123", "new-owner@test.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody.CustomerID != "cust_123" {
+		t.Errorf("customer_id = %q, want cust_123", gotBody.CustomerID)
+	}
+	if gotBody.Email != "new-owner@test.com" {
+		t.Errorf("email = %q, want new-owner@test.com", gotBody.Email)
+	}
+}
+
 func TestAttachReturnsPaymentURL(t *testing.T) {
 	cleanup := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/billing.attach" {

--- a/backend/libs/autumn/testhelpers/testhelpers.go
+++ b/backend/libs/autumn/testhelpers/testhelpers.go
@@ -51,6 +51,14 @@ func MockUpdate(t *testing.T, fn func(ctx context.Context, req autumn.UpdateRequ
 	t.Cleanup(func() { autumn.Update = orig })
 }
 
+// MockUpdateCustomer swaps autumn.UpdateCustomer for the duration of the test.
+func MockUpdateCustomer(t *testing.T, fn func(ctx context.Context, customerID, email string) error) {
+	t.Helper()
+	orig := autumn.UpdateCustomer
+	autumn.UpdateCustomer = fn
+	t.Cleanup(func() { autumn.UpdateCustomer = orig })
+}
+
 // MockGetCustomer swaps autumn.GetCustomer for the duration of the test.
 func MockGetCustomer(t *testing.T, fn func(ctx context.Context, customerID string) (*autumn.Customer, error)) {
 	t.Helper()

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -66,6 +66,12 @@ type createCustomerRequest struct {
 	Name  string `json:"name,omitempty"`
 }
 
+// updateCustomerRequest is the payload for POST /v1/customers.update.
+type updateCustomerRequest struct {
+	CustomerID string `json:"customer_id"`
+	Email      string `json:"email,omitempty"`
+}
+
 // AttachRequest is the payload for POST /v1/billing.attach.
 type AttachRequest struct {
 	CustomerID            string         `json:"customer_id"`

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -37,10 +37,15 @@ func InviteExistingUserEmail(inviterEmail, role, teamName, siteOrigin string) (s
 }
 
 // RemovedFromTeamEmail builds the email sent when a user is removed from a team.
+// memberTeamId is the member's remaining default team; pass an empty string
+// when the member has no team left, which links to the dashboard root.
 func RemovedFromTeamEmail(teamName, removedByEmail, siteOrigin, memberTeamId string) (subject, body string) {
 	subject = "Removed from Measure team"
 	msg := fmt.Sprintf("You have been removed from team <b>%s</b> by <b>%s</b>", teamName, removedByEmail)
-	url := siteOrigin + "/" + memberTeamId + "/overview"
+	url := siteOrigin
+	if memberTeamId != "" {
+		url = siteOrigin + "/" + memberTeamId + "/overview"
+	}
 	body = RenderEmailBody(subject, MessageContent(msg), "Go to Dashboard", url)
 	return
 }

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -640,3 +640,30 @@ func TestUsageLimitEmail_NonStandardThreshold(t *testing.T) {
 	}
 	mustNotContainByteNumbers(t, "UsageLimitEmail(50)", body)
 }
+
+func TestRemovedFromTeamEmail(t *testing.T) {
+	t.Run("links to the member's remaining team", func(t *testing.T) {
+		subject, body := RemovedFromTeamEmail("Acme Corp", "owner@example.com", "https://measure.sh", "team-abc")
+
+		if subject != "Removed from Measure team" {
+			t.Errorf("subject = %q", subject)
+		}
+		if !strings.Contains(body, "removed from team <b>Acme Corp</b> by <b>owner@example.com</b>") {
+			t.Error("body missing removal copy")
+		}
+		if !strings.Contains(body, `href="https://measure.sh/team-abc/overview"`) {
+			t.Error("body missing team dashboard link")
+		}
+	})
+
+	t.Run("links to the dashboard root when no team is left", func(t *testing.T) {
+		_, body := RemovedFromTeamEmail("Acme Corp", "owner@example.com", "https://measure.sh", "")
+
+		if !strings.Contains(body, `href="https://measure.sh"`) {
+			t.Error("body missing root dashboard link")
+		}
+		if strings.Contains(body, "/overview") {
+			t.Error("body should not contain an overview link without a team")
+		}
+	})
+}

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"backend/libs/autumn"
@@ -194,6 +195,45 @@ func ProvisionAutumnCustomer(ctx context.Context, billingEnabled bool, tx pgx.Tx
 		return "", fmt.Errorf("save autumn customer id: %w", err)
 	}
 	return cust.ID, nil
+}
+
+// SyncBillingEmailOnOwnerExit points a team's Autumn customer email at a
+// remaining owner after the member it belonged to was removed or demoted.
+// The customer email is set at team creation to the creating owner's email,
+// and Autumn/Stripe send invoices, receipts and dunning notices there, so a
+// departed owner's address must not stay on the record. An email that does
+// not match the departing member (for example a finance inbox set through
+// the billing portal) is left alone.
+func SyncBillingEmailOnOwnerExit(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID, departedEmail string) error {
+	if !billingEnabled || departedEmail == "" {
+		return nil
+	}
+
+	customerID, err := GetAutumnCustomerID(ctx, pg, teamID)
+	if err != nil {
+		return err
+	}
+	if customerID == "" {
+		return nil
+	}
+
+	cust, err := autumn.GetCustomer(ctx, customerID)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(cust.Email, departedEmail) {
+		return nil
+	}
+
+	owner, found, err := GetTeamOwner(ctx, pg, teamID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("no owner left on team %s to receive billing email", teamID)
+	}
+
+	return autumn.UpdateCustomer(ctx, customerID, owner.Email)
 }
 
 // resetAppsRetention resets all apps for a team to the given retention.

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -552,3 +552,127 @@ func TestTeamCreateEmptyOwnerEmail(t *testing.T) {
 func errContains(err error, s string) bool {
 	return err != nil && strings.Contains(err.Error(), s)
 }
+
+// --------------------------------------------------------------------------
+// SyncBillingEmailOnOwnerExit
+// --------------------------------------------------------------------------
+
+func TestSyncBillingEmailOnOwnerExit(t *testing.T) {
+	ctx := context.Background()
+
+	seedTeamWithOwner := func(t *testing.T, ownerEmail string) uuid.UUID {
+		t.Helper()
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, ownerEmail)
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+		return teamID
+	}
+
+	t.Run("billing disabled is a no-op", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := seedTeamWithOwner(t, "owner@example.com")
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			t.Error("GetCustomer called with billing disabled")
+			return nil, nil
+		})
+
+		if err := SyncBillingEmailOnOwnerExit(ctx, deps.PgPool, false, teamID, "departed@example.com"); err != nil {
+			t.Fatalf("SyncBillingEmailOnOwnerExit: %v", err)
+		}
+	})
+
+	t.Run("team without autumn customer is a no-op", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := seedTeamWithOwner(t, "owner@example.com")
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			t.Error("GetCustomer called without an autumn customer")
+			return nil, nil
+		})
+
+		if err := SyncBillingEmailOnOwnerExit(ctx, deps.PgPool, true, teamID, "departed@example.com"); err != nil {
+			t.Fatalf("SyncBillingEmailOnOwnerExit: %v", err)
+		}
+	})
+
+	t.Run("customer email differing from the departed member is left alone", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := seedTeamWithOwner(t, "owner@example.com")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "finance@example.com"}, nil
+		})
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, _, _ string) error {
+			t.Error("UpdateCustomer called for a non-matching email")
+			return nil
+		})
+
+		if err := SyncBillingEmailOnOwnerExit(ctx, deps.PgPool, true, teamID, "departed@example.com"); err != nil {
+			t.Fatalf("SyncBillingEmailOnOwnerExit: %v", err)
+		}
+	})
+
+	t.Run("matching email moves to the earliest remaining owner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		earlierID := uuid.New().String()
+		laterID := uuid.New().String()
+		seedUser(ctx, t, earlierID, "earlier-owner@example.com")
+		seedUser(ctx, t, laterID, "later-owner@example.com")
+		now := time.Now()
+		seedMembershipAt(ctx, t, teamID.String(), earlierID, "owner", now.Add(-time.Hour))
+		seedMembershipAt(ctx, t, teamID.String(), laterID, "owner", now)
+
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		// mixed case exercises the case-insensitive match
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "Departed@Example.com"}, nil
+		})
+		var gotCustomerID, gotEmail string
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, customerID, email string) error {
+			gotCustomerID = customerID
+			gotEmail = email
+			return nil
+		})
+
+		if err := SyncBillingEmailOnOwnerExit(ctx, deps.PgPool, true, teamID, "departed@example.com"); err != nil {
+			t.Fatalf("SyncBillingEmailOnOwnerExit: %v", err)
+		}
+		if gotCustomerID != custID {
+			t.Errorf("customer = %q, want %q", gotCustomerID, custID)
+		}
+		if gotEmail != "earlier-owner@example.com" {
+			t.Errorf("email = %q, want earlier-owner@example.com", gotEmail)
+		}
+	})
+
+	t.Run("no remaining owner returns an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{ID: custID, Email: "departed@example.com"}, nil
+		})
+		autumntest.MockUpdateCustomer(t, func(_ context.Context, _, _ string) error {
+			t.Error("UpdateCustomer called with no remaining owner")
+			return nil
+		})
+
+		if err := SyncBillingEmailOnOwnerExit(ctx, deps.PgPool, true, teamID, "departed@example.com"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/backend/libs/measure/team.go
+++ b/backend/libs/measure/team.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"backend/libs/chrono"
 
@@ -380,19 +382,103 @@ func (t *Team) AddMembers(ctx context.Context, pg *pgxpool.Pool, invitees []Invi
 	return nil
 }
 
-func (t *Team) RemoveMember(ctx context.Context, pg *pgxpool.Pool, memberId *uuid.UUID) error {
-	stmt := sqlf.PostgreSQL.DeleteFrom("team_membership").
-		Where("team_id = ?", nil).
-		Where("user_id = ?", nil)
+// ErrLastOwner is returned when a removal or role change would leave a team
+// with no owner. An ownerless team could never regain one: only owners can
+// assign the owner role.
+var ErrLastOwner = errors.New("team must have at least one owner")
+
+// lockTeamForMembershipChange takes a write lock on the team row and holds
+// it until the transaction ends. Membership changes take this lock first so
+// that, for any one team, they run one at a time. Without it, two requests
+// removing a team's two owners at once would each still see the other owner
+// present, pass the last-owner check, and leave the team with no owner.
+func lockTeamForMembershipChange(ctx context.Context, tx pgx.Tx, teamId *uuid.UUID) error {
+	stmt := sqlf.PostgreSQL.
+		Select("1").
+		From("teams").
+		Where("id = ?", teamId).
+		Clause("FOR UPDATE")
 	defer stmt.Close()
 
-	_, err := pg.Exec(ctx, stmt.String(), t.ID, memberId)
+	_, err := tx.Exec(ctx, stmt.String(), stmt.Args()...)
+	return err
+}
 
+// memberRoleInTeam reads a member's current role. Call with the team row
+// locked so the value stays authoritative for the rest of the transaction.
+func memberRoleInTeam(ctx context.Context, tx pgx.Tx, teamId, memberId *uuid.UUID) (role string, err error) {
+	stmt := sqlf.PostgreSQL.
+		Select("role").
+		From("team_membership").
+		Where("team_id = ?", teamId).
+		Where("user_id = ?", memberId)
+	defer stmt.Close()
+
+	err = tx.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&role)
+	return
+}
+
+// otherOwnerExists reports whether the team has an owner other than the
+// given member. Call with the team row locked.
+func otherOwnerExists(ctx context.Context, tx pgx.Tx, teamId, memberId *uuid.UUID) (bool, error) {
+	stmt := sqlf.PostgreSQL.
+		Select("count(*)").
+		From("team_membership").
+		Where("team_id = ?", teamId).
+		Where("user_id != ?", memberId).
+		Where("role = ?", "owner")
+	defer stmt.Close()
+
+	var count int
+	if err := tx.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// RemoveMember deletes a member's team membership. Removing the only owner
+// of a team is rejected with ErrLastOwner.
+func (t *Team) RemoveMember(ctx context.Context, pg *pgxpool.Pool, memberId *uuid.UUID) error {
+	tx, err := pg.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	if err := lockTeamForMembershipChange(ctx, tx, t.ID); err != nil {
+		return err
+	}
+
+	role, err := memberRoleInTeam(ctx, tx, t.ID, memberId)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Already not a member, e.g. a concurrent removal won the race.
+		// Treat as done so the operation stays idempotent.
+		return nil
+	}
 	if err != nil {
 		return err
 	}
 
-	return nil
+	if role == "owner" {
+		hasOther, err := otherOwnerExists(ctx, tx, t.ID, memberId)
+		if err != nil {
+			return err
+		}
+		if !hasOther {
+			return ErrLastOwner
+		}
+	}
+
+	stmt := sqlf.PostgreSQL.DeleteFrom("team_membership").
+		Where("team_id = ?", t.ID).
+		Where("user_id = ?", memberId)
+	defer stmt.Close()
+
+	if _, err := tx.Exec(ctx, stmt.String(), stmt.Args()...); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }
 
 // areInviteesMember provides the index of the invitee if that invitee
@@ -414,18 +500,50 @@ func (t *Team) AreInviteesMember(ctx context.Context, pg *pgxpool.Pool, invitees
 	return -1, nil
 }
 
+// ChangeRole updates a member's role. Moving the only owner of a team to a
+// lower role is rejected with ErrLastOwner.
 func (t *Team) ChangeRole(ctx context.Context, pg *pgxpool.Pool, memberId *uuid.UUID, role Rank) error {
-	stmt := sqlf.PostgreSQL.Update("team_membership").
-		Set("role", nil).
-		Set("role_updated_at", nil).
-		Where("team_id = ? and user_id = ?", nil, nil)
-	defer stmt.Close()
+	tx, err := pg.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
 
-	if _, err := pg.Exec(ctx, stmt.String(), role, time.Now(), t.ID, memberId); err != nil {
+	if err := lockTeamForMembershipChange(ctx, tx, t.ID); err != nil {
 		return err
 	}
 
-	return nil
+	current, err := memberRoleInTeam(ctx, tx, t.ID, memberId)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Membership vanished under a concurrent change; nothing to update.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if current == "owner" && role != owner {
+		hasOther, err := otherOwnerExists(ctx, tx, t.ID, memberId)
+		if err != nil {
+			return err
+		}
+		if !hasOther {
+			return ErrLastOwner
+		}
+	}
+
+	stmt := sqlf.PostgreSQL.Update("team_membership").
+		Set("role", role).
+		Set("role_updated_at", time.Now()).
+		Where("team_id = ?", t.ID).
+		Where("user_id = ?", memberId)
+	defer stmt.Close()
+
+	if _, err := tx.Exec(ctx, stmt.String(), stmt.Args()...); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }
 
 // create inserts a new team into database, establishes the user's membership
@@ -487,6 +605,165 @@ func (t *Team) Create(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool
 	}
 
 	return
+}
+
+// isAlphanumeric reports whether s consists only of letters and digits.
+func isAlphanumeric(s string) bool {
+	return !strings.ContainsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+// personalTeamName names a user's personal team: "<first name>'s team",
+// falling back to the leading part of the email address when OAuth gave us
+// no display name (anup@measure.sh becomes "Anup's team"), then to a
+// generic name when there is no email or its leading part contains
+// anything other than letters and digits.
+func personalTeamName(u *User) string {
+	if u.Name != nil {
+		if first := u.FirstName(); first != "" {
+			return fmt.Sprintf("%s's team", first)
+		}
+	}
+	if u.Email != nil {
+		if local, _, found := strings.Cut(*u.Email, "@"); found {
+			if i := strings.IndexAny(local, ".+_-"); i >= 0 {
+				local = local[:i]
+			}
+			if local != "" && isAlphanumeric(local) {
+				r, size := utf8.DecodeRuneInString(local)
+				return fmt.Sprintf("%s's team", string(unicode.ToUpper(r))+local[size:])
+			}
+		}
+	}
+	return "Personal team"
+}
+
+// CreatePersonalTeam creates the "<first name>'s team" a user owns, in its
+// own transaction, and fires the team-created analytics event. Called at
+// signup, and via EnsureDefaultTeam for a user who no longer has any team.
+func CreatePersonalTeam(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, u *User) (*Team, error) {
+	if u.Name == nil || u.Email == nil {
+		if err := u.GetUserDetails(ctx, pg); err != nil {
+			return nil, fmt.Errorf("fetch user details: %w", err)
+		}
+	}
+
+	tx, err := pg.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	team, err := createPersonalTeamTx(ctx, pg, billingEnabled, u, &tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	FireTeamCreatedEvent(ctx, u, team)
+
+	return team, nil
+}
+
+// createPersonalTeamTx creates the personal team inside the caller's
+// transaction; the caller commits and fires the analytics event. u.Name and
+// u.Email must be loaded before calling: this function runs inside the
+// caller's transaction and must not query the pool.
+func createPersonalTeamTx(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, u *User, tx *pgx.Tx) (*Team, error) {
+	teamName := personalTeamName(u)
+	team := &Team{
+		Name: &teamName,
+	}
+
+	if err := team.Create(ctx, pg, billingEnabled, u, tx); err != nil {
+		return nil, err
+	}
+
+	return team, nil
+}
+
+// teamProvisionLockClass is the first key of the two-key advisory lock
+// around personal-team creation; the second key is a hash of the user id.
+// All advisory locks in a database draw from one shared set of numbers, so
+// this fixed first key keeps our per-user locks from ever matching a lock
+// some other feature takes. The value itself is arbitrary; it encodes the
+// ASCII letters "msmt" (measure team), and when inspecting pg_locks it
+// appears in the classid column as 1836281204, identifying us as the owner.
+const teamProvisionLockClass int32 = 0x6d736d74
+
+// EnsureDefaultTeam returns the user's default team, creating a personal
+// team first when the user has no team memberships at all, for example
+// after being removed from every team they belonged to. Sign-in and session
+// flows rely on every user resolving to some team.
+func EnsureDefaultTeam(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, u *User) (*Team, error) {
+	team, err := u.GetDefaultTeam(ctx, pg)
+	if err == nil {
+		return team, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	// The user has no team, so create one. Two requests for the same user
+	// can reach this point at the same time (for example two browser tabs),
+	// and each would create its own team and Autumn customer. The advisory
+	// lock below prevents that by making requests take turns: the first
+	// proceeds, the rest wait until it finishes.
+
+	// fetched before Begin so the transaction below never needs a pool query
+	if u.Name == nil || u.Email == nil {
+		if err := u.GetUserDetails(ctx, pg); err != nil {
+			return nil, fmt.Errorf("fetch user details: %w", err)
+		}
+	}
+
+	// This transaction holds one pool connection until it ends, and every
+	// request waiting for the lock holds one of its own. All database access
+	// until the commit must therefore run on tx, not pg: if the pool were
+	// empty, a query through pg would wait for a free connection while the
+	// requests holding them wait for this one to finish.
+	tx, err := pg.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	stmt := sqlf.PostgreSQL.
+		Select("pg_advisory_xact_lock(?::int4, hashtext(?))", teamProvisionLockClass, u.ID)
+	defer stmt.Close()
+
+	if _, err := tx.Exec(ctx, stmt.String(), stmt.Args()...); err != nil {
+		return nil, err
+	}
+
+	// While this request waited for the lock, another request may have
+	// already created the team. Its work is committed by the time the lock
+	// frees, so this check finds that team and returns it instead of
+	// creating a second one.
+	team, err = defaultTeam(ctx, tx, u.ID)
+	if err == nil {
+		return team, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	team, err = createPersonalTeamTx(ctx, pg, billingEnabled, u, &tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	FireTeamCreatedEvent(ctx, u, team)
+
+	return team, nil
 }
 
 func GetValidInvitesForEmail(ctx context.Context, pg *pgxpool.Pool, email string) ([]Invite, error) {

--- a/backend/libs/measure/team_test.go
+++ b/backend/libs/measure/team_test.go
@@ -1,0 +1,982 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// getMembershipRole returns the member's role in a team, or "" when the
+// membership row does not exist.
+func getMembershipRole(ctx context.Context, t *testing.T, teamID uuid.UUID, userID string) string {
+	t.Helper()
+	var role string
+	err := th.PgPool.QueryRow(ctx,
+		`SELECT role FROM team_membership WHERE team_id = $1 AND user_id = $2`, teamID, userID).Scan(&role)
+	if err != nil {
+		return ""
+	}
+	return role
+}
+
+// setUserName sets users.name, which SeedUser leaves NULL.
+func setUserName(ctx context.Context, t *testing.T, userID, name string) {
+	t.Helper()
+	if _, err := th.PgPool.Exec(ctx, `UPDATE users SET name = $1 WHERE id = $2`, name, userID); err != nil {
+		t.Fatalf("set user name: %v", err)
+	}
+}
+
+func TestRemoveMember(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removing the last owner returns ErrLastOwner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		viewerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedUser(ctx, t, viewerID, "viewer@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+		seedTeamMembership(ctx, t, teamID, viewerID, "viewer")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(ownerID)
+		err := team.RemoveMember(ctx, deps.PgPool, &memberID)
+		if !errors.Is(err, ErrLastOwner) {
+			t.Fatalf("err = %v, want ErrLastOwner", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("owner membership = %q, want intact", role)
+		}
+	})
+
+	t.Run("removing an owner succeeds when another owner remains", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		firstOwnerID := uuid.New().String()
+		secondOwnerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, firstOwnerID, "first-owner@example.com")
+		seedUser(ctx, t, secondOwnerID, "second-owner@example.com")
+		seedTeamMembership(ctx, t, teamID, firstOwnerID, "owner")
+		seedTeamMembership(ctx, t, teamID, secondOwnerID, "owner")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(firstOwnerID)
+		if err := team.RemoveMember(ctx, deps.PgPool, &memberID); err != nil {
+			t.Fatalf("RemoveMember: %v", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, firstOwnerID); role != "" {
+			t.Errorf("membership still present with role %q, want removed", role)
+		}
+	})
+
+	t.Run("removing a non-owner member succeeds with a sole owner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		devID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedUser(ctx, t, devID, "dev@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+		seedTeamMembership(ctx, t, teamID, devID, "developer")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(devID)
+		if err := team.RemoveMember(ctx, deps.PgPool, &memberID); err != nil {
+			t.Fatalf("RemoveMember: %v", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, devID); role != "" {
+			t.Errorf("membership still present with role %q, want removed", role)
+		}
+	})
+
+	t.Run("removing a non-member is an idempotent no-op", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+
+		// stands in for a member a concurrent request already removed
+		stranger := uuid.New()
+		team := &Team{ID: &teamID}
+		if err := team.RemoveMember(ctx, deps.PgPool, &stranger); err != nil {
+			t.Fatalf("RemoveMember on non-member: %v, want nil", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("owner membership = %q, want intact", role)
+		}
+	})
+}
+
+func TestChangeRole(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("demoting the last owner returns ErrLastOwner", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(ownerID)
+		err := team.ChangeRole(ctx, deps.PgPool, &memberID, RoleMap["admin"])
+		if !errors.Is(err, ErrLastOwner) {
+			t.Fatalf("err = %v, want ErrLastOwner", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("role = %q, want owner", role)
+		}
+	})
+
+	t.Run("keeping the last owner at owner succeeds", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(ownerID)
+		if err := team.ChangeRole(ctx, deps.PgPool, &memberID, RoleMap["owner"]); err != nil {
+			t.Fatalf("ChangeRole: %v", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("role = %q, want owner", role)
+		}
+	})
+
+	t.Run("demoting a co-owner succeeds when another owner remains", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		firstOwnerID := uuid.New().String()
+		secondOwnerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, firstOwnerID, "first-owner@example.com")
+		seedUser(ctx, t, secondOwnerID, "second-owner@example.com")
+		seedTeamMembership(ctx, t, teamID, firstOwnerID, "owner")
+		seedTeamMembership(ctx, t, teamID, secondOwnerID, "owner")
+
+		team := &Team{ID: &teamID}
+		memberID := uuid.MustParse(firstOwnerID)
+		if err := team.ChangeRole(ctx, deps.PgPool, &memberID, RoleMap["viewer"]); err != nil {
+			t.Fatalf("ChangeRole: %v", err)
+		}
+		if role := getMembershipRole(ctx, t, teamID, firstOwnerID); role != "viewer" {
+			t.Errorf("role = %q, want viewer", role)
+		}
+	})
+
+	t.Run("changing the role of a non-member is an idempotent no-op", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		ownerID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedTeamMembership(ctx, t, teamID, ownerID, "owner")
+
+		stranger := uuid.New()
+		team := &Team{ID: &teamID}
+		if err := team.ChangeRole(ctx, deps.PgPool, &stranger, RoleMap["admin"]); err != nil {
+			t.Fatalf("ChangeRole on non-member: %v, want nil", err)
+		}
+	})
+}
+
+func TestCreatePersonalTeam(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("names the team after the user's first name", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "ada@example.com")
+		setUserName(ctx, t, userID, "Ada Lovelace")
+
+		team, err := CreatePersonalTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), &User{ID: &userID})
+		if err != nil {
+			t.Fatalf("CreatePersonalTeam: %v", err)
+		}
+		if team.Name == nil || *team.Name != "Ada's team" {
+			t.Errorf("team name = %v, want Ada's team", team.Name)
+		}
+		if role := getMembershipRole(ctx, t, *team.ID, userID); role != "owner" {
+			t.Errorf("role = %q, want owner", role)
+		}
+		if id := getTeamAutumnCustomerID(ctx, t, *team.ID); id == nil || *id == "" {
+			t.Error("autumn customer not provisioned")
+		}
+	})
+
+	t.Run("derives the name from the email when the user has no name", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "john.doe+work@example.com")
+
+		team, err := CreatePersonalTeam(ctx, deps.PgPool, false, &User{ID: &userID})
+		if err != nil {
+			t.Fatalf("CreatePersonalTeam: %v", err)
+		}
+		if team.Name == nil || *team.Name != "John's team" {
+			t.Errorf("team name = %v, want John's team", team.Name)
+		}
+	})
+
+	t.Run("email-derived names", func(t *testing.T) {
+		empty := ""
+		cases := []struct {
+			email string
+			want  string
+		}{
+			{"anup@measure.sh", "Anup's team"},
+			{"john.doe@example.com", "John's team"},
+			{"mary_jane@example.com", "Mary's team"},
+			{"jean-pierre@example.com", "Jean's team"},
+			{"dev+staging@example.com", "Dev's team"},
+			{"josé@example.com", "José's team"},
+			{`"john doe"@example.com`, "Personal team"},
+			{"notanemail", "Personal team"},
+			{"@example.com", "Personal team"},
+			{"", "Personal team"},
+		}
+		for _, c := range cases {
+			email := c.email
+			if got := personalTeamName(&User{Name: &empty, Email: &email}); got != c.want {
+				t.Errorf("personalTeamName(%q) = %q, want %q", c.email, got, c.want)
+			}
+		}
+		if got := personalTeamName(&User{}); got != "Personal team" {
+			t.Errorf("personalTeamName with nil fields = %q, want Personal team", got)
+		}
+	})
+}
+
+func TestGetDefaultTeam(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns ErrNoRows when the user has no memberships", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "orphan@example.com")
+
+		_, err := (&User{ID: &userID}).GetDefaultTeam(ctx, deps.PgPool)
+		if !errors.Is(err, pgx.ErrNoRows) {
+			t.Fatalf("err = %v, want pgx.ErrNoRows", err)
+		}
+	})
+}
+
+func TestEnsureDefaultTeam(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("prefers an owned team over an earlier membership", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "member@example.com")
+
+		memberTeamID := uuid.New()
+		seedTeam(ctx, t, memberTeamID, "someone-elses-team")
+		ownedTeamID := uuid.New()
+		seedTeam(ctx, t, ownedTeamID, "owned-team")
+
+		now := time.Now()
+		seedMembershipAt(ctx, t, memberTeamID.String(), userID, "viewer", now.Add(-24*time.Hour))
+		seedMembershipAt(ctx, t, ownedTeamID.String(), userID, "owner", now)
+
+		team, err := EnsureDefaultTeam(ctx, deps.PgPool, false, &User{ID: &userID})
+		if err != nil {
+			t.Fatalf("EnsureDefaultTeam: %v", err)
+		}
+		if team.ID == nil || *team.ID != ownedTeamID {
+			t.Errorf("default team = %v, want owned team %v", team.ID, ownedTeamID)
+		}
+	})
+
+	t.Run("falls back to a membership team when the user owns none", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "member@example.com")
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "someone-elses-team")
+		seedTeamMembership(ctx, t, teamID, userID, "viewer")
+
+		team, err := EnsureDefaultTeam(ctx, deps.PgPool, false, &User{ID: &userID})
+		if err != nil {
+			t.Fatalf("EnsureDefaultTeam: %v", err)
+		}
+		if team.ID == nil || *team.ID != teamID {
+			t.Errorf("default team = %v, want membership team %v", team.ID, teamID)
+		}
+	})
+
+	t.Run("creates a personal team when the user has no memberships", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "orphan@example.com")
+
+		team, err := EnsureDefaultTeam(ctx, deps.PgPool, false, &User{ID: &userID})
+		if err != nil {
+			t.Fatalf("EnsureDefaultTeam: %v", err)
+		}
+		if team.ID == nil {
+			t.Fatal("EnsureDefaultTeam returned team without id")
+		}
+		if role := getMembershipRole(ctx, t, *team.ID, userID); role != "owner" {
+			t.Errorf("role in created team = %q, want owner", role)
+		}
+	})
+
+	t.Run("concurrent calls for a teamless user create exactly one team", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "racer@example.com")
+
+		const callers = 8
+		teamIDs := make([]uuid.UUID, callers)
+		errs := make([]error, callers)
+
+		var wg sync.WaitGroup
+		for i := range callers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				team, err := EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), &User{ID: &userID})
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				teamIDs[i] = *team.ID
+			}()
+		}
+		wg.Wait()
+
+		for i, err := range errs {
+			if err != nil {
+				t.Fatalf("caller %d: %v", i, err)
+			}
+		}
+		for i, id := range teamIDs {
+			if id != teamIDs[0] {
+				t.Errorf("caller %d got team %v, want %v (all callers must agree)", i, id, teamIDs[0])
+			}
+		}
+
+		var memberships int
+		if err := th.PgPool.QueryRow(ctx,
+			`SELECT count(*) FROM team_membership WHERE user_id = $1`, userID).Scan(&memberships); err != nil {
+			t.Fatalf("count memberships: %v", err)
+		}
+		if memberships != 1 {
+			t.Errorf("memberships = %d, want exactly 1 team created", memberships)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// Helpers for invite and team assertions
+// --------------------------------------------------------------------------
+
+// seedInviteAt inserts an invites row with an explicit updated_at so tests
+// can control invite validity (valid = updated_at within TeamInviteValidity).
+func seedInviteAt(ctx context.Context, t *testing.T, inviteID, teamID uuid.UUID, byUserID, role, email string, updatedAt time.Time) {
+	t.Helper()
+	_, err := th.PgPool.Exec(ctx,
+		`INSERT INTO invites (id, invited_by_user_id, invited_to_team_id, invited_as_role, email, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $6)`,
+		inviteID, byUserID, teamID, role, email, updatedAt)
+	if err != nil {
+		t.Fatalf("seed invite: %v", err)
+	}
+}
+
+func countTeamInvites(ctx context.Context, t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var count int
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT count(*) FROM invites WHERE invited_to_team_id = $1`, teamID).Scan(&count); err != nil {
+		t.Fatalf("count invites: %v", err)
+	}
+	return count
+}
+
+func getInviteUpdatedAt(ctx context.Context, t *testing.T, inviteID uuid.UUID) time.Time {
+	t.Helper()
+	var updatedAt time.Time
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT updated_at FROM invites WHERE id = $1`, inviteID).Scan(&updatedAt); err != nil {
+		t.Fatalf("get invite updated_at: %v", err)
+	}
+	return updatedAt
+}
+
+func readTeamName(ctx context.Context, t *testing.T, teamID uuid.UUID) string {
+	t.Helper()
+	var name string
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT name FROM teams WHERE id = $1`, teamID).Scan(&name); err != nil {
+		t.Fatalf("read team name: %v", err)
+	}
+	return name
+}
+
+// --------------------------------------------------------------------------
+// GetApps
+// --------------------------------------------------------------------------
+
+func TestGetApps(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns only the team's apps", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeam(ctx, t, otherTeamID, "other-team")
+
+		appA := uuid.New()
+		appB := uuid.New()
+		outsideApp := uuid.New()
+		seedApp(ctx, t, appA, teamID, 90)
+		seedApp(ctx, t, appB, teamID, 90)
+		seedApp(ctx, t, outsideApp, otherTeamID, 90)
+
+		seedAPIKey(ctx, t, appA, "msrsh", "key-a", "checksum-a", false, nil, time.Now())
+		seedAPIKey(ctx, t, appB, "msrsh", "key-b", "checksum-b", false, nil, time.Now())
+		seedAPIKey(ctx, t, outsideApp, "msrsh", "key-c", "checksum-c", false, nil, time.Now())
+
+		team := &Team{ID: &teamID}
+		apps, err := team.GetApps(ctx, deps.PgPool)
+		if err != nil {
+			t.Fatalf("GetApps: %v", err)
+		}
+		if len(apps) != 2 {
+			t.Fatalf("len(apps) = %d, want 2", len(apps))
+		}
+		got := map[uuid.UUID]bool{}
+		for _, a := range apps {
+			if a.TeamId != teamID {
+				t.Errorf("app %v team = %v, want %v", a.ID, a.TeamId, teamID)
+			}
+			got[*a.ID] = true
+		}
+		if !got[appA] || !got[appB] {
+			t.Errorf("apps = %v, want both %v and %v", got, appA, appB)
+		}
+	})
+
+	t.Run("returns empty for a team with no apps", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+
+		team := &Team{ID: &teamID}
+		apps, err := team.GetApps(ctx, deps.PgPool)
+		if err != nil {
+			t.Fatalf("GetApps: %v", err)
+		}
+		if len(apps) != 0 {
+			t.Errorf("len(apps) = %d, want 0", len(apps))
+		}
+	})
+
+}
+
+// --------------------------------------------------------------------------
+// GetMembers
+// --------------------------------------------------------------------------
+
+func TestGetMembers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns members ordered by membership age with roles", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeam(ctx, t, otherTeamID, "other-team")
+
+		ownerID := uuid.New().String()
+		viewerID := uuid.New().String()
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, ownerID, "owner@example.com")
+		seedUser(ctx, t, viewerID, "viewer@example.com")
+		seedUser(ctx, t, outsiderID, "outsider@example.com")
+
+		now := time.Now()
+		seedMembershipAt(ctx, t, teamID.String(), ownerID, "owner", now.Add(-time.Hour))
+		seedMembershipAt(ctx, t, teamID.String(), viewerID, "viewer", now)
+		seedTeamMembership(ctx, t, otherTeamID, outsiderID, "owner")
+
+		team := &Team{ID: &teamID}
+		members, err := team.GetMembers(ctx, deps.PgPool)
+		if err != nil {
+			t.Fatalf("GetMembers: %v", err)
+		}
+		if len(members) != 2 {
+			t.Fatalf("len(members) = %d, want 2", len(members))
+		}
+		if *members[0].Email != "owner@example.com" || *members[0].Role != "owner" {
+			t.Errorf("members[0] = %s/%s, want owner@example.com/owner", *members[0].Email, *members[0].Role)
+		}
+		if *members[1].Email != "viewer@example.com" || *members[1].Role != "viewer" {
+			t.Errorf("members[1] = %s/%s, want viewer@example.com/viewer", *members[1].Email, *members[1].Role)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// GetName / Rename
+// --------------------------------------------------------------------------
+
+func TestGetName(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fills the team name", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+
+		team := &Team{ID: &teamID}
+		if err := team.GetName(ctx, deps.PgPool); err != nil {
+			t.Fatalf("GetName: %v", err)
+		}
+		if team.Name == nil || *team.Name != testTeamName {
+			t.Errorf("name = %v, want %q", team.Name, testTeamName)
+		}
+	})
+
+	t.Run("unknown team returns an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		unknownID := uuid.New()
+		team := &Team{ID: &unknownID}
+		if err := team.GetName(ctx, deps.PgPool); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestRename(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+
+	newName := "renamed-team"
+	team := &Team{ID: &teamID, Name: &newName}
+	if err := team.Rename(ctx, deps.PgPool); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if got := readTeamName(ctx, t, teamID); got != "renamed-team" {
+		t.Errorf("name = %q, want renamed-team", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Invites
+// --------------------------------------------------------------------------
+
+func TestAddInvites(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("inserts invites and returns email to id map", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		inviterID := uuid.New().String()
+		seedUser(ctx, t, inviterID, "inviter@example.com")
+
+		team := &Team{ID: &teamID}
+		invitees := []Invitee{{Email: "new@example.com", Role: RoleMap["admin"]}}
+		m, err := team.AddInvites(ctx, deps.PgPool, inviterID, invitees)
+		if err != nil {
+			t.Fatalf("AddInvites: %v", err)
+		}
+		if _, ok := m["new@example.com"]; !ok || len(m) != 1 {
+			t.Errorf("map = %v, want one entry for new@example.com", m)
+		}
+		if n := countTeamInvites(ctx, t, teamID); n != 1 {
+			t.Errorf("invites = %d, want 1", n)
+		}
+	})
+
+	t.Run("all invitees already invited returns an error", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		inviterID := uuid.New().String()
+		seedUser(ctx, t, inviterID, "inviter@example.com")
+
+		team := &Team{ID: &teamID}
+		invitees := []Invitee{{Email: "new@example.com", Role: RoleMap["viewer"]}}
+		if _, err := team.AddInvites(ctx, deps.PgPool, inviterID, invitees); err != nil {
+			t.Fatalf("AddInvites: %v", err)
+		}
+		_, err := team.AddInvites(ctx, deps.PgPool, inviterID, invitees)
+		if !errContains(err, "already invited") {
+			t.Fatalf("err = %v, want already invited", err)
+		}
+		if n := countTeamInvites(ctx, t, teamID); n != 1 {
+			t.Errorf("invites = %d, want 1", n)
+		}
+	})
+
+	t.Run("skips already invited emails and adds the rest", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		inviterID := uuid.New().String()
+		seedUser(ctx, t, inviterID, "inviter@example.com")
+
+		team := &Team{ID: &teamID}
+		if _, err := team.AddInvites(ctx, deps.PgPool, inviterID, []Invitee{{Email: "dup@example.com", Role: RoleMap["viewer"]}}); err != nil {
+			t.Fatalf("AddInvites: %v", err)
+		}
+
+		m, err := team.AddInvites(ctx, deps.PgPool, inviterID, []Invitee{
+			{Email: "dup@example.com", Role: RoleMap["viewer"]},
+			{Email: "fresh@example.com", Role: RoleMap["viewer"]},
+		})
+		if err != nil {
+			t.Fatalf("AddInvites: %v", err)
+		}
+		if _, ok := m["fresh@example.com"]; !ok || len(m) != 1 {
+			t.Errorf("map = %v, want only fresh@example.com", m)
+		}
+		if n := countTeamInvites(ctx, t, teamID); n != 2 {
+			t.Errorf("invites = %d, want 2", n)
+		}
+	})
+}
+
+func TestGetValidInvites(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	inviterID := uuid.New().String()
+	seedUser(ctx, t, inviterID, "inviter@example.com")
+
+	freshID := uuid.New()
+	staleID := uuid.New()
+	seedInviteAt(ctx, t, freshID, teamID, inviterID, "admin", "fresh@example.com", time.Now())
+	seedInviteAt(ctx, t, staleID, teamID, inviterID, "viewer", "stale@example.com", time.Now().Add(-8*24*time.Hour))
+
+	team := &Team{ID: &teamID}
+	invites, err := team.GetValidInvites(ctx, deps.PgPool)
+	if err != nil {
+		t.Fatalf("GetValidInvites: %v", err)
+	}
+	if len(invites) != 1 {
+		t.Fatalf("len(invites) = %d, want 1 (stale excluded)", len(invites))
+	}
+	inv := invites[0]
+	if inv.Email != "fresh@example.com" || inv.InvitedAsRole != RoleMap["admin"] {
+		t.Errorf("invite = %s/%s, want fresh@example.com/admin", inv.Email, inv.InvitedAsRole.String())
+	}
+	if inv.InvitedByEmail != "inviter@example.com" {
+		t.Errorf("invited by = %q, want inviter@example.com", inv.InvitedByEmail)
+	}
+	if !inv.ValidUntil.After(time.Now()) {
+		t.Errorf("ValidUntil = %v, want in the future", inv.ValidUntil)
+	}
+}
+
+func TestGetInviteById(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns the invite", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		inviterID := uuid.New().String()
+		seedUser(ctx, t, inviterID, "inviter@example.com")
+
+		inviteID := uuid.New()
+		seedInviteAt(ctx, t, inviteID, teamID, inviterID, "developer", "dev@example.com", time.Now())
+
+		team := &Team{ID: &teamID}
+		inv, err := team.GetInviteById(ctx, deps.PgPool, inviteID.String())
+		if err != nil {
+			t.Fatalf("GetInviteById: %v", err)
+		}
+		if inv.Email != "dev@example.com" || inv.InvitedAsRole != RoleMap["developer"] {
+			t.Errorf("invite = %s/%s, want dev@example.com/developer", inv.Email, inv.InvitedAsRole.String())
+		}
+	})
+
+	t.Run("invite of another team is not found", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New()
+		otherTeamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedTeam(ctx, t, otherTeamID, "other-team")
+		inviterID := uuid.New().String()
+		seedUser(ctx, t, inviterID, "inviter@example.com")
+
+		inviteID := uuid.New()
+		seedInviteAt(ctx, t, inviteID, teamID, inviterID, "viewer", "dev@example.com", time.Now())
+
+		otherTeam := &Team{ID: &otherTeamID}
+		if _, err := otherTeam.GetInviteById(ctx, deps.PgPool, inviteID.String()); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestResendInvite(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	inviterID := uuid.New().String()
+	seedUser(ctx, t, inviterID, "inviter@example.com")
+
+	inviteID := uuid.New()
+	seedInviteAt(ctx, t, inviteID, teamID, inviterID, "viewer", "dev@example.com", time.Now().Add(-8*24*time.Hour))
+
+	before := getInviteUpdatedAt(ctx, t, inviteID)
+
+	team := &Team{ID: &teamID}
+	if err := team.ResendInvite(ctx, deps.PgPool, inviteID); err != nil {
+		t.Fatalf("ResendInvite: %v", err)
+	}
+
+	after := getInviteUpdatedAt(ctx, t, inviteID)
+	if !after.After(before) {
+		t.Errorf("updated_at not bumped: before %v, after %v", before, after)
+	}
+
+	// a resent stale invite becomes valid again
+	invites, err := team.GetValidInvites(ctx, deps.PgPool)
+	if err != nil {
+		t.Fatalf("GetValidInvites: %v", err)
+	}
+	if len(invites) != 1 {
+		t.Errorf("len(invites) = %d, want 1 after resend", len(invites))
+	}
+}
+
+func TestRemoveInvite(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	inviterID := uuid.New().String()
+	seedUser(ctx, t, inviterID, "inviter@example.com")
+
+	inviteID := uuid.New()
+	seedInviteAt(ctx, t, inviteID, teamID, inviterID, "viewer", "dev@example.com", time.Now())
+
+	team := &Team{ID: &teamID}
+	if err := team.RemoveInvite(ctx, deps.PgPool, inviteID); err != nil {
+		t.Fatalf("RemoveInvite: %v", err)
+	}
+	if n := countTeamInvites(ctx, t, teamID); n != 0 {
+		t.Errorf("invites = %d, want 0", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// AddMembers / AreInviteesMember
+// --------------------------------------------------------------------------
+
+func TestAddMembers(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	adminID := uuid.New()
+	viewerID := uuid.New()
+	seedUser(ctx, t, adminID.String(), "admin@example.com")
+	seedUser(ctx, t, viewerID.String(), "viewer@example.com")
+
+	team := &Team{ID: &teamID}
+	err := team.AddMembers(ctx, deps.PgPool, []Invitee{
+		{ID: adminID, Email: "admin@example.com", Role: RoleMap["admin"]},
+		{ID: viewerID, Email: "viewer@example.com", Role: RoleMap["viewer"]},
+	})
+	if err != nil {
+		t.Fatalf("AddMembers: %v", err)
+	}
+	if role := getMembershipRole(ctx, t, teamID, adminID.String()); role != "admin" {
+		t.Errorf("admin role = %q, want admin", role)
+	}
+	if role := getMembershipRole(ctx, t, teamID, viewerID.String()); role != "viewer" {
+		t.Errorf("viewer role = %q, want viewer", role)
+	}
+}
+
+func TestAreInviteesMember(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	memberID := uuid.New().String()
+	seedUser(ctx, t, memberID, "member@example.com")
+	seedTeamMembership(ctx, t, teamID, memberID, "viewer")
+
+	team := &Team{ID: &teamID}
+
+	// email match is case-insensitive
+	idx, err := team.AreInviteesMember(ctx, deps.PgPool, []Invitee{
+		{Email: "nobody@example.com"},
+		{Email: "MEMBER@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("AreInviteesMember: %v", err)
+	}
+	if idx != 1 {
+		t.Errorf("idx = %d, want 1", idx)
+	}
+
+	idx, err = team.AreInviteesMember(ctx, deps.PgPool, []Invitee{{Email: "nobody@example.com"}})
+	if err != nil {
+		t.Fatalf("AreInviteesMember: %v", err)
+	}
+	if idx != -1 {
+		t.Errorf("idx = %d, want -1", idx)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Create
+// --------------------------------------------------------------------------
+
+func TestTeamCreate(t *testing.T) {
+	ctx := context.Background()
+
+	create := func(t *testing.T, billingEnabled bool, userID string) *Team {
+		t.Helper()
+		name := "created-team"
+		team := &Team{Name: &name}
+		u := &User{ID: &userID}
+
+		tx, err := deps.PgPool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer tx.Rollback(ctx)
+
+		if err := team.Create(ctx, deps.PgPool, billingEnabled, u, &tx); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		return team
+	}
+
+	t.Run("billing enabled provisions an autumn customer", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "creator@example.com")
+
+		team := create(t, true, userID)
+		if got := readTeamName(ctx, t, *team.ID); got != "created-team" {
+			t.Errorf("name = %q, want created-team", got)
+		}
+		if role := getMembershipRole(ctx, t, *team.ID, userID); role != "owner" {
+			t.Errorf("creator role = %q, want owner", role)
+		}
+		if id := getTeamAutumnCustomerID(ctx, t, *team.ID); id == nil || *id == "" {
+			t.Error("autumn customer not provisioned")
+		}
+	})
+
+	t.Run("billing disabled skips autumn", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		userID := uuid.New().String()
+		seedUser(ctx, t, userID, "creator@example.com")
+
+		team := create(t, false, userID)
+		if id := getTeamAutumnCustomerID(ctx, t, *team.ID); id != nil {
+			t.Errorf("autumn customer id = %v, want nil with billing disabled", *id)
+		}
+	})
+}
+
+// --------------------------------------------------------------------------
+// GetValidInvitesForEmail
+// --------------------------------------------------------------------------
+
+func TestGetValidInvitesForEmail(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	staleTeamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	seedTeam(ctx, t, staleTeamID, "stale-team")
+	inviterID := uuid.New().String()
+	seedUser(ctx, t, inviterID, "inviter@example.com")
+
+	seedInviteAt(ctx, t, uuid.New(), teamID, inviterID, "admin", "invitee@example.com", time.Now())
+	seedInviteAt(ctx, t, uuid.New(), staleTeamID, inviterID, "viewer", "invitee@example.com", time.Now().Add(-8*24*time.Hour))
+	seedInviteAt(ctx, t, uuid.New(), teamID, inviterID, "viewer", "someone-else@example.com", time.Now())
+
+	invites, err := GetValidInvitesForEmail(ctx, deps.PgPool, "invitee@example.com")
+	if err != nil {
+		t.Fatalf("GetValidInvitesForEmail: %v", err)
+	}
+	if len(invites) != 1 {
+		t.Fatalf("len(invites) = %d, want 1 (stale and other emails excluded)", len(invites))
+	}
+	if invites[0].InvitedToTeamId != teamID || invites[0].InvitedAsRole != RoleMap["admin"] {
+		t.Errorf("invite = %v/%s, want %v/admin", invites[0].InvitedToTeamId, invites[0].InvitedAsRole.String(), teamID)
+	}
+}

--- a/backend/libs/measure/user.go
+++ b/backend/libs/measure/user.go
@@ -87,25 +87,43 @@ func (u *User) GetTeams(pg *pgxpool.Pool) ([]map[string]string, error) {
 	return teams, nil
 }
 
-// GetOwnTeam gets a user's own team.
-func (u *User) GetOwnTeam(ctx context.Context, pg *pgxpool.Pool) (team *Team, err error) {
+// pgxQuerier is satisfied by both *pgxpool.Pool and pgx.Tx, so defaultTeam
+// can run either on the pool or inside EnsureDefaultTeam's transaction.
+// EnsureDefaultTeam needs the latter: it must do all its work on the one
+// connection it already holds, because requests queued behind its lock hold
+// connections of their own, and if they use up the pool, a request that asks
+// for one more connection would wait forever on requests that are in turn
+// waiting for it.
+type pgxQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// GetDefaultTeam returns the team a user starts on by default: their earliest
+// owned team when they own any, otherwise their earliest membership team.
+// Returns pgx.ErrNoRows when the user has no team memberships at all; use
+// EnsureDefaultTeam in flows that must always resolve to a team.
+func (u *User) GetDefaultTeam(ctx context.Context, pg *pgxpool.Pool) (*Team, error) {
+	return defaultTeam(ctx, pg, u.ID)
+}
+
+// defaultTeam runs the default-team query on a pool or transaction handle.
+func defaultTeam(ctx context.Context, q pgxQuerier, userID *string) (*Team, error) {
 	stmt := sqlf.PostgreSQL.
 		Select("teams.id, teams.name").
 		From("teams").
-		LeftJoin("team_membership", "teams.id = team_membership.team_id and team_membership.role = 'owner'").
-		Where("team_membership.user_id = ?", u.ID).
-		OrderBy("team_membership.created_at").
+		Join("team_membership", "teams.id = team_membership.team_id").
+		Where("team_membership.user_id = ?", userID).
+		OrderBy("(team_membership.role = 'owner') desc", "team_membership.created_at").
 		Limit(1)
 
 	defer stmt.Close()
 
-	team = &Team{}
-
-	if err = pg.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&team.ID, &team.Name); err != nil {
-		return
+	team := &Team{}
+	if err := q.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&team.ID, &team.Name); err != nil {
+		return nil, err
 	}
 
-	return
+	return team, nil
 }
 
 func (u *User) GetRole(pg *pgxpool.Pool, teamId string) (Rank, error) {


### PR DESCRIPTION
# Description

- Owners can now be removed or demoted from their default team. A last-owner check rejects any change that would leave a team with no owner. Membership changes lock the team row so the check is consistent on concurrent requests.
- Sign-in, session and CreateTeam no longer need the user to own a team. The default team is their earliest owned team, or their earliest membership of any role when they own none. A user with no teams at all gets a fresh personal team at next sign-in.
- Personal teams are named from the email when OAuth gives no name: dev@mhacker.sh becomes "Dev's team". This fixes the old "'s team" names. MCP signup now uses the same code path.
- When a removed or demoted owner's email is on the Autumn customer, it moves to a remaining owner.
- ChangeMemberRole rejects roles above the caller's rank. An admin could previously assign the owner role.
- CreateTeam and RenameTeam return 400 for a missing or blank name instead of panicking.
- The removal email links to the member's remaining team, or the site root when none is left.
- Fixed an authorization bypass in RenameTeam and RenameApp where a body-supplied id could redirect the write to another tenant's team/app. Both now bind name-only DTOs; ChangeMemberRole got the same treatment.
- Adds tests

## Related issue
Closes #4052



