### PR TITLE
Team membership: clean authz responses and enforce one membership per user per team

### DIFF
--- a/backend/api/handlers/apikey_test.go
+++ b/backend/api/handlers/apikey_test.go
@@ -60,7 +60,7 @@ func TestRotateApiKeyHandler(t *testing.T) {
 		wantJSONContains(t, w, "error", "no team exists for app")
 	})
 
-	t.Run("no membership returns auth error", func(t *testing.T) {
+	t.Run("no membership is denied", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 
 		userID := uuid.New().String()
@@ -76,10 +76,10 @@ func TestRotateApiKeyHandler(t *testing.T) {
 
 		h.RotateApiKey(c)
 
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
 		}
-		wantJSONContains(t, w, "error", "couldn't perform authorization checks")
+		wantJSONContains(t, w, "error", "you don't have permissions to rotate app api keys")
 	})
 
 	t.Run("all roles authz behavior", func(t *testing.T) {

--- a/backend/api/handlers/app_health_handler_test.go
+++ b/backend/api/handlers/app_health_handler_test.go
@@ -112,7 +112,7 @@ func TestGetHealthOverviewPlotInstancesHandler(t *testing.T) {
 		wantJSONContains(t, w, "error", "no team exists for app")
 	})
 
-	t.Run("user without membership returns 500", func(t *testing.T) {
+	t.Run("user without membership is denied", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 
 		userID := uuid.New().String()
@@ -128,10 +128,10 @@ func TestGetHealthOverviewPlotInstancesHandler(t *testing.T) {
 
 		h.GetHealthOverviewPlotInstances(c)
 
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 		}
-		wantJSONContains(t, w, "error", "authoriz")
+		wantJSONContains(t, w, "error", "not authorized")
 	})
 
 	t.Run("missing userId returns 500", func(t *testing.T) {

--- a/backend/api/handlers/app_threshold_prefs_test.go
+++ b/backend/api/handlers/app_threshold_prefs_test.go
@@ -104,7 +104,7 @@ func TestGetAppThresholdPrefs(t *testing.T) {
 		}
 	})
 
-	t.Run("missing membership returns internal server error", func(t *testing.T) {
+	t.Run("missing membership is denied", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID := uuid.New().String()
 		teamID := uuid.New()
@@ -118,8 +118,8 @@ func TestGetAppThresholdPrefs(t *testing.T) {
 		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
 
 		h.GetAppThresholdPrefs(c)
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusForbidden, w.Body.String())
 		}
 	})
 
@@ -225,7 +225,7 @@ func TestUpdateAppThresholdPrefs(t *testing.T) {
 		}
 	})
 
-	t.Run("missing membership returns internal server error", func(t *testing.T) {
+	t.Run("missing membership is denied", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID := uuid.New().String()
 		teamID := uuid.New()
@@ -239,8 +239,8 @@ func TestUpdateAppThresholdPrefs(t *testing.T) {
 		c.Set("userId", userID)
 		c.Params = gin.Params{{Key: "id", Value: appID.String()}}
 		h.UpdateAppThresholdPrefs(c)
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusForbidden, w.Body.String())
 		}
 	})
 

--- a/backend/api/handlers/build_test.go
+++ b/backend/api/handlers/build_test.go
@@ -130,12 +130,9 @@ func TestGetBuilds(t *testing.T) {
 		outsiderID := uuid.New().String()
 		seedUser(ctx, t, outsiderID, "outsider@test.com")
 
-		// a user with no membership resolves to the 'unknown' role,
-		// which PerformAuthz reports as an error, so the handler
-		// answers 500 rather than 403
 		_, w := getBuildsRequest(t, outsiderID, appID.String(), "")
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 		}
 	})
 

--- a/backend/api/handlers/error_common_path_test.go
+++ b/backend/api/handlers/error_common_path_test.go
@@ -81,8 +81,8 @@ func TestGetErrorGroupCommonPathHandler(t *testing.T) {
 
 		h.GetErrorGroupCommonPath(c)
 
-		if w.Code != http.StatusInternalServerError {
-			t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusForbidden, w.Body.String())
 		}
 	})
 

