### PR TITLE
chore(frontend): add twitter card tags to docs and marketing pages

### DIFF
--- a/frontend/dashboard/__tests__/utils/metadata_test.ts
+++ b/frontend/dashboard/__tests__/utils/metadata_test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  pageMetadata,
+  previewImage,
+  siteHandle,
+  siteMetadata,
+  siteXUrl,
+} from "@/app/utils/metadata";
+
+const seo = {
+  title: "Pricing & Plans",
+  description: "What Measure costs.",
+  path: "/pricing",
+};
+
+type OpenGraphTags = {
+  title?: string;
+  description?: string;
+  url?: string;
+  type?: string;
+  siteName?: string;
+  images?: { url: string; alt?: string; width?: number; height?: number }[];
+  publishedTime?: string;
+  authors?: string[];
+};
+
+type TwitterTags = {
+  card?: string;
+  site?: string;
+  creator?: string;
+  title?: string;
+  description?: string;
+  images?: { url: string; alt?: string }[];
+};
+
+function openGraphOf(metadata: { openGraph?: unknown }): OpenGraphTags {
+  return metadata.openGraph as OpenGraphTags;
+}
+
+function twitterOf(metadata: { twitter?: unknown }): TwitterTags {
+  return metadata.twitter as TwitterTags;
+}
+
+describe("pageMetadata", () => {
+  it("carries the page title, description and canonical path", () => {
+    const metadata = pageMetadata(seo);
+
+    expect(metadata.title).toBe("Pricing & Plans");
+    expect(metadata.description).toBe("What Measure costs.");
+    expect(metadata.alternates).toEqual({ canonical: "/pricing" });
+    expect(openGraphOf(metadata).url).toBe("/pricing");
+  });
+
+  it("appends the Measure suffix to the social titles by default", () => {
+    const metadata = pageMetadata(seo);
+
+    expect(openGraphOf(metadata).title).toBe("Pricing & Plans | Measure");
+    expect(twitterOf(metadata).title).toBe("Pricing & Plans | Measure");
+  });
+
+  it("leaves the social titles alone when the suffix is turned off", () => {
+    const metadata = pageMetadata(seo, { addMeasureSuffixToTitle: false });
+
+    expect(openGraphOf(metadata).title).toBe("Pricing & Plans");
+    expect(twitterOf(metadata).title).toBe("Pricing & Plans");
+    expect(metadata.title).toBe("Pricing & Plans");
+  });
+
+  it("gives Open Graph and Twitter the same title and description", () => {
+    const metadata = pageMetadata(seo);
+
+    expect(twitterOf(metadata).title).toBe(openGraphOf(metadata).title);
+    expect(twitterOf(metadata).description).toBe(
+      openGraphOf(metadata).description,
+    );
+  });
+
+  it("builds a large image card attributed to the Measure account", () => {
+    const twitter = twitterOf(pageMetadata(seo));
+
+    expect(twitter.card).toBe("summary_large_image");
+    expect(twitter.site).toBe(siteHandle);
+    expect(twitter.creator).toBe(siteHandle);
+  });
+
+  it("falls back to the site-wide preview image with its dimensions", () => {
+    const metadata = pageMetadata(seo);
+    const expected = [
+      {
+        url: previewImage,
+        width: 1200,
+        height: 630,
+        alt: "Measure preview image",
+      },
+    ];
+
+    expect(openGraphOf(metadata).images).toEqual(expected);
+    expect(twitterOf(metadata).images).toEqual(expected);
+  });
+
+  it("uses the page's own images for both tag sets when given", () => {
+    const images = [{ url: "/blog/assets/hero.webp", alt: "A post" }];
+    const metadata = pageMetadata(seo, { images });
+
+    expect(openGraphOf(metadata).images).toEqual(images);
+    expect(twitterOf(metadata).images).toEqual(images);
+  });
+
+  it("describes a page as a website unless it is an article", () => {
+    expect(openGraphOf(pageMetadata(seo)).type).toBe("website");
+  });
+
+  it("adds the publication date and authors for an article", () => {
+    const metadata = pageMetadata(seo, {
+      article: {
+        publishedTime: "2026-07-19T00:00:00.000Z",
+        authors: ["Anup Cowkur"],
+      },
+    });
+    const openGraph = openGraphOf(metadata);
+
+    expect(openGraph.type).toBe("article");
+    expect(openGraph.publishedTime).toBe("2026-07-19T00:00:00.000Z");
+    expect(openGraph.authors).toEqual(["Anup Cowkur"]);
+  });
+
+  it("omits the description when a page has none", () => {
+    const metadata = pageMetadata({ title: "Untitled", path: "/untitled" });
+
+    expect(metadata.description).toBeUndefined();
+    expect(openGraphOf(metadata).description).toBeUndefined();
+    expect(twitterOf(metadata).description).toBeUndefined();
+  });
+});
+
+describe("siteMetadata", () => {
+  it("suffixes every page's document title through the template", () => {
+    expect(siteMetadata.title).toEqual({
+      default: "Measure",
+      template: "%s | Measure",
+    });
+  });
+
+  it("declares no canonical link, which pages would inherit", () => {
+    expect(siteMetadata.alternates).toBeUndefined();
+  });
+
+  it("carries fallback social tags for routes without their own", () => {
+    expect(openGraphOf(siteMetadata).title).toBe("Measure");
+    expect(twitterOf(siteMetadata).title).toBe("Measure");
+    expect(twitterOf(siteMetadata).site).toBe(siteHandle);
+  });
+
+  it("resolves relative paths against the site origin", () => {
+    expect(siteMetadata.metadataBase?.toString()).toBe("https://measure.sh/");
+  });
+});
+
+describe("the X account", () => {
+  it("gives the handle and the profile URL the same username", () => {
+    expect(siteXUrl).toBe(`https://x.com/${siteHandle.replace("@", "")}`);
+  });
+});

