### PR TITLE
perf(android): speed up database reads and bulk writes

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/Database.kt
@@ -3,11 +3,11 @@ package sh.measure.android.storage
 import android.annotation.SuppressLint
 import android.content.ContentValues
 import android.content.Context
-import android.database.sqlite.SQLiteConstraintException
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteDatabase.CONFLICT_IGNORE
 import android.database.sqlite.SQLiteException
 import android.database.sqlite.SQLiteOpenHelper
+import android.database.sqlite.SQLiteStatement
 import kotlinx.serialization.encodeToString
 import sh.measure.android.events.EventType
 import sh.measure.android.exporter.AttachmentPacket
@@ -395,6 +395,7 @@ internal class DatabaseImpl(
     override fun onConfigure(db: SQLiteDatabase) {
         setWriteAheadLoggingEnabled(true)
         db.setForeignKeyConstraintsEnabled(true)
+        db.execSQL("PRAGMA synchronous = NORMAL")
     }
 
     // ========================================================================================
@@ -441,12 +442,11 @@ internal class DatabaseImpl(
 
     override fun getSessionIds(excludeSessionId: String): List<String> {
         val sessionIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getSessionIds(excludeSessionId), null)
+        readableDatabase.rawQuery(Sql.getSessionIds, arrayOf(excludeSessionId))
             .use {
+                val sessionIdIndex = it.getColumnIndex(SessionsTable.COL_SESSION_ID)
                 while (it.moveToNext()) {
-                    val sessionIdIndex = it.getColumnIndex(SessionsTable.COL_SESSION_ID)
-                    val sessionId = it.getString(sessionIdIndex)
-                    sessionIds.add(sessionId)
+                    sessionIds.add(it.getString(sessionIdIndex))
                 }
             }
         return sessionIds
@@ -454,9 +454,9 @@ internal class DatabaseImpl(
 
     override fun getRecentSessionIds(count: Int): List<String> {
         val sessionIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getRecentSessionIds(count), null).use {
+        readableDatabase.rawQuery(Sql.getRecentSessionIds, arrayOf(count.toString())).use {
+            val sessionIdIndex = it.getColumnIndex(SessionsTable.COL_SESSION_ID)
             while (it.moveToNext()) {
-                val sessionIdIndex = it.getColumnIndex(SessionsTable.COL_SESSION_ID)
                 sessionIds.add(it.getString(sessionIdIndex))
             }
         }
@@ -465,7 +465,7 @@ internal class DatabaseImpl(
 
     override fun getOldestSessionWithSignals(): String? {
         val sessionId: String
-        readableDatabase.rawQuery(Sql.getOldestSessionWithSignals(), null).use {
+        readableDatabase.rawQuery(Sql.getOldestSessionWithSignals, null).use {
             if (it.count == 0) {
                 return null
             }
@@ -522,90 +522,28 @@ internal class DatabaseImpl(
     // Events
     // ========================================================================================
 
-    @SuppressLint("UseKtx")
-    override fun insertEvent(event: EventEntity): Boolean {
-        writableDatabase.beginTransaction()
-        try {
-            val values = ContentValues().apply {
-                put(EventTable.COL_ID, event.id)
-                put(EventTable.COL_TYPE, event.type.value)
-                put(EventTable.COL_TIMESTAMP, event.timestamp)
-                put(EventTable.COL_SESSION_ID, event.sessionId)
-                put(EventTable.COL_USER_TRIGGERED, event.userTriggered)
-                if (event.filePath != null) {
-                    put(EventTable.COL_DATA_FILE_PATH, event.filePath)
-                } else if (event.serializedData != null) {
-                    put(EventTable.COL_DATA_SERIALIZED, event.serializedData)
-                }
-                put(EventTable.COL_ATTRIBUTES, event.serializedAttributes)
-                put(EventTable.COL_USER_DEFINED_ATTRIBUTES, event.serializedUserDefAttributes)
-                put(EventTable.COL_ATTACHMENT_SIZE, event.attachmentsSize)
-                put(EventTable.COL_ATTACHMENTS, event.serializedAttachments)
-                put(EventTable.COL_SAMPLED, event.isSampled)
-            }
-
-            val result = writableDatabase.insert(EventTable.TABLE_NAME, null, values)
-            if (result == -1L) {
-                logger.log(LogLevel.Debug, "Failed to insert event ${event.type}")
-                return false
-            }
-
-            event.attachmentEntities?.forEach { attachment ->
-                val attachmentValues = ContentValues().apply {
-                    put(AttachmentV1Table.COL_ID, attachment.id)
-                    put(AttachmentV1Table.COL_EVENT_ID, event.id)
-                    put(AttachmentV1Table.COL_TYPE, attachment.type)
-                    put(AttachmentV1Table.COL_TIMESTAMP, event.timestamp)
-                    put(AttachmentV1Table.COL_SESSION_ID, event.sessionId)
-                    put(AttachmentV1Table.COL_FILE_PATH, attachment.path)
-                    put(AttachmentV1Table.COL_NAME, attachment.name)
-                }
-                val attachmentResult =
-                    writableDatabase.insert(AttachmentV1Table.TABLE_NAME, null, attachmentValues)
-                if (attachmentResult == -1L) {
-                    logger.log(
-                        LogLevel.Debug,
-                        "Failed to insert attachment(${attachment.type}) for event(${event.type})",
-                    )
-                    return false
-                }
-            }
-            writableDatabase.setTransactionSuccessful()
-            return true
-        } catch (e: SQLiteConstraintException) {
-            // Expected if session insertion failed before event was triggered.
-            // Can happen for exceptions/ANRs written on main thread while session insertion
-            // happens in background.
-            logger.log(
-                LogLevel.Debug,
-                "Failed to insert event(${event.type}) for session(${event.sessionId})",
-                e,
-            )
-            return false
-        } finally {
-            writableDatabase.endTransaction()
-        }
-    }
+    // Returns false (via insertSignals' rollback) when the event's session row does not exist yet:
+    // an exception/ANR can be recorded on the main thread before the session is written in background.
+    override fun insertEvent(event: EventEntity): Boolean = insertSignals(listOf(event), emptyList())
 
     override fun getEventPackets(eventIds: List<String>): List<EventPacket> {
         if (eventIds.isEmpty()) {
             return emptyList()
         }
-        readableDatabase.rawQuery(Sql.getEventsForIds(eventIds), null).use {
+        readableDatabase.rawQuery(Sql.getEventsForIds(eventIds.size), eventIds.toTypedArray()).use {
             val eventPackets = mutableListOf<EventPacket>()
+            val eventIdIndex = it.getColumnIndex(EventTable.COL_ID)
+            val sessionIdIndex = it.getColumnIndex(EventTable.COL_SESSION_ID)
+            val timestampIndex = it.getColumnIndex(EventTable.COL_TIMESTAMP)
+            val userTriggeredIndex = it.getColumnIndex(EventTable.COL_USER_TRIGGERED)
+            val typeIndex = it.getColumnIndex(EventTable.COL_TYPE)
+            val serializedDataIndex = it.getColumnIndex(EventTable.COL_DATA_SERIALIZED)
+            val serializedDataFilePathIndex = it.getColumnIndex(EventTable.COL_DATA_FILE_PATH)
+            val attachmentsIndex = it.getColumnIndex(EventTable.COL_ATTACHMENTS)
+            val serializedAttributesIndex = it.getColumnIndex(EventTable.COL_ATTRIBUTES)
+            val serializedUserDefinedAttributesIndex =
+                it.getColumnIndex(EventTable.COL_USER_DEFINED_ATTRIBUTES)
             while (it.moveToNext()) {
-                val eventIdIndex = it.getColumnIndex(EventTable.COL_ID)
-                val sessionIdIndex = it.getColumnIndex(EventTable.COL_SESSION_ID)
-                val timestampIndex = it.getColumnIndex(EventTable.COL_TIMESTAMP)
-                val userTriggeredIndex = it.getColumnIndex(EventTable.COL_USER_TRIGGERED)
-                val typeIndex = it.getColumnIndex(EventTable.COL_TYPE)
-                val serializedDataIndex = it.getColumnIndex(EventTable.COL_DATA_SERIALIZED)
-                val serializedDataFilePathIndex = it.getColumnIndex(EventTable.COL_DATA_FILE_PATH)
-                val attachmentsIndex = it.getColumnIndex(EventTable.COL_ATTACHMENTS)
-                val serializedAttributesIndex = it.getColumnIndex(EventTable.COL_ATTRIBUTES)
-                val serializedUserDefinedAttributesIndex =
-                    it.getColumnIndex(EventTable.COL_USER_DEFINED_ATTRIBUTES)
-
                 val eventId = it.getString(eventIdIndex)
                 val sessionId = it.getString(sessionIdIndex)
                 val timestamp = it.getString(timestampIndex)
@@ -640,11 +578,10 @@ internal class DatabaseImpl(
 
     override fun getEventsForSession(session: String): List<String> {
         val eventIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getEventsForSession(session), null).use {
+        readableDatabase.rawQuery(Sql.getEventsForSession, arrayOf(session)).use {
+            val eventIdIndex = it.getColumnIndex(EventTable.COL_ID)
             while (it.moveToNext()) {
-                val eventIdIndex = it.getColumnIndex(EventTable.COL_ID)
-                val eventId = it.getString(eventIdIndex)
-                eventIds.add(eventId)
+                eventIds.add(it.getString(eventIdIndex))
             }
         }
         return eventIds
@@ -652,7 +589,7 @@ internal class DatabaseImpl(
 
     override fun getEventsCount(): Int {
         val count: Int
-        readableDatabase.rawQuery(Sql.getEventsCount(), null).use {
+        readableDatabase.rawQuery(Sql.getEventsCount, null).use {
             it.moveToFirst()
             val countIndex = it.getColumnIndex("count")
             count = it.getInt(countIndex)
@@ -661,7 +598,7 @@ internal class DatabaseImpl(
     }
 
     override fun getEventsCount(sessionId: String): Int {
-        val count = readableDatabase.rawQuery(Sql.getEventsCount(sessionId), null).use {
+        val count = readableDatabase.rawQuery(Sql.getEventsCountForSession, arrayOf(sessionId)).use {
             if (it.count == 0) {
                 return 0
             }
@@ -675,9 +612,9 @@ internal class DatabaseImpl(
     override fun deleteEvents(excludeSessionId: String, batchSize: Int): List<String> {
         val eventIds = mutableListOf<String>()
 
-        readableDatabase.rawQuery(Sql.getEventsForDeletion(excludeSessionId, batchSize), null).use {
+        readableDatabase.rawQuery(Sql.getEventsForDeletion, arrayOf(excludeSessionId, batchSize.toString())).use {
+            val idIndex = it.getColumnIndex(EventTable.COL_ID)
             while (it.moveToNext()) {
-                val idIndex = it.getColumnIndex(EventTable.COL_ID)
                 eventIds.add(it.getString(idIndex))
             }
         }
@@ -705,8 +642,11 @@ internal class DatabaseImpl(
         writableDatabase.beginTransaction()
         try {
             writableDatabase
-                .compileStatement(Sql.markTimelineForReporting(timestamp, durationSeconds))
+                .compileStatement(Sql.markTimelineForReporting)
                 .use { statement ->
+                    statement.bindString(1, timestamp)
+                    statement.bindString(2, "-$durationSeconds seconds")
+                    statement.bindString(3, timestamp)
                     val eventRowsUpdated = statement.executeUpdateDelete()
                     logger.log(
                         LogLevel.Debug,
@@ -715,8 +655,9 @@ internal class DatabaseImpl(
                 }
 
             writableDatabase
-                .compileStatement(Sql.markSessionAsPriority(sessionId))
+                .compileStatement(Sql.markSessionAsPriority)
                 .use { statement ->
+                    statement.bindString(1, sessionId)
                     val sessionsUpdated = statement.executeUpdateDelete()
                     if (sessionsUpdated > 0) {
                         logger.log(
@@ -764,24 +705,23 @@ internal class DatabaseImpl(
         if (spanIds.isEmpty()) {
             return emptyList()
         }
-        readableDatabase.rawQuery(Sql.getSpansForIds(spanIds), null).use {
+        readableDatabase.rawQuery(Sql.getSpansForIds(spanIds.size), spanIds.toTypedArray()).use {
             val spanPackets = mutableListOf<SpanPacket>()
+            val nameIndex = it.getColumnIndex(SpansTable.COL_NAME)
+            val sessionIdIndex = it.getColumnIndex(SpansTable.COL_SESSION_ID)
+            val spanIdIndex = it.getColumnIndex(SpansTable.COL_SPAN_ID)
+            val traceIdIndex = it.getColumnIndex(SpansTable.COL_TRACE_ID)
+            val parentIdIndex = it.getColumnIndex(SpansTable.COL_PARENT_ID)
+            val startTimeIndex = it.getColumnIndex(SpansTable.COL_START_TIME)
+            val endTimeIndex = it.getColumnIndex(SpansTable.COL_END_TIME)
+            val durationIndex = it.getColumnIndex(SpansTable.COL_DURATION)
+            val statusIndex = it.getColumnIndex(SpansTable.COL_STATUS)
+            val serializedAttrsIndex = it.getColumnIndex(SpansTable.COL_SERIALIZED_ATTRS)
+            val serializedUserDefAttrsIndex =
+                it.getColumnIndex(SpansTable.COL_SERIALIZED_USER_DEFINED_ATTRS)
+            val serializedCheckpointsIndex =
+                it.getColumnIndex(SpansTable.COL_SERIALIZED_SPAN_EVENTS)
             while (it.moveToNext()) {
-                val nameIndex = it.getColumnIndex(SpansTable.COL_NAME)
-                val sessionIdIndex = it.getColumnIndex(SpansTable.COL_SESSION_ID)
-                val spanIdIndex = it.getColumnIndex(SpansTable.COL_SPAN_ID)
-                val traceIdIndex = it.getColumnIndex(SpansTable.COL_TRACE_ID)
-                val parentIdIndex = it.getColumnIndex(SpansTable.COL_PARENT_ID)
-                val startTimeIndex = it.getColumnIndex(SpansTable.COL_START_TIME)
-                val endTimeIndex = it.getColumnIndex(SpansTable.COL_END_TIME)
-                val durationIndex = it.getColumnIndex(SpansTable.COL_DURATION)
-                val statusIndex = it.getColumnIndex(SpansTable.COL_STATUS)
-                val serializedAttrsIndex = it.getColumnIndex(SpansTable.COL_SERIALIZED_ATTRS)
-                val serializedUserDefAttrsIndex =
-                    it.getColumnIndex(SpansTable.COL_SERIALIZED_USER_DEFINED_ATTRS)
-                val serializedCheckpointsIndex =
-                    it.getColumnIndex(SpansTable.COL_SERIALIZED_SPAN_EVENTS)
-
                 val name = it.getString(nameIndex)
                 val sessionId = it.getString(sessionIdIndex)
                 val spanId = it.getString(spanIdIndex)
@@ -818,7 +758,7 @@ internal class DatabaseImpl(
 
     override fun getSpansCount(): Int {
         val count: Int
-        readableDatabase.rawQuery(Sql.getSpansCount(), null).use {
+        readableDatabase.rawQuery(Sql.getSpansCount, null).use {
             it.moveToFirst()
             val countIndex = it.getColumnIndex("count")
             count = it.getInt(countIndex)
@@ -827,7 +767,7 @@ internal class DatabaseImpl(
     }
 
     override fun getSpansCount(sessionId: String): Int {
-        val count = readableDatabase.rawQuery(Sql.getSpansCount(sessionId), null).use {
+        val count = readableDatabase.rawQuery(Sql.getSpansCountForSession, arrayOf(sessionId)).use {
             if (it.count == 0) {
                 return 0
             }
@@ -841,9 +781,9 @@ internal class DatabaseImpl(
     override fun deleteSpans(excludeSessionId: String, batchSize: Int): List<String> {
         val spanIds = mutableListOf<String>()
 
-        readableDatabase.rawQuery(Sql.getSpansForDeletion(excludeSessionId, batchSize), null).use {
+        readableDatabase.rawQuery(Sql.getSpansForDeletion, arrayOf(excludeSessionId, batchSize.toString())).use {
+            val idIndex = it.getColumnIndex(SpansTable.COL_SPAN_ID)
             while (it.moveToNext()) {
-                val idIndex = it.getColumnIndex(SpansTable.COL_SPAN_ID)
                 spanIds.add(it.getString(idIndex))
             }
         }
@@ -862,91 +802,97 @@ internal class DatabaseImpl(
         return if (deletedCount > 0) spanIds else emptyList()
     }
 
-    @SuppressLint("UseKtx")
+    // ========================================================================================
+    // Bulk Signal Operations
+    // ========================================================================================
+
     override fun insertSignals(
         eventEntities: List<EventEntity>,
         spanEntities: List<SpanEntity>,
     ): Boolean {
-        writableDatabase.beginTransaction()
+        val db = writableDatabase
+        db.beginTransaction()
+        val eventStatement = db.compileStatement(Sql.INSERT_EVENT)
+        val attachmentStatement = db.compileStatement(Sql.INSERT_ATTACHMENT)
+        val spanStatement = db.compileStatement(Sql.INSERT_SPAN)
         try {
             eventEntities.forEach { event ->
-                val values = ContentValues(11).apply {
-                    put(EventTable.COL_ID, event.id)
-                    put(EventTable.COL_TYPE, event.type.value)
-                    put(EventTable.COL_TIMESTAMP, event.timestamp)
-                    put(EventTable.COL_SESSION_ID, event.sessionId)
-                    put(EventTable.COL_USER_TRIGGERED, event.userTriggered)
-                    if (event.filePath != null) {
-                        put(EventTable.COL_DATA_FILE_PATH, event.filePath)
-                    } else if (event.serializedData != null) {
-                        put(EventTable.COL_DATA_SERIALIZED, event.serializedData)
-                    }
-                    put(EventTable.COL_ATTRIBUTES, event.serializedAttributes)
-                    put(EventTable.COL_USER_DEFINED_ATTRIBUTES, event.serializedUserDefAttributes)
-                    put(EventTable.COL_ATTACHMENT_SIZE, event.attachmentsSize)
-                    put(EventTable.COL_ATTACHMENTS, event.serializedAttachments)
-                    put(EventTable.COL_SAMPLED, event.isSampled)
-                }
-
-                if (writableDatabase.insert(EventTable.TABLE_NAME, null, values) == -1L) {
+                eventStatement.bindEvent(event)
+                if (eventStatement.executeInsert() == -1L) {
                     return false
                 }
 
                 event.attachmentEntities?.forEach { attachment ->
-                    val attachmentValues = ContentValues(7).apply {
-                        put(AttachmentV1Table.COL_ID, attachment.id)
-                        put(AttachmentV1Table.COL_EVENT_ID, event.id)
-                        put(AttachmentV1Table.COL_TYPE, attachment.type)
-                        put(AttachmentV1Table.COL_TIMESTAMP, event.timestamp)
-                        put(AttachmentV1Table.COL_SESSION_ID, event.sessionId)
-                        put(AttachmentV1Table.COL_FILE_PATH, attachment.path)
-                        put(AttachmentV1Table.COL_NAME, attachment.name)
-                    }
-
-                    if (writableDatabase.insert(
-                            AttachmentV1Table.TABLE_NAME,
-                            null,
-                            attachmentValues,
-                        ) == -1L
-                    ) {
+                    attachmentStatement.bindAttachment(attachment, event)
+                    if (attachmentStatement.executeInsert() == -1L) {
                         return false
                     }
                 }
             }
 
             spanEntities.forEach { span ->
-                val values = ContentValues(12).apply {
-                    put(SpansTable.COL_NAME, span.name)
-                    put(SpansTable.COL_SESSION_ID, span.sessionId)
-                    put(SpansTable.COL_SPAN_ID, span.spanId)
-                    put(SpansTable.COL_TRACE_ID, span.traceId)
-                    put(SpansTable.COL_PARENT_ID, span.parentId)
-                    put(SpansTable.COL_START_TIME, span.startTime)
-                    put(SpansTable.COL_END_TIME, span.endTime)
-                    put(SpansTable.COL_DURATION, span.duration)
-                    put(SpansTable.COL_SERIALIZED_ATTRS, span.serializedAttributes)
-                    put(
-                        SpansTable.COL_SERIALIZED_USER_DEFINED_ATTRS,
-                        span.serializedUserDefinedAttrs,
-                    )
-                    put(SpansTable.COL_SERIALIZED_SPAN_EVENTS, span.serializedCheckpoints)
-                    put(SpansTable.COL_SAMPLED, span.sampled)
-                    put(SpansTable.COL_STATUS, span.status.value)
-                }
-
-                if (writableDatabase.insert(SpansTable.TABLE_NAME, null, values) == -1L) {
+                spanStatement.bindSpan(span)
+                if (spanStatement.executeInsert() == -1L) {
                     return false
                 }
             }
 
-            writableDatabase.setTransactionSuccessful()
+            db.setTransactionSuccessful()
             return true
         } catch (e: SQLiteException) {
             logger.log(LogLevel.Debug, "Failed to insert signals", e)
             return false
         } finally {
-            writableDatabase.endTransaction()
+            eventStatement.close()
+            attachmentStatement.close()
+            spanStatement.close()
+            db.endTransaction()
         }
+    }
+
+    private fun SQLiteStatement.bindStringOrNull(index: Int, value: String?) {
+        if (value == null) bindNull(index) else bindString(index, value)
+    }
+
+    private fun SQLiteStatement.bindEvent(event: EventEntity) {
+        bindString(1, event.id)
+        bindString(2, event.type.value)
+        bindString(3, event.timestamp)
+        bindString(4, event.sessionId)
+        bindLong(5, if (event.userTriggered) 1 else 0)
+        bindStringOrNull(6, event.filePath)
+        bindStringOrNull(7, event.serializedData)
+        bindStringOrNull(8, event.serializedAttributes)
+        bindStringOrNull(9, event.serializedUserDefAttributes)
+        bindLong(10, event.attachmentsSize)
+        bindStringOrNull(11, event.serializedAttachments)
+        bindLong(12, if (event.isSampled) 1 else 0)
+    }
+
+    private fun SQLiteStatement.bindAttachment(attachment: AttachmentEntity, event: EventEntity) {
+        bindString(1, attachment.id)
+        bindString(2, event.id)
+        bindString(3, attachment.type)
+        bindString(4, event.timestamp)
+        bindString(5, event.sessionId)
+        bindString(6, attachment.path)
+        bindString(7, attachment.name)
+    }
+
+    private fun SQLiteStatement.bindSpan(span: SpanEntity) {
+        bindString(1, span.name)
+        bindString(2, span.sessionId)
+        bindString(3, span.spanId)
+        bindString(4, span.traceId)
+        bindStringOrNull(5, span.parentId)
+        bindLong(6, span.startTime)
+        bindLong(7, span.endTime)
+        bindLong(8, span.duration)
+        bindStringOrNull(9, span.serializedAttributes)
+        bindStringOrNull(10, span.serializedUserDefinedAttrs)
+        bindStringOrNull(11, span.serializedCheckpoints)
+        bindLong(12, if (span.sampled) 1 else 0)
+        bindLong(13, span.status.value.toLong())
     }
 
     // ========================================================================================
@@ -955,7 +901,7 @@ internal class DatabaseImpl(
 
     override fun getAttachmentsForEvents(events: List<String>): List<String> {
         val attachmentIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getAttachmentsForEvents(events), null).use { cursor ->
+        readableDatabase.rawQuery(Sql.getAttachmentsForEvents(events.size), events.toTypedArray()).use { cursor ->
             val attachmentIdIndex = cursor.getColumnIndex(AttachmentV1Table.COL_ID)
             if (attachmentIdIndex == -1) {
                 return attachmentIds
@@ -968,24 +914,23 @@ internal class DatabaseImpl(
         return attachmentIds
     }
 
-    override fun getAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getAttachmentsToUpload(maxCount))
+    override fun getAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getAttachmentsToUpload, arrayOf(maxCount.toString()))
 
-    override fun getProfileAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getProfileAttachmentsToUpload(maxCount))
+    override fun getProfileAttachmentsToUpload(maxCount: Int): List<AttachmentPacket> = queryAttachmentsToUpload(Sql.getProfileAttachmentsToUpload, arrayOf(maxCount.toString()))
 
-    private fun queryAttachmentsToUpload(sql: String): List<AttachmentPacket> {
+    private fun queryAttachmentsToUpload(sql: String, args: Array<String>): List<AttachmentPacket> {
         val attachments = mutableListOf<AttachmentPacket>()
         try {
-            readableDatabase.rawQuery(sql, null).use {
+            readableDatabase.rawQuery(sql, args).use {
+                val idIndex = it.getColumnIndex(AttachmentV1Table.COL_ID)
+                val urlIndex = it.getColumnIndex(AttachmentV1Table.COL_UPLOAD_URL)
+                val expiresAtIndex = it.getColumnIndex(AttachmentV1Table.COL_URL_EXPIRES_AT)
+                val typeIndex = it.getColumnIndex(AttachmentV1Table.COL_TYPE)
+                val nameIndex = it.getColumnIndex(AttachmentV1Table.COL_NAME)
+                val filePathIndex = it.getColumnIndex(AttachmentV1Table.COL_FILE_PATH)
+                val sessionIdIndex = it.getColumnIndex(AttachmentV1Table.COL_SESSION_ID)
+                val headersIndex = it.getColumnIndex(AttachmentV1Table.COL_URL_HEADERS)
                 while (it.moveToNext()) {
-                    val idIndex = it.getColumnIndex(AttachmentV1Table.COL_ID)
-                    val urlIndex = it.getColumnIndex(AttachmentV1Table.COL_UPLOAD_URL)
-                    val expiresAtIndex = it.getColumnIndex(AttachmentV1Table.COL_URL_EXPIRES_AT)
-                    val typeIndex = it.getColumnIndex(AttachmentV1Table.COL_TYPE)
-                    val nameIndex = it.getColumnIndex(AttachmentV1Table.COL_NAME)
-                    val filePathIndex = it.getColumnIndex(AttachmentV1Table.COL_FILE_PATH)
-                    val sessionIdIndex = it.getColumnIndex(AttachmentV1Table.COL_SESSION_ID)
-                    val headersIndex = it.getColumnIndex(AttachmentV1Table.COL_URL_HEADERS)
-
                     val id = it.getString(idIndex)
                     val url = it.getString(urlIndex)
                     val expiresAt = it.getString(expiresAtIndex)
@@ -1079,7 +1024,7 @@ internal class DatabaseImpl(
     override fun getExpiredAttachments(currentTime: String, batchSize: Int): List<String> {
         val attachmentIds = mutableListOf<String>()
         try {
-            readableDatabase.rawQuery(Sql.getExpiredAttachments(currentTime, batchSize), null)
+            readableDatabase.rawQuery(Sql.getExpiredAttachments, arrayOf(currentTime, batchSize.toString()))
                 .use { cursor ->
                     val idIndex = cursor.getColumnIndex(AttachmentV1Table.COL_ID)
                     while (cursor.moveToNext()) {
@@ -1098,48 +1043,49 @@ internal class DatabaseImpl(
 
     @SuppressLint("UseKtx")
     override fun insertBatch(batchEntity: BatchEntity): Boolean {
-        writableDatabase.beginTransaction()
+        val db = writableDatabase
+        db.beginTransaction()
+        val spanBatchStatement = db.compileStatement(Sql.INSERT_SPANS_BATCH)
+        val eventBatchStatement = db.compileStatement(Sql.INSERT_EVENTS_BATCH)
         try {
             val batches = ContentValues().apply {
                 put(BatchesTable.COL_BATCH_ID, batchEntity.batchId)
                 put(BatchesTable.COL_CREATED_AT, batchEntity.createdAt)
             }
 
-            writableDatabase.insertWithOnConflict(
+            db.insertWithOnConflict(
                 BatchesTable.TABLE_NAME,
                 null,
                 batches,
                 CONFLICT_IGNORE,
             )
             batchEntity.spanIds.forEach { spanId ->
-                val spanBatches = ContentValues().apply {
-                    put(SpansBatchTable.COL_SPAN_ID, spanId)
-                    put(SpansBatchTable.COL_BATCH_ID, batchEntity.batchId)
-                    put(SpansBatchTable.COL_CREATED_AT, batchEntity.createdAt)
-                }
-                val result = writableDatabase.insert(SpansBatchTable.TABLE_NAME, null, spanBatches)
-                if (result == -1L) {
+                spanBatchStatement.bindString(1, spanId)
+                spanBatchStatement.bindString(2, batchEntity.batchId)
+                spanBatchStatement.bindLong(3, batchEntity.createdAt)
+                if (spanBatchStatement.executeInsert() == -1L) {
                     logger.log(LogLevel.Debug, "Failed to insert span($spanId)")
                     return false
                 }
             }
             batchEntity.eventIds.forEach { eventId ->
-                val eventBatches = ContentValues().apply {
-                    put(EventsBatchTable.COL_EVENT_ID, eventId)
-                    put(EventsBatchTable.COL_BATCH_ID, batchEntity.batchId)
-                    put(EventsBatchTable.COL_CREATED_AT, batchEntity.createdAt)
-                }
-                val result =
-                    writableDatabase.insert(EventsBatchTable.TABLE_NAME, null, eventBatches)
-                if (result == -1L) {
+                eventBatchStatement.bindString(1, eventId)
+                eventBatchStatement.bindString(2, batchEntity.batchId)
+                eventBatchStatement.bindLong(3, batchEntity.createdAt)
+                if (eventBatchStatement.executeInsert() == -1L) {
                     logger.log(LogLevel.Debug, "Failed to insert event($eventId)")
                     return false
                 }
             }
-            writableDatabase.setTransactionSuccessful()
+            db.setTransactionSuccessful()
             return true
+        } catch (e: SQLiteException) {
+            logger.log(LogLevel.Debug, "Failed to insert batch(${batchEntity.batchId})", e)
+            return false
         } finally {
-            writableDatabase.endTransaction()
+            spanBatchStatement.close()
+            eventBatchStatement.close()
+            db.endTransaction()
         }
     }
 
@@ -1241,8 +1187,8 @@ internal class DatabaseImpl(
         }
 
         for (sessionId in sessionIds) {
-            forEachEvent(Sql.getSampledEvents(sessionId), ::addEvent)
-            forEachSpan(Sql.getSampledSpans(sessionId), ::addSpan)
+            forEachEvent(Sql.getSampledEvents, arrayOf(sessionId), ::addEvent)
+            forEachSpan(Sql.getSampledSpans, arrayOf(sessionId), ::addSpan)
         }
 
         // Insert any remaining events/spans
@@ -1251,11 +1197,41 @@ internal class DatabaseImpl(
         return batchesInserted
     }
 
+    private fun getSessionsToBatch(): List<String> {
+        val query = Sql.getSessionsToBatch
+        val sessionIds = mutableListOf<String>()
+        readableDatabase.rawQuery(query, null).use { cursor ->
+            val sessionIdIndex = cursor.getColumnIndex(SessionsTable.COL_SESSION_ID)
+            while (cursor.moveToNext()) {
+                sessionIds.add(cursor.getString(sessionIdIndex))
+            }
+        }
+        return sessionIds
+    }
+
+    private inline fun forEachEvent(query: String, args: Array<String>, action: (String) -> Unit) {
+        readableDatabase.rawQuery(query, args).use { cursor ->
+            val idIndex = cursor.getColumnIndex(EventTable.COL_ID)
+            while (cursor.moveToNext()) {
+                action(cursor.getString(idIndex))
+            }
+        }
+    }
+
+    private inline fun forEachSpan(query: String, args: Array<String>, action: (String) -> Unit) {
+        readableDatabase.rawQuery(query, args).use { cursor ->
+            val idIndex = cursor.getColumnIndex(SpansTable.COL_SPAN_ID)
+            while (cursor.moveToNext()) {
+                action(cursor.getString(idIndex))
+            }
+        }
+    }
+
     override fun getBatchIds(): List<String> {
         val batchIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getBatchIds(), null).use {
+        readableDatabase.rawQuery(Sql.getBatchIds, null).use {
+            val batchIdIndex = it.getColumnIndex(BatchesTable.COL_BATCH_ID)
             while (it.moveToNext()) {
-                val batchIdIndex = it.getColumnIndex(BatchesTable.COL_BATCH_ID)
                 batchIds.add(it.getString(batchIdIndex))
             }
         }
@@ -1265,16 +1241,16 @@ internal class DatabaseImpl(
     override fun getBatch(batchId: String): Batch {
         val eventIds = mutableListOf<String>()
         val spanIds = mutableListOf<String>()
-        readableDatabase.rawQuery(Sql.getBatchedEventIds(listOf(batchId)), null).use {
+        readableDatabase.rawQuery(Sql.getBatchedEventIds(1), arrayOf(batchId)).use {
+            val eventIdIndex = it.getColumnIndex(EventsBatchTable.COL_EVENT_ID)
             while (it.moveToNext()) {
-                val eventIdIndex = it.getColumnIndex(EventsBatchTable.COL_EVENT_ID)
                 eventIds.add(it.getString(eventIdIndex))
             }
         }
 
-        readableDatabase.rawQuery(Sql.getBatchedSpanIds(listOf(batchId)), null).use {
+        readableDatabase.rawQuery(Sql.getBatchedSpanIds(1), arrayOf(batchId)).use {
+            val spanIdIndex = it.getColumnIndex(SpansBatchTable.COL_SPAN_ID)
             while (it.moveToNext()) {
-                val spanIdIndex = it.getColumnIndex(SpansBatchTable.COL_SPAN_ID)
                 spanIds.add(it.getString(spanIdIndex))
             }
         }
@@ -1290,14 +1266,17 @@ internal class DatabaseImpl(
     // App Exit Tracking
     // ========================================================================================
 
-    override fun getSessionForAppExit(pid: Int): SessionRecord? = querySessionRecord(Sql.getSessionForAppExit(pid))
+    override fun getSessionForAppExit(pid: Int): SessionRecord? = querySessionRecord(Sql.getSessionForAppExit, arrayOf(pid.toString()))
 
-    override fun getSessionForTime(timeMs: Long): SessionRecord? = querySessionRecord(Sql.getSessionForTime(timeMs))
+    override fun getSessionForTime(timeMs: Long): SessionRecord? = querySessionRecord(Sql.getSessionForTime, arrayOf(timeMs.toString()))
 
-    override fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord? = querySessionRecord(Sql.getSessionForAnr(timeMs, maxGapMs))
+    override fun getSessionForAnr(timeMs: Long, maxGapMs: Long): SessionRecord? = querySessionRecord(
+        Sql.getSessionForAnr,
+        arrayOf(timeMs.toString(), timeMs.toString(), maxGapMs.toString()),
+    )
 
-    private fun querySessionRecord(query: String): SessionRecord? {
-        readableDatabase.rawQuery(query, null).use {
+    private fun querySessionRecord(query: String, args: Array<String>): SessionRecord? {
+        readableDatabase.rawQuery(query, args).use {
             if (!it.moveToFirst()) {
                 return null
             }
@@ -1313,7 +1292,10 @@ internal class DatabaseImpl(
     }
 
     override fun setSessionAnrTime(sessionId: String, anrTimeMs: Long) {
-        writableDatabase.compileStatement(Sql.setSessionAnrTime(sessionId, anrTimeMs)).use {
+        writableDatabase.compileStatement(Sql.setSessionAnrTime).use {
+            it.bindLong(1, anrTimeMs)
+            it.bindString(2, sessionId)
+            it.bindLong(3, anrTimeMs)
             it.executeUpdateDelete()
         }
     }
@@ -1333,35 +1315,5 @@ internal class DatabaseImpl(
     override fun close() {
         writableDatabase.close()
         super.close()
-    }
-
-    private fun getSessionsToBatch(): List<String> {
-        val query = Sql.getSessionsToBatch()
-        val sessionIds = mutableListOf<String>()
-        readableDatabase.rawQuery(query, null).use { cursor ->
-            while (cursor.moveToNext()) {
-                val sessionIdIndex = cursor.getColumnIndex(SessionsTable.COL_SESSION_ID)
-                sessionIds.add(cursor.getString(sessionIdIndex))
-            }
-        }
-        return sessionIds
-    }
-
-    private inline fun forEachEvent(query: String, action: (String) -> Unit) {
-        readableDatabase.rawQuery(query, null).use { cursor ->
-            val idIndex = cursor.getColumnIndex(EventTable.COL_ID)
-            while (cursor.moveToNext()) {
-                action(cursor.getString(idIndex))
-            }
-        }
-    }
-
-    private inline fun forEachSpan(query: String, action: (String) -> Unit) {
-        readableDatabase.rawQuery(query, null).use { cursor ->
-            val idIndex = cursor.getColumnIndex(SpansTable.COL_SPAN_ID)
-            while (cursor.moveToNext()) {
-                action(cursor.getString(idIndex))
-            }
-        }
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/DbConstants.kt
@@ -1,7 +1,6 @@
 package sh.measure.android.storage
 
 import sh.measure.android.events.AttachmentType
-import sh.measure.android.events.EventType
 
 internal object DbConstants {
     const val DATABASE_NAME = "measure.db"
@@ -129,12 +128,6 @@ internal object SpansTable {
 }
 
 internal object Sql {
-    private val journeyEventTypes = listOf(
-        EventType.LIFECYCLE_ACTIVITY,
-        EventType.LIFECYCLE_FRAGMENT,
-        EventType.SCREEN_VIEW,
-    )
-
     const val CREATE_EVENTS_TABLE = """
         CREATE TABLE IF NOT EXISTS ${EventTable.TABLE_NAME} (
             ${EventTable.COL_ID} TEXT PRIMARY KEY,
@@ -272,8 +265,73 @@ internal object Sql {
         ON ${SessionsTable.TABLE_NAME}(${SessionsTable.COL_PID}, ${SessionsTable.COL_CREATED_AT} DESC)
     """
 
-    fun getEventsForIds(eventIds: List<String>): String = """
-            SELECT 
+    const val INSERT_EVENT = """
+        INSERT INTO ${EventTable.TABLE_NAME} (
+            ${EventTable.COL_ID},
+            ${EventTable.COL_TYPE},
+            ${EventTable.COL_TIMESTAMP},
+            ${EventTable.COL_SESSION_ID},
+            ${EventTable.COL_USER_TRIGGERED},
+            ${EventTable.COL_DATA_FILE_PATH},
+            ${EventTable.COL_DATA_SERIALIZED},
+            ${EventTable.COL_ATTRIBUTES},
+            ${EventTable.COL_USER_DEFINED_ATTRIBUTES},
+            ${EventTable.COL_ATTACHMENT_SIZE},
+            ${EventTable.COL_ATTACHMENTS},
+            ${EventTable.COL_SAMPLED}
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    const val INSERT_ATTACHMENT = """
+        INSERT INTO ${AttachmentV1Table.TABLE_NAME} (
+            ${AttachmentV1Table.COL_ID},
+            ${AttachmentV1Table.COL_EVENT_ID},
+            ${AttachmentV1Table.COL_TYPE},
+            ${AttachmentV1Table.COL_TIMESTAMP},
+            ${AttachmentV1Table.COL_SESSION_ID},
+            ${AttachmentV1Table.COL_FILE_PATH},
+            ${AttachmentV1Table.COL_NAME}
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    """
+
+    const val INSERT_SPAN = """
+        INSERT INTO ${SpansTable.TABLE_NAME} (
+            ${SpansTable.COL_NAME},
+            ${SpansTable.COL_SESSION_ID},
+            ${SpansTable.COL_SPAN_ID},
+            ${SpansTable.COL_TRACE_ID},
+            ${SpansTable.COL_PARENT_ID},
+            ${SpansTable.COL_START_TIME},
+            ${SpansTable.COL_END_TIME},
+            ${SpansTable.COL_DURATION},
+            ${SpansTable.COL_SERIALIZED_ATTRS},
+            ${SpansTable.COL_SERIALIZED_USER_DEFINED_ATTRS},
+            ${SpansTable.COL_SERIALIZED_SPAN_EVENTS},
+            ${SpansTable.COL_SAMPLED},
+            ${SpansTable.COL_STATUS}
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    const val INSERT_SPANS_BATCH = """
+        INSERT INTO ${SpansBatchTable.TABLE_NAME} (
+            ${SpansBatchTable.COL_SPAN_ID},
+            ${SpansBatchTable.COL_BATCH_ID},
+            ${SpansBatchTable.COL_CREATED_AT}
+        ) VALUES (?, ?, ?)
+    """
+
+    const val INSERT_EVENTS_BATCH = """
+        INSERT INTO ${EventsBatchTable.TABLE_NAME} (
+            ${EventsBatchTable.COL_EVENT_ID},
+            ${EventsBatchTable.COL_BATCH_ID},
+            ${EventsBatchTable.COL_CREATED_AT}
+        ) VALUES (?, ?, ?)
+    """
+
+    private fun placeholders(count: Int): String = List(count) { "?" }.joinToString(", ")
+
+    fun getEventsForIds(count: Int): String = """
+            SELECT
                 ${EventTable.COL_ID},
                 ${EventTable.COL_SESSION_ID},
                 ${EventTable.COL_TIMESTAMP},
@@ -285,11 +343,11 @@ internal object Sql {
                 ${EventTable.COL_ATTRIBUTES},
                 ${EventTable.COL_USER_DEFINED_ATTRIBUTES}
             FROM ${EventTable.TABLE_NAME}
-            WHERE ${EventTable.COL_ID} IN (${eventIds.joinToString(", ") { "\'$it\'" }})
+            WHERE ${EventTable.COL_ID} IN (${placeholders(count)})
     """.trimIndent()
 
-    fun getSpansForIds(spanIds: List<String>): String = """
-            SELECT 
+    fun getSpansForIds(count: Int): String = """
+            SELECT
                 ${SpansTable.COL_NAME},
                 ${SpansTable.COL_SESSION_ID},
                 ${SpansTable.COL_SPAN_ID},
@@ -303,29 +361,29 @@ internal object Sql {
                 ${SpansTable.COL_SERIALIZED_SPAN_EVENTS},
                 ${SpansTable.COL_SERIALIZED_USER_DEFINED_ATTRS}
             FROM ${SpansTable.TABLE_NAME}
-            WHERE ${SpansTable.COL_SPAN_ID} IN (${spanIds.joinToString(", ") { "\'$it\'" }})
+            WHERE ${SpansTable.COL_SPAN_ID} IN (${placeholders(count)})
     """.trimIndent()
 
-    fun getEventsForSession(session: String): String = """
+    val getEventsForSession: String = """
             SELECT ${EventTable.COL_ID}
             FROM ${EventTable.TABLE_NAME}
-            WHERE ${EventTable.COL_SESSION_ID} = '$session'
+            WHERE ${EventTable.COL_SESSION_ID} = ?
     """.trimIndent()
 
-    fun getAttachmentsForEvents(events: List<String>): String = """
+    fun getAttachmentsForEvents(count: Int): String = """
             SELECT ${AttachmentV1Table.COL_ID}
             FROM ${AttachmentV1Table.TABLE_NAME}
-            WHERE ${AttachmentV1Table.COL_EVENT_ID} IN (${events.joinToString(", ") { "\'$it\'" }})
+            WHERE ${AttachmentV1Table.COL_EVENT_ID} IN (${placeholders(count)})
     """.trimIndent()
 
-    fun getRecentSessionIds(count: Int): String = """
+    val getRecentSessionIds: String = """
             SELECT ${SessionsTable.COL_SESSION_ID}
             FROM ${SessionsTable.TABLE_NAME}
             ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
-            LIMIT $count
+            LIMIT ?
     """.trimIndent()
 
-    fun getOldestSessionWithSignals(): String = """
+    val getOldestSessionWithSignals: String = """
             SELECT ${SessionsTable.COL_SESSION_ID}
             FROM ${SessionsTable.TABLE_NAME}
             WHERE EXISTS (
@@ -339,24 +397,24 @@ internal object Sql {
             LIMIT 1
     """.trimIndent()
 
-    fun getEventsCount(): String = """
+    val getEventsCount: String = """
             SELECT COUNT(${EventTable.COL_ID}) AS count
             FROM ${EventTable.TABLE_NAME}
     """.trimIndent()
 
-    fun getEventsCount(sessionId: String): String = """
+    val getEventsCountForSession: String = """
             SELECT COUNT(${EventTable.COL_ID}) AS count
             FROM ${EventTable.TABLE_NAME}
-            WHERE ${EventTable.COL_SESSION_ID} = '$sessionId'
+            WHERE ${EventTable.COL_SESSION_ID} = ?
     """.trimIndent()
 
-    fun getSpansCount(sessionId: String): String = """
+    val getSpansCountForSession: String = """
             SELECT COUNT(${SpansTable.COL_SPAN_ID}) AS count
             FROM ${SpansTable.TABLE_NAME}
-            WHERE ${SpansTable.COL_SESSION_ID} = '$sessionId'
+            WHERE ${SpansTable.COL_SESSION_ID} = ?
     """.trimIndent()
 
-    fun getSpansCount(): String = """
+    val getSpansCount: String = """
             SELECT COUNT(${SpansTable.COL_SPAN_ID}) AS count
             FROM ${SpansTable.TABLE_NAME}
     """.trimIndent()
@@ -370,69 +428,68 @@ internal object Sql {
         SessionsTable.COL_LAST_ANR_TIME,
     ).joinToString(", ")
 
-    fun getSessionForAppExit(pid: Int): String = """
+    val getSessionForAppExit: String = """
             SELECT $SESSION_RECORD_COLUMNS
             FROM ${SessionsTable.TABLE_NAME}
-            WHERE ${SessionsTable.COL_PID} = $pid AND ${SessionsTable.COL_APP_EXIT_TRACKED} = 0
+            WHERE ${SessionsTable.COL_PID} = ? AND ${SessionsTable.COL_APP_EXIT_TRACKED} = 0
             ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
             LIMIT 1
     """.trimIndent()
 
-    fun getSessionForTime(timeMs: Long): String = """
+    val getSessionForTime: String = """
             SELECT $SESSION_RECORD_COLUMNS
             FROM ${SessionsTable.TABLE_NAME}
-            WHERE ${SessionsTable.COL_CREATED_AT} <= $timeMs
+            WHERE ${SessionsTable.COL_CREATED_AT} <= ?
             ORDER BY ${SessionsTable.COL_CREATED_AT} DESC
             LIMIT 1
     """.trimIndent()
 
-    fun getSessionForAnr(timeMs: Long, maxGapMs: Long): String = """
+    val getSessionForAnr: String = """
             SELECT $SESSION_RECORD_COLUMNS
             FROM ${SessionsTable.TABLE_NAME}
             WHERE ${SessionsTable.COL_LAST_ANR_TIME} IS NOT NULL
-                AND ${SessionsTable.COL_LAST_ANR_TIME} <= $timeMs
-                AND $timeMs - ${SessionsTable.COL_LAST_ANR_TIME} <= $maxGapMs
+                AND ${SessionsTable.COL_LAST_ANR_TIME} <= ?
+                AND ${SessionsTable.COL_LAST_ANR_TIME} >= ? - ?
             ORDER BY ${SessionsTable.COL_LAST_ANR_TIME} DESC
             LIMIT 1
     """.trimIndent()
 
-    fun setSessionAnrTime(sessionId: String, anrTimeMs: Long): String = """
+    val setSessionAnrTime: String = """
             UPDATE ${SessionsTable.TABLE_NAME}
-            SET ${SessionsTable.COL_LAST_ANR_TIME} = $anrTimeMs
-            WHERE ${SessionsTable.COL_SESSION_ID} = '$sessionId'
-                AND (${SessionsTable.COL_LAST_ANR_TIME} IS NULL OR ${SessionsTable.COL_LAST_ANR_TIME} < $anrTimeMs)
+            SET ${SessionsTable.COL_LAST_ANR_TIME} = ?
+            WHERE ${SessionsTable.COL_SESSION_ID} = ?
+                AND (${SessionsTable.COL_LAST_ANR_TIME} IS NULL OR ${SessionsTable.COL_LAST_ANR_TIME} < ?)
     """.trimIndent()
 
-    fun getBatchedEventIds(batchIds: List<String>): String = """
+    fun getBatchedEventIds(count: Int): String = """
             SELECT
                 ${EventsBatchTable.COL_EVENT_ID},
                 ${EventsBatchTable.COL_BATCH_ID}
             FROM
                 ${EventsBatchTable.TABLE_NAME}
             WHERE
-                ${EventsBatchTable.COL_BATCH_ID} 
-                IN (${batchIds.joinToString(", ") { "'$it'" }})
+                ${EventsBatchTable.COL_BATCH_ID}
+                IN (${placeholders(count)})
     """.trimIndent()
 
-    fun getBatchedSpanIds(batchIds: List<String>): String = """
+    fun getBatchedSpanIds(count: Int): String = """
             SELECT
                 ${SpansBatchTable.COL_SPAN_ID},
                 ${SpansBatchTable.COL_BATCH_ID}
             FROM
                 ${SpansBatchTable.TABLE_NAME}
             WHERE
-                ${SpansBatchTable.COL_BATCH_ID} 
-                IN (${batchIds.joinToString(", ") { "'$it'" }})
+                ${SpansBatchTable.COL_BATCH_ID}
+                IN (${placeholders(count)})
     """.trimIndent()
 
-    // Profiles are uploaded by their own WorkManager worker, not the in-process drain.
     private val profileTypesList = listOf(
         AttachmentType.PERFETTO_TRACE,
         AttachmentType.HEAP_DUMP,
         AttachmentType.HEAP_PROFILE,
     ).joinToString(", ") { "'$it'" }
 
-    fun getAttachmentsToUpload(maxCount: Int): String = """
+    val getAttachmentsToUpload: String = """
             SELECT
                 ${AttachmentV1Table.COL_ID},
                 ${AttachmentV1Table.COL_EVENT_ID},
@@ -450,10 +507,10 @@ internal object Sql {
                 ${AttachmentV1Table.COL_UPLOAD_URL} IS NOT NULL
                 AND ${AttachmentV1Table.COL_TYPE} NOT IN ($profileTypesList)
             LIMIT
-                $maxCount
+                ?
     """.trimIndent()
 
-    fun getProfileAttachmentsToUpload(maxCount: Int): String = """
+    val getProfileAttachmentsToUpload: String = """
             SELECT
                 ${AttachmentV1Table.COL_ID},
                 ${AttachmentV1Table.COL_EVENT_ID},
@@ -471,88 +528,88 @@ internal object Sql {
                 ${AttachmentV1Table.COL_UPLOAD_URL} IS NOT NULL
                 AND ${AttachmentV1Table.COL_TYPE} IN ($profileTypesList)
             LIMIT
-                $maxCount
+                ?
     """.trimIndent()
 
-    fun getSessionsToBatch(): String = """
+    val getSessionsToBatch: String = """
             SELECT ${SessionsTable.COL_SESSION_ID}
             FROM ${SessionsTable.TABLE_NAME}
             ORDER BY ${SessionsTable.COL_PRIORITY_SESSION} DESC
     """.trimIndent()
 
-    fun getSampledEvents(sessionId: String): String = """
+    val getSampledEvents: String = """
         SELECT e.${EventTable.COL_ID}
         FROM ${EventTable.TABLE_NAME} e
         LEFT JOIN ${EventsBatchTable.TABLE_NAME} eb
             ON e.${EventTable.COL_ID} = eb.${EventsBatchTable.COL_EVENT_ID}
-        WHERE e.${EventTable.COL_SESSION_ID} = '$sessionId'
+        WHERE e.${EventTable.COL_SESSION_ID} = ?
             AND e.${EventTable.COL_SAMPLED} = 1
             AND eb.${EventsBatchTable.COL_EVENT_ID} IS NULL
         ORDER BY e.${EventTable.COL_TIMESTAMP} ASC
     """.trimIndent()
 
-    fun getSampledSpans(sessionId: String): String = """
+    val getSampledSpans: String = """
         SELECT sp.${SpansTable.COL_SPAN_ID}
         FROM ${SpansTable.TABLE_NAME} sp
         LEFT JOIN ${SpansBatchTable.TABLE_NAME} sb
             ON sp.${SpansTable.COL_SPAN_ID} = sb.${SpansBatchTable.COL_SPAN_ID}
-        WHERE sp.${SpansTable.COL_SESSION_ID} = '$sessionId'
+        WHERE sp.${SpansTable.COL_SESSION_ID} = ?
             AND sp.${SpansTable.COL_SAMPLED} = 1
             AND sb.${SpansBatchTable.COL_SPAN_ID} IS NULL
         ORDER BY sp.${SpansTable.COL_START_TIME} ASC
     """.trimIndent()
 
-    fun getEventsForDeletion(excludeSessionId: String, limit: Int): String = """
+    val getEventsForDeletion: String = """
         SELECT e.${EventTable.COL_ID}
         FROM ${EventTable.TABLE_NAME} e
         LEFT JOIN ${EventsBatchTable.TABLE_NAME} eb
             ON e.${EventTable.COL_ID} = eb.${EventsBatchTable.COL_EVENT_ID}
-        WHERE e.${EventTable.COL_SESSION_ID} != '$excludeSessionId'
+        WHERE e.${EventTable.COL_SESSION_ID} != ?
             AND e.${EventTable.COL_SAMPLED} = 0
             AND eb.${EventsBatchTable.COL_EVENT_ID} IS NULL
-        LIMIT $limit
+        LIMIT ?
     """.trimIndent()
 
-    fun getSpansForDeletion(excludeSessionId: String, limit: Int): String = """
+    val getSpansForDeletion: String = """
         SELECT e.${SpansTable.COL_SPAN_ID}
         FROM ${SpansTable.TABLE_NAME} e
         LEFT JOIN ${SpansBatchTable.TABLE_NAME} eb
             ON e.${SpansTable.COL_SPAN_ID} = eb.${SpansBatchTable.COL_SPAN_ID}
-        WHERE e.${SpansTable.COL_SESSION_ID} != '$excludeSessionId'
+        WHERE e.${SpansTable.COL_SESSION_ID} != ?
             AND e.${SpansTable.COL_SAMPLED} = 0
             AND eb.${SpansBatchTable.COL_SPAN_ID} IS NULL
-        LIMIT $limit
+        LIMIT ?
     """.trimIndent()
 
-    fun markTimelineForReporting(endTime: String, durationSeconds: Int): String = """
+    val markTimelineForReporting: String = """
         UPDATE ${EventTable.TABLE_NAME}
         SET ${EventTable.COL_SAMPLED} = 1
-        WHERE ${EventTable.COL_TIMESTAMP} BETWEEN 
-            strftime('%Y-%m-%dT%H:%M:%fZ', '$endTime', '-$durationSeconds seconds') 
-            AND '$endTime'
+        WHERE ${EventTable.COL_TIMESTAMP} BETWEEN
+            strftime('%Y-%m-%dT%H:%M:%fZ', ?, ?)
+            AND ?
     """.trimIndent()
 
-    fun getSessionIds(excludeSessionId: String): String = """
+    val getSessionIds: String = """
             SELECT ${SessionsTable.COL_SESSION_ID}
             FROM ${SessionsTable.TABLE_NAME}
-            WHERE ${SessionsTable.COL_SESSION_ID} != '$excludeSessionId'
+            WHERE ${SessionsTable.COL_SESSION_ID} != ?
     """.trimIndent()
 
-    fun markSessionAsPriority(sessionId: String): String = """
+    val markSessionAsPriority: String = """
             UPDATE ${SessionsTable.TABLE_NAME}
             SET ${SessionsTable.COL_PRIORITY_SESSION} = 1
-            WHERE ${SessionsTable.COL_SESSION_ID} = '$sessionId'
+            WHERE ${SessionsTable.COL_SESSION_ID} = ?
     """.trimIndent()
 
-    fun getExpiredAttachments(currentTime: String, limit: Int): String = """
+    val getExpiredAttachments: String = """
             SELECT ${AttachmentV1Table.COL_ID}, ${AttachmentV1Table.COL_FILE_PATH}
             FROM ${AttachmentV1Table.TABLE_NAME}
             WHERE ${AttachmentV1Table.COL_URL_EXPIRES_AT} IS NOT NULL
-                AND ${AttachmentV1Table.COL_URL_EXPIRES_AT} < '$currentTime'
-            LIMIT $limit
+                AND ${AttachmentV1Table.COL_URL_EXPIRES_AT} < ?
+            LIMIT ?
     """.trimIndent()
 
-    fun getBatchIds(): String = """
+    val getBatchIds: String = """
             SELECT ${BatchesTable.COL_BATCH_ID}
             FROM ${BatchesTable.TABLE_NAME}
             ORDER BY ${BatchesTable.COL_CREATED_AT} ASC


### PR DESCRIPTION
# Description

This is the first set of improvements to event and span insertion and retreival from SQLite.

- Reuse prepared statements for bulk writes.
- Set `synchronous = NORMAL` to reduce fsync overhead.
- Move out column lookups out of loops.
- Parameterize queries instead of building SQL strings. Queries now use `?` placeholders rather than pasting values into the SQL text. This help utilize SQLite's compiled-statement cache.

DatabaseBenchmark run on Pixel 4a (API 36)

| Benchmark | Before | After | Δ time | Allocs before → after | Δ allocs |
|---|---:|---:|---:|---:|---:|
| `insertSignals_240events_60spans` | 19.99 ms | 12.39 ms | **−38%** | 6,606 → 500 | **−92%** |
| `getEventPackets_500` | 10.80 ms | 6.65 ms | **−38%** | 15,473 → 6,084 | **−61%** |
| `getSpanPackets_500` | 22.44 ms | 17.03 ms | **−24%** | 50,562 → 41,674 | **−18%** |

Each row in the table is one operation. "Before" and "After" are the median times across many repetitions. "Δ time" is how much faster it got, and "Δ allocs" is how much less allocations it did.

[db_benchmark_results.zip](https://github.com/user-attachments/files/30247464/results.zip)

## Method

The micro-benchmark writes a batch of events and spans and reads them back. It drives these operations repeatedly on a Pixel 4a  device and records how long each takes along with how many allocations were made. The same benchmark is run twice, once without the optimizations and then with optimizations. 

Writes improved the most: about 40% faster while allocating 92% fewer objects. Reads got faster too. The span read improved the least because it still formats a timestamp for every row it reads, that will be tackled in a separate PR.

Side by side comparison of the metrics from _Perfetto_.

<img width="1647" height="161" alt="image" src="https://github.com/user-attachments/assets/e4328ec3-a16a-4fd5-82f7-206b9909d928" />

# References

References #4114