### PR TITLE
fix(backend): symboloader dedup gate not considering `patch_id` during builds upload

### DIFF
--- a/backend/symboloader/process.go
+++ b/backend/symboloader/process.go
@@ -53,6 +53,10 @@ type Mapping struct {
 	Difs           []*symbol.Dif `json:"difs,omitempty"`
 	ShouldUpload   bool          `json:"should_upload,omitempty"`
 	UploadComplete bool          `json:"upload_complete,omitempty"`
+	// PatchID scopes the dedup gate to a single OTA patch. Loaded
+	// per row so identical (zero-byte) bundle content from a
+	// different patch does not falsely dedup. Internal only.
+	PatchID uuid.UUID `json:"-"`
 }
 
 // extractDif prepares & extracts debug information
@@ -207,7 +211,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 					return
 				}
 
-				if b.artifactExists(dif.Key, checksum) {
+				if b.artifactExists(dif.Key, checksum, b.PatchID) {
 					continue
 				}
 
@@ -259,7 +263,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 						return
 					}
 
-					if b.artifactExists(dif.Key, checksum) {
+					if b.artifactExists(dif.Key, checksum, b.PatchID) {
 						continue
 					}
 
@@ -341,7 +345,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 						return
 					}
 
-					if b.artifactExists(dif.Key, checksum) {
+					if b.artifactExists(dif.Key, checksum, b.PatchID) {
 						continue
 					}
 
@@ -422,7 +426,7 @@ func (b *Build) upload(ctx context.Context) (err error) {
 					return
 				}
 
-				if b.artifactExists(dif.Key, checksum) {
+				if b.artifactExists(dif.Key, checksum, b.PatchID) {
 					continue
 				}
 
@@ -464,13 +468,16 @@ func (b *Build) upload(ctx context.Context) (err error) {
 }
 
 // artifactExists reports whether a loaded sibling row already
-// holds this exact object, matched by key & per-object checksum.
-// It is the dedup gate: a redelivered notification reloads the
-// rows written by the first delivery, so every dif matches here
-// & is skipped, keeping processing idempotent.
-func (b *Build) artifactExists(key, checksum string) bool {
+// holds this exact object, matched by key, per-object checksum &
+// patch id. It is the dedup gate: a redelivered notification
+// reloads the rows written by the first delivery, so every dif
+// matches here & is skipped, keeping processing idempotent. The
+// patch id scoping stops a different patch's identical (zero-byte)
+// bundle content from colliding, since bundle keys are content
+// addressed & every empty bundle hashes alike.
+func (b *Build) artifactExists(key, checksum string, patchID uuid.UUID) bool {
 	for _, m := range b.Mappings {
-		if m.Key == key && m.Checksum == checksum {
+		if m.Key == key && m.Checksum == checksum && m.PatchID == patchID {
 			return true
 		}
 	}
@@ -536,6 +543,7 @@ func (b *Build) load(ctx context.Context, id uuid.UUID) (err error) {
 		Select("location").
 		Select("fnv1_hash").
 		Select("file_size").
+		Select("patch_id").
 		From("build_mappings").
 		Where("app_id = ?", b.AppID).
 		Where("version_name = ?", b.VersionName).
@@ -549,7 +557,7 @@ func (b *Build) load(ctx context.Context, id uuid.UUID) (err error) {
 	for rows.Next() {
 		var mapping Mapping
 
-		if err := rows.Scan(&mapping.ID, &mapping.Type, &mapping.Key, &mapping.Location, &mapping.Checksum, &mapping.Size); err != nil {
+		if err := rows.Scan(&mapping.ID, &mapping.Type, &mapping.Key, &mapping.Location, &mapping.Checksum, &mapping.Size, &mapping.PatchID); err != nil {
 			return err
 		}
 

--- a/backend/symboloader/process_test.go
+++ b/backend/symboloader/process_test.go
@@ -6,6 +6,8 @@ import (
 	"backend/libs/symbol"
 
 	"symboloader/server"
+
+	"github.com/google/uuid"
 )
 
 // TestRecordArtifact checks the one-row-per-artifact split: the
@@ -67,23 +69,33 @@ func TestRecordArtifact(t *testing.T) {
 }
 
 // TestArtifactExists is the dedup gate: an object is skipped only
-// when a sibling row matches on both key & checksum. This is what
-// makes a redelivered notification idempotent.
+// when a sibling row matches on key, checksum & patch id. Matching
+// on key+checksum alone makes a redelivered notification
+// idempotent; the patch id term stops a different patch's identical
+// zero-byte bundle content from falsely colliding.
 func TestArtifactExists(t *testing.T) {
+	patchA := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001")
+	patchB := uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002")
+
 	b := &Build{
 		Mappings: []*Mapping{
-			{Key: "8d/f7/main.jsbundle", Checksum: "C1"},
-			{Key: "bb/8f/main.jsbundle.map", Checksum: "C2"},
+			{Key: "8d/f7/main.jsbundle", Checksum: "C1", PatchID: patchA},
+			{Key: "bb/8f/main.jsbundle.map", Checksum: "C2", PatchID: patchA},
 		},
 	}
 
-	if !b.artifactExists("8d/f7/main.jsbundle", "C1") {
-		t.Fatal("exact key+checksum match should exist")
+	if !b.artifactExists("8d/f7/main.jsbundle", "C1", patchA) {
+		t.Fatal("exact key+checksum+patch match should exist")
 	}
-	if b.artifactExists("8d/f7/main.jsbundle", "C9") {
+	if b.artifactExists("8d/f7/main.jsbundle", "C9", patchA) {
 		t.Fatal("same key different checksum must not match")
 	}
-	if b.artifactExists("zz/00/other.js", "C1") {
+	if b.artifactExists("zz/00/other.js", "C1", patchA) {
 		t.Fatal("unknown key must not match")
+	}
+	// Same key+checksum, different patch: a different OTA patch's
+	// identical (zero-byte) bundle must not dedup against this one.
+	if b.artifactExists("8d/f7/main.jsbundle", "C1", patchB) {
+		t.Fatal("same key+checksum different patch must not match")
 	}
 }

--- a/backend/symboloader/symbolsjs.go
+++ b/backend/symboloader/symbolsjs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -124,10 +123,6 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 		versionName := c.Query("version_name")
 		versionCode := c.Query("version_code")
 		urls := c.QueryArray("url")
-		fmt.Println("app_id", appID)
-		fmt.Println("versionName", versionName)
-		fmt.Println("versionCode", versionCode)
-		fmt.Println("urls", urls)
 		if versionName != "" && versionCode != "" && len(urls) > 0 {
 			pairs, err = resolveByURL(ctx, appID, versionName, versionCode, urls)
 		}
@@ -157,9 +152,6 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 	for _, p := range pairs {
 		emitPair(ctx, config, gcsClient, s3Client, p, &results)
 	}
-
-	resultsJson, _ := json.Marshal(results)
-	fmt.Println("results", string(resultsJson))
 
 	c.JSON(http.StatusOK, results)
 }

--- a/backend/symboloader/symbolsjs.go
+++ b/backend/symboloader/symbolsjs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -123,6 +124,10 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 		versionName := c.Query("version_name")
 		versionCode := c.Query("version_code")
 		urls := c.QueryArray("url")
+		fmt.Println("app_id", appID)
+		fmt.Println("versionName", versionName)
+		fmt.Println("versionCode", versionCode)
+		fmt.Println("urls", urls)
 		if versionName != "" && versionCode != "" && len(urls) > 0 {
 			pairs, err = resolveByURL(ctx, appID, versionName, versionCode, urls)
 		}
@@ -152,6 +157,9 @@ func HandleSymbolsJsRequest(c *gin.Context) {
 	for _, p := range pairs {
 		emitPair(ctx, config, gcsClient, s3Client, p, &results)
 	}
+
+	resultsJson, _ := json.Marshal(results)
+	fmt.Println("results", string(resultsJson))
 
 	c.JSON(http.StatusOK, results)
 }


### PR DESCRIPTION
## Summary

This PR fixes OTA (React Native) symbolication silently failing for every patch uploaded after the first one for an app. The per-object dedup gate in symboloader compared only key & checksum; since OTA bundles are content-addressed & the uploader ships a zero-byte placeholder bundle, every empty bundle across patches shared the same key & checksum. A new patch's identical empty bundle matched an earlier patch's row & was skipped, leaving the new patch's mapping with an empty `key`. `/symbols/js` then had no minified artifact to bind to the frame's abs_path, so Symbolicator left frames unsymbolicated. The gate is now also scoped by `patch_id`, loaded per row in `load()` with no filtering so cross-patch collisions are still caught & rejected correctly.

## Tasks

- [x] Add `PatchID` to `Mapping` & select `patch_id` per row in `load()`
- [x] Scope `artifactExists` by key, checksum & patch id
- [x] Add cross-patch regression case to `TestArtifactExists`
