### PR TITLE
chore(frontend): update global error and 404 pages

### DIFF
--- a/frontend/dashboard/app/global-error.tsx
+++ b/frontend/dashboard/app/global-error.tsx
@@ -1,56 +1,88 @@
 "use client";
 
-import Link from "next/link";
 import posthog from "posthog-js";
 import { useEffect } from "react";
 import { Button } from "./components/button";
-import { underlineLinkStyle } from "./utils/shared_styles";
+import { ThemeProvider } from "./components/theme_provider";
+import "./globals.css";
+import { isCloud } from "./utils/env_utils";
+import { fira_code, josefin_sans, work_sans } from "./utils/fonts";
 
+// Rendered in place of the root layout when an error reaches the root
+// boundary, so it applies the layout's font variables, theme handling and
+// global styles itself.
 export default function Error({
   error,
-  reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // Empty string until posthog initializes; self-host never initializes it.
+  const posthogSessionId = isCloud() ? posthog.get_session_id() : "";
+
+  // GitHub rejects issue titles longer than 256 characters.
+  const reportIssueTitle = error.message
+    ? `Error: ${error.message}`.slice(0, 256)
+    : "";
+
   useEffect(() => {
     posthog.captureException(error);
   }, [error]);
 
   return (
-    <html>
-      <body>
-        <div className="flex flex-col items-center justify-center font-body p-24 w-full h-screen">
-          <p className="font-display font-regular text-4xl">
-            Something went wrong!
-          </p>
-          <div className="py-2" />
-          <Link
-            target="_blank"
-            className={underlineLinkStyle}
-            href="https://github.com/measure-sh/measure/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title="
-          >
-            Report issue
-          </Link>
-          <div className="py-8" />
-          {error.message && (
-            <div className="w-fit">
-              <p className="">Error message: </p>
-              <div className="py-1" />
-              <p className="w-fit bg-red-200 border border-black grid text-left text-sm font-body whitespace-pre-wrap rounded-md p-4">
-                {error.message}
+    <html lang="en" suppressHydrationWarning>
+      <body
+        className={`${josefin_sans.variable} ${work_sans.variable} ${fira_code.variable}`}
+      >
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <div className="flex flex-col items-center justify-center font-body p-24 w-full h-screen">
+            <p className="font-display font-regular text-4xl">
+              Something went wrong!
+            </p>
+            <div className="py-2" />
+            {isCloud() && (
+              <>
+                <p className="w-fit text-center">
+                  A bug report has been submitted and we are looking into the
+                  issue. Thanks for your patience!
+                </p>
+                <div className="py-2" />
+              </>
+            )}
+            {error.message && (
+              <p className="w-fit text-left text-sm text-muted-foreground whitespace-pre-wrap">
+                {posthogSessionId
+                  ? `Error: ${error.message}, Session: ${posthogSessionId}`
+                  : `Error: ${error.message}`}
               </p>
-              <div className="py-2" />
-              <Button
-                variant="outline"
-                className="font-display border border-black select-none"
-                onClick={() => navigator.clipboard.writeText(error.message)}
-              >
-                Copy
+            )}
+            <div className="py-4" />
+            <div className="flex flex-row items-center gap-4">
+              {/* Plain anchor instead of Link so the app boots fresh after a
+                  fatal error; the login page forwards signed-in users to
+                  their team overview. */}
+              <Button asChild>
+                {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                <a href="/auth/login">Go to Dashboard</a>
               </Button>
+              {!isCloud() && (
+                <Button variant="secondary" asChild>
+                  <a
+                    target="_blank"
+                    href={`https://github.com/measure-sh/measure/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=${encodeURIComponent(reportIssueTitle)}`}
+                  >
+                    Report Issue
+                  </a>
+                </Button>
+              )}
             </div>
-          )}
-        </div>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next";
-import { Fira_Code, Josefin_Sans, Work_Sans } from "next/font/google";
 import AttributionCapture from "./components/analytics/attribution_capture";
 import { ClientProviders } from "./components/client_providers";
 import { ConsentManager } from "./components/consent_manager";
@@ -7,28 +6,8 @@ import { ThemeProvider } from "./components/theme_provider";
 import { Toaster } from "./components/toaster";
 import UTMCapture from "./components/analytics/utm_capture";
 import "./globals.css";
+import { fira_code, josefin_sans, work_sans } from "./utils/fonts";
 import { previewImage, sharedOpenGraph } from "./utils/metadata";
-
-const josefin_sans = Josefin_Sans({
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["100", "200", "300", "400", "500", "600", "700"],
-  variable: "--font-josefin-sans",
-});
-
-const work_sans = Work_Sans({
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
-  variable: "--font-work-sans",
-});
-
-const fira_code = Fira_Code({
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["300", "400", "500", "600", "700"],
-  variable: "--font-fira-code",
-});
 
 const title = "Measure";
 const description =

--- a/frontend/dashboard/app/not-found.tsx
+++ b/frontend/dashboard/app/not-found.tsx
@@ -1,15 +1,7 @@
-"use client";
-
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Button } from "./components/button";
 
 export default function NotFound() {
-  const router = useRouter();
-
-  const goBack = async () => {
-    router.back();
-  };
-
   return (
     <div className="flex flex-col items-center justify-center p-24 w-screen h-screen">
       <p className="font-display font-regular text-4xl text-center">404</p>
@@ -18,12 +10,8 @@ export default function NotFound() {
         Sorry, we couldn&apos;t find the page you were looking for...
       </p>
       <div className="py-4" />
-      <Button
-        variant="outline"
-        className="font-display border border-black select-none"
-        onClick={() => goBack()}
-      >
-        Go Back
+      <Button asChild>
+        <Link href="/auth/login">Go to Dashboard</Link>
       </Button>
     </div>
   );

--- a/frontend/dashboard/app/utils/fonts.ts
+++ b/frontend/dashboard/app/utils/fonts.ts
@@ -1,0 +1,24 @@
+import { Fira_Code, Josefin_Sans, Work_Sans } from "next/font/google";
+
+// Used by both the root layout and global-error. global-error replaces the
+// root layout when it renders, so it has to apply these variables itself.
+export const josefin_sans = Josefin_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["100", "200", "300", "400", "500", "600", "700"],
+  variable: "--font-josefin-sans",
+});
+
+export const work_sans = Work_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-work-sans",
+});
+
+export const fira_code = Fira_Code({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["300", "400", "500", "600", "700"],
+  variable: "--font-fira-code",
+});


### PR DESCRIPTION
# Description

- match theme styling for both pages with rest of app
- global error page shows bug report submitted message in cloud with posthog session id if available. In self-host, report issue button is shown with error message as title in github issue deeplink
- 404 page shows "Go to Dashboard" instead of "Go Back" since users can arrive at 404 page from anywhere not just the app

## Related issue
Closes #4057



