### PR TITLE
chore: show server error messages for test Slack alert failures

### DIFF
--- a/backend/api/handlers/slack.go
+++ b/backend/api/handlers/slack.go
@@ -30,6 +30,14 @@ import (
 // tests can point it at a stub server.
 var slackAccessURL = "https://slack.com/api/oauth.v2.access"
 
+// slackPostMessageURL is Slack's message send endpoint. A package var so
+// tests can point it at a stub server.
+var slackPostMessageURL = "https://slack.com/api/chat.postMessage"
+
+// slackConversationsInfoURL is Slack's channel info endpoint. A package var
+// so tests can point it at a stub server.
+var slackConversationsInfoURL = "https://slack.com/api/conversations.info"
+
 type TeamSlack struct {
 	SlackTeamName string `json:"slack_team_name"`
 	IsActive      bool   `json:"is_active"`
@@ -563,7 +571,7 @@ func sendTestSlackMessages(botToken string, channelIds []string) error {
 	// We'll try to fetch channel names via conversations.info and include them
 	// in the success/failure message. If fetching the name fails, we fall back
 	// to using the channel ID.
-	url := "https://slack.com/api/chat.postMessage"
+	url := slackPostMessageURL
 
 	var failed []struct {
 		ChannelID   string
@@ -675,7 +683,7 @@ func sendTestSlackMessages(botToken string, channelIds []string) error {
 // channel ID so callers can still show a usable identifier.
 func getSlackChannelName(botToken, channelID string) string {
 	// build URL with query param
-	infoURL := fmt.Sprintf("https://slack.com/api/conversations.info?channel=%s", url.QueryEscape(channelID))
+	infoURL := fmt.Sprintf("%s?channel=%s", slackConversationsInfoURL, url.QueryEscape(channelID))
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", infoURL, nil)
 	if err != nil {

--- a/backend/api/handlers/slack_test.go
+++ b/backend/api/handlers/slack_test.go
@@ -750,3 +750,224 @@ func TestGetTeamSlackNeedsReauth(t *testing.T) {
 		})
 	}
 }
+
+// --------------------------------------------------------------------------
+// SendTestSlackAlert
+// --------------------------------------------------------------------------
+
+// withSlackSendURLs points the message send and channel info endpoints at a
+// stub for a test.
+func withSlackSendURLs(t *testing.T, postMessageURL, conversationsInfoURL string) {
+	t.Helper()
+	origPost, origInfo := slackPostMessageURL, slackConversationsInfoURL
+	slackPostMessageURL = postMessageURL
+	slackConversationsInfoURL = conversationsInfoURL
+	t.Cleanup(func() {
+		slackPostMessageURL = origPost
+		slackConversationsInfoURL = origInfo
+	})
+}
+
+// newSlackSendStub stands in for Slack's chat.postMessage and
+// conversations.info endpoints and points the handler at it for a test.
+// conversations.info always resolves the channel name to "general".
+func newSlackSendStub(t *testing.T, postMessage http.HandlerFunc) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat.postMessage", postMessage)
+	mux.HandleFunc("/conversations.info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": map[string]string{"name": "general"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	withSlackSendURLs(t, srv.URL+"/chat.postMessage", srv.URL+"/conversations.info")
+}
+
+// rejectSends is a chat.postMessage stub for tests where the handler must
+// bail out before sending anything.
+func rejectSends(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t.Error("chat.postMessage was called, want no send attempt")
+	}
+}
+
+func seedTeamSlackWithChannels(ctx context.Context, t *testing.T, teamID uuid.UUID, botToken string, channels []string) {
+	t.Helper()
+	_, err := th.PgPool.Exec(ctx,
+		`INSERT INTO team_slack
+		 (team_id, slack_team_id, slack_team_name, bot_token, bot_user_id, channel_ids, scopes, is_active, created_at, updated_at)
+		 VALUES ($1, 'T1', 'Acme Workspace', $2, 'U1', $3, 'chat:write', true, now(), now())`,
+		teamID, botToken, channels)
+	if err != nil {
+		t.Fatalf("seed team_slack with channels: %v", err)
+	}
+}
+
+func newTestAlertContext(userID string, teamID string) (*gin.Context, *httptest.ResponseRecorder) {
+	c, w := newTestGinContext("POST", "/teams/"+teamID+"/slack/test", nil)
+	c.Set("userId", userID)
+	c.Params = gin.Params{{Key: "id", Value: teamID}}
+	return c, w
+}
+
+func TestSendTestSlackAlert(t *testing.T) {
+	ctx := context.Background()
+
+	readError := func(t *testing.T, w *httptest.ResponseRecorder) string {
+		t.Helper()
+		var body struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal error body %q: %v", w.Body.String(), err)
+		}
+		return body.Error
+	}
+
+	t.Run("invalid team id gives 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		c, w := newTestAlertContext(uuid.New().String(), "not-a-uuid")
+		h.SendTestSlackAlert(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	// sending a test alert needs ScopeTeamAll, which only owner holds
+	for _, role := range []string{"admin", "developer", "viewer"} {
+		t.Run(role+" is forbidden", func(t *testing.T) {
+			defer cleanupAll(ctx, t)
+			newSlackSendStub(t, rejectSends(t))
+
+			userID, teamID := seedTeamAndMemberWithRole(t, ctx, role)
+			seedTeamSlackWithChannels(ctx, t, teamID, "xoxb-test", []string{"C1"})
+
+			c, w := newTestAlertContext(userID, teamID.String())
+			h.SendTestSlackAlert(c)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("role %s: status = %d, want 403, body: %s", role, w.Code, w.Body.String())
+			}
+		})
+	}
+
+	t.Run("no slack connection gives 500", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		newSlackSendStub(t, rejectSends(t))
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		c, w := newTestAlertContext(ownerID, teamID.String())
+		h.SendTestSlackAlert(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		}
+		if got := readError(t, w); !strings.Contains(got, "error occurred while querying team slack") {
+			t.Errorf("error = %q, want it to mention the team slack query", got)
+		}
+	})
+
+	t.Run("no subscribed channels gives 500 with subscribe guidance", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		newSlackSendStub(t, rejectSends(t))
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		seedTeamSlackWithChannels(ctx, t, teamID, "xoxb-test", []string{})
+
+		c, w := newTestAlertContext(ownerID, teamID.String())
+		h.SendTestSlackAlert(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		}
+		got := readError(t, w)
+		if !strings.Contains(got, "No registered alert channels found for Workspace Acme Workspace") {
+			t.Errorf("error = %q, want the workspace named in the no-channels message", got)
+		}
+		if !strings.Contains(got, "/subscribe-alerts") {
+			t.Errorf("error = %q, want the /subscribe-alerts instruction", got)
+		}
+	})
+
+	t.Run("owner with subscribed channels gets 200 and a message per channel", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		var gotChannels, gotAuth []string
+		newSlackSendStub(t, func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Channel string `json:"channel"`
+				Text    string `json:"text"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			gotChannels = append(gotChannels, body.Channel)
+			gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+			if body.Text == "" {
+				t.Error("message text is empty")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		})
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		seedTeamSlackWithChannels(ctx, t, teamID, "xoxb-test", []string{"C1", "C2"})
+
+		c, w := newTestAlertContext(ownerID, teamID.String())
+		h.SendTestSlackAlert(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		if len(gotChannels) != 2 || gotChannels[0] != "C1" || gotChannels[1] != "C2" {
+			t.Errorf("sent to channels %v, want [C1 C2]", gotChannels)
+		}
+		for _, auth := range gotAuth {
+			if auth != "Bearer xoxb-test" {
+				t.Errorf("Authorization = %q, want the stored bot token as bearer", auth)
+			}
+		}
+	})
+
+	t.Run("a failed channel gives 500 naming successes and failures", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		newSlackSendStub(t, func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			w.Header().Set("Content-Type", "application/json")
+			if body.Channel == "C2" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		})
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		seedTeamSlackWithChannels(ctx, t, teamID, "xoxb-test", []string{"C1", "C2"})
+
+		c, w := newTestAlertContext(ownerID, teamID.String())
+		h.SendTestSlackAlert(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+		}
+		got := readError(t, w)
+		if !strings.Contains(got, "Successes") || !strings.Contains(got, "C1") {
+			t.Errorf("error = %q, want the delivered channel listed under successes", got)
+		}
+		if !strings.Contains(got, "Failures") || !strings.Contains(got, "C2") {
+			t.Errorf("error = %q, want the failed channel listed under failures", got)
+		}
+		if !strings.Contains(got, "channel_not_found") {
+			t.Errorf("error = %q, want the slack error reason included", got)
+		}
+	})
+}

--- a/frontend/dashboard/__tests__/integration/team_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/team_msw_test.tsx
@@ -98,6 +98,7 @@ afterAll(() => server.close());
 // --- Store/component imports ---
 import TeamOverview from "@/app/[teamId]/team/page";
 import { Team } from "@/app/api/api_calls";
+import { Toaster } from "@/app/components/toaster";
 import { useCreateTeamMutation } from "@/app/query/hooks";
 import { queryClient } from "@/app/query/query_client";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -1252,6 +1253,47 @@ describe("Team Page — mutations", () => {
       // Wait a bit and verify no API call
       await new Promise((r) => setTimeout(r, 300));
       expect(postCalled).toBe(false);
+    });
+
+    it("shows the server error message in the toast when the API fails", async () => {
+      const serverError =
+        "No registered alert channels found for Workspace Acme. Please add Measure app to a channel and use /subscribe-alerts";
+      server.use(
+        http.post("*/api/teams/:teamId/slack/test", () => {
+          return HttpResponse.json({ error: serverError }, { status: 500 });
+        }),
+      );
+
+      renderWithProviders(
+        <>
+          <TeamOverview params={promiseParams({ teamId: "team-001" })} />
+          <Toaster />
+        </>,
+      );
+      await waitFor(
+        () => {
+          expect(screen.getByText("Send Test Alert")).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Send Test Alert"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Yes, I'm sure")).toBeTruthy();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Yes, I'm sure"));
+      });
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(serverError)).toBeTruthy();
+        },
+        { timeout: 5000 },
+      );
     });
   });
 

--- a/frontend/dashboard/__tests__/pages/team_test.tsx
+++ b/frontend/dashboard/__tests__/pages/team_test.tsx
@@ -449,7 +449,7 @@ jest.mock("@/app/query/hooks", () => ({
         if (result) {
           opts?.onSuccess?.();
         } else {
-          opts?.onError?.();
+          opts?.onError?.(new Error("Failed to send test Slack alert"));
         }
       },
       isPending: s.testSlackAlertApiStatus === "loading",
@@ -1649,7 +1649,7 @@ describe("Team Page", () => {
 
     await waitFor(() => {
       expect(mockToastNegative).toHaveBeenCalledWith(
-        "Error sending test Slack alerts",
+        "Failed to send test Slack alert",
       );
     });
   });

--- a/frontend/dashboard/app/[teamId]/team/page.tsx
+++ b/frontend/dashboard/app/[teamId]/team/page.tsx
@@ -385,8 +385,8 @@ export default function TeamOverview(props: {
         onSuccess: () => {
           toastPositive(`Slack integration test alert sent successfully`);
         },
-        onError: () => {
-          toastNegative(`Error sending test Slack alerts`);
+        onError: (error) => {
+          toastNegative(error.message);
         },
       },
     );

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -1641,6 +1641,9 @@ export function useTestSlackAlertMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
       const result = await sendTestSlackAlertFromServer(params.teamId);
+      if (result.status === TestSlackAlertApiStatus.Error) {
+        throw new Error(result.error ?? "Failed to send test Slack alert");
+      }
       if (result.status !== TestSlackAlertApiStatus.Success) {
         throw new Error("Failed to send test Slack alert");
       }


### PR DESCRIPTION
# Description

The test Slack alert toast showed a hardcoded message because the mutation hook discarded the API error body, hiding guidance like the /subscribe-alerts instruction. The hook now throws the server message and the team page shows it in the toast.

Adds an MSW test for the propagation and backend coverage for SendTestSlackAlert, with the Slack send URLs made package vars so tests can stub them.

## Related issue\
Closes #4061



