### PR TITLE
Slack updates

### DIFF
--- a/backend/alerts/slack/slack.go
+++ b/backend/alerts/slack/slack.go
@@ -22,7 +22,7 @@ type SlackMessageData struct {
 }
 
 // Base interface for all block types
-type SlackBlock interface{}
+type SlackBlock any
 
 // Specific block types
 type SlackHeaderBlock struct {
@@ -72,14 +72,25 @@ type SlackMessage struct {
 	Blocks []SlackBlock `json:"blocks"`
 }
 
-// List of errors that require channel removal
+// errorsToRemoveMessageAndChannel are Slack errors that permanently fail the
+// message and mean the channel is unusable for the team: the queued message
+// is dropped and the channel is unsubscribed.
 var errorsToRemoveMessageAndChannel = map[string]bool{
-	"access_denied": true,
-	// "channel_not_found": true,
+	"access_denied":     true,
 	"is_archived":       true,
 	"no_permission":     true,
 	"ekm_access_denied": true,
 	"account_inactive":  true,
+}
+
+// errorsToRemoveMessageOnly are Slack errors that permanently fail the message
+// while the subscription must be kept. Slack reports channel_not_found for a
+// private channel the bot was removed from, and re-inviting the bot restores
+// delivery, so unsubscribing would drop a channel that can come back (#2899).
+// The message itself can never send either way, and an undeliverable message
+// left queued is retried at the front of every batch indefinitely.
+var errorsToRemoveMessageOnly = map[string]bool{
+	"channel_not_found": true,
 }
 
 // SendPendingAlertSlackMessages checks the pending alert messages in the database and sends them as Slack messages.
@@ -141,8 +152,12 @@ func SendPendingAlertSlackMessages(ctx context.Context) error {
 	return nil
 }
 
+// slackPostMessageURL is Slack's message post endpoint. A package var so tests
+// can point it at a stub server.
+var slackPostMessageURL = "https://slack.com/api/chat.postMessage"
+
 func SendSlackMessage(ctx context.Context, msgID uuid.UUID, teamID uuid.UUID, slackMsgData SlackMessageData) error {
-	url := "https://slack.com/api/chat.postMessage"
+	url := slackPostMessageURL
 
 	payload := map[string]any{
 		"channel": slackMsgData.Channel,
@@ -193,12 +208,14 @@ func SendSlackMessage(ctx context.Context, msgID uuid.UUID, teamID uuid.UUID, sl
 
 	if !slackResponse.OK {
 
-		if errorsToRemoveMessageAndChannel[slackResponse.Error] {
+		if errorsToRemoveMessageAndChannel[slackResponse.Error] || errorsToRemoveMessageOnly[slackResponse.Error] {
 			fmt.Printf("Removing pending alert %s due to error: %s\n", msgID, slackResponse.Error)
 			if err := removePendingAlert(ctx, msgID); err != nil {
 				fmt.Printf("failed to remove pending alert %s: %s\n", msgID, err)
 			}
+		}
 
+		if errorsToRemoveMessageAndChannel[slackResponse.Error] {
 			fmt.Printf("Removing channel %s from channel list due to error: %s\n", slackMsgData.Channel, slackResponse.Error)
 			if err := removeChannelFromList(ctx, teamID, slackMsgData.Channel); err != nil {
 				fmt.Printf("failed to remove channel %s from team %s: %s\n", slackMsgData.Channel, teamID, err)

--- a/backend/alerts/slack/slack_test.go
+++ b/backend/alerts/slack/slack_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"testing"
+
+	"backend/alerts/server"
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+	"github.com/leporo/sqlf"
+)
+
+var th *testinfra.TestHelper
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgPool, pgCleanup := testinfra.SetupPostgres(ctx)
+	chConn, chCleanup := testinfra.SetupClickHouse(ctx)
+	vk, vkCleanup := testinfra.SetupValkey(ctx)
+
+	th = testinfra.NewTestHelper(pgPool, chConn, vk)
+
+	sqlf.SetDialect(sqlf.PostgreSQL)
+
+	code := m.Run()
+
+	vkCleanup()
+	pgCleanup()
+	chCleanup()
+	os.Exit(code)
+}
+
+// withSlackPostMessageURL points chat.postMessage at a stub for a test.
+func withSlackPostMessageURL(t *testing.T, u string) {
+	t.Helper()
+	orig := slackPostMessageURL
+	slackPostMessageURL = u
+	t.Cleanup(func() { slackPostMessageURL = orig })
+}
+
+// stubSlackError serves a Slack-shaped error response for every post.
+func stubSlackError(t *testing.T, slackErr string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": slackErr})
+	}))
+	t.Cleanup(srv.Close)
+	withSlackPostMessageURL(t, srv.URL)
+}
+
+func seedPendingSlackMessage(ctx context.Context, t *testing.T, msgID, teamID uuid.UUID) {
+	t.Helper()
+	if _, err := th.PgPool.Exec(ctx,
+		`INSERT INTO pending_alert_messages (id, team_id, channel, data)
+		 VALUES ($1, $2, 'slack', '{"channel":"C1","bot_token":"xoxb"}')`,
+		msgID, teamID); err != nil {
+		t.Fatalf("seed pending alert message: %v", err)
+	}
+}
+
+func TestSendSlackMessageErrorHandling(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		slackErr     string
+		wantPending  int
+		wantChannels []string
+	}{
+		// the channel is unusable for good: message and subscription both go
+		{"is_archived", 0, []string{"C2"}},
+		// the bot may be re-invited to a private channel: the message goes,
+		// the subscription stays
+		{"channel_not_found", 0, []string{"C1", "C2"}},
+		// an unlisted error is treated as transient: the message stays queued
+		{"ratelimited", 1, []string{"C1", "C2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.slackErr, func(t *testing.T) {
+			defer th.CleanupAll(ctx, t)
+			server.InitForTest(&server.ServerConfig{
+				SiteOrigin: "https://test.measure.sh",
+			}, th.PgPool, th.ChConn, th.VK)
+			stubSlackError(t, tc.slackErr)
+
+			teamID := uuid.New()
+			th.SeedTeam(ctx, t, teamID.String(), "test team")
+			th.SeedTeamSlack(ctx, t, teamID.String(), []string{"C1", "C2"})
+			msgID := uuid.New()
+			seedPendingSlackMessage(ctx, t, msgID, teamID)
+
+			err := SendSlackMessage(ctx, msgID, teamID, SlackMessageData{
+				Channel:  "C1",
+				BotToken: "xoxb",
+			})
+			if err == nil {
+				t.Fatal("SendSlackMessage returned nil, want the slack API error")
+			}
+
+			var pending int
+			if err := th.PgPool.QueryRow(ctx,
+				`SELECT count(*) FROM pending_alert_messages WHERE id = $1`, msgID).Scan(&pending); err != nil {
+				t.Fatalf("count pending: %v", err)
+			}
+			if pending != tc.wantPending {
+				t.Errorf("pending rows = %d, want %d", pending, tc.wantPending)
+			}
+
+			var channels []string
+			if err := th.PgPool.QueryRow(ctx,
+				`SELECT channel_ids FROM team_slack WHERE team_id = $1`, teamID).Scan(&channels); err != nil {
+				t.Fatalf("read channel_ids: %v", err)
+			}
+			if !slices.Equal(channels, tc.wantChannels) {
+				t.Errorf("channel_ids = %v, want %v", channels, tc.wantChannels)
+			}
+		})
+	}
+}

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -246,9 +246,13 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		return
 	}
 
-	// Save Slack integration details to the database. channel_ids is not
-	// written here: a first connect gets the column default (empty array) and
-	// a reconnect keeps the channels the team already subscribed.
+	// Save Slack integration details to the database. channel_ids is not in
+	// the insert column list, so a first connect gets the column default
+	// (empty array). On conflict, a same-workspace reconnect keeps the
+	// subscribed channels, while a switch to a different workspace resets
+	// them: channel IDs are scoped to a workspace, so carrying them over
+	// would leave alerts pointed at channels the new bot token cannot post
+	// to.
 	stmt := sqlf.PostgreSQL.
 		InsertInto("measure.team_slack").
 		Set("team_id", teamID).
@@ -273,6 +277,11 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		bot_user_id = EXCLUDED.bot_user_id,
 		slack_app_id = EXCLUDED.slack_app_id,
 		scopes = EXCLUDED.scopes,
+		channel_ids = CASE
+			WHEN team_slack.slack_team_id = EXCLUDED.slack_team_id
+			THEN team_slack.channel_ids
+			ELSE '{}'
+		END,
 		is_active = EXCLUDED.is_active,
 		updated_at = NOW()`
 

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -444,15 +444,24 @@ func (h Handlers) DeleteTeamSlack(c *gin.Context) {
 		return
 	}
 
+	msg := fmt.Sprintf("error occurred while deleting team slack: %s", teamId)
+	tx, err := deps.PgPool.Begin(ctx)
+	if err != nil {
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	defer tx.Rollback(ctx)
+
 	stmt := sqlf.PostgreSQL.
 		DeleteFrom("team_slack").
 		Where("team_id = ?", teamId)
 
 	defer stmt.Close()
 
-	commandTag, err := deps.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
+	commandTag, err := tx.Exec(ctx, stmt.String(), stmt.Args()...)
 	if err != nil {
-		msg := fmt.Sprintf("error occurred while deleting team slack: %s", teamId)
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return
@@ -460,6 +469,28 @@ func (h Handlers) DeleteTeamSlack(c *gin.Context) {
 
 	if commandTag.RowsAffected() == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "no slack integration found for the team"})
+		return
+	}
+
+	// Queued Slack alerts embed the bot token and channel in their payload and
+	// the sender posts from that without re-reading team_slack, so rows left
+	// behind would keep delivering after the connection is removed.
+	pendingStmt := sqlf.PostgreSQL.
+		DeleteFrom("pending_alert_messages").
+		Where("team_id = ?", teamId).
+		Where("channel = ?", "slack")
+
+	defer pendingStmt.Close()
+
+	if _, err := tx.Exec(ctx, pendingStmt.String(), pendingStmt.Args()...); err != nil {
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return
 	}
 

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -66,6 +66,12 @@ var slackRequiredScopes = []string{
 
 // slackConnectionNeedsReauth reports whether granted scopes are missing any
 // currently required scope. An empty granted string (unknown) returns false.
+//
+// Granted scopes beyond the required set deliberately do not trigger reauth:
+// Slack scope grants are additive per installation and cannot be downgraded
+// by re-running the OAuth flow ("It is not possible to downgrade an access
+// token's scopes"), so a reconnect prompt for extra scopes could never clear
+// itself. Only uninstalling the app from the workspace contracts a grant.
 func slackConnectionNeedsReauth(granted string) bool {
 	if granted == "" {
 		return false

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/leporo/sqlf"
 )
 
@@ -276,6 +277,16 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		updated_at = NOW()`
 
 	if _, err := deps.PgPool.Exec(ctx, query, stmt.Args()...); err != nil {
+		// The upsert arbitrates only on team_id; a unique violation on
+		// slack_team_id means the workspace is connected to a different team.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "team_slack_slack_team_id_key" {
+			fmt.Println(msg, "workspace already connected to another team:", slackResp.Team.ID)
+			c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+				"error": "This Slack workspace is already connected to a different Measure team. Remove the connection there first, then try again.",
+			})
+			return
+		}
 		fmt.Println(msg, "failed to save Slack integration:", err)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -409,6 +409,54 @@ func (h Handlers) UpdateTeamSlackStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": "done"})
 }
 
