### PR TITLE
fix(backend): return session attribute for session_start-only sessions

### DIFF
--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log"
@@ -3506,13 +3505,6 @@ func (h Handlers) GetSession(c *gin.Context) {
 		return
 	}
 
-	if errors.Is(err, sql.ErrNoRows) {
-		msg := fmt.Sprintf(`session %q for app %q does not exist`, sessionId, app.ID)
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": msg,
-		})
-	}
-
 	var attachmentGroup errgroup.Group
 	attachmentGroup.SetLimit(16)
 
@@ -3743,7 +3735,7 @@ func (h Handlers) GetSession(c *gin.Context) {
 		if err != nil {
 			msg := fmt.Sprintf(`unable to compute exceptions for session %q for app %q`, sessionId, app.ID)
 			fmt.Println(msg, err)
-			c.JSON(http.StatusNotFound, gin.H{
+			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": msg,
 			})
 			return
@@ -3758,7 +3750,7 @@ func (h Handlers) GetSession(c *gin.Context) {
 		if err != nil {
 			msg := fmt.Sprintf(`unable to compute ANRs for session %q for app %q`, sessionId, app.ID)
 			fmt.Println(msg, err)
-			c.JSON(http.StatusNotFound, gin.H{
+			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": msg,
 			})
 			return
@@ -3781,6 +3773,16 @@ func (h Handlers) GetSession(c *gin.Context) {
 		msg := `failed to fetch trace data for timeline`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	// no event rows & no traces means the session
+	// does not exist for this app
+	if session.Attribute == nil && len(sessionTraces) == 0 {
+		msg := fmt.Sprintf(`session %q for app %q does not exist`, sessionId, app.ID)
+		c.JSON(http.StatusNotFound, gin.H{
 			"error": msg,
 		})
 		return

--- a/backend/api/handlers/session_test.go
+++ b/backend/api/handlers/session_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// seedSessionStartEvent inserts a single "session_start" event with an
+// explicit attribute.user_id. SeedEventRows has no user_id field, so this
+// bypasses it with a raw insert; sessions_index_mv still picks the row up
+// like any other events insert.
+func seedSessionStartEvent(ctx context.Context, t *testing.T, teamID, appID, sessionID, userID string, ts time.Time) {
+	t.Helper()
+	query := fmt.Sprintf(
+		`INSERT INTO measure.events (id, type, session_id, app_id, team_id, timestamp, user_triggered, `+
+			"`attribute.installation_id`, `attribute.app_version`, `attribute.app_build`, "+
+			"`attribute.app_unique_id`, `attribute.measure_sdk_version`, `attribute.user_id`) "+
+			`VALUES ('%s', 'session_start', '%s', '%s', '%s', '%s', false, '%s', 'v1', '1', 'com.test', '0.1', '%s')`,
+		uuid.New().String(), sessionID, appID, teamID,
+		ts.UTC().Format("2006-01-02 15:04:05"), uuid.New().String(), userID)
+	if err := th.ChConn.Exec(ctx, query); err != nil {
+		t.Fatalf("seed session_start event: %v", err)
+	}
+}
+
+func newGetSessionContext(callerID string, appID, sessionID uuid.UUID) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/sessions/"+sessionID.String(), nil)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: appID.String()}, {Key: "sessionId", Value: sessionID.String()}}
+	return c, w
+}
+
+func TestGetSession(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("session whose only row is session_start still returns its attribute", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+
+		sessionID := uuid.New()
+		userID := "user-" + sessionID.String()[:8]
+		seedSessionStartEvent(ctx, t, teamID.String(), appID.String(), sessionID.String(), userID, time.Now())
+
+		c, w := newGetSessionContext(ownerID, appID, sessionID)
+		h.GetSession(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+
+		var body struct {
+			Attribute *struct {
+				UserID string `json:"user_id"`
+			} `json:"attribute"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if body.Attribute == nil {
+			t.Fatalf("attribute = nil, want non-nil")
+		}
+		if body.Attribute.UserID != userID {
+			t.Errorf("attribute.user_id = %q, want %q", body.Attribute.UserID, userID)
+		}
+	})
+
+	t.Run("session with no events & no spans returns 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+
+		sessionID := uuid.New()
+
+		c, w := newGetSessionContext(ownerID, appID, sessionID)
+		h.GetSession(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+		wantJSONContains(t, w, "error", "does not exist")
+	})
+}

--- a/backend/api/handlers/session_test.go
+++ b/backend/api/handlers/session_test.go
@@ -77,6 +77,48 @@ func TestGetSession(t *testing.T) {
 		}
 	})
 
+	t.Run("session with usual event data returns computed duration & threads", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 90)
+
+		sessionID := uuid.New()
+		start := time.Now().Add(-time.Minute)
+		// 2 navigation events & 1 exception event, all recognized by the
+		// timeline type switch, spanning a 20s window.
+		exceptionsJSON := `[{"type":"java.lang.RuntimeException","message":"boom","frames":[{"line_num":42,"file_name":"Test.java","method_name":"testMethod"}]}]`
+		seedNavigationEventInSession(ctx, t, teamID.String(), appID.String(), sessionID.String(), "home", start)
+		seedIssueEventWithDataInSession(ctx, t, teamID.String(), appID.String(), sessionID.String(), "exception", "", false, exceptionsJSON, start.Add(10*time.Second))
+		seedNavigationEventInSession(ctx, t, teamID.String(), appID.String(), sessionID.String(), "settings", start.Add(20*time.Second))
+
+		c, w := newGetSessionContext(ownerID, appID, sessionID)
+		h.GetSession(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+
+		var body struct {
+			SessionID string           `json:"session_id"`
+			Duration  int64            `json:"duration"`
+			Threads   map[string][]any `json:"threads"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if body.SessionID != sessionID.String() {
+			t.Errorf("session_id = %q, want %q", body.SessionID, sessionID.String())
+		}
+		if body.Duration <= 0 {
+			t.Errorf("duration = %d, want > 0", body.Duration)
+		}
+		if len(body.Threads) == 0 {
+			t.Errorf("threads = empty, want events grouped by thread")
+		}
+	})
+
 	t.Run("session with no events & no spans returns 404", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -5009,6 +5009,7 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 
 	var session Session
 	var firstUserID string
+	var firstAttr *event.Attribute
 
 	for rows.Next() {
 		var ev event.EventField
@@ -5311,6 +5312,14 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			firstUserID = ev.Attribute.UserID
 		}
 
+		// capture first scanned row's attribute so sessions
+		// whose rows are all dropped by the type switch
+		// still carry an attribute
+		if firstAttr == nil {
+			attr := ev.Attribute
+			firstAttr = &attr
+		}
+
 		// populate user defined attribute
 		if len(userDefAttr) > 0 {
 			ev.UserDefinedAttribute.Scan(userDefAttr)
@@ -5498,6 +5507,11 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			attr.UserID = firstUserID
 		}
 		session.Attribute = &attr
+	} else if firstAttr != nil {
+		if firstUserID != "" {
+			firstAttr.UserID = firstUserID
+		}
+		session.Attribute = firstAttr
 	}
 
 	return &session, nil

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -4203,6 +4203,8 @@ paths:
           description: Either the user's access token is invalid or has expired.
         "403":
           description: Requester does not have access to this resource.
+        "404":
+          description: No session with this id exists for this app.
         "429":
           description: Rate limit of the requester has crossed maximum limits.
         "500":


### PR DESCRIPTION
## Summary

This PR fixes a session timeline crash caused by `attribute: null` for sessions whose only event is `session_start` & tightens the API's not-found behaviour for empty sessions.

## Tasks

- [x] Capture the first scanned row's attribute in `GetSessionEvents`
- [x] Return 404 from `GetSession` when a session has no events & no traces
- [x] Relabel compute error branches from 404 to 500
- [x] Add integration tests for `GetSession`
- [x] Document the 404 response in the dashboard OpenAPI spec
- [x] Add happy path get session test

## See also

- fixes #4095
