### PR TITLE
fix(backend): fail fast on unreachable valkey at boot

### DIFF
--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -1,0 +1,76 @@
+name: Libs
+on:
+  pull_request:
+    paths:
+      - .github/workflows/libs.yml
+      - backend/libs/**/*.go
+      - backend/libs/**/*.mod
+      - backend/libs/**/*.sum
+  push:
+    branches:
+      - "main"
+    paths:
+      - .github/workflows/libs.yml
+      - backend/libs/**/*.go
+      - backend/libs/**/*.mod
+      - backend/libs/**/*.sum
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25.x", "1.26.x"]
+    defaults:
+      run:
+        working-directory: backend/libs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: backend/libs/go.sum
+      - name: Display go version
+        run: go version
+      - name: Install dependencies
+        run: go get .
+      - name: Build with ${{ matrix.go-version }}
+        run: go build -v ./...
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25.x", "1.26.x"]
+    defaults:
+      run:
+        working-directory: backend/libs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: backend/libs/go.sum
+      - name: Display go version
+        run: go version
+      - name: Install dependencies
+        run: go get .
+      # Integration tagged tests are skipped, they need containers & resolve
+      # backend/testinfra only through the workspace.
+      - name: Test with ${{ matrix.go-version }}
+        run: go test ./...

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
       - name: Vet with ${{ matrix.go-version }}