+// DeleteTeamSlack removes a team's Slack integration. It only deletes our
+// record, including the stored bot token and subscribed channels; the Measure
+// app stays installed in the Slack workspace until someone removes it there.
+func (h Handlers) DeleteTeamSlack(c *gin.Context) {
+	deps := h.Deps
+	ctx := c.Request.Context()
+	userId := c.GetString("userId")
+	teamId, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `team id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+
+	if ok, err := measure.PerformAuthz(deps.PgPool, userId, teamId.String(), *measure.ScopeTeamAll); err != nil {
+		msg := `couldn't perform authorization checks`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	} else if !ok {
+		msg := fmt.Sprintf(`you don't have permissions for team [%s]`, teamId)
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
+	stmt := sqlf.PostgreSQL.
+		DeleteFrom("team_slack").
+		Where("team_id = ?", teamId)
+
+	defer stmt.Close()
+
+	commandTag, err := deps.PgPool.Exec(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		msg := fmt.Sprintf("error occurred while deleting team slack: %s", teamId)
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+
+	if commandTag.RowsAffected() == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no slack integration found for the team"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": "done"})
+}
+
 func (h Handlers) SendTestSlackAlert(c *gin.Context) {
 	deps := h.Deps
 	ctx := c.Request.Context()

--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/leporo/sqlf"
 )
 
@@ -240,7 +239,9 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		return
 	}
 
-	// Save Slack integration details to the database
+	// Save Slack integration details to the database. channel_ids is not
+	// written here: a first connect gets the column default (empty array) and
+	// a reconnect keeps the channels the team already subscribed.
 	stmt := sqlf.PostgreSQL.
 		InsertInto("measure.team_slack").
 		Set("team_id", teamID).
@@ -252,7 +253,6 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		Set("bot_user_id", slackResp.BotUserID).
 		Set("slack_app_id", slackResp.AppID).
 		Set("scopes", slackResp.Scope).
