### PR TITLE
fix(backend): map mcp oauth callback errors to proper status codes

### DIFF
--- a/backend/agent/mcp/auth.go
+++ b/backend/agent/mcp/auth.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -264,8 +265,10 @@ func mcpCallback(ctx context.Context, deps *server.Deps, code, state string) (re
 	vk := deps.VK
 	siteOrigin := deps.Config.SiteOrigin
 
+	// GETDEL so concurrent callbacks can't both consume the same state & then
+	// exchange the same single-use provider code.
 	key := mcpValkeyStateKey(state)
-	val, vkErr := vk.Do(ctx, vk.B().Get().Key(key).Build()).ToString()
+	val, vkErr := vk.Do(ctx, vk.B().Getdel().Key(key).Build()).ToString()
 	if vkErr != nil {
 		return "", &mcpHTTPError{http.StatusBadRequest, "unknown or expired state"}
 	}
@@ -274,9 +277,6 @@ func mcpCallback(ctx context.Context, deps *server.Deps, code, state string) (re
 	if jsonErr := json.Unmarshal([]byte(val), &statePayload); jsonErr != nil {
 		return "", &mcpHTTPError{http.StatusInternalServerError, "failed to decode state"}
 	}
-
-	// Delete state from Valkey (one-time use).
-	_ = vk.Do(ctx, vk.B().Del().Key(key).Build()).Error()
 
 	if code == "" {
 		return "", &mcpHTTPError{http.StatusBadRequest, "missing code"}
@@ -291,12 +291,17 @@ func mcpCallback(ctx context.Context, deps *server.Deps, code, state string) (re
 	case "github":
 		ghToken, exchErr := mcpExchangeGitHubCodeFn(code, callbackURL, deps.Config.OAuthGitHubKey, deps.Config.OAuthGitHubSecret)
 		if exchErr != nil {
-			return "", &mcpHTTPError{http.StatusBadGateway, "failed to exchange GitHub code"}
+			fmt.Println("mcp: failed to exchange github code:", exchErr)
+			if errors.Is(exchErr, authsession.ErrInvalidOAuthCode) {
+				return "", &mcpHTTPError{http.StatusBadRequest, "invalid or expired GitHub code"}
+			}
+			return "", &mcpHTTPError{http.StatusInternalServerError, "failed to exchange GitHub code"}
 		}
 
 		u, userErr := mcpGetGitHubUserFn(ghToken)
 		if userErr != nil {
-			return "", &mcpHTTPError{http.StatusBadGateway, "failed to get GitHub user"}
+			fmt.Println("mcp: failed to get github user info:", userErr)
+			return "", &mcpHTTPError{http.StatusInternalServerError, "failed to get GitHub user"}
 		}
 
 		userName = u.Name
@@ -307,12 +312,17 @@ func mcpCallback(ctx context.Context, deps *server.Deps, code, state string) (re
 	case "google":
 		refreshToken, idToken, exchErr := mcpExchangeGoogleCodeFn(code, callbackURL, deps.Config.OAuthGoogleKey, deps.Config.OAuthGoogleSecret)
 		if exchErr != nil {
-			return "", &mcpHTTPError{http.StatusBadGateway, "failed to exchange Google code"}
+			fmt.Println("mcp: failed to exchange google code:", exchErr)
+			if errors.Is(exchErr, authsession.ErrInvalidOAuthCode) {
+				return "", &mcpHTTPError{http.StatusBadRequest, "invalid or expired Google code"}
+			}
+			return "", &mcpHTTPError{http.StatusInternalServerError, "failed to exchange Google code"}
 		}
 
 		gUser, userErr := mcpGetGoogleUserFromIDTokenFn(idToken)
 		if userErr != nil {
-			return "", &mcpHTTPError{http.StatusBadGateway, "failed to get Google user info"}
+			fmt.Println("mcp: failed to get google user info:", userErr)
+			return "", &mcpHTTPError{http.StatusInternalServerError, "failed to get Google user info"}
 		}
 
 		userName = gUser.Name

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -745,8 +745,28 @@ func TestMCPCallbackExchange(t *testing.T) {
 		c, w := newTestGinContextJSON("POST", "/mcp/auth/callback", map[string]any{"code": "ghcode", "state": "cbstate_ghfail"})
 		h.MCPCallbackExchange(c)
 
-		if w.Code < 400 {
-			t.Fatalf("want error status, got %d: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("GitHub invalid code returns 400", func(t *testing.T) {
+		cleanupAll(ctx, t)
+
+		mcpExchangeGitHubCodeFn = func(code, redirectURI, _, _ string) (string, error) {
+			return "", fmt.Errorf("%w: bad_verification_code", authsession.ErrInvalidOAuthCode)
+		}
+
+		clientID := "clientCBBadCode"
+		redirectURI := "http://localhost:9999/cb"
+		seedMCPClient(ctx, t, clientID, "App", []string{redirectURI}, "secret")
+		storeTestStateWithProvider(ctx, t, "cbstate_ghbadcode", clientID, redirectURI, "challenge", "mcpstate_badcode", "github")
+
+		c, w := newTestGinContextJSON("POST", "/mcp/auth/callback", map[string]any{"code": "usedcode", "state": "cbstate_ghbadcode"})
+		h.MCPCallbackExchange(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 
@@ -765,8 +785,66 @@ func TestMCPCallbackExchange(t *testing.T) {
 		c, w := newTestGinContextJSON("POST", "/mcp/auth/callback", map[string]any{"code": "googlecode", "state": "cbstate_gfail"})
 		h.MCPCallbackExchange(c)
 
-		if w.Code < 400 {
-			t.Fatalf("want error status, got %d: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("Google invalid code returns 400", func(t *testing.T) {
+		cleanupAll(ctx, t)
+
+		mcpExchangeGoogleCodeFn = func(code, redirectURI, _, _ string) (string, string, error) {
+			return "", "", fmt.Errorf("%w: invalid_grant", authsession.ErrInvalidOAuthCode)
+		}
+
+		clientID := "clientCBGBadCode"
+		redirectURI := "http://localhost:9999/cb"
+		seedMCPClient(ctx, t, clientID, "App", []string{redirectURI}, "secret")
+		storeTestStateWithProvider(ctx, t, "cbstate_gbadcode", clientID, redirectURI, "challenge", "mcpstate_gbadcode", "google")
+
+		c, w := newTestGinContextJSON("POST", "/mcp/auth/callback", map[string]any{"code": "usedcode", "state": "cbstate_gbadcode"})
+		h.MCPCallbackExchange(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	// State is consumed with GETDEL, so a replayed callback never reaches the
+	// provider a second time with the same single-use code.
+	t.Run("replayed state returns 400", func(t *testing.T) {
+		cleanupAll(ctx, t)
+
+		var exchanges int
+		mcpExchangeGitHubCodeFn = func(code, redirectURI, _, _ string) (string, error) {
+			exchanges++
+			return "ghtoken", nil
+		}
+		mcpGetGitHubUserFn = func(token string) (authsession.GitHubUser, error) {
+			return authsession.GitHubUser{Name: "Replay User", Email: "replay@example.com"}, nil
+		}
+
+		clientID := "clientCBReplay"
+		redirectURI := "http://localhost:9999/cb"
+		seedMCPClient(ctx, t, clientID, "App", []string{redirectURI}, "secret")
+		storeTestStateWithProvider(ctx, t, "cbstate_replay", clientID, redirectURI, "challenge", "mcpstate_replay", "github")
+
+		body := map[string]any{"code": "ghcode", "state": "cbstate_replay"}
+
+		c, w := newTestGinContextJSON("POST", "/mcp/auth/callback", body)
+		h.MCPCallbackExchange(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("first callback: want 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		c, w = newTestGinContextJSON("POST", "/mcp/auth/callback", body)
+		h.MCPCallbackExchange(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("replayed callback: want 400, got %d: %s", w.Code, w.Body.String())
+		}
+
+		if exchanges != 1 {
+			t.Errorf("exchanges = %d, want 1", exchanges)
 		}
 	})
 

--- a/backend/libs/authsession/authstate.go
+++ b/backend/libs/authsession/authstate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/leporo/sqlf"
 )
+
+// ErrInvalidOAuthCode reports a provider rejecting the authorization code as
+// unknown, already used or expired.
+var ErrInvalidOAuthCode = errors.New("invalid oauth code")
+
+// errBodyLimit caps how much of a provider's response body ends up in an error.
+const errBodyLimit = 256
 
 // AuthState represents temporary state
 // to store code and other details during
@@ -181,9 +189,17 @@ func GetGitHubUser(token string) (user GitHubUser, err error) {
 	return
 }
 
+// truncBody caps a provider response body for safe inclusion in an error.
+func truncBody(body []byte) string {
+	return string(body[:min(len(body), errBodyLimit)])
+}
+
+// githubTokenEndpoint is GitHub's OAuth token endpoint. Override in tests.
+var githubTokenEndpoint = "https://github.com/login/oauth/access_token"
+
 // ExchangeGitHubCodeForToken exchanges a GitHub OAuth code for an access token.
 func ExchangeGitHubCodeForToken(code, redirectURI, clientID, clientSecret string) (string, error) {
-	endpoint := "https://github.com/login/oauth/access_token"
+	endpoint := githubTokenEndpoint
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
@@ -209,25 +225,41 @@ func ExchangeGitHubCodeForToken(code, redirectURI, clientID, clientSecret string
 	}
 
 	var result struct {
-		AccessToken string `json:"access_token"`
-		Error       string `json:"error"`
+		AccessToken      string `json:"access_token"`
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
-		return "", fmt.Errorf("failed to parse GitHub token response: %w", err)
+		return "", fmt.Errorf("failed to parse GitHub token response, status %d: %s", resp.StatusCode, truncBody(body))
 	}
+
+	// GitHub reports OAuth errors in the body with a 200, so check the body
+	// before the status code.
 	if result.Error != "" {
-		return "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
+		err := fmt.Errorf("GitHub OAuth error: %s: %s", result.Error, result.ErrorDescription)
+		if result.Error == "bad_verification_code" {
+			err = fmt.Errorf("%w: %w", ErrInvalidOAuthCode, err)
+		}
+		return "", err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub token endpoint returned %d: %s", resp.StatusCode, truncBody(body))
+	}
+
 	if result.AccessToken == "" {
 		return "", fmt.Errorf("GitHub returned empty access token")
 	}
 	return result.AccessToken, nil
 }
 
+// googleTokenEndpoint is Google's OAuth token endpoint. Override in tests.
+var googleTokenEndpoint = "https://oauth2.googleapis.com/token"
+
 // ExchangeGoogleCode exchanges a Google authorization code for a refresh token
 // and ID token using the server-side OAuth flow.
 func ExchangeGoogleCode(code, redirectURI, clientID, clientSecret string) (refreshToken, idToken string, err error) {
-	endpoint := "https://oauth2.googleapis.com/token"
+	endpoint := googleTokenEndpoint
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
@@ -259,11 +291,23 @@ func ExchangeGoogleCode(code, redirectURI, clientID, clientSecret string) (refre
 		ErrorDesc    string `json:"error_description"`
 	}
 	if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
-		return "", "", fmt.Errorf("failed to parse Google token response: %w", jsonErr)
+		return "", "", fmt.Errorf("failed to parse Google token response, status %d: %s", resp.StatusCode, truncBody(body))
 	}
+
+	// Google reports OAuth errors in the body with a 400, so check the body
+	// before the status code.
 	if result.Error != "" {
-		return "", "", fmt.Errorf("Google OAuth error: %s: %s", result.Error, result.ErrorDesc)
+		err = fmt.Errorf("Google OAuth error: %s: %s", result.Error, result.ErrorDesc)
+		if result.Error == "invalid_grant" {
+			err = fmt.Errorf("%w: %w", ErrInvalidOAuthCode, err)
+		}
+		return "", "", err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("Google token endpoint returned %d: %s", resp.StatusCode, truncBody(body))
+	}
+
 	if result.IDToken == "" {
 		return "", "", fmt.Errorf("Google returned empty id_token")
 	}

--- a/backend/libs/authsession/authstate_test.go
+++ b/backend/libs/authsession/authstate_test.go
@@ -3,8 +3,8 @@ package authsession
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,95 +13,27 @@ import (
 )
 
 // --------------------------------------------------------------------------
-// Test helpers — configurable-endpoint clones of the production functions
+// Test helpers — point the production functions at a test endpoint
 // --------------------------------------------------------------------------
 
-// exchangeGitHubCodeForTokenWithURL is a test-only clone of ExchangeGitHubCodeForToken
-// that hits a configurable endpoint URL.
+// exchangeGitHubCodeForTokenWithURL calls ExchangeGitHubCodeForToken against a
+// test endpoint. Swaps a package var, so not parallel safe.
 func exchangeGitHubCodeForTokenWithURL(endpoint, code, redirectURI, clientID, clientSecret string) (string, error) {
-	data := url.Values{}
-	data.Set("client_id", clientID)
-	data.Set("client_secret", clientSecret)
-	data.Set("code", code)
-	data.Set("redirect_uri", redirectURI)
+	orig := githubTokenEndpoint
+	githubTokenEndpoint = endpoint
+	defer func() { githubTokenEndpoint = orig }()
 
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(data.Encode()))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var result struct {
-		AccessToken string `json:"access_token"`
-		Error       string `json:"error"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return "", fmt.Errorf("failed to parse GitHub token response: %w", err)
-	}
-	if result.Error != "" {
-		return "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
-	}
-	if result.AccessToken == "" {
-		return "", fmt.Errorf("GitHub returned empty access token")
-	}
-	return result.AccessToken, nil
+	return ExchangeGitHubCodeForToken(code, redirectURI, clientID, clientSecret)
 }
 
-// exchangeGoogleCodeWithEndpoint is a test-only clone of ExchangeGoogleCode
-// that hits a configurable endpoint URL.
+// exchangeGoogleCodeWithEndpoint calls ExchangeGoogleCode against a test
+// endpoint. Swaps a package var, so not parallel safe.
 func exchangeGoogleCodeWithEndpoint(endpoint, code, redirectURI, clientID, clientSecret string) (refreshToken, idToken string, err error) {
-	data := url.Values{}
-	data.Set("client_id", clientID)
-	data.Set("client_secret", clientSecret)
-	data.Set("code", code)
-	data.Set("redirect_uri", redirectURI)
-	data.Set("grant_type", "authorization_code")
+	orig := googleTokenEndpoint
+	googleTokenEndpoint = endpoint
+	defer func() { googleTokenEndpoint = orig }()
 
-	req, reqErr := http.NewRequest("POST", endpoint, strings.NewReader(data.Encode()))
-	if reqErr != nil {
-		return "", "", reqErr
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, doErr := http.DefaultClient.Do(req)
-	if doErr != nil {
-		return "", "", doErr
-	}
-	defer resp.Body.Close()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return "", "", readErr
-	}
-
-	var result struct {
-		RefreshToken string `json:"refresh_token"`
-		IDToken      string `json:"id_token"`
-		Error        string `json:"error"`
-		ErrorDesc    string `json:"error_description"`
-	}
-	if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
-		return "", "", fmt.Errorf("failed to parse Google token response: %w", jsonErr)
-	}
-	if result.Error != "" {
-		return "", "", fmt.Errorf("Google OAuth error: %s: %s", result.Error, result.ErrorDesc)
-	}
-	if result.IDToken == "" {
-		return "", "", fmt.Errorf("Google returned empty id_token")
-	}
-	return result.RefreshToken, result.IDToken, nil
+	return ExchangeGoogleCode(code, redirectURI, clientID, clientSecret)
 }
 
 // validateGoogleRefreshTokenWithEndpoint is a test-only clone of ValidateGoogleRefreshToken
@@ -152,10 +84,13 @@ func TestExchangeGitHubCodeForToken(t *testing.T) {
 		}
 	})
 
-	t.Run("GitHub returns error field", func(t *testing.T) {
+	t.Run("bad_verification_code is an invalid code error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{"error": "bad_verification_code"})
+			json.NewEncoder(w).Encode(map[string]string{
+				"error":             "bad_verification_code",
+				"error_description": "The code passed is incorrect or expired.",
+			})
 		}))
 		defer srv.Close()
 
@@ -163,8 +98,64 @@ func TestExchangeGitHubCodeForToken(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if got := err.Error(); got != "GitHub OAuth error: bad_verification_code" {
-			t.Errorf("error = %q", got)
+		if !errors.Is(err, ErrInvalidOAuthCode) {
+			t.Errorf("error = %q, want ErrInvalidOAuthCode", err)
+		}
+		if !strings.Contains(err.Error(), "The code passed is incorrect or expired.") {
+			t.Errorf("error = %q, want error_description included", err)
+		}
+	})
+
+	t.Run("other OAuth errors are not invalid code errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"error": "incorrect_client_credentials"})
+		}))
+		defer srv.Close()
+
+		_, err := exchangeGitHubCodeForTokenWithURL(srv.URL, "code", "http://localhost/cb", "cid", "cs")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if errors.Is(err, ErrInvalidOAuthCode) {
+			t.Errorf("error = %q, want not ErrInvalidOAuthCode", err)
+		}
+		if !strings.Contains(err.Error(), "incorrect_client_credentials") {
+			t.Errorf("error = %q, want provider error included", err)
+		}
+	})
+
+	t.Run("non-200 status returns error naming the status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"message": "unavailable"})
+		}))
+		defer srv.Close()
+
+		_, err := exchangeGitHubCodeForTokenWithURL(srv.URL, "code", "http://localhost/cb", "cid", "cs")
+		if err == nil {
+			t.Fatal("expected error for non-200 status")
+		}
+		if !strings.Contains(err.Error(), "503") {
+			t.Errorf("error = %q, want status 503 included", err)
+		}
+	})
+
+	t.Run("oversized error body is truncated", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(strings.Repeat("x", 5000)))
+		}))
+		defer srv.Close()
+
+		_, err := exchangeGitHubCodeForTokenWithURL(srv.URL, "code", "http://localhost/cb", "cid", "cs")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if strings.Count(err.Error(), "x") != errBodyLimit {
+			t.Errorf("body length = %d, want %d", strings.Count(err.Error(), "x"), errBodyLimit)
 		}
 	})
 
@@ -267,9 +258,12 @@ func TestExchangeGoogleCode(t *testing.T) {
 		}
 	})
 
-	t.Run("Google returns error with description", func(t *testing.T) {
+	// Google reports invalid_grant with a 400, so the body must be inspected
+	// before the status code.
+	t.Run("invalid_grant with 400 is an invalid code error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{
 				"error":             "invalid_grant",
 				"error_description": "Code was already redeemed",
@@ -280,6 +274,46 @@ func TestExchangeGoogleCode(t *testing.T) {
 		_, _, err := exchangeGoogleCodeWithEndpoint(srv.URL, "code", "http://localhost/cb", "cid", "cs")
 		if err == nil {
 			t.Fatal("expected error")
+		}
+		if !errors.Is(err, ErrInvalidOAuthCode) {
+			t.Errorf("error = %q, want ErrInvalidOAuthCode", err)
+		}
+		if !strings.Contains(err.Error(), "Code was already redeemed") {
+			t.Errorf("error = %q, want error_description included", err)
+		}
+	})
+
+	t.Run("other OAuth errors are not invalid code errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid_client"})
+		}))
+		defer srv.Close()
+
+		_, _, err := exchangeGoogleCodeWithEndpoint(srv.URL, "code", "http://localhost/cb", "cid", "cs")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if errors.Is(err, ErrInvalidOAuthCode) {
+			t.Errorf("error = %q, want not ErrInvalidOAuthCode", err)
+		}
+	})
+
+	t.Run("non-200 status returns error naming the status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"message": "unavailable"})
+		}))
+		defer srv.Close()
+
+		_, _, err := exchangeGoogleCodeWithEndpoint(srv.URL, "code", "http://localhost/cb", "cid", "cs")
+		if err == nil {
+			t.Fatal("expected error for non-200 status")
+		}
+		if !strings.Contains(err.Error(), "503") {
+			t.Errorf("error = %q, want status 503 included", err)
 		}
 	})
 

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -15,7 +15,8 @@ info:
 
     ```json
     {
-      "error": "Error message"
+      "error": "Error message",
+      "details": "Additional error details, when available"
     }
     ```
 servers:
@@ -128,6 +129,8 @@ paths:
                     own_team_id: e47ac49d-0697-4e85-8607-1a34536c04e3
         "400":
           description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+        "401":
+          description: GitHub rejected the sign-in. The authorization code is invalid, already used or expired.
         "429":
           description: Rate limit of the requester has crossed maximum limits.
         "500":
@@ -209,6 +212,8 @@ paths:
                     own_team_id: e47ac49d-0697-4e85-8607-1a34536c04e3
         "400":
           description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+        "401":
+          description: Google rejected the sign-in. The authorization code is invalid, already used or expired.
         "429":
           description: Rate limit of the requester has crossed maximum limits.
         "500":


### PR DESCRIPTION
## Summary

This PR fixes `POST /mcp/auth/callback` in the agent service returning a generic `502` for every failure. It now logs the real provider error, maps an invalid or expired OAuth code to `400` & everything else to `500`, surfaces GitHub's `error_description`, checks `resp.StatusCode` in both the GitHub & Google token exchange functions, caps provider error bodies before logging, & swaps a non-atomic Valkey `GET`+`DEL` of the OAuth state for an atomic `GETDEL` to stop concurrent callbacks from reusing the same single-use provider code.

## Tasks

- [x] Log the real provider error instead of swallowing it
- [x] Map invalid or expired OAuth code to `400` & other failures to `500`
- [x] Surface GitHub's `error_description` in exchange errors
- [x] Check `resp.StatusCode` in the GitHub & Google token exchange functions
- [x] Cap provider error body size before logging
- [x] Replace `GET`+`DEL` of OAuth state with atomic `GETDEL`
- [x] Replace hand-copied test clones with helpers calling the real exchange functions
- [x] Add tests for status mapping & callback replay
- [x] Update OpenAPI documentation to reflect correct HTTP status codes for authentication endpoints

## See also

- fixes #4160
