### PR TITLE
fix(ios): ignore non http urls in url session interceptor

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		CF7CABBB2F27BE4000A9DC30 /* SignalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABBA2F27BE4000A9DC30 /* SignalStoreTests.swift */; };
 		CF7CAE552D952FA600E15CDB /* HttpEventValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */; };
 		CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */; };
+		CF1A2B3D2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1A2B3C2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift */; };
 		CF83E2E32E0D21EB00FE7041 /* MeasureDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF83E2E22E0D21EB00FE7041 /* MeasureDispatchQueue.swift */; };
 		CF83E2E52E0DA3AE00FE7041 /* MockMeasureDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF83E2E42E0DA3AE00FE7041 /* MockMeasureDispatchQueue.swift */; };
 		CF83E3212E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF83E3202E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift */; };
@@ -620,6 +621,7 @@
 		CF7CABBA2F27BE4000A9DC30 /* SignalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalStoreTests.swift; sourceTree = "<group>"; };
 		CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpEventValidator.swift; sourceTree = "<group>"; };
 		CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpEventValidatorTests.swift; sourceTree = "<group>"; };
+		CF1A2B3C2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskInterceptorTests.swift; sourceTree = "<group>"; };
 		CF83E2E22E0D21EB00FE7041 /* MeasureDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDispatchQueue.swift; sourceTree = "<group>"; };
 		CF83E2E42E0DA3AE00FE7041 /* MockMeasureDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMeasureDispatchQueue.swift; sourceTree = "<group>"; };
 		CF83E3202E0FF85C00FE7041 /* MsrRequestHeadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MsrRequestHeadersProvider.swift; sourceTree = "<group>"; };
@@ -1399,6 +1401,7 @@
 			isa = PBXGroup;
 			children = (
 				CF7CAE572D95344100E15CDB /* HttpEventValidatorTests.swift */,
+				CF1A2B3C2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift */,
 			);
 			path = Http;
 			sourceTree = "<group>";
@@ -1995,6 +1998,7 @@
 				CF12A6902E97B0A9001C8112 /* AttributeValueValidatorTests.swift in Sources */,
 				52B7F14D2D757F81001498BC /* Attributes+Extension.swift in Sources */,
 				CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */,
+				CF1A2B3D2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift in Sources */,
 				52B7F1342D757F81001498BC /* AttributeProcessorTests.swift in Sources */,
 				CFB838212DAFEF780023592B /* SpanProcessorTests.swift in Sources */,
 			);

--- a/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
@@ -82,6 +82,7 @@ final class URLSessionTaskInterceptor {
               let configProvider = self.configProvider,
               let signalSampler = self.signalSampler else { return }
 
+        guard isHttpUrl(url) else { return }
         guard configProvider.shouldTrackHttpUrl(url: url) else { return }
         guard signalSampler.shouldTrackLaunchEvents() else { return }
 
@@ -120,6 +121,18 @@ final class URLSessionTaskInterceptor {
             return String(data: data, encoding: .utf8)
         }
         return nil
+    }
+
+    private func isHttpUrl(_ url: String) -> Bool {
+        guard let parsedUrl = URL(string: url),
+              let scheme = parsedUrl.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = parsedUrl.host,
+              !host.isEmpty else {
+            return false
+        }
+
+        return true
     }
 
     /// React Native uses multiple parallel connections for a single request, all of which are canceled

--- a/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Http/URLSessionTaskInterceptor.swift
@@ -123,7 +123,7 @@ final class URLSessionTaskInterceptor {
         return nil
     }
 
-    private func isHttpUrl(_ url: String) -> Bool {
+    func isHttpUrl(_ url: String) -> Bool {
         guard let parsedUrl = URL(string: url),
               let scheme = parsedUrl.scheme?.lowercased(),
               scheme == "http" || scheme == "https",

--- a/ios/Tests/MeasureSDKTests/Http/URLSessionTaskInterceptorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Http/URLSessionTaskInterceptorTests.swift
@@ -1,0 +1,63 @@
+//
+//  URLSessionTaskInterceptorTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 29/07/26.
+//
+
+import XCTest
+@testable import Measure
+
+class URLSessionTaskInterceptorTests: XCTestCase {
+    private var interceptor: URLSessionTaskInterceptor!
+
+    override func setUp() {
+        super.setUp()
+        interceptor = URLSessionTaskInterceptor.shared
+    }
+
+    func test_isHttpUrl_whenSchemeIsHttp() {
+        XCTAssertTrue(interceptor.isHttpUrl("http://example.com/path"), "http requests should be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsHttps() {
+        XCTAssertTrue(interceptor.isHttpUrl("https://example.com/path?query=1"), "https requests should be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsUppercase() {
+        XCTAssertTrue(interceptor.isHttpUrl("HTTPS://Example.com"), "Scheme comparison should be case insensitive")
+    }
+
+    func test_isHttpUrl_whenUrlIsTheSwizzlerProbe() {
+        XCTAssertFalse(interceptor.isHttpUrl("msr"), "A url with no scheme should not be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsMissing() {
+        XCTAssertFalse(interceptor.isHttpUrl("//example.com/path"), "A protocol relative url should not be tracked")
+    }
+
+    func test_isHttpUrl_whenHostIsMissing() {
+        XCTAssertFalse(interceptor.isHttpUrl("http://"), "A url with no host should not be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsFile() {
+        XCTAssertFalse(interceptor.isHttpUrl("file:///var/tmp/image.png"), "file requests should not be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsWebSocket() {
+        XCTAssertFalse(interceptor.isHttpUrl("ws://example.com/socket"), "ws requests should not be tracked")
+        XCTAssertFalse(interceptor.isHttpUrl("wss://example.com/socket"), "wss requests should not be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsCustom() {
+        XCTAssertFalse(interceptor.isHttpUrl("myapp://example.com/path"), "Custom scheme requests should not be tracked")
+    }
+
+    func test_isHttpUrl_whenSchemeIsData() {
+        XCTAssertFalse(interceptor.isHttpUrl("data:text/plain;base64,bWVhc3VyZQ=="), "data urls should not be tracked")
+    }
+
+    func test_isHttpUrl_whenUrlIsEmpty() {
+        XCTAssertFalse(interceptor.isHttpUrl(""), "An empty url should not be tracked")
+    }
+}


### PR DESCRIPTION
# Description

The swizzler creates a throwaway data task with the url "msr" to discover which NSURLSessionTask subclass implements setState:. cancel() is async, so the probe task's state transition lands after the swizzle is installed and gets reported as an http event on every sdk start.

## Related issue
Fixes #3931