-		Set("channel_ids", pgtype.Array[string]{}).
 		Set("is_active", true).
 		Set("created_at", time.Now()).
 		Set("updated_at", time.Now())
@@ -266,7 +266,6 @@ func (h Handlers) ConnectTeamSlack(c *gin.Context) {
 		bot_user_id = EXCLUDED.bot_user_id,
 		slack_app_id = EXCLUDED.slack_app_id,
 		scopes = EXCLUDED.scopes,
-		channel_ids = EXCLUDED.channel_ids,
 		is_active = EXCLUDED.is_active,
 		updated_at = NOW()`
 

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -278,6 +278,8 @@ func TestSlackConnectionNeedsReauth(t *testing.T) {
 		{"all present with spaces", strings.ReplaceAll(full, ",", ", "), false},
 		{"missing one scope", strings.Join(slackRequiredScopes[1:], ","), true},
 		{"unrelated scope only", "channels:read", true},
+		{"extra scopes do not prompt, slack grants cannot shrink", full + ",team:read", false},
+		{"duplicate and trailing comma are not extras", full + "," + slackRequiredScopes[0] + ",", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -482,6 +484,7 @@ func TestGetTeamSlackNeedsReauth(t *testing.T) {
 	}{
 		{"full scopes: no reauth", strings.Join(slackRequiredScopes, ","), false},
 		{"missing a scope: reauth", strings.Join(slackRequiredScopes[1:], ","), true},
+		{"extra scope: no reauth", strings.Join(slackRequiredScopes, ",") + ",team:read", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -458,6 +458,79 @@ func TestConnectTeamSlackReconnectPreservesChannels(t *testing.T) {
 	}
 }
 
+func TestConnectTeamSlackWorkspaceTakenConflict(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	withSlackConfig(t, "client-123", "state-secret", "https://app.example.com")
+
+	// stub Slack's oauth.v2.access for the workspace team A already holds
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":           true,
+			"access_token": "xoxb-new",
+			"scope":        "chat:write",
+			"bot_user_id":  "U1",
+			"app_id":       "A1",
+			"team":         map[string]string{"id": "T-slack", "name": "Acme Workspace"},
+		})
+	}))
+	defer srv.Close()
+	withSlackAccessURL(t, srv.URL)
+
+	teamA := uuid.New()
+	seedTeam(ctx, t, teamA, "team a")
+	if _, err := th.PgPool.Exec(ctx,
+		`INSERT INTO team_slack
+		 (team_id, slack_team_id, slack_team_name, bot_token, bot_user_id, channel_ids, scopes, is_active, created_at, updated_at)
+		 VALUES ($1, 'T-slack', 'Acme Workspace', 'xoxb-a', 'U1', $2, 'chat:write', true, now(), now())`,
+		teamA, []string{"C1"}); err != nil {
+		t.Fatalf("seed team_slack for team a: %v", err)
+	}
+
+	// team B completes the OAuth flow for the same workspace
+	teamB := uuid.New()
+	seedTeam(ctx, t, teamB, "team b")
+	state, err := signSlackState("state-secret", teamB.String(), time.Now())
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	c, w := newConnectContext(fmt.Sprintf(`{"code":"the-code","state":%q}`, state))
+	h.ConnectTeamSlack(c)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(body.Error, "already connected to a different Measure team") {
+		t.Errorf("error = %q, want the workspace-taken message", body.Error)
+	}
+
+	// team A's integration is untouched and team B gained no row
+	var botToken string
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT bot_token FROM team_slack WHERE team_id = $1`, teamA).Scan(&botToken); err != nil {
+		t.Fatalf("read team a row: %v", err)
+	}
+	if botToken != "xoxb-a" {
+		t.Errorf("team a bot_token = %q, want xoxb-a untouched", botToken)
+	}
+	var count int
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT count(*) FROM team_slack WHERE team_id = $1`, teamB).Scan(&count); err != nil {
+		t.Fatalf("count team b rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("team b has %d team_slack rows, want 0", count)
+	}
+}
+
 // --------------------------------------------------------------------------
 // GetTeamSlack needs_reauth
 // --------------------------------------------------------------------------

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -458,6 +458,68 @@ func TestConnectTeamSlackReconnectPreservesChannels(t *testing.T) {
 	}
 }
 
+func TestConnectTeamSlackWorkspaceSwitchResetsChannels(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	withSlackConfig(t, "client-123", "state-secret", "https://app.example.com")
+
+	// stub Slack's oauth.v2.access granting a different workspace
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":           true,
+			"access_token": "xoxb-new",
+			"scope":        "chat:write",
+			"bot_user_id":  "U2",
+			"app_id":       "A1",
+			"team":         map[string]string{"id": "T-new", "name": "New Workspace"},
+		})
+	}))
+	defer srv.Close()
+	withSlackAccessURL(t, srv.URL)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+
+	// the team is connected to another workspace with subscribed channels
+	if _, err := th.PgPool.Exec(ctx,
+		`INSERT INTO team_slack
+		 (team_id, slack_team_id, slack_team_name, bot_token, bot_user_id, channel_ids, scopes, is_active, created_at, updated_at)
+		 VALUES ($1, 'T-old', 'Old Workspace', 'xoxb-old', 'U1', $2, 'chat:write', true, now(), now())`,
+		teamID, []string{"C1", "C2"}); err != nil {
+		t.Fatalf("seed team_slack: %v", err)
+	}
+
+	state, err := signSlackState("state-secret", teamID.String(), time.Now())
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	c, w := newConnectContext(fmt.Sprintf(`{"code":"the-code","state":%q}`, state))
+	h.ConnectTeamSlack(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	// the row now points at the new workspace and the old workspace's
+	// channels are gone: channel IDs are not valid across workspaces
+	var slackTeamID string
+	var emptyNotNull bool
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT slack_team_id, channel_ids IS NOT NULL AND channel_ids = '{}'
+		 FROM team_slack WHERE team_id = $1`, teamID).
+		Scan(&slackTeamID, &emptyNotNull); err != nil {
+		t.Fatalf("read team_slack after switch: %v", err)
+	}
+	if slackTeamID != "T-new" {
+		t.Errorf("slack_team_id = %q, want T-new", slackTeamID)
+	}
+	if !emptyNotNull {
+		t.Error("channel_ids should be reset to an empty array on workspace switch")
+	}
+}
+
 func TestConnectTeamSlackWorkspaceTakenConflict(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -609,6 +609,16 @@ func seedTeamSlackWithScopes(ctx context.Context, t *testing.T, teamID uuid.UUID
 	}
 }
 
