### PR TITLE
chore(frontend): match docs theme switcher to rest of app

### DIFF
--- a/frontend/dashboard/__tests__/docs/docs_theme_switch_test.tsx
+++ b/frontend/dashboard/__tests__/docs/docs_theme_switch_test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Pins the docs theme switch to the app's own toggle: the fumadocs
+ * themeSwitch slot must render the shared ThemeToggle so docs theming
+ * matches the dashboard and marketing pages, and it must keep the
+ * className fumadocs passes (ms-auto aligns it in the sidebar footer).
+ */
+import { describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockSetTheme = jest.fn();
+
+jest.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", setTheme: mockSetTheme }),
+}));
+
+jest.mock("lucide-react", () => ({
+  Sun: () => <span data-testid="sun-icon" />,
+  Moon: () => <span data-testid="moon-icon" />,
+}));
+
+jest.mock("@/app/components/button", () => ({
+  Button: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+import DocsThemeSwitch from "@/app/docs/components/docs_theme_switch";
+
+describe("DocsThemeSwitch", () => {
+  it("renders the app theme toggle", () => {
+    render(<DocsThemeSwitch />);
+    expect(
+      screen.getByRole("button", { name: /toggle theme/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the className fumadocs passes on the wrapper", () => {
+    const { container } = render(<DocsThemeSwitch className="ms-auto" />);
+    expect(container.firstChild).toHaveClass("ms-auto");
+  });
+
+  it("switches the theme on click", () => {
+    render(<DocsThemeSwitch />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle theme/i }));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+});

--- a/frontend/dashboard/app/docs/components/docs_theme_switch.tsx
+++ b/frontend/dashboard/app/docs/components/docs_theme_switch.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ThemeToggle } from "@/app/components/theme_toggle";
+
+// Rendered through fumadocs' themeSwitch slot so the docs use the same
+// theme toggle as the dashboard and marketing pages. Fumadocs calls the
+// slot with positioning classes (e.g. ms-auto in the sidebar footer), so
+// they are kept on the wrapper div.
+export default function DocsThemeSwitch({ className }: { className?: string }) {
+  return (
+    <div className={className}>
+      <ThemeToggle />
+    </div>
+  );
+}

--- a/frontend/dashboard/app/docs/layout.tsx
+++ b/frontend/dashboard/app/docs/layout.tsx
@@ -3,6 +3,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import Image from "next/image";
 import AskAI from "./components/ai/ask_ai";
+import DocsThemeSwitch from "./components/docs_theme_switch";
 import DocsTracking from "./components/docs_tracking";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -10,8 +11,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     // RootProvider is scoped to the docs subtree so the search dialog and
     // fumadocs contexts stay out of the marketing pages and the dashboard.
     // The app's own next-themes provider in the root layout handles theming,
-    // so fumadocs' bundled one is disabled; its theme switch still works
-    // because both resolve the same next-themes context.
+    // so fumadocs' bundled one is disabled; the themeSwitch slot renders the
+    // app's toggle in place of fumadocs' light/dark/system pill.
     // Search uses /docs/search because fumadocs' default /api/search would
     // be captured by the /api/* reverse proxy in proxy.ts.
     <RootProvider
@@ -22,6 +23,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <DocsLayout
         tree={source.getPageTree()}
         githubUrl="https://github.com/measure-sh/measure"
+        slots={{ themeSwitch: DocsThemeSwitch }}
         nav={{
           title: (
             <>


### PR DESCRIPTION
# Description

Match docs theme switcher to rest of app

## Related issue
Closes #4072