--- a/backend/api/handlers/issue_common_path_handler_test.go
+++ b/backend/api/handlers/issue_common_path_handler_test.go
@@ -68,8 +68,7 @@ func TestGetCrashGroupCommonPathHandler(t *testing.T) {
 		appID := uuid.New()
 		seedApp(ctx, t, appID, teamID, 30)
 
-		// Different user who is not a team member — PerformAuthz returns
-		// an error for unknown roles, so the handler responds with 500.
+		// a different user who is not a team member
 		otherID := uuid.New().String()
 		seedUser(ctx, t, otherID, "cp-other@test.com")
 
@@ -79,8 +78,8 @@ func TestGetCrashGroupCommonPathHandler(t *testing.T) {
 
 		h.GetCrashGroupCommonPath(c)
 
-		if w.Code != http.StatusInternalServerError {
-			t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusForbidden, w.Body.String())
 		}
 	})
 

--- a/backend/api/handlers/team.go
+++ b/backend/api/handlers/team.go
@@ -262,16 +262,6 @@ func (h Handlers) InviteMembers(c *gin.Context) {
 
 	ok, err := measure.PerformAuthz(deps.PgPool, userId, teamId.String(), *measure.ScopeTeamInviteSameOrLower)
 	if err != nil {
-		// FIXME: improve error handling, this is quite brittle way of
-		// doing errors. not ideal.
-		if err.Error() == "received 'unknown' role" {
-			msg := `couldn't find team, perhaps team id is invalid`
-			fmt.Println(msg)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": msg,
-			})
-			return
-		}
 		msg := `couldn't perform authorization checks`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -562,16 +552,6 @@ func (h Handlers) ResendInvite(c *gin.Context) {
 
 	ok, err := measure.PerformAuthz(deps.PgPool, userId, teamId.String(), *measure.ScopeTeamInviteSameOrLower)
 	if err != nil {
-		// FIXME: improve error handling, this is quite brittle way of
-		// doing errors. not ideal.
-		if err.Error() == "received 'unknown' role" {
-			msg := `couldn't find team, perhaps team id is invalid`
-			fmt.Println(msg)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": msg,
-			})
-			return
-		}
 		msg := `couldn't perform authorization checks`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -698,16 +678,6 @@ func (h Handlers) RemoveInvite(c *gin.Context) {
 
 	ok, err := measure.PerformAuthz(deps.PgPool, userId, teamId.String(), *measure.ScopeTeamInviteSameOrLower)
 	if err != nil {
-		// FIXME: improve error handling, this is quite brittle way of
-		// doing errors. not ideal.
-		if err.Error() == "received 'unknown' role" {
-			msg := `couldn't find team, perhaps team id is invalid`
-			fmt.Println(msg)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": msg,
-			})
-			return
-		}
 		msg := `couldn't perform authorization checks`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -923,10 +893,11 @@ func (h Handlers) RemoveTeamMember(c *gin.Context) {
 		return
 	}
 
+	// an unknown role means the caller has no membership row, for example
+	// when a concurrent request removed them from the team
 	if userRole.IsUnknown() {
-		msg := `couldn't perform authorization checks`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		msg := fmt.Sprintf(`you don't have modify permissions to team [%s]`, teamId)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
 		return
 	}
 
@@ -960,10 +931,10 @@ func (h Handlers) RemoveTeamMember(c *gin.Context) {
 		return
 	}
 
+	// no membership row: the member left or was already removed
 	if memberRole.IsUnknown() {
-		msg := "couldn't perform authorization checks: member role unknown"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		msg := fmt.Sprintf("member [%s] is not part of team [%s]", memberId, teamId)
+		c.JSON(http.StatusNotFound, gin.H{"error": msg})
 		return
 	}
 
@@ -1067,10 +1038,11 @@ func (h Handlers) ChangeMemberRole(c *gin.Context) {
 		return
 	}
 
+	// an unknown role means the caller has no membership row, for example
+	// when a concurrent request removed them from the team
 	if userRole.IsUnknown() {
-		msg := `couldn't perform authorization checks`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		msg := fmt.Sprintf(`you don't have modify permissions to team [%s]`, teamId)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
 		return
 	}
 
@@ -1137,10 +1109,10 @@ func (h Handlers) ChangeMemberRole(c *gin.Context) {
 		return
 	}
 
+	// no membership row: the member left or was already removed
 	if memberRole.IsUnknown() {
-		msg := "couldn't perform authorization checks: member role unknown"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		msg := fmt.Sprintf("member [%s] is not part of team [%s]", memberId, teamId)
+		c.JSON(http.StatusNotFound, gin.H{"error": msg})
 		return
 	}
 

--- a/backend/api/handlers/team_test.go
+++ b/backend/api/handlers/team_test.go
@@ -207,6 +207,42 @@ func TestRemoveTeamMember(t *testing.T) {
 			t.Error("UpdateCustomer called, want billing email left alone")
 		}
 	})