+func seedPendingAlertMessage(ctx context.Context, t *testing.T, teamID uuid.UUID, channel string) {
+	t.Helper()
+	if _, err := th.PgPool.Exec(ctx,
+		`INSERT INTO pending_alert_messages (id, team_id, channel, data)
+		 VALUES ($1, $2, $3, '{"channel":"C1","bot_token":"xoxb"}')`,
+		uuid.New(), teamID, channel); err != nil {
+		t.Fatalf("seed pending alert message: %v", err)
+	}
+}
+
 func TestDeleteTeamSlack(t *testing.T) {
 	ctx := context.Background()
 
@@ -631,6 +641,15 @@ func TestDeleteTeamSlack(t *testing.T) {
 			userID, teamID := seedTeamAndMemberWithRole(t, ctx, tc.role)
 			seedTeamSlackWithScopes(ctx, t, teamID, "chat:write")
 
+			// queued alert messages: slack and email for this team, and a
+			// slack one for another team that must survive every outcome
+			otherTeamID := uuid.New()
+			seedTeam(ctx, t, otherTeamID, "other team")
+			seedPendingAlertMessage(ctx, t, teamID, "slack")
+			seedPendingAlertMessage(ctx, t, teamID, "slack")
+			seedPendingAlertMessage(ctx, t, teamID, "email")
+			seedPendingAlertMessage(ctx, t, otherTeamID, "slack")
+
 			c, w := newTestGinContext("DELETE", "/teams/"+teamID.String()+"/slack", nil)
 			c.Set("userId", userID)
 			c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
@@ -646,6 +665,32 @@ func TestDeleteTeamSlack(t *testing.T) {
 			}
 			if count != tc.wantRows {
 				t.Errorf("team_slack rows = %d, want %d", count, tc.wantRows)
+			}
+
+			pendingCount := func(id uuid.UUID, channel string) int {
+				var n int
+				if err := th.PgPool.QueryRow(ctx,
+					`SELECT count(*) FROM pending_alert_messages WHERE team_id = $1 AND channel = $2`,
+					id, channel).Scan(&n); err != nil {
+					t.Fatalf("count pending alert messages: %v", err)
+				}
+				return n
+			}
+
+			// a successful delete purges the team's queued slack messages and
+			// nothing else. A rejected delete leaves the queue untouched
+			wantPendingSlack := 2
+			if tc.wantCode == http.StatusOK {
+				wantPendingSlack = 0
+			}
+			if got := pendingCount(teamID, "slack"); got != wantPendingSlack {
+				t.Errorf("pending slack messages = %d, want %d", got, wantPendingSlack)
+			}
+			if got := pendingCount(teamID, "email"); got != 1 {
+				t.Errorf("pending email messages = %d, want 1 untouched", got)
+			}
+			if got := pendingCount(otherTeamID, "slack"); got != 1 {
+				t.Errorf("other team pending slack messages = %d, want 1 untouched", got)
 			}
 		})
 	}

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -547,6 +547,63 @@ func seedTeamSlackWithScopes(ctx context.Context, t *testing.T, teamID uuid.UUID
 	}
 }
 
