### PR TITLE
Agent updates

### DIFF
--- a/backend/agent/agent/agent.go
+++ b/backend/agent/agent/agent.go
@@ -221,14 +221,12 @@ func (c *Config) dashboardLink(teamID uuid.UUID, page string) string {
 const maxQuestionApps = 50
 
 type askQuestionInput struct {
-	AppIDs         []string `json:"app_ids" jsonschema:"UUIDs of the apps the question is about, at most 50; all must belong to one team"`
-	Question       string   `json:"question" jsonschema:"Natural-language question about the apps' telemetry"`
-	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"Conversation id from a previous answer; pass it to continue that conversation"`
+	AppIDs   []string `json:"app_ids" jsonschema:"UUIDs of the apps the question is about, at most 50; all must belong to one team"`
+	Question string   `json:"question" jsonschema:"Self-contained natural-language question about the apps' telemetry; each call is independent, so include any relevant findings from earlier answers"`
 }
 
 type askQuestionOutput struct {
-	Answer         string `json:"answer"`
-	ConversationID string `json:"conversation_id"`
+	Answer string `json:"answer"`
 }
 
 const systemPrompt = `You are Measure's query agent. You answer questions about the telemetry of a team's mobile apps (events, exceptions, ANRs, sessions, spans, network requests). The team's apps are listed at the end of this message; a question can be about one app, several, or all of them.
@@ -251,6 +249,16 @@ Rules:
 - If a query fails, read the error and fix the query.
 - Answer concisely: lead with the concrete numbers, then a line or two on what was measured (data, filters, time range). If the data can't answer the question, say so plainly.
 - Describe how you computed things in product terms only. Severity (for example "fatal" crashes) is fine to mention. Never mention internals: no table or column names, no SQL, no tool names, no raw ids, and never bring up the legacy handled-flag fallback. Refer to apps by their names; when two of the team's apps share a name, add the unique identifier to tell them apart.`
+
+// mcpMethodRule joins the system rules on MCP turns only. The MCP caller
+// keeps the conversation on its side and restates earlier findings in a
+// follow-up question, so each answer must state its method in a form the
+// caller can quote back; a restated method keeps the recomputation consistent
+// with the original. Slack threads carry server-side history, so there the
+// line would be noise. The method stays within the product-terms rule above:
+// internals like SQL, table names, tool names and raw ids are still off
+// limits.
+const mcpMethodRule = `- The caller is a program that keeps the conversation on its side; each call reaches you with no memory of earlier ones, and a follow-up restates what it needs from earlier answers. So that a restated follow-up recomputes consistently, end every answer that reports data with a single line starting "Method: " giving, in product terms, the apps covered, the exact UTC time range, any filters applied, and how each number was defined. Definitions stay at the product level: "crashes = fatal exceptions" is complete, the legacy handled-flag fallback stays out of it like everywhere else. The limits above apply to this line too: no table or column names, no SQL, no tool names, no raw ids.`
 
 // focusAppsNote names the apps the MCP caller passed, appended to the call's
 // user message. The note focuses the turn without restricting it; the app
@@ -297,8 +305,66 @@ var builtinTools = []chatTool{
 	},
 }
 
+// resolveAppsAccess verifies every app exists, all belong to one team, and
+// the user is a member of that team. It returns the team's id and Autumn
+// customer id, read off the team row in the same query since the billing
+// gate needs it next.
+func (c *Config) resolveAppsAccess(ctx context.Context, userID uuid.UUID, appIDs []uuid.UUID) (teamID uuid.UUID, customerID string, err error) {
+	if len(appIDs) == 0 {
+		return uuid.Nil, "", fmt.Errorf("no apps given")
+	}
+
+	deps := c.Deps
+	// pgx has no encode plan for []uuid.UUID; pass strings and cast.
+	ids := uuid.UUIDs(appIDs).Strings()
+	stmt := sqlf.PostgreSQL.
+		Select("a.id, t.id, t.autumn_customer_id").
+		From("apps a").
+		Join("teams t", "a.team_id = t.id").
+		Join("team_membership tm", "tm.team_id = t.id").
+		Where("a.id = any(?::uuid[])", ids).
+		Where("tm.user_id = ?", userID)
+	defer stmt.Close()
+
+	rows, err := deps.PgPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return uuid.Nil, "", err
+	}
+	defer rows.Close()
+
+	found := map[uuid.UUID]bool{}
+	teams := map[uuid.UUID]bool{}
+	for rows.Next() {
+		var appID, appTeamID uuid.UUID
+		var autumnCustomerID *string
+		if err := rows.Scan(&appID, &appTeamID, &autumnCustomerID); err != nil {
+			return uuid.Nil, "", err
+		}
+		found[appID] = true
+		teams[appTeamID] = true
+		teamID = appTeamID
+		if autumnCustomerID != nil {
+			customerID = *autumnCustomerID
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return uuid.Nil, "", err
+	}
+
+	for _, appID := range appIDs {
+		if !found[appID] {
+			return uuid.Nil, "", fmt.Errorf("app not found or access denied")
+		}
+	}
+	if len(teams) > 1 {
+		return uuid.Nil, "", fmt.Errorf("all apps must belong to one team")
+	}
+	return teamID, customerID, nil
+}
+
 // askQuestion answers one MCP question: authenticate, check access and
-// billing, resolve the conversation, then run the turn.
+// billing, then run the turn. Each call is independent: the MCP client holds
+// the conversational context and restates what a follow-up needs.
 func (c *Config) askQuestion(ctx context.Context, in askQuestionInput) (out askQuestionOutput, err error) {
 	ctx, span := tracer.Start(ctx, "agent.ask_question")
 	defer span.End()
@@ -353,21 +419,12 @@ func (c *Config) askQuestion(ctx context.Context, in askQuestionInput) (out askQ
 		return out, errors.New(agentNotAllowedReply(c.dashboardLink(teamID, "usage")))
 	}
 
-	var conv *conversation
-	if in.ConversationID != "" {
-		cid, err := uuid.Parse(in.ConversationID)
-		if err != nil {
-			return out, fmt.Errorf("invalid conversation_id")
-		}
-		conv, err = c.getConversation(ctx, cid)
-		if err != nil || conv.UserID != userID || conv.TeamID != teamID {
-			return out, fmt.Errorf("conversation not found")
-		}
-	} else {
-		conv = &conversation{UserID: userID, TeamID: teamID, Surface: "mcp"}
-		if err := c.createConversation(ctx, conv, conversationTitle(question)); err != nil {
-			return out, err
-		}
+	// Every call runs as its own conversation. The row exists for the
+	// transcript and token metering, not for continuation: follow-up context
+	// is the caller's to carry in the question.
+	conv := &conversation{UserID: userID, TeamID: teamID, Surface: "mcp"}
+	if err := c.createConversation(ctx, conv, conversationTitle(question)); err != nil {
+		return out, err
 	}
 
 	turnRan = true
@@ -377,7 +434,6 @@ func (c *Config) askQuestion(ctx context.Context, in askQuestionInput) (out askQ
 		teamID:     teamID,
 		customerID: customerID,
 		conv:       conv,
-		continued:  in.ConversationID != "",
 		question:   question,
 		entryPoint: "mcp",
 		appIDs:     appIDs,
@@ -390,7 +446,6 @@ func (c *Config) askQuestion(ctx context.Context, in askQuestionInput) (out askQ
 	}
 
 	out.Answer = answer
-	out.ConversationID = conv.ID.String()
 	return out, nil
 }
 
@@ -578,7 +633,11 @@ func (c *Config) runTurn(ctx context.Context, t turn) (answer string, chartsOut 
 		}
 		appList = b.String()
 	}
-	sysMsg := fmt.Sprintf("%s\n%s\n\n%s", systemPrompt, budgetRule, appList)
+	rules := systemPrompt
+	if t.entryPoint == "mcp" {
+		rules += "\n" + mcpMethodRule
+	}
+	sysMsg := fmt.Sprintf("%s\n%s\n\n%s", rules, budgetRule, appList)
 	messages = append(messages, chatMessage{Role: "system", Content: sysMsg})
 	for _, m := range history {
 		messages = append(messages, m.msg)

--- a/backend/agent/agent/billing.go
+++ b/backend/agent/agent/billing.go
@@ -10,9 +10,6 @@ import (
 
 	"backend/libs/autumn"
 	"backend/libs/concur"
-
-	"github.com/google/uuid"
-	"github.com/leporo/sqlf"
 )
 
 // agentNotAllowedReply is shown on both surfaces (Slack and MCP) when the team
@@ -90,60 +87,4 @@ func trackAgentTokens(deps *server.Deps, customerID, model string, usage tokenUs
 			}
 		}
 	})
