### PR TITLE
chore(ios): update podspec to add proper import for measure webp

### DIFF
--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -10,7 +10,8 @@ Pod::Spec.new do |spec|
   spec.swift_version = "5.10"
   spec.static_framework = true
   spec.source       = { :git => "https://github.com/measure-sh/measure.git",
-                        :tag => "ios-v#{spec.version}" }
+                        :tag => "ios-v#{spec.version}",
+                        :submodules => true }
   spec.source_files = "ios/Sources/MeasureSDK/Swift/**/*.{swift}", "ios/Sources/MeasureSDK/ObjC/**/*.{h,m}"
   spec.public_header_files = "ios/Sources/MeasureSDK/ObjC/include/**/*.h"
   spec.pod_target_xcconfig = {
@@ -43,6 +44,7 @@ Pod::Spec.new do |spec|
       "ios/Sources/MeasureWebP/libwebp/src/webp/types.h",
       "ios/Sources/MeasureWebP/include/MeasureWebP.h",
     ]
+    ss.preserve_paths = "ios/Sources/MeasureWebP/libwebp/**/*.h"
     ss.public_header_files = "ios/Sources/MeasureWebP/include/MeasureWebP.h"
     ss.pod_target_xcconfig = {
       "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ios/Sources/MeasureWebP/libwebp\" \"$(PODS_TARGET_SRCROOT)/ios/Sources/MeasureWebP/libwebp/src\""


### PR DESCRIPTION
# Description

Fixes pod trunk push failing for the WebP subspec. Adds `:submodules => true` to spec.source so the vendored libwebp submodule is fetched on a fresh git clone, and adds `preserve_paths` for the libwebp headers so transitive #includes (e.g. src/dsp/dsp.h, src/dec/vp8_dec.h) survive CocoaPods' file pruning. 

Previously only pod lib lint (local path) passed; pod spec lint/trunk push failed with undefined WebP symbols and missing-header errors.