### PR TITLE
fix(ios): correct misspelled lifecycle api names

### DIFF
--- a/frontend/dashboard/content/docs/navigation-tracking.mdx
+++ b/frontend/dashboard/content/docs/navigation-tracking.mdx
@@ -144,13 +144,13 @@ class CheckoutViewController: MsrViewController {
 }
 ```
 
-For SwiftUI, wrap a view in `MsrMoniterView` or use the `moniterWithMsr` extension to record `onAppear` and `onDisappear`:
+For SwiftUI, wrap a view in `MsrMonitorView` or use the `monitorWithMsr` extension to record `onAppear` and `onDisappear`:
 
 ```swift
 struct CheckoutView: View {
     var body: some View {
         CheckoutForm()
-            .moniterWithMsr("Checkout")
+            .monitorWithMsr("Checkout")
     }
 }
 ```

--- a/ios/DemoApp/Podfile.lock
+++ b/ios/DemoApp/Podfile.lock
@@ -22,10 +22,10 @@ PODS:
   - KSCrash/Sinks (2.5.1):
     - KSCrash/Filters
     - KSCrash/Recording
-  - measure-sh (0.11.0):
+  - measure-sh (0.12.1):
     - KSCrash (~> 2.5)
-    - measure-sh/WebP (= 0.11.0)
-  - measure-sh/WebP (0.11.0):
+    - measure-sh/WebP (= 0.12.1)
+  - measure-sh/WebP (0.12.1):
     - KSCrash (~> 2.5)
 
 DEPENDENCIES:
@@ -41,7 +41,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
-  measure-sh: 653622eb0cf3ca79dd81d1a6f541b26f8814d392
+  measure-sh: 15d4312ca81891b387ba9133a1dddba8436a4801
 
 PODFILE CHECKSUM: 828d9701ce9dd588cdabe7bc1a8cb829d2a17f97
 

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 		526D18692D5A1913009A2E90 /* LifecycleEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */; };
 		526D186A2D5A1913009A2E90 /* LifecycleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17E92D5A1913009A2E90 /* LifecycleManager.swift */; };
 		526D186B2D5A1913009A2E90 /* MsrViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EA2D5A1913009A2E90 /* MsrViewController.swift */; };
-		526D186C2D5A1913009A2E90 /* MsrMoniterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */; };
+		526D186C2D5A1913009A2E90 /* MsrMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EB2D5A1913009A2E90 /* MsrMonitorView.swift */; };
 		526D186D2D5A1913009A2E90 /* NetworkChangeCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17ED2D5A1913009A2E90 /* NetworkChangeCallback.swift */; };
 		526D186E2D5A1913009A2E90 /* NetworkChangeCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EE2D5A1913009A2E90 /* NetworkChangeCollector.swift */; };
 		526D186F2D5A1913009A2E90 /* NetworkChangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17EF2D5A1913009A2E90 /* NetworkChangeData.swift */; };
@@ -456,7 +456,7 @@
 		526D17E82D5A1913009A2E90 /* LifecycleEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleEvents.swift; sourceTree = "<group>"; };
 		526D17E92D5A1913009A2E90 /* LifecycleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleManager.swift; sourceTree = "<group>"; };
 		526D17EA2D5A1913009A2E90 /* MsrViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrViewController.swift; sourceTree = "<group>"; };
-		526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrMoniterView.swift; sourceTree = "<group>"; };
+		526D17EB2D5A1913009A2E90 /* MsrMonitorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MsrMonitorView.swift; sourceTree = "<group>"; };
 		526D17ED2D5A1913009A2E90 /* NetworkChangeCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChangeCallback.swift; sourceTree = "<group>"; };
 		526D17EE2D5A1913009A2E90 /* NetworkChangeCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChangeCollector.swift; sourceTree = "<group>"; };
 		526D17EF2D5A1913009A2E90 /* NetworkChangeData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChangeData.swift; sourceTree = "<group>"; };
@@ -945,7 +945,7 @@
 				CF9D74C42E6169F3007D6D30 /* LifecycleManagerInternal.swift */,
 				526D17E92D5A1913009A2E90 /* LifecycleManager.swift */,
 				526D17EA2D5A1913009A2E90 /* MsrViewController.swift */,
-				526D17EB2D5A1913009A2E90 /* MsrMoniterView.swift */,
+				526D17EB2D5A1913009A2E90 /* MsrMonitorView.swift */,
 			);
 			path = Lifecycle;
 			sourceTree = "<group>";
@@ -1857,7 +1857,7 @@
 				526D18452D5A1913009A2E90 /* Attachment.swift in Sources */,
 				CF893DDB2E950DEE00D99D45 /* EventOb+CoreDataProperties.swift in Sources */,
 				CF1BB5532DE4370A00588506 /* MsrDimensions.swift in Sources */,
-				526D186C2D5A1913009A2E90 /* MsrMoniterView.swift in Sources */,
+				526D186C2D5A1913009A2E90 /* MsrMonitorView.swift in Sources */,
 				526D183B2D5A1913009A2E90 /* CoreDataManager.swift in Sources */,
 				526D18832D5A1913009A2E90 /* IdProvider.swift in Sources */,
 				526D18652D5A1913009A2E90 /* URLSessionTaskSwizzler.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
-// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
+// swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
+// swift-module-flags: -target arm64-apple-ios12-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -40,30 +40,30 @@ extension Measure.AttributeValue : Swift.Codable {
   public init(from decoder: any Swift.Decoder) throws
 }
 public typealias SessionObCoreDataClassSet = Foundation.NSSet
-@_inheritsConvenienceInitializers @objc(SessionOb) public class SessionOb : CoreData.NSManagedObject {
-  @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
+@_inheritsConvenienceInitializers @objc(SessionOb) nonisolated public class SessionOb : CoreData.NSManagedObject {
+  @objc override nonisolated dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
   @objc deinit
 }
 public typealias SessionObCoreDataPropertiesSet = Foundation.NSSet
 extension Measure.SessionOb {
   @nonobjc public class func fetchRequest() -> CoreData.NSFetchRequest<Measure.SessionOb>
-  @objc @NSManaged dynamic public var crashed: Swift.Bool {
+  @objc @NSManaged nonisolated dynamic public var crashed: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var createdAt: Swift.Int64 {
+  @objc @NSManaged nonisolated dynamic public var createdAt: Swift.Int64 {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var needsReporting: Swift.Bool {
+  @objc @NSManaged nonisolated dynamic public var needsReporting: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var pid: Swift.Int32 {
+  @objc @NSManaged nonisolated dynamic public var pid: Swift.Int32 {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var sessionId: Swift.String? {
+  @objc @NSManaged nonisolated dynamic public var sessionId: Swift.String? {
     @objc get
     @objc set
   }
@@ -324,16 +324,22 @@ public enum ScreenshotMaskLevel : Swift.String, Swift.Codable, Swift.CaseIterabl
   @objc deinit
 }
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
-@_Concurrency.MainActor @preconcurrency public struct MsrMoniterView<Content> : SwiftUICore.View where Content : SwiftUICore.View {
+@_Concurrency.MainActor @preconcurrency public struct MsrMonitorView<Content> : SwiftUICore.View where Content : SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public init(_ viewName: Swift.String? = nil, content: @escaping () -> Content)
   @_Concurrency.MainActor @preconcurrency public var body: some SwiftUICore.View {
     get
   }
   @available(iOS 13, tvOS 13, watchOS 6.0, macOS 10.15, *)
-  public typealias Body = @_opaqueReturnTypeOf("$s7Measure14MsrMoniterViewV4bodyQrvp", 0) __<Content>
+  public typealias Body = @_opaqueReturnTypeOf("$s7Measure14MsrMonitorViewV4bodyQrvp", 0) __<Content>
 }
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
+@available(*, deprecated, renamed: "MsrMonitorView")
+public typealias MsrMoniterView<Content> = Measure.MsrMonitorView<Content> where Content : SwiftUICore.View
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func monitorWithMsr(_ viewName: Swift.String? = nil) -> some SwiftUICore.View
+  
+  @available(*, deprecated, renamed: "monitorWithMsr(_:)")
   @_Concurrency.MainActor @preconcurrency public func moniterWithMsr(_ viewName: Swift.String? = nil) -> some SwiftUICore.View
   
 }
@@ -441,7 +447,7 @@ extension Measure.VCLifecycleEventType : Swift.Equatable {}
 extension Measure.VCLifecycleEventType : Swift.Hashable {}
 extension Measure.VCLifecycleEventType : Swift.RawRepresentable {}
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
-extension Measure.MsrMoniterView : Swift.Sendable {}
+extension Measure.MsrMonitorView : Swift.Sendable {}
 extension Measure.LogSeverity : Swift.Equatable {}
 extension Measure.LogSeverity : Swift.Hashable {}
 extension Measure.LogSeverity : Swift.RawRepresentable {}

--- a/ios/Sources/MeasureSDK/Swift/Lifecycle/MsrMonitorView.swift
+++ b/ios/Sources/MeasureSDK/Swift/Lifecycle/MsrMonitorView.swift
@@ -1,5 +1,5 @@
 //
-//  MsrMoniterView.swift
+//  MsrMonitorView.swift
 //  MeasureSDK
 //
 //  Created by Adwin Ross on 29/10/24.
@@ -13,14 +13,14 @@ import SwiftUI
 /// ```swift
 /// struct ContentView: View {
 ///     var body: some View {
