### PR TITLE
chore(backend): add optional patch_version to ota builds

### DIFF
--- a/backend/ingest/measure/build.go
+++ b/backend/ingest/measure/build.go
@@ -39,6 +39,9 @@ type Mapping struct {
 	// caller so the build script can confirm the value persisted
 	// against this mapping row.
 	PatchID uuid.UUID `json:"patch_id,omitempty"`
+	// PatchVersion echoes the build's optional patch_version
+	// back to the caller, like PatchID.
+	PatchVersion string `json:"patch_version,omitempty"`
 }
 
 type Build struct {
@@ -53,6 +56,9 @@ type Build struct {
 	// the OTA handler (PutOTABuilds); PUT /builds neither accepts
 	// nor returns it.
 	PatchID uuid.UUID `json:"-"`
+	// PatchVersion is the human-facing OTA patch version. Free-form
+	// text, optional. Set only by the OTA handler, like PatchID.
+	PatchVersion string `json:"-"`
 }
 
 type BuildResponse struct {
@@ -64,8 +70,11 @@ type BuildResponse struct {
 // build number or build size. The app is resolved from the
 // request's API key (like PutBuilds), never from the body.
 type OTABuild struct {
-	PatchID  uuid.UUID  `json:"patch_id" binding:"required"`
-	Mappings []*Mapping `json:"mappings" binding:"required,dive,required"`
+	PatchID uuid.UUID `json:"patch_id" binding:"required"`
+	// PatchVersion is the human-facing OTA patch version.
+	// Free-form text, optional. Not used for symbolication.
+	PatchVersion string     `json:"patch_version" binding:"omitempty,max=256"`
+	Mappings     []*Mapping `json:"mappings" binding:"required,dive,required"`
 }
 
 func (b Build) hasMapping() bool {
@@ -124,6 +133,7 @@ func (b Build) insertNewMappings(ctx context.Context, tx *pgx.Tx) (err error) {
 			Set(`location`, m.Location).
 			Set(`fnv1_hash`, m.Checksum).
 			Set(`patch_id`, b.PatchID).
+			Set(`patch_version`, b.PatchVersion).
 			Set(`last_updated`, now)
 	}
 
@@ -360,9 +370,10 @@ func PutOTABuilds(c *gin.Context) {
 	// model the OTA upload as a build with no version/size; the
 	// patch_id is the sole lookup key for these mapping rows.
 	build := Build{
-		AppID:    appId,
-		PatchID:  ota.PatchID,
-		Mappings: ota.Mappings,
+		AppID:        appId,
+		PatchID:      ota.PatchID,
+		PatchVersion: strings.TrimSpace(ota.PatchVersion),
+		Mappings:     ota.Mappings,
 	}
 
 	// each OTA mapping gets a fresh id; a re-uploaded patch_id
@@ -489,6 +500,7 @@ func presignMappingsGCS(ctx context.Context, config *server.ServerConfig, build 
 		mapping.UploadURL = url
 		mapping.ExpiresAt = expiry
 		mapping.PatchID = build.PatchID
+		mapping.PatchVersion = build.PatchVersion
 		mapping.Headers = make(map[string]string)
 		mapping.Headers["x-goog-meta-mapping_id"] = mapping.ID.String()
 		mapping.Headers["x-goog-meta-original_file_name"] = mapping.Filename
@@ -523,6 +535,7 @@ func presignMappingsS3(ctx context.Context, config *server.ServerConfig, build *
 		mapping.UploadURL = proxyUrl
 		mapping.ExpiresAt = time.Now().Add(time.Hour)
 		mapping.PatchID = build.PatchID
+		mapping.PatchVersion = build.PatchVersion
 		mapping.Headers = make(map[string]string)
 		mapping.Headers["x-amz-meta-mapping_id"] = mapping.ID.String()
 		mapping.Headers["x-amz-meta-original_file_name"] = mapping.Filename

--- a/backend/symboloader/process.go
+++ b/backend/symboloader/process.go
@@ -517,6 +517,7 @@ func (b *Build) load(ctx context.Context, id uuid.UUID) (err error) {
 		Select("version_code").
 		Select("mapping_type").
 		Select("patch_id").
+		Select("patch_version").
 		From("build_mappings").
 		Where("id = ?", id)
 
@@ -524,7 +525,7 @@ func (b *Build) load(ctx context.Context, id uuid.UUID) (err error) {
 
 	var mappingType string
 
-	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&b.AppID, &b.VersionName, &b.VersionCode, &mappingType, &b.PatchID); err != nil {
+	if err := server.Server.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&b.AppID, &b.VersionName, &b.VersionCode, &mappingType, &b.PatchID, &b.PatchVersion); err != nil {
 		return err
 	}
 
@@ -614,6 +615,7 @@ func (b *Build) insertExtras(ctx context.Context, now time.Time) (err error) {
 			Set("fnv1_hash", m.Checksum).
 			Set("file_size", m.Size).
 			Set("patch_id", b.PatchID).
+			Set("patch_version", b.PatchVersion).
 			Set("last_updated", now)
 	}
 
@@ -635,6 +637,9 @@ type Build struct {
 	// build, loaded from the existing row so extra artifact
 	// rows carry it too.
 	PatchID uuid.UUID
+	// PatchVersion is the human-facing OTA patch version shared
+	// by every row of this build, loaded like PatchID.
+	PatchVersion string
 	// Extras holds additional artifact rows to insert when one
 	// mapping extracts to more than one object.
 	Extras []*Mapping

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -2093,6 +2093,9 @@ paths:
 
         - `patch_id` is required and must be a UUID. Tag your OTA patch with a UUID;
           it is echoed back on each mapping in the response.
+        - `patch_version` is optional. Set it to the human-facing version of the
+          patch (max 256 characters); it is echoed back on each mapping in the
+          response.
         - The app is determined from your API key. Do not send an app identifier in
           the body.
         - `mappings` is required and must contain at least one mapping. Mapping
@@ -2121,6 +2124,12 @@ paths:
                   type: string
                   format: uuid
                   description: UUID identifier for the OTA patch.
+                patch_version:
+                  type: string
+                  maxLength: 256
+                  description: >
+                    Optional human-facing version of the OTA patch. Free-form
+                    text. Not used for symbolication.
                 mappings:
                   type: array
                   minItems: 1
@@ -2146,6 +2155,7 @@ paths:
                         description: Filename of the mapping file.
             example:
               patch_id: "550e8400-e29b-41d4-a716-446655440000"
+              patch_version: "1.4.2-patch.3"
               mappings:
                 - type: jsbundle
                   filename: main.jsbundle.tgz
@@ -2156,7 +2166,8 @@ paths:
           description: >
             OTA mappings accepted; pre-signed upload URLs returned. The response
             contains a `mappings` array with the pre-signed upload URL for each
-            mapping file. Each mapping echoes back the request's `patch_id`.
+            mapping file. Each mapping echoes back the request's `patch_id` and
+            `patch_version` (when sent).
           content:
             application/json:
               schema:
@@ -2196,6 +2207,11 @@ paths:
                           type: string
                           format: uuid
                           description: The request's `patch_id`, echoed back.
+                        patch_version:
+                          type: string
+                          description: >
+                            The request's `patch_version`, echoed back. Omitted
+                            when not sent.
               example:
                 mappings:
                   - id: "e2bbcad8-0566-44ea-af43-9dd114c64e8c"
@@ -2207,6 +2223,7 @@ paths:
                       x-amz-meta-mapping_id: "e2bbcad8-0566-44ea-af43-9dd114c64e8c"
                       x-amz-meta-original_file_name: main.jsbundle.tgz
                     patch_id: "550e8400-e29b-41d4-a716-446655440000"
+                    patch_version: "1.4.2-patch.3"
                   - id: "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc"
                     type: jsbundle
                     filename: main.jsbundle.map.tgz
@@ -2216,6 +2233,7 @@ paths:
                       x-amz-meta-mapping_id: "77ac8159-9f0e-4cc7-a9f1-60c05fccd4dc"
                       x-amz-meta-original_file_name: main.jsbundle.map.tgz
                     patch_id: "550e8400-e29b-41d4-a716-446655440000"
+                    patch_version: "1.4.2-patch.3"
         "400":
           description: >
             Request body is malformed or is missing `patch_id`/`mappings`. Check the

--- a/self-host/postgres/20260720062134_alter_build_mappings_table.sql
+++ b/self-host/postgres/20260720062134_alter_build_mappings_table.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+alter table "measure"."build_mappings" add column if not exists patch_version varchar(256) not null default '';
+comment on column measure.build_mappings.patch_version is 'human-facing OTA patch version, free-form, optional, not used for symbolication';
+
+-- migrate:down
+alter table "measure"."build_mappings" drop column if exists patch_version;

--- a/self-host/sessionator/app/app.go
+++ b/self-host/sessionator/app/app.go
@@ -25,14 +25,18 @@ type Build struct {
 	// PatchID identifies an OTA patch. Set only for OTA builds
 	// (replayed to /builds/ota); empty for regular builds.
 	PatchID string
+	// PatchVersion is the human-facing OTA patch version. Read
+	// from the optional patch_version sidecar file; empty when
+	// the recording carried none.
+	PatchVersion string
 }
 
 // App represents each combination of app and version
 // along with its events and related build info.
 type App struct {
-	Name              string
-	VersionName       string
-	Builds            map[string]*Build
+	Name        string
+	VersionName string
+	Builds      map[string]*Build
 	// OTABuilds holds OTA patches keyed by patch_id, replayed to
 	// /builds/ota. Kept separate from Builds so the two replay paths
 	// stay self-documenting.

--- a/self-host/sessionator/app/scan.go
+++ b/self-host/sessionator/app/scan.go
@@ -4,6 +4,7 @@ import (
 	"backend/libs/symbol"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -227,9 +228,6 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 				if err != nil {
 					return err
 				}
-				if info.Size() < 1 {
-					return fmt.Errorf(`%q has empty OTA jsbundle mapping file. check %q`, app.FullName(), rel)
-				}
 
 				patchID := filepath.Base(filepath.Dir(rel))
 				otaCode := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(rel))))
@@ -238,6 +236,21 @@ func Scan(rootPath string, opts *ScanOpts) (apps *Apps, err error) {
 						VersionCode: otaCode,
 						PatchID:     patchID,
 					}
+				}
+
+				// the patch_version sidecar is metadata, not a
+				// mapping file. Read it & move on.
+				if filepath.Base(rel) == "patch_version" {
+					version, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+					app.OTABuilds[patchID].PatchVersion = strings.TrimSpace(string(version))
+					return nil
+				}
+
+				if info.Size() < 1 {
+					return fmt.Errorf(`%q has empty OTA jsbundle mapping file. check %q`, app.FullName(), rel)
 				}
 
 				app.OTABuilds[patchID].MappingFiles = append(app.OTABuilds[patchID].MappingFiles, path)

--- a/self-host/sessionator/app/scan_test.go
+++ b/self-host/sessionator/app/scan_test.go
@@ -15,6 +15,7 @@ func TestScanOTADiscovery(t *testing.T) {
 	patchID := "3f2b8c1a-0000-4000-8000-000000000000"
 	regular := filepath.Join(root, "foo-app", "1.2.3", "1000", "jsbundle", "main.jsbundle.tgz")
 	ota := filepath.Join(root, "foo-app", "1.2.3", "1000", "jsbundle", patchID, "main.jsbundle.tgz")
+	sidecar := filepath.Join(root, "foo-app", "1.2.3", "1000", "jsbundle", patchID, "patch_version")
 
 	for _, p := range []string{regular, ota} {
 		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
@@ -23,6 +24,9 @@ func TestScanOTADiscovery(t *testing.T) {
 		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.WriteFile(sidecar, []byte("1.2.3-patch.7\n"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
 	apps, err := Scan(root, &ScanOpts{})
@@ -44,6 +48,11 @@ func TestScanOTADiscovery(t *testing.T) {
 	}
 	if len(otaBuild.MappingFiles) != 1 {
 		t.Errorf("expected 1 OTA mapping file, got %d", len(otaBuild.MappingFiles))
+	}
+	// the patch_version sidecar populates PatchVersion, trimmed,
+	// without counting as a mapping file
+	if otaBuild.PatchVersion != "1.2.3-patch.7" {
+		t.Errorf("expected patch version 1.2.3-patch.7, got %q", otaBuild.PatchVersion)
 	}
 
 	// regular jsbundle must not leak into OTABuilds nor be missed by Builds

--- a/self-host/sessionator/cmd/ingest.go
+++ b/self-host/sessionator/cmd/ingest.go
@@ -358,7 +358,7 @@ func UploadOTABuilds(url, apiKey string, app app.App) (status string, err error)
 			return http.StatusText(http.StatusInternalServerError), err
 		}
 
-		build := measure.OTABuild{PatchID: patchID}
+		build := measure.OTABuild{PatchID: patchID, PatchVersion: otaBuild.PatchVersion}
 		mappingFilesMap := make(map[string]string)
 
 		for index, mappingType := range otaBuild.MappingTypes {

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -766,7 +766,16 @@ func writeOTABuild(c *gin.Context) {
 	// only when non-empty; scan treats absence as no patch_version.
 	patchVersion := strings.TrimSpace(req.PatchVersion)
 	if patchVersion != "" {
-		sidecar := filepath.Join(outputDir, req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", req.PatchID, "patch_version")
+		rootDir, err := filepath.Abs(outputDir)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to acquire directory: %q", outputDir)})
+			return
+		}
+		sidecar, err := resolveUploadPath(rootDir, filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", req.PatchID, "patch_version"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		if err := os.MkdirAll(filepath.Dir(sidecar), 0755); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create OTA patch directory: " + err.Error()})
 			return

--- a/self-host/sessionator/cmd/record.go
+++ b/self-host/sessionator/cmd/record.go
@@ -52,27 +52,29 @@ type uploadInfo struct {
 // mapping mirrors the ingest service's build mapping descriptor, used in both
 // the PUT /builds request and response. See backend/ingest/measure/build.go.
 type mapping struct {
-	ID        string            `json:"id"`
-	Type      string            `json:"type"`
-	Filename  string            `json:"filename"`
-	Key       string            `json:"key,omitempty"`
-	Checksum  string            `json:"checksum,omitempty"`
-	Size      int64             `json:"size,omitempty"`
-	UploadURL string            `json:"upload_url,omitempty"`
-	ExpiresAt time.Time         `json:"expires_at"`
-	Headers   map[string]string `json:"headers,omitempty"`
-	PatchID   string            `json:"patch_id,omitempty"`
+	ID           string            `json:"id"`
+	Type         string            `json:"type"`
+	Filename     string            `json:"filename"`
+	Key          string            `json:"key,omitempty"`
+	Checksum     string            `json:"checksum,omitempty"`
+	Size         int64             `json:"size,omitempty"`
+	UploadURL    string            `json:"upload_url,omitempty"`
+	ExpiresAt    time.Time         `json:"expires_at"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	PatchID      string            `json:"patch_id,omitempty"`
+	PatchVersion string            `json:"patch_version,omitempty"`
 }
 
 // buildRequest is the JSON payload PUT /builds accepts from newer SDKs.
 type buildRequest struct {
-	AppUniqueID string     `json:"app_unique_id"`
-	VersionName string     `json:"version_name"`
-	VersionCode string     `json:"version_code"`
-	Type        string     `json:"build_type"`
-	Size        uint       `json:"build_size"`
-	PatchID     string     `json:"patch_id"`
-	Mappings    []*mapping `json:"mappings"`
+	AppUniqueID  string     `json:"app_unique_id"`
+	VersionName  string     `json:"version_name"`
+	VersionCode  string     `json:"version_code"`
+	Type         string     `json:"build_type"`
+	Size         uint       `json:"build_size"`
+	PatchID      string     `json:"patch_id"`
+	PatchVersion string     `json:"patch_version"`
+	Mappings     []*mapping `json:"mappings"`
 }
 
 // uploadExpiry is a cosmetic expiry stamped on the upload URLs we return.
@@ -759,6 +761,22 @@ func writeOTABuild(c *gin.Context) {
 		return
 	}
 
+	// optional patch_version persists as a plain-text sidecar file
+	// next to the mapping files so scan.go can replay it. Written
+	// only when non-empty; scan treats absence as no patch_version.
+	patchVersion := strings.TrimSpace(req.PatchVersion)
+	if patchVersion != "" {
+		sidecar := filepath.Join(outputDir, req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", req.PatchID, "patch_version")
+		if err := os.MkdirAll(filepath.Dir(sidecar), 0755); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create OTA patch directory: " + err.Error()})
+			return
+		}
+		if err := os.WriteFile(sidecar, []byte(patchVersion), 0644); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to write patch_version file: " + err.Error()})
+			return
+		}
+	}
+
 	for _, m := range req.Mappings {
 		if m.Type != symbol.TypeJsBundle.String() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(`OTA "type" must be %q`, symbol.TypeJsBundle.String())})
@@ -769,6 +787,7 @@ func writeOTABuild(c *gin.Context) {
 		relPath := filepath.Join(req.AppUniqueID, req.VersionName, req.VersionCode, "jsbundle", req.PatchID, filename)
 		m.ID = uuid.NewString()
 		m.PatchID = req.PatchID
+		m.PatchVersion = patchVersion
 		m.UploadURL = uploadURL(c, relPath)
 		m.ExpiresAt = time.Now().Add(uploadExpiry)
 	}


### PR DESCRIPTION
## Summary

This PR adds an optional `patch_version` field to OTA build uploads & round-trips it end to end. `PUT /builds/ota` accepts `patch_version` (max 256 chars, trimmed) & stores it in a new `build_mappings.patch_version` column, response mappings echo it alongside `patch_id`, symboloader inherits it onto extra artifact rows, & sessionator persists/reads/replays it via a `patch_version` sidecar file & the OTA ingest wire body.

## Tasks

- [x] Add `patch_version` column via Postgres migration on `build_mappings`
- [x] Accept & validate `patch_version` in the OTA build endpoint
- [x] Echo `patch_version` in build mapping responses
- [x] Inherit `patch_version` onto extra artifacts in symboloader
- [x] Round-trip `patch_version` through sessionator record/scan/ingest
- [x] Update OpenAPI docs for the new field

## See also

- closes #4038