### PR TITLE
fix(backend): exclude session_start-only sessions from list endpoints

### DIFF
--- a/backend/api/handlers/sessions_overview_test.go
+++ b/backend/api/handlers/sessions_overview_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// seedNormalSession seeds a session with a session_start event plus a
+// navigation event, so it survives the "session_start-only" Having filter
+// on the sessions CTE.
+func seedNormalSession(ctx context.Context, t *testing.T, teamID, appID, sessionID, userID string, ts time.Time) {
+	t.Helper()
+	seedSessionStartEvent(ctx, t, teamID, appID, sessionID, userID, ts)
+	seedNavigationEventInSession(ctx, t, teamID, appID, sessionID, "home", ts.Add(time.Second))
+}
+
+func newSessionsOverviewContext(callerID string, appID uuid.UUID, rawQuery string) (*gin.Context, *httptest.ResponseRecorder) {
+	path := "/apps/" + appID.String() + "/sessions"
+	if rawQuery != "" {
+		path += "?" + rawQuery
+	}
+	c, w := newTestGinContext("GET", path, nil)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+	return c, w
+}
+
+func newSessionsPlotInstancesContext(callerID string, appID uuid.UUID, rawQuery string) (*gin.Context, *httptest.ResponseRecorder) {
+	path := "/apps/" + appID.String() + "/sessions/plots/instances"
+	if rawQuery != "" {
+		path += "?" + rawQuery
+	}
+	c, w := newTestGinContext("GET", path, nil)
+	c.Set("userId", callerID)
+	c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+	return c, w
+}
+
+// fixed reference instant for seeded session timestamps, matched by an
+// explicit from/to query range rather than relying on real wall-clock "now"
+// & the handler's default lookback window.
+var sessionsOverviewTestTime = time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+func sessionsOverviewTimeRangeQuery() string {
+	from := sessionsOverviewTestTime.Add(-time.Hour).Format("2006-01-02T15:04:05.000Z")
+	to := sessionsOverviewTestTime.Add(time.Hour).Format("2006-01-02T15:04:05.000Z")
+	return "from=" + from + "&to=" + to
+}
+
+func TestGetSessionsOverview(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+	appID := uuid.New()
+	seedApp(ctx, t, appID, teamID, 90)
+
+	now := sessionsOverviewTestTime
+	sessionStartOnlyID := uuid.New()
+	normalSessionID := uuid.New()
+	seedSessionStartEvent(ctx, t, teamID.String(), appID.String(), sessionStartOnlyID.String(), "user-a", now)
+	seedNormalSession(ctx, t, teamID.String(), appID.String(), normalSessionID.String(), "user-b", now)
+	c, w := newSessionsOverviewContext(ownerID, appID, sessionsOverviewTimeRangeQuery())
+	h.GetSessionsOverview(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Results []struct {
+			SessionID string `json:"session_id"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	var gotIDs []string
+	for _, r := range body.Results {
+		gotIDs = append(gotIDs, r.SessionID)
+	}
+
+	foundNormal := false
+	for _, id := range gotIDs {
+		if id == normalSessionID.String() {
+			foundNormal = true
+		}
+		if id == sessionStartOnlyID.String() {
+			t.Errorf("results contains session_start-only session %q, want it filtered out", id)
+		}
+	}
+	if !foundNormal {
+		t.Errorf("results = %v, want to contain normal session %q", gotIDs, normalSessionID.String())
+	}
+}
+
+func TestGetSessionsOverviewPlotInstances(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+	appID := uuid.New()
+	seedApp(ctx, t, appID, teamID, 90)
+
+	now := sessionsOverviewTestTime
+	sessionStartOnlyID := uuid.New()
+	normalSessionID := uuid.New()
+	seedSessionStartEvent(ctx, t, teamID.String(), appID.String(), sessionStartOnlyID.String(), "user-a", now)
+	seedNormalSession(ctx, t, teamID.String(), appID.String(), normalSessionID.String(), "user-b", now)
+	c, w := newSessionsPlotInstancesContext(ownerID, appID, "timezone=Etc/UTC&"+sessionsOverviewTimeRangeQuery())
+	h.GetSessionsOverviewPlotInstances(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var body []struct {
+		ID   string `json:"id"`
+		Data []struct {
+			Datetime  string `json:"datetime"`
+			Instances uint64 `json:"instances"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	var totalInstances uint64
+	for _, entry := range body {
+		for _, d := range entry.Data {
+			totalInstances += d.Instances
+		}
+	}
+
+	// only the normal session counts; the session_start-only session must
+	// not inflate the instance count.
+	if totalInstances != 1 {
+		t.Errorf("total instances = %d, want 1", totalInstances)
+	}
+}

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -2926,6 +2926,10 @@ func (a App) GetSessionsInstancesPlot(ctx context.Context, rch driver.Conn, af *
 		GroupBy("session_id").
 		GroupBy("app_version")
 
+	// exclude sessions whose only events are session_start,
+	// they carry no real content & are pointless to return
+	base.Having("sum(event_count) > sumMap(event_type_counts)['session_start']")
+
 	stmt := sqlf.
 		With("base", base).
 		From("base").
@@ -3180,6 +3184,10 @@ func (a App) GetSessionsWithFilter(ctx context.Context, rch driver.Conn, af *fil
 		GroupBy("device_name").
 		GroupBy("device_model").
 		GroupBy("device_manufacturer")
+
+	// exclude sessions whose only events are session_start,
+	// they carry no real content & are pointless to return
+	base.Having("sum(event_count) > sumMap(event_type_counts)['session_start']")
 
 	stmt := sqlf.With("base", base).
 		From("base").

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -3611,6 +3611,9 @@ paths:
         always `null` in list responses; it is populated only on the
         single-session detail endpoint. `duration` is the session duration in
         milliseconds.
+
+        Sessions that contain only a session start event, with no other
+        activity, are always excluded from results regardless of filters.
       parameters:
         - name: id
           in: path
@@ -3854,6 +3857,10 @@ paths:
 
         For multiple comma separated fields, make sure no whitespace characters
         exist before or after commas.
+
+        Sessions that contain only a session start event, with no other
+        activity, are always excluded from the instance counts regardless of
+        filters.
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
## Summary

This PR excludes sessions whose only event is `session_start` from the session list endpoints, since such sessions carry no real content & are pointless to show. The filter is added as a `HAVING` clause on `GetSessionsWithFilter` & `GetSessionsInstancesPlot` in `app.go`, applied unconditionally regardless of request filters.

## Tasks

- [x] Filter session_start-only sessions via `HAVING` in `GetSessionsWithFilter`
- [x] Filter session_start-only sessions via `HAVING` in `GetSessionsInstancesPlot`
- [x] Add integration tests for the new filtering behavior
- [x] Document the behavior in the dashboard OpenAPI spec

## See also

- fixes #4093