-}
-
-// resolveAppsAccess verifies every app exists, all belong to one team, and
-// the user is a member of that team. It returns the team's id and Autumn
-// customer id.
-func (c *Config) resolveAppsAccess(ctx context.Context, userID uuid.UUID, appIDs []uuid.UUID) (teamID uuid.UUID, customerID string, err error) {
-	if len(appIDs) == 0 {
-		return uuid.Nil, "", fmt.Errorf("no apps given")
-	}
-
-	deps := c.Deps
-	// pgx has no encode plan for []uuid.UUID; pass strings and cast.
-	ids := uuid.UUIDs(appIDs).Strings()
-	stmt := sqlf.PostgreSQL.
-		Select("a.id, t.id, t.autumn_customer_id").
-		From("apps a").
-		Join("teams t", "a.team_id = t.id").
-		Join("team_membership tm", "tm.team_id = t.id").
-		Where("a.id = any(?::uuid[])", ids).
-		Where("tm.user_id = ?", userID)
-	defer stmt.Close()
-
-	rows, err := deps.PgPool.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return uuid.Nil, "", err
-	}
-	defer rows.Close()
-
-	found := map[uuid.UUID]bool{}
-	teams := map[uuid.UUID]bool{}
-	for rows.Next() {
-		var appID, appTeamID uuid.UUID
-		var autumnCustomerID *string
-		if err := rows.Scan(&appID, &appTeamID, &autumnCustomerID); err != nil {
-			return uuid.Nil, "", err
-		}
-		found[appID] = true
-		teams[appTeamID] = true
-		teamID = appTeamID
-		if autumnCustomerID != nil {
-			customerID = *autumnCustomerID
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return uuid.Nil, "", err
-	}
-
-	for _, appID := range appIDs {
-		if !found[appID] {
-			return uuid.Nil, "", fmt.Errorf("app not found or access denied")
-		}
-	}
-	if len(teams) > 1 {
-		return uuid.Nil, "", fmt.Errorf("all apps must belong to one team")
-	}
-	return teamID, customerID, nil
 }