+func TestDeleteTeamSlack(t *testing.T) {
+	ctx := context.Background()
+
+	// Only the owner role holds the team:* scope the handler requires; every
+	// other role is rejected and the integration stays.
+	cases := []struct {
+		role     string
+		wantCode int
+		wantRows int
+	}{
+		{"owner", http.StatusOK, 0},
+		{"admin", http.StatusForbidden, 1},
+		{"developer", http.StatusForbidden, 1},
+		{"viewer", http.StatusForbidden, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			defer cleanupAll(ctx, t)
+
+			userID, teamID := seedTeamAndMemberWithRole(t, ctx, tc.role)
+			seedTeamSlackWithScopes(ctx, t, teamID, "chat:write")
+
+			c, w := newTestGinContext("DELETE", "/teams/"+teamID.String()+"/slack", nil)
+			c.Set("userId", userID)
+			c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+			h.DeleteTeamSlack(c)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d, body: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			var count int
+			if err := th.PgPool.QueryRow(ctx,
+				`SELECT count(*) FROM team_slack WHERE team_id = $1`, teamID).Scan(&count); err != nil {
+				t.Fatalf("count team_slack rows: %v", err)
+			}
+			if count != tc.wantRows {
+				t.Errorf("team_slack rows = %d, want %d", count, tc.wantRows)
+			}
+		})
+	}
+
+	t.Run("no integration gives 404", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newTestGinContext("DELETE", "/teams/"+teamID.String()+"/slack", nil)
+		c.Set("userId", ownerID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.DeleteTeamSlack(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
 func TestGetTeamSlackNeedsReauth(t *testing.T) {
 	ctx := context.Background()
 

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -378,6 +378,82 @@ func TestConnectTeamSlackHappyPath(t *testing.T) {
 	if savedName != "Acme Workspace" {
 		t.Errorf("saved slack_team_name = %q, want Acme Workspace", savedName)
 	}
+
+	// a first connect gets the channel_ids column default: an empty array
+	var emptyNotNull bool
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT channel_ids IS NOT NULL AND channel_ids = '{}' FROM team_slack WHERE team_id = $1`, teamID).Scan(&emptyNotNull); err != nil {
+		t.Fatalf("read channel_ids: %v", err)
+	}
+	if !emptyNotNull {
+		t.Error("channel_ids should be an empty array, not NULL")
+	}
+}
+
+func TestConnectTeamSlackReconnectPreservesChannels(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+	withSlackConfig(t, "client-123", "state-secret", "https://app.example.com")
+
+	// stub Slack's oauth.v2.access returning a fresh token and scopes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":           true,
+			"access_token": "xoxb-new",
+			"scope":        "chat:write,channels:read",
+			"bot_user_id":  "U1",
+			"app_id":       "A1",
+			"team":         map[string]string{"id": "T-slack", "name": "Acme Workspace"},
+		})
+	}))
+	defer srv.Close()
+	withSlackAccessURL(t, srv.URL)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+
+	// an existing paused integration for the same workspace with subscribed channels
+	if _, err := th.PgPool.Exec(ctx,
+		`INSERT INTO team_slack
+		 (team_id, slack_team_id, slack_team_name, bot_token, bot_user_id, channel_ids, scopes, is_active, created_at, updated_at)
+		 VALUES ($1, 'T-slack', 'Acme Workspace', 'xoxb-old', 'U1', $2, 'chat:write', false, now(), now())`,
+		teamID, []string{"C1", "C2"}); err != nil {
+		t.Fatalf("seed team_slack: %v", err)
+	}
+
+	state, err := signSlackState("state-secret", teamID.String(), time.Now())
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	c, w := newConnectContext(fmt.Sprintf(`{"code":"the-code","state":%q}`, state))
+	h.ConnectTeamSlack(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var botToken, scopes string
+	var channels []string
+	var isActive bool
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT bot_token, scopes, channel_ids, is_active FROM team_slack WHERE team_id = $1`, teamID).
+		Scan(&botToken, &scopes, &channels, &isActive); err != nil {
+		t.Fatalf("read team_slack after reconnect: %v", err)
+	}
+	if botToken != "xoxb-new" {
+		t.Errorf("bot_token = %q, want xoxb-new", botToken)
+	}
+	if scopes != "chat:write,channels:read" {
+		t.Errorf("scopes = %q, want the refreshed grant", scopes)
+	}
+	if !isActive {
+		t.Error("is_active = false, want reconnect to re-enable the integration")
+	}
+	if len(channels) != 2 || channels[0] != "C1" || channels[1] != "C2" {
+		t.Errorf("channel_ids = %v, want [C1 C2] preserved across reconnect", channels)
+	}
 }
 
 // --------------------------------------------------------------------------

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -204,6 +204,7 @@ func main() {
 		teams.DELETE(":id/members/:memberId", hdl.RemoveTeamMember)
 		teams.GET(":id/usage", hdl.GetUsage)
 		teams.GET(":id/slack", hdl.GetTeamSlack)
+		teams.DELETE(":id/slack", hdl.DeleteTeamSlack)
 		teams.GET(":id/slack/connect-url", hdl.CreateTeamSlackConnectURL)
 		teams.PATCH(":id/slack/status", hdl.UpdateTeamSlackStatus)
 		teams.POST(":id/slack/test", hdl.SendTestSlackAlert)

--- a/frontend/dashboard/__tests__/integration/team_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/team_msw_test.tsx
@@ -251,7 +251,7 @@ describe("Team Page (MSW integration)", () => {
     it("shows Change Role and Remove buttons for non-current members", async () => {
       await renderAndWaitForData();
       expect(screen.getByText("Change Role")).toBeTruthy();
-      expect(screen.getByText("Remove")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Remove" })).toBeTruthy();
     });
 
     it("does not show Change Role or Remove for current user", async () => {
@@ -259,7 +259,7 @@ describe("Team Page (MSW integration)", () => {
       await renderAndWaitForData();
       // There should be exactly 1 Change Role and 1 Remove (for the other member)
       expect(screen.getAllByText("Change Role").length).toBe(1);
-      expect(screen.getAllByText("Remove").length).toBe(1);
+      expect(screen.getAllByRole("button", { name: "Remove" }).length).toBe(1);
     });
 
     it('renders other member role as "Admin" (formatToCamelCase)', async () => {
@@ -305,7 +305,10 @@ describe("Team Page (MSW integration)", () => {
         { timeout: 5000 },
       );
 
-      expect(screen.getByText("Remove").closest("button")?.disabled).toBe(true);
+      expect(
+        screen.getByRole("button", { name: "Remove" }).closest("button")
+          ?.disabled,
+      ).toBe(true);
     });
   });
 
@@ -422,7 +425,7 @@ describe("Team Page (MSW integration)", () => {
   describe("remove member", () => {
     it("renders Remove button for non-current members", async () => {
       await renderAndWaitForData();
-      expect(screen.getByText("Remove")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Remove" })).toBeTruthy();
     });
   });
 
@@ -554,6 +557,11 @@ describe("Team Page (MSW integration)", () => {
       expect(
         screen.getByText("Send Test Alert").closest("button")?.disabled,
       ).toBe(true);
+      expect(
+        screen
+          .getByRole("button", { name: "Remove Slack connection" })
+          .closest("button")?.disabled,
+      ).toBe(false);
     });
 
     it("Slack actions disabled when can_manage_slack is false", async () => {
@@ -575,6 +583,11 @@ describe("Team Page (MSW integration)", () => {
       );
       expect(
         screen.getByText("Send Test Alert").closest("button")?.disabled,
+      ).toBe(true);
+      expect(
+        screen
+          .getByRole("button", { name: "Remove Slack connection" })
+          .closest("button")?.disabled,
       ).toBe(true);
     });
 
@@ -606,7 +619,7 @@ describe("Team Page (MSW integration)", () => {
       await renderAndWaitForData();
 
       await act(async () => {
-        fireEvent.click(screen.getByText("Remove"));
+        fireEvent.click(screen.getByRole("button", { name: "Remove" }));
       });
 
       await waitFor(() => {
@@ -633,7 +646,7 @@ describe("Team Page (MSW integration)", () => {
 
       // Open dialog
       await act(async () => {
-        fireEvent.click(screen.getByText("Remove"));
+        fireEvent.click(screen.getByRole("button", { name: "Remove" }));
       });
       await waitFor(() => {
         expect(screen.getByText("Are you sure?")).toBeTruthy();
@@ -662,7 +675,7 @@ describe("Team Page (MSW integration)", () => {
 
       // Open dialog
       await act(async () => {
-        fireEvent.click(screen.getByText("Remove"));
+        fireEvent.click(screen.getByRole("button", { name: "Remove" }));
       });
       await waitFor(() => {
         expect(screen.getByText("Yes, I'm sure")).toBeTruthy();
@@ -919,7 +932,7 @@ describe("Team Page — mutations", () => {
 
       // Click Remove
       await act(async () => {
-        fireEvent.click(screen.getByText("Remove"));
+        fireEvent.click(screen.getByRole("button", { name: "Remove" }));
       });
 
       // Confirm the dialog
@@ -1242,6 +1255,159 @@ describe("Team Page — mutations", () => {
     });
   });
 
+  describe("remove Slack connection", () => {
+    it("calls DELETE /teams/:teamId/slack after confirmation and returns to the connect state", async () => {
+      let deleteCalled = false;
+      let deletePath = "";
+      server.use(
+        // once the delete lands, the status refetch reports no connection
+        http.get("*/api/teams/:teamId/slack", () => {
+          return deleteCalled
+            ? HttpResponse.json(null)
+            : HttpResponse.json(makeSlackStatusFixture());
+        }),
+        http.delete("*/api/teams/:teamId/slack", ({ request }) => {
+          deleteCalled = true;
+          deletePath = new URL(request.url).pathname;
+          return HttpResponse.json({ ok: "done" });
+        }),
+      );
+
+      await renderAndWaitForData();
+
+      await waitFor(
+        () => {
+          expect(
+            screen.getByRole("button", { name: "Remove Slack connection" }),
+          ).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Remove Slack connection" }),
+        );
+      });
+
+      // the dialog explains the deletion and that the app stays installed
+      // in the workspace
+      await waitFor(() => {
+        expect(
+          screen.getByText(/will delete your Slack connection/),
+        ).toBeTruthy();
+        expect(screen.getByText(/remain in your workspace/)).toBeTruthy();
+        expect(screen.getByText("Yes, I'm sure")).toBeTruthy();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, I'm sure"));
+      });
+
+      await waitFor(
+        () => {
+          expect(deleteCalled).toBe(true);
+          expect(deletePath).toBe("/api/teams/team-001/slack");
+        },
+        { timeout: 5000 },
+      );
+
+      // the status query invalidation refetches and the connect button returns
+      await waitFor(
+        () => {
+          expect(screen.getByAltText("Add to Slack")).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+    });
+
+    it("already-removed integration resolves to the connect state, not an error", async () => {
+      // another session removed the integration: DELETE 404s and the status
+      // refetch reports no connection
+      let deleteCalled = false;
+      server.use(
+        http.get("*/api/teams/:teamId/slack", () => {
+          return deleteCalled
+            ? HttpResponse.json(null)
+            : HttpResponse.json(makeSlackStatusFixture());
+        }),
+        http.delete("*/api/teams/:teamId/slack", () => {
+          deleteCalled = true;
+          return HttpResponse.json(
+            { error: "no slack integration found for the team" },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await renderAndWaitForData();
+
+      await waitFor(
+        () => {
+          expect(
+            screen.getByRole("button", { name: "Remove Slack connection" }),
+          ).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Remove Slack connection" }),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Yes, I'm sure")).toBeTruthy();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, I'm sure"));
+      });
+
+      // 404 counts as removed: the section flips to the connect state
+      await waitFor(
+        () => {
+          expect(screen.getByAltText("Add to Slack")).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+    });
+
+    it("does not call the API when the dialog is cancelled", async () => {
+      let deleteCalled = false;
+      server.use(
+        http.delete("*/api/teams/:teamId/slack", () => {
+          deleteCalled = true;
+          return HttpResponse.json({ ok: "done" });
+        }),
+      );
+
+      await renderAndWaitForData();
+
+      await waitFor(
+        () => {
+          expect(
+            screen.getByRole("button", { name: "Remove Slack connection" }),
+          ).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Remove Slack connection" }),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Cancel")).toBeTruthy();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Cancel"));
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+      expect(deleteCalled).toBe(false);
+    });
+  });
+
   // ================================================================
   // SLACK CONNECT URL
   // ================================================================
@@ -1380,7 +1546,9 @@ describe("Team Page — mutations", () => {
         { timeout: 5000 },
       );
 
-      const removeBtn = screen.getByText("Remove").closest("button")!;
+      const removeBtn = screen
+        .getByRole("button", { name: "Remove" })
+        .closest("button")!;
       expect(removeBtn.disabled).toBe(true);
 
       await act(async () => {
@@ -1544,7 +1712,7 @@ describe("Team Page — mutations", () => {
 
       // Click Remove
       await act(async () => {
-        fireEvent.click(screen.getByText("Remove"));
+        fireEvent.click(screen.getByRole("button", { name: "Remove" }));
       });
 
       // Confirm dialog

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -367,12 +367,17 @@ export const handlers = [
     return HttpResponse.json({ ok: true });
   }),
 
-  // 60. GET /api/prefs/notifPrefs
+  // 60. DELETE /api/teams/:teamId/slack
+  http.delete("*/api/teams/:teamId/slack", () => {
+    return HttpResponse.json({ ok: "done" });
+  }),
+
+  // 61. GET /api/prefs/notifPrefs
   http.get("*/api/prefs/notifPrefs", () => {
     return HttpResponse.json(makeNotifPrefsFixture());
   }),
 
-  // 61. PATCH /api/prefs/notifPrefs
+  // 62. PATCH /api/prefs/notifPrefs
   http.patch("*/api/prefs/notifPrefs", () => {
     return HttpResponse.json({ ok: true });
   }),
@@ -394,24 +399,24 @@ export const handlers = [
     });
   }),
 
-  // 62. GET /api/teams/:teamId/usage
+  // 63. GET /api/teams/:teamId/usage
   http.get("*/api/teams/:teamId/usage", () => {
     return HttpResponse.json(makeUsageFixture());
   }),
 
-  // 63. PATCH /api/teams/:teamId/billing/checkout
+  // 64. PATCH /api/teams/:teamId/billing/checkout
   http.patch("*/api/teams/:teamId/billing/checkout", () => {
     return HttpResponse.json({
       checkout_url: "https://checkout.stripe.com/test",
     });
   }),
 
-  // 65. PATCH /api/teams/:teamId/billing/downgrade
+  // 66. PATCH /api/teams/:teamId/billing/downgrade
   http.patch("*/api/teams/:teamId/billing/downgrade", () => {
     return HttpResponse.json({ ok: true });
   }),
 
-  // 66. POST /api/teams/:teamId/billing/portal
+  // 67. POST /api/teams/:teamId/billing/portal
   http.post("*/api/teams/:teamId/billing/portal", () => {
     return HttpResponse.json({ url: "https://billing.stripe.com/portal/test" });
   }),

--- a/frontend/dashboard/__tests__/pages/team_test.tsx
+++ b/frontend/dashboard/__tests__/pages/team_test.tsx
@@ -237,6 +237,7 @@ const teamPageStore = createBridge(() => ({
   fetchTeamSlackStatusApiStatus: "init",
   refetchSlackStatus: jest.fn(),
   updateTeamSlackStatusApiStatus: "init",
+  removeTeamSlackApiStatus: "init",
   testSlackAlertApiStatus: "init",
   teamNameChangeApiStatus: "init",
   inviteMemberApiStatus: "init",
@@ -256,6 +257,7 @@ const teamPageStore = createBridge(() => ({
   removePendingInvite: jest.fn(),
   changeRole: jest.fn(),
   updateSlackStatus: jest.fn(),
+  removeTeamSlack: jest.fn(),
   testSlackAlert: jest.fn(),
   reset: jest.fn(),
 }));
@@ -423,6 +425,20 @@ jest.mock("@/app/query/hooks", () => ({
         }
       },
       isPending: s.updateTeamSlackStatusApiStatus === "loading",
+    };
+  },
+  useRemoveTeamSlackMutation: () => {
+    const s = teamPageStore.getState();
+    return {
+      mutate: async (params: any, opts: any) => {
+        const result = await s.removeTeamSlack(params.teamId);
+        if (result) {
+          opts?.onSuccess?.();
+        } else {
+          opts?.onError?.();
+        }
+      },
+      isPending: s.removeTeamSlackApiStatus === "loading",
     };
   },
   useTestSlackAlertMutation: () => {
@@ -608,6 +624,7 @@ describe("Team Page", () => {
       fetchTeamSlackStatusApiStatus: "init",
       refetchSlackStatus: jest.fn(),
       updateTeamSlackStatusApiStatus: "init",
+      removeTeamSlackApiStatus: "init",
       testSlackAlertApiStatus: "init",
       teamNameChangeApiStatus: "init",
       inviteMemberApiStatus: "init",
@@ -627,6 +644,7 @@ describe("Team Page", () => {
       removePendingInvite: jest.fn(),
       changeRole: jest.fn(),
       updateSlackStatus: jest.fn(),
+      removeTeamSlack: jest.fn(),
       testSlackAlert: jest.fn(),
       reset: jest.fn(),
     });
@@ -1095,6 +1113,9 @@ describe("Team Page", () => {
     expect(
       screen.getByRole("button", { name: "Send Test Alert" }),
     ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    ).toBeDisabled();
   });
 
   it("handles slack enable action", async () => {
@@ -1135,6 +1156,66 @@ describe("Team Page", () => {
     await waitFor(() => {
       expect(mockTestSlackAlert).toHaveBeenCalledWith("team-1");
     });
+  });
+
+  it("keeps remove slack enabled when the integration is disabled", async () => {
+    setDefaultTeamsState();
+    setDefaultTeamPageState();
+    useTeamPageStore.setState({
+      teamSlack: { slack_team_name: "Measure", is_active: false },
+    });
+
+    render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
+    await screen.findByTestId("slack-switch");
+
+    expect(
+      screen.getByRole("button", { name: "Send Test Alert" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    ).toBeEnabled();
+  });
+
+  it("handles remove slack action through the confirmation dialog", async () => {
+    const mockRemoveTeamSlack = jest.fn().mockResolvedValue(true);
+
+    setDefaultTeamsState();
+    setDefaultTeamPageState();
+    useTeamPageStore.setState({
+      removeTeamSlack: mockRemoveTeamSlack,
+    });
+
+    render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
+    await screen.findByRole("button", { name: "Remove Slack connection" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Yes, I'm sure" }));
+
+    await waitFor(() => {
+      expect(mockRemoveTeamSlack).toHaveBeenCalledWith("team-1");
+    });
+  });
+
+  it("cancelling the remove slack dialog makes no call", async () => {
+    const mockRemoveTeamSlack = jest.fn().mockResolvedValue(true);
+
+    setDefaultTeamsState();
+    setDefaultTeamPageState();
+    useTeamPageStore.setState({
+      removeTeamSlack: mockRemoveTeamSlack,
+    });
+
+    render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
+    await screen.findByRole("button", { name: "Remove Slack connection" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockRemoveTeamSlack).not.toHaveBeenCalled();
   });
 
   it("shows add-to-slack button when slack is not connected and user can manage slack", async () => {
@@ -1569,6 +1650,54 @@ describe("Team Page", () => {
     await waitFor(() => {
       expect(mockToastNegative).toHaveBeenCalledWith(
         "Error sending test Slack alerts",
+      );
+    });
+  });
+
+  it("shows success toast when removing slack connection succeeds", async () => {
+    const mockRemoveTeamSlack = jest.fn().mockResolvedValue(true);
+
+    setDefaultTeamsState();
+    setDefaultTeamPageState();
+    useTeamPageStore.setState({
+      removeTeamSlack: mockRemoveTeamSlack,
+    });
+
+    render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
+    await screen.findByRole("button", { name: "Remove Slack connection" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Yes, I'm sure" }));
+
+    await waitFor(() => {
+      expect(mockToastPositive).toHaveBeenCalledWith(
+        "Slack connection removed",
+      );
+    });
+  });
+
+  it("shows error toast when removing slack connection fails", async () => {
+    const mockRemoveTeamSlack = jest.fn().mockResolvedValue(false);
+
+    setDefaultTeamsState();
+    setDefaultTeamPageState();
+    useTeamPageStore.setState({
+      removeTeamSlack: mockRemoveTeamSlack,
+    });
+
+    render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
+    await screen.findByRole("button", { name: "Remove Slack connection" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove Slack connection" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Yes, I'm sure" }));
+
+    await waitFor(() => {
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        "Error removing Slack connection",
       );
     });
   });

--- a/frontend/dashboard/app/[teamId]/team/page.tsx
+++ b/frontend/dashboard/app/[teamId]/team/page.tsx
@@ -7,6 +7,7 @@ import {
   usePendingInvitesQuery,
   useRemoveMemberMutation,
   useRemovePendingInviteMutation,
+  useRemoveTeamSlackMutation,
   useResendPendingInviteMutation,
   useSessionQuery,
   useTeamSlackConnectUrlQuery,
@@ -174,6 +175,7 @@ export default function TeamOverview(props: {
   const removePendingInviteMutation = useRemovePendingInviteMutation();
   const changeRoleMutation = useChangeRoleMutation();
   const updateSlackStatusMutation = useUpdateSlackStatusMutation();
+  const removeTeamSlackMutation = useRemoveTeamSlackMutation();
   const testSlackAlertMutation = useTestSlackAlertMutation();
 
   const [saveTeamNameButtonDisabled, setSaveTeamNameButtonDisabled] =
@@ -215,6 +217,10 @@ export default function TeamOverview(props: {
   const [
     disableSlackConfirmationDialogOpen,
     setDisableSlackConfirmationDialogOpen,
+  ] = useState(false);
+  const [
+    removeSlackConfirmationDialogOpen,
+    setRemoveSlackConfirmationDialogOpen,
   ] = useState(false);
   const [
     testSlackAlertConfirmationDialogOpen,
@@ -381,6 +387,20 @@ export default function TeamOverview(props: {
         },
         onError: () => {
           toastNegative(`Error sending test Slack alerts`);
+        },
+      },
+    );
+  };
+
+  const removeTeamSlack = async () => {
+    removeTeamSlackMutation.mutate(
+      { teamId: params.teamId },
+      {
+        onSuccess: () => {
+          toastPositive("Slack connection removed");
+        },
+        onError: () => {
+          toastNegative("Error removing Slack connection");
         },
       },
     );
@@ -613,6 +633,33 @@ export default function TeamOverview(props: {
               updateSlackStatus(false);
             }}
             onCancelAction={() => setDisableSlackConfirmationDialogOpen(false)}
+          />
+
+          {/* Dialog for confirming slack connection removal */}
+          <DangerConfirmationDialog
+            body={
+              <p className="font-body">
+                Are you sure you want to remove the Slack connection for team{" "}
+                <span className="font-display font-bold">{team!.name}</span>?
+                <br />
+                <br />
+                This will delete your Slack connection and your subscribed alert
+                channels. The Measure Slack bot will no longer send any alerts
+                or messages.
+                <br />
+                <br />
+                The Measure app will remain in your workspace. You can manually
+                uninstall it from your Slack workspace settings.
+              </p>
+            }
+            open={removeSlackConfirmationDialogOpen}
+            affirmativeText="Yes, I'm sure"
+            cancelText="Cancel"
+            onAffirmativeAction={() => {
+              setRemoveSlackConfirmationDialogOpen(false);
+              removeTeamSlack();
+            }}
+            onCancelAction={() => setRemoveSlackConfirmationDialogOpen(false)}
           />
 
           {/* Dialog for confirming test slack alert */}
@@ -1102,19 +1149,33 @@ export default function TeamOverview(props: {
 
               <div className="py-4" />
 
-              <Button
-                variant="outline"
-                className="w-fit"
-                disabled={
-                  !authz.can_manage_slack ||
-                  testSlackAlertMutation.isPending ||
-                  teamSlack.is_active === false
-                }
-                loading={testSlackAlertMutation.isPending}
-                onClick={() => setTestSlackAlertConfirmationDialogOpen(true)}
-              >
-                Send Test Alert
-              </Button>
+              <div className="flex flex-row w-full items-center justify-between">
+                <Button
+                  variant="outline"
+                  className="w-fit"
+                  disabled={
+                    !authz.can_manage_slack ||
+                    testSlackAlertMutation.isPending ||
+                    teamSlack.is_active === false
+                  }
+                  loading={testSlackAlertMutation.isPending}
+                  onClick={() => setTestSlackAlertConfirmationDialogOpen(true)}
+                >
+                  Send Test Alert
+                </Button>
+                <Button
+                  variant="destructive"
+                  className="w-fit"
+                  aria-label="Remove Slack connection"
+                  disabled={
+                    !authz.can_manage_slack || removeTeamSlackMutation.isPending
+                  }
+                  loading={removeTeamSlackMutation.isPending}
+                  onClick={() => setRemoveSlackConfirmationDialogOpen(true)}
+                >
+                  Remove
+                </Button>
+              </div>
             </div>
           )}
 

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -287,6 +287,14 @@ export enum UpdateTeamSlackStatusApiStatus {
   Cancelled,
 }
 
+export enum RemoveTeamSlackApiStatus {
+  Init,
+  Loading,
+  Success,
+  Error,
+  Cancelled,
+}
+
 export enum FetchAppThresholdPrefsApiStatus {
   Init,
   Loading,
@@ -2520,6 +2528,35 @@ export const updateTeamSlackStatusFromServer = async (
     return { status: UpdateTeamSlackStatusApiStatus.Success };
   } catch {
     return { status: UpdateTeamSlackStatusApiStatus.Cancelled };
+  }
+};
+
+export const removeTeamSlackFromServer = async (teamId: string) => {
+  const opts = {
+    method: "DELETE",
+  };
+
+  try {
+    const res = await apiClient.fetch(`/api/teams/${teamId}/slack`, opts);
+
+    // A 404 means there is no integration to remove, so the goal state is
+    // already reached. Report success rather than an error.
+    if (res.status === 404) {
+      return { status: RemoveTeamSlackApiStatus.Success };
+    }
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return {
+        status: RemoveTeamSlackApiStatus.Error,
+        error: data.error,
+      };
+    }
+
+    return { status: RemoveTeamSlackApiStatus.Success };
+  } catch {
+    return { status: RemoveTeamSlackApiStatus.Cancelled };
   }
 };
 

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -52,6 +52,7 @@ import {
   AppHealthPlotApiStatus,
   SpanMetricsPlotApiStatus,
   SpansApiStatus,
+  RemoveTeamSlackApiStatus,
   Team,
   TeamNameChangeApiStatus,
   TeamsApiStatus,
@@ -118,6 +119,7 @@ import {
   inviteMemberFromServer,
   removeMemberFromServer,
   removePendingInviteFromServer,
+  removeTeamSlackFromServer,
   resendPendingInviteFromServer,
   sendTestSlackAlertFromServer,
   undoDowngradeFromServer,
@@ -1608,6 +1610,26 @@ export function useUpdateSlackStatusMutation() {
       }
     },
     onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["teamSlackStatus", variables.teamId],
+      });
+    },
+  });
+}
+
+export function useRemoveTeamSlackMutation() {
+  return useMutation({
+    mutationFn: async (params: { teamId: string }) => {
+      const result = await removeTeamSlackFromServer(params.teamId);
+      if (result.status !== RemoveTeamSlackApiStatus.Success) {
+        throw new Error("Failed to remove Slack integration");
+      }
+    },
+    // Settled, not just success: a failed remove can mean the integration is
+    // already gone (removed from another session) or that the response was
+    // lost after the server deleted the row, so refetch the status in either
+    // case.
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["teamSlackStatus", variables.teamId],
       });

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -8488,7 +8488,8 @@ paths:
       summary: Remove a team's Slack integration
       description: |
         Remove a team's Slack integration. Deletes the stored connection,
-        including the bot token and subscribed alert channels. The Measure
+        including the bot token and subscribed alert channels, along with any
+        queued Slack alert messages that have not been sent yet. The Measure
         app stays installed in the Slack workspace and can be manually removed
         from Slack settings.
       parameters:

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -8481,6 +8481,50 @@ paths:
           description: Rate limit of the requester has crossed maximum limits.
         "500":
           description: Measure server encountered an unfortunate error. Report this to your server administrator.
+    delete:
+      operationId: deleteTeamSlack
+      tags:
+        - Teams
+      summary: Remove a team's Slack integration
+      description: |
+        Remove a team's Slack integration. Deletes the stored connection,
+        including the bot token and subscribed alert channels. The Measure
+        app stays installed in the Slack workspace and can be manually removed
+        from Slack settings.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Team's UUID.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Successful response, no errors.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: string
+              examples:
+                response:
+                  value:
+                    ok: done
+        "400":
+          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+        "401":
+          description: Either the user's access token is invalid or has expired.
+        "403":
+          description: Requester does not have access to this resource.
+        "404":
+          description: The team has no Slack integration to remove.
+        "429":
+          description: Rate limit of the requester has crossed maximum limits.
+        "500":
+          description: Measure server encountered an unfortunate error. Report this to your server administrator.
   /teams/{id}/slack/status:
     patch:
       operationId: updateTeamSlackStatus


### PR DESCRIPTION
# Description

- Reconnecting Slack no longer wipes a team's subscribed alert channels, and a fresh connect stores an empty array instead of NULL.
-  Connecting a workspace already held by another team returns 409 with a clear message instead of a generic 500.
-  New Remove button, confirmation dialog, DELETE endpoint, spec entry, and tests for removing a team's Slack connection.
-  Channels are preserved only on a same-workspace reconnect. Switching workspaces resets them since channel IDs don't carry over.
-  Removing the integration also purges the team's queued Slack alert messages, in one transaction.
-  Slack alerts failing with `channel_not_found` are dequeued instead of retrying forever, while the channel subscription is kept.



