### PR TITLE
chore(android): prepare next development version 0.20.0-SNAPSHOT

### DIFF
--- a/android/measure-android/gradle.properties
+++ b/android/measure-android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.19.0
+MEASURE_VERSION_NAME=0.20.0-SNAPSHOT
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/measure-gradle-plugin/gradle/libs.versions.toml
+++ b/android/measure-gradle-plugin/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ squareup-okio = "3.7.0"
 kotlinx-serialization-json = "1.6.2"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests.
-measure-android = "0.19.0"
+measure-android = "0.20.0-SNAPSHOT"
 semver = "1.1.2"
 junit = "4.13.2"
 junit-jupiter = "5.10.2"

--- a/flutter/packages/measure_flutter/android/build.gradle
+++ b/flutter/packages/measure_flutter/android/build.gradle
@@ -47,7 +47,7 @@ android {
     }
 
     dependencies {
-        api("sh.measure:measure-android:0.19.0-SNAPSHOT")
+        api("sh.measure:measure-android:0.20.0-SNAPSHOT")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
     }
 

--- a/react-native/android/build.gradle.kts
+++ b/react-native/android/build.gradle.kts
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     implementation("com.facebook.react:react-native:+")
-    compileOnly("sh.measure:measure-android:0.19.0-SNAPSHOT")
+    compileOnly("sh.measure:measure-android:0.20.0-SNAPSHOT")
 }

--- a/react-native/example/rnExample/android/app/build.gradle
+++ b/react-native/example/rnExample/android/app/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:flipper-integration")
     implementation project(':measuresh-react-native')
-    implementation("sh.measure:measure-android:0.19.0-SNAPSHOT")
+    implementation("sh.measure:measure-android:0.20.0-SNAPSHOT")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")


### PR DESCRIPTION
This PR prepares the next development version of the Android SDK.

**Changes:**
- Updated version to `0.20.0-SNAPSHOT` in gradle.properties
- Updated version to `0.20.0-SNAPSHOT` in libs.versions.toml
- Updated measure-android to `0.20.0-SNAPSHOT` in React Native SDK (android/build.gradle.kts and example app)
- Updated measure-android to `0.20.0-SNAPSHOT` in Flutter SDK (measure_flutter/android/build.gradle)

**Version:** 0.20.0-SNAPSHOT