### PR TITLE
fix(gradle): stop hashing the entire sdk in AabSizeTask

### DIFF
--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/AabSizeTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/AabSizeTask.kt
@@ -10,7 +10,7 @@ import com.android.tools.build.bundletool.commands.GetSizeCommand
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
@@ -37,8 +37,18 @@ import java.nio.file.Path
  */
 abstract class AabSizeTask : DefaultTask() {
 
+    // Deliberately @Internal, not @InputDirectory: this points at the whole
+    // resolved Android SDK root, but getAapt2Location() only ever reads one
+    // file out of it (build-tools/<version>/aapt2). @InputDirectory forces
+    // Gradle to content-hash every file under the SDK before it can decide
+    // this task is up-to-date - on CI runners with a large preinstalled SDK
+    // (e.g. GitHub Actions' ubuntu-latest image: 200k+ files) and no prior
+    // successful run to have warmed Gradle's file-hash cache, that hash can
+    // take 10+ minutes on its own, with zero task output in the meantime.
+    // bundleFileProperty (@InputFile) already forces re-execution whenever
+    // the AAB content changes, which covers every real release build.
     @get:Optional
-    @get:InputDirectory
+    @get:Internal
     abstract val androidSdkDir: DirectoryProperty
 
     @get:InputFile

--- a/android/measure-gradle-plugin/src/main/kotlin/sh/measure/AabSizeTask.kt
+++ b/android/measure-gradle-plugin/src/main/kotlin/sh/measure/AabSizeTask.kt
@@ -12,7 +12,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -37,17 +36,6 @@ import java.nio.file.Path
  */
 abstract class AabSizeTask : DefaultTask() {
 
-    // Deliberately @Internal, not @InputDirectory: this points at the whole
-    // resolved Android SDK root, but getAapt2Location() only ever reads one
-    // file out of it (build-tools/<version>/aapt2). @InputDirectory forces
-    // Gradle to content-hash every file under the SDK before it can decide
-    // this task is up-to-date - on CI runners with a large preinstalled SDK
-    // (e.g. GitHub Actions' ubuntu-latest image: 200k+ files) and no prior
-    // successful run to have warmed Gradle's file-hash cache, that hash can
-    // take 10+ minutes on its own, with zero task output in the meantime.
-    // bundleFileProperty (@InputFile) already forces re-execution whenever
-    // the AAB content changes, which covers every real release build.
-    @get:Optional
     @get:Internal
     abstract val androidSdkDir: DirectoryProperty
 


### PR DESCRIPTION
## Description

`AabSizeTask.androidSdkDir` was declared `@InputDirectory`, bound to the
whole resolved Android SDK root, though `getAapt2Location()` only ever
reads one file out of it (`build-tools/<version>/aapt2`). Gradle must
content-hash every file under an `@InputDirectory` property before it can
decide a task is up-to-date, so this made `calculateAabSizeRelease`'s
pre-execution cost scale with the size of the entire installed SDK rather
than the one file actually used.

On CI runners with a large preinstalled SDK and no prior successful run to
warm Gradle's file-hash cache, this hangs for 10+ minutes with zero task
output (full root-cause writeup, live thread dumps, and `strace` evidence in
the linked issue). Measured on GitHub Actions' `ubuntu-latest` image:
209,659 files / 11GB under the SDK root, vs. 34,662 files on a typical local
dev install at similar total size.

This PR marks `androidSdkDir` `@Internal` instead. `bundleFileProperty`
(`@InputFile`) already forces re-execution whenever the AAB content
changes, which covers every real release build, so `androidSdkDir` doesn't
need to be a tracked Gradle input at all.

Happy to switch to a narrower `@Input`/`@InputFiles` declaration (e.g. the
resolved build-tools version, or a glob scoped to `build-tools/*/aapt2`)
instead of `@Internal` if stricter up-to-date correctness is preferred —
noted as an alternative in the issue.

**Note:** I couldn't run the module's test suite locally — `compileTestKotlin`
needs authenticated access to `maven.pkg.github.com/measure-sh/measure` for
an internal SNAPSHOT dependency unrelated to this change. `compileKotlin`
succeeds cleanly with this change, and the existing `AabSizeTaskTest` doesn't
exercise `androidSdkDir`'s annotation either way.

## Related issue
Fixes #4170