@@ -69,7 +69,7 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       # Integration tagged tests are skipped, they need containers & resolve
       # backend/testinfra only through the workspace.
       - name: Test with ${{ matrix.go-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,42 @@ jobs:
       - name: Test with ${{ matrix.go-version }}
         run: go test -tags=integration ./...
 
+  build-test-libs:
+    name: Build & Test Libs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25.x", "1.26.x"]
+    defaults:
+      run:
+        working-directory: backend/libs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set Go module cache
+        run: echo "GOMODCACHE=$RUNNER_TEMP/gomodcache-${{ matrix.go-version }}" >> "$GITHUB_ENV"
+
+      - name: Setup Go ${{ matrix.go-version}}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: backend/libs/go.sum
+
+      - name: Display go version
+        run: go version
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Build with ${{ matrix.go-version }}
+        run: go build -v ./...
+
+      # Integration tagged tests are skipped, they need containers & resolve
+      # backend/testinfra only through the workspace.
+      - name: Test with ${{ matrix.go-version }}
+        run: go test ./...
+
   build-test-dashboard:
     name: Build & Test dashboard
     runs-on: ubuntu-latest
@@ -123,7 +159,13 @@ jobs:
   trigger-cloud-deploy:
     name: Trigger Cloud Deploy
     runs-on: ubuntu-latest
-    needs: [build-test-ingest, build-test-api, build-test-dashboard]
+    needs:
+      [
+        build-test-ingest,
+        build-test-api,
+        build-test-libs,
+        build-test-dashboard,
+      ]
     steps:
       - name: Dispatch Cloud Deploy
         uses: peter-evans/repository-dispatch@v4

--- a/backend/agent/mcp/auth.go
+++ b/backend/agent/mcp/auth.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,6 +49,20 @@ type mcpHTTPError struct {
 }
 
 func (e *mcpHTTPError) Error() string { return e.Message }
+
+// mcpAbortWithError ends the request with the status carried by err. Errors
+// that are not *mcpHTTPError carry no status, so they become a 500 with the
+// real cause logged rather than sent to the client.
+func mcpAbortWithError(c *gin.Context, err error) {
+	var herr *mcpHTTPError
+	if errors.As(err, &herr) {
+		c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+		return
+	}
+
+	fmt.Printf("mcp: unexpected error on %s: %v\n", c.Request.URL.Path, err)
+	c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+}
 
 // mcpGoogleUser holds the Google user info decoded from an ID token.
 type mcpGoogleUser struct {
@@ -605,8 +620,7 @@ func (h Handlers) MCPRegisterClient(c *gin.Context) {
 
 	clientID, rawSecret, err := mcpRegisterClient(ctx, deps, req.ClientName, req.RedirectURIs)
 	if err != nil {
-		herr := err.(*mcpHTTPError)
-		c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+		mcpAbortWithError(c, err)
 		return
 	}
 
@@ -660,8 +674,7 @@ func (h Handlers) MCPAuthorize(c *gin.Context) {
 
 	providerURL, err := mcpAuthorize(ctx, deps, provider, clientID, redirectURI, mcpState, codeChallenge, gaClientID, gclid)
 	if err != nil {
-		herr := err.(*mcpHTTPError)
-		c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+		mcpAbortWithError(c, err)
 		return
 	}
 
@@ -693,8 +706,7 @@ func (h Handlers) MCPCallbackExchange(c *gin.Context) {
 
 	redirectURL, err := mcpCallback(ctx, deps, req.Code, req.State)
 	if err != nil {
-		herr := err.(*mcpHTTPError)
-		c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+		mcpAbortWithError(c, err)
 		return
 	}
 
@@ -742,8 +754,7 @@ func (h Handlers) MCPToken(c *gin.Context) {
 
 	rawToken, err := mcpToken(ctx, deps, code, redirectURI, clientID, codeVerifier)
 	if err != nil {
-		herr := err.(*mcpHTTPError)
-		c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+		mcpAbortWithError(c, err)
 		return
 	}
 
@@ -763,16 +774,14 @@ func (h Handlers) ValidateMCPToken() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		rawToken, err := mcpParseBearerToken(c.GetHeader("Authorization"))
 		if err != nil {
-			herr := err.(*mcpHTTPError)
-			c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+			mcpAbortWithError(c, err)
 			return
 		}
 
 		ctx := c.Request.Context()
 		info, err := mcpValidateToken(ctx, deps, rawToken)
 		if err != nil {
-			herr := err.(*mcpHTTPError)
-			c.AbortWithStatusJSON(herr.Status, gin.H{"error": herr.Message})
+			mcpAbortWithError(c, err)
 			return
 		}
 

--- a/backend/agent/server/server.go
+++ b/backend/agent/server/server.go
@@ -2,9 +2,9 @@
 // and Deps types, reads and builds them (NewConfig, Connect), and the agent's
 // main threads a *Deps explicitly into the handlers and domain code.
 //
-// Each service owns its copy of this boot code: the shared libs carry only
-// domain logic and the plain Config/Deps data types, never the construction.
-// Kept in sync with the other services' server packages by hand.
+// Each service owns its copy of this boot code & it is kept in sync with the
+// other services' server packages by hand. The exception is libs/boot, which
+// holds the handful of handle builders that are identical everywhere.
 package server
 
 import (
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"backend/libs/autumn"
+	"backend/libs/boot"
 	"backend/libs/chquery"
 	"backend/libs/ga4"
 	"backend/libs/inet"
@@ -325,12 +326,12 @@ func NewConfig() *Config {
 
 	redisHost := os.Getenv("REDIS_HOST")
 	if redisHost == "" {
-		log.Println("REDIS_HOST env var is not set, caching will not work")
+		log.Fatal("REDIS_HOST env var is not set, cannot start valkey client")
 	}
 
 	redisPortStr := os.Getenv("REDIS_PORT")
 	if redisPortStr == "" {
-		log.Println("REDIS_PORT env var is not set, caching will not work")
+		log.Fatal("REDIS_PORT env var is not set, cannot start valkey client")
 	}
 
 	redisPort, err := strconv.Atoi(redisPortStr)
@@ -485,31 +486,11 @@ func NewConfig() *Config {
 	}
 }
 
-func WaitForPg(ctx context.Context, pgPool *pgxpool.Pool, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		if err := pgPool.Ping(ctx); err == nil {
-			return nil // Ready
-		} else {
-			fmt.Printf("PG ping failed: %v; Retrying...\n", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
-	}
-}
-
 // Connect opens every infrastructure handle named in the config and returns
 // them bundled in a Deps. Connection failures are logged but not fatal, so a
-// service starts and degrades rather than refusing to come up.
+// service starts and degrades rather than refusing to come up. Valkey is the
+// exception, its client cannot be built without a live server & never heals
+// once construction failed, so an unreachable valkey is fatal.
 func Connect(config *Config) *Deps {
 	ctx := context.Background()
 	var pgPool *pgxpool.Pool
@@ -554,7 +535,7 @@ func Connect(config *Config) *Deps {
 	}
 	pgPool = pool
 
-	if err := WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
+	if err := boot.WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
 		fmt.Printf("Postgres pool not ready: %v\n", err)
 	}
 
@@ -614,18 +595,10 @@ func Connect(config *Config) *Deps {
 		log.Printf("Unable to initialize geo ip lookup system: %v\n", err)
 	}
 
-	// init redis client
-	addr := fmt.Sprintf("%s:%d", config.RD.Host, config.RD.Port)
-	options := redis.ClientOption{
-		InitAddress: []string{addr},
-	}
-
-	options.ConnWriteTimeout = 30 * time.Second
-	options.ClientName = "measure-agent"
-
-	vkClient, err := redis.NewClient(options)
+	// init valkey client
+	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "agent", 15*time.Second)
 	if err != nil {
-		log.Printf("failed to create redis client: %v\n", err)
+		log.Fatalf("Unable to create valkey client: %v", err)
 	}
 
 	return &Deps{

--- a/backend/alerts/server/server.go
+++ b/backend/alerts/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"backend/libs/autumn"
+	"backend/libs/boot"
 	"backend/libs/secret"
 	"context"
 	"fmt"
@@ -19,7 +20,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/leporo/sqlf"
 	"github.com/valkey-io/valkey-go"
-	redis "github.com/valkey-io/valkey-go"
 	"github.com/wneessen/go-mail"
 )
 
@@ -109,12 +109,12 @@ func NewConfig() *ServerConfig {
 
 	redisHost := os.Getenv("REDIS_HOST")
 	if redisHost == "" {
-		log.Println("REDIS_HOST env var is not set, caching will not work")
+		log.Fatal("REDIS_HOST env var is not set, cannot start valkey client")
 	}
 
 	redisPortStr := os.Getenv("REDIS_PORT")
 	if redisPortStr == "" {
-		log.Println("REDIS_PORT env var is not set, caching will not work")
+		log.Fatal("REDIS_PORT env var is not set, cannot start valkey client")
 	}
 
 	redisPort, err := strconv.Atoi(redisPortStr)
@@ -281,18 +281,10 @@ func Init(config *ServerConfig) {
 		}
 	}
 
-	// init redis client
-	addr := fmt.Sprintf("%s:%d", config.RD.Host, config.RD.Port)
-	options := redis.ClientOption{
-		InitAddress: []string{addr},
-	}
-
-	options.ConnWriteTimeout = 30 * time.Second
-	options.ClientName = "measure-alerts"
-
-	vkClient, err := redis.NewClient(options)
+	// init valkey client
+	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "alerts", 15*time.Second)
 	if err != nil {
-		log.Printf("failed to create redis client: %v\n", err)
+		log.Fatalf("Unable to create valkey client: %v", err)
 	}
 
 	Server = &server{

--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -3,9 +3,9 @@
 // *Deps explicitly into the handlers and domain code. It also wires the bus
 // producer that ships Slack events to the agent service.
 //
-// Each service owns its copy of this boot code: the shared libs carry only
-// domain logic and the plain Config/Deps data types, never the construction.
-// Kept in sync with the other services' server packages by hand.
+// Each service owns its copy of this boot code & it is kept in sync with the
+// other services' server packages by hand. The exception is libs/boot, which
+// holds the handful of handle builders that are identical everywhere.
 package server
 
 import (
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"backend/libs/autumn"
+	"backend/libs/boot"
 	"backend/libs/bus"
 	"backend/libs/chquery"
 	"backend/libs/ga4"
@@ -312,12 +313,12 @@ func NewConfig() *Config {
 
 	redisHost := os.Getenv("REDIS_HOST")
 	if redisHost == "" {
-		log.Println("REDIS_HOST env var is not set, caching will not work")
+		log.Fatal("REDIS_HOST env var is not set, cannot start valkey client")
 	}
 
 	redisPortStr := os.Getenv("REDIS_PORT")
 	if redisPortStr == "" {
-		log.Println("REDIS_PORT env var is not set, caching will not work")
+		log.Fatal("REDIS_PORT env var is not set, cannot start valkey client")
 	}
 
 	redisPort, err := strconv.Atoi(redisPortStr)
@@ -525,31 +526,11 @@ func NewConfig() *Config {
 	}
 }
 
-func WaitForPg(ctx context.Context, pgPool *pgxpool.Pool, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		if err := pgPool.Ping(ctx); err == nil {
-			return nil // Ready
-		} else {
-			fmt.Printf("PG ping failed: %v; Retrying...\n", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
-	}
-}
-
 // Connect opens every infrastructure handle named in the config and returns
 // them bundled in a Deps. Connection failures are logged but not fatal, so a
-// service starts and degrades rather than refusing to come up.
+// service starts and degrades rather than refusing to come up. Valkey is the
+// exception, its client cannot be built without a live server & never heals
+// once construction failed, so an unreachable valkey is fatal.
 func Connect(config *Config) *Deps {
 	ctx := context.Background()
 	var pgPool *pgxpool.Pool
@@ -594,7 +575,7 @@ func Connect(config *Config) *Deps {
 	}
 	pgPool = pool
 
-	if err := WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
+	if err := boot.WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
 		fmt.Printf("Postgres pool not ready: %v\n", err)
 	}
 
@@ -640,18 +621,10 @@ func Connect(config *Config) *Deps {
 		log.Printf("Unable to initialize geo ip lookup system: %v\n", err)
 	}
 
-	// init redis client
-	addr := fmt.Sprintf("%s:%d", config.RD.Host, config.RD.Port)
-	options := redis.ClientOption{
-		InitAddress: []string{addr},
-	}
-
-	options.ConnWriteTimeout = 30 * time.Second
-	options.ClientName = "measure-api"
-
-	vkClient, err := redis.NewClient(options)
+	// init valkey client
+	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "api", 15*time.Second)
 	if err != nil {
-		log.Printf("failed to create redis client: %v\n", err)
+		log.Fatalf("Unable to create valkey client: %v", err)
 	}
 
 	// init email client

--- a/backend/ingest-worker/server/server.go
+++ b/backend/ingest-worker/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"backend/libs/autumn"
+	"backend/libs/boot"
 	"backend/libs/bus"
 	"backend/libs/ga4"
 	"backend/libs/inet"
@@ -212,12 +213,12 @@ func NewConfig() *ServerConfig {
 
 	redisHost := os.Getenv("REDIS_HOST")
 	if redisHost == "" {
-		log.Println("REDIS_HOST env var is not set, caching will not work")
+		log.Fatal("REDIS_HOST env var is not set, cannot start valkey client")
 	}
 
 	redisPortStr := os.Getenv("REDIS_PORT")
 	if redisPortStr == "" {
-		log.Println("REDIS_PORT env var is not set, caching will not work")
+		log.Fatal("REDIS_PORT env var is not set, cannot start valkey client")
 	}
 
 	redisPort, err := strconv.Atoi(redisPortStr)
@@ -329,28 +330,6 @@ func NewConfig() *ServerConfig {
 	}
 }
 
-func WaitForPg(ctx context.Context, pgPool *pgxpool.Pool, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		if err := pgPool.Ping(ctx); err == nil {
-			return nil
-		} else {
-			log.Printf("PG ping failed: %v; Retrying...\n", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
-	}
-}
-
 func Init(config *ServerConfig) {
 	ctx := context.Background()
 	var pgPool *pgxpool.Pool
@@ -393,7 +372,7 @@ func Init(config *ServerConfig) {
 	}
 	pgPool = pool
 
-	if err := WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
+	if err := boot.WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
 		log.Printf("Postgres pool not ready: %v\n", err)
 	}
 
@@ -423,17 +402,10 @@ func Init(config *ServerConfig) {
 		log.Printf("Unable to initialize geo ip lookup system: %v\n", err)
 	}
 
-	addr := fmt.Sprintf("%s:%d", config.RD.Host, config.RD.Port)
-	options := redis.ClientOption{
-		InitAddress: []string{addr},
-	}
-
-	options.ConnWriteTimeout = 30 * time.Second
-	options.ClientName = "measure-ingest-worker"
-
-	vkClient, err := redis.NewClient(options)
+	// init valkey client
+	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "ingest-worker", 15*time.Second)
 	if err != nil {
-		log.Printf("failed to create redis client: %v\n", err)
+		log.Fatalf("Unable to create valkey client: %v", err)
 	}
 
 	sqlf.SetDialect(sqlf.PostgreSQL)

--- a/backend/ingest/server/server.go
+++ b/backend/ingest/server/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"backend/libs/autumn"
+	"backend/libs/boot"
 	"backend/libs/bus"
 	"backend/libs/secret"
 
@@ -207,12 +208,12 @@ func NewConfig() *ServerConfig {
 
 	redisHost := os.Getenv("REDIS_HOST")
 	if redisHost == "" {
-		log.Println("REDIS_HOST env var is not set, caching will not work")
+		log.Fatal("REDIS_HOST env var is not set, cannot start valkey client")
 	}
 
 	redisPortStr := os.Getenv("REDIS_PORT")
 	if redisPortStr == "" {
-		log.Println("REDIS_PORT env var is not set, caching will not work")
+		log.Fatal("REDIS_PORT env var is not set, cannot start valkey client")
 	}
 
 	iggyAddr := os.Getenv("IGGY_ADDR")
@@ -278,28 +279,6 @@ func NewConfig() *ServerConfig {
 	}
 }
 
-func WaitForPg(ctx context.Context, pgPool *pgxpool.Pool, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		if err := pgPool.Ping(ctx); err == nil {
-			return nil
-		} else {
-			fmt.Printf("PG ping failed: %v; Retrying...\n", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
-	}
-}
-
 func Init(config *ServerConfig) {
 	ctx := context.Background()
 	var pgPool *pgxpool.Pool
@@ -342,7 +321,7 @@ func Init(config *ServerConfig) {
 	}
 	pgPool = pool
 
-	if err := WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
+	if err := boot.WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
 		fmt.Printf("Postgres pool not ready: %v\n", err)
 	}
 
@@ -368,17 +347,10 @@ func Init(config *ServerConfig) {
 		log.Printf("Unable to create CH connection pool: %v\n", err)
 	}
 
-	addr := fmt.Sprintf("%s:%d", config.RD.Host, config.RD.Port)
-	options := redis.ClientOption{
-		InitAddress: []string{addr},
-	}
-
-	options.ConnWriteTimeout = 30 * time.Second
-	options.ClientName = "measure-ingest"
-
-	vkClient, err := redis.NewClient(options)
+	// init valkey client
+	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "ingest", 15*time.Second)
 	if err != nil {
-		log.Printf("failed to create redis client: %v\n", err)
+		log.Fatalf("Unable to create valkey client: %v", err)
 	}
 
 	sqlf.SetDialect(sqlf.PostgreSQL)

--- a/backend/libs/boot/boot.go
+++ b/backend/libs/boot/boot.go
@@ -1,0 +1,67 @@
+package boot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	redis "github.com/valkey-io/valkey-go"
+)
+
+// WaitForPg blocks until the pool answers a ping or the timeout elapses.
+func WaitForPg(ctx context.Context, pgPool *pgxpool.Pool, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		if err := pgPool.Ping(ctx); err == nil {
+			return nil // Ready
+		} else {
+			fmt.Printf("PG ping failed: %v; Retrying...\n", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// ConnectValkey builds a valkey client, retrying until timeout.
+//
+// The pg & clickhouse handles connect lazily, so they survive a dependency
+// that is not up yet. valkey-go dials eagerly & returns a nil client on
+// failure, which would leave the client nil for the process lifetime.
+func ConnectValkey(ctx context.Context, host string, port int, clientName string, timeout time.Duration) (client redis.Client, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	options := redis.ClientOption{
+		InitAddress: []string{fmt.Sprintf("%s:%d", host, port)},
+	}
+
+	options.ConnWriteTimeout = 30 * time.Second
+	options.ClientName = clientName
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		client, err = redis.NewClient(options)
+		if err == nil {
+			return client, nil
+		}
+		fmt.Printf("Valkey client creation failed: %v; Retrying...\n", err)
+
+		select {
+		case <-ctx.Done():
+			return nil, err
+		case <-ticker.C:
+		}
+	}
+}

--- a/backend/libs/boot/boot_test.go
+++ b/backend/libs/boot/boot_test.go
@@ -1,0 +1,23 @@
+package boot
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestConnectValkeyUnreachable checks that an unreachable valkey ends in an
+// error after the timeout, never a nil client with a nil error.
+func TestConnectValkeyUnreachable(t *testing.T) {
+	start := time.Now()
+	client, err := ConnectValkey(context.Background(), "127.0.0.1", 1, "test", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error for unreachable valkey")
+	}
+	if client != nil {
+		t.Fatal("expected nil client on failure")
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("returned after %v, expected retries until the timeout", elapsed)
+	}
+}

--- a/backend/libs/boot/doc.go
+++ b/backend/libs/boot/doc.go
@@ -1,0 +1,33 @@
+// Package boot builds the infrastructure handles every service opens at
+// startup in the same way.
+//
+// Each service owns its own boot sequence in its server package, reading its
+// own env contract & wiring its own handles. Only the builders that are
+// identical across services live here, so a fix lands once instead of five
+// times.
+//
+// # Usage
+//
+//	if err := boot.WaitForPg(ctx, pgPool, 5*time.Second); err != nil {
+//	    fmt.Printf("Postgres pool not ready: %v\n", err)
+//	}
+//
+//	vkClient, err := boot.ConnectValkey(ctx, config.RD.Host, config.RD.Port, "agent", 15*time.Second)
+//	if err != nil {
+//	    log.Fatalf("Unable to create valkey client: %v", err)
+//	}
+//
+// # Why the two differ
+//
+// [WaitForPg] is advisory. A pgxpool that fails its ping is still usable, it
+// dials lazily & reconnects on its own, so a caller may log & carry on.
+//
+// [ConnectValkey] is not. valkey-go dials during construction & returns a nil
+// client on failure, which no amount of later retrying inside the service will
+// repair. Callers should treat its error as fatal & let the orchestrator
+// restart them, otherwise the process serves traffic with a nil client that
+// panics on first use.
+//
+// Once built, the valkey client heals its own dropped connections, so only
+// construction needs this care.
+package boot


### PR DESCRIPTION
## Summary

This PR fixes a production panic in the agent service caused by a nil valkey client after a boot-time connection failure. Valkey client construction now retries with a bounded loop then fails fast instead of leaving a nil client, applied across all 5 backend services. `mcp/auth.go` also drops its unchecked type assertions for a single safe error-abort helper, & the duplicated valkey/Postgres boot helpers are consolidated into a new shared `backend/libs/boot` package with CI coverage.

## Tasks

- [x] Retry valkey connection at boot with a bounded loop, fail fast instead of leaving a nil client
- [x] Make unset REDIS_HOST/REDIS_PORT fatal at boot
- [x] Apply the fix to agent, API, alerts, ingest & ingest-worker services
- [x] Replace unchecked type assertions in mcp/auth.go with a single error-abort helper
- [x] Extract shared valkey/Postgres boot helpers into backend/libs/boot with tests
- [x] Add CI coverage for backend/libs

## See also

- fixes #4159