+
+	t.Run("removing someone who is not a member gets 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newRemoveMemberContext(ownerID, teamID, outsiderID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "not part of team")
+	})
+
+	t.Run("a caller who is no longer a member gets 403", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		// the caller lost their membership mid-flight, e.g. to a concurrent
+		// mutual removal; they must see a permission error, not a 500
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		removedID := uuid.New().String()
+		seedUser(ctx, t, removedID, "removed@test.com")
+
+		c, w := newRemoveMemberContext(removedID, teamID, ownerID)
+		h.RemoveTeamMember(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("owner membership = %q, want intact", role)
+		}
+	})
 }
 
 func TestChangeMemberRole(t *testing.T) {
@@ -330,6 +366,40 @@ func TestChangeMemberRole(t *testing.T) {
 		}
 		if updatedEmail != "new-owner@test.com" {
 			t.Errorf("updated email = %q, want new-owner@test.com", updatedEmail)
+		}
+	})
+
+	t.Run("changing role of someone who is not a member gets 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		outsiderID := uuid.New().String()
+		seedUser(ctx, t, outsiderID, "outsider@test.com")
+
+		c, w := newChangeRoleContext(ownerID, teamID, outsiderID, "viewer")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "not part of team")
+	})
+
+	t.Run("a caller who is no longer a member gets 403", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		removedID := uuid.New().String()
+		seedUser(ctx, t, removedID, "removed@test.com")
+
+		c, w := newChangeRoleContext(removedID, teamID, ownerID, "viewer")
+		h.ChangeMemberRole(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+		if role := getMemberRole(ctx, t, teamID, ownerID); role != "owner" {
+			t.Errorf("owner role = %q, want unchanged", role)
 		}
 	})
 }
@@ -571,9 +641,8 @@ func TestGetTeamApps(t *testing.T) {
 		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
 		h.GetTeamApps(c)
 
-		// PerformAuthz errors on an unknown role, so a non-member gets 500
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 		}
 	})
 }
@@ -633,9 +702,8 @@ func TestGetTeamApp(t *testing.T) {
 		c.Params = gin.Params{{Key: "id", Value: teamID.String()}, {Key: "appId", Value: appID.String()}}
 		h.GetTeamApp(c)
 
-		// PerformAuthz errors on an unknown role, so a non-member gets 500
-		if w.Code != http.StatusInternalServerError {
-			t.Fatalf("status = %d, want 500 for unknown role, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 		}
 	})
 }

--- a/backend/libs/measure/authz.go
+++ b/backend/libs/measure/authz.go
@@ -3,7 +3,6 @@ package measure
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 
@@ -164,8 +163,9 @@ func PerformAuthz(pg *pgxpool.Pool, uid string, rid string, scope scope) (bool, 
 		return false, err
 	}
 
+	// no membership row for this user and team
 	if role == unknown {
-		return false, errors.New("received 'unknown' role")
+		return false, nil
 	}
 	roleScope := ScopeMap[role]
 