-///         MsrMoniterView("ContentView") {
+///         MsrMonitorView("ContentView") {
 ///             Text("Hello, World!")
 ///         }
 ///     }
 /// }
 /// ```
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
-public struct MsrMoniterView<Content: View>: View {
+public struct MsrMonitorView<Content: View>: View {
     @State private var hasViewAppeared = false
 
     let content: () -> Content
@@ -47,20 +47,29 @@ public struct MsrMoniterView<Content: View>: View {
 }
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
+@available(*, deprecated, renamed: "MsrMonitorView")
+public typealias MsrMoniterView<Content: View> = MsrMonitorView<Content>
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 public extension View {
-    /// An extension function on View that wraps the view in an MsrMoniterView to monitor its lifecycle events.
+    /// An extension function on View that wraps the view in an MsrMonitorView to monitor its lifecycle events.
     /// - Parameter viewName: viewName: An optional String representing the name of the view to be monitored. If nil, it defaults to the type name of the view itself.
     /// - Returns: some View
     /// ```swift
     /// struct ContentView: View {
     ///     var body: some View {
     ///         Text("Hello, World!")
-    ///             .moniterWithMsr("ContentView")
+    ///             .monitorWithMsr("ContentView")
     ///     }
     /// }
-    func moniterWithMsr(_ viewName: String? = nil) -> some View {
-        return MsrMoniterView(viewName) {
+    func monitorWithMsr(_ viewName: String? = nil) -> some View {
+        return MsrMonitorView(viewName) {
             return self
         }
+    }
+
+    @available(*, deprecated, renamed: "monitorWithMsr(_:)")
+    func moniterWithMsr(_ viewName: String? = nil) -> some View {
+        return monitorWithMsr(viewName)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/EventSerializerTests.swift
@@ -465,7 +465,6 @@ final class EventSerializerTests: XCTestCase { // swiftlint:disable:this type_bo
             XCTAssertEqual(attributesDict?["device_locale"] as? String, attributes.deviceLocale)
             XCTAssertEqual(attributesDict?["os_name"] as? String, attributes.osName)
             XCTAssertEqual(attributesDict?["os_version"] as? String, attributes.osVersion)
-            XCTAssertNil(attributesDict?["platform"])
             XCTAssertEqual(attributesDict?["network_type"] as? String, attributes.networkType?.rawValue)
             XCTAssertEqual(attributesDict?["network_generation"] as? String, attributes.networkGeneration?.rawValue)
             XCTAssertEqual(attributesDict?["network_provider"] as? String, attributes.networkProvider)


### PR DESCRIPTION
# Description

## API changes

  | Old (deprecated) | New |
  | --- | --- |
  | `MsrMoniterView` | `MsrMonitorView` |
  | `moniterWithMsr(_:)` | `monitorWithMsr(_:)` |

The old names remain available as deprecated aliases annotated with `renamed:`, so existing code keeps compiling and Xcode offers a fix-it to migrate.

## Related issue
Closes #4148 