--- a/backend/agent/agent/memory.go
+++ b/backend/agent/agent/memory.go
@@ -87,17 +87,6 @@ func scanConversation(row pgx.Row) (*conversation, error) {
 	return conv, nil
 }
 
-func (c *Config) getConversation(ctx context.Context, id uuid.UUID) (*conversation, error) {
-	deps := c.Deps
-	stmt := sqlf.PostgreSQL.
-		Select(conversationColumns).
-		From("agent_conversations").
-		Where("id = ?", id)
-	defer stmt.Close()
-
-	return scanConversation(deps.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...))
-}
-
 // findSlackConversation returns the conversation rooted at a Slack thread,
 // or nil when the thread has none yet.
 func (c *Config) findSlackConversation(ctx context.Context, channelID, threadTS string) (*conversation, error) {

--- a/backend/agent/agent/memory_test.go
+++ b/backend/agent/agent/memory_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestConversationRoundtrip checks createConversation assigns an id and
-// getConversation reads the row back intact.
+// persists the row intact.
 func TestConversationRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
@@ -25,12 +25,15 @@ func TestConversationRoundtrip(t *testing.T) {
 		t.Fatal("createConversation did not assign an id")
 	}
 
-	got, err := c.getConversation(ctx, conv.ID)
-	if err != nil {
-		t.Fatalf("getConversation: %v", err)
+	var gotUser, gotTeam uuid.UUID
+	var gotSurface string
+	if err := deps.PgPool.QueryRow(ctx,
+		`select user_id, team_id, surface from measure.agent_conversations where id = $1`, conv.ID).
+		Scan(&gotUser, &gotTeam, &gotSurface); err != nil {
+		t.Fatalf("read conversation row: %v", err)
 	}
-	if got.UserID != userID || got.TeamID != teamID || got.Surface != "mcp" {
-		t.Errorf("roundtrip mismatch: got %+v", got)
+	if gotUser != userID || gotTeam != teamID || gotSurface != "mcp" {
+		t.Errorf("roundtrip mismatch: user %s team %s surface %q", gotUser, gotTeam, gotSurface)
 	}
 }
 
@@ -92,9 +95,12 @@ func TestSetSlackContextThrough(t *testing.T) {
 	if err := c.setSlackContextThrough(ctx, conv.ID, "1700000000.5"); err != nil {
 		t.Fatalf("setSlackContextThrough: %v", err)
 	}
-	got, err := c.getConversation(ctx, conv.ID)
+	got, err := c.findSlackConversation(ctx, "C1", "1.1")
 	if err != nil {
-		t.Fatalf("getConversation: %v", err)
+		t.Fatalf("findSlackConversation: %v", err)
+	}
+	if got == nil {
+		t.Fatal("conversation not found by its thread")
 	}
 	if got.SlackContextThroughTS != "1700000000.5" {
 		t.Errorf("through ts = %q, want 1700000000.5", got.SlackContextThroughTS)

--- a/backend/agent/agent/slack_branches_test.go
+++ b/backend/agent/agent/slack_branches_test.go
@@ -480,6 +480,11 @@ func TestSlackTurnCarriesAppList(t *testing.T) {
 	if strings.Contains(turnReq, "runs on android (no ANRs)") {
 		t.Error("the android line should not carry the ANR caveat")
 	}
+	// The method rule is for stateless MCP callers; Slack threads keep
+	// server-side history and must not carry it.
+	if strings.Contains(turnReq, "each call reaches you with no memory of earlier ones") {
+		t.Error("slack turn request should not carry the mcp method rule")
+	}
 	if !strings.Contains(*delivered, "12 crashes this week.") {
 		t.Errorf("reply should carry the model's answer, got %q", *delivered)
 	}

--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -39,6 +39,8 @@ const (
 	maxResultChars = 16000
 	// maxQuerySeconds is the most seconds one query may run.
 	maxQuerySeconds = 30
+	// maxQueryMemoryBytes is the most server memory one query may use.
+	maxQueryMemoryBytes = 500 << 20
 )
 
 // agentTables are the tables the agent may query via {{table}} placeholders,
@@ -209,6 +211,7 @@ func (c *Config) runSQL(ctx context.Context, query string, teamID uuid.UUID, app
 		"readonly":             1,
 		chquery.AgentScopeKey:  clickhouse.CustomSetting{Value: teamID.String()},
 		"max_execution_time":   maxQuerySeconds,
+		"max_memory_usage":     maxQueryMemoryBytes,
 		"max_result_rows":      maxResultRows,
 		"result_overflow_mode": "break",
 	})

--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -367,8 +367,11 @@ func askQuestionTool(cfg *Config) Tool {
 		Description: "Ask a natural-language question about the telemetry of one or more apps (crashes, ANRs, errors, " +
 			"sessions, spans, network) that the other Measure tools don't cover. The agent picks the right tool or explores " +
 			"the raw data with read-only SQL and answers with concrete numbers, including comparisons across apps. " +
-			"Pass the app_ids the question is about; all must belong to one team. Use list_apps to discover app ids. " +
-			"Pass conversation_id from a previous answer to continue that conversation.",
+			"Pass the app_ids the question is about - all must belong to one team. Use list_apps to discover app ids " +
+			"and each app's team. " +
+			"Each call is independent: make the question self-contained, and when asking a follow-up include the " +
+			"relevant findings and numbers from earlier answers in the question, along with the answer's Method " +
+			"line so the recomputation stays consistent.",
 		InputSchema: mcpMustInferSchema[askQuestionInput](),
 	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in askQuestionInput) (*mcpsdk.CallToolResult, any, error) {
 		// The one agent-backed tool: while the agent is disabled it returns
@@ -395,7 +398,7 @@ func commonTools(cfg *Config) []Tool {
 		// list_apps
 		newTool(&mcpsdk.Tool{
 			Name:        "list_apps",
-			Description: "List all apps the authenticated user has access to",
+			Description: "List all apps the authenticated user has access to, each with the team it belongs to",
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpListAppsInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpListApps(ctx, in)
 		}),
@@ -1129,21 +1132,26 @@ func (c *Config) mcpListApps(ctx context.Context, _ mcpListAppsInput) (*mcpsdk.C
 	}
 
 	pgPool := deps.PgPool
+	// The team fields let a caller spanning several teams tell which apps
+	// share one, which ask_question requires of its app_ids.
 	type appRow struct {
 		ID               string   `json:"id"`
 		Name             string   `json:"name"`
 		OsNames          []string `json:"os_names"`
 		UniqueIdentifier string   `json:"unique_identifier"`
+		TeamID           string   `json:"team_id"`
+		TeamName         string   `json:"team_name"`
 	}
 	stmt := sqlf.PostgreSQL.
-		Select("a.id, coalesce(a.app_name, ''), a.os_names, coalesce(a.unique_identifier, '')").
+		Select("a.id, coalesce(a.app_name, ''), a.os_names, coalesce(a.unique_identifier, ''), a.team_id, coalesce(t.name, '')").
 		From("apps a").
+		Join("teams t", "a.team_id = t.id").
 		Join("team_membership tm", "a.team_id = tm.team_id").
 		Where("tm.user_id = ?", userID).
-		OrderBy("a.created_at desc")
+		OrderBy("t.name, a.created_at desc")
 	defer stmt.Close()
 	// A team-scoped turn (Slack) lists only that team's apps; without a
-	// scope (MCP) the user sees every team's.
+	// scope (MCP) the user sees apps of every team they are a member of.
 	if teamID, ok := teamScopeFromContext(ctx); ok {
 		stmt.Where("a.team_id = ?", teamID)
 	}
@@ -1156,7 +1164,7 @@ func (c *Config) mcpListApps(ctx context.Context, _ mcpListAppsInput) (*mcpsdk.C
 	var apps []appRow
 	for rows.Next() {
 		var row appRow
-		if err := rows.Scan(&row.ID, &row.Name, &row.OsNames, &row.UniqueIdentifier); err != nil {
+		if err := rows.Scan(&row.ID, &row.Name, &row.OsNames, &row.UniqueIdentifier, &row.TeamID, &row.TeamName); err != nil {
 			return nil, nil, fmt.Errorf("failed to query apps: %w", err)
 		}
 		apps = append(apps, row)

--- a/backend/agent/agent/turn_test.go
+++ b/backend/agent/agent/turn_test.go
@@ -83,8 +83,9 @@ func TestRunTurnToolLoop(t *testing.T) {
 }
 
 // TestAskQuestionEndToEnd drives the MCP entry point: authz, the (no-customer)
-// billing gate, conversation creation, and the turn. A follow-up with the
-// returned id continues the same conversation rather than starting a new one.
+// billing gate, and the turn. ask_question is stateless: each call runs as its
+// own conversation, so a follow-up gets a fresh transcript and carries any
+// context it needs in the question itself.
 func TestAskQuestionEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
@@ -103,36 +104,53 @@ func TestAskQuestionEndToEnd(t *testing.T) {
 	if out.Answer != "All good." {
 		t.Errorf("answer = %q, want All good.", out.Answer)
 	}
-	if out.ConversationID == "" {
-		t.Fatal("expected a conversation id")
-	}
 	if stub.callCount() != 1 {
 		t.Errorf("llm calls = %d, want 1", stub.callCount())
 	}
 
-	out2, err := c.askQuestion(ctx, askQuestionInput{
-		AppIDs: []string{appID.String()}, Question: "and now?", ConversationID: out.ConversationID,
-	})
+	out2, err := c.askQuestion(ctx, askQuestionInput{AppIDs: []string{appID.String()}, Question: "and now?"})
 	if err != nil {
 		t.Fatalf("askQuestion follow-up: %v", err)
 	}
-	if out2.ConversationID != out.ConversationID {
-		t.Errorf("follow-up started a new conversation: %s vs %s", out2.ConversationID, out.ConversationID)
+	if out2.Answer != "Still good." {
+		t.Errorf("answer = %q, want Still good.", out2.Answer)
 	}
 
-	// The continued conversation holds both turns: 2 questions + 2 answers,
-	// with the caller's focus appended to each question rather than stored
+	// Two calls, two conversations: each holds one question + one answer,
+	// with the caller's focus appended to the question rather than stored
 	// as its own row.
-	cid, _ := uuid.Parse(out.ConversationID)
-	loaded, err := c.loadMessages(ctx, cid)
+	rows, err := deps.PgPool.Query(ctx,
+		`select id from measure.agent_conversations where user_id = $1`, userID)
 	if err != nil {
-		t.Fatalf("loadMessages: %v", err)
+		t.Fatalf("query conversations: %v", err)
 	}
-	if got := len(loaded); got != 4 {
-		t.Errorf("persisted messages = %d, want 4 (two q/a turns): %v", got, msgRoles(loaded))
+	defer rows.Close()
+	var convIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan conversation id: %v", err)
+		}
+		convIDs = append(convIDs, id)
 	}
-	if loaded[0].msg.Role != "user" || !strings.Contains(loaded[0].msg.Content, "The caller asked about these apps") {
-		t.Errorf("the question should carry the focus note, got role %q content %q", loaded[0].msg.Role, loaded[0].msg.Content)
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read conversations: %v", err)
+	}
+	if len(convIDs) != 2 {
+		t.Fatalf("conversations = %d, want 2 (one per call)", len(convIDs))
+	}
+	for _, cid := range convIDs {
+		loaded, err := c.loadMessages(ctx, cid)
+		if err != nil {
+			t.Fatalf("loadMessages: %v", err)
+		}
+		if got := len(loaded); got != 2 {
+			t.Errorf("conversation %s: persisted messages = %d, want 2 (one q/a pair): %v", cid, got, msgRoles(loaded))
+			continue
+		}
+		if loaded[0].msg.Role != "user" || !strings.Contains(loaded[0].msg.Content, "The caller asked about these apps") {
+			t.Errorf("the question should carry the focus note, got role %q content %q", loaded[0].msg.Role, loaded[0].msg.Content)
+		}
 	}
 }
 
@@ -170,5 +188,10 @@ func TestAskQuestionMultiApp(t *testing.T) {
 	}
 	if !strings.Contains(req, "second (second)") {
 		t.Errorf("focus note should carry the second app's label, got request without it")
+	}
+	// MCP turns carry the method rule: the stateless caller quotes the
+	// Method line back in follow-ups.
+	if !strings.Contains(req, "each call reaches you with no memory of earlier ones") {
+		t.Error("mcp turn request should carry the method rule")
 	}
 }

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -1629,6 +1629,14 @@ func TestMCPListApps(t *testing.T) {
 			if app["name"] == nil {
 				t.Error("app missing name field")
 			}
+			// The team fields tell a multi-team caller which apps may go into
+			// one ask_question call together.
+			if app["team_id"] != teamID.String() {
+				t.Errorf("app team_id = %v, want %s", app["team_id"], teamID)
+			}
+			if app["team_name"] != "twoapps team" {
+				t.Errorf("app team_name = %v, want twoapps team", app["team_name"])
+			}
 		}
 	})
 


### PR DESCRIPTION
# Description

- Make MCP conversations single turn. The caller has the responsibility to maintain conversation context instead of us. This prevents us from having only partial conversation context.
- Add max memory limit to agent Clickhouse queries



