### PR TITLE
chore(ios): prepare sdk release 0.12.0

### DIFF
--- a/frontend/dashboard/content/docs/sdk-integration-guide.mdx
+++ b/frontend/dashboard/content/docs/sdk-integration-guide.mdx
@@ -277,7 +277,7 @@ Add Measure as a dependency by adding `dependencies` value to your `Package.swif
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.11.0")
+    .package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.12.0")
 ]
 ```
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -5,437 +5,453 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ios-v0.12.0] - 2026-07-22
+
+### :hammer: Misc
+
+
+- (**ios**): Reuse shared encoder and decoder (#4101) by @adwinross in #4101
+- (**ios**): Add github action to prepare ios release (#3632) by @adwinross in #3632
+- (**ios**): Collect http body only for json content type (#3964) by @abhaysood in #3964
+
+### :sparkles: New features
+
+
+- (**ios**): Implement logging (#4021) by @abhaysood
+
 ## [ios-v0.11.0] - 2026-06-11
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Enable kscrash before checking for crash reports (#3881)
-- (**ios**): Ensure sdk remains stopped when moving to foreground (#3847)
-- (**ios**): Send correct user defined attributes for bug report (#3665)
-- (**ios**): Remove orphaned attachment cleanup logic (#3600)
-- (**ios**): Send correct user defined attributes json (#3589)
-- (**ios**): Update incorrect filename (#3544)
-- (**ios**): Add proper masking to swiftui components (#3515)
-- (**ios**): Ignore http events with empty url (#3511)
-- (**ios**): Send lifecycle app event reliably (#3463)
+- (**ios**): Enabled kscrash before checking for crash reports (#3881) by @adwinross in #3881
+- (**ios**): Ensure sdk remains stopped when moving to foreground (#3847) by @adwinross in #3847
+- (**ios**): Send correct user defined attributes for bug report (#3665) by @adwinross in #3665
+- (**ios**): Remove orphaned attachment cleanup logic (#3600) by @adwinross in #3600
+- (**ios**): Send correct user defined attributes json (#3589) by @adwinross in #3589
+- (**ios**): Update incorrect filename (#3544) by @adwinross in #3544
+- (**ios**): Add proper masking to swiftui components (#3515) by @adwinross in #3515
+- (**ios**): Ignore http events with empty url (#3511) by @adwinross in #3511
+- (**ios**): Send lifecycle app event reliably (#3463) by @adwinross in #3463
 
 ### :hammer: Misc
 
 
-- (**ios**): Update exception data json structure (#3694)
-- (**ios**): Export data once dynamic config is loaded (#3683)
-- (**ios**): Remove capture layout snapshot api (#3680)
-- (**ios**): Run export when moving to foreground (#3657)
-- (**ios**): Save measure related files in application support directory (#3627)
-- (**ios**): Update sdk version (#3612)
-- (**ios**): Add objc api to track http events (#3598)
-- (**ios**): Encode gallery images using webp (#3559)
-- (**ios**): Limit batch size to 10 mb (#3557)
-- (**ios**): Use webp encoding for screenshots (#3504)
-- (**ios**): Update release script (#3446)
-- (**ios**): Generate correct os build number (#3430)
+- (**ios**): Prepare sdk release 0.11.0 (#3882) by @adwinross in #3882
+- (**ios**): Update exception data json structure (#3694) by @adwinross in #3694
+- (**ios**): Export data once dynamic config is loaded (#3683) by @adwinross in #3683
+- (**ios**): Remove capture layout snapshot api (#3680) by @adwinross in #3680
+- (**ios**): Run export when moving to foreground (#3657) by @adwinross in #3657
+- (**ios**): Save measure related files in application support directory (#3627) by @adwinross in #3627
+- (**ios**): Update sdk version (#3612) by @adwinross in #3612
+- (**ios**): Add objc api to track http events (#3598) by @adwinross in #3598
+- (**ios**): Encode gallery images using webp (#3559) by @adwinross in #3559
+- (**ios**): Limit batch size to 10 mb (#3557) by @adwinross in #3557
+- (**ios**): Use webp encoding for screenshots (#3504) by @adwinross in #3504
+- (**ios**): Update release script (#3446) by @adwinross in #3446
+- (**ios**): Generate correct os build number (#3430) by @adwinross in #3430
 
 ### :sparkles: New features
 
 
-- (**ios**): Add performance tracing apis for objc (#3560)
-- (**ios**): Add diagnostic mode for SDK logging (#3433)
+- (**ios**): Add performance tracing apis for objc (#3560) by @adwinross in #3560
+- (**ios**): Add diagnostic mode for SDK logging (#3433) by @adwinross in #3433
 
 ## [ios-v0.10.0] - 2026-04-03
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Send proper symbol address (#3389)
-- (**ios**): Use dispatch queues to track http events (#3384)
+- (**ios**): Send proper symbol address (#3389) by @adwinross in #3389
+- (**ios**): Use dispatch queues to track http events (#3384) by @adwinross in #3384
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.10.0 (#3391)
-- (**ios**): Send attachment size in the event payload (#3355)
-- (**ios**): Update sdk integration docs (#3341)
-- (**ios**): Use correct session start time (#3339)
-- (**ios**): Use core data to save gzip data (#3331)
-- (**ios**): Add correct url host to http events (#3330)
+- (**ios**): Prepare sdk release 0.10.0 (#3391) by @adwinross in #3391
+- (**ios**): Send attachment size in the event payload (#3355) by @adwinross in #3355
+- (**ios**): Update sdk integration docs (#3341) by @adwinross in #3341
+- (**ios**): Use correct session start time (#3339) by @adwinross in #3339
+- (**ios**): Use core data to save gzip data (#3331) by @adwinross in #3331
+- (**ios**): Add correct url host to http events (#3330) by @adwinross in #3330
 
 ### :sparkles: New features
 
 
-- (**ios**): Implement improved layout snapshots (#3327)
-- (**ios**): Integrate kscrash (#3255)
+- (**ios**): Implement improved layout snapshots (#3327) by @adwinross in #3327
+- (**ios**): Integrate kscrash (#3255) by @adwinross in #3255
 
 ## [ios-v0.9.2] - 2026-03-05
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Use correct data type for session start time attribute (#3256)
+- (**ios**): Use correct data type for session start time attribute (#3256) by @adwinross in #3256
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.9.2 (#3264)
-- (**ios**): Delete expired attachments on cleanup (#3262)
-- (**ios**): Add session start timestamp to attributes (#3250)
-- (**ios**): Add http_sampling_rate dynamic config (#3231)
+- (**ios**): Prepare sdk release 0.9.2 (#3264) by @adwinross in #3264
+- (**ios**): Delete expired attachments on cleanup (#3262) by @adwinross in #3262
+- (**ios**): Add session start timestamp to attributes (#3250) by @adwinross in #3250
+- (**ios**): Add http_sampling_rate dynamic config (#3231) by @abhaysood in #3231
 
 ## [ios-v0.9.1] - 2026-02-23
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Make config api call asynchronously (#3202)
+- (**ios**): Make config api call asynchronously (#3202) by @adwinross in #3202
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.9.1 (#3203)
+- (**ios**): Prepare sdk release 0.9.1 (#3203) by @adwinross in #3203
 
 ## [ios-v0.9.0] - 2026-02-19
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Swizzle url session task only once (#3137)
+- (**ios**): Swizzle url session task only once (#3137) by @adwinross in #3137
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.9.0 (#3146)
-- (**ios**): Enable internal logging based on macro (#3141)
-- (**ios**): Add cleanup logic for stale attachments (#3135)
-- (**ios**): Update exporting logic (#3134)
-- (**ios**): Update plcrashreporter version (#3120)
-- (**ios**): Update ci checks (#3068)
-- (**ios**): Rename userJourneySamplingRate to journeySamplingRate (#2957)
+- (**ios**): Prepare sdk release 0.9.0 (#3146) by @adwinross in #3146
+- (**ios**): Enable internal logging based on macro (#3141) by @adwinross in #3141
+- (**ios**): Add cleanup logic for stale attachments (#3135) by @adwinross in #3135
+- (**ios**): Update exporting logic (#3134) by @adwinross in #3134
+- (**ios**): Update plcrashreporter version (#3120) by @adwinross in #3120
+- (**ios**): Update ci checks (#3068) by @adwinross in #3068
+- (**ios**): Rename userJourneySamplingRate to journeySamplingRate (#2957) by @adwinross in #2957
 
 ### :sparkles: New features
 
 
-- (**ios**): Implement dynamic config with new session definition (#3077)
-- (**ios**): Expose measure init api for cpp app delegate (#3028)
+- (**ios**): Implement dynamic config with new session definition (#3077) by @adwinross in #3077
+- (**ios**): Expose measure init api for cpp app delegate (#3028) by @adwinross in #3028
 
 ## [ios-v0.8.1] - 2025-11-26
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Use correct coding keys for userJourneysSamplingRate (#2939)
+- (**ios**): Use correct coding keys for userJourneysSamplingRate (#2939) by @adwinross in #2939
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.8.1 (#2941)
+- (**ios**): Prepare sdk release 0.8.1 (#2941) by @adwinross in #2941
 
 ## [ios-v0.8.0] - 2025-11-25
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Update network interceptor to generate proper request body (#2889)
+- (**ios**): Update network interceptor to generate proper request body (#2889) by @adwinross in #2889
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.8.0 (#2937)
-- (**ios**): Update measure config and default event collection
+- (**ios**): Prepare sdk release 0.8.0 (#2937) by @adwinross in #2937
+- (**ios**): Update measure config and default event collection by @adwinross in #2935
 
 ## [ios-v0.7.1] - 2025-10-29
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Filter HTTP body fields instead of discarding events (#2856)
-- (**ios**): Log proper error message on failure
+- (**ios**): Filter HTTP body fields instead of discarding events (#2856) by @adwinross in #2856
+- (**ios**): Log proper error message on failure by @adwinross in #2807
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.7.1 (#2858)
-- (**ios**): Limit http data body size to 256 kb (#2852)
+- (**ios**): Prepare sdk release 0.7.1 (#2858) by @adwinross in #2858
+- (**ios**): Limit http data body size to 256 kb (#2852) by @adwinross in #2852
 
 ## [ios-v0.7.0] - 2025-10-22
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Track proper session duration (#2641)
+- (**ios**): Track proper session duration (#2641) by @adwinross in #2641
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.7.0 (#2799)
-- (**ios**): Use signed urls to upload dsyms (#2785)
-- (**ios**): Continue existing attachment export on unregister (#2796)
-- (**ios**): Update core data model version (#2775)
-- (**ios**): Implement serial attachment upload (#2730)
-- (**ios**): Centralize custom attribute validation logic (#2716)
-- (**ios**): Remove maxSessionDurationMs from internal config (#2696)
-- (**ios**): Add jitter to periodic export (#2695)
-- (**ios**): Update upload dyms scripts (#2626)
+- (**ios**): Prepare sdk release 0.7.0 (#2799) by @adwinross in #2799
+- (**ios**): Use signed urls to upload dsyms (#2785) by @adwinross in #2785
+- (**ios**): Continue existing attachment export on unregister (#2796) by @adwinross in #2796
+- (**ios**): Update core data model version (#2775) by @adwinross in #2775
+- (**ios**): Implement serial attachment upload (#2730) by @adwinross in #2730
+- (**ios**): Centralize custom attribute validation logic (#2716) by @adwinross in #2716
+- (**ios**): Remove maxSessionDurationMs from internal config (#2696) by @adwinross in #2696
+- (**ios**): Add jitter to periodic export (#2695) by @adwinross in #2695
+- (**ios**): Update upload dyms scripts (#2626) by @adwinross in #2626
 
 ### :sparkles: New features
 
 
-- (**ios**): Expose API to track http events (#2788)
-- (**ios**): Add session start event (#2607)
+- (**ios**): Expose API to track http events (#2788) by @adwinross in #2788
+- (**ios**): Add session start event (#2607) by @adwinross in #2607
 
 ## [ios-v0.6.0] - 2025-09-01
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Add proper implementation for LifecycleManagerInternal (#2603)
-- (**ios**): Update process start time logic (#2597)
-- (**ios**): Add safe uiapplication swizzling (#2593)
-- (**ios**): Only call functions if sdk is started (#2583)
-- (**ios**): Fix blank svg generation (#2580)
-- (**ios**): Disable shake listener when app moves to background (#2566)
-- (**ios**): Remove deprecated UIWebView usage (#2538)
-- (**ios**): Prepare crash file if crash data is cleared (#2533)
-- (**ios**): Make MsrAttachment properties public (#2534)
+- (**ios**): Add proper implementation for LifecycleManagerInternal (#2603) by @adwinross in #2603
+- (**ios**): Update process start time logic (#2597) by @adwinross in #2597
+- (**ios**): Add safe uiapplication swizzling (#2593) by @adwinross in #2593
+- (**ios**): Only call functions if sdk is started (#2583) by @adwinross in #2583
+- (**ios**): Fix blank svg generation (#2580) by @adwinross in #2580
+- (**ios**): Disable shake listener when app moves to background (#2566) by @adwinross in #2566
+- (**ios**): Remove deprecated UIWebView usage (#2538) by @hoermannpaul in #2538
+- (**ios**): Prepare crash file if crash data is cleared (#2533) by @adwinross in #2533
+- (**ios**): Make MsrAttachment properties public (#2534) by @adwinross in #2534
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.6.0 (#2606)
-- (**ios**): Update performance docs (#2605)
-- (**ios**): Update ios project structure (#2601)
-- (**ios**): Update package.swift to include objc code (#2599)
-- (**ios**): Add script to upload dsyms from xcarchive (#2585)
-- (**ios**): Add more view controllers to be ignored (#2565)
-- (**ios**): Add lifecycleViewControllerExcludeList to internal config (#2468)
-- (**ios**): Add more view controllers to be ignored (#2461)
+- (**ios**): Prepare sdk release 0.6.0 (#2606) by @adwinross in #2606
+- (**ios**): Update performance docs (#2605) by @adwinross in #2605
+- (**ios**): Update ios project structure (#2601) by @adwinross in #2601
+- (**ios**): Update package.swift to include objc code (#2599) by @adwinross in #2599
+- (**ios**): Add script to upload dsyms from xcarchive (#2585) by @adwinross in #2585
+- (**ios**): Add more view controllers to be ignored (#2565) by @adwinross in #2565
+- (**ios**): Add lifecycleViewControllerExcludeList to internal config (#2468) by @adwinross in #2468
+- (**ios**): Add more view controllers to be ignored (#2461) by @abhaysood in #2461
 
 ### :sparkles: New features
 
 
-- (**ios**): Add user defined attributes to screen view events (#2592)
-- (**ios**): Provide configurable storage limits (#2470)
+- (**ios**): Add user defined attributes to screen view events (#2592) by @adwinross in #2592
+- (**ios**): Provide configurable storage limits (#2470) by @adwinross in #2470
 
 ## [ios-v0.5.1] - 2025-07-11
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.5.1 (#2400)
+- (**ios**): Prepare sdk release 0.5.1 (#2400) by @adwinross in #2400
 
 ## [ios-v0.5.0] - 2025-07-09
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Convert float to int safely (#2381)
-- (**ios**): Generate non nil network attributes for first event (#2372)
-- (**ios**): Make attribute processor thread safe (#2351)
-- (**ios**): Prevent network change callback from firing on SDK initialisation (#2345)
+- (**ios**): Convert float to int safely (#2381) by @adwinross in #2381
+- (**ios**): Generate non nil network attributes for first event (#2372) by @adwinross in #2372
+- (**ios**): Make attribute processor thread safe (#2351) by @adwinross in #2351
+- (**ios**): Prevent network change callback from firing on SDK initialisation (#2345) by @adwinross in #2345
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.5.0 (#2376)
-- (**ios**): Update apis to support objc initialisation (#2374)
-- (**ios**): Update shake detector api (#2365)
-- (**ios**): Remove shake to launch bug report config (#2358)
-- (**ios**): Update unreliable tests in ci environment (#2336)
-- (**ios**): Update release script (#2342)
+- (**ios**): Prepare sdk release 0.5.0 (#2376) by @adwinross in #2376
+- (**ios**): Update apis to support objc initialisation (#2374) by @adwinross in #2374
+- (**ios**): Update shake detector api (#2365) by @adwinross in #2365
+- (**ios**): Remove shake to launch bug report config (#2358) by @abhaysood in #2358
+- (**ios**): Update unreliable tests in ci environment (#2336) by @adwinross in #2336
+- (**ios**): Update release script (#2342) by @adwinross in #2342
 
 ### :recycle: Refactor
 
 
-- (**ios**): Rename Attachment to MsrAttachment (#2368)
+- (**ios**): Rename Attachment to MsrAttachment (#2368) by @adwinross in #2368
 
 ### :sparkles: New features
 
 
-- (**ios**): Add support for custom header (#2355)
+- (**ios**): Add support for custom header (#2355) by @adwinross in #2355
 
 ## [ios-v0.4.0] - 2025-06-19
 
 ### :books: Documentation
 
 
-- (**ios**): Add app size monitoring documentation (#2321)
+- (**ios**): Add app size monitoring documentation (#2321) by @adwinross in #2321
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Remove hardcoded values from upload dysm script (#2322)
-- (**ios**): Make session id API public (#2315)
+- (**ios**): Remove hardcoded values from upload dysm script (#2322) by @adwinross in #2322
+- (**ios**): Make session id API public (#2315) by @abhaysood in #2315
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.4.0 (#2333)
-- (**ios**): Add measure api url to http blocklist (#2317)
-- (**ios**): Add performance data (#2295)
+- (**ios**): Prepare sdk release 0.4.0 (#2333) by @adwinross in #2333
+- (**ios**): Add measure api url to http blocklist (#2317) by @adwinross in #2317
+- (**ios**): Add performance data (#2295) by @adwinross in #2295
 
 ### :recycle: Refactor
 
 
-- (**ios**): Update public api interface (#2319)
+- (**ios**): Update public api interface (#2319) by @adwinross in #2319
 
 ### :sparkles: New features
 
 
-- (**ios**): Implement handled exception tracking (#2331)
+- (**ios**): Implement handled exception tracking (#2331) by @adwinross in #2331
 
 ## [ios-v0.3.1] - 2025-06-04
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Swizzle UIApplication.sendEvent to avoid breaking keyboard input (#2267)
-- (**ios**): Update core data Initialization logic (#2257)
-- (**ios**): Replaces uses of TARGET_OS_SIMULATOR (#2244)
+- (**ios**): Swizzle UIApplication.sendEvent to avoid breaking keyboard input (#2267) by @adwinross in #2267
+- (**ios**): Update core data Initialization logic (#2257) by @adwinross in #2257
+- (**ios**): Replaces uses of TARGET_OS_SIMULATOR (#2244) by @DominatorVbN in #2244
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.3.1 (#2276)
+- (**ios**): Prepare sdk release 0.3.1 (#2276) by @adwinross in #2276
 
 ## [ios-v0.3.0] - 2025-05-28
 
 ### :books: Documentation
 
 
-- (**ios**): Update readme.md (#2132)
+- (**ios**): Update readme.md (#2132) by @DominatorVbN in #2132
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Attach crash report to the correct session (#2196)
+- (**ios**): Attach crash report to the correct session (#2196) by @adwinross in #2196
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.3.0 (#2229)
+- (**ios**): Prepare sdk release 0.3.0 (#2229) by @adwinross in #2229
 
 ### :sparkles: New features
 
 
-- (**ios**): Add bug report (#2203)
+- (**ios**): Add bug report (#2203) by @adwinross in #2203
 
 ## [ios-v0.2.0] - 2025-04-29
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Update cgfloat to int conversion logic (#2098)
-- (**ios**): Update cpu frequency generation logic (#2092)
-- (**ios**): Start the sdk when autostart is enabled (#2036)
+- (**ios**): Update cgfloat to int conversion logic (#2098) by @adwinross in #2098
+- (**ios**): Update cpu frequency generation logic (#2092) by @adwinross in #2092
+- (**ios**): Start the sdk when autostart is enabled (#2036) by @adwinross in #2036
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.2.0 (#2099)
-- (**ios**): Update swizzling logic (#2079)
-- (**ios**): Update swiftlint config (#2027)
-- (**ios**): Update json encoding logic (#1959)
-- (**ios**): Remove swift-lint check on ci (#2017)
+- (**ios**): Prepare sdk release 0.2.0 (#2099) by @adwinross in #2099
+- (**ios**): Update swizzling logic (#2079) by @adwinross in #2079
+- (**ios**): Update swiftlint config (#2027) by @adwinross in #2027
+- (**ios**): Update json encoding logic (#1959) by @adwinross in #1959
+- (**ios**): Remove swift-lint check on ci (#2017) by @adwinross in #2017
 
 ### :sparkles: New features
 
 
-- (**ios**): Track view controller ttid (#2083)
-- (**ios**): Implement performance tracing (#2076)
-- (**ios**): Expose APIs to allow start/stop of SDK (#2007)
+- (**ios**): Track view controller ttid (#2083) by @adwinross in #2083
+- (**ios**): Implement performance tracing (#2076) by @adwinross in #2076
+- (**ios**): Expose APIs to allow start/stop of SDK (#2007) by @adwinross in #2007
 
 ## [ios-v0.1.0] - 2025-03-28
 
 ### :books: Documentation
 
 
-- (**ios**): Update readme (#1956)
-- (**ios**): Add feature documentation (#1863)
+- (**ios**): Update readme (#1956) by @adwinross in #1956
+- (**ios**): Add feature documentation (#1863) by @adwinross in #1863
 
 ### :bug: Bug fixes
 
 
-- (**ios**): Skip sdk initialisation if api key or api url is invalid (#1970)
-- (**ios**): Update in_app generation logic (#1885)
-- (**ios**): Update long press timeout (#1801)
-- (**ios**): Data type issue
-- (**ios**): Data ingestion failure
+- (**ios**): Skip sdk initialisation if api key or api url is invalid (#1970) by @adwinross in #1970
+- (**ios**): Update in_app generation logic (#1885) by @adwinross in #1885
+- (**ios**): Update long press timeout (#1801) by @adwinross in #1801
+- (**ios**): Data type issue by @adwinross in #1734
+- (**ios**): Data ingestion failure by @adwinross in #1626
 
 ### :hammer: Misc
 
 
-- (**ios**): Prepare sdk release 0.1.0 (#2000)
-- (**ios**): Update release script (#1999)
-- (**ios**): Update pod name to measure-sh (#1998)
-- (**ios**): Update heartbeat tests (#1994)
-- (**ios**): Prepare sdk release 0.1.0 (#1987)
-- (**ios**): Add http event configurations to measure config (#1980)
-- (**ios**): Log error messages when upload dsym script fails (#1975)
-- (**ios**): Create new session if build number or app version is updated (#1972)
-- (**ios**): Rename MeasureSDK to Measure (#1957)
-- (**ios**): Update plcrashreporter config (#1938)
-- (**ios**): Remove fatal errors (#1932)
-- (**ios**): Update cpu frequency generation logic
-- (**ios**): Prepare sdk release 0.0.1-rc1 (#1877)
-- (**ios**): Update release scripts (#1876)
-- (**ios**): Add release scripts (#1869)
-- (**ios**): Update public apis (#1841)
-- (**ios**): Add scripts to upload dsyms (#1823)
-- (**ios**): Add binary images to exception (#1802)
-- (**ios**): Add spm and cocoapod support (#1796)
-- (**ios**): Add layout snapshots to gestures (#1779)
-- (**ios**): Add privacy manifest (#1782)
-- (**ios**): Add sessionator data (#1749)
-- (**ios**): Add public apis to set and unset userid
-- (**ios**): Add session sampling and data cleanup (#1733)
-- (**ios**): Add screen view event (#1721)
-- (**ios**): Add custom event tracking (#1676)
-- (**ios**): Track and export network change events (#1683)
-- (**ios**): Track and export http events (#1612)
-- (**ios**): Track app termination event (#1678)
-- (**ios**): Add launch event tracking (#1535)
-- (**ios**): Add cpu and memory tracking (#1519)
-- (**ios**): Update time provider (#1478)
-- (**ios**): Add lifecycle tracking (#1444)
-- (**ios**): Update session creation logic (#1398)
-- (**ios**): Batch and send events (#1369)
-- (**ios**): Update event store to save gesture data (#1365)
-- (**ios**): Update project structure (#1328)
-- (**ios**): Detect and save gesture events (#1324)
-- (**ios**): Save events and sessions to core data (#1307)
-- (**ios**): Add crash reporting (#1267)
-- (**ios**): Add signpost for performance testing (#1208)
-- (**ios**): Add event processor (#1206)
-- (**ios**): Add attribute processor (#1192)
-- (**ios**): Add session manager (#1162)
-- (**ios**): Update sdk initialisation (#1146)
-- (**ios**): Update ios sdk initialisation (#1119)
-- (**ios**): Add swiftLint to ios
+- (**ios**): Prepare sdk release 0.1.0 (#2000) by @adwinross in #2000
+- (**ios**): Update release script (#1999) by @adwinross in #1999
+- (**ios**): Update pod name to measure-sh (#1998) by @adwinross in #1998
+- (**ios**): Update heartbeat tests (#1994) by @adwinross in #1994
+- (**ios**): Prepare sdk release 0.1.0 (#1987) by @adwinross in #1987
+- (**ios**): Add http event configurations to measure config (#1980) by @adwinross in #1980
+- (**ios**): Log error messages when upload dsym script fails (#1975) by @adwinross in #1975
+- (**ios**): Create new session if build number or app version is updated (#1972) by @adwinross in #1972
+- (**ios**): Rename MeasureSDK to Measure (#1957) by @adwinross in #1957
+- (**ios**): Update plcrashreporter config (#1938) by @adwinross in #1938
+- (**ios**): Remove fatal errors (#1932) by @adwinross in #1932
+- (**ios**): Update cpu frequency generation logic by @adwinross in #1904
+- (**ios**): Prepare sdk release 0.0.1-rc1 (#1877) by @adwinross in #1877
+- (**ios**): Update release scripts (#1876) by @adwinross in #1876
+- (**ios**): Add release scripts (#1869) by @adwinross in #1869
+- (**ios**): Update public apis (#1841) by @adwinross in #1841
+- (**ios**): Add scripts to upload dsyms (#1823) by @adwinross in #1823
+- (**ios**): Add binary images to exception (#1802) by @adwinross in #1802
+- (**ios**): Add spm and cocoapod support (#1796) by @adwinross in #1796
+- (**ios**): Add layout snapshots to gestures (#1779) by @adwinross in #1779
+- (**ios**): Add privacy manifest (#1782) by @adwinross in #1782
+- (**ios**): Add sessionator data (#1749) by @adwinross in #1749
+- (**ios**): Add public apis to set and unset userid by @adwinross in #1753
+- (**ios**): Add session sampling and data cleanup (#1733) by @adwinross in #1733
+- (**ios**): Add screen view event (#1721) by @adwinross in #1721
+- (**ios**): Add custom event tracking (#1676) by @adwinross in #1676
+- (**ios**): Track and export network change events (#1683) by @adwinross in #1683
+- (**ios**): Track and export http events (#1612) by @adwinross in #1612
+- (**ios**): Track app termination event (#1678) by @adwinross in #1678
+- (**ios**): Add launch event tracking (#1535) by @adwinross in #1535
+- (**ios**): Add cpu and memory tracking (#1519) by @adwinross in #1519
+- (**ios**): Update time provider (#1478) by @adwinross in #1478
+- (**ios**): Add lifecycle tracking (#1444) by @adwinross in #1444
+- (**ios**): Update session creation logic (#1398) by @adwinross in #1398
+- (**ios**): Batch and send events (#1369) by @adwinross in #1369
+- (**ios**): Update event store to save gesture data (#1365) by @adwinross in #1365
+- (**ios**): Update project structure (#1328) by @adwinross in #1328
+- (**ios**): Detect and save gesture events (#1324) by @adwinross in #1324
+- (**ios**): Save events and sessions to core data (#1307) by @adwinross in #1307
+- (**ios**): Add crash reporting (#1267) by @adwinross in #1267
+- (**ios**): Add signpost for performance testing (#1208) by @adwinross in #1208
+- (**ios**): Add event processor (#1206) by @adwinross in #1206
+- (**ios**): Add attribute processor (#1192) by @adwinross in #1192
+- (**ios**): Add session manager (#1162) by @adwinross in #1162
+- (**ios**): Update sdk initialisation (#1146) by @adwinross in #1146
+- (**ios**): Update ios sdk initialisation (#1119) by @adwinross in #1119
+- (**ios**): Add swiftLint to ios by @adwinross in #1100
 
 ### :recycle: Refactor
 
 
-- (**ios**): Rename NetworkInterceptor to MsrNetworkInterceptor (#1922)
+- (**ios**): Rename NetworkInterceptor to MsrNetworkInterceptor (#1922) by @adwinross in #1922
 
 ### :sparkles: New features
 
 
-- (**ios**): Expose API to get current session ID (#1677)
-- (**ios**): Initial project setup  (#1034)
+- (**ios**): Expose API to get current session ID (#1677) by @adwinross in #1677
+- (**ios**): Initial project setup  (#1034) by @adwinross in #1034
 
-[ios-v0.11.0]: https://github.com///compare/ios-v0.10.0..ios-v0.11.0
-[ios-v0.10.0]: https://github.com///compare/ios-v0.9.2..ios-v0.10.0
-[ios-v0.9.2]: https://github.com///compare/ios-v0.9.1..ios-v0.9.2
-[ios-v0.9.1]: https://github.com///compare/ios-v0.9.0..ios-v0.9.1
-[ios-v0.9.0]: https://github.com///compare/ios-v0.8.1..ios-v0.9.0
-[ios-v0.8.1]: https://github.com///compare/ios-v0.8.0..ios-v0.8.1
-[ios-v0.8.0]: https://github.com///compare/ios-v0.7.1..ios-v0.8.0
-[ios-v0.7.1]: https://github.com///compare/ios-v0.7.0..ios-v0.7.1
-[ios-v0.7.0]: https://github.com///compare/ios-v0.6.0..ios-v0.7.0
-[ios-v0.6.0]: https://github.com///compare/ios-v0.5.1..ios-v0.6.0
-[ios-v0.5.1]: https://github.com///compare/ios-v0.5.0..ios-v0.5.1
-[ios-v0.5.0]: https://github.com///compare/ios-v0.4.0..ios-v0.5.0
-[ios-v0.4.0]: https://github.com///compare/ios-v0.3.1..ios-v0.4.0
-[ios-v0.3.1]: https://github.com///compare/ios-v0.3.0..ios-v0.3.1
-[ios-v0.3.0]: https://github.com///compare/ios-v0.2.0..ios-v0.3.0
-[ios-v0.2.0]: https://github.com///compare/ios-v0.1.0..ios-v0.2.0
+[ios-v0.12.0]: https://github.com/measure-sh/measure/compare/ios-v0.11.0..ios-v0.12.0
+[ios-v0.11.0]: https://github.com/measure-sh/measure/compare/ios-v0.10.0..ios-v0.11.0
+[ios-v0.10.0]: https://github.com/measure-sh/measure/compare/ios-v0.9.2..ios-v0.10.0
+[ios-v0.9.2]: https://github.com/measure-sh/measure/compare/ios-v0.9.1..ios-v0.9.2
+[ios-v0.9.1]: https://github.com/measure-sh/measure/compare/ios-v0.9.0..ios-v0.9.1
+[ios-v0.9.0]: https://github.com/measure-sh/measure/compare/ios-v0.8.1..ios-v0.9.0
+[ios-v0.8.1]: https://github.com/measure-sh/measure/compare/ios-v0.8.0..ios-v0.8.1
+[ios-v0.8.0]: https://github.com/measure-sh/measure/compare/ios-v0.7.1..ios-v0.8.0
+[ios-v0.7.1]: https://github.com/measure-sh/measure/compare/ios-v0.7.0..ios-v0.7.1
+[ios-v0.7.0]: https://github.com/measure-sh/measure/compare/ios-v0.6.0..ios-v0.7.0
+[ios-v0.6.0]: https://github.com/measure-sh/measure/compare/ios-v0.5.1..ios-v0.6.0
+[ios-v0.5.1]: https://github.com/measure-sh/measure/compare/ios-v0.5.0..ios-v0.5.1
+[ios-v0.5.0]: https://github.com/measure-sh/measure/compare/ios-v0.4.0..ios-v0.5.0
+[ios-v0.4.0]: https://github.com/measure-sh/measure/compare/ios-v0.3.1..ios-v0.4.0
+[ios-v0.3.1]: https://github.com/measure-sh/measure/compare/ios-v0.3.0..ios-v0.3.1
+[ios-v0.3.0]: https://github.com/measure-sh/measure/compare/ios-v0.2.0..ios-v0.3.0
+[ios-v0.2.0]: https://github.com/measure-sh/measure/compare/ios-v0.1.0..ios-v0.2.0
 

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -40,30 +40,30 @@ extension Measure.AttributeValue : Swift.Codable {
   public init(from decoder: any Swift.Decoder) throws
 }
 public typealias SessionObCoreDataClassSet = Foundation.NSSet
-@_inheritsConvenienceInitializers @objc(SessionOb) nonisolated public class SessionOb : CoreData.NSManagedObject {
-  @objc override nonisolated dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
+@_inheritsConvenienceInitializers @objc(SessionOb) public class SessionOb : CoreData.NSManagedObject {
+  @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
   @objc deinit
 }
 public typealias SessionObCoreDataPropertiesSet = Foundation.NSSet
 extension Measure.SessionOb {
   @nonobjc public class func fetchRequest() -> CoreData.NSFetchRequest<Measure.SessionOb>
-  @objc @NSManaged nonisolated dynamic public var crashed: Swift.Bool {
+  @objc @NSManaged dynamic public var crashed: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var createdAt: Swift.Int64 {
+  @objc @NSManaged dynamic public var createdAt: Swift.Int64 {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var needsReporting: Swift.Bool {
+  @objc @NSManaged dynamic public var needsReporting: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var pid: Swift.Int32 {
+  @objc @NSManaged dynamic public var pid: Swift.Int32 {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var sessionId: Swift.String? {
+  @objc @NSManaged dynamic public var sessionId: Swift.String? {
     @objc get
     @objc set
   }

--- a/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
+++ b/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct FrameworkInfo {
-    static let version = "0.11.0"
+    static let version = "0.12.0"
 }

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "measure-sh"
   spec.module_name  = "Measure"
-  spec.version      = "0.11.0"
+  spec.version      = "0.12.0"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
   spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@measuresh/react-native",
   "version": "0.1.1",
   "measureIosSdk": {
-    "version": "0.11.0",
+    "version": "0.12.0",
     "spmUrl": "https://github.com/measure-sh/measure.git",
     "revision": "6d550f29a9a662de51c9beeb9afb67c793eb3b62"
   },


### PR DESCRIPTION
This PR prepares the iOS SDK for release version 0.12.0.

Changes:
- Updated version to 0.12.0 in FrameworkInfo.swift
- Updated version to 0.12.0 in measure-sh.podspec
- Updated version in frontend/dashboard/content/docs/sdk-integration-guide.mdx
- Generated changelog for version 0.12.0