### PR TITLE
fix(android): label ANR stacktrace with main thread name

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/anr/AnrCollector.kt
@@ -41,6 +41,7 @@ internal class AnrCollector(
             data = toMeasureException(anrError),
             timestamp = anrError.timestamp,
             type = EventType.ANR,
+            threadName = anrError.thread.name,
             takeScreenshot = true,
         )
     }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/anr/AnrCollectorTest.kt
@@ -69,7 +69,7 @@ class AnrCollectorTest {
             attributes = attributesCaptor.capture(),
             userDefinedAttributes = userDefinedAttributeCaptor.capture(),
             attachments = attachmentsCaptor.capture(),
-            threadName = eq(null),
+            threadName = eq(thread.name),
             takeScreenshot = eq(true),
         )
 


### PR DESCRIPTION
# Description

Fix main thread mislabeled as watchdog thread in ANRs. The ANR event labeled the top-level stacktrace with the SDK's internal watchdog thread name (Thread-N) instead of `main`, even though the stacktrace itself was of the main thread's.
 
## Related issue
Fixes #4109 