--- a/frontend/dashboard/__tests__/utils/social_tags_ownership_test.ts
+++ b/frontend/dashboard/__tests__/utils/social_tags_ownership_test.ts
@@ -1,0 +1,54 @@
+/**
+ * Keeps the Open Graph and Twitter card tags in one place. Next merges a
+ * page's metadata into the root layout's one field at a time, so a page
+ * that writes its own openGraph and forgets twitter keeps the layout's
+ * card and shares the home page title under its own URL. That shipped
+ * once already.
+ *
+ * pageMetadata() in app/utils/metadata.ts builds both together, and the
+ * unit tests next to this file cover it. This test is what makes that
+ * coverage reach every page: no other file under app/ may write either
+ * key, so a new page has to go through the helper.
+ */
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const APP_DIR = path.join(ROOT, "app");
+
+// The one file allowed to write the tags, relative to the app directory.
+const METADATA_HELPER = path.join("utils", "metadata.ts");
+
+// An object key rather than the word anywhere, so referrer parsing that
+// talks about "twitter" as a traffic source stays out of the results.
+const SOCIAL_TAG_KEY = /^\s*(openGraph|twitter)\s*:/;
+
+function sourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...sourceFiles(fullPath));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function filesWritingSocialTags(): string[] {
+  return sourceFiles(APP_DIR)
+    .filter((file) => {
+      const lines = fs.readFileSync(file, "utf8").split("\n");
+      return lines.some((line) => SOCIAL_TAG_KEY.test(line));
+    })
+    .map((file) => path.relative(APP_DIR, file))
+    .sort();
+}
+
+describe("social tag ownership", () => {
+  it("builds the openGraph and twitter tags only in the metadata helper", () => {
+    expect(filesWritingSocialTags()).toEqual([METADATA_HELPER]);
+  });
+});

--- a/frontend/dashboard/app/about/page.tsx
+++ b/frontend/dashboard/app/about/page.tsx
@@ -8,7 +8,7 @@ import LandingFooter from "../components/landing_footer";
 import TrackCtaLink from "../components/analytics/track_cta_link";
 import JsonLd from "../components/json_ld";
 import { webPageJsonLd } from "../utils/json_ld";
