### PR TITLE
chore(ios): prepare sdk release 0.13.0

### DIFF
--- a/frontend/dashboard/content/docs/sdk-integration-guide.mdx
+++ b/frontend/dashboard/content/docs/sdk-integration-guide.mdx
@@ -277,7 +277,7 @@ Add Measure as a dependency by adding `dependencies` value to your `Package.swif
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.12.1")
+    .package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.13.0")
 ]
 ```
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :hammer: Misc
 
 
+- (**ios**): Prepare sdk release 0.12.1 (#4123) by @adwinross in #4123
 - (**ios**): Update podspec to add proper import for measure webp (#4117) by @adwinross in #4117
 
 ## [ios-v0.12.0] - 2026-07-22

--- a/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
+++ b/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct FrameworkInfo {
-    static let version = "0.12.1"
+    static let version = "0.13.0"
 }

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "measure-sh"
   spec.module_name  = "Measure"
-  spec.version      = "0.12.1"
+  spec.version      = "0.13.0"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
   spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@measuresh/react-native",
   "version": "0.1.1",
   "measureIosSdk": {
-    "version": "0.12.1",
+    "version": "0.13.0",
     "spmUrl": "https://github.com/measure-sh/measure.git",
     "revision": "6d550f29a9a662de51c9beeb9afb67c793eb3b62"
   },


### PR DESCRIPTION
This PR prepares the iOS SDK for release version 0.13.0.

Changes:
- Updated version to 0.13.0 in FrameworkInfo.swift
- Updated version to 0.13.0 in measure-sh.podspec
- Synced measureIosSdk.version to 0.13.0 in react-native/package.json
- Updated version in frontend/dashboard/content/docs/sdk-integration-guide.mdx
- Generated changelog for version 0.13.0