### PR TITLE
fix(flutter): pass widgetFilter from MeasureConfig to config provider

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -120,6 +120,7 @@ final class MeasureInitializer {
         enableLogging: inputConfig.enableLogging,
         autoStart: inputConfig.autoStart,
         enableDiagnosticMode: inputConfig.enableDiagnosticMode,
+        widgetFilter: inputConfig.widgetFilter,
       ),
     );
     _signalProcessor = DefaultSignalProcessor(logger: logger, channel: _methodChannel, configProvider: _configProvider);

--- a/flutter/packages/measure_flutter/test/measure_initializer_test.dart
+++ b/flutter/packages/measure_flutter/test/measure_initializer_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/config/measure_config.dart';
+import 'package:measure_flutter/src/measure_initializer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('passes every MeasureConfig field to the config provider', () {
+    final initializer = MeasureInitializer(
+      const MeasureConfig(
+        enableLogging: true,
+        autoStart: false,
+        enableDiagnosticMode: true,
+        widgetFilter: {ElevatedButton: 'CheckoutButton'},
+      ),
+    );
+
+    final provider = initializer.configProvider;
+    expect(provider.enableLogging, true);
+    expect(provider.autoStart, false);
+    expect(provider.enableDiagnosticMode, true);
+    expect(provider.widgetFilter, {ElevatedButton: 'CheckoutButton'});
+  });
+}


### PR DESCRIPTION
# Description

Fixes `MeasureConfig.widgetFilter` being silently dropped during SDK initialization. `MeasureInitializer` only copied `enableLogging`, `autoStart`, and `enableDiagnosticMode` into the internal `Config`, so the config provider always returned an empty widget filter and custom widget names generated by `measure_build` never appeared in layout snapshots.

Passes `widgetFilter` through to `Config` and adds a regression test asserting every `MeasureConfig` field reaches the config provider, each set to a non-default value.

## Related issue
Fixes #4146