-import { marketingPageMetadata } from "../utils/metadata";
+import { pageMetadata } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 
 const seo = {
@@ -18,7 +18,7 @@ const seo = {
   path: "/about",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function About() {
   const team = [

--- a/frontend/dashboard/app/blog/[slug]/page.tsx
+++ b/frontend/dashboard/app/blog/[slug]/page.tsx
@@ -6,7 +6,7 @@ import {
   postDateISO,
 } from "@/app/utils/blog_source";
 import { blogPostingJsonLd } from "@/app/utils/json_ld";
-import { sharedOpenGraph } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import { InlineTOC } from "fumadocs-ui/components/inline-toc";
 import type { Metadata } from "next";
 import Image from "next/image";
@@ -103,33 +103,23 @@ export async function generateMetadata(props: PageParams): Promise<Metadata> {
     notFound();
   }
 
-  // The post's own card image when it declares one, the site-wide preview
-  // (with its known dimensions) otherwise. The twitter block must be set
-  // per-page: Next merges metadata shallowly, so without it the root
-  // layout's twitter tags win and X shows the generic site card.
-  const socialImages = page.data.image
-    ? [{ url: page.data.image, alt: page.data.title }]
-    : sharedOpenGraph.images;
-
-  return {
-    title: page.data.title,
-    description: page.data.description,
-    alternates: { canonical: page.url },
-    openGraph: {
-      ...sharedOpenGraph,
-      type: "article",
-      publishedTime: postDate(page).toISOString(),
-      authors: [page.data.author.name],
+  return pageMetadata(
+    {
       title: page.data.title,
       description: page.data.description,
-      url: page.url,
-      images: socialImages,
+      path: page.url,
     },
-    twitter: {
-      card: "summary_large_image",
-      title: page.data.title,
-      description: page.data.description,
-      images: socialImages,
+    {
+      addMeasureSuffixToTitle: false,
+      // The post's own card image when it declares one; leaving this out
+      // falls back to the site-wide preview.
+      images: page.data.image
+        ? [{ url: page.data.image, alt: page.data.title }]
+        : undefined,
+      article: {
+        publishedTime: postDate(page).toISOString(),
+        authors: [page.data.author.name],
+      },
     },
-  };
+  );
 }

--- a/frontend/dashboard/app/blog/page.tsx
+++ b/frontend/dashboard/app/blog/page.tsx
@@ -4,32 +4,24 @@ import {
   getSortedBlogPosts,
   toPostSummary,
 } from "@/app/utils/blog_source";
-import { sharedOpenGraph } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import PostsList from "./components/posts_list";
 
 const title = "Blog";
 
+const base = pageMetadata(
+  { title, description: blogDescription, path: "/blog" },
+  { addMeasureSuffixToTitle: false },
+);
+
 export const metadata: Metadata = {
-  title,
-  description: blogDescription,
+  ...base,
+  // The feed link belongs to this page alone, so it is added on top of
+  // the canonical link the shared helper produces.
   alternates: {
-    canonical: "/blog",
+    ...base.alternates,
     types: { "application/rss+xml": "/blog/rss.xml" },
-  },
-  openGraph: {
-    ...sharedOpenGraph,
-    title,
-    description: blogDescription,
-    url: "/blog",
-  },
-  // Set per-page so X shows this page's card instead of the root
-  // layout's twitter tags (Next merges metadata shallowly).
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description: blogDescription,
-    images: sharedOpenGraph.images,
   },
 };
 

--- a/frontend/dashboard/app/blog/tags/[tag]/page.tsx
+++ b/frontend/dashboard/app/blog/tags/[tag]/page.tsx
@@ -3,7 +3,7 @@ import {
   getPostsByTag,
   toPostSummary,
 } from "@/app/utils/blog_source";
-import { sharedOpenGraph } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -53,23 +53,8 @@ export async function generateMetadata(props: PageParams): Promise<Metadata> {
   const title = `Blog posts tagged ${params.tag}`;
   const description = `Measure blog posts tagged ${params.tag}.`;
 
-  return {
-    title,
-    description,
-    alternates: { canonical: `/blog/tags/${params.tag}` },
-    openGraph: {
-      ...sharedOpenGraph,
-      title,
-      description,
-      url: `/blog/tags/${params.tag}`,
-    },
-    // Set per-page so X shows this page's card instead of the root
-    // layout's twitter tags (Next merges metadata shallowly).
-    twitter: {
-      card: "summary_large_image",
-      title,
-      description,
-      images: sharedOpenGraph.images,
-    },
-  };
+  return pageMetadata(
+    { title, description, path: `/blog/tags/${params.tag}` },
+    { addMeasureSuffixToTitle: false },
+  );
 }

--- a/frontend/dashboard/app/bugsnag-alternative/page.tsx
+++ b/frontend/dashboard/app/bugsnag-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/bugsnag-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/components/alternative_page.tsx
+++ b/frontend/dashboard/app/components/alternative_page.tsx
@@ -1,7 +1,7 @@
 import { LucideCheck, LucideX } from "lucide-react";
 import type { ReactNode } from "react";
 import { webPageJsonLd } from "../utils/json_ld";
-import type { MarketingPageSeo } from "../utils/metadata";
+import type { PageSeo } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import TrackCtaLink from "./analytics/track_cta_link";
 import { buttonVariants } from "./button_variants";
@@ -24,7 +24,7 @@ export type AlternativeDifferentiator = {
 };
 
 export type AlternativePageProps = {
-  seo: MarketingPageSeo;
+  seo: PageSeo;
   title: string;
   intro: ReactNode;
   differentiators: AlternativeDifferentiator[];

--- a/frontend/dashboard/app/components/for_platform_page.tsx
+++ b/frontend/dashboard/app/components/for_platform_page.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import type { ReactNode } from "react";
 import { webPageJsonLd } from "../utils/json_ld";
-import type { MarketingPageSeo } from "../utils/metadata";
+import type { PageSeo } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import TrackCtaLink from "./analytics/track_cta_link";
 import { buttonVariants } from "./button_variants";
@@ -32,7 +32,7 @@ export type PlatformLogo = {
 };
 
 export type ForPlatformPageProps = {
-  seo: MarketingPageSeo;
+  seo: PageSeo;
   title: string;
   logo: PlatformLogo;
   intro: ReactNode;

--- a/frontend/dashboard/app/components/landing_footer.tsx
+++ b/frontend/dashboard/app/components/landing_footer.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { siteXUrl } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { buttonVariants } from "./button_variants";
 import { CookiePreferencesLink } from "./cookie_preferences_link";
@@ -425,7 +426,7 @@ export default function LandingFooter() {
                 />
               </Link>
               <Link
-                href="https://x.com/measure_sh"
+                href={siteXUrl}
                 target="_blank"
                 className={cn(buttonVariants({ variant: "ghost" }), "group")}
               >

--- a/frontend/dashboard/app/components/product_page.tsx
+++ b/frontend/dashboard/app/components/product_page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 import { codingAgents } from "../utils/coding_agents";
 import { webPageJsonLd } from "../utils/json_ld";
-import type { MarketingPageSeo } from "../utils/metadata";
+import type { PageSeo } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import TrackCtaLink from "./analytics/track_cta_link";
 import { buttonVariants } from "./button_variants";
@@ -29,7 +29,7 @@ export type CodingAgentsSection = {
 };
 
 export type ProductPageProps = {
-  seo: MarketingPageSeo;
+  seo: PageSeo;
   title: string;
   intro: ReactNode;
   demo: ProductPageDemo;

--- a/frontend/dashboard/app/crashlytics-alternative/page.tsx
+++ b/frontend/dashboard/app/crashlytics-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/crashlytics-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/datadog-alternative/page.tsx
+++ b/frontend/dashboard/app/datadog-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/datadog-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/docs/[[...slug]]/page.tsx
+++ b/frontend/dashboard/app/docs/[[...slug]]/page.tsx
@@ -2,7 +2,7 @@ import JsonLd from "@/app/components/json_ld";
 import { openapi } from "@/app/utils/openapi_source";
 import { source } from "@/app/utils/docs_source";
 import { breadcrumbJsonLd, techArticleJsonLd } from "@/app/utils/json_ld";
-import { sharedOpenGraph } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import { getBreadcrumbItems } from "fumadocs-core/breadcrumb";
 import {
   DocsBody,
@@ -132,15 +132,8 @@ export async function generateMetadata(props: PageParams): Promise<Metadata> {
   // visible page heading and sidebar label.
   const title = page.data.seoTitle ?? page.data.title;
 
-  return {
-    title,
-    description: page.data.description,
-    alternates: { canonical: page.url },
-    openGraph: {
-      ...sharedOpenGraph,
-      title,
-      description: page.data.description,
-      url: page.url,
-    },
-  };
+  return pageMetadata(
+    { title, description: page.data.description, path: page.url },
+    { addMeasureSuffixToTitle: false },
+  );
 }

--- a/frontend/dashboard/app/embrace-alternative/page.tsx
+++ b/frontend/dashboard/app/embrace-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/embrace-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/for/android/page.tsx
+++ b/frontend/dashboard/app/for/android/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/android",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/for/flutter/page.tsx
+++ b/frontend/dashboard/app/for/flutter/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/flutter",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/for/ios/page.tsx
+++ b/frontend/dashboard/app/for/ios/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/ios",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/for/ipados/page.tsx
+++ b/frontend/dashboard/app/for/ipados/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/ipados",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/for/kmp/page.tsx
+++ b/frontend/dashboard/app/for/kmp/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/kmp",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/for/react-native/page.tsx
+++ b/frontend/dashboard/app/for/react-native/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import ForPlatformPage, {
   type PlatformFeature,
 } from "../../components/for_platform_page";
@@ -14,7 +14,7 @@ const seo = {
   path: "/for/react-native",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const features: PlatformFeature[] = [
   {

--- a/frontend/dashboard/app/layout.tsx
+++ b/frontend/dashboard/app/layout.tsx
@@ -7,36 +7,9 @@ import { Toaster } from "./components/toaster";
 import UTMCapture from "./components/analytics/utm_capture";
 import "./globals.css";
 import { fira_code, josefin_sans, work_sans } from "./utils/fonts";
-import { previewImage, sharedOpenGraph, siteOrigin } from "./utils/metadata";
+import { siteMetadata } from "./utils/metadata";
 
-const title = "Measure";
-const description =
-  "Measure helps mobile teams monitor and fix crashes, ANRs, bugs, and performance issues. The open source alternative to Firebase Crashlytics.";
-
-export const metadata: Metadata = {
-  metadataBase: new URL(siteOrigin),
-
-  title: {
-    default: title,
-    template: `%s | ${title}`,
-  },
-
-  description: description,
-
-  openGraph: {
-    ...sharedOpenGraph,
-    title: title,
-    description: description,
-    url: "/",
-  },
-
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-    images: [previewImage],
-  },
-};
+export const metadata: Metadata = siteMetadata;
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/frontend/dashboard/app/luciq-alternative/page.tsx
+++ b/frontend/dashboard/app/luciq-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/luciq-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/new-relic-alternative/page.tsx
+++ b/frontend/dashboard/app/new-relic-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/new-relic-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/page.tsx
+++ b/frontend/dashboard/app/page.tsx
@@ -20,7 +20,7 @@ import {
   softwareApplicationJsonLd,
   webSiteJsonLd,
 } from "./utils/json_ld";
-import { marketingPageMetadata } from "./utils/metadata";
+import { pageMetadata } from "./utils/metadata";
 import { cn } from "./utils/shadcn_utils";
 import { underlineLinkStyle } from "./utils/shared_styles";
 
@@ -31,7 +31,7 @@ const seo = {
   path: "/",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const KukuFmLogo = ({ className }: { className?: string }) => (
   <svg

--- a/frontend/dashboard/app/pricing/page.tsx
+++ b/frontend/dashboard/app/pricing/page.tsx
@@ -7,7 +7,7 @@ import LandingHeader from "../components/landing_header";
 import PricingViewed from "./pricing_viewed";
 import JsonLd from "../components/json_ld";
 import { webPageJsonLd } from "../utils/json_ld";
-import { marketingPageMetadata } from "../utils/metadata";
+import { pageMetadata } from "../utils/metadata";
 import {
   FREE_GB,
   FREE_RETENTION_DAYS,
@@ -26,7 +26,7 @@ const seo = {
   path: "/pricing",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function Pricing() {
   return (

--- a/frontend/dashboard/app/privacy-policy/page.tsx
+++ b/frontend/dashboard/app/privacy-policy/page.tsx
@@ -6,7 +6,7 @@ import LandingHeader from "../components/landing_header";
 import TrackCtaLink from "../components/analytics/track_cta_link";
 import JsonLd from "../components/json_ld";
 import { webPageJsonLd } from "../utils/json_ld";
-import { marketingPageMetadata } from "../utils/metadata";
+import { pageMetadata } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -17,7 +17,7 @@ const seo = {
   path: "/privacy-policy",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function PrivacyPolicy() {
   return (

--- a/frontend/dashboard/app/product/adaptive-capture/page.tsx
+++ b/frontend/dashboard/app/product/adaptive-capture/page.tsx
@@ -1,6 +1,6 @@
 import AdaptiveCaptureDemo from "@/app/components/adaptive_capture_demo";
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 
 const seo = {
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/adaptive-capture",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductAdaptiveCapture() {
   return (

--- a/frontend/dashboard/app/product/agent/page.tsx
+++ b/frontend/dashboard/app/product/agent/page.tsx
@@ -1,6 +1,6 @@
 import AgentDemo from "@/app/components/agent_demo";
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 
 const seo = {
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/agent",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductAgent() {
   return (

--- a/frontend/dashboard/app/product/app-health/page.tsx
+++ b/frontend/dashboard/app/product/app-health/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import OverviewDemo from "./overview_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/app-health",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductAppHealth() {
   return (

--- a/frontend/dashboard/app/product/bug-reports/page.tsx
+++ b/frontend/dashboard/app/product/bug-reports/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import BugReportDemo from "./bug_report_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/bug-reports",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductBugReports() {
   return (

--- a/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
+++ b/frontend/dashboard/app/product/crashes-and-anrs/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import ExceptionsDemo from "./exceptions_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/crashes-and-anrs",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductCrashesAndANRs() {
   return (

--- a/frontend/dashboard/app/product/mcp/page.tsx
+++ b/frontend/dashboard/app/product/mcp/page.tsx
@@ -1,6 +1,6 @@
 import MCPDemo from "@/app/components/mcp_demo";
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 
 const seo = {
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/mcp",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductMCP() {
   return (

--- a/frontend/dashboard/app/product/network-performance/page.tsx
+++ b/frontend/dashboard/app/product/network-performance/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import NetworkDemo from "./network_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/network-performance",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductNetworkPerformance() {
   return (

--- a/frontend/dashboard/app/product/performance-traces/page.tsx
+++ b/frontend/dashboard/app/product/performance-traces/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import TraceDemo from "./trace_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/performance-traces",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductPerformanceTraces() {
   return (

--- a/frontend/dashboard/app/product/session-timelines/page.tsx
+++ b/frontend/dashboard/app/product/session-timelines/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import SessionTimelineDemo from "./session_timeline_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/session-timelines",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductSessionTimelines() {
   return (

--- a/frontend/dashboard/app/product/user-journeys/page.tsx
+++ b/frontend/dashboard/app/product/user-journeys/page.tsx
@@ -1,5 +1,5 @@
 import ProductPage from "@/app/components/product_page";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import type { Metadata } from "next";
 import UserJourneysDemo from "./user_journeys_demo";
 
@@ -10,7 +10,7 @@ const seo = {
   path: "/product/user-journeys",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function ProductUserJourneys() {
   return (

--- a/frontend/dashboard/app/security/page.tsx
+++ b/frontend/dashboard/app/security/page.tsx
@@ -7,7 +7,7 @@ import TrackCtaLink from "../components/analytics/track_cta_link";
 import TrackGithubLink from "../components/analytics/track_github_link";
 import JsonLd from "../components/json_ld";
 import { webPageJsonLd } from "../utils/json_ld";
-import { marketingPageMetadata } from "../utils/metadata";
+import { pageMetadata } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -18,7 +18,7 @@ const seo = {
   path: "/security",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function Security() {
   return (

--- a/frontend/dashboard/app/sentry-alternative/page.tsx
+++ b/frontend/dashboard/app/sentry-alternative/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import AlternativePage, {
   type AlternativeComparisonRow,
   type AlternativeDifferentiator,
@@ -22,7 +22,7 @@ const seo = {
   path: "/sentry-alternative",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 const differentiators: AlternativeDifferentiator[] = [
   {

--- a/frontend/dashboard/app/terms-of-service/page.tsx
+++ b/frontend/dashboard/app/terms-of-service/page.tsx
@@ -6,7 +6,7 @@ import LandingHeader from "../components/landing_header";
 import TrackCtaLink from "../components/analytics/track_cta_link";
 import JsonLd from "../components/json_ld";
 import { webPageJsonLd } from "../utils/json_ld";
-import { marketingPageMetadata } from "../utils/metadata";
+import { pageMetadata } from "../utils/metadata";
 import { cn } from "../utils/shadcn_utils";
 import { underlineLinkStyle } from "../utils/shared_styles";
 
@@ -17,7 +17,7 @@ const seo = {
   path: "/terms-of-service",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function TermsOfService() {
   return (

--- a/frontend/dashboard/app/utils/json_ld.ts
+++ b/frontend/dashboard/app/utils/json_ld.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { previewImage, siteOrigin, type MarketingPageSeo } from "./metadata";
+import { previewImage, siteOrigin, siteXUrl, type PageSeo } from "./metadata";
 
 // Builders return schema.org nodes without "@context"; the JsonLd
 // component adds it when rendering.
@@ -22,7 +22,7 @@ export const organizationJsonLd = {
   },
   sameAs: [
     "https://github.com/measure-sh/measure",
-    "https://x.com/measure_sh",
+    siteXUrl,
     "https://www.linkedin.com/company/measure-sh",
     "https://bsky.app/profile/measure.sh",
   ],
@@ -53,7 +53,7 @@ export function softwareApplicationJsonLd(description: string) {
 }
 
 export function webPageJsonLd(
-  seo: MarketingPageSeo,
+  seo: PageSeo,
   type: "WebPage" | "AboutPage" = "WebPage",
 ) {
   return {

--- a/frontend/dashboard/app/utils/metadata.ts
+++ b/frontend/dashboard/app/utils/metadata.ts
@@ -4,48 +4,143 @@ export const siteOrigin = "https://measure.sh";
 
 const siteName = "measure.sh";
 
+const siteTitle = "Measure";
+
+const siteDescription =
+  "Measure helps mobile teams monitor and fix crashes, ANRs, bugs, and performance issues. The open source alternative to Firebase Crashlytics.";
+
 export const previewImage = "/images/social_preview.png";
 
-export const sharedOpenGraph = {
+// The X account, in the two shapes its consumers need: the @handle for
+// the twitter card tags, and the profile URL for the footer link and the
+// Organization sameAs list.
+const xUsername = "measure_sh";
+export const siteHandle = `@${xUsername}`;
+export const siteXUrl = `https://x.com/${xUsername}`;
+
+const sharedOpenGraph = {
   siteName,
-  images: [
-    {
-      url: previewImage,
-      width: 1200,
-      height: 630,
-      alt: "Measure preview image",
-    },
-  ],
   locale: "en_US",
   type: "website" as const,
 };
 
-export type MarketingPageSeo = {
+type CardImage = {
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+};
+
+const sharedImages: CardImage[] = [
+  {
+    url: previewImage,
+    width: 1200,
+    height: 630,
+    alt: "Measure preview image",
+  },
+];
+
+export type PageSeo = {
   title: string;
-  description: string;
+  description?: string;
   path: string;
 };
 
+export type PageMetadataOptions = {
+  /**
+   * Appends " | Measure" to the Open Graph and card titles, matching the
+   * document title that the root layout's title template produces. Docs
+   * and blog pages turn this off because their titles read as standalone
+   * headlines and already run long.
+   */
+  addMeasureSuffixToTitle?: boolean;
+  /** Share images for this page; the site-wide preview when omitted. */
+  images?: CardImage[];
+  /** Set on blog posts, which are articles rather than site pages. */
+  article?: { publishedTime: string; authors: string[] };
+};
+
+type SocialTags = Pick<Metadata, "openGraph" | "twitter">;
+
 /**
- * Standard metadata for a marketing page: SEO title and description,
- * canonical path and Open Graph tags. The Open Graph title carries the
- * "| Measure" suffix explicitly because the root layout's title template
- * only applies to the document title.
+ * Open Graph and Twitter card tags for one page. Both carry the same
+ * title, description and images, because a scraper reads whichever of
+ * the two it supports and the two disagreeing means the same URL shares
+ * differently on different networks.
+ *
+ * Next merges page metadata into the root layout's one field at a time,
+ * so a page that fills in only openGraph keeps the layout's twitter tags
+ * and X shows the home page title on that page's URL. Building both here
+ * is what keeps a page from setting one and forgetting the other.
  */
-export function marketingPageMetadata({
-  title,
-  description,
-  path,
-}: MarketingPageSeo): Metadata {
+function socialTags(
+  socialTitle: string,
+  description: string | undefined,
+  path: string,
+  images: CardImage[],
+  article: PageMetadataOptions["article"],
+): SocialTags {
+  return {
+    openGraph: {
+      ...sharedOpenGraph,
+      ...(article ? { type: "article" as const, ...article } : {}),
+      title: socialTitle,
+      description,
+      url: path,
+      images,
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: siteHandle,
+      creator: siteHandle,
+      title: socialTitle,
+      description,
+      images,
+    },
+  };
+}
+
+/**
+ * The metadata every page of the site needs: SEO title and description,
+ * canonical path, Open Graph and Twitter card tags. Pages call this
+ * instead of writing the tags themselves, so a new page cannot ship with
+ * half of them filled in.
+ */
+export function pageMetadata(
+  { title, description, path }: PageSeo,
+  {
+    addMeasureSuffixToTitle = true,
+    images = sharedImages,
+    article,
+  }: PageMetadataOptions = {},
+): Metadata {
   return {
     title,
     description,
     alternates: { canonical: path },
-    openGraph: {
-      ...sharedOpenGraph,
-      title: `${title} | Measure`,
+    ...socialTags(
+      addMeasureSuffixToTitle ? `${title} | ${siteTitle}` : title,
       description,
-      url: path,
-    },
+      path,
+      images,
+      article,
+    ),
   };
 }
+
+/**
+ * Metadata for the root layout. It carries the title template that gives
+ * every page its "| Measure" document title, and the social tags that a
+ * route without its own metadata falls back to. It sets no canonical
+ * link: pages declare their own, and one here would be inherited by
+ * every page that does not.
+ */
+export const siteMetadata: Metadata = {
+  metadataBase: new URL(siteOrigin),
+  title: {
+    default: siteTitle,
+    template: `%s | ${siteTitle}`,
+  },
+  description: siteDescription,
+  ...socialTags(siteTitle, siteDescription, "/", sharedImages, undefined),
+};

--- a/frontend/dashboard/app/why-measure/page.tsx
+++ b/frontend/dashboard/app/why-measure/page.tsx
@@ -1,7 +1,7 @@
 import { buttonVariants } from "@/app/components/button_variants";
 import JsonLd from "@/app/components/json_ld";
 import { webPageJsonLd } from "@/app/utils/json_ld";
-import { marketingPageMetadata } from "@/app/utils/metadata";
+import { pageMetadata } from "@/app/utils/metadata";
 import { cn } from "@/app/utils/shadcn_utils";
 import {
   LucideBug,
@@ -24,7 +24,7 @@ const seo = {
   path: "/why-measure",
 };
 
-export const metadata: Metadata = marketingPageMetadata(seo);
+export const metadata: Metadata = pageMetadata(seo);
 
 export default function WhyMeasure() {
   return (


### PR DESCRIPTION
# Description

Next merges page metadata into the root layout's one field at a time, so a page that set only openGraph kept the layout's twitter block. Docs and all 30 marketing pages served the home page title and description in their twitter tags while their Open Graph tags were correct.

Build the title, description, canonical link and both social tag sets in one pageMetadata() helper, and call it from the marketing pages, the docs page, the three blog files and the root layout. Docs and blog opt out of the "| Measure" title suffix to keep their titles as they are. The cards now also carry twitter:site and twitter:creator, which no page had.

Add unit tests for the helper, plus a test that fails if any file under app/ other than the helper writes an openGraph or twitter key, so the unit tests speak for every page.

## Related issue
Closes #4073