--- a/backend/libs/measure/authz_test.go
+++ b/backend/libs/measure/authz_test.go
@@ -350,7 +350,7 @@ func TestPerformAuthzMatrix(t *testing.T) {
 func TestPerformAuthzErrorPaths(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("unknown role when membership missing", func(t *testing.T) {
+	t.Run("missing membership denies without error", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 
 		userID := uuid.New().String()
@@ -359,11 +359,8 @@ func TestPerformAuthzErrorPaths(t *testing.T) {
 		seedTeam(ctx, t, teamID, "team")
 
 		allowed, err := PerformAuthz(deps.PgPool, userID, teamID.String(), *ScopeAppRead)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if err.Error() != "received 'unknown' role" {
-			t.Fatalf("err = %q, want %q", err.Error(), "received 'unknown' role")
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
 		}
 		if allowed {
 			t.Fatal("allowed = true, want false")

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -213,6 +213,8 @@ func SyncBillingEmailOnOwnerExit(ctx context.Context, pg *pgxpool.Pool, billingE
 	if err != nil {
 		return err
 	}
+	// In self hosted environments, a team will have no autumn customer and no billing email,
+	// nothing to do, return
 	if customerID == "" {
 		return nil
 	}

--- a/backend/libs/measure/team.go
+++ b/backend/libs/measure/team.go
@@ -358,7 +358,8 @@ func (t *Team) RemoveInvite(ctx context.Context, pg *pgxpool.Pool, inviteId uuid
 }
 
 // addMembers makes invitees member of the team according
-// to each invitee's role.
+// to each invitee's role. An invitee who is already a member is skipped and
+// keeps their current role.
 func (t *Team) AddMembers(ctx context.Context, pg *pgxpool.Pool, invitees []Invitee) error {
 	now := time.Now()
 	stmt := sqlf.PostgreSQL.InsertInto("team_membership")
@@ -373,6 +374,7 @@ func (t *Team) AddMembers(ctx context.Context, pg *pgxpool.Pool, invitees []Invi
 			Set("created_at", nil)
 		args = append(args, t.ID, invitee.ID, invitee.Role, now, now)
 	}
+	stmt.Clause("on conflict (team_id, user_id) do nothing")
 
 	_, err := pg.Exec(ctx, stmt.String(), args...)
 	if err != nil {

--- a/backend/libs/measure/team_test.go
+++ b/backend/libs/measure/team_test.go
@@ -856,6 +856,46 @@ func TestAddMembers(t *testing.T) {
 	}
 }
 
+func TestAddMembersAlreadyMember(t *testing.T) {
+	ctx := context.Background()
+
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	memberID := uuid.New()
+	freshID := uuid.New()
+	seedUser(ctx, t, memberID.String(), "member@example.com")
+	seedUser(ctx, t, freshID.String(), "fresh@example.com")
+	seedTeamMembership(ctx, t, teamID, memberID.String(), "admin")
+
+	// the batch adds one existing member and one new user: the existing
+	// membership must survive with its role, the new one must be created
+	team := &Team{ID: &teamID}
+	err := team.AddMembers(ctx, deps.PgPool, []Invitee{
+		{ID: memberID, Email: "member@example.com", Role: RoleMap["viewer"]},
+		{ID: freshID, Email: "fresh@example.com", Role: RoleMap["viewer"]},
+	})
+	if err != nil {
+		t.Fatalf("AddMembers: %v", err)
+	}
+	if role := getMembershipRole(ctx, t, teamID, memberID.String()); role != "admin" {
+		t.Errorf("existing member role = %q, want admin (unchanged)", role)
+	}
+	if role := getMembershipRole(ctx, t, teamID, freshID.String()); role != "viewer" {
+		t.Errorf("fresh member role = %q, want viewer", role)
+	}
+
+	var n int
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT count(*) FROM team_membership WHERE team_id = $1 AND user_id = $2`, teamID, memberID.String()).Scan(&n); err != nil {
+		t.Fatalf("count memberships: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("membership rows = %d, want 1", n)
+	}
+}
+
 func TestAreInviteesMember(t *testing.T) {
 	ctx := context.Background()
 

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -8148,6 +8148,8 @@ paths:
           description: Either the user's access token is invalid or has expired.
         "403":
           description: Requester does not have access to this resource.
+        "404":
+          description: This user is not a member of this team.
         "429":
           description: Rate limit of the requester has crossed maximum limits.
         "500":
@@ -8207,6 +8209,8 @@ paths:
           description: Either the user's access token is invalid or has expired.
         "403":
           description: Requester does not have access to this resource.
+        "404":
+          description: This user is not a member of this team.
         "429":
           description: Rate limit of the requester has crossed maximum limits.
         "500":

--- a/self-host/postgres/20260718161933_alter_team_membership_table.sql
+++ b/self-host/postgres/20260718161933_alter_team_membership_table.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+-- collapse duplicate memberships if any before the unique index below, keeping the
+-- earliest row per (team_id, user_id) with the id as tie-break
+delete from measure.team_membership tm
+using measure.team_membership dup
+where tm.team_id = dup.team_id
+  and tm.user_id = dup.user_id
+  and (tm.created_at > dup.created_at
+       or (tm.created_at = dup.created_at and tm.id > dup.id));
+
+-- a user is a member of a team at most once
+create unique index if not exists team_membership_team_id_user_id_idx on measure.team_membership (team_id, user_id);
+
+-- migrate:down
+drop index if exists measure.team_membership_team_id_user_id_idx;


### PR DESCRIPTION
# Description

- Non-members get 403 instead of 500 in authz checks
- Removing or changing the role of someone who is not a member returns 404.
- The loser of two concurrent owner removals gets a 403 instead of a 500.
- New unique index: a user can only be a member of a team once. Migration removes any duplicate membership that potentially exist (shouldn't be but just a precaution)
- AddMembers skips invitees who are already members instead of failing.



