### PR TITLE
refactor(frontend): throw from api fetchers instead of returning status objects

### DIFF
--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -18,16 +18,7 @@ jest.mock("@/app/api/api_client", () => ({
 }));
 
 import {
-  AlertsOverviewApiStatus,
-  AppApiKeyChangeApiStatus,
-  AppNameChangeApiStatus,
-  AppsApiStatus,
-  AuthzAndMembersApiStatus,
-  BugReportApiStatus,
-  BugReportsOverviewApiStatus,
-  BugReportsOverviewPlotApiStatus,
   BugReportStatus,
-  BuildsApiStatus,
   buildShortFiltersPostBody,
   changeAppApiKeyFromServer,
   changeAppNameFromServer,
@@ -36,19 +27,14 @@ import {
   createAppFromServer,
   createTeamFromServer,
   defaultFilters,
-  DowngradeToFreeApiStatus,
   downgradeToFreeFromServer,
   downloadBuildFile,
-  UndoDowngradeApiStatus,
   undoDowngradeFromServer,
   fetchAlertsOverviewFromServer,
-  FetchAppRetentionApiStatus,
   fetchAppRetentionFromServer,
   fetchAppsFromServer,
-  FetchAppThresholdPrefsApiStatus,
   fetchAppThresholdPrefsFromServer,
   fetchAuthzAndMembersFromServer,
-  FetchBillingInfoApiStatus,
   fetchBillingInfoFromServer,
   fetchBugReportFromServer,
   fetchBugReportsOverviewFromServer,
@@ -60,15 +46,7 @@ import {
   fetchErrorsDistributionPlotFromServer,
   fetchErrorsOverviewFromServer,
   fetchErrorsOverviewPlotFromServer,
-  ErrorGroupCommonPathApiStatus,
-  ErrorsDetailsApiStatus,
-  ErrorsDetailsPlotApiStatus,
-  ErrorsDistributionPlotApiStatus,
-  ErrorsOverviewApiStatus,
-  ErrorsOverviewPlotApiStatus,
-  FetchCheckoutSessionApiStatus,
   fetchCheckoutSessionFromServer,
-  FetchCustomerPortalUrlApiStatus,
   fetchCustomerPortalUrlFromServer,
   fetchFiltersFromServer,
   fetchJourneyFromServer,
@@ -81,7 +59,6 @@ import {
   fetchNetworkPathsFromServer,
   fetchNetworkTimelinePlotFromServer,
   fetchNetworkTrendsFromServer,
-  FetchNotifPrefsApiStatus,
   fetchNotifPrefsFromServer,
   fetchPendingInvitesFromServer,
   fetchRootSpanNamesFromServer,
@@ -93,66 +70,29 @@ import {
   fetchSpanMetricsPlotFromServer,
   fetchSpansFromServer,
   fetchTeamsFromServer,
-  FetchTeamSlackConnectUrlApiStatus,
   fetchTeamSlackConnectUrlFromServer,
-  FetchTeamSlackStatusApiStatus,
   fetchTeamSlackStatusFromServer,
   fetchTraceFromServer,
-  FetchUsageApiStatus,
   fetchUsageFromServer,
   Filters,
-  FiltersApiStatus,
   FilterSource,
-  InviteMemberApiStatus,
   inviteMemberFromServer,
-  JourneyApiStatus,
   JourneyType,
-  MetricsApiStatus,
-  NetworkDomainsApiStatus,
-  NetworkEndpointLatencyPlotApiStatus,
-  NetworkEndpointStatusCodesPlotApiStatus,
-  NetworkEndpointTimelinePlotApiStatus,
-  NetworkOverviewStatusCodesPlotApiStatus,
-  NetworkPathsApiStatus,
-  NetworkTimelinePlotApiStatus,
-  NetworkTrendsApiStatus,
-  PendingInvitesApiStatus,
-  RemoveMemberApiStatus,
   removeMemberFromServer,
-  RemovePendingInviteApiStatus,
   removePendingInviteFromServer,
-  ResendPendingInviteApiStatus,
   resendPendingInviteFromServer,
-  RoleChangeApiStatus,
   saveListFiltersToServer,
   SdkConfig,
-  SdkConfigApiStatus,
   sendTestSlackAlertFromServer,
-  AppHealthPlotApiStatus,
-  SessionTimelineApiStatus,
-  SessionTimelinesOverviewApiStatus,
-  SessionTimelinesOverviewPlotApiStatus,
-  SpanMetricsPlotApiStatus,
-  SpansApiStatus,
-  TeamNameChangeApiStatus,
-  TeamsApiStatus,
-  TestSlackAlertApiStatus,
-  TraceApiStatus,
-  UpdateAppRetentionApiStatus,
   updateAppRetentionFromServer,
-  UpdateAppThresholdPrefsApiStatus,
   updateAppThresholdPrefsFromServer,
-  UpdateBugReportStatusApiStatus,
   updateBugReportStatusFromServer,
-  UpdateNotifPrefsApiStatus,
   updateNotifPrefsFromServer,
-  UpdateSdkConfigApiStatus,
   updateSdkConfigFromServer,
-  UpdateTeamSlackStatusApiStatus,
   updateTeamSlackStatusFromServer,
-  ValidateInviteApiStatus,
   validateInvitesFromServer,
 } from "@/app/api/api_calls";
+import { ApiError, RequestError } from "@/app/api/api_error";
 
 jest.spyOn(console, "log").mockImplementation(() => {});
 jest.spyOn(console, "error").mockImplementation(() => {});
@@ -315,85 +255,95 @@ describe("saveListFiltersToServer", () => {
 // ========================================================================
 describe("simple GET helpers", () => {
   describe("fetchTeamsFromServer", () => {
-    it("hits /api/teams and returns Success with data", async () => {
+    it("hits /api/teams and returns the body", async () => {
       const data = [{ id: "t1", name: "Team 1" }];
       mockApiClientFetch.mockResolvedValueOnce(successResponse(data));
       const result = await fetchTeamsFromServer();
       expect(lastFetchUrl()).toBe("/api/teams");
-      expect(result).toEqual({ status: TeamsApiStatus.Success, data });
+      expect(result).toEqual(data);
     });
 
-    it("returns Error on non-ok response", async () => {
+    it("throws on non-ok response", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      const result = await fetchTeamsFromServer();
-      expect(result).toEqual({ status: TeamsApiStatus.Error, data: null });
+      await expect(fetchTeamsFromServer()).rejects.toThrow(ApiError);
     });
 
-    it("returns Cancelled on exception", async () => {
+    it("throws on exception", async () => {
       mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-      const result = await fetchTeamsFromServer();
-      expect(result).toEqual({ status: TeamsApiStatus.Cancelled, data: null });
+      await expect(fetchTeamsFromServer()).rejects.toThrow(RequestError);
     });
   });
 
   describe("fetchAppsFromServer", () => {
-    it("returns Success on 200", async () => {
+    it("returns the body on 200", async () => {
       mockApiClientFetch.mockResolvedValueOnce(successResponse([{ id: "a1" }]));
       const result = await fetchAppsFromServer("team-1");
       expect(lastFetchUrl()).toBe("/api/teams/team-1/apps");
-      expect(result.status).toBe(AppsApiStatus.Success);
-      expect(result.data).toEqual([{ id: "a1" }]);
+      expect(result).toEqual([{ id: "a1" }]);
     });
 
-    it("returns NoApps on 404", async () => {
+    it("returns an empty list on 404", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse(404));
       const result = await fetchAppsFromServer("team-1");
-      expect(result).toEqual({ status: AppsApiStatus.NoApps, data: null });
+      expect(result).toEqual([]);
     });
 
-    it("returns Error on other non-ok statuses", async () => {
+    it("throws on other non-ok statuses", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse(500));
-      const result = await fetchAppsFromServer("team-1");
-      expect(result).toEqual({ status: AppsApiStatus.Error, data: null });
+      await expect(fetchAppsFromServer("team-1")).rejects.toThrow(ApiError);
     });
 
-    it("returns Cancelled on exception", async () => {
+    it("throws on exception", async () => {
       mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-      const result = await fetchAppsFromServer("team-1");
-      expect(result.status).toBe(AppsApiStatus.Cancelled);
+      await expect(fetchAppsFromServer("team-1")).rejects.toThrow(RequestError);
     });
   });
 
   describe("fetchRootSpanNamesFromServer", () => {
     const app = { id: "app-1" } as any;
 
-    it("hits /spans/roots/names and returns Success", async () => {
+    it("hits /spans/roots/names and returns the names", async () => {
       mockApiClientFetch.mockResolvedValueOnce(
         successResponse({ results: ["main", "db"] }),
       );
       const result = await fetchRootSpanNamesFromServer(app);
       expect(lastFetchUrl()).toBe("/api/apps/app-1/spans/roots/names");
-      expect((result as any).data.results).toEqual(["main", "db"]);
+      expect(result).toEqual(["main", "db"]);
     });
 
-    it("returns NoData when data.results is null", async () => {
+    it("returns null when the app has never reported a trace", async () => {
       mockApiClientFetch.mockResolvedValueOnce(
         successResponse({ results: null }),
       );
       const result = await fetchRootSpanNamesFromServer(app);
-      expect(result.data).toBeNull();
+      expect(result).toBeNull();
     });
 
-    it("returns Error on non-ok", async () => {
+    it("keeps an empty results list distinct from a null one", async () => {
+      mockApiClientFetch.mockResolvedValueOnce(
+        successResponse({ results: [] }),
+      );
+      const result = await fetchRootSpanNamesFromServer(app);
+      expect(result).toEqual([]);
+    });
+
+    it("throws on non-ok", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      const result = await fetchRootSpanNamesFromServer(app);
-      expect(result.data).toBeNull();
+      await expect(fetchRootSpanNamesFromServer(app)).rejects.toThrow(ApiError);
     });
 
-    it("returns Cancelled on exception", async () => {
+    it("throws a RequestError when the body is missing altogether", async () => {
+      mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
+      const err = await fetchRootSpanNamesFromServer(app).catch((e) => e);
+      expect(err).toBeInstanceOf(RequestError);
+      expect(err.message).toBe("Failed to fetch root span names");
+    });
+
+    it("throws on exception", async () => {
       mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-      const result = await fetchRootSpanNamesFromServer(app);
-      expect(result.data).toBeNull();
+      await expect(fetchRootSpanNamesFromServer(app)).rejects.toThrow(
+        RequestError,
+      );
     });
   });
 
@@ -404,19 +354,19 @@ describe("simple GET helpers", () => {
       );
       const result = await fetchTraceFromServer("app-1", "t1");
       expect(lastFetchUrl()).toBe("/api/apps/app-1/traces/t1");
-      expect(result.status).toBe(TraceApiStatus.Success);
+      expect(result).toEqual({ trace_id: "t1" });
     });
 
-    it("returns Error on non-ok", async () => {
+    it("throws on non-ok", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      const result = await fetchTraceFromServer("a", "t");
-      expect(result.status).toBe(TraceApiStatus.Error);
+      await expect(fetchTraceFromServer("a", "t")).rejects.toThrow(ApiError);
     });
 
-    it("returns Cancelled on exception", async () => {
+    it("throws on exception", async () => {
       mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-      const result = await fetchTraceFromServer("a", "t");
-      expect(result.status).toBe(TraceApiStatus.Cancelled);
+      await expect(fetchTraceFromServer("a", "t")).rejects.toThrow(
+        RequestError,
+      );
     });
   });
 });
@@ -451,7 +401,17 @@ describe("fetchFiltersFromServer", () => {
     expect(url).toContain("ud_attr_keys=1");
   });
 
-  it("returns Success when the server has filter data", async () => {
+  it("throws a RequestError when the body is missing altogether", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
+    const err = await fetchFiltersFromServer(
+      onboardedApp,
+      FilterSource.Events,
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect(err.message).toBe("Failed to fetch filters");
+  });
+
+  it("reports options when the server has filter data", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ versions: ["1.0.0"] }),
     );
@@ -459,7 +419,7 @@ describe("fetchFiltersFromServer", () => {
       onboardedApp,
       FilterSource.Events,
     );
-    expect(result.status).toBe(FiltersApiStatus.Success);
+    expect(result).toEqual({ kind: "options", data: { versions: ["1.0.0"] } });
   });
 
   it("returns NoBuilds for the Builds source when the app has no builds", async () => {
@@ -470,10 +430,10 @@ describe("fetchFiltersFromServer", () => {
       onboardedApp,
       FilterSource.Builds,
     );
-    expect(result.status).toBe(FiltersApiStatus.NoBuilds);
+    expect(result).toEqual({ kind: "no-builds" });
   });
 
-  it("returns NoData when the app is onboarded but has no versions", async () => {
+  it("reports no-data when the app is onboarded but has no versions", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ versions: null }),
     );
@@ -481,7 +441,7 @@ describe("fetchFiltersFromServer", () => {
       onboardedApp,
       FilterSource.Events,
     );
-    expect(result.status).toBe(FiltersApiStatus.NoData);
+    expect(result).toEqual({ kind: "no-data" });
   });
 
   it("returns NotOnboarded when the app is not onboarded", async () => {
@@ -492,25 +452,21 @@ describe("fetchFiltersFromServer", () => {
       notOnboardedApp,
       FilterSource.Events,
     );
-    expect(result.status).toBe(FiltersApiStatus.NotOnboarded);
+    expect(result).toEqual({ kind: "not-onboarded" });
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const result = await fetchFiltersFromServer(
-      onboardedApp,
-      FilterSource.Events,
-    );
-    expect(result.status).toBe(FiltersApiStatus.Error);
+    await expect(
+      fetchFiltersFromServer(onboardedApp, FilterSource.Events),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const result = await fetchFiltersFromServer(
-      onboardedApp,
-      FilterSource.Events,
-    );
-    expect(result.status).toBe(FiltersApiStatus.Cancelled);
+    await expect(
+      fetchFiltersFromServer(onboardedApp, FilterSource.Events),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -537,33 +493,18 @@ describe("fetch functions that use applyGenericFiltersToUrl", () => {
   });
 
   it.each([
-    [
-      "fetchMetricsFromServer",
-      fetchMetricsFromServer,
-      MetricsApiStatus.Success,
-      MetricsApiStatus.Error,
-      MetricsApiStatus.Cancelled,
-    ],
-    [
-      "fetchSpanMetricsPlotFromServer",
-      fetchSpanMetricsPlotFromServer,
-      SpanMetricsPlotApiStatus.Success,
-      SpanMetricsPlotApiStatus.Error,
-      SpanMetricsPlotApiStatus.Cancelled,
-    ],
-  ])(
-    "%s: Success / Error / Cancelled status transitions",
-    async (_name, fn, okStatus, errStatus, cancelStatus) => {
-      mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-      expect((await (fn as any)(makeFilters())).status).toBe(okStatus);
+    ["fetchMetricsFromServer", fetchMetricsFromServer],
+    ["fetchSpanMetricsPlotFromServer", fetchSpanMetricsPlotFromServer],
+  ])("%s: returns data, throws on failure", async (_name, fn) => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ a: 1 }));
+    expect(await (fn as any)(makeFilters())).toEqual({ a: 1 });
 
-      mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      expect((await (fn as any)(makeFilters())).status).toBe(errStatus);
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect((fn as any)(makeFilters())).rejects.toThrow(ApiError);
 
-      mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-      expect((await (fn as any)(makeFilters())).status).toBe(cancelStatus);
-    },
-  );
+    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+    await expect((fn as any)(makeFilters())).rejects.toThrow(RequestError);
+  });
 
   it("fetchSpansFromServer includes limit/offset in URL", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
@@ -582,25 +523,25 @@ describe("fetch functions that use applyGenericFiltersToUrl", () => {
     expect(lastFetchUrl()).toContain("offset=20");
   });
 
-  it("fetchSessionTimelinesOverviewPlotFromServer returns NoData when data is null", async () => {
+  it("fetchSessionTimelinesOverviewPlotFromServer returns null when the body is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const result =
       await fetchSessionTimelinesOverviewPlotFromServer(makeFilters());
-    expect(result.status).toBe(SessionTimelinesOverviewPlotApiStatus.NoData);
+    expect(result).toBeNull();
   });
 
-  it("fetchSessionTimelinesOverviewPlotFromServer returns Error on non-ok", async () => {
+  it("fetchSessionTimelinesOverviewPlotFromServer throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const result =
-      await fetchSessionTimelinesOverviewPlotFromServer(makeFilters());
-    expect(result.status).toBe(SessionTimelinesOverviewPlotApiStatus.Error);
+    await expect(
+      fetchSessionTimelinesOverviewPlotFromServer(makeFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("fetchSessionTimelinesOverviewPlotFromServer returns Cancelled on exception", async () => {
+  it("fetchSessionTimelinesOverviewPlotFromServer throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const result =
-      await fetchSessionTimelinesOverviewPlotFromServer(makeFilters());
-    expect(result.status).toBe(SessionTimelinesOverviewPlotApiStatus.Cancelled);
+    await expect(
+      fetchSessionTimelinesOverviewPlotFromServer(makeFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -631,16 +572,18 @@ describe("fetchJourneyFromServer", () => {
     expect(lastFetchUrl()).toContain("/api/apps/app-a/journey");
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchJourneyFromServer(false, makeFilters());
-    expect(r.status).toBe(JourneyApiStatus.Error);
+    await expect(fetchJourneyFromServer(false, makeFilters())).rejects.toThrow(
+      ApiError,
+    );
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchJourneyFromServer(false, makeFilters());
-    expect(r.status).toBe(JourneyApiStatus.Cancelled);
+    await expect(fetchJourneyFromServer(false, makeFilters())).rejects.toThrow(
+      RequestError,
+    );
   });
 });
 
@@ -648,7 +591,7 @@ describe("fetchJourneyFromServer", () => {
 // fetchAppHealthPlotFromServer — single /health/plots/instances fetch
 // ========================================================================
 describe("fetchAppHealthPlotFromServer", () => {
-  it("returns Success and maps the three server series to display series", async () => {
+  it("maps the three server series to display series", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse([
         { id: "sessions", data: [{ datetime: "2026-01-01", instances: 100 }] },
@@ -658,12 +601,7 @@ describe("fetchAppHealthPlotFromServer", () => {
     );
 
     const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.Success);
-    expect(r.data?.map((s: any) => s.id)).toEqual([
-      "Sessions",
-      "Crashes",
-      "ANRs",
-    ]);
+    expect(r?.map((s: any) => s.id)).toEqual(["Sessions", "Crashes", "ANRs"]);
   });
 
   it("hits the health plots endpoint", async () => {
@@ -674,19 +612,20 @@ describe("fetchAppHealthPlotFromServer", () => {
     );
   });
 
-  it("returns Error when the fetch returns a non-ok response", async () => {
+  it("throws when the fetch returns a non-ok response", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.Error);
+    await expect(fetchAppHealthPlotFromServer(makeFilters())).rejects.toThrow(
+      ApiError,
+    );
   });
 
-  it("returns NoData when the response body is null", async () => {
+  it("returns null when the response body is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("returns NoData when every series value is zero", async () => {
+  it("returns null when every series value is zero", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse([
         { id: "sessions", data: [{ datetime: "2026-01-01", instances: 0 }] },
@@ -695,7 +634,7 @@ describe("fetchAppHealthPlotFromServer", () => {
       ]),
     );
     const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
   it("drops the ANRs series when all ANR values are zero", async () => {
@@ -707,8 +646,7 @@ describe("fetchAppHealthPlotFromServer", () => {
       ]),
     );
     const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.Success);
-    expect(r.data?.map((s: any) => s.id)).toEqual(["Sessions", "Crashes"]);
+    expect(r?.map((s: any) => s.id)).toEqual(["Sessions", "Crashes"]);
   });
 });
 
@@ -718,7 +656,7 @@ describe("fetchAppHealthPlotFromServer", () => {
 describe("network endpoint fetches", () => {
   const app = { id: "app-1" } as any;
 
-  it("fetchNetworkDomainsFromServer hits /networkRequests/domains with from/to and returns Success with results", async () => {
+  it("fetchNetworkDomainsFromServer hits /networkRequests/domains with from/to and returns the results", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: ["example.com"] }),
     );
@@ -727,10 +665,10 @@ describe("network endpoint fetches", () => {
     expect(url).toContain("/api/apps/app-1/networkRequests/domains");
     expect(url).toContain("from=");
     expect(url).toContain("to=");
-    expect(r.status).toBe(NetworkDomainsApiStatus.Success);
+    expect(r).toEqual({ results: ["example.com"] });
   });
 
-  it("fetchNetworkPathsFromServer hits /networkRequests/paths with domain/search and returns Success with results", async () => {
+  it("fetchNetworkPathsFromServer hits /networkRequests/paths with domain/search and returns the results", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: ["/api/users"] }),
     );
@@ -744,10 +682,10 @@ describe("network endpoint fetches", () => {
     expect(url).toContain("/api/apps/app-1/networkRequests/paths");
     expect(url).toContain("domain=api.example.com");
     expect(url).toContain("search=search");
-    expect(r.status).toBe(NetworkPathsApiStatus.Success);
+    expect(r).toEqual({ results: ["/api/users"] });
   });
 
-  it("fetchNetworkEndpointLatencyPlotFromServer uses endpointLatency path and returns Success on non-null body", async () => {
+  it("fetchNetworkEndpointLatencyPlotFromServer uses endpointLatency path and returns the body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ points: [1] }));
     const r = await fetchNetworkEndpointLatencyPlotFromServer(
       makeFilters(),
@@ -757,10 +695,10 @@ describe("network endpoint fetches", () => {
     expect(lastFetchUrl()).toContain(
       "/api/apps/app-a/networkRequests/plots/endpointLatency",
     );
-    expect(r.status).toBe(NetworkEndpointLatencyPlotApiStatus.Success);
+    expect(r).toEqual({ points: [1] });
   });
 
-  it("fetchNetworkEndpointStatusCodesPlotFromServer uses endpointStatusCodes path and returns Success on non-null body", async () => {
+  it("fetchNetworkEndpointStatusCodesPlotFromServer uses endpointStatusCodes path and returns the body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ points: [1] }));
     const r = await fetchNetworkEndpointStatusCodesPlotFromServer(
       makeFilters(),
@@ -770,10 +708,10 @@ describe("network endpoint fetches", () => {
     expect(lastFetchUrl()).toContain(
       "/api/apps/app-a/networkRequests/plots/endpointStatusCodes",
     );
-    expect(r.status).toBe(NetworkEndpointStatusCodesPlotApiStatus.Success);
+    expect(r).toEqual({ points: [1] });
   });
 
-  it("fetchNetworkEndpointTimelinePlotFromServer uses endpointTimeline path and returns Success with points", async () => {
+  it("fetchNetworkEndpointTimelinePlotFromServer uses endpointTimeline path and returns the points", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ points: [{ t: 1 }] }),
     );
@@ -785,10 +723,10 @@ describe("network endpoint fetches", () => {
     expect(lastFetchUrl()).toContain(
       "/api/apps/app-a/networkRequests/plots/endpointTimeline",
     );
-    expect(r.status).toBe(NetworkEndpointTimelinePlotApiStatus.Success);
+    expect(r).toEqual({ points: [{ t: 1 }] });
   });
 
-  it("fetchNetworkTimelinePlotFromServer uses overviewTimeline path and returns Success with points", async () => {
+  it("fetchNetworkTimelinePlotFromServer uses overviewTimeline path and returns the points", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ points: [{ t: 1 }] }),
     );
@@ -798,20 +736,20 @@ describe("network endpoint fetches", () => {
       "/api/apps/app-a/networkRequests/plots/overviewTimeline",
     );
     expect(url).toContain("timeline_limit=25");
-    expect(r.status).toBe(NetworkTimelinePlotApiStatus.Success);
+    expect(r).toEqual({ points: [{ t: 1 }] });
   });
 
-  it("fetchNetworkOverviewStatusCodesPlotFromServer uses overviewStatusCodes path and returns Success with data", async () => {
+  it("fetchNetworkOverviewStatusCodesPlotFromServer uses overviewStatusCodes path and returns the body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([{ code: 200 }]));
     const r =
       await fetchNetworkOverviewStatusCodesPlotFromServer(makeFilters());
     expect(lastFetchUrl()).toContain(
       "/api/apps/app-a/networkRequests/plots/overviewStatusCodes",
     );
-    expect(r.status).toBe(NetworkOverviewStatusCodesPlotApiStatus.Success);
+    expect(r).toEqual([{ code: 200 }]);
   });
 
-  it("fetchNetworkTrendsFromServer uses /networkRequests/trends with trends_limit and handles status transitions", async () => {
+  it("fetchNetworkTrendsFromServer uses /networkRequests/trends with trends_limit and throws on failure", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
     await fetchNetworkTrendsFromServer(makeFilters(), 15);
     const url = lastFetchUrl();
@@ -819,13 +757,13 @@ describe("network endpoint fetches", () => {
     expect(url).toContain("trends_limit=15");
 
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    expect((await fetchNetworkTrendsFromServer(makeFilters())).status).toBe(
-      NetworkTrendsApiStatus.Error,
+    await expect(fetchNetworkTrendsFromServer(makeFilters())).rejects.toThrow(
+      ApiError,
     );
 
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    expect((await fetchNetworkTrendsFromServer(makeFilters())).status).toBe(
-      NetworkTrendsApiStatus.Cancelled,
+    await expect(fetchNetworkTrendsFromServer(makeFilters())).rejects.toThrow(
+      RequestError,
     );
   });
 });
@@ -846,17 +784,17 @@ describe("sessions, bug reports, alerts", () => {
     expect(lastFetchUrl()).toContain("/api/apps/app-a/bugReports");
   });
 
-  it("fetchBugReportsOverviewPlotFromServer returns NoData on null", async () => {
+  it("fetchBugReportsOverviewPlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchBugReportsOverviewPlotFromServer(makeFilters());
-    expect(r.status).toBe(BugReportsOverviewPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchBugReportFromServer returns Success on 200", async () => {
+  it("fetchBugReportFromServer returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ bug: {} }));
     const r = await fetchBugReportFromServer("app-1", "bug-1");
     expect(lastFetchUrl()).toContain("/api/apps/app-1/bugReports/bug-1");
-    expect(r.status).toBe(BugReportApiStatus.Success);
+    expect(r).toEqual({ bug: {} });
   });
 
   it("updateBugReportStatusFromServer PATCHes with new status", async () => {
@@ -884,16 +822,18 @@ describe("sessions, bug reports, alerts", () => {
     expect(url).toContain("offset=20");
   });
 
-  it("fetchBuildsFromServer returns Error on a non-ok response", async () => {
+  it("fetchBuildsFromServer throws on a non-ok response", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const result = await fetchBuildsFromServer(makeFilters(), 10, 0);
-    expect(result.status).toBe(BuildsApiStatus.Error);
+    await expect(fetchBuildsFromServer(makeFilters(), 10, 0)).rejects.toThrow(
+      ApiError,
+    );
   });
 
-  it("fetchBuildsFromServer returns Error when the request throws", async () => {
+  it("fetchBuildsFromServer throws when the request throws", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-    const result = await fetchBuildsFromServer(makeFilters(), 10, 0);
-    expect(result.status).toBe(BuildsApiStatus.Error);
+    await expect(fetchBuildsFromServer(makeFilters(), 10, 0)).rejects.toThrow(
+      RequestError,
+    );
   });
 });
 
@@ -955,25 +895,25 @@ describe("downloadBuildFile", () => {
 // ========================================================================
 describe("team management mutations", () => {
   describe("changeTeamNameFromServer", () => {
-    it("returns Success on 200", async () => {
+    it("returns the body on 200", async () => {
       mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
       const r = await changeTeamNameFromServer("t1", "New");
       expect(lastFetchOpts().method).toBe("PATCH");
       expect(JSON.parse(lastFetchOpts().body).name).toBe("New");
-      expect(r.status).toBe(TeamNameChangeApiStatus.Success);
+      expect(r).toBeUndefined();
     });
 
-    it("returns Error on non-ok", async () => {
+    it("throws on non-ok", async () => {
       mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      expect((await changeTeamNameFromServer("t", "x")).status).toBe(
-        TeamNameChangeApiStatus.Error,
+      await expect(changeTeamNameFromServer("t", "x")).rejects.toThrow(
+        ApiError,
       );
     });
 
-    it("returns Cancelled on exception", async () => {
+    it("throws on exception", async () => {
       mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-      expect((await changeTeamNameFromServer("t", "x")).status).toBe(
-        TeamNameChangeApiStatus.Cancelled,
+      await expect(changeTeamNameFromServer("t", "x")).rejects.toThrow(
+        RequestError,
       );
     });
   });
@@ -1008,12 +948,13 @@ describe("team management mutations", () => {
     expect(body[0].role).toBe("admin"); // lowercased
   });
 
-  it("inviteMemberFromServer returns Error with error message", async () => {
+  it("inviteMemberFromServer throws the server error message", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       mockResponse(false, 400, { error: "bad" }),
     );
-    const r = await inviteMemberFromServer("t1", "x@y.z", "admin");
-    expect(r.status).toBe(InviteMemberApiStatus.Error);
+    await expect(
+      inviteMemberFromServer("t1", "x@y.z", "admin"),
+    ).rejects.toThrow("bad");
   });
 
   it("removeMemberFromServer DELETEs", async () => {
@@ -1036,18 +977,18 @@ describe("team management mutations", () => {
     expect(lastFetchOpts().method).toBe("DELETE");
   });
 
-  it("fetchPendingInvitesFromServer returns Success with data", async () => {
+  it("fetchPendingInvitesFromServer returns the body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([{ id: "i1" }]));
     const r = await fetchPendingInvitesFromServer("t1");
     expect(lastFetchUrl()).toContain("/api/teams/t1/invites");
-    expect(r.status).toBe(PendingInvitesApiStatus.Success);
+    expect(r).toEqual([{ id: "i1" }]);
   });
 
-  it("fetchAuthzAndMembersFromServer returns Success with data", async () => {
+  it("fetchAuthzAndMembersFromServer returns the body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ members: [] }));
     const r = await fetchAuthzAndMembersFromServer("t1");
     expect(lastFetchUrl()).toContain("/api/teams/t1/authz");
-    expect(r.status).toBe(AuthzAndMembersApiStatus.Success);
+    expect(r).toEqual({ members: [] });
   });
 });
 
@@ -1060,16 +1001,14 @@ describe("slack and notifications", () => {
       successResponse({ url: "https://slack/oauth" }),
     );
     const r = await fetchTeamSlackConnectUrlFromServer("t1");
-    expect(mockApiClientFetch).toHaveBeenCalledWith(
-      "/api/teams/t1/slack/connect-url",
-    );
-    expect(r.status).toBe(FetchTeamSlackConnectUrlApiStatus.Success);
+    expect(lastFetchUrl()).toBe("/api/teams/t1/slack/connect-url");
+    expect(r).toEqual({ url: "https://slack/oauth" });
   });
 
-  it("fetchTeamSlackStatusFromServer returns Success", async () => {
+  it("fetchTeamSlackStatusFromServer returns the status body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ active: true }));
     const r = await fetchTeamSlackStatusFromServer("t1");
-    expect(r.status).toBe(FetchTeamSlackStatusApiStatus.Success);
+    expect(r).toEqual({ active: true });
   });
 
   it("updateTeamSlackStatusFromServer PATCHes with active flag", async () => {
@@ -1188,7 +1127,7 @@ describe("billing endpoints", () => {
     const r = await downgradeToFreeFromServer("t1");
     expect(lastFetchUrl()).toContain("/api/teams/t1/billing/downgrade");
     expect(lastFetchOpts().method).toBe("PATCH");
-    expect(r.status).toBe(DowngradeToFreeApiStatus.Success);
+    expect(r).toEqual({});
   });
 
   it("undoDowngradeFromServer PATCHes the undo-downgrade endpoint", async () => {
@@ -1198,7 +1137,7 @@ describe("billing endpoints", () => {
     const r = await undoDowngradeFromServer("t1");
     expect(lastFetchUrl()).toContain("/api/teams/t1/billing/undo-downgrade");
     expect(lastFetchOpts().method).toBe("PATCH");
-    expect(r.status).toBe(UndoDowngradeApiStatus.Success);
+    expect(r).toEqual({ status: "cancellation_reverted" });
   });
 
   it("fetchCustomerPortalUrlFromServer POSTs with return url", async () => {
@@ -1209,7 +1148,7 @@ describe("billing endpoints", () => {
     expect(lastFetchOpts().method).toBe("POST");
     const body = JSON.parse(lastFetchOpts().body);
     expect(body.return_url).toBe("https://back");
-    expect(r.status).toBe(FetchCustomerPortalUrlApiStatus.Success);
+    expect(r).toEqual({ url: "https://portal" });
   });
 });
 
@@ -1332,142 +1271,74 @@ describe("applyHttpMethodsToUrl and applySpanFiltersToUrl", () => {
 });
 
 // ========================================================================
-// Error / Cancelled paths for the fetch functions that didn't get them
-// in the happy-path tests above. Parameterized to keep it compact.
+// Failure paths for the fetch functions that didn't get them in the
+// happy-path tests above. Parameterized to keep it compact.
 // ========================================================================
-describe("fetch functions: Error / Cancelled paths", () => {
-  const cases: Array<[string, () => Promise<{ status: any }>, any, any]> = [
+describe("fetch functions: failure paths", () => {
+  const cases: Array<[string, () => Promise<unknown>]> = [
     [
       "fetchSpanMetricsPlotFromServer",
       () => fetchSpanMetricsPlotFromServer(makeFilters()),
-      SpanMetricsPlotApiStatus.Error,
-      SpanMetricsPlotApiStatus.Cancelled,
     ],
-    [
-      "fetchSpansFromServer",
-      () => fetchSpansFromServer(makeFilters(), 10, 0),
-      SpansApiStatus.Error,
-      SpansApiStatus.Cancelled,
-    ],
+    ["fetchSpansFromServer", () => fetchSpansFromServer(makeFilters(), 10, 0)],
     [
       "fetchJourneyFromServer",
       () => fetchJourneyFromServer(false, makeFilters()),
-      JourneyApiStatus.Error,
-      JourneyApiStatus.Cancelled,
     ],
-    [
-      "fetchMetricsFromServer",
-      () => fetchMetricsFromServer(makeFilters()),
-      MetricsApiStatus.Error,
-      MetricsApiStatus.Cancelled,
-    ],
+    ["fetchMetricsFromServer", () => fetchMetricsFromServer(makeFilters())],
     [
       "fetchSessionTimelinesOverviewFromServer",
       () => fetchSessionTimelinesOverviewFromServer(makeFilters(), 10, 0),
-      SessionTimelinesOverviewApiStatus.Error,
-      SessionTimelinesOverviewApiStatus.Cancelled,
     ],
     [
       "fetchAuthzAndMembersFromServer",
       () => fetchAuthzAndMembersFromServer("t1"),
-      AuthzAndMembersApiStatus.Error,
-      AuthzAndMembersApiStatus.Cancelled,
     ],
     [
       "fetchSessionTimelineFromServer",
       () => fetchSessionTimelineFromServer("a", "s"),
-      SessionTimelineApiStatus.Error,
-      SessionTimelineApiStatus.Cancelled,
     ],
     [
       "fetchBugReportsOverviewFromServer",
       () => fetchBugReportsOverviewFromServer(makeFilters(), 5, 0),
-      BugReportsOverviewApiStatus.Error,
-      BugReportsOverviewApiStatus.Cancelled,
     ],
     [
       "fetchBugReportsOverviewPlotFromServer",
       () => fetchBugReportsOverviewPlotFromServer(makeFilters()),
-      BugReportsOverviewPlotApiStatus.Error,
-      BugReportsOverviewPlotApiStatus.Cancelled,
     ],
-    [
-      "fetchBugReportFromServer",
-      () => fetchBugReportFromServer("a", "b"),
-      BugReportApiStatus.Error,
-      BugReportApiStatus.Cancelled,
-    ],
+    ["fetchBugReportFromServer", () => fetchBugReportFromServer("a", "b")],
     [
       "fetchAlertsOverviewFromServer",
       () => fetchAlertsOverviewFromServer(makeFilters(), 20, 0),
-      AlertsOverviewApiStatus.Error,
-      AlertsOverviewApiStatus.Cancelled,
     ],
     [
       "fetchPendingInvitesFromServer",
       () => fetchPendingInvitesFromServer("t1"),
-      PendingInvitesApiStatus.Error,
-      PendingInvitesApiStatus.Cancelled,
     ],
     [
       "fetchTeamSlackConnectUrlFromServer",
       () => fetchTeamSlackConnectUrlFromServer("t"),
-      FetchTeamSlackConnectUrlApiStatus.Error,
-      FetchTeamSlackConnectUrlApiStatus.Cancelled,
     ],
     [
       "fetchTeamSlackStatusFromServer",
       () => fetchTeamSlackStatusFromServer("t1"),
-      FetchTeamSlackStatusApiStatus.Error,
-      FetchTeamSlackStatusApiStatus.Cancelled,
     ],
     [
       "fetchAppThresholdPrefsFromServer",
       () => fetchAppThresholdPrefsFromServer("a"),
-      FetchAppThresholdPrefsApiStatus.Error,
-      FetchAppThresholdPrefsApiStatus.Cancelled,
     ],
-    [
-      "fetchAppRetentionFromServer",
-      () => fetchAppRetentionFromServer("a"),
-      FetchAppRetentionApiStatus.Error,
-      FetchAppRetentionApiStatus.Cancelled,
-    ],
-    [
-      "fetchSdkConfigFromServer",
-      () => fetchSdkConfigFromServer("a"),
-      SdkConfigApiStatus.Error,
-      SdkConfigApiStatus.Cancelled,
-    ],
-    [
-      "fetchBillingInfoFromServer",
-      () => fetchBillingInfoFromServer("t"),
-      FetchBillingInfoApiStatus.Error,
-      FetchBillingInfoApiStatus.Cancelled,
-    ],
-    [
-      "fetchUsageFromServer",
-      () => fetchUsageFromServer("t"),
-      FetchUsageApiStatus.Error,
-      FetchUsageApiStatus.Cancelled,
-    ],
+    ["fetchAppRetentionFromServer", () => fetchAppRetentionFromServer("a")],
+    ["fetchSdkConfigFromServer", () => fetchSdkConfigFromServer("a")],
+    ["fetchBillingInfoFromServer", () => fetchBillingInfoFromServer("t")],
+    ["fetchUsageFromServer", () => fetchUsageFromServer("t")],
     [
       "fetchCheckoutSessionFromServer",
       () => fetchCheckoutSessionFromServer("t", "o"),
-      FetchCheckoutSessionApiStatus.Error,
-      FetchCheckoutSessionApiStatus.Cancelled,
     ],
-    [
-      "fetchNotifPrefsFromServer",
-      () => fetchNotifPrefsFromServer(),
-      FetchNotifPrefsApiStatus.Error,
-      FetchNotifPrefsApiStatus.Cancelled,
-    ],
+    ["fetchNotifPrefsFromServer", () => fetchNotifPrefsFromServer()],
     [
       "fetchNetworkDomainsFromServer",
       () => fetchNetworkDomainsFromServer({ id: "a" } as any, makeFilters()),
-      NetworkDomainsApiStatus.Error,
-      NetworkDomainsApiStatus.Cancelled,
     ],
     [
       "fetchNetworkPathsFromServer",
@@ -1478,205 +1349,101 @@ describe("fetch functions: Error / Cancelled paths", () => {
           "s",
           makeFilters(),
         ),
-      NetworkPathsApiStatus.Error,
-      NetworkPathsApiStatus.Cancelled,
     ],
     [
       "fetchNetworkEndpointLatencyPlotFromServer",
       () => fetchNetworkEndpointLatencyPlotFromServer(makeFilters(), "d", "p"),
-      NetworkEndpointLatencyPlotApiStatus.Error,
-      NetworkEndpointLatencyPlotApiStatus.Cancelled,
     ],
     [
       "fetchNetworkEndpointStatusCodesPlotFromServer",
       () =>
         fetchNetworkEndpointStatusCodesPlotFromServer(makeFilters(), "d", "p"),
-      NetworkEndpointStatusCodesPlotApiStatus.Error,
-      NetworkEndpointStatusCodesPlotApiStatus.Cancelled,
     ],
     [
       "fetchNetworkEndpointTimelinePlotFromServer",
       () => fetchNetworkEndpointTimelinePlotFromServer(makeFilters(), "d", "p"),
-      NetworkEndpointTimelinePlotApiStatus.Error,
-      NetworkEndpointTimelinePlotApiStatus.Cancelled,
     ],
     [
       "fetchNetworkTimelinePlotFromServer",
       () => fetchNetworkTimelinePlotFromServer(makeFilters(), 10),
-      NetworkTimelinePlotApiStatus.Error,
-      NetworkTimelinePlotApiStatus.Cancelled,
     ],
     [
       "fetchNetworkOverviewStatusCodesPlotFromServer",
       () => fetchNetworkOverviewStatusCodesPlotFromServer(makeFilters()),
-      NetworkOverviewStatusCodesPlotApiStatus.Error,
-      NetworkOverviewStatusCodesPlotApiStatus.Cancelled,
     ],
   ];
 
-  it.each(cases)(
-    "%s returns Error on non-ok",
-    async (_name, fn, errStatus, _cancelStatus) => {
-      mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      const result = await fn();
-      expect(result.status).toBe(errStatus);
-    },
-  );
+  it.each(cases)("%s throws on non-ok", async (_name, fn) => {
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(fn()).rejects.toThrow(ApiError);
+  });
 
-  it.each(cases)(
-    "%s returns Cancelled on exception",
-    async (_name, fn, _errStatus, cancelStatus) => {
-      mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-      const result = await fn();
-      expect(result.status).toBe(cancelStatus);
-    },
-  );
+  it.each(cases)("%s throws on exception", async (_name, fn) => {
+    mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
+    await expect(fn()).rejects.toThrow(RequestError);
+  });
 });
 
 // ========================================================================
-// Mutation Error / Cancelled paths
+// Mutation failure paths
 // ========================================================================
-describe("mutation functions: Error / Cancelled paths", () => {
-  const mutations: Array<[string, () => Promise<{ status: any }>, any, any]> = [
-    [
-      "createTeamFromServer",
-      () => createTeamFromServer("x") as any,
-      undefined,
-      undefined,
-    ],
-    [
-      "createAppFromServer",
-      () => createAppFromServer("t", "a") as any,
-      undefined,
-      undefined,
-    ],
-    [
-      "changeTeamNameFromServer",
-      () => changeTeamNameFromServer("t", "x"),
-      TeamNameChangeApiStatus.Error,
-      TeamNameChangeApiStatus.Cancelled,
-    ],
-    [
-      "changeRoleFromServer",
-      () => changeRoleFromServer("t", "admin", "m"),
-      RoleChangeApiStatus.Error,
-      RoleChangeApiStatus.Cancelled,
-    ],
+describe("mutation functions: failure paths", () => {
+  const mutations: Array<[string, () => Promise<unknown>]> = [
+    ["createTeamFromServer", () => createTeamFromServer("x") as any],
+    ["createAppFromServer", () => createAppFromServer("t", "a") as any],
+    ["changeTeamNameFromServer", () => changeTeamNameFromServer("t", "x")],
+    ["changeRoleFromServer", () => changeRoleFromServer("t", "admin", "m")],
     [
       "inviteMemberFromServer",
       () => inviteMemberFromServer("t", "x@y.z", "admin"),
-      InviteMemberApiStatus.Error,
-      InviteMemberApiStatus.Cancelled,
     ],
-    [
-      "removeMemberFromServer",
-      () => removeMemberFromServer("t", "m"),
-      RemoveMemberApiStatus.Error,
-      RemoveMemberApiStatus.Cancelled,
-    ],
+    ["removeMemberFromServer", () => removeMemberFromServer("t", "m")],
     [
       "resendPendingInviteFromServer",
       () => resendPendingInviteFromServer("t", "i"),
-      ResendPendingInviteApiStatus.Error,
-      ResendPendingInviteApiStatus.Cancelled,
     ],
     [
       "removePendingInviteFromServer",
       () => removePendingInviteFromServer("t", "i"),
-      RemovePendingInviteApiStatus.Error,
-      RemovePendingInviteApiStatus.Cancelled,
     ],
     [
       "updateTeamSlackStatusFromServer",
       () => updateTeamSlackStatusFromServer("t", true),
-      UpdateTeamSlackStatusApiStatus.Error,
-      UpdateTeamSlackStatusApiStatus.Cancelled,
     ],
-    [
-      "sendTestSlackAlertFromServer",
-      () => sendTestSlackAlertFromServer("t"),
-      TestSlackAlertApiStatus.Error,
-      TestSlackAlertApiStatus.Cancelled,
-    ],
+    ["sendTestSlackAlertFromServer", () => sendTestSlackAlertFromServer("t")],
     [
       "updateAppThresholdPrefsFromServer",
       () => updateAppThresholdPrefsFromServer("a", {} as any),
-      UpdateAppThresholdPrefsApiStatus.Error,
-      UpdateAppThresholdPrefsApiStatus.Cancelled,
     ],
     [
       "updateAppRetentionFromServer",
       () => updateAppRetentionFromServer("a", {} as any),
-      UpdateAppRetentionApiStatus.Error,
-      UpdateAppRetentionApiStatus.Cancelled,
     ],
-    [
-      "changeAppNameFromServer",
-      () => changeAppNameFromServer("a", "n"),
-      AppNameChangeApiStatus.Error,
-      AppNameChangeApiStatus.Cancelled,
-    ],
-    [
-      "changeAppApiKeyFromServer",
-      () => changeAppApiKeyFromServer("a"),
-      AppApiKeyChangeApiStatus.Error,
-      AppApiKeyChangeApiStatus.Cancelled,
-    ],
-    [
-      "updateNotifPrefsFromServer",
-      () => updateNotifPrefsFromServer({} as any),
-      UpdateNotifPrefsApiStatus.Error,
-      UpdateNotifPrefsApiStatus.Cancelled,
-    ],
-    [
-      "updateSdkConfigFromServer",
-      () => updateSdkConfigFromServer("a", {}),
-      UpdateSdkConfigApiStatus.Error,
-      UpdateSdkConfigApiStatus.Cancelled,
-    ],
+    ["changeAppNameFromServer", () => changeAppNameFromServer("a", "n")],
+    ["changeAppApiKeyFromServer", () => changeAppApiKeyFromServer("a")],
+    ["updateNotifPrefsFromServer", () => updateNotifPrefsFromServer({} as any)],
+    ["updateSdkConfigFromServer", () => updateSdkConfigFromServer("a", {})],
     [
       "updateBugReportStatusFromServer",
       () => updateBugReportStatusFromServer("a", "b", 1),
-      UpdateBugReportStatusApiStatus.Error,
-      UpdateBugReportStatusApiStatus.Cancelled,
     ],
-    [
-      "downgradeToFreeFromServer",
-      () => downgradeToFreeFromServer("t"),
-      DowngradeToFreeApiStatus.Error,
-      DowngradeToFreeApiStatus.Cancelled,
-    ],
-    [
-      "undoDowngradeFromServer",
-      () => undoDowngradeFromServer("t"),
-      UndoDowngradeApiStatus.Error,
-      UndoDowngradeApiStatus.Cancelled,
-    ],
+    ["downgradeToFreeFromServer", () => downgradeToFreeFromServer("t")],
+    ["undoDowngradeFromServer", () => undoDowngradeFromServer("t")],
     [
       "fetchCustomerPortalUrlFromServer",
       () => fetchCustomerPortalUrlFromServer("t", "url"),
-      FetchCustomerPortalUrlApiStatus.Error,
-      FetchCustomerPortalUrlApiStatus.Cancelled,
     ],
   ];
 
-  it.each(mutations.filter(([, , err]) => err !== undefined))(
-    "%s returns Error on non-ok",
-    async (_name, fn, errStatus, _cancelStatus) => {
-      mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-      const result = await fn();
-      expect(result.status).toBe(errStatus);
-    },
-  );
+  it.each(mutations)("%s throws on non-ok", async (_name, fn) => {
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(fn()).rejects.toThrow(ApiError);
+  });
 
-  it.each(mutations.filter(([, , _err, cancel]) => cancel !== undefined))(
-    "%s returns Cancelled on exception",
-    async (_name, fn, _errStatus, cancelStatus) => {
-      mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-      const result = await fn();
-      expect(result.status).toBe(cancelStatus);
-    },
-  );
+  it.each(mutations)("%s throws on exception", async (_name, fn) => {
+    mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
+    await expect(fn()).rejects.toThrow(RequestError);
+  });
 });
 
 // ========================================================================
@@ -1684,16 +1451,17 @@ describe("mutation functions: Error / Cancelled paths", () => {
 // all SessionType values via session-timeline fetches, etc.
 // ========================================================================
 describe("additional branch coverage", () => {
-  it("fetchSpanMetricsPlotFromServer returns NoData when response data is null", async () => {
+  it("fetchSpanMetricsPlotFromServer returns null when response data is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchSpanMetricsPlotFromServer(makeFilters());
-    expect(r.status).toBe(SpanMetricsPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchAppHealthPlotFromServer returns Error when the fetch throws", async () => {
+  it("fetchAppHealthPlotFromServer throws when the fetch throws", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("network down"));
-    const r = await fetchAppHealthPlotFromServer(makeFilters());
-    expect(r.status).toBe(AppHealthPlotApiStatus.Error);
+    await expect(fetchAppHealthPlotFromServer(makeFilters())).rejects.toThrow(
+      RequestError,
+    );
   });
 
   it("appends all span statuses (Unset/Ok/Error) to span endpoint URLs", async () => {
@@ -1746,19 +1514,30 @@ describe("additional branch coverage", () => {
     expect(url).toContain("background=1");
   });
 
-  it("fetchBugReportsOverviewPlotFromServer returns Error on non-ok", async () => {
+  it("fetchBugReportsOverviewPlotFromServer throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchBugReportsOverviewPlotFromServer(makeFilters());
-    expect(r.status).toBe(BugReportsOverviewPlotApiStatus.Error);
+    await expect(
+      fetchBugReportsOverviewPlotFromServer(makeFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("fetchUsageFromServer returns NoApps on 404", async () => {
+  it("fetchUsageFromServer returns null on 404", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse(404));
     const r = await fetchUsageFromServer("t1");
-    expect(r.status).toBe(FetchUsageApiStatus.NoApps);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkDomainsFromServer returns NoData when data.results is null", async () => {
+  it("fetchNetworkDomainsFromServer reports an unparsable date as a RequestError", async () => {
+    const err = await fetchNetworkDomainsFromServer(
+      { id: "app-1" } as any,
+      makeFilters({ startDate: "not-a-date" }),
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect(err.message).toBe("Failed to fetch network domains");
+    expect(mockApiClientFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetchNetworkDomainsFromServer returns null when data.results is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: null }),
     );
@@ -1766,10 +1545,22 @@ describe("additional branch coverage", () => {
       { id: "a" } as any,
       makeFilters(),
     );
-    expect(r.status).toBe(NetworkDomainsApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkPathsFromServer returns NoData when data.results is null", async () => {
+  it("fetchNetworkPathsFromServer reports an unparsable date as a RequestError", async () => {
+    const err = await fetchNetworkPathsFromServer(
+      { id: "app-1" } as any,
+      "api.example.com",
+      "search",
+      makeFilters({ startDate: "not-a-date" }),
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect(err.message).toBe("Failed to fetch network paths");
+    expect(mockApiClientFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetchNetworkPathsFromServer returns null when data.results is null", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: null }),
     );
@@ -1779,56 +1570,56 @@ describe("additional branch coverage", () => {
       "s",
       makeFilters(),
     );
-    expect(r.status).toBe(NetworkPathsApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkEndpointLatencyPlotFromServer returns NoData on null body", async () => {
+  it("fetchNetworkEndpointLatencyPlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchNetworkEndpointLatencyPlotFromServer(
       makeFilters(),
       "d",
       "p",
     );
-    expect(r.status).toBe(NetworkEndpointLatencyPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkEndpointStatusCodesPlotFromServer returns NoData on null body", async () => {
+  it("fetchNetworkEndpointStatusCodesPlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchNetworkEndpointStatusCodesPlotFromServer(
       makeFilters(),
       "d",
       "p",
     );
-    expect(r.status).toBe(NetworkEndpointStatusCodesPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkEndpointTimelinePlotFromServer returns NoData on null body", async () => {
+  it("fetchNetworkEndpointTimelinePlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchNetworkEndpointTimelinePlotFromServer(
       makeFilters(),
       "d",
       "p",
     );
-    expect(r.status).toBe(NetworkEndpointTimelinePlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkTimelinePlotFromServer returns NoData on null body", async () => {
+  it("fetchNetworkTimelinePlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchNetworkTimelinePlotFromServer(makeFilters(), 10);
-    expect(r.status).toBe(NetworkTimelinePlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkOverviewStatusCodesPlotFromServer returns NoData on null body", async () => {
+  it("fetchNetworkOverviewStatusCodesPlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r =
       await fetchNetworkOverviewStatusCodesPlotFromServer(makeFilters());
-    expect(r.status).toBe(NetworkOverviewStatusCodesPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("fetchNetworkTrendsFromServer returns NoData on null body", async () => {
+  it("fetchNetworkTrendsFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchNetworkTrendsFromServer(makeFilters());
-    expect(r.status).toBe(NetworkTrendsApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
   it("AppVersion class constructs name/code/displayName", async () => {
@@ -1861,42 +1652,71 @@ describe("additional branch coverage", () => {
     expect(new OsVersion("windows", "11").displayName).toBe("windows 11");
   });
 
-  it("fetchBugReportsOverviewPlotFromServer returns NoData when data is empty", async () => {
+  it("fetchBugReportsOverviewPlotFromServer passes an empty body through", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
     const r = await fetchBugReportsOverviewPlotFromServer(makeFilters());
-    // Pin whatever the current code considers "no data" for this endpoint.
-    expect([
-      BugReportsOverviewPlotApiStatus.NoData,
-      BugReportsOverviewPlotApiStatus.Success,
-    ]).toContain(r.status);
+    expect(r).toEqual({});
   });
 
-  it("createTeamFromServer returns Error with message on non-ok", async () => {
+  it("createTeamFromServer throws the server message on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       mockResponse(false, 400, { error: "name taken" }),
     );
-    const r = await createTeamFromServer("x");
-    expect(r.status).toBeDefined();
+    await expect(createTeamFromServer("x")).rejects.toThrow("name taken");
   });
 
-  it("createTeamFromServer returns Cancelled on exception", async () => {
+  it("reports a dropped connection as a RequestError naming the operation", async () => {
+    mockApiClientFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const err = await createTeamFromServer("x").catch((e) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect(err.message).toBe("Failed to create team");
+    expect(err.cause).toBeInstanceOf(TypeError);
+  });
+
+  it("reports an unreadable success body as a RequestError", async () => {
+    mockApiClientFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    });
+    const err = await createTeamFromServer("x").catch((e) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect(err.message).toBe("Failed to create team");
+  });
+
+  it("createTeamFromServer falls back when the error body is not JSON", async () => {
+    // A proxy that answers 502 with an HTML page makes res.json() throw.
+    // The message that the user sees must still name the operation.
+    mockApiClientFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError("Unexpected token '<'");
+      },
+    });
+    const err = await createTeamFromServer("x").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(502);
+    expect(err.message).toBe("Failed to create team");
+  });
+
+  it("createTeamFromServer throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await createTeamFromServer("x");
-    expect(r.status).toBeDefined();
+    await expect(createTeamFromServer("x")).rejects.toThrow(RequestError);
   });
 
-  it("createAppFromServer returns Error with message on non-ok", async () => {
+  it("createAppFromServer throws the server message on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       mockResponse(false, 400, { error: "oops" }),
     );
-    const r = await createAppFromServer("t", "a");
-    expect(r.status).toBeDefined();
+    await expect(createAppFromServer("t", "a")).rejects.toThrow("oops");
   });
 
-  it("createAppFromServer returns Cancelled on exception", async () => {
+  it("createAppFromServer throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await createAppFromServer("t", "a");
-    expect(r.status).toBeDefined();
+    await expect(createAppFromServer("t", "a")).rejects.toThrow(RequestError);
   });
 });
 
@@ -1941,13 +1761,12 @@ function lastFetchParams(): URLSearchParams {
 }
 
 describe("fetchErrorsOverviewFromServer", () => {
-  it("returns Success and data on 200", async () => {
+  it("returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: [{ id: "g1" }] }),
     );
     const r = await fetchErrorsOverviewFromServer(makeErrorsFilters(), 5, 0);
-    expect(r.status).toBe(ErrorsOverviewApiStatus.Success);
-    expect(r.data).toEqual({ results: [{ id: "g1" }] });
+    expect(r).toEqual({ results: [{ id: "g1" }] });
   });
 
   it("hits /apps/:id/errorGroups", async () => {
@@ -2004,26 +1823,28 @@ describe("fetchErrorsOverviewFromServer", () => {
     expect(params.has("custom")).toBe(false);
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse(500));
-    const r = await fetchErrorsOverviewFromServer(makeErrorsFilters(), 5, 0);
-    expect(r.status).toBe(ErrorsOverviewApiStatus.Error);
+    await expect(
+      fetchErrorsOverviewFromServer(makeErrorsFilters(), 5, 0),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-    const r = await fetchErrorsOverviewFromServer(makeErrorsFilters(), 5, 0);
-    expect(r.status).toBe(ErrorsOverviewApiStatus.Cancelled);
+    await expect(
+      fetchErrorsOverviewFromServer(makeErrorsFilters(), 5, 0),
+    ).rejects.toThrow(RequestError);
   });
 });
 
 describe("fetchErrorsOverviewPlotFromServer", () => {
-  it("returns Success with data on 200", async () => {
+  it("returns the plot body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse([{ data: [{ datetime: "x", instances: 1 }] }]),
     );
     const r = await fetchErrorsOverviewPlotFromServer(makeErrorsFilters());
-    expect(r.status).toBe(ErrorsOverviewPlotApiStatus.Success);
+    expect(r).toEqual([{ data: [{ datetime: "x", instances: 1 }] }]);
   });
 
   it("hits /apps/:id/errorGroups/plots/instances", async () => {
@@ -2061,22 +1882,24 @@ describe("fetchErrorsOverviewPlotFromServer", () => {
     expect(params.has("custom")).toBe(false);
   });
 
-  it("returns NoData on null body", async () => {
+  it("returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchErrorsOverviewPlotFromServer(makeErrorsFilters());
-    expect(r.status).toBe(ErrorsOverviewPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchErrorsOverviewPlotFromServer(makeErrorsFilters());
-    expect(r.status).toBe(ErrorsOverviewPlotApiStatus.Error);
+    await expect(
+      fetchErrorsOverviewPlotFromServer(makeErrorsFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchErrorsOverviewPlotFromServer(makeErrorsFilters());
-    expect(r.status).toBe(ErrorsOverviewPlotApiStatus.Cancelled);
+    await expect(
+      fetchErrorsOverviewPlotFromServer(makeErrorsFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -2089,7 +1912,7 @@ describe("fetchErrorsDetailsFromServer", () => {
     );
   });
 
-  it("returns Success on 200", async () => {
+  it("returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: [{ id: "e1" }] }),
     );
@@ -2098,8 +1921,7 @@ describe("fetchErrorsDetailsFromServer", () => {
       0,
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDetailsApiStatus.Success);
-    expect(r.data).toEqual({ results: [{ id: "e1" }] });
+    expect(r).toEqual({ results: [{ id: "e1" }] });
   });
 
   it("does NOT append type/severity/custom (single-group endpoint, filters don't apply)", async () => {
@@ -2132,24 +1954,18 @@ describe("fetchErrorsDetailsFromServer", () => {
     expect(params.has("custom")).toBe(false);
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchErrorsDetailsFromServer(
-      "group-1",
-      0,
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDetailsApiStatus.Error);
+    await expect(
+      fetchErrorsDetailsFromServer("group-1", 0, makeErrorsFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchErrorsDetailsFromServer(
-      "group-1",
-      0,
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDetailsApiStatus.Cancelled);
+    await expect(
+      fetchErrorsDetailsFromServer("group-1", 0, makeErrorsFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -2188,7 +2004,7 @@ describe("fetchErrorGroupCommonPathFromServer", () => {
     expect(url).not.toContain("filter_short_code=");
   });
 
-  it("returns Success on 200", async () => {
+  it("returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ sessions_analyzed: 3, steps: [] }),
     );
@@ -2196,26 +2012,21 @@ describe("fetchErrorGroupCommonPathFromServer", () => {
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorGroupCommonPathApiStatus.Success);
-    expect((r.data as any).sessions_analyzed).toBe(3);
+    expect((r as any).sessions_analyzed).toBe(3);
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchErrorGroupCommonPathFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorGroupCommonPathApiStatus.Error);
+    await expect(
+      fetchErrorGroupCommonPathFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchErrorGroupCommonPathFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorGroupCommonPathApiStatus.Cancelled);
+    await expect(
+      fetchErrorGroupCommonPathFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -2249,7 +2060,7 @@ describe("fetchErrorsDetailsPlotFromServer", () => {
     expect(url).not.toContain("custom=");
   });
 
-  it("returns Success on 200", async () => {
+  it("returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse([{ data: [{ datetime: "x", instances: 1 }] }]),
     );
@@ -2257,34 +2068,30 @@ describe("fetchErrorsDetailsPlotFromServer", () => {
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDetailsPlotApiStatus.Success);
+    expect(r).toEqual([{ data: [{ datetime: "x", instances: 1 }] }]);
   });
 
-  it("returns NoData on null body", async () => {
+  it("returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchErrorsDetailsPlotFromServer(
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDetailsPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchErrorsDetailsPlotFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDetailsPlotApiStatus.Error);
+    await expect(
+      fetchErrorsDetailsPlotFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchErrorsDetailsPlotFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDetailsPlotApiStatus.Cancelled);
+    await expect(
+      fetchErrorsDetailsPlotFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -2320,7 +2127,7 @@ describe("fetchErrorsDistributionPlotFromServer", () => {
     expect(params.get("custom")).toBeNull();
   });
 
-  it("returns Success on non-empty body", async () => {
+  it("returns the body when it is non-empty", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ os_version: { "android 13": 5 } }),
     );
@@ -2328,19 +2135,19 @@ describe("fetchErrorsDistributionPlotFromServer", () => {
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDistributionPlotApiStatus.Success);
+    expect(r).toEqual({ os_version: { "android 13": 5 } });
   });
 
-  it("returns NoData on null body", async () => {
+  it("returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
     const r = await fetchErrorsDistributionPlotFromServer(
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDistributionPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("returns NoData on body where every attribute is empty", async () => {
+  it("returns null on a body where every attribute is empty", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ os_version: {}, country: {} }),
     );
@@ -2348,25 +2155,21 @@ describe("fetchErrorsDistributionPlotFromServer", () => {
       "group-1",
       makeErrorsFilters(),
     );
-    expect(r.status).toBe(ErrorsDistributionPlotApiStatus.NoData);
+    expect(r).toBeNull();
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    const r = await fetchErrorsDistributionPlotFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDistributionPlotApiStatus.Error);
+    await expect(
+      fetchErrorsDistributionPlotFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(ApiError);
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await fetchErrorsDistributionPlotFromServer(
-      "group-1",
-      makeErrorsFilters(),
-    );
-    expect(r.status).toBe(ErrorsDistributionPlotApiStatus.Cancelled);
+    await expect(
+      fetchErrorsDistributionPlotFromServer("group-1", makeErrorsFilters()),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -2374,23 +2177,25 @@ describe("fetchErrorsDistributionPlotFromServer", () => {
 // validateInvitesFromServer
 // ========================================================================
 describe("validateInvitesFromServer", () => {
-  it("returns Success on 200", async () => {
+  it("returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
     const r = await validateInvitesFromServer("invite-1");
     expect(lastFetchUrl()).toContain("/api/auth/validateInvite");
     expect(lastFetchOpts().method).toBe("POST");
-    expect(r.status).toBe(ValidateInviteApiStatus.Success);
+    expect(r).toBeUndefined();
   });
 
-  it("returns Error on non-ok", async () => {
+  it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse(400));
-    const r = await validateInvitesFromServer("invite-1");
-    expect(r.status).toBe(ValidateInviteApiStatus.Error);
+    await expect(validateInvitesFromServer("invite-1")).rejects.toThrow(
+      ApiError,
+    );
   });
 
-  it("returns Cancelled on exception", async () => {
+  it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    const r = await validateInvitesFromServer("invite-1");
-    expect(r.status).toBe(ValidateInviteApiStatus.Cancelled);
+    await expect(validateInvitesFromServer("invite-1")).rejects.toThrow(
+      RequestError,
+    );
   });
 });

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -103,15 +103,7 @@ jest.mock("@/app/stores/provider", () => ({
     useStore(storeInstance, selector ?? ((s: any) => s)),
 }));
 
-import {
-  App,
-  AppsApiStatus,
-  AppVersion,
-  FiltersApiStatus,
-  FilterSource,
-  OsVersion,
-  RootSpanNamesApiStatus,
-} from "@/app/api/api_calls";
+import { App, AppVersion, FilterSource, OsVersion } from "@/app/api/api_calls";
 import Filters, {
   AppVersionsInitialSelectionType,
   deserializeUrlFilters,
@@ -195,13 +187,13 @@ function setAppsPending() {
 function setAppsSuccess(apps: App[]) {
   appsQueryState = {
     status: "success",
-    data: { status: AppsApiStatus.Success, data: apps },
+    data: apps,
   };
 }
 function setAppsNoApps() {
   appsQueryState = {
     status: "success",
-    data: { status: AppsApiStatus.NoApps, data: [] },
+    data: [],
   };
 }
 function setAppsError() {
@@ -211,25 +203,25 @@ function setAppsError() {
 function setFiltersSuccess() {
   filterOptionsQueryState = {
     status: "success",
-    data: { status: FiltersApiStatus.Success, data: filterOptionsFixture },
+    data: { kind: "options", data: filterOptionsFixture },
   };
 }
 function setFiltersNoData() {
   filterOptionsQueryState = {
     status: "success",
-    data: { status: FiltersApiStatus.NoData, data: null },
+    data: { kind: "no-data" },
   };
 }
 function setFiltersNoBuilds() {
   filterOptionsQueryState = {
     status: "success",
-    data: { status: FiltersApiStatus.NoBuilds, data: null },
+    data: { kind: "no-builds" },
   };
 }
 function setFiltersNotOnboarded() {
   filterOptionsQueryState = {
     status: "success",
-    data: { status: FiltersApiStatus.NotOnboarded, data: null },
+    data: { kind: "not-onboarded" },
   };
 }
 function setFiltersError() {
@@ -246,8 +238,13 @@ function setFiltersPending() {
 function setRootSpansSuccess(names = ["root.a", "root.b"]) {
   rootSpanNamesQueryState = {
     status: "success",
-    data: { status: RootSpanNamesApiStatus.Success, data: names },
+    data: names,
   };
+}
+// An app that has never reported a trace answers with a null list. The
+// fetcher sends the null through, and does not change it to an empty array.
+function setRootSpansNoData() {
+  rootSpanNamesQueryState = { status: "success", data: null };
 }
 function setRootSpansPending() {
   rootSpanNamesQueryState = { status: "pending", data: undefined };
@@ -420,6 +417,17 @@ describe("Filters — Span filter source", () => {
     });
   });
 
+  it("shows the no-traces message when the app has never reported a trace", async () => {
+    setRootSpansNoData();
+    await renderFilters({ filterSource: FilterSource.Spans });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No traces received for this app yet/),
+      ).toBeInTheDocument();
+    });
+    expect(storeInstance.getState().rootSpanNamesState).toBe("no-data");
+  });
+
   it("renders the trace name dropdown once root span names load", async () => {
     setRootSpansSuccess();
     await renderFilters({ filterSource: FilterSource.Spans });
@@ -447,8 +455,16 @@ describe("Filters — store state after queries resolve", () => {
     await waitFor(() => {
       const state = storeInstance.getState();
       expect(state.apps).toHaveLength(1);
-      expect(state.appsApiStatus).toBe(AppsApiStatus.Success);
-      expect(state.filtersApiStatus).toBe(FiltersApiStatus.Success);
+      expect(state.appsState).toBe("loaded");
+      expect(state.filterOptionsState).toBe("loaded");
+    });
+  });
+
+  it("mirrors an empty apps response as the no-apps state", async () => {
+    setAppsNoApps();
+    await renderFilters();
+    await waitFor(() => {
+      expect(storeInstance.getState().appsState).toBe("no-apps");
     });
   });
 
@@ -493,7 +509,7 @@ describe("Filters — store state after queries resolve", () => {
     setAppsSuccess([makeApp("a")]);
     filterOptionsQueryState = {
       status: "success",
-      data: { status: FiltersApiStatus.Success, data: fixture },
+      data: { kind: "options", data: fixture },
     };
     await renderFilters();
     await waitFor(() => {
@@ -542,7 +558,7 @@ describe("Filters — selectedApp sync on refetch", () => {
     await act(async () => {
       // Mirrors the refetch landing in the store; forces the sync effect
       // (keyed on appsQuery.data) to re-run against the fresh apps list.
-      storeInstance.getState().setApps([next], AppsApiStatus.Success);
+      storeInstance.getState().setApps([next], "loaded");
     });
 
     await waitFor(() => {
@@ -563,7 +579,7 @@ describe("Filters — selectedApp sync on refetch", () => {
     const next = makeApp("a", true);
     setAppsSuccess([next]);
     await act(async () => {
-      storeInstance.getState().setApps([next], AppsApiStatus.Success);
+      storeInstance.getState().setApps([next], "loaded");
     });
 
     await waitFor(() => {
@@ -584,7 +600,7 @@ describe("Filters — selectedApp sync on refetch", () => {
     const refetched = makeApp("a");
     setAppsSuccess([refetched]);
     await act(async () => {
-      storeInstance.getState().setApps([refetched], AppsApiStatus.Success);
+      storeInstance.getState().setApps([refetched], "loaded");
     });
 
     // appsEqual sees no change, so the store keeps the same object reference.

--- a/frontend/dashboard/__tests__/components/metrics_card_test.tsx
+++ b/frontend/dashboard/__tests__/components/metrics_card_test.tsx
@@ -99,8 +99,6 @@ jest.mock("lucide-react", () => ({
   ),
 }));
 
-// MetricsCard now uses string union type 'pending' | 'success' | 'error' instead of MetricsApiStatus enum
-
 describe("MetricsCard", () => {
   const createCrashFreeSessionsProps = (
     overrides = {},

--- a/frontend/dashboard/__tests__/components/onboarding_test.tsx
+++ b/frontend/dashboard/__tests__/components/onboarding_test.tsx
@@ -1,3 +1,4 @@
+import { ApiError } from "@/app/api/api_error";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import {
@@ -51,8 +52,7 @@ jest.mock("@/app/query/hooks", () => ({
     data: { can_create_app: mockCanCreateApp },
   }),
   useAppsQuery: () => ({
-    // AppsApiStatus.Success = 1
-    data: { status: 1, data: mockApps },
+    data: mockApps,
     status: "success",
   }),
 }));
@@ -265,12 +265,9 @@ beforeEach(() => {
   mockIsPending = false;
   mockCanCreateApp = true;
   mockRefetchQueries.mockResolvedValue(undefined);
-  mockFetchAppsFromServer.mockResolvedValue({ status: 1, data: [] });
-  // FiltersApiStatus.Success = 1. Default the polling's filters probe to
-  // Success so tests that drive the apps endpoint to onboarded=true reach
-  // the verified state without per-test setup.
+  mockFetchAppsFromServer.mockResolvedValue([]);
   mockFetchFiltersFromServer.mockResolvedValue({
-    status: 1,
+    kind: "options",
     data: {
       versions: [],
       os_versions: [],
@@ -1330,10 +1327,9 @@ describe("Onboarding — Step 3: Verify", () => {
 
   describe("Polling", () => {
     it("polls fetchAppsFromServer immediately on entering verify step", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1, // AppsApiStatus.Success
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1343,10 +1339,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("shows waiting state while not yet onboarded", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1358,10 +1353,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("polls again every 3 seconds", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1379,14 +1373,12 @@ describe("Onboarding — Step 3: Verify", () => {
 
     it("advances to verified state when target app onboarded flips to true", async () => {
       mockFetchAppsFromServer
-        .mockResolvedValueOnce({
-          status: 1,
-          data: [makeApp({ id: "target-app", onboarded: false })],
-        })
-        .mockResolvedValueOnce({
-          status: 1,
-          data: [makeApp({ id: "target-app", onboarded: true })],
-        });
+        .mockResolvedValueOnce([
+          makeApp({ id: "target-app", onboarded: false }),
+        ])
+        .mockResolvedValueOnce([
+          makeApp({ id: "target-app", onboarded: true }),
+        ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1401,13 +1393,10 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("ignores onboarded flag of other apps in the response", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [
-          makeApp({ id: "target-app", onboarded: false }),
-          makeApp({ id: "other-app", onboarded: true }),
-        ],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+        makeApp({ id: "other-app", onboarded: true }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(3000);
@@ -1418,8 +1407,10 @@ describe("Onboarding — Step 3: Verify", () => {
       expect(screen.getByTestId("onboarding-waiting")).toBeInTheDocument();
     });
 
-    it("does not advance when fetch returns error status", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({ status: 2, data: null });
+    it("does not advance when the apps fetch fails", async () => {
+      mockFetchAppsFromServer.mockRejectedValue(
+        new ApiError(500, "Failed to fetch apps"),
+      );
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(3000);
@@ -1428,10 +1419,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("stops polling after onboarded flag flips", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: true })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: true }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1447,10 +1437,9 @@ describe("Onboarding — Step 3: Verify", () => {
 
   describe("Verified state", () => {
     beforeEach(() => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: true })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: true }),
+      ]);
     });
 
     it("shows the success message", async () => {
@@ -1495,10 +1484,9 @@ describe("Onboarding — Step 3: Verify", () => {
 
   describe("Back to integrate", () => {
     it("renders a Back button while waiting for the crash", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       expect(
         screen.getByTestId("onboarding-back-to-integrate-button"),
@@ -1506,10 +1494,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("returns to the integrate step on click", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         fireEvent.click(
@@ -1526,10 +1513,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("preserves the previously selected platform when going back", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       renderOnboarding({ teamId: "team-7" });
       // Pick iOS, advance to verify, go back, iOS should still be selected.
       fireEvent.click(screen.getByTestId("tab-iOS"));
@@ -1551,10 +1537,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("stops polling once the user goes back", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
@@ -1572,10 +1557,9 @@ describe("Onboarding — Step 3: Verify", () => {
     });
 
     it("persists the step rollback to localStorage", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       await reachVerifyStep();
       await act(async () => {
         fireEvent.click(
@@ -1591,10 +1575,9 @@ describe("Onboarding — Step 3: Verify", () => {
 
   describe("Cleanup", () => {
     it("stops polling after the component unmounts", async () => {
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: false })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: false }),
+      ]);
       const { unmount } = renderOnboarding({ teamId: "team-7" });
       await act(async () => {
         fireEvent.click(screen.getByTestId("onboarding-next-button"));
@@ -1616,10 +1599,9 @@ describe("Onboarding — Step 3: Verify", () => {
       onboardingStoreInstance
         .getState()
         .setOnboardingStep("target-app", "verify");
-      mockFetchAppsFromServer.mockResolvedValue({
-        status: 1,
-        data: [makeApp({ id: "target-app", onboarded: true })],
-      });
+      mockFetchAppsFromServer.mockResolvedValue([
+        makeApp({ id: "target-app", onboarded: true }),
+      ]);
       renderOnboarding({ teamId: "team-7" });
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);

--- a/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
+++ b/frontend/dashboard/__tests__/components/sdk_configurator_test.tsx
@@ -12,13 +12,6 @@ import {
 // Mock API calls
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
-  UpdateSdkConfigApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Error: "error",
-    Success: "success",
-    Cancelled: "cancelled",
-  },
 }));
 
 // The component calls saveSdkConfigMutation.mutate({ appId, config }, { onSuccess, onError })

--- a/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
@@ -154,10 +154,10 @@ function appsListHandler(apps: any[]) {
 }
 
 function notOnboardedFiltersHandler() {
-  // The filters API returns 200 with versions:null to signal NotOnboarded
-  // (the api_calls helper checks selectedApp.onboarded to disambiguate
-  // NotOnboarded from NoData). versions:null + selectedApp.onboarded=false
-  // → FiltersApiStatus.NotOnboarded.
+  // The filters API answers 200 with versions:null when it has no filters
+  // to provide. fetchFiltersFromServer then reads selectedApp.onboarded to
+  // tell the two empty cases apart, so versions:null on an app whose
+  // onboarded flag is false comes back as { kind: "not-onboarded" }.
   return http.get("*/api/apps/:appId/filters", () => {
     return HttpResponse.json({
       versions: null,

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -328,12 +328,6 @@ describe("Traces Overview (MSW integration)", () => {
       ).toContain("3 points");
     });
 
-    it("store status is Success after data loads", async () => {
-      await renderAndWaitForData();
-      const { SpansApiStatus } = require("@/app/api/api_calls");
-      // Data loaded successfully - verified by DOM content above
-    });
-
     it("shows error when spans API returns 500", async () => {
       server.use(
         http.get("*/api/apps/:appId/spans", ({ request }) => {

--- a/frontend/dashboard/__tests__/pages/apps_test.tsx
+++ b/frontend/dashboard/__tests__/pages/apps_test.tsx
@@ -51,72 +51,6 @@ jest.mock("@/app/utils/env_utils", () => ({
 
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
-  AppsApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    NoApps: 3,
-    Cancelled: 4,
-  },
-  AuthzAndMembersApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  FetchBillingInfoApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  FetchAppRetentionApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  SdkConfigApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  UpdateAppRetentionApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  AppNameChangeApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  AppApiKeyChangeApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  FetchAppThresholdPrefsApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  UpdateAppThresholdPrefsApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
   defaultAppThresholdPrefs: {
     error_good_threshold: 95,
     error_caution_threshold: 85,
@@ -143,23 +77,21 @@ jest.mock("@/app/api/api_calls", () => ({
 // --- Bridge store: tests control this, query hook mocks read from it ---
 const { create: createBridge } = jest.requireActual("zustand") as any;
 const appsStore = createBridge((set: any) => ({
-  // Permissions (derived from authzAndMembers query)
+  // Permissions (derived from the authzAndMembers query)
   canCreateApp: false,
   canRenameApp: false,
   canChangeRetention: false,
   canRotateApiKey: false,
   canWriteSdkConfig: false,
   canChangeAppThresholdPrefs: false,
-  // Page load status (legacy mapping)
-  pageLoadStatus: "Init",
-  // Query data
+  pageLoadState: "idle",
   appRetention: { retention: 90 },
   updatedAppRetention: { retention: 90 },
   sdkConfig: null as any,
-  fetchBillingInfoApiStatus: "loading",
+  billingInfoState: "loading",
   retentionChangeAllowed: false,
-  fetchAppThresholdPrefsApiStatus: "Init",
-  updateAppThresholdPrefsApiStatus: "Init",
+  appThresholdPrefsState: "idle",
+  updateAppThresholdPrefsState: "idle",
   appThresholdPrefs: {
     error_good_threshold: 2,
     error_caution_threshold: 5,
@@ -172,10 +104,9 @@ const appsStore = createBridge((set: any) => ({
     error_spike_min_count_threshold: 100,
     error_spike_min_rate_threshold: 5,
   },
-  updateAppRetentionApiStatus: "Init",
-  appNameChangeApiStatus: "Init",
-  appApiKeyChangeApiStatus: "Init",
-  // Action mocks
+  updateAppRetentionState: "idle",
+  appNameChangeState: "idle",
+  appApiKeyChangeState: "idle",
   fetchPermissions: jest.fn(),
   loadPageData: jest.fn(),
   fetchBillingInfo: jest.fn(),
@@ -189,32 +120,27 @@ const appsStore = createBridge((set: any) => ({
   setAppThresholdPrefs: jest.fn((prefs: any) =>
     set({ appThresholdPrefs: prefs }),
   ),
-  setUpdateAppThresholdPrefsApiStatus: jest.fn((status: any) =>
-    set({ updateAppThresholdPrefsApiStatus: status }),
+  setUpdateAppThresholdPrefsState: jest.fn((status: any) =>
+    set({ updateAppThresholdPrefsState: status }),
   ),
-  setAppNameChangeApiStatus: jest.fn((status: any) =>
-    set({ appNameChangeApiStatus: status }),
+  setAppNameChangeState: jest.fn((status: any) =>
+    set({ appNameChangeState: status }),
   ),
   reset: jest.fn(),
 }));
 
-// Map legacy pageLoadStatus to TanStack query statuses
+// The page reads two queries that load together, so one fixture state drives
+// both. Anything before the load finishes counts as pending.
 function deriveQueryStatuses(state: any) {
-  const pls = state.pageLoadStatus;
-  if (pls === "Loading") {
-    return { retentionStatus: "pending", sdkStatus: "pending" };
-  }
-  if (pls === "Error") {
-    return { retentionStatus: "error", sdkStatus: "error" };
-  }
-  if (pls === "Success") {
-    return { retentionStatus: "success", sdkStatus: "success" };
-  }
-  return { retentionStatus: "pending", sdkStatus: "pending" };
+  const status =
+    state.pageLoadState === "error" || state.pageLoadState === "success"
+      ? state.pageLoadState
+      : "pending";
+  return { retentionStatus: status, sdkStatus: status };
 }
 
 function deriveThresholdStatus(state: any) {
-  const s = state.fetchAppThresholdPrefsApiStatus;
+  const s = state.appThresholdPrefsState;
   if (s === "success") {
     return "success";
   }
@@ -270,22 +196,22 @@ jest.mock("@/app/query/hooks", () => ({
         if (result && typeof result.then === "function") {
           result.then(() => {
             const st = appsStore.getState();
-            if (st.updateAppRetentionApiStatus === "success") {
+            if (st.updateAppRetentionState === "success") {
               opts?.onSuccess?.();
-            } else if (st.updateAppRetentionApiStatus === "error") {
+            } else if (st.updateAppRetentionState === "error") {
               opts?.onError?.();
             }
           });
         } else {
           const st = appsStore.getState();
-          if (st.updateAppRetentionApiStatus === "success") {
+          if (st.updateAppRetentionState === "success") {
             opts?.onSuccess?.();
-          } else if (st.updateAppRetentionApiStatus === "error") {
+          } else if (st.updateAppRetentionState === "error") {
             opts?.onError?.();
           }
         }
       },
-      isPending: s.updateAppRetentionApiStatus === "loading",
+      isPending: s.updateAppRetentionState === "loading",
     };
   },
   useChangeAppNameMutation: () => {
@@ -303,7 +229,7 @@ jest.mock("@/app/query/hooks", () => ({
           });
         }
       },
-      isPending: s.appNameChangeApiStatus === "loading",
+      isPending: s.appNameChangeState === "loading",
     };
   },
   useChangeAppApiKeyMutation: () => {
@@ -321,7 +247,7 @@ jest.mock("@/app/query/hooks", () => ({
           });
         }
       },
-      isPending: s.appApiKeyChangeApiStatus === "loading",
+      isPending: s.appApiKeyChangeState === "loading",
     };
   },
   useUpdateAppThresholdPrefsMutation: () => {
@@ -341,7 +267,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onSuccess?.();
         }
       },
-      isPending: s.updateAppThresholdPrefsApiStatus === "loading",
+      isPending: s.updateAppThresholdPrefsState === "loading",
     };
   },
 }));
@@ -480,12 +406,12 @@ const defaultLoadedAppsState = {
   canRotateApiKey: true,
   canWriteSdkConfig: true,
   canChangeAppThresholdPrefs: true,
-  pageLoadStatus: "Success",
+  pageLoadState: "success",
   appRetention: { retention: 30 },
   updatedAppRetention: { retention: 30 },
   sdkConfig: { session_sampling_rate: 100 },
   retentionChangeAllowed: true,
-  fetchAppThresholdPrefsApiStatus: "success",
+  appThresholdPrefsState: "success",
   appThresholdPrefs: {
     error_good_threshold: 95,
     error_caution_threshold: 85,
@@ -514,7 +440,7 @@ const renderLoadedPage = async () => {
     changeAppApiKey: jest.fn().mockResolvedValue(true),
     updateAppThresholdPrefs: jest.fn().mockResolvedValue(true),
     saveAppRetention: jest.fn().mockImplementation(async () => {
-      useAppsStore.setState({ updateAppRetentionApiStatus: "success" });
+      useAppsStore.setState({ updateAppRetentionState: "success" });
     }),
   });
 
@@ -580,14 +506,14 @@ describe("Apps Page", () => {
       canRotateApiKey: false,
       canWriteSdkConfig: false,
       canChangeAppThresholdPrefs: false,
-      pageLoadStatus: "Init",
+      pageLoadState: "idle",
       appRetention: { retention: 90 },
       updatedAppRetention: { retention: 90 },
       sdkConfig: null,
-      fetchBillingInfoApiStatus: "loading",
+      billingInfoState: "loading",
       retentionChangeAllowed: false,
-      fetchAppThresholdPrefsApiStatus: "Init",
-      updateAppThresholdPrefsApiStatus: "Init",
+      appThresholdPrefsState: "idle",
+      updateAppThresholdPrefsState: "idle",
       appThresholdPrefs: {
         error_good_threshold: 2,
         error_caution_threshold: 5,
@@ -600,9 +526,9 @@ describe("Apps Page", () => {
         error_spike_min_count_threshold: 100,
         error_spike_min_rate_threshold: 5,
       },
-      updateAppRetentionApiStatus: "Init",
-      appNameChangeApiStatus: "Init",
-      appApiKeyChangeApiStatus: "Init",
+      updateAppRetentionState: "idle",
+      appNameChangeState: "idle",
+      appApiKeyChangeState: "idle",
       fetchPermissions: jest.fn(),
       loadPageData: jest.fn(),
       fetchBillingInfo: jest.fn(),
@@ -616,11 +542,11 @@ describe("Apps Page", () => {
       setAppThresholdPrefs: jest.fn((prefs: any) =>
         useAppsStore.setState({ appThresholdPrefs: prefs }),
       ),
-      setUpdateAppThresholdPrefsApiStatus: jest.fn((status: any) =>
-        useAppsStore.setState({ updateAppThresholdPrefsApiStatus: status }),
+      setUpdateAppThresholdPrefsState: jest.fn((status: any) =>
+        useAppsStore.setState({ updateAppThresholdPrefsState: status }),
       ),
-      setAppNameChangeApiStatus: jest.fn((status: any) =>
-        useAppsStore.setState({ appNameChangeApiStatus: status }),
+      setAppNameChangeState: jest.fn((status: any) =>
+        useAppsStore.setState({ appNameChangeState: status }),
       ),
       reset: jest.fn(),
     });
@@ -664,7 +590,7 @@ describe("Apps Page", () => {
   it("shows loading state while app settings are being fetched", async () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
-      pageLoadStatus: "Loading",
+      pageLoadState: "pending",
     });
 
     await renderPage();
@@ -685,7 +611,7 @@ describe("Apps Page", () => {
   it("shows error message when app settings fetch fails", async () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
-      pageLoadStatus: "Error",
+      pageLoadState: "error",
       sdkConfig: null,
     });
 
@@ -969,11 +895,10 @@ describe("Apps Page", () => {
     expect(mockRefreshFilters).not.toHaveBeenCalled();
   });
 
-  it("handles cancelled rotate without toasts", async () => {
+  it("re-enables the Rotate button after a failed rotation", async () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
       changeAppApiKey: jest.fn().mockResolvedValue(false),
-      appApiKeyChangeApiStatus: "cancelled",
     });
 
     await renderPage();
@@ -1007,7 +932,7 @@ describe("Apps Page", () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
       changeAppApiKey: jest.fn().mockImplementation(() => {
-        useAppsStore.setState({ appApiKeyChangeApiStatus: "loading" });
+        useAppsStore.setState({ appApiKeyChangeState: "loading" });
         return pendingPromise;
       }),
     });
@@ -1094,7 +1019,7 @@ describe("Apps Page", () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
       changeAppName: jest.fn().mockImplementation(() => {
-        useAppsStore.setState({ appNameChangeApiStatus: "loading" });
+        useAppsStore.setState({ appNameChangeState: "loading" });
         return pendingPromise;
       }),
     });
@@ -1241,7 +1166,7 @@ describe("Apps Page", () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
       saveAppRetention: jest.fn().mockImplementation(() => {
-        useAppsStore.setState({ updateAppRetentionApiStatus: "loading" });
+        useAppsStore.setState({ updateAppRetentionState: "loading" });
         return pendingPromise;
       }),
     });
@@ -1284,7 +1209,7 @@ describe("Apps Page", () => {
     useAppsStore.setState({
       ...defaultLoadedAppsState,
       saveAppRetention: jest.fn().mockImplementation(async () => {
-        useAppsStore.setState({ updateAppRetentionApiStatus: "error" });
+        useAppsStore.setState({ updateAppRetentionState: "error" });
       }),
     });
 
@@ -1307,36 +1232,6 @@ describe("Apps Page", () => {
     });
 
     expect(mockToastNegative).toHaveBeenCalledWith("Error saving app settings");
-  });
-
-  it("handles cancelled retention update without toasts", async () => {
-    useAppsStore.setState({
-      ...defaultLoadedAppsState,
-      saveAppRetention: jest.fn().mockImplementation(async () => {
-        useAppsStore.setState({ updateAppRetentionApiStatus: "cancelled" });
-      }),
-    });
-
-    await renderPage();
-
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
-    });
-
-    await openRetentionDialog();
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Yes, I'm sure" }));
-    });
-
-    expect(mockToastPositive).not.toHaveBeenCalled();
-    expect(mockToastNegative).not.toHaveBeenCalled();
   });
 
   it("cancels retention update and does not call API", async () => {
@@ -1564,7 +1459,7 @@ describe("Apps Page", () => {
     it("shows loading state while threshold prefs are fetched", async () => {
       useAppsStore.setState({
         ...defaultLoadedAppsState,
-        fetchAppThresholdPrefsApiStatus: "loading",
+        appThresholdPrefsState: "loading",
       });
 
       await renderPage();
@@ -1586,7 +1481,7 @@ describe("Apps Page", () => {
     it("shows error message when threshold prefs fetch fails", async () => {
       useAppsStore.setState({
         ...defaultLoadedAppsState,
-        fetchAppThresholdPrefsApiStatus: "error",
+        appThresholdPrefsState: "error",
       });
 
       await renderPage();

--- a/frontend/dashboard/__tests__/pages/login/login_page_test.tsx
+++ b/frontend/dashboard/__tests__/pages/login/login_page_test.tsx
@@ -2,12 +2,11 @@ import { promiseParams } from "@/__tests__/helpers/promise_params";
 import Login from "@/app/auth/login/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
+import { ApiError } from "@/app/api/api_error";
 import { act, render, screen } from "@testing-library/react";
 
 const mockRouterReplace = jest.fn();
-const mockValidateInvites = jest.fn((_arg?: any) =>
-  Promise.resolve({ status: "success" }),
-);
+const mockValidateInvites = jest.fn((_arg?: any) => Promise.resolve());
 const mockPosthogIdentify = jest.fn();
 const mockFetchCurrentSession = jest.fn((...args: any[]) =>
   Promise.resolve(null as any),
@@ -33,7 +32,6 @@ jest.mock("@/app/stores/reset_all", () => ({
 }));
 
 jest.mock("@/app/api/api_calls", () => ({
-  ValidateInviteApiStatus: { Error: "error", Success: "success" },
   validateInvitesFromServer: (arg: any) => mockValidateInvites(arg),
 }));
 
@@ -79,7 +77,7 @@ describe("Login Page", () => {
     mockAssign.mockClear();
     mockRouterReplace.mockClear();
     mockValidateInvites.mockClear();
-    mockValidateInvites.mockResolvedValue({ status: "success" });
+    mockValidateInvites.mockResolvedValue(undefined);
     mockPosthogIdentify.mockClear();
     mockFetchCurrentSession.mockReset();
     mockFetchCurrentSession.mockResolvedValue(null);
@@ -282,8 +280,8 @@ describe("Login Page", () => {
     expect(mockValidateInvites).toHaveBeenCalledWith("invite-123");
   });
 
-  it("shows invalid invite message when invite validation fails", async () => {
-    mockValidateInvites.mockResolvedValue({ status: "error" });
+  it("shows invalid invite message when the server rejects the invite", async () => {
+    mockValidateInvites.mockRejectedValue(new ApiError(404, "no such invite"));
 
     await act(async () => {
       render(
@@ -297,11 +295,25 @@ describe("Login Page", () => {
   });
 
   it("does not show invalid invite message when invite is valid", async () => {
-    mockValidateInvites.mockResolvedValue({ status: "success" });
+    mockValidateInvites.mockResolvedValue(undefined);
 
     await act(async () => {
       render(
         <Login searchParams={promiseParams({ inviteId: "good-invite" })} />,
+      );
+    });
+
+    expect(
+      screen.queryByText("Invalid or expired invite link."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves the invite unjudged when the network fails", async () => {
+    mockValidateInvites.mockRejectedValue(new Error("network down"));
+
+    await act(async () => {
+      render(
+        <Login searchParams={promiseParams({ inviteId: "some-invite" })} />,
       );
     });
 

--- a/frontend/dashboard/__tests__/pages/team_test.tsx
+++ b/frontend/dashboard/__tests__/pages/team_test.tsx
@@ -107,94 +107,6 @@ const mockTeam = { id: "team-1", name: "Team One" };
 
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
-  TeamsApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  TeamNameChangeApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  AuthzAndMembersApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  PendingInvitesApiStatus: {
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  InviteMemberApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  RemoveMemberApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  RoleChangeApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  ResendPendingInviteApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  RemovePendingInviteApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  FetchTeamSlackConnectUrlApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  FetchTeamSlackStatusApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  UpdateTeamSlackStatusApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
-  TestSlackAlertApiStatus: {
-    Init: "init",
-    Loading: "loading",
-    Success: "success",
-    Error: "error",
-    Cancelled: "cancelled",
-  },
   defaultAuthzAndMembers: {
     can_invite_roles: ["viewer"],
     can_change_billing: false,
@@ -212,7 +124,7 @@ jest.mock("@/app/api/api_calls", () => ({
 // --- Bridge stores: tests control these, query hook mocks read from them ---
 const { create: createBridge } = jest.requireActual("zustand") as any;
 const teamsStore = createBridge(() => ({
-  teamsApiStatus: "loading",
+  teamsState: "loading",
   teams: null as any,
   selectedTeam: null as any,
   fetchTeams: jest.fn(),
@@ -221,30 +133,30 @@ const teamsStore = createBridge(() => ({
 }));
 const teamPageStore = createBridge(() => ({
   currentUserId: undefined as string | undefined,
-  authzAndMembersApiStatus: "loading",
+  authzAndMembersState: "loading",
   authzAndMembers: {
     can_invite_roles: [] as string[],
     can_rename_team: false,
     can_manage_slack: false,
     members: [] as any[],
   },
-  pendingInvitesApiStatus: "loading",
+  pendingInvitesState: "loading",
   pendingInvites: null as any,
   teamSlackConnectUrl: null as string | null,
-  fetchTeamSlackConnectUrlApiStatus: "init",
+  teamSlackConnectUrlState: "init",
   refetchSlackConnectUrl: jest.fn(),
   teamSlack: null as any,
-  fetchTeamSlackStatusApiStatus: "init",
+  teamSlackState: "init",
   refetchSlackStatus: jest.fn(),
-  updateTeamSlackStatusApiStatus: "init",
-  removeTeamSlackApiStatus: "init",
-  testSlackAlertApiStatus: "init",
-  teamNameChangeApiStatus: "init",
-  inviteMemberApiStatus: "init",
-  removeMemberApiStatus: "init",
-  resendPendingInviteApiStatus: "init",
-  removePendingInviteApiStatus: "init",
-  roleChangeApiStatus: "init",
+  updateSlackStatusState: "init",
+  removeTeamSlackState: "init",
+  testSlackAlertState: "init",
+  teamNameChangeState: "init",
+  inviteMemberState: "init",
+  removeMemberState: "init",
+  resendPendingInviteState: "init",
+  removePendingInviteState: "init",
+  roleChangeState: "init",
   fetchCurrentUserId: jest.fn(),
   fetchAuthzAndMembers: jest.fn(),
   fetchPendingInvites: jest.fn(),
@@ -283,27 +195,27 @@ jest.mock("@/app/query/hooks", () => ({
   },
   useTeamsQuery: () => {
     const s = teamsStore.getState();
-    return { data: s.teams, status: mapStatus(s.teamsApiStatus) };
+    return { data: s.teams, status: mapStatus(s.teamsState) };
   },
   useAuthzAndMembersQuery: () => {
     const s = teamPageStore.getState();
     return {
       data: s.authzAndMembers,
-      status: mapStatus(s.authzAndMembersApiStatus),
+      status: mapStatus(s.authzAndMembersState),
     };
   },
   usePendingInvitesQuery: () => {
     const s = teamPageStore.getState();
     return {
       data: s.pendingInvites,
-      status: mapStatus(s.pendingInvitesApiStatus),
+      status: mapStatus(s.pendingInvitesState),
     };
   },
   useTeamSlackConnectUrlQuery: () => {
     const s = teamPageStore.getState();
     return {
       data: s.teamSlackConnectUrl,
-      status: mapStatus(s.fetchTeamSlackConnectUrlApiStatus),
+      status: mapStatus(s.teamSlackConnectUrlState),
       refetch: s.refetchSlackConnectUrl,
     };
   },
@@ -311,7 +223,7 @@ jest.mock("@/app/query/hooks", () => ({
     const s = teamPageStore.getState();
     return {
       data: s.teamSlack,
-      status: mapStatus(s.fetchTeamSlackStatusApiStatus),
+      status: mapStatus(s.teamSlackState),
       refetch: s.refetchSlackStatus,
     };
   },
@@ -326,7 +238,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.teamNameChangeApiStatus === "loading",
+      isPending: s.teamNameChangeState === "loading",
     };
   },
   useInviteMemberMutation: () => {
@@ -344,7 +256,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.inviteMemberApiStatus === "loading",
+      isPending: s.inviteMemberState === "loading",
     };
   },
   useRemoveMemberMutation: () => {
@@ -358,7 +270,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.removeMemberApiStatus === "loading",
+      isPending: s.removeMemberState === "loading",
     };
   },
   useResendPendingInviteMutation: () => {
@@ -375,7 +287,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.resendPendingInviteApiStatus === "loading",
+      isPending: s.resendPendingInviteState === "loading",
     };
   },
   useRemovePendingInviteMutation: () => {
@@ -392,7 +304,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.removePendingInviteApiStatus === "loading",
+      isPending: s.removePendingInviteState === "loading",
     };
   },
   useChangeRoleMutation: () => {
@@ -410,7 +322,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.roleChangeApiStatus === "loading",
+      isPending: s.roleChangeState === "loading",
     };
   },
   useUpdateSlackStatusMutation: () => {
@@ -424,7 +336,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.updateTeamSlackStatusApiStatus === "loading",
+      isPending: s.updateSlackStatusState === "loading",
     };
   },
   useRemoveTeamSlackMutation: () => {
@@ -438,7 +350,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.();
         }
       },
-      isPending: s.removeTeamSlackApiStatus === "loading",
+      isPending: s.removeTeamSlackState === "loading",
     };
   },
   useTestSlackAlertMutation: () => {
@@ -452,7 +364,7 @@ jest.mock("@/app/query/hooks", () => ({
           opts?.onError?.(new Error("Failed to send test Slack alert"));
         }
       },
-      isPending: s.testSlackAlertApiStatus === "loading",
+      isPending: s.testSlackAlertState === "loading",
     };
   },
 }));
@@ -558,7 +470,7 @@ jest.mock("@/app/components/confirmation_dialog", () => ({
 
 const setDefaultTeamsState = () => {
   useTeamsStore.setState({
-    teamsApiStatus: "success",
+    teamsState: "success",
     teams: [mockTeam],
     selectedTeam: mockTeam,
   });
@@ -567,13 +479,13 @@ const setDefaultTeamsState = () => {
 const setDefaultTeamPageState = () => {
   useTeamPageStore.setState({
     currentUserId: "user-1",
-    authzAndMembersApiStatus: "success",
+    authzAndMembersState: "success",
     authzAndMembers: defaultAuthz,
-    pendingInvitesApiStatus: "success",
+    pendingInvitesState: "success",
     pendingInvites: defaultPendingInvites,
-    fetchTeamSlackConnectUrlApiStatus: "success",
+    teamSlackConnectUrlState: "success",
     teamSlackConnectUrl: "https://slack/connect",
-    fetchTeamSlackStatusApiStatus: "success",
+    teamSlackState: "success",
     teamSlack: { slack_team_name: "Measure", is_active: true },
   });
 };
@@ -599,7 +511,7 @@ describe("Team Page", () => {
     jest.clearAllMocks();
     mockIsCloud = false;
     useTeamsStore.setState({
-      teamsApiStatus: "loading",
+      teamsState: "loading",
       teams: null,
       selectedTeam: null,
       fetchTeams: jest.fn(),
@@ -608,30 +520,30 @@ describe("Team Page", () => {
     });
     useTeamPageStore.setState({
       currentUserId: undefined,
-      authzAndMembersApiStatus: "loading",
+      authzAndMembersState: "loading",
       authzAndMembers: {
         can_invite_roles: [],
         can_rename_team: false,
         can_manage_slack: false,
         members: [],
       },
-      pendingInvitesApiStatus: "loading",
+      pendingInvitesState: "loading",
       pendingInvites: null,
       teamSlackConnectUrl: null,
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       refetchSlackConnectUrl: jest.fn(),
       teamSlack: null,
-      fetchTeamSlackStatusApiStatus: "init",
+      teamSlackState: "init",
       refetchSlackStatus: jest.fn(),
-      updateTeamSlackStatusApiStatus: "init",
-      removeTeamSlackApiStatus: "init",
-      testSlackAlertApiStatus: "init",
-      teamNameChangeApiStatus: "init",
-      inviteMemberApiStatus: "init",
-      removeMemberApiStatus: "init",
-      resendPendingInviteApiStatus: "init",
-      removePendingInviteApiStatus: "init",
-      roleChangeApiStatus: "init",
+      updateSlackStatusState: "init",
+      removeTeamSlackState: "init",
+      testSlackAlertState: "init",
+      teamNameChangeState: "init",
+      inviteMemberState: "init",
+      removeMemberState: "init",
+      resendPendingInviteState: "init",
+      removePendingInviteState: "init",
+      roleChangeState: "init",
       fetchCurrentUserId: jest.fn(),
       fetchAuthzAndMembers: jest.fn(),
       fetchPendingInvites: jest.fn(),
@@ -699,7 +611,7 @@ describe("Team Page", () => {
 
   it("shows team fetch error when teams API fails", async () => {
     useTeamsStore.setState({
-      teamsApiStatus: "error",
+      teamsState: "error",
       teams: null,
       selectedTeam: null,
     });
@@ -717,13 +629,13 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     useTeamPageStore.setState({
       currentUserId: "user-1",
-      authzAndMembersApiStatus: "error",
+      authzAndMembersState: "error",
       authzAndMembers: defaultAuthz,
-      pendingInvitesApiStatus: "success",
+      pendingInvitesState: "success",
       pendingInvites: defaultPendingInvites,
-      fetchTeamSlackConnectUrlApiStatus: "success",
+      teamSlackConnectUrlState: "success",
       teamSlackConnectUrl: "https://slack/connect",
-      fetchTeamSlackStatusApiStatus: "success",
+      teamSlackState: "success",
       teamSlack: { slack_team_name: "Measure", is_active: true },
     });
 
@@ -741,8 +653,8 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     useTeamPageStore.setState({
       currentUserId: "user-1",
-      authzAndMembersApiStatus: "loading",
-      pendingInvitesApiStatus: "loading",
+      authzAndMembersState: "loading",
+      pendingInvitesState: "loading",
     });
 
     render(<TeamOverview params={promiseParams({ teamId: "team-1" })} />);
@@ -755,13 +667,13 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     useTeamPageStore.setState({
       currentUserId: "user-1",
-      authzAndMembersApiStatus: "success",
+      authzAndMembersState: "success",
       authzAndMembers: defaultAuthz,
-      pendingInvitesApiStatus: "error",
+      pendingInvitesState: "error",
       pendingInvites: null,
-      fetchTeamSlackConnectUrlApiStatus: "success",
+      teamSlackConnectUrlState: "success",
       teamSlackConnectUrl: "https://slack/connect",
-      fetchTeamSlackStatusApiStatus: "success",
+      teamSlackState: "success",
       teamSlack: { slack_team_name: "Measure", is_active: true },
     });
 
@@ -779,13 +691,13 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     useTeamPageStore.setState({
       currentUserId: "user-1",
-      authzAndMembersApiStatus: "success",
+      authzAndMembersState: "success",
       authzAndMembers: defaultAuthz,
-      pendingInvitesApiStatus: "loading",
+      pendingInvitesState: "loading",
       pendingInvites: null,
-      fetchTeamSlackConnectUrlApiStatus: "success",
+      teamSlackConnectUrlState: "success",
       teamSlackConnectUrl: "https://slack/connect",
-      fetchTeamSlackStatusApiStatus: "success",
+      teamSlackState: "success",
       teamSlack: { slack_team_name: "Measure", is_active: true },
     });
 
@@ -1238,7 +1150,7 @@ describe("Team Page", () => {
       teamSlack: null,
       // The connect url query is disabled for users who cannot manage Slack,
       // so it reports pending forever. The section must not wait on it.
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       teamSlackConnectUrl: null,
     });
 
@@ -1262,7 +1174,7 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      fetchTeamSlackStatusApiStatus: "error",
+      teamSlackState: "error",
       teamSlack: null,
     });
 
@@ -1281,7 +1193,7 @@ describe("Team Page", () => {
     setDefaultTeamPageState();
     useTeamPageStore.setState({
       teamSlack: null,
-      fetchTeamSlackConnectUrlApiStatus: "error",
+      teamSlackConnectUrlState: "error",
       teamSlackConnectUrl: null,
     });
 
@@ -1299,7 +1211,7 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      fetchTeamSlackConnectUrlApiStatus: "error",
+      teamSlackConnectUrlState: "error",
       teamSlackConnectUrl: null,
     });
 
@@ -1318,7 +1230,7 @@ describe("Team Page", () => {
     setDefaultTeamPageState();
     useTeamPageStore.setState({
       authzAndMembers: { ...defaultAuthz, can_manage_slack: false },
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       teamSlackConnectUrl: null,
     });
 
@@ -1338,7 +1250,7 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      fetchTeamSlackStatusApiStatus: "error",
+      teamSlackState: "error",
       teamSlack: null,
       refetchSlackStatus: mockRefetchSlackStatus,
     });
@@ -1356,7 +1268,7 @@ describe("Team Page", () => {
     setDefaultTeamPageState();
     useTeamPageStore.setState({
       teamSlack: null,
-      fetchTeamSlackConnectUrlApiStatus: "error",
+      teamSlackConnectUrlState: "error",
       teamSlackConnectUrl: null,
       refetchSlackConnectUrl: mockRefetchSlackConnectUrl,
       refetchSlackStatus: mockRefetchSlackStatus,
@@ -1374,7 +1286,7 @@ describe("Team Page", () => {
     setDefaultTeamPageState();
     useTeamPageStore.setState({
       teamSlack: null,
-      fetchTeamSlackConnectUrlApiStatus: "loading",
+      teamSlackConnectUrlState: "loading",
       teamSlackConnectUrl: null,
     });
 
@@ -1399,7 +1311,7 @@ describe("Team Page", () => {
         is_active: true,
         needs_reauth: true,
       },
-      fetchTeamSlackConnectUrlApiStatus: "error",
+      teamSlackConnectUrlState: "error",
       teamSlackConnectUrl: null,
     });
 
@@ -1423,7 +1335,7 @@ describe("Team Page", () => {
         is_active: true,
         needs_reauth: true,
       },
-      fetchTeamSlackConnectUrlApiStatus: "loading",
+      teamSlackConnectUrlState: "loading",
       teamSlackConnectUrl: null,
     });
 
@@ -1439,10 +1351,10 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      authzAndMembersApiStatus: "error",
+      authzAndMembersState: "error",
       authzAndMembers: null,
       teamSlack: null,
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       teamSlackConnectUrl: null,
     });
 
@@ -1466,9 +1378,9 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      authzAndMembersApiStatus: "error",
+      authzAndMembersState: "error",
       authzAndMembers: null,
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       teamSlackConnectUrl: null,
     });
 
@@ -1511,7 +1423,7 @@ describe("Team Page", () => {
         is_active: true,
         needs_reauth: true,
       },
-      fetchTeamSlackConnectUrlApiStatus: "init",
+      teamSlackConnectUrlState: "init",
       teamSlackConnectUrl: null,
     });
 
@@ -1531,7 +1443,7 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      fetchTeamSlackStatusApiStatus: "error",
+      teamSlackState: "error",
       teamSlack: null,
     });
 
@@ -1547,7 +1459,7 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     setDefaultTeamPageState();
     useTeamPageStore.setState({
-      fetchTeamSlackStatusApiStatus: "error",
+      teamSlackState: "error",
       teamSlack: null,
     });
 
@@ -1749,13 +1661,13 @@ describe("Team Page", () => {
     setDefaultTeamsState();
     useTeamPageStore.setState({
       currentUserId: undefined,
-      authzAndMembersApiStatus: "success",
+      authzAndMembersState: "success",
       authzAndMembers: defaultAuthz,
-      pendingInvitesApiStatus: "success",
+      pendingInvitesState: "success",
       pendingInvites: defaultPendingInvites,
-      fetchTeamSlackConnectUrlApiStatus: "success",
+      teamSlackConnectUrlState: "success",
       teamSlackConnectUrl: "https://slack/connect",
-      fetchTeamSlackStatusApiStatus: "success",
+      teamSlackState: "success",
       teamSlack: { slack_team_name: "Measure", is_active: true },
     });
 

--- a/frontend/dashboard/__tests__/pages/usage_test.tsx
+++ b/frontend/dashboard/__tests__/pages/usage_test.tsx
@@ -21,49 +21,6 @@ jest.mock("@/app/utils/use_toast", () => ({
 // Mock API calls - only need the enum/constant exports, not the fetch functions
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
-  FetchUsageApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    NoApps: 3,
-    Cancelled: 4,
-  },
-  FetchBillingInfoApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
-  FetchCheckoutSessionApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
-  DowngradeToFreeApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
-  AuthzAndMembersApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
-  FetchSubscriptionInfoApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
-  FetchCustomerPortalUrlApiStatus: {
-    Loading: 0,
-    Success: 1,
-    Error: 2,
-    Cancelled: 3,
-  },
   emptyUsage: [
     {
       app_id: "",
@@ -78,12 +35,12 @@ jest.mock("@/app/api/api_calls", () => ({
 // --- Bridge store for usage page ---
 const { create: createBridge } = jest.requireActual("zustand") as any;
 const usageBridge = createBridge(() => ({
-  fetchUsageApiStatus: 0, // Loading
+  usageState: "pending",
   usage: [] as any[],
   months: [] as string[],
   selectedMonth: undefined as string | undefined,
   selectedMonthUsage: [] as any[],
-  fetchBillingInfoApiStatus: 0, // Loading
+  billingInfoState: "pending",
   billingInfo: null as any,
   currentUserCanChangePlan: false,
   fetchUsage: jest.fn(),
@@ -97,31 +54,11 @@ const usageBridge = createBridge(() => ({
   reset: jest.fn(),
 }));
 
-function usageStatusMap(s: number) {
-  // 0=Loading, 1=Success, 2=Error, 3=NoApps
-  if (s === 0) {
-    return "pending";
-  }
-  if (s === 1) {
+function queryStatus(state: string) {
+  if (state === "loaded" || state === "no-apps") {
     return "success";
   }
-  if (s === 2) {
-    return "error";
-  }
-  if (s === 3) {
-    return "success";
-  } // NoApps returns null data
-  return "pending";
-}
-
-function billingStatusMap(s: number) {
-  if (s === 0) {
-    return "pending";
-  }
-  if (s === 1) {
-    return "success";
-  }
-  if (s === 2) {
+  if (state === "error") {
     return "error";
   }
   return "pending";
@@ -131,11 +68,10 @@ jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
   useUsageQuery: () => {
     const s = usageBridge.getState();
-    // For NoApps (3), return null as data with success status
     const data =
-      s.fetchUsageApiStatus === 3
+      s.usageState === "no-apps"
         ? null
-        : s.fetchUsageApiStatus === 1 &&
+        : s.usageState === "loaded" &&
             s.usage.length === 0 &&
             s.months.length > 0
           ? // Build usage data from months/selectedMonthUsage
@@ -155,7 +91,7 @@ jest.mock("@/app/query/hooks", () => ({
           : s.usage.length > 0
             ? s.usage
             : undefined;
-    return { data, status: usageStatusMap(s.fetchUsageApiStatus) };
+    return { data, status: queryStatus(s.usageState) };
   },
   useUsagePermissionsQuery: () => {
     const s = usageBridge.getState();
@@ -165,7 +101,7 @@ jest.mock("@/app/query/hooks", () => ({
     const s = usageBridge.getState();
     return {
       data: s.billingInfo,
-      status: billingStatusMap(s.fetchBillingInfoApiStatus),
+      status: queryStatus(s.billingInfoState),
     };
   },
   useHandleUpgradeMutation: () => {
@@ -354,12 +290,12 @@ describe("Usage Page", () => {
 
     // Reset store to defaults
     useUsageStore.setState({
-      fetchUsageApiStatus: 0, // Loading
+      usageState: "pending",
       usage: [],
       months: [],
       selectedMonth: undefined,
       selectedMonthUsage: [],
-      fetchBillingInfoApiStatus: 0, // Loading
+      billingInfoState: "pending",
       billingInfo: null,
       currentUserCanChangePlan: false,
       fetchUsage: jest.fn(),
@@ -397,7 +333,7 @@ describe("Usage Page", () => {
   // ---- Usage section ----
 
   it("shows loading spinner while fetching usage", async () => {
-    useUsageStore.setState({ fetchUsageApiStatus: 0 }); // Loading
+    useUsageStore.setState({ usageState: "pending" }); // Loading
 
     await act(async () => {
       render(<Usage params={promiseParams({ teamId: "team1" })} />);
@@ -408,7 +344,7 @@ describe("Usage Page", () => {
   });
 
   it("shows error message when usage fetch fails", async () => {
-    useUsageStore.setState({ fetchUsageApiStatus: 2 }); // Error
+    useUsageStore.setState({ usageState: "error" }); // Error
 
     await act(async () => {
       render(<Usage params={promiseParams({ teamId: "team1" })} />);
@@ -418,7 +354,7 @@ describe("Usage Page", () => {
   });
 
   it("shows a neutral empty state when no apps exist (no onboarding push)", async () => {
-    useUsageStore.setState({ fetchUsageApiStatus: 3 }); // NoApps
+    useUsageStore.setState({ usageState: "no-apps" }); // NoApps
 
     await act(async () => {
       render(<Usage params={promiseParams({ teamId: "team1" })} />);
@@ -439,7 +375,7 @@ describe("Usage Page", () => {
 
   it("renders pie chart and month dropdown on success", async () => {
     useUsageStore.setState({
-      fetchUsageApiStatus: 1, // Success
+      usageState: "loaded",
       months: ["2025-01", "2025-02"],
       selectedMonth: "2025-02",
       selectedMonthUsage: [
@@ -493,7 +429,7 @@ describe("Usage Page", () => {
   });
 
   it("shows billing loading spinner while billing info loads", async () => {
-    useUsageStore.setState({ fetchBillingInfoApiStatus: 0 }); // Loading
+    useUsageStore.setState({ billingInfoState: "pending" }); // Loading
 
     await act(async () => {
       render(<Usage params={promiseParams({ teamId: "team1" })} />);
@@ -505,7 +441,7 @@ describe("Usage Page", () => {
   });
 
   it("shows billing error message when billing info fetch fails", async () => {
-    useUsageStore.setState({ fetchBillingInfoApiStatus: 2 }); // Error
+    useUsageStore.setState({ billingInfoState: "error" }); // Error
 
     await act(async () => {
       render(<Usage params={promiseParams({ teamId: "team1" })} />);
@@ -516,7 +452,7 @@ describe("Usage Page", () => {
 
   it("renders free plan card with Current Plan badge and pricing when on free plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -533,7 +469,7 @@ describe("Usage Page", () => {
 
   it("renders pro plan card with Current Plan badge when on pro plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -551,8 +487,8 @@ describe("Usage Page", () => {
 
   it("shows free plan usage progress bar with percentage and GB", async () => {
     useUsageStore.setState({
-      fetchUsageApiStatus: 1, // Success
-      fetchBillingInfoApiStatus: 1, // Success
+      usageState: "loaded",
+      billingInfoState: "loaded",
       billingInfo: { ...freeBillingInfo, bytes_used: 1_000_000 }, // 1 MB
       months: ["2025-01", "2025-02"],
       selectedMonth: "2025-02",
@@ -584,8 +520,8 @@ describe("Usage Page", () => {
 
   it("shows 0% when there is no usage", async () => {
     useUsageStore.setState({
-      fetchUsageApiStatus: 1, // Success
-      fetchBillingInfoApiStatus: 1, // Success
+      usageState: "loaded",
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       months: ["2025-02"],
       selectedMonth: "2025-02",
@@ -611,8 +547,8 @@ describe("Usage Page", () => {
 
   it("shows minimum 0.01% for very small usage", async () => {
     useUsageStore.setState({
-      fetchUsageApiStatus: 1, // Success
-      fetchBillingInfoApiStatus: 1, // Success
+      usageState: "loaded",
+      billingInfoState: "loaded",
       billingInfo: { ...freeBillingInfo, bytes_used: 48 },
       months: ["2025-02"],
       selectedMonth: "2025-02",
@@ -639,7 +575,7 @@ describe("Usage Page", () => {
 
   it("does not show free plan progress bar when on pro plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -656,7 +592,7 @@ describe("Usage Page", () => {
 
   it("upgrade button is disabled when user cannot change billing", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: false,
     });
@@ -674,7 +610,7 @@ describe("Usage Page", () => {
       .fn()
       .mockResolvedValue({ redirect: "https://checkout.stripe.com/test" });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: true,
       handleUpgrade,
@@ -698,7 +634,7 @@ describe("Usage Page", () => {
       .fn()
       .mockResolvedValue({ alreadyUpgraded: true });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: true,
       handleUpgrade,
@@ -721,7 +657,7 @@ describe("Usage Page", () => {
   it("upgrade error shows toast", async () => {
     const handleUpgrade = jest.fn().mockResolvedValue({ error: true });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: true,
       handleUpgrade,
@@ -746,7 +682,7 @@ describe("Usage Page", () => {
 
   it("clicking downgrade opens confirmation dialog", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -766,7 +702,7 @@ describe("Usage Page", () => {
   it("confirming downgrade calls API and shows success toast", async () => {
     const handleDowngrade = jest.fn().mockResolvedValue(true);
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleDowngrade,
@@ -803,7 +739,7 @@ describe("Usage Page", () => {
   it("downgrade error shows error toast", async () => {
     const handleDowngrade = jest.fn().mockResolvedValue(false);
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleDowngrade,
@@ -845,7 +781,7 @@ describe("Usage Page", () => {
 
   it("shows Undo Cancellation button when cancellation is scheduled", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -860,7 +796,7 @@ describe("Usage Page", () => {
 
   it("shows scheduled-for date below Undo Cancellation button", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -875,7 +811,7 @@ describe("Usage Page", () => {
   it("clicking Undo Cancellation calls undo API and shows success toast", async () => {
     const handleUndoDowngrade = jest.fn().mockResolvedValue(true);
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
       handleUndoDowngrade,
@@ -898,7 +834,7 @@ describe("Usage Page", () => {
   it("Undo Cancellation error shows error toast", async () => {
     const handleUndoDowngrade = jest.fn().mockResolvedValue(false);
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
       handleUndoDowngrade,
@@ -924,7 +860,7 @@ describe("Usage Page", () => {
     // — Autumn's auto-flip to Free will arrive shortly.
     const pastEnd = Math.floor(Date.UTC(2020, 0, 1) / 1000);
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         canceled_at: 1700100000,
@@ -946,7 +882,7 @@ describe("Usage Page", () => {
 
   it("Undo Cancellation button disabled when user cannot change plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: false,
     });
@@ -960,7 +896,7 @@ describe("Usage Page", () => {
 
   it("pro plan with no scheduled cancellation shows Downgrade button and no scheduled-for line", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: { ...proBillingInfo, canceled_at: 0 },
       currentUserCanChangePlan: true,
     });
@@ -985,7 +921,7 @@ describe("Usage Page", () => {
         }),
     );
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
       handleUndoDowngrade,
@@ -1009,7 +945,7 @@ describe("Usage Page", () => {
   it('hides "Next invoice" line when cancellation is scheduled', async () => {
     // current_period_end is the cancellation date, not a future invoice.
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1026,7 +962,7 @@ describe("Usage Page", () => {
 
   it('shows "Next invoice" line on Pro plan when no cancellation is scheduled', async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: { ...proBillingInfo, canceled_at: 0 },
       currentUserCanChangePlan: true,
     });
@@ -1047,7 +983,7 @@ describe("Usage Page", () => {
         }),
     );
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: scheduledCancelBillingInfo,
       currentUserCanChangePlan: true,
       handleUndoDowngrade,
@@ -1152,7 +1088,7 @@ describe("Usage Page", () => {
 
   it("shows pro plan feature list and personalised-plans contact prompt when on free plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
     });
 
@@ -1168,7 +1104,7 @@ describe("Usage Page", () => {
 
   it("hides pro plan feature list when on pro plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1186,7 +1122,7 @@ describe("Usage Page", () => {
 
   it("shows subscription info on pro plan when user can change billing", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1204,7 +1140,7 @@ describe("Usage Page", () => {
 
   it("does not show subscription info when on free plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1219,7 +1155,7 @@ describe("Usage Page", () => {
 
   it("does not show subscription info when can_change_billing is false", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: false,
     });
@@ -1233,7 +1169,7 @@ describe("Usage Page", () => {
 
   it("handles missing subscription state gracefully", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         status: undefined,
@@ -1255,7 +1191,7 @@ describe("Usage Page", () => {
 
   it("Free plan card shows 'Data: X of Y used' from Autumn values", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...freeBillingInfo,
         bytes_used: 1_000_000_000,
@@ -1280,7 +1216,7 @@ describe("Usage Page", () => {
     // future "use Autumn for everything" attempt doesn't silently delete the
     // pitch bullets.
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
     });
 
@@ -1303,7 +1239,7 @@ describe("Usage Page", () => {
 
   it("Pro plan Data line shows 'X of Y used' when under quota", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         bytes_used: 1_000_000_000, // 1 GB
@@ -1323,7 +1259,7 @@ describe("Usage Page", () => {
 
   it("Pro plan Data line appends ', Z overage' when used > granted and overage is allowed", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         bytes_used: 30_000_000_000, // 30 GB
@@ -1344,7 +1280,7 @@ describe("Usage Page", () => {
 
   it("Pro plan Token credits line shows 'X of Y used' when agent credits have been used", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         token_credits_used: 1_500_000,
@@ -1365,7 +1301,7 @@ describe("Usage Page", () => {
     // proBillingInfo carries no token credit fields, so usage is zero and the
     // line must not render — we only surface credits once the agent has run.
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1381,7 +1317,7 @@ describe("Usage Page", () => {
 
   it("Pro plan Token credits line reads 'X used' when the plan grants no credit allowance", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         token_credits_used: 1_500_000,
@@ -1402,7 +1338,7 @@ describe("Usage Page", () => {
 
   it("Pro plan Token credits line appends ', Z overage' when used > granted and overage is allowed", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...proBillingInfo,
         token_credits_used: 12_000_000,
@@ -1424,7 +1360,7 @@ describe("Usage Page", () => {
     // isn't populated yet the whole block is omitted, so "Data:" must not
     // appear on the Pro card.
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: { ...proBillingInfo, status: undefined },
       currentUserCanChangePlan: true,
     });
@@ -1444,7 +1380,7 @@ describe("Usage Page", () => {
 
   it("shows Manage Billing button when on pro plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1458,7 +1394,7 @@ describe("Usage Page", () => {
 
   it("hides Manage Billing button when on free plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: freeBillingInfo,
     });
 
@@ -1471,7 +1407,7 @@ describe("Usage Page", () => {
 
   it("Manage Billing button is disabled when user cannot change billing", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: false,
     });
@@ -1489,7 +1425,7 @@ describe("Usage Page", () => {
       redirect: "https://billing.stripe.com/session/test",
     });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1521,7 +1457,7 @@ describe("Usage Page", () => {
         }),
     );
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1549,7 +1485,7 @@ describe("Usage Page", () => {
       .fn()
       .mockResolvedValue({ error: "Please try again." });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1574,7 +1510,7 @@ describe("Usage Page", () => {
       .fn()
       .mockResolvedValue({ error: "Request was cancelled." });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1603,7 +1539,7 @@ describe("Usage Page", () => {
         }),
     );
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1635,7 +1571,7 @@ describe("Usage Page", () => {
         }),
     );
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleDowngrade,
@@ -1662,7 +1598,7 @@ describe("Usage Page", () => {
 
   it("shows skeleton placeholders while subscription info is loading on pro plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1680,7 +1616,7 @@ describe("Usage Page", () => {
       .fn()
       .mockResolvedValue({ error: "No portal URL returned." });
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1, // Success
+      billingInfoState: "loaded",
       billingInfo: proBillingInfo,
       currentUserCanChangePlan: true,
       handleManageBilling,
@@ -1706,7 +1642,7 @@ describe("Usage Page", () => {
 
   it("renders Enterprise card with ENTERPRISE title on enterprise plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1719,7 +1655,7 @@ describe("Usage Page", () => {
 
   it("Enterprise Data line reads 'Unlimited' when bytes_unlimited is true", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1735,7 +1671,7 @@ describe("Usage Page", () => {
 
   it("Enterprise Data line reads 'X of Y used' for bounded plans without overage", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...enterpriseBillingInfo,
         bytes_unlimited: false,
@@ -1756,7 +1692,7 @@ describe("Usage Page", () => {
 
   it("Enterprise Data line appends ', Z overage' when overage allowed and used > granted", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...enterpriseBillingInfo,
         bytes_unlimited: false,
@@ -1777,7 +1713,7 @@ describe("Usage Page", () => {
 
   it("Enterprise Data line omits overage even when used > granted if overage is not allowed", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...enterpriseBillingInfo,
         bytes_unlimited: false,
@@ -1799,7 +1735,7 @@ describe("Usage Page", () => {
 
   it("shows retention line when retention_days is set on enterprise", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1813,7 +1749,7 @@ describe("Usage Page", () => {
 
   it("hides retention line when retention_days is missing on enterprise", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: { ...enterpriseBillingInfo, retention_days: 0 },
     });
 
@@ -1826,7 +1762,7 @@ describe("Usage Page", () => {
 
   it("shows plan period when both period timestamps are set on enterprise", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1839,7 +1775,7 @@ describe("Usage Page", () => {
 
   it("hides plan period when timestamps are missing on enterprise", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: {
         ...enterpriseBillingInfo,
         current_period_start: 0,
@@ -1859,7 +1795,7 @@ describe("Usage Page", () => {
     // aren't recurring. Whatever variant the Data line takes, it's just
     // "Data:".
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1874,7 +1810,7 @@ describe("Usage Page", () => {
 
   it("hides Free and Pro cards on enterprise plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1890,7 +1826,7 @@ describe("Usage Page", () => {
 
   it('hides "personalised plans" footer on enterprise plan', async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
     });
 
@@ -1903,7 +1839,7 @@ describe("Usage Page", () => {
 
   it("shows Manage Billing button on enterprise plan", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
       currentUserCanChangePlan: true,
     });
@@ -1917,7 +1853,7 @@ describe("Usage Page", () => {
 
   it("Manage Billing on enterprise is disabled when user cannot change billing", async () => {
     useUsageStore.setState({
-      fetchBillingInfoApiStatus: 1,
+      billingInfoState: "loaded",
       billingInfo: enterpriseBillingInfo,
       currentUserCanChangePlan: false,
     });

--- a/frontend/dashboard/__tests__/query/hooks_test.tsx
+++ b/frontend/dashboard/__tests__/query/hooks_test.tsx
@@ -3,19 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 
-import {
-  AppsApiStatus,
-  BuildsApiStatus,
-  ErrorGroupCommonPathApiStatus,
-  ErrorsDetailsApiStatus,
-  ErrorsDetailsPlotApiStatus,
-  ErrorsDistributionPlotApiStatus,
-  ErrorsOverviewApiStatus,
-  ErrorsOverviewPlotApiStatus,
-  FiltersApiStatus,
-  FilterSource,
-  RootSpanNamesApiStatus,
-} from "@/app/api/api_calls";
+import { FilterSource } from "@/app/api/api_calls";
+import { ApiError } from "@/app/api/api_error";
 
 jest.mock("@/app/api/api_calls", () => {
   const actual = jest.requireActual("@/app/api/api_calls");
@@ -135,54 +124,38 @@ describe("useAppsQuery", () => {
     expect(mockFetchApps).not.toHaveBeenCalled();
   });
 
-  it("returns parsed result on Success", async () => {
-    mockFetchApps.mockResolvedValueOnce({
-      status: AppsApiStatus.Success,
-      data: [{ id: "a1", name: "App 1" }],
-    });
+  it("returns the apps list", async () => {
+    mockFetchApps.mockResolvedValueOnce([{ id: "a1", name: "App 1" }]);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useAppsQuery("team-1"), { wrapper });
 
     await waitFor(() => expect(result.current.status).toBe("success"));
 
-    expect(result.current.data).toEqual({
-      status: AppsApiStatus.Success,
-      data: [{ id: "a1", name: "App 1" }],
-    });
+    expect(result.current.data).toEqual([{ id: "a1", name: "App 1" }]);
     expect(mockFetchApps).toHaveBeenCalledWith("team-1");
   });
 
-  it("passes through NoApps status", async () => {
-    mockFetchApps.mockResolvedValueOnce({
-      status: AppsApiStatus.NoApps,
-      data: null,
-    });
+  it("passes an empty list through", async () => {
+    mockFetchApps.mockResolvedValueOnce([]);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useAppsQuery("team-1"), { wrapper });
 
     await waitFor(() => expect(result.current.status).toBe("success"));
 
-    expect(result.current.data).toEqual({
-      status: AppsApiStatus.NoApps,
-      data: [],
-    });
+    expect(result.current.data).toEqual([]);
   });
 
-  it("throws on Error status", async () => {
-    mockFetchApps.mockResolvedValueOnce({
-      status: AppsApiStatus.Error,
-      data: null,
-    });
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchApps.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useAppsQuery("team-1"), { wrapper });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
-    expect((result.current.error as Error).message).toMatch(
-      /Failed to fetch apps/,
-    );
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -209,16 +182,13 @@ describe("useFilterOptionsQuery", () => {
 
     await waitFor(() => expect(result.current.status).toBe("success"));
 
-    expect(result.current.data).toEqual({
-      status: FiltersApiStatus.NotOnboarded,
-      data: null,
-    });
+    expect(result.current.data).toEqual({ kind: "not-onboarded" });
     expect(mockFetchFilters).not.toHaveBeenCalled();
   });
 
   it("fetches for the Builds source even when the app is never onboarded", async () => {
     mockFetchFilters.mockResolvedValueOnce({
-      status: FiltersApiStatus.Success,
+      kind: "options",
       data: {
         versions: [{ name: "1.0.2", code: "2" }],
         os_versions: null,
@@ -245,13 +215,13 @@ describe("useFilterOptionsQuery", () => {
       notOnboardedApp,
       FilterSource.Builds,
     );
-    expect(result.current.data?.status).toBe(FiltersApiStatus.Success);
-    expect(result.current.data?.data?.versions).toHaveLength(1);
+    expect(result.current.data?.kind).toBe("options");
+    expect((result.current.data as any)?.data?.versions).toHaveLength(1);
   });
 
   it("fetches and parses on Success when app is onboarded", async () => {
     mockFetchFilters.mockResolvedValueOnce({
-      status: FiltersApiStatus.Success,
+      kind: "options",
       data: {
         versions: [{ name: "1.0", code: "100" }],
         os_versions: [{ name: "android", version: "13" }],
@@ -278,17 +248,14 @@ describe("useFilterOptionsQuery", () => {
       onboardedApp,
       FilterSource.Errors,
     );
-    expect(result.current.data?.status).toBe(FiltersApiStatus.Success);
-    expect(result.current.data?.data?.countries).toEqual(["US"]);
-    expect(result.current.data?.data?.versions).toHaveLength(1);
-    expect(result.current.data?.data?.osVersions).toHaveLength(1);
+    expect(result.current.data?.kind).toBe("options");
+    expect((result.current.data as any)?.data?.countries).toEqual(["US"]);
+    expect((result.current.data as any)?.data?.versions).toHaveLength(1);
+    expect((result.current.data as any)?.data?.osVersions).toHaveLength(1);
   });
 
-  it("passes through NoData status", async () => {
-    mockFetchFilters.mockResolvedValueOnce({
-      status: FiltersApiStatus.NoData,
-      data: null,
-    });
+  it("passes the no-data outcome through", async () => {
+    mockFetchFilters.mockResolvedValueOnce({ kind: "no-data" });
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -297,17 +264,12 @@ describe("useFilterOptionsQuery", () => {
     );
 
     await waitFor(() => expect(result.current.status).toBe("success"));
-    expect(result.current.data).toEqual({
-      status: FiltersApiStatus.NoData,
-      data: null,
-    });
+    expect(result.current.data).toEqual({ kind: "no-data" });
   });
 
-  it("throws on Error status", async () => {
-    mockFetchFilters.mockResolvedValueOnce({
-      status: FiltersApiStatus.Error,
-      data: null,
-    });
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchFilters.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -316,11 +278,12 @@ describe("useFilterOptionsQuery", () => {
     );
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 
   it("refetches when the onboarded flag flips", async () => {
     mockFetchFilters.mockResolvedValueOnce({
-      status: FiltersApiStatus.Success,
+      kind: "options",
       data: {
         versions: [{ name: "1.0", code: "100" }],
         os_versions: null,
@@ -346,15 +309,13 @@ describe("useFilterOptionsQuery", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.data?.status).toBe(FiltersApiStatus.NotOnboarded),
+      expect(result.current.data?.kind).toBe("not-onboarded"),
     );
     expect(mockFetchFilters).not.toHaveBeenCalled();
 
     rerender({ app: onboardedApp });
 
-    await waitFor(() =>
-      expect(result.current.data?.status).toBe(FiltersApiStatus.Success),
-    );
+    await waitFor(() => expect(result.current.data?.kind).toBe("options"));
     expect(mockFetchFilters).toHaveBeenCalledTimes(1);
   });
 });
@@ -373,10 +334,7 @@ describe("useRootSpanNamesQuery", () => {
   });
 
   it("fetches when filterSource is Spans and returns the parsed results", async () => {
-    mockFetchRootSpanNames.mockResolvedValueOnce({
-      status: RootSpanNamesApiStatus.Success,
-      data: { results: ["root.a", "root.b"] },
-    });
+    mockFetchRootSpanNames.mockResolvedValueOnce(["root.a", "root.b"]);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -386,17 +344,12 @@ describe("useRootSpanNamesQuery", () => {
 
     await waitFor(() => expect(result.current.status).toBe("success"));
 
-    expect(result.current.data).toEqual({
-      status: RootSpanNamesApiStatus.Success,
-      data: ["root.a", "root.b"],
-    });
+    expect(result.current.data).toEqual(["root.a", "root.b"]);
   });
 
-  it("throws on Error status", async () => {
-    mockFetchRootSpanNames.mockResolvedValueOnce({
-      status: RootSpanNamesApiStatus.Error,
-      data: null,
-    });
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchRootSpanNames.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -405,6 +358,7 @@ describe("useRootSpanNamesQuery", () => {
     );
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -533,10 +487,7 @@ describe("useErrorsOverviewQuery", () => {
 
   it("returns success with data once the fetch resolves", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsOverview.mockResolvedValueOnce({
-      status: ErrorsOverviewApiStatus.Success,
-      data: { results: [{ id: "g1" }] },
-    });
+    mockFetchErrorsOverview.mockResolvedValueOnce({ results: [{ id: "g1" }] });
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsOverviewQuery(0), { wrapper });
@@ -552,20 +503,16 @@ describe("useErrorsOverviewQuery", () => {
     expect((result.current.data as any).results[0].id).toBe("g1");
   });
 
-  it("throws on Error status", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsOverview.mockResolvedValueOnce({
-      status: ErrorsOverviewApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorsOverview.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsOverviewQuery(0), { wrapper });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
-    expect((result.current.error as Error).message).toMatch(
-      /Failed to fetch errors overview/,
-    );
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -581,11 +528,8 @@ describe("useBuildsQuery", () => {
   it("returns success with data once the fetch resolves", async () => {
     mockFiltersState = readyFilters();
     mockFetchBuilds.mockResolvedValueOnce({
-      status: BuildsApiStatus.Success,
-      data: {
-        results: [{ id: "b1" }],
-        meta: { next: false, previous: false },
-      },
+      results: [{ id: "b1" }],
+      meta: { next: false, previous: false },
     });
 
     const { wrapper } = makeWrapper();
@@ -598,20 +542,16 @@ describe("useBuildsQuery", () => {
     expect((result.current.data as any).results[0].id).toBe("b1");
   });
 
-  it("throws on Error status", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchBuilds.mockResolvedValueOnce({
-      status: BuildsApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchBuilds.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useBuildsQuery(0), { wrapper });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
-    expect((result.current.error as Error).message).toMatch(
-      /Failed to fetch builds/,
-    );
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -628,10 +568,9 @@ describe("useErrorsOverviewPlotQuery", () => {
 
   it("returns mapped data on success", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsOverviewPlot.mockResolvedValueOnce({
-      status: ErrorsOverviewPlotApiStatus.Success,
-      data: [{ id: "android", data: [{ datetime: "x", instances: 1 }] }],
-    });
+    mockFetchErrorsOverviewPlot.mockResolvedValueOnce([
+      { id: "android", data: [{ datetime: "x", instances: 1 }] },
+    ]);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsOverviewPlotQuery(), {
@@ -647,10 +586,7 @@ describe("useErrorsOverviewPlotQuery", () => {
 
   it("returns null on NoData", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsOverviewPlot.mockResolvedValueOnce({
-      status: ErrorsOverviewPlotApiStatus.NoData,
-      data: null,
-    });
+    mockFetchErrorsOverviewPlot.mockResolvedValueOnce(null);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsOverviewPlotQuery(), {
@@ -661,12 +597,10 @@ describe("useErrorsOverviewPlotQuery", () => {
     expect(result.current.data).toBeNull();
   });
 
-  it("throws on Error", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsOverviewPlot.mockResolvedValueOnce({
-      status: ErrorsOverviewPlotApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorsOverviewPlot.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsOverviewPlotQuery(), {
@@ -674,6 +608,7 @@ describe("useErrorsOverviewPlotQuery", () => {
     });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -700,10 +635,7 @@ describe("useErrorsDetailsQuery", () => {
 
   it("returns success with data once the fetch resolves", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDetails.mockResolvedValueOnce({
-      status: ErrorsDetailsApiStatus.Success,
-      data: { results: [{ id: "e1" }] },
-    });
+    mockFetchErrorsDetails.mockResolvedValueOnce({ results: [{ id: "e1" }] });
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsDetailsQuery("group-1", 3), {
@@ -721,12 +653,10 @@ describe("useErrorsDetailsQuery", () => {
     );
   });
 
-  it("throws on Error status", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDetails.mockResolvedValueOnce({
-      status: ErrorsDetailsApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorsDetails.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsDetailsQuery("group-1", 0), {
@@ -734,6 +664,7 @@ describe("useErrorsDetailsQuery", () => {
     });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -760,10 +691,9 @@ describe("useErrorsDetailsPlotQuery", () => {
 
   it("returns mapped data on success", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDetailsPlot.mockResolvedValueOnce({
-      status: ErrorsDetailsPlotApiStatus.Success,
-      data: [{ id: "ios", data: [{ datetime: "y", instances: 2 }] }],
-    });
+    mockFetchErrorsDetailsPlot.mockResolvedValueOnce([
+      { id: "ios", data: [{ datetime: "y", instances: 2 }] },
+    ]);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsDetailsPlotQuery("group-1"), {
@@ -779,10 +709,7 @@ describe("useErrorsDetailsPlotQuery", () => {
 
   it("returns null on NoData", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDetailsPlot.mockResolvedValueOnce({
-      status: ErrorsDetailsPlotApiStatus.NoData,
-      data: null,
-    });
+    mockFetchErrorsDetailsPlot.mockResolvedValueOnce(null);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsDetailsPlotQuery("group-1"), {
@@ -793,12 +720,10 @@ describe("useErrorsDetailsPlotQuery", () => {
     expect(result.current.data).toBeNull();
   });
 
-  it("throws on Error", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDetailsPlot.mockResolvedValueOnce({
-      status: ErrorsDetailsPlotApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorsDetailsPlot.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useErrorsDetailsPlotQuery("group-1"), {
@@ -806,6 +731,7 @@ describe("useErrorsDetailsPlotQuery", () => {
     });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -834,11 +760,8 @@ describe("useErrorsDistributionPlotQuery", () => {
   it("returns parsed distribution data on success", async () => {
     mockFiltersState = readyFilters();
     mockFetchErrorsDistributionPlot.mockResolvedValueOnce({
-      status: ErrorsDistributionPlotApiStatus.Success,
-      data: {
-        os_version: { "android 13": 5 },
-        country: { US: 3 },
-      },
+      os_version: { "android 13": 5 },
+      country: { US: 3 },
     });
 
     const { wrapper } = makeWrapper();
@@ -856,10 +779,7 @@ describe("useErrorsDistributionPlotQuery", () => {
 
   it("returns null on NoData", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDistributionPlot.mockResolvedValueOnce({
-      status: ErrorsDistributionPlotApiStatus.NoData,
-      data: null,
-    });
+    mockFetchErrorsDistributionPlot.mockResolvedValueOnce(null);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -871,12 +791,10 @@ describe("useErrorsDistributionPlotQuery", () => {
     expect(result.current.data).toBeNull();
   });
 
-  it("throws on Error", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorsDistributionPlot.mockResolvedValueOnce({
-      status: ErrorsDistributionPlotApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorsDistributionPlot.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -885,6 +803,7 @@ describe("useErrorsDistributionPlotQuery", () => {
     );
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });
 
@@ -913,8 +832,8 @@ describe("useErrorGroupCommonPathQuery", () => {
   it("returns success with data", async () => {
     mockFiltersState = readyFilters();
     mockFetchErrorGroupCommonPath.mockResolvedValueOnce({
-      status: ErrorGroupCommonPathApiStatus.Success,
-      data: { sessions_analyzed: 7, steps: [] },
+      sessions_analyzed: 7,
+      steps: [],
     });
 
     const { wrapper } = makeWrapper();
@@ -933,12 +852,10 @@ describe("useErrorGroupCommonPathQuery", () => {
     expect(result.current.data?.sessions_analyzed).toBe(7);
   });
 
-  it("throws on Error", async () => {
+  it("surfaces a failed fetch as a query error", async () => {
     mockFiltersState = readyFilters();
-    mockFetchErrorGroupCommonPath.mockResolvedValueOnce({
-      status: ErrorGroupCommonPathApiStatus.Error,
-      data: null,
-    });
+    const failure = new ApiError(500, "request failed");
+    mockFetchErrorGroupCommonPath.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
@@ -947,5 +864,6 @@ describe("useErrorGroupCommonPathQuery", () => {
     );
 
     await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
   });
 });

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -2,14 +2,11 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 
 import {
   App,
-  AppsApiStatus,
   AppVersion,
   BugReportStatus,
-  FiltersApiStatus,
   FilterSource,
   HttpMethod,
   OsVersion,
-  RootSpanNamesApiStatus,
   SessionType,
   SpanStatus,
 } from "@/app/api/api_calls";
@@ -467,7 +464,7 @@ describe("filtersStore actions", () => {
     const store = createFiltersStore();
     const a = makeApp("a", { onboarded: false });
     const b = makeApp("b", { onboarded: false });
-    store.getState().setApps([a, b], AppsApiStatus.Success);
+    store.getState().setApps([a, b], "loaded");
     store.getState().setSelectedApp(a);
 
     store.getState().markAppOnboarded("a");
@@ -485,7 +482,7 @@ describe("filtersStore actions", () => {
     const store = createFiltersStore();
     const a = makeApp("a", { onboarded: false });
     const b = makeApp("b", { onboarded: false });
-    store.getState().setApps([a, b], AppsApiStatus.Success);
+    store.getState().setApps([a, b], "loaded");
     store.getState().setSelectedApp(b);
 
     store.getState().markAppOnboarded("a");
@@ -497,7 +494,7 @@ describe("filtersStore actions", () => {
   it("resetForTeamChange clears apps and selections but keeps config", () => {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
     store.getState().setSelectedVersions([new AppVersion("1.0", "100")]);
 
@@ -513,7 +510,7 @@ describe("filtersStore actions", () => {
   it("reset wipes everything back to initial state", () => {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
 
     store.getState().reset();
@@ -538,9 +535,9 @@ describe("filtersStore actions", () => {
       userDefAttrs: [{ key: "plan", type: "string" }],
       userDefAttrOps: new Map([["string", ["eq"]]]),
     };
-    store.getState().setFilterOptions(data, FiltersApiStatus.Success);
+    store.getState().setFilterOptions(data, "loaded");
 
-    expect(store.getState().filtersApiStatus).toBe(FiltersApiStatus.Success);
+    expect(store.getState().filterOptionsState).toBe("loaded");
     expect(store.getState().versions).toEqual(data.versions);
     expect(store.getState().osVersions).toEqual(data.osVersions);
     expect(store.getState().userDefAttrs).toEqual(data.userDefAttrs);
@@ -548,30 +545,22 @@ describe("filtersStore actions", () => {
 
   it("setFilterOptions with null data only updates status", () => {
     const store = createFiltersStore();
-    store.getState().setFilterOptions(null, FiltersApiStatus.NotOnboarded);
-    expect(store.getState().filtersApiStatus).toBe(
-      FiltersApiStatus.NotOnboarded,
-    );
+    store.getState().setFilterOptions(null, "not-onboarded");
+    expect(store.getState().filterOptionsState).toBe("not-onboarded");
     expect(store.getState().versions).toEqual([]);
   });
 
   it("setRootSpanNames stores list and status", () => {
     const store = createFiltersStore();
-    store
-      .getState()
-      .setRootSpanNames(["a", "b"], RootSpanNamesApiStatus.Success);
+    store.getState().setRootSpanNames(["a", "b"], "loaded");
     expect(store.getState().rootSpanNames).toEqual(["a", "b"]);
-    expect(store.getState().rootSpanNamesApiStatus).toBe(
-      RootSpanNamesApiStatus.Success,
-    );
+    expect(store.getState().rootSpanNamesState).toBe("loaded");
   });
 
   it("setRootSpanNames with null data only updates status", () => {
     const store = createFiltersStore();
-    store.getState().setRootSpanNames(null, RootSpanNamesApiStatus.NoData);
-    expect(store.getState().rootSpanNamesApiStatus).toBe(
-      RootSpanNamesApiStatus.NoData,
-    );
+    store.getState().setRootSpanNames(null, "no-data");
+    expect(store.getState().rootSpanNamesState).toBe("no-data");
     expect(store.getState().rootSpanNames).toEqual([]);
   });
 
@@ -618,7 +607,7 @@ describe("computed filters object", () => {
   function readyStore() {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
     store.getState().setFilterOptions(
       {
@@ -634,7 +623,7 @@ describe("computed filters object", () => {
         userDefAttrs: [],
         userDefAttrOps: new Map(),
       },
-      FiltersApiStatus.Success,
+      "loaded",
     );
     return store;
   }
@@ -647,8 +636,15 @@ describe("computed filters object", () => {
   it("filters.ready is false while apps are loading", () => {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
-    store.getState().setApps([], AppsApiStatus.Loading);
+    store.getState().setApps([], "pending");
     expect(store.getState().filters.ready).toBe(false);
+  });
+
+  it("filters.ready is false when the team has no apps", () => {
+    const store = readyStore();
+    store.getState().setApps([], "no-apps");
+    expect(store.getState().filters.ready).toBe(false);
+    expect(store.getState().filters.loading).toBe(false);
   });
 
   it("filters.app reflects selectedApp", () => {
@@ -685,7 +681,7 @@ describe("computed filters object", () => {
         userDefAttrs: [],
         userDefAttrOps: new Map(),
       },
-      FiltersApiStatus.Success,
+      "loaded",
     );
     store.getState().setSelectedOsVersions([osVersions[0]]);
     expect(store.getState().filters.osVersions.all).toBe(false);
@@ -702,45 +698,45 @@ describe("computed filters object", () => {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
     mockFetchQuery.mockClear();
-    store.getState().setApps([], AppsApiStatus.Loading);
+    store.getState().setApps([], "pending");
     expect(mockFetchQuery).not.toHaveBeenCalled();
   });
 
-  it("filters.ready is false when both showNoData+showNotOnboarded require Success but status is NoData", () => {
+  it("filters.ready is false when both showNoData+showNotOnboarded require loaded options but the state is no-data", () => {
     const store = createFiltersStore();
     store
       .getState()
       .setConfig({ ...baseConfig, showNoData: true, showNotOnboarded: true });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
-    store.getState().setFilterOptions(null, FiltersApiStatus.NoData);
+    store.getState().setFilterOptions(null, "no-data");
     expect(store.getState().filters.ready).toBe(false);
   });
 
   it("filters.ready is false on NoBuilds when showNoBuilds is set (filters component renders the NoBuilds UI)", () => {
     const store = createFiltersStore();
     store.getState().setConfig({ ...baseConfig, showNoBuilds: true });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
-    store.getState().setFilterOptions(null, FiltersApiStatus.NoBuilds);
+    store.getState().setFilterOptions(null, "no-builds");
     expect(store.getState().filters.ready).toBe(false);
   });
 
   it("filters.ready is true on NoBuilds when showNoBuilds is not set", () => {
     const store = createFiltersStore();
     store.getState().setConfig(baseConfig);
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
-    store.getState().setFilterOptions(null, FiltersApiStatus.NoBuilds);
+    store.getState().setFilterOptions(null, "no-builds");
     expect(store.getState().filters.ready).toBe(true);
   });
 
   it("filters.ready is false on NoData when showNoData is set (filters component renders the NoData UI)", () => {
     const store = createFiltersStore();
     store.getState().setConfig({ ...baseConfig, showNoData: true });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
-    store.getState().setFilterOptions(null, FiltersApiStatus.NoData);
+    store.getState().setFilterOptions(null, "no-data");
     expect(store.getState().filters.ready).toBe(false);
   });
 
@@ -749,9 +745,9 @@ describe("computed filters object", () => {
     store
       .getState()
       .setConfig({ ...baseConfig, showNoData: false, showNotOnboarded: false });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
-    store.getState().setFilterOptions(null, FiltersApiStatus.NoData);
+    store.getState().setFilterOptions(null, "no-data");
     expect(store.getState().filters.ready).toBe(true);
   });
 });
@@ -825,7 +821,7 @@ describe("errors-source filter state", () => {
     store
       .getState()
       .setConfig({ ...baseConfig, filterSource: FilterSource.Errors });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
     store.getState().setFilterOptions(
       {
@@ -841,7 +837,7 @@ describe("errors-source filter state", () => {
         userDefAttrs: [],
         userDefAttrOps: new Map(),
       },
-      FiltersApiStatus.Success,
+      "loaded",
     );
     return store;
   }
@@ -860,7 +856,7 @@ describe("errors-source filter state", () => {
     store
       .getState()
       .setConfig({ ...baseConfig, filterSource: FilterSource.Events });
-    store.getState().setApps([makeApp("a")], AppsApiStatus.Success);
+    store.getState().setApps([makeApp("a")], "loaded");
     store.getState().setSelectedApp(makeApp("a"));
     store.getState().setFilterOptions(
       {
@@ -876,7 +872,7 @@ describe("errors-source filter state", () => {
         userDefAttrs: [],
         userDefAttrOps: new Map(),
       },
-      FiltersApiStatus.Success,
+      "loaded",
     );
     store.getState().setSelectedErrorTypes(["error", "anr"]);
     const params = new URLSearchParams(

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -12,7 +12,6 @@ import {
 import { useFiltersStore } from "@/app/stores/provider";
 
 import {
-  AppsApiStatus,
   FilterSource,
   defaultAppThresholdPrefs,
   emptyAppRetention,
@@ -41,12 +40,12 @@ import { use, useRef, useState } from "react";
 export default function Apps(props: { params: Promise<{ teamId: string }> }) {
   const params = use(props.params);
   const filters = useFiltersStore((state) => state.filters);
-  const appsApiStatus = useFiltersStore((state) => state.appsApiStatus);
-  // No apps yet → render <Onboarding> via Filters and hide the CreateApp
-  // button so the onboarding flow is the only call-to-action. As soon as
-  // the user creates an app, appsApiStatus flips to Success and the page
-  // falls back to its normal app-settings layout.
-  const hasNoApps = appsApiStatus === AppsApiStatus.NoApps;
+  const appsState = useFiltersStore((state) => state.appsState);
+  // The team has no apps yet. Render <Onboarding> through Filters, and hide
+  // the CreateApp button, so the onboarding flow is the only call to action.
+  // After the user creates an app, the apps query resolves to "loaded", and
+  // the page shows its usual app-settings layout.
+  const hasNoApps = appsState === "no-apps";
 
   // TanStack Query: reads
   const appId = filters.ready ? filters.app?.id : undefined;

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1,82 +1,36 @@
+/**
+ * Every server call the dashboard makes lives in this file, as a function
+ * that builds a URL and hands it to `request` below. A fetcher returns the
+ * response body.
+ *
+ * TanStack Query holds whether a call is in flight, and the hooks in
+ * app/query/hooks.ts pass that to components.
+ *
+ * `request` throws on failure: an ApiError when the server answered and
+ * rejected the call, carrying the HTTP status, or a RequestError when no
+ * answer came back, such as a dropped connection or an unreadable body.
+ * Catch ApiError and check `status` where a code is an outcome rather than
+ * a fault.
+ *
+ * An empty result is a return value: null, an empty array, or a
+ * discriminated union when the emptiness has several causes the user needs
+ * to know about.
+ *
+ * A new fetcher needs a URL, a failure message naming the operation for
+ * when the server sends no error of its own, and a return type.
+ */
+
 import {
   formatUserInputDateToServerFormat,
   getPlotTimeGroupForRange,
   getTimeZoneForServer,
 } from "../utils/time_utils";
 import { apiClient } from "./api_client";
+import { ApiError, RequestError } from "./api_error";
 
 export enum JourneyType {
   Paths,
   Exceptions,
-}
-
-export enum ValidateInviteApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum TeamsApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum AppsApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoApps,
-  Cancelled,
-}
-
-export enum RootSpanNamesApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum SpanMetricsPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum SpansApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum TraceApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FiltersApiStatus {
-  Loading,
-  Success,
-  Error,
-  NotOnboarded,
-  NoData,
-  NoBuilds,
-  Cancelled,
-}
-export enum SaveFiltersApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
 }
 
 export enum FilterSource {
@@ -84,440 +38,6 @@ export enum FilterSource {
   Spans,
   Errors,
   Builds,
-}
-
-export enum AppHealthPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum JourneyApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum MetricsApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum SessionTimelinesOverviewApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum SessionTimelinesOverviewPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum ErrorsOverviewApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum ErrorsOverviewPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum ErrorsDetailsApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum ErrorGroupCommonPathApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum ErrorsDetailsPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum ErrorsDistributionPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum CreateTeamApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum CreateAppApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum TeamNameChangeApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum AppNameChangeApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum AppApiKeyChangeApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum RoleChangeApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum PendingInvitesApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum ResendPendingInviteApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum RemovePendingInviteApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum InviteMemberApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum RemoveMemberApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum AuthzAndMembersApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchTeamSlackConnectUrlApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchTeamSlackStatusApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateTeamSlackStatusApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum RemoveTeamSlackApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchAppThresholdPrefsApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateAppThresholdPrefsApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum TestSlackAlertApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum SessionTimelineApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchNotifPrefsApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateNotifPrefsApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchAppRetentionApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateAppRetentionApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchUsageApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoApps,
-  Cancelled,
-}
-
-export enum FetchCheckoutSessionApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum DowngradeToFreeApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UndoDowngradeApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchBillingInfoApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum FetchCustomerPortalUrlApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum BugReportsOverviewApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum BugReportsOverviewPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum BugReportApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateBugReportStatusApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum BuildsApiStatus {
-  Success,
-  Error,
-}
-
-export enum AlertsOverviewApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum SdkConfigApiStatus {
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum UpdateSdkConfigApiStatus {
-  Init,
-  Loading,
-  Success,
-  Error,
-  Cancelled,
-}
-
-export enum NetworkDomainsApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkPathsApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkEndpointLatencyPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkEndpointTimelinePlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkEndpointStatusCodesPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkTrendsApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkOverviewStatusCodesPlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
-}
-
-export enum NetworkTimelinePlotApiStatus {
-  Loading,
-  Success,
-  Error,
-  NoData,
-  Cancelled,
 }
 
 export enum SessionType {
@@ -1614,81 +1134,112 @@ function appendHttpMethodsToUrl(url: string, filters: Filters): string {
   return u.toString();
 }
 
+/**
+ * The options for `request`. `failsWith` is the message that the user sees
+ * when the server sends no error of its own. The other options go to fetch.
+ */
+type RequestOptions = RequestInit & {
+  failsWith: string;
+  /**
+   * Set false when body parsing is not needed. Leaving it true on an endpoint
+   * that returns no body will cause the parse to throw and fail the call.
+   */
+  parseBody?: boolean;
+};
+
+/**
+ * Sends a request and returns its parsed body. A server rejection becomes
+ * an ApiError carrying the status, and anything that stops the request
+ * itself from executing becomes a RequestError named after the operation.
+ */
+function request(
+  url: string,
+  opts: RequestOptions & { parseBody: false },
+): Promise<void>;
+function request<T = any>(url: string, opts: RequestOptions): Promise<T>;
+async function request<T = any>(
+  url: string,
+  { failsWith, parseBody = true, ...init }: RequestOptions,
+): Promise<T | void> {
+  let res: Response;
+  try {
+    res = await apiClient.fetch(url, init);
+  } catch (e) {
+    throw new RequestError(failsWith, { cause: e });
+  }
+
+  if (!res.ok) {
+    // A rejected request does not always have a JSON body. A proxy can send
+    // an HTML error page, so use our own message when the parse fails.
+    const body = await res.json().catch(() => null);
+    throw new ApiError(res.status, body?.error ?? failsWith);
+  }
+
+  if (!parseBody) {
+    return;
+  }
+
+  try {
+    return (await res.json()) as T;
+  } catch (e) {
+    throw new RequestError(failsWith, { cause: e });
+  }
+}
+
 export const validateInvitesFromServer = async (inviteId: string) => {
   try {
-    const res = await apiClient.fetch(`/api/auth/validateInvite`, {
+    await request(`/api/auth/validateInvite`, {
       method: "POST",
       body: JSON.stringify({ invite_id: inviteId }),
+      failsWith: "Failed to validate invite",
+      parseBody: false,
     });
-
-    if (!res.ok) {
-      console.log("Validate invite failed with status:", res.status);
-      return { status: ValidateInviteApiStatus.Error };
+  } catch (e) {
+    if (e instanceof ApiError) {
+      console.log("Validate invite failed with status:", e.status);
+    } else {
+      console.log("Validate invite cancelled due to exception");
     }
-
-    console.log("Validate invite succeeded");
-    return { status: ValidateInviteApiStatus.Success };
-  } catch {
-    console.log("Validate invite cancelled due to exception");
-    return { status: ValidateInviteApiStatus.Cancelled };
+    throw e;
   }
+
+  console.log("Validate invite succeeded");
 };
 
 export const fetchTeamsFromServer = async () => {
+  const data: [{ id: string; name: string }] = await request(`/api/teams`, {
+    failsWith: "Failed to fetch teams",
+  });
+
+  return data;
+};
+
+export const fetchAppsFromServer = async (teamId: string): Promise<App[]> => {
   try {
-    const res = await apiClient.fetch(`/api/teams`);
-
-    if (!res.ok) {
-      return { status: TeamsApiStatus.Error, data: null };
+    return await request<App[]>(`/api/teams/${teamId}/apps`, {
+      failsWith: "Failed to fetch apps",
+    });
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) {
+      return [];
     }
-
-    const data: [{ id: string; name: string }] = await res.json();
-
-    return { status: TeamsApiStatus.Success, data: data };
-  } catch {
-    return { status: TeamsApiStatus.Cancelled, data: null };
+    throw e;
   }
 };
 
-export const fetchAppsFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/apps`);
+export const fetchRootSpanNamesFromServer = async (
+  selectedApp: App,
+): Promise<string[] | null> => {
+  const failsWith = "Failed to fetch root span names";
+  const data = await request(`/api/apps/${selectedApp.id}/spans/roots/names`, {
+    failsWith,
+  });
 
-    if (!res.ok && res.status == 404) {
-      return { status: AppsApiStatus.NoApps, data: null };
-    }
-
-    if (!res.ok) {
-      return { status: AppsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-    return { status: AppsApiStatus.Success, data: data };
-  } catch {
-    return { status: AppsApiStatus.Cancelled, data: null };
+  if (data === null) {
+    throw new RequestError(failsWith);
   }
-};
 
-export const fetchRootSpanNamesFromServer = async (selectedApp: App) => {
-  try {
-    const res = await apiClient.fetch(
-      `/api/apps/${selectedApp.id}/spans/roots/names`,
-    );
-
-    if (!res.ok) {
-      return { status: RootSpanNamesApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data.results === null) {
-      return { status: RootSpanNamesApiStatus.NoData, data: null };
-    }
-
-    return { status: RootSpanNamesApiStatus.Success, data: data };
-  } catch {
-    return { status: RootSpanNamesApiStatus.Cancelled, data: null };
-  }
+  return (data.results as string[] | null) ?? null;
 };
 
 export const fetchSpansFromServer = async (
@@ -1701,19 +1252,9 @@ export const fetchSpansFromServer = async (
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
   url = appendSpanFiltersToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, { failsWith: "Failed to fetch spans" });
 
-    if (!res.ok) {
-      return { status: SpansApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: SpansApiStatus.Success, data: data };
-  } catch {
-    return { status: SpansApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchSpanMetricsPlotFromServer = async (filters: Filters) => {
@@ -1723,44 +1264,36 @@ export const fetchSpanMetricsPlotFromServer = async (filters: Filters) => {
   url = appendSpanFiltersToUrl(url, filters);
   url = appendPlotTimeGroupToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch span metrics plot",
+  });
 
-    if (!res.ok) {
-      return { status: SpanMetricsPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: SpanMetricsPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: SpanMetricsPlotApiStatus.Success, data: data };
-  } catch {
-    return { status: SpanMetricsPlotApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchTraceFromServer = async (appId: string, traceId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appId}/traces/${traceId}`);
-    if (!res.ok) {
-      return { status: TraceApiStatus.Error, data: null };
-    }
+  const data = await request(`/api/apps/${appId}/traces/${traceId}`, {
+    failsWith: "Failed to fetch trace",
+  });
 
-    const data = await res.json();
-
-    return { status: TraceApiStatus.Success, data: data };
-  } catch {
-    return { status: TraceApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
+
+/**
+ * A filters response is a set of options, or one of three empty outcomes.
+ * The dashboard explains each empty outcome differently: an app that sent no
+ * events, an app with no builds, and an app with no events of this kind.
+ */
+export type FilterOptionsResult =
+  | { kind: "options"; data: any }
+  | { kind: "no-data" }
+  | { kind: "not-onboarded" }
+  | { kind: "no-builds" };
 
 export const fetchFiltersFromServer = async (
   selectedApp: App,
   filterSource: FilterSource,
-) => {
+): Promise<FilterOptionsResult> => {
   let url = `/api/apps/${selectedApp.id}/filters`;
 
   // fetch the user defined attributes
@@ -1776,33 +1309,26 @@ export const fetchFiltersFromServer = async (
     url += "&builds=1";
   }
 
-  try {
-    const res = await apiClient.fetch(url);
+  const failsWith = "Failed to fetch filters";
+  const data = await request(url, { failsWith });
 
-    if (!res.ok) {
-      return { status: FiltersApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data.versions === null) {
-      // Builds are uploaded independently of event data, so an empty
-      // builds source means no builds; the event-derived NoData and
-      // NotOnboarded split does not apply to it.
-      if (filterSource === FilterSource.Builds) {
-        return { status: FiltersApiStatus.NoBuilds, data: null };
-      }
-      if (!selectedApp.onboarded) {
-        return { status: FiltersApiStatus.NotOnboarded, data: null };
-      } else {
-        return { status: FiltersApiStatus.NoData, data: null };
-      }
-    }
-
-    return { status: FiltersApiStatus.Success, data: data };
-  } catch {
-    return { status: FiltersApiStatus.Cancelled, data: null };
+  if (data === null) {
+    throw new RequestError(failsWith);
   }
+
+  if (data.versions === null) {
+    // Builds are uploaded independently of event data, so an empty
+    // builds source means no builds
+    if (filterSource === FilterSource.Builds) {
+      return { kind: "no-builds" };
+    }
+    if (!selectedApp.onboarded) {
+      return { kind: "not-onboarded" };
+    }
+    return { kind: "no-data" };
+  }
+
+  return { kind: "options", data };
 };
 
 export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
@@ -1811,21 +1337,12 @@ export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
   url = await applyGenericFiltersToUrl(url, filters, null, null);
   url = appendPlotTimeGroupToUrl(url, filters);
 
-  let data: any;
-  try {
-    const res = await apiClient.fetch(url);
-
-    if (!res.ok) {
-      return { status: AppHealthPlotApiStatus.Error, data: null };
-    }
-
-    data = await res.json();
-  } catch {
-    return { status: AppHealthPlotApiStatus.Error, data: null };
-  }
+  const data = await request(url, {
+    failsWith: "Failed to fetch app health plot",
+  });
 
   if (data === null) {
-    return { status: AppHealthPlotApiStatus.NoData, data: null };
+    return null;
   }
 
   // The server returns three sparse series keyed by id: "sessions", "crashes"
@@ -1873,9 +1390,9 @@ export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
     buildSeries("ANRs", dateMaps.anrs),
   ];
 
-  // If all are empty, return NoData
+  // If all the series are empty, there is nothing to plot.
   if (result.every((series) => series.data.every((point) => point.y === 0))) {
-    return { status: AppHealthPlotApiStatus.NoData, data: null };
+    return null;
   }
 
   // Remove ANRs if all y values are 0
@@ -1886,10 +1403,7 @@ export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
     return true;
   });
 
-  return {
-    status: AppHealthPlotApiStatus.Success,
-    data: filteredResult,
-  };
+  return filteredResult;
 };
 
 export const fetchJourneyFromServer = async (
@@ -1903,19 +1417,9 @@ export const fetchJourneyFromServer = async (
 
   url = await applyGenericFiltersToUrl(url, filters, null, null);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, { failsWith: "Failed to fetch journey" });
 
-    if (!res.ok) {
-      return { status: JourneyApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: JourneyApiStatus.Success, data: data };
-  } catch {
-    return { status: JourneyApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchMetricsFromServer = async (filters: Filters) => {
@@ -1923,19 +1427,9 @@ export const fetchMetricsFromServer = async (filters: Filters) => {
 
   url = await applyGenericFiltersToUrl(url, filters, null, null);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, { failsWith: "Failed to fetch metrics" });
 
-    if (!res.ok) {
-      return { status: MetricsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: MetricsApiStatus.Success, data: data };
-  } catch {
-    return { status: MetricsApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchSessionTimelinesOverviewFromServer = async (
@@ -1948,19 +1442,11 @@ export const fetchSessionTimelinesOverviewFromServer = async (
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
   url = appendSessionTypesToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch session timelines overview",
+  });
 
-    if (!res.ok) {
-      return { status: SessionTimelinesOverviewApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: SessionTimelinesOverviewApiStatus.Success, data: data };
-  } catch {
-    return { status: SessionTimelinesOverviewApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchSessionTimelinesOverviewPlotFromServer = async (
@@ -1972,35 +1458,11 @@ export const fetchSessionTimelinesOverviewPlotFromServer = async (
   url = appendSessionTypesToUrl(url, filters);
   url = appendPlotTimeGroupToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch session timelines overview plot",
+  });
 
-    if (!res.ok) {
-      return {
-        status: SessionTimelinesOverviewPlotApiStatus.Error,
-        data: null,
-      };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return {
-        status: SessionTimelinesOverviewPlotApiStatus.NoData,
-        data: null,
-      };
-    }
-
-    return {
-      status: SessionTimelinesOverviewPlotApiStatus.Success,
-      data: data,
-    };
-  } catch {
-    return {
-      status: SessionTimelinesOverviewPlotApiStatus.Cancelled,
-      data: null,
-    };
-  }
+  return data;
 };
 
 function appendErrorFiltersToUrl(url: string, filters: Filters): string {
@@ -2027,19 +1489,11 @@ export const fetchErrorsOverviewFromServer = async (
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
   url = appendErrorFiltersToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch errors overview",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorsOverviewApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: ErrorsOverviewApiStatus.Success, data: data };
-  } catch {
-    return { status: ErrorsOverviewApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchErrorsOverviewPlotFromServer = async (filters: Filters) => {
@@ -2049,23 +1503,11 @@ export const fetchErrorsOverviewPlotFromServer = async (filters: Filters) => {
   url = appendPlotTimeGroupToUrl(url, filters);
   url = appendErrorFiltersToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch errors overview plot",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorsOverviewPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: ErrorsOverviewPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: ErrorsOverviewPlotApiStatus.Success, data: data };
-  } catch {
-    return { status: ErrorsOverviewPlotApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchErrorsDetailsFromServer = async (
@@ -2078,19 +1520,11 @@ export const fetchErrorsDetailsFromServer = async (
 
   url = await applyGenericFiltersToUrl(url, filters, limit, paginationOffset);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch errors details",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorsDetailsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: ErrorsDetailsApiStatus.Success, data: data };
-  } catch {
-    return { status: ErrorsDetailsApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchErrorGroupCommonPathFromServer = async (
@@ -2099,19 +1533,11 @@ export const fetchErrorGroupCommonPathFromServer = async (
 ) => {
   const url = `/api/apps/${filters.app!.id}/errorGroups/${errorGroupId}/path`;
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch error group common path",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorGroupCommonPathApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: ErrorGroupCommonPathApiStatus.Success, data: data };
-  } catch {
-    return { status: ErrorGroupCommonPathApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchErrorsDetailsPlotFromServer = async (
@@ -2123,23 +1549,11 @@ export const fetchErrorsDetailsPlotFromServer = async (
   url = await applyGenericFiltersToUrl(url, filters, null, null);
   url = appendPlotTimeGroupToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch errors details plot",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorsDetailsPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: ErrorsDetailsPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: ErrorsDetailsPlotApiStatus.Success, data: data };
-  } catch {
-    return { status: ErrorsDetailsPlotApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchErrorsDistributionPlotFromServer = async (
@@ -2150,130 +1564,76 @@ export const fetchErrorsDistributionPlotFromServer = async (
 
   url = await applyGenericFiltersToUrl(url, filters, null, null);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch errors distribution plot",
+  });
 
-    if (!res.ok) {
-      return { status: ErrorsDistributionPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (
-      data === null ||
-      Object.values(data).every(
-        (value) =>
-          typeof value === "object" &&
-          value !== null &&
-          Object.keys(value).length === 0,
-      )
-    ) {
-      return { status: ErrorsDistributionPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: ErrorsDistributionPlotApiStatus.Success, data: data };
-  } catch {
-    return {
-      status: ErrorsDistributionPlotApiStatus.Cancelled,
-      data: null,
-    };
+  if (
+    data === null ||
+    Object.values(data).every(
+      (value) =>
+        typeof value === "object" &&
+        value !== null &&
+        Object.keys(value).length === 0,
+    )
+  ) {
+    return null;
   }
+
+  return data;
 };
 
 export const fetchAuthzAndMembersFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/authz`);
-    if (!res.ok) {
-      return { status: AuthzAndMembersApiStatus.Error, data: null };
-    }
+  const data = await request(`/api/teams/${teamId}/authz`, {
+    failsWith: "Failed to fetch authz and members",
+  });
 
-    const data = await res.json();
-
-    return { status: AuthzAndMembersApiStatus.Success, data: data };
-  } catch {
-    return { status: AuthzAndMembersApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchSessionTimelineFromServer = async (
   appId: string,
   sessionId: string,
 ) => {
-  try {
-    const res = await apiClient.fetch(
-      `/api/apps/${appId}/sessions/${sessionId}`,
-    );
-    if (!res.ok) {
-      return { status: SessionTimelineApiStatus.Error, data: null };
-    }
+  const data = await request(`/api/apps/${appId}/sessions/${sessionId}`, {
+    failsWith: "Failed to fetch session timeline",
+  });
 
-    const data = await res.json();
-
-    return { status: SessionTimelineApiStatus.Success, data: data };
-  } catch {
-    return { status: SessionTimelineApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const changeTeamNameFromServer = async (
   teamId: string,
   newTeamName: string,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/rename`, {
     method: "PATCH",
     body: JSON.stringify({ name: newTeamName }),
-  };
+    failsWith: "Failed to change team name",
+    parseBody: false,
+  });
 
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/rename`, opts);
-    if (!res.ok) {
-      return { status: TeamNameChangeApiStatus.Error };
-    }
-
-    return { status: TeamNameChangeApiStatus.Success };
-  } catch {
-    return { status: TeamNameChangeApiStatus.Cancelled };
-  }
+  return;
 };
 
 export const createTeamFromServer = async (teamName: string) => {
-  const opts = {
+  const data = await request(`/api/teams`, {
     method: "POST",
     body: JSON.stringify({ name: teamName }),
-  };
+    failsWith: "Failed to create team",
+  });
 
-  try {
-    const res = await apiClient.fetch(`/api/teams`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: CreateTeamApiStatus.Error, error: data.error };
-    }
-
-    return { status: CreateTeamApiStatus.Success, data: data };
-  } catch {
-    return { status: CreateTeamApiStatus.Cancelled };
-  }
+  return data;
 };
 
 export const createAppFromServer = async (teamId: string, appName: string) => {
-  const opts = {
+  const data = await request(`/api/teams/${teamId}/apps`, {
     method: "POST",
     body: JSON.stringify({ name: appName }),
-  };
+    failsWith: "Failed to create app",
+  });
 
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/apps`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: CreateAppApiStatus.Error, error: data.error };
-    }
-
-    return { status: CreateAppApiStatus.Success, data: data };
-  } catch {
-    return { status: CreateAppApiStatus.Cancelled };
-  }
+  return data;
 };
 
 export const changeRoleFromServer = async (
@@ -2281,91 +1641,39 @@ export const changeRoleFromServer = async (
   newRole: string,
   memberId: string,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/members/${memberId}/role`, {
     method: "PATCH",
     body: JSON.stringify({ role: newRole.toLocaleLowerCase() }),
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/members/${memberId}/role`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: RoleChangeApiStatus.Error, error: data.error };
-    }
-
-    return { status: RoleChangeApiStatus.Success };
-  } catch {
-    return { status: RoleChangeApiStatus.Cancelled };
-  }
+    failsWith: "Failed to change role",
+  });
 };
 
 export const fetchPendingInvitesFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/invites`);
-    const data = await res.json();
+  const data = await request(`/api/teams/${teamId}/invites`, {
+    failsWith: "Failed to fetch pending invites",
+  });
 
-    if (!res.ok) {
-      return { status: PendingInvitesApiStatus.Error, error: data.error };
-    }
-
-    return { status: PendingInvitesApiStatus.Success, data: data };
-  } catch {
-    return { status: PendingInvitesApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const resendPendingInviteFromServer = async (
   teamId: string,
   inviteId: string,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/invite/${inviteId}`, {
     method: "PATCH",
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/invite/${inviteId}`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: ResendPendingInviteApiStatus.Error, error: data.error };
-    }
-
-    return { status: ResendPendingInviteApiStatus.Success };
-  } catch {
-    return { status: ResendPendingInviteApiStatus.Cancelled };
-  }
+    failsWith: "Failed to resend pending invite",
+  });
 };
 
 export const removePendingInviteFromServer = async (
   teamId: string,
   inviteId: string,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/invite/${inviteId}`, {
     method: "DELETE",
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/invite/${inviteId}`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: RemovePendingInviteApiStatus.Error, error: data.error };
-    }
-
-    return { status: RemovePendingInviteApiStatus.Success };
-  } catch {
-    return { status: RemovePendingInviteApiStatus.Cancelled };
-  }
+    failsWith: "Failed to remove pending invite",
+  });
 };
 
 export const inviteMemberFromServer = async (
@@ -2374,359 +1682,175 @@ export const inviteMemberFromServer = async (
   role: string,
 ) => {
   const lowerCaseRole = role.toLocaleLowerCase();
-  const opts = {
+  await request(`/api/teams/${teamId}/invite`, {
     method: "POST",
     headers: {
       "Content-Type": `application/json`,
     },
     body: JSON.stringify([{ email: email, role: lowerCaseRole }]),
-  };
-
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/invite`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: InviteMemberApiStatus.Error, error: data.error };
-    }
-
-    return { status: InviteMemberApiStatus.Success };
-  } catch {
-    return { status: InviteMemberApiStatus.Cancelled };
-  }
+    failsWith: "Failed to invite member",
+  });
 };
 
 export const removeMemberFromServer = async (
   teamId: string,
   memberId: string,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/members/${memberId}`, {
     method: "DELETE",
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/members/${memberId}`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: RemoveMemberApiStatus.Error, error: data.error };
-    }
-
-    return { status: RemoveMemberApiStatus.Success };
-  } catch {
-    return { status: RemoveMemberApiStatus.Cancelled };
-  }
+    failsWith: "Failed to remove member",
+  });
 };
 
 export const fetchTeamSlackConnectUrlFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/slack/connect-url`);
-    const data = await res.json();
+  const data = await request(`/api/teams/${teamId}/slack/connect-url`, {
+    failsWith: "Failed to fetch team Slack connect url",
+  });
 
-    if (!res.ok) {
-      return {
-        status: FetchTeamSlackConnectUrlApiStatus.Error,
-        error: data.error,
-      };
-    }
-
-    return { status: FetchTeamSlackConnectUrlApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchTeamSlackConnectUrlApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchTeamSlackStatusFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/slack`);
-    const data = await res.json();
+  const data = await request(`/api/teams/${teamId}/slack`, {
+    failsWith: "Failed to fetch team Slack status",
+  });
 
-    if (!res.ok) {
-      return { status: FetchTeamSlackStatusApiStatus.Error, error: data.error };
-    }
-
-    return { status: FetchTeamSlackStatusApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchTeamSlackStatusApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchAppThresholdPrefsFromServer = async (appId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appId}/thresholdPrefs`);
-    const data = await res.json();
+  const data = await request(`/api/apps/${appId}/thresholdPrefs`, {
+    failsWith: "Failed to fetch app threshold prefs",
+  });
 
-    if (!res.ok) {
-      return {
-        status: FetchAppThresholdPrefsApiStatus.Error,
-        error: data.error,
-        data: null,
-      };
-    }
-
-    return { status: FetchAppThresholdPrefsApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchAppThresholdPrefsApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const updateAppThresholdPrefsFromServer = async (
   appId: string,
   prefs: typeof defaultAppThresholdPrefs,
 ) => {
-  const opts = {
+  await request(`/api/apps/${appId}/thresholdPrefs`, {
     method: "PATCH",
     body: JSON.stringify(prefs),
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/apps/${appId}/thresholdPrefs`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return {
-        status: UpdateAppThresholdPrefsApiStatus.Error,
-        error: data.error,
-      };
-    }
-
-    return { status: UpdateAppThresholdPrefsApiStatus.Success };
-  } catch {
-    return { status: UpdateAppThresholdPrefsApiStatus.Cancelled };
-  }
+    failsWith: "Failed to update app threshold prefs",
+  });
 };
 
 export const updateTeamSlackStatusFromServer = async (
   teamId: string,
   slackStatus: boolean,
 ) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/slack/status`, {
     method: "PATCH",
     body: JSON.stringify({ is_active: slackStatus }),
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/slack/status`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return {
-        status: UpdateTeamSlackStatusApiStatus.Error,
-        error: data.error,
-      };
-    }
-
-    return { status: UpdateTeamSlackStatusApiStatus.Success };
-  } catch {
-    return { status: UpdateTeamSlackStatusApiStatus.Cancelled };
-  }
+    failsWith: "Failed to update team Slack status",
+  });
 };
 
 export const removeTeamSlackFromServer = async (teamId: string) => {
-  const opts = {
-    method: "DELETE",
-  };
-
   try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/slack`, opts);
-
-    // A 404 means there is no integration to remove, so the goal state is
-    // already reached. Report success rather than an error.
-    if (res.status === 404) {
-      return { status: RemoveTeamSlackApiStatus.Success };
+    await request(`/api/teams/${teamId}/slack`, {
+      method: "DELETE",
+      failsWith: "Failed to remove team Slack",
+    });
+  } catch (e) {
+    // A 404 shows that there is no integration to remove. The goal state is
+    // already correct, so report success and not an error.
+    if (e instanceof ApiError && e.status === 404) {
+      return;
     }
-
-    const data = await res.json();
-
-    if (!res.ok) {
-      return {
-        status: RemoveTeamSlackApiStatus.Error,
-        error: data.error,
-      };
-    }
-
-    return { status: RemoveTeamSlackApiStatus.Success };
-  } catch {
-    return { status: RemoveTeamSlackApiStatus.Cancelled };
+    throw e;
   }
 };
 
 export const sendTestSlackAlertFromServer = async (teamId: string) => {
-  const opts = {
+  await request(`/api/teams/${teamId}/slack/test`, {
     method: "POST",
-  };
-
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/slack/test`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: TestSlackAlertApiStatus.Error, error: data.error };
-    }
-
-    return { status: TestSlackAlertApiStatus.Success };
-  } catch {
-    return { status: TestSlackAlertApiStatus.Cancelled };
-  }
+    failsWith: "Failed to send test Slack alert",
+  });
 };
 
 export const fetchNotifPrefsFromServer = async () => {
-  try {
-    const res = await apiClient.fetch(`/api/prefs/notifPrefs`);
+  const data = await request(`/api/prefs/notifPrefs`, {
+    failsWith: "Failed to fetch notif prefs",
+  });
 
-    if (!res.ok) {
-      return { status: FetchNotifPrefsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchNotifPrefsApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchNotifPrefsApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const updateNotifPrefsFromServer = async (
   notifPrefs: typeof emptyNotifPrefs,
 ) => {
-  const opts = {
+  await request(`/api/prefs/notifPrefs`, {
     method: "PATCH",
     body: JSON.stringify(notifPrefs),
-  };
-
-  try {
-    const res = await apiClient.fetch(`/api/prefs/notifPrefs`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: UpdateNotifPrefsApiStatus.Error, error: data.error };
-    }
-
-    return { status: UpdateNotifPrefsApiStatus.Success };
-  } catch {
-    return { status: UpdateNotifPrefsApiStatus.Cancelled };
-  }
+    failsWith: "Failed to update notif prefs",
+  });
 };
 
 export const fetchAppRetentionFromServer = async (appId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appId}/retention`);
+  const data = await request(`/api/apps/${appId}/retention`, {
+    failsWith: "Failed to fetch app retention",
+  });
 
-    if (!res.ok) {
-      return { status: FetchAppRetentionApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchAppRetentionApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchAppRetentionApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const updateAppRetentionFromServer = async (
   appdId: string,
   appRetention: typeof emptyAppRetention,
 ) => {
-  const opts = {
+  await request(`/api/apps/${appdId}/retention`, {
     method: "PATCH",
     body: JSON.stringify(appRetention),
-  };
-
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appdId}/retention`, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return { status: UpdateAppRetentionApiStatus.Error, error: data.error };
-    }
-
-    return { status: UpdateAppRetentionApiStatus.Success };
-  } catch {
-    return { status: UpdateAppRetentionApiStatus.Cancelled };
-  }
+    failsWith: "Failed to update app retention",
+  });
 };
 
 export const changeAppNameFromServer = async (
   appId: string,
   newAppName: string,
 ) => {
-  const opts = {
+  await request(`/api/apps/${appId}/rename`, {
     method: "PATCH",
     body: JSON.stringify({ name: newAppName }),
-  };
+    failsWith: "Failed to change app name",
+    parseBody: false,
+  });
 
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appId}/rename`, opts);
-    if (!res.ok) {
-      return { status: AppNameChangeApiStatus.Error };
-    }
-
-    return { status: AppNameChangeApiStatus.Success };
-  } catch {
-    return { status: AppNameChangeApiStatus.Cancelled };
-  }
+  return;
 };
 
 export const changeAppApiKeyFromServer = async (appId: string) => {
-  const opts = {
+  await request(`/api/apps/${appId}/apiKey`, {
     method: "PATCH",
-  };
+    failsWith: "Failed to change app api key",
+    parseBody: false,
+  });
 
-  try {
-    const res = await apiClient.fetch(`/api/apps/${appId}/apiKey`, opts);
-    if (!res.ok) {
-      return { status: AppApiKeyChangeApiStatus.Error };
-    }
-
-    return { status: AppApiKeyChangeApiStatus.Success };
-  } catch {
-    return { status: AppApiKeyChangeApiStatus.Cancelled };
-  }
+  return;
 };
 
 export const fetchBillingInfoFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/billing/info`);
+  const data = await request(`/api/teams/${teamId}/billing/info`, {
+    failsWith: "Failed to fetch billing info",
+  });
 
-    if (!res.ok) {
-      return { status: FetchBillingInfoApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchBillingInfoApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchBillingInfoApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchUsageFromServer = async (teamId: string) => {
   try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/usage`);
-
-    if (!res.ok && res.status == 404) {
-      return { status: FetchUsageApiStatus.NoApps, data: null };
+    return await request(`/api/teams/${teamId}/usage`, {
+      failsWith: "Failed to fetch usage",
+    });
+  } catch (e) {
+    // A team with no apps has no usage to report, and answers with a 404.
+    if (e instanceof ApiError && e.status === 404) {
+      return null;
     }
-
-    if (!res.ok) {
-      return { status: FetchUsageApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchUsageApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchUsageApiStatus.Cancelled, data: null };
+    throw e;
   }
 };
 
@@ -2734,96 +1858,54 @@ export const fetchCheckoutSessionFromServer = async (
   teamId: string,
   successUrl: string,
 ) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/billing/checkout`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        success_url: successUrl,
-      }),
-    });
+  const data = await request(`/api/teams/${teamId}/billing/checkout`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      success_url: successUrl,
+    }),
+    failsWith: "Failed to fetch checkout session",
+  });
 
-    if (!res.ok) {
-      return { status: FetchCheckoutSessionApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchCheckoutSessionApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchCheckoutSessionApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const downgradeToFreeFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/billing/downgrade`,
-      {
-        method: "PATCH",
-      },
-    );
+  const data = await request(`/api/teams/${teamId}/billing/downgrade`, {
+    method: "PATCH",
+    failsWith: "Failed to downgrade to free",
+  });
 
-    if (!res.ok) {
-      return { status: DowngradeToFreeApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: DowngradeToFreeApiStatus.Success, data: data };
-  } catch {
-    return { status: DowngradeToFreeApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const undoDowngradeFromServer = async (teamId: string) => {
-  try {
-    const res = await apiClient.fetch(
-      `/api/teams/${teamId}/billing/undo-downgrade`,
-      {
-        method: "PATCH",
-      },
-    );
+  const data = await request(`/api/teams/${teamId}/billing/undo-downgrade`, {
+    method: "PATCH",
+    failsWith: "Failed to undo downgrade",
+  });
 
-    if (!res.ok) {
-      return { status: UndoDowngradeApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: UndoDowngradeApiStatus.Success, data: data };
-  } catch {
-    return { status: UndoDowngradeApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchCustomerPortalUrlFromServer = async (
   teamId: string,
   returnUrl: string,
 ) => {
-  try {
-    const res = await apiClient.fetch(`/api/teams/${teamId}/billing/portal`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        return_url: returnUrl,
-      }),
-    });
+  const data = await request(`/api/teams/${teamId}/billing/portal`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      return_url: returnUrl,
+    }),
+    failsWith: "Failed to fetch customer portal url",
+  });
 
-    if (!res.ok) {
-      return { status: FetchCustomerPortalUrlApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: FetchCustomerPortalUrlApiStatus.Success, data: data };
-  } catch {
-    return { status: FetchCustomerPortalUrlApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchBugReportsOverviewFromServer = async (
@@ -2836,19 +1918,11 @@ export const fetchBugReportsOverviewFromServer = async (
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
   url = appendBugReportStatusesToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch bug reports overview",
+  });
 
-    if (!res.ok) {
-      return { status: BugReportsOverviewApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: BugReportsOverviewApiStatus.Success, data: data };
-  } catch {
-    return { status: BugReportsOverviewApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchBugReportsOverviewPlotFromServer = async (
@@ -2860,43 +1934,22 @@ export const fetchBugReportsOverviewPlotFromServer = async (
   url = appendBugReportStatusesToUrl(url, filters);
   url = appendPlotTimeGroupToUrl(url, filters);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch bug reports overview plot",
+  });
 
-    if (!res.ok) {
-      return { status: BugReportsOverviewPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: BugReportsOverviewPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: BugReportsOverviewPlotApiStatus.Success, data: data };
-  } catch {
-    return { status: BugReportsOverviewPlotApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchBugReportFromServer = async (
   appId: string,
   bugReportId: string,
 ) => {
-  try {
-    const res = await apiClient.fetch(
-      `/api/apps/${appId}/bugReports/${bugReportId}`,
-    );
-    if (!res.ok) {
-      return { status: BugReportApiStatus.Error, data: null };
-    }
+  const data = await request(`/api/apps/${appId}/bugReports/${bugReportId}`, {
+    failsWith: "Failed to fetch bug report",
+  });
 
-    const data = await res.json();
-
-    return { status: BugReportApiStatus.Success, data: data };
-  } catch {
-    return { status: BugReportApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const updateBugReportStatusFromServer = async (
@@ -2904,29 +1957,11 @@ export const updateBugReportStatusFromServer = async (
   bugReportId: string,
   status: number,
 ) => {
-  const opts = {
+  await request(`/api/apps/${appId}/bugReports/${bugReportId}`, {
     method: "PATCH",
     body: JSON.stringify({ status: Number(status) }),
-  };
-
-  try {
-    const res = await apiClient.fetch(
-      `/api/apps/${appId}/bugReports/${bugReportId}`,
-      opts,
-    );
-    const data = await res.json();
-
-    if (!res.ok) {
-      return {
-        status: UpdateBugReportStatusApiStatus.Error,
-        error: data.error,
-      };
-    }
-
-    return { status: UpdateBugReportStatusApiStatus.Success };
-  } catch {
-    return { status: UpdateBugReportStatusApiStatus.Cancelled };
-  }
+    failsWith: "Failed to update bug report status",
+  });
 };
 
 // downloadBuildFile triggers a build mapping file download. The download is
@@ -2963,19 +1998,9 @@ export const fetchBuildsFromServer = async (
 
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, { failsWith: "Failed to fetch builds" });
 
-    if (!res.ok) {
-      return { status: BuildsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: BuildsApiStatus.Success, data: data };
-  } catch {
-    return { status: BuildsApiStatus.Error, data: null };
-  }
+  return data;
 };
 
 export const fetchAlertsOverviewFromServer = async (
@@ -2987,34 +2012,19 @@ export const fetchAlertsOverviewFromServer = async (
 
   url = await applyGenericFiltersToUrl(url, filters, limit, offset);
 
-  try {
-    const res = await apiClient.fetch(url);
+  const data = await request(url, {
+    failsWith: "Failed to fetch alerts overview",
+  });
 
-    if (!res.ok) {
-      return { status: AlertsOverviewApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    return { status: AlertsOverviewApiStatus.Success, data: data };
-  } catch {
-    return { status: AlertsOverviewApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchSdkConfigFromServer = async (appId: String) => {
   const url = `/api/apps/${appId}/config`;
 
-  try {
-    const res = await apiClient.fetch(url);
-    if (!res.ok) {
-      return { status: SdkConfigApiStatus.Error, data: null };
-    }
-    const data = await res.json();
-    return { status: SdkConfigApiStatus.Success, data: data };
-  } catch {
-    return { status: SdkConfigApiStatus.Cancelled, data: null };
-  }
+  const data = await request(url, { failsWith: "Failed to fetch sdk config" });
+
+  return data;
 };
 
 export const updateSdkConfigFromServer = async (
@@ -3023,65 +2033,40 @@ export const updateSdkConfigFromServer = async (
 ) => {
   const url = `/api/apps/${appId}/config`;
 
-  const opts = {
+  const data = await request(url, {
     method: "PATCH",
     body: JSON.stringify(config),
-  };
+    failsWith: "Failed to update sdk config",
+  });
 
-  try {
-    const res = await apiClient.fetch(url, opts);
-    const data = await res.json();
-
-    if (!res.ok) {
-      return {
-        status: UpdateSdkConfigApiStatus.Error,
-        data: null,
-        error: data?.error,
-      };
-    }
-
-    return {
-      status: UpdateSdkConfigApiStatus.Success,
-      data,
-    };
-  } catch {
-    return {
-      status: UpdateSdkConfigApiStatus.Cancelled,
-      data: null,
-    };
-  }
+  return data;
 };
 
 export const fetchNetworkDomainsFromServer = async (
   selectedApp: App,
   filters: Filters,
 ) => {
+  const failsWith = "Failed to fetch network domains";
+
+  // An unparsable date throws before the code builds the request. The caller
+  // must get the same kind of error as it gets for a dropped connection.
+  let url: string;
   try {
-    const serverFormattedStartDate = formatUserInputDateToServerFormat(
-      filters.startDate,
-    );
-    const serverFormattedEndDate = formatUserInputDateToServerFormat(
-      filters.endDate,
-    );
-
-    const res = await apiClient.fetch(
-      `/api/apps/${selectedApp.id}/networkRequests/domains?from=${serverFormattedStartDate}&to=${serverFormattedEndDate}`,
-    );
-
-    if (!res.ok) {
-      return { status: NetworkDomainsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data.results === null || data.results.length === 0) {
-      return { status: NetworkDomainsApiStatus.NoData, data: null };
-    }
-
-    return { status: NetworkDomainsApiStatus.Success, data: data };
-  } catch {
-    return { status: NetworkDomainsApiStatus.Cancelled, data: null };
+    url = `/api/apps/${selectedApp.id}/networkRequests/domains?from=${formatUserInputDateToServerFormat(filters.startDate)}&to=${formatUserInputDateToServerFormat(filters.endDate)}`;
+  } catch (e) {
+    throw new RequestError(failsWith, { cause: e });
   }
+
+  const data = await request(url, { failsWith });
+
+  if (data === null) {
+    throw new RequestError(failsWith);
+  }
+  if (data.results === null || data.results.length === 0) {
+    return null;
+  }
+
+  return data;
 };
 
 export const fetchNetworkPathsFromServer = async (
@@ -3090,32 +2075,33 @@ export const fetchNetworkPathsFromServer = async (
   search: string,
   filters: Filters,
 ) => {
+  const failsWith = "Failed to fetch network paths";
+
+  // An unparsable date throws before the code builds the request. The caller
+  // must get the same kind of error as it gets for a dropped connection.
+  let url: string;
   try {
-    const serverFormattedStartDate = formatUserInputDateToServerFormat(
-      filters.startDate,
+    const from = encodeURIComponent(
+      formatUserInputDateToServerFormat(filters.startDate),
     );
-    const serverFormattedEndDate = formatUserInputDateToServerFormat(
-      filters.endDate,
+    const to = encodeURIComponent(
+      formatUserInputDateToServerFormat(filters.endDate),
     );
-
-    const res = await apiClient.fetch(
-      `/api/apps/${selectedApp.id}/networkRequests/paths?domain=${encodeURIComponent(domain)}&search=${encodeURIComponent(search)}&from=${encodeURIComponent(serverFormattedStartDate)}&to=${encodeURIComponent(serverFormattedEndDate)}`,
-    );
-
-    if (!res.ok) {
-      return { status: NetworkPathsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data.results === null || data.results.length === 0) {
-      return { status: NetworkPathsApiStatus.NoData, data: null };
-    }
-
-    return { status: NetworkPathsApiStatus.Success, data: data };
-  } catch {
-    return { status: NetworkPathsApiStatus.Cancelled, data: null };
+    url = `/api/apps/${selectedApp.id}/networkRequests/paths?domain=${encodeURIComponent(domain)}&search=${encodeURIComponent(search)}&from=${from}&to=${to}`;
+  } catch (e) {
+    throw new RequestError(failsWith, { cause: e });
   }
+
+  const data = await request(url, { failsWith });
+
+  if (data === null) {
+    throw new RequestError(failsWith);
+  }
+  if (data.results === null || data.results.length === 0) {
+    return null;
+  }
+
+  return data;
 };
 
 export const fetchNetworkEndpointLatencyPlotFromServer = async (
@@ -3134,26 +2120,11 @@ export const fetchNetworkEndpointLatencyPlotFromServer = async (
   u.searchParams.append("path", path);
   apiUrl = u.toString();
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network endpoint latency plot",
+  });
 
-    if (!res.ok) {
-      return { status: NetworkEndpointLatencyPlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: NetworkEndpointLatencyPlotApiStatus.NoData, data: null };
-    }
-
-    return { status: NetworkEndpointLatencyPlotApiStatus.Success, data: data };
-  } catch {
-    return {
-      status: NetworkEndpointLatencyPlotApiStatus.Cancelled,
-      data: null,
-    };
-  }
+  return data;
 };
 
 export const fetchNetworkEndpointStatusCodesPlotFromServer = async (
@@ -3172,35 +2143,11 @@ export const fetchNetworkEndpointStatusCodesPlotFromServer = async (
   u.searchParams.append("path", path);
   apiUrl = u.toString();
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network endpoint status codes plot",
+  });
 
-    if (!res.ok) {
-      return {
-        status: NetworkEndpointStatusCodesPlotApiStatus.Error,
-        data: null,
-      };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return {
-        status: NetworkEndpointStatusCodesPlotApiStatus.NoData,
-        data: null,
-      };
-    }
-
-    return {
-      status: NetworkEndpointStatusCodesPlotApiStatus.Success,
-      data: data,
-    };
-  } catch {
-    return {
-      status: NetworkEndpointStatusCodesPlotApiStatus.Cancelled,
-      data: null,
-    };
-  }
+  return data;
 };
 
 export const fetchNetworkEndpointTimelinePlotFromServer = async (
@@ -3218,29 +2165,15 @@ export const fetchNetworkEndpointTimelinePlotFromServer = async (
   u.searchParams.append("path", path);
   apiUrl = u.toString();
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network endpoint timeline plot",
+  });
 
-    if (!res.ok) {
-      return { status: NetworkEndpointTimelinePlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null || !data.points || data.points.length === 0) {
-      return {
-        status: NetworkEndpointTimelinePlotApiStatus.NoData,
-        data: null,
-      };
-    }
-
-    return { status: NetworkEndpointTimelinePlotApiStatus.Success, data: data };
-  } catch {
-    return {
-      status: NetworkEndpointTimelinePlotApiStatus.Cancelled,
-      data: null,
-    };
+  if (data === null || !data.points || data.points.length === 0) {
+    return null;
   }
+
+  return data;
 };
 
 export const fetchNetworkTrendsFromServer = async (
@@ -3252,23 +2185,11 @@ export const fetchNetworkTrendsFromServer = async (
   apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
   apiUrl += `&trends_limit=${trendsLimit}`;
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network trends",
+  });
 
-    if (!res.ok) {
-      return { status: NetworkTrendsApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null) {
-      return { status: NetworkTrendsApiStatus.NoData, data: null };
-    }
-
-    return { status: NetworkTrendsApiStatus.Success, data: data };
-  } catch {
-    return { status: NetworkTrendsApiStatus.Cancelled, data: null };
-  }
+  return data;
 };
 
 export const fetchNetworkTimelinePlotFromServer = async (
@@ -3280,23 +2201,15 @@ export const fetchNetworkTimelinePlotFromServer = async (
   apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
   apiUrl += `&timeline_limit=${timelineLimit}`;
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network timeline plot",
+  });
 
-    if (!res.ok) {
-      return { status: NetworkTimelinePlotApiStatus.Error, data: null };
-    }
-
-    const data = await res.json();
-
-    if (data === null || !data.points || data.points.length === 0) {
-      return { status: NetworkTimelinePlotApiStatus.NoData, data: null };
-    }
-
-    return { status: NetworkTimelinePlotApiStatus.Success, data: data };
-  } catch {
-    return { status: NetworkTimelinePlotApiStatus.Cancelled, data: null };
+  if (data === null || !data.points || data.points.length === 0) {
+    return null;
   }
+
+  return data;
 };
 
 export const fetchNetworkOverviewStatusCodesPlotFromServer = async (
@@ -3307,33 +2220,13 @@ export const fetchNetworkOverviewStatusCodesPlotFromServer = async (
   apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
   apiUrl = appendPlotTimeGroupToUrl(apiUrl, filters);
 
-  try {
-    const res = await apiClient.fetch(apiUrl);
+  const data = await request(apiUrl, {
+    failsWith: "Failed to fetch network overview status codes plot",
+  });
 
-    if (!res.ok) {
-      return {
-        status: NetworkOverviewStatusCodesPlotApiStatus.Error,
-        data: null,
-      };
-    }
-
-    const data = await res.json();
-
-    if (data === null || (Array.isArray(data) && data.length === 0)) {
-      return {
-        status: NetworkOverviewStatusCodesPlotApiStatus.NoData,
-        data: null,
-      };
-    }
-
-    return {
-      status: NetworkOverviewStatusCodesPlotApiStatus.Success,
-      data: data,
-    };
-  } catch {
-    return {
-      status: NetworkOverviewStatusCodesPlotApiStatus.Cancelled,
-      data: null,
-    };
+  if (data === null || (Array.isArray(data) && data.length === 0)) {
+    return null;
   }
+
+  return data;
 };

--- a/frontend/dashboard/app/api/api_error.ts
+++ b/frontend/dashboard/app/api/api_error.ts
@@ -1,0 +1,25 @@
+/**
+ * The server answered and rejected the request. `status` is the HTTP status.
+ * The message is the server's own `error` field, when the server sends one.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * The call failed, but the server did not reject it. The connection failed,
+ * the code could not build the URL, or the code could not read the response
+ * body. The message names the operation, and `cause` holds the first error.
+ */
+export class RequestError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "RequestError";
+  }
+}

--- a/frontend/dashboard/app/auth/login/page.tsx
+++ b/frontend/dashboard/app/auth/login/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import {
-  ValidateInviteApiStatus,
-  validateInvitesFromServer,
-} from "@/app/api/api_calls";
+import { validateInvitesFromServer } from "@/app/api/api_calls";
+import { ApiError } from "@/app/api/api_error";
 import { fetchCurrentSession, type Session } from "@/app/query/hooks";
 import { queryClient } from "@/app/query/query_client";
 import { useMeasureStoreRegistry } from "@/app/stores/provider";
@@ -57,15 +55,16 @@ export default function Login(props: {
       return;
     }
     const validateInvite = async () => {
-      const result = await validateInvitesFromServer(inviteId as string);
-
-      switch (result.status) {
-        case ValidateInviteApiStatus.Error:
+      try {
+        await validateInvitesFromServer(inviteId as string);
+        setInviteInvalid(false);
+      } catch (e) {
+        // Only a rejection from the server shows that the invite is bad. A
+        // failure with no verdict leaves the invite unjudged, so a bad
+        // connection does not tell the user that the link is invalid.
+        if (e instanceof ApiError) {
           setInviteInvalid(true);
-          break;
-        case ValidateInviteApiStatus.Success:
-          setInviteInvalid(false);
-          break;
+        }
       }
     };
     validateInvite();

--- a/frontend/dashboard/app/components/bug_report.tsx
+++ b/frontend/dashboard/app/components/bug_report.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { UpdateBugReportStatusApiStatus } from "@/app/api/api_calls";
 import { Button } from "@/app/components/button";
 import { buttonVariants } from "@/app/components/button_variants";
 import { Skeleton } from "@/app/components/skeleton";
@@ -96,9 +95,7 @@ export default function BugReport({
 
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
   const [demoStatusToggled, setDemoStatusToggled] = useState(false);
-  const [demoUpdateStatus, setDemoUpdateStatus] = useState(
-    UpdateBugReportStatusApiStatus.Init,
-  );
+  const [demoUpdating, setDemoUpdating] = useState(false);
 
   const displayBugReport = demo
     ? {
@@ -110,18 +107,14 @@ export default function BugReport({
           : demoBugReport.status,
       }
     : bugReportQuery.data;
-  const displayBugReportApiStatus = demo
+  const bugReportState = demo
     ? "success"
     : bugReportQuery.isSuccess
       ? "success"
       : bugReportQuery.isError
         ? "error"
         : "loading";
-  const displayUpdateStatus = demo
-    ? demoUpdateStatus
-    : toggleStatusMutation.isPending
-      ? UpdateBugReportStatusApiStatus.Loading
-      : UpdateBugReportStatusApiStatus.Init;
+  const isUpdating = demo ? demoUpdating : toggleStatusMutation.isPending;
 
   const handleImageError = (key: string) => {
     setImageErrors((prev) => new Set(prev).add(key));
@@ -130,10 +123,10 @@ export default function BugReport({
   const handleToggleStatus: FormEventHandler = async (event) => {
     event.preventDefault();
     if (demo) {
-      setDemoUpdateStatus(UpdateBugReportStatusApiStatus.Loading);
+      setDemoUpdating(true);
       setTimeout(() => {
         setDemoStatusToggled((prev) => !prev);
-        setDemoUpdateStatus(UpdateBugReportStatusApiStatus.Success);
+        setDemoUpdating(false);
       }, 100);
       return;
     }
@@ -161,7 +154,7 @@ export default function BugReport({
       </p>
       <div className="py-2" />
 
-      {displayBugReportApiStatus === "loading" && (
+      {bugReportState === "loading" && (
         <div className="flex flex-col w-full py-4">
           {/* Pills */}
           <div className="flex flex-wrap gap-2 py-2 pb-12">
@@ -191,13 +184,13 @@ export default function BugReport({
         </div>
       )}
 
-      {displayBugReportApiStatus === "error" && (
+      {bugReportState === "error" && (
         <p className="font-body text-sm">
           Error fetching bug report, please refresh page to try again
         </p>
       )}
 
-      {displayBugReportApiStatus === "success" && displayBugReport && (
+      {bugReportState === "success" && displayBugReport && (
         <div>
           <div className="flex flex-wrap gap-2 py-2 pb-12 items-center">
             <Pill
@@ -268,10 +261,7 @@ export default function BugReport({
             <Button
               variant="outline"
               className="w-fit"
-              disabled={
-                !canUpdateStatus ||
-                displayUpdateStatus === UpdateBugReportStatusApiStatus.Loading
-              }
+              disabled={!canUpdateStatus || isUpdating}
               onClick={handleToggleStatus}
             >
               {displayBugReport.status === 0

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -19,18 +19,14 @@ import React, {
 } from "react";
 import {
   App,
-  AppsApiStatus,
   AppVersion,
   BugReportStatus,
-  FiltersApiStatus,
   FilterSource,
   HttpMethod,
-  RootSpanNamesApiStatus,
   SessionType,
   SpanStatus,
 } from "../api/api_calls";
 import {
-  type AppsQueryResult,
   useAppsQuery,
   useFilterOptionsQuery,
   useRootSpanNamesQuery,
@@ -651,24 +647,24 @@ const FiltersComponent = forwardRef<
 
     useEffect(() => {
       if (appsQuery.status === "pending") {
-        store.setApps([], AppsApiStatus.Loading);
+        store.setApps([], "pending");
         return;
       }
       if (appsQuery.status === "error") {
-        store.setApps([], AppsApiStatus.Error);
+        store.setApps([], "error");
         return;
       }
-      store.setApps(appsQuery.data.data, appsQuery.data.status);
+      // A team with no apps also resolves the query. The empty list is the
+      // answer, and not a failure or an unfinished load.
+      const apps = appsQuery.data;
+      store.setApps(apps, apps.length === 0 ? "no-apps" : "loaded");
     }, [appsQuery.status, appsQuery.data]);
 
     useEffect(() => {
       if (appsQuery.status !== "success") {
         return;
       }
-      if (appsQuery.data.status !== AppsApiStatus.Success) {
-        return;
-      }
-      const apps = appsQuery.data.data;
+      const apps = appsQuery.data;
       if (apps.length === 0) {
         return;
       }
@@ -692,26 +688,28 @@ const FiltersComponent = forwardRef<
         return;
       }
       if (filterOptionsQuery.status === "pending") {
-        store.setFilterOptions(null, FiltersApiStatus.Loading);
+        store.setFilterOptions(null, "pending");
         return;
       }
       if (filterOptionsQuery.status === "error") {
-        store.setFilterOptions(null, FiltersApiStatus.Error);
+        store.setFilterOptions(null, "error");
         return;
       }
-      // Query resolved — inner status is Success, NoData, or NotOnboarded.
-      const { status, data } = filterOptionsQuery.data;
-      if (status === FiltersApiStatus.Success && data) {
+      // The query resolved. The result is thus the options themselves, or
+      // one of the three empty outcomes. The kind of an empty outcome is
+      // also the store state.
+      const result = filterOptionsQuery.data;
+      if (result.kind === "options") {
         const selections = applyFilterOptions(
-          data,
+          result.data,
           selectedApp,
           initConfig,
           store,
         );
-        store.setFilterOptions(data, FiltersApiStatus.Success);
+        store.setFilterOptions(result.data, "loaded");
         store.applySelections(selections);
       } else {
-        store.setFilterOptions(null, status);
+        store.setFilterOptions(null, result.kind);
       }
     }, [
       filterOptionsQuery.status,
@@ -730,22 +728,24 @@ const FiltersComponent = forwardRef<
         return;
       }
       if (rootSpanNamesQuery.status === "pending") {
-        store.setRootSpanNames(null, RootSpanNamesApiStatus.Loading);
+        store.setRootSpanNames(null, "pending");
         return;
       }
       if (rootSpanNamesQuery.status === "error") {
-        store.setRootSpanNames(null, RootSpanNamesApiStatus.Error);
+        store.setRootSpanNames(null, "error");
         return;
       }
-      const { status, data } = rootSpanNamesQuery.data;
-      if (status === RootSpanNamesApiStatus.Success && data) {
-        store.setRootSpanNames(data, RootSpanNamesApiStatus.Success);
-        store.setSelectedRootSpanName(
-          resolveRootSpanName(data, initConfig, selectedApp),
-        );
-      } else {
-        store.setRootSpanNames(null, status);
+      // An app that has never reported a trace answers with a null list.
+      // This is not the same as a server that answers with an empty list.
+      const names = rootSpanNamesQuery.data;
+      if (names === null) {
+        store.setRootSpanNames(null, "no-data");
+        return;
       }
+      store.setRootSpanNames(names, "loaded");
+      store.setSelectedRootSpanName(
+        resolveRootSpanName(names, initConfig, selectedApp),
+      );
     }, [
       rootSpanNamesQuery.status,
       rootSpanNamesQuery.data,
@@ -762,8 +762,7 @@ const FiltersComponent = forwardRef<
         });
         if (appIdToSelect) {
           const apps =
-            queryClient.getQueryData<AppsQueryResult>(["filterApps", teamId])
-              ?.data ?? [];
+            queryClient.getQueryData<App[]>(["filterApps", teamId]) ?? [];
           const app = apps.find((a) => a.id === appIdToSelect);
           if (app) {
             store.setSelectedApp(app);
@@ -1376,15 +1375,14 @@ const FiltersComponent = forwardRef<
 
     return (
       <div>
-        {store.appsApiStatus === AppsApiStatus.Loading &&
-          filtersSkeleton(skeletonMainRowCount)}
+        {store.appsState === "pending" && filtersSkeleton(skeletonMainRowCount)}
 
-        {store.appsApiStatus === AppsApiStatus.Error && (
+        {store.appsState === "error" && (
           <p className="font-body text-sm">
             Error fetching apps, please refresh page to try again
           </p>
         )}
-        {store.appsApiStatus === AppsApiStatus.NoApps &&
+        {store.appsState === "no-apps" &&
           (showNotOnboarded ? (
             <Onboarding teamId={teamId} initConfig={initConfig} />
           ) : (
@@ -1400,72 +1398,63 @@ const FiltersComponent = forwardRef<
             </p>
           ))}
 
-        {store.appsApiStatus === AppsApiStatus.Success &&
-          store.filtersApiStatus !== FiltersApiStatus.Success && (
+        {store.appsState === "loaded" &&
+          store.filterOptionsState !== "loaded" && (
             <div className="flex flex-col">
               {showAppSelector &&
-                store.filtersApiStatus === FiltersApiStatus.Loading &&
+                store.filterOptionsState === "pending" &&
                 filtersSkeleton(skeletonMainRowCount - 1, appSelectorDropdown)}
-              {showAppSelector &&
-                store.filtersApiStatus !== FiltersApiStatus.Loading && (
-                  <div className="flex flex-wrap gap-8 items-center">
-                    {appSelectorDropdown}
-                  </div>
-                )}
+              {showAppSelector && store.filterOptionsState !== "pending" && (
+                <div className="flex flex-wrap gap-8 items-center">
+                  {appSelectorDropdown}
+                </div>
+              )}
               <div className="py-4" />
-              {store.filtersApiStatus === FiltersApiStatus.Error && (
+              {store.filterOptionsState === "error" && (
                 <p className="font-body text-sm">
                   Error fetching filters, please refresh page or select a
                   different app to try again
                 </p>
               )}
-              {showNoData &&
-                store.filtersApiStatus === FiltersApiStatus.NoData && (
-                  <p className="font-body text-sm">
-                    No{" "}
-                    {filterSource === FilterSource.Errors ? "errors" : "data"}{" "}
-                    received for this app yet
-                  </p>
-                )}
-              {showNoBuilds &&
-                store.filtersApiStatus === FiltersApiStatus.NoBuilds && (
-                  <p className="font-body text-sm">
-                    No builds uploaded for this app yet
-                  </p>
-                )}
+              {showNoData && store.filterOptionsState === "no-data" && (
+                <p className="font-body text-sm">
+                  No {filterSource === FilterSource.Errors ? "errors" : "data"}{" "}
+                  received for this app yet
+                </p>
+              )}
+              {showNoBuilds && store.filterOptionsState === "no-builds" && (
+                <p className="font-body text-sm">
+                  No builds uploaded for this app yet
+                </p>
+              )}
               {showNotOnboarded &&
-                store.filtersApiStatus === FiltersApiStatus.NotOnboarded && (
+                store.filterOptionsState === "not-onboarded" && (
                   <Onboarding teamId={teamId} initConfig={initConfig} />
                 )}
             </div>
           )}
 
-        {store.appsApiStatus === AppsApiStatus.Success &&
-          store.filtersApiStatus === FiltersApiStatus.Success &&
+        {store.appsState === "loaded" &&
+          store.filterOptionsState === "loaded" &&
           filterSource === FilterSource.Spans &&
-          store.rootSpanNamesApiStatus !== RootSpanNamesApiStatus.Success && (
+          store.rootSpanNamesState !== "loaded" && (
             <div className="flex flex-col">
               {showAppSelector &&
-                store.rootSpanNamesApiStatus ===
-                  RootSpanNamesApiStatus.Loading &&
+                store.rootSpanNamesState === "pending" &&
                 filtersSkeleton(skeletonMainRowCount - 1, appSelectorDropdown)}
-              {showAppSelector &&
-                store.rootSpanNamesApiStatus !==
-                  RootSpanNamesApiStatus.Loading && (
-                  <div className="flex flex-wrap gap-8 items-center">
-                    {appSelectorDropdown}
-                  </div>
-                )}
+              {showAppSelector && store.rootSpanNamesState !== "pending" && (
+                <div className="flex flex-wrap gap-8 items-center">
+                  {appSelectorDropdown}
+                </div>
+              )}
               <div className="py-4" />
-              {store.rootSpanNamesApiStatus ===
-                RootSpanNamesApiStatus.Error && (
+              {store.rootSpanNamesState === "error" && (
                 <p className="font-body text-sm">
                   Error fetching traces list, please refresh page or select a
                   different app to try again
                 </p>
               )}
-              {store.rootSpanNamesApiStatus ===
-                RootSpanNamesApiStatus.NoData && (
+              {store.rootSpanNamesState === "no-data" && (
                 <p className="font-body text-sm">
                   No traces received for this app yet
                 </p>
@@ -1473,11 +1462,11 @@ const FiltersComponent = forwardRef<
             </div>
           )}
 
-        {store.appsApiStatus === AppsApiStatus.Success &&
+        {store.appsState === "loaded" &&
           ((filterSource === FilterSource.Spans &&
-            store.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+            store.rootSpanNamesState === "loaded") ||
             filterSource !== FilterSource.Spans) &&
-          store.filtersApiStatus === FiltersApiStatus.Success && (
+          store.filterOptionsState === "loaded" && (
             <div>
               <div className="flex flex-wrap gap-8 items-center">
                 {showAppSelector && (

--- a/frontend/dashboard/app/components/onboarding.tsx
+++ b/frontend/dashboard/app/components/onboarding.tsx
@@ -6,10 +6,8 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import {
   App,
-  AppsApiStatus,
   fetchAppsFromServer,
   fetchFiltersFromServer,
-  FiltersApiStatus,
   FilterSource,
 } from "../api/api_calls";
 import {
@@ -584,8 +582,7 @@ export default function Onboarding({ teamId, initConfig }: OnboardingProps) {
   const selectedApp = useFiltersStore((state) => state.selectedApp);
 
   const appsQuery = useAppsQuery(teamId);
-  const apps: App[] =
-    appsQuery.data?.status === AppsApiStatus.Success ? appsQuery.data.data : [];
+  const apps: App[] = appsQuery.data ?? [];
 
   const createApp = useCreateAppMutation();
   const { data: authzAndMembers } = useAuthzAndMembersQuery(teamId);
@@ -672,21 +669,22 @@ export default function Onboarding({ teamId, initConfig }: OnboardingProps) {
     // materialised view before proceeding so that the destination page
     // does not show "No Data" when users heads there.
     const firstEventHasLanded = async (): Promise<boolean> => {
-      const appsResult = await fetchAppsFromServer(teamId);
-      if (appsResult.status !== AppsApiStatus.Success || !appsResult.data) {
+      try {
+        const polledApps = await fetchAppsFromServer(teamId);
+        const refetchedApp = polledApps.find((app) => app.id === targetAppId);
+        if (!refetchedApp?.onboarded) {
+          return false;
+        }
+        const errorsFilterResult = await fetchFiltersFromServer(
+          refetchedApp,
+          FilterSource.Errors,
+        );
+        return errorsFilterResult.kind === "options";
+      } catch {
+        // A failed poll looks the same as an app that has not reported yet.
+        // The caller tries again in both conditions.
         return false;
       }
-      const refetchedApp = (appsResult.data as App[]).find(
-        (app) => app.id === targetAppId,
-      );
-      if (!refetchedApp?.onboarded) {
-        return false;
-      }
-      const errorsFilterResult = await fetchFiltersFromServer(
-        refetchedApp,
-        FilterSource.Errors,
-      );
-      return errorsFilterResult.status === FiltersApiStatus.Success;
     };
 
     const pollForFirstEvent = async () => {

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -1,70 +1,9 @@
 "use client";
 
 import {
-  AlertsOverviewApiStatus,
-  AppApiKeyChangeApiStatus,
-  AppNameChangeApiStatus,
-  AuthzAndMembersApiStatus,
-  BugReportApiStatus,
-  BugReportsOverviewApiStatus,
-  BugReportsOverviewPlotApiStatus,
-  BuildsApiStatus,
-  CreateAppApiStatus,
-  CreateTeamApiStatus,
-  DowngradeToFreeApiStatus,
-  ErrorGroupCommonPathApiStatus,
-  ErrorsDetailsApiStatus,
-  ErrorsDetailsPlotApiStatus,
-  ErrorsDistributionPlotApiStatus,
-  ErrorsOverviewApiStatus,
-  ErrorsOverviewPlotApiStatus,
-  FetchAppRetentionApiStatus,
-  FetchAppThresholdPrefsApiStatus,
-  FetchBillingInfoApiStatus,
-  FetchCheckoutSessionApiStatus,
-  FetchCustomerPortalUrlApiStatus,
-  FetchNotifPrefsApiStatus,
-  FetchTeamSlackConnectUrlApiStatus,
-  FetchTeamSlackStatusApiStatus,
-  FetchUsageApiStatus,
-  InviteMemberApiStatus,
-  JourneyApiStatus,
   JourneyType,
-  MetricsApiStatus,
-  NetworkDomainsApiStatus,
-  NetworkEndpointLatencyPlotApiStatus,
-  NetworkEndpointStatusCodesPlotApiStatus,
-  NetworkEndpointTimelinePlotApiStatus,
-  NetworkOverviewStatusCodesPlotApiStatus,
-  NetworkPathsApiStatus,
-  NetworkTimelinePlotApiStatus,
-  NetworkTrendsApiStatus,
-  PendingInvitesApiStatus,
-  RemoveMemberApiStatus,
-  RemovePendingInviteApiStatus,
-  ResendPendingInviteApiStatus,
-  RoleChangeApiStatus,
   SdkConfig,
-  SdkConfigApiStatus,
-  SessionTimelineApiStatus,
-  SessionTimelinesOverviewApiStatus,
-  SessionTimelinesOverviewPlotApiStatus,
-  AppHealthPlotApiStatus,
-  SpanMetricsPlotApiStatus,
-  SpansApiStatus,
-  RemoveTeamSlackApiStatus,
   Team,
-  TeamNameChangeApiStatus,
-  TeamsApiStatus,
-  TestSlackAlertApiStatus,
-  TraceApiStatus,
-  UndoDowngradeApiStatus,
-  UpdateAppRetentionApiStatus,
-  UpdateAppThresholdPrefsApiStatus,
-  UpdateBugReportStatusApiStatus,
-  UpdateNotifPrefsApiStatus,
-  UpdateSdkConfigApiStatus,
-  UpdateTeamSlackStatusApiStatus,
   changeAppApiKeyFromServer,
   changeAppNameFromServer,
   changeRoleFromServer,
@@ -132,17 +71,15 @@ import {
 } from "@/app/api/api_calls";
 import {
   App,
-  AppsApiStatus,
   AppVersion,
   fetchAppsFromServer,
   fetchFiltersFromServer,
   fetchRootSpanNamesFromServer,
-  FiltersApiStatus,
   FilterSource,
   OsVersion,
-  RootSpanNamesApiStatus,
   UserDefAttr,
 } from "@/app/api/api_calls";
+import { ApiError } from "@/app/api/api_error";
 import { apiClient } from "@/app/api/api_client";
 import { queryClient } from "@/app/query/query_client";
 import type { FilterOptionsData } from "@/app/stores/filters_store";
@@ -200,38 +137,29 @@ function parseFilterResponse(data: any): FilterOptionsData {
   };
 }
 
-export type AppsQueryResult = {
-  status: AppsApiStatus;
-  data: App[];
-};
-
 export function useAppsQuery(teamId: string | undefined) {
-  return useQuery<AppsQueryResult>({
+  return useQuery<App[]>({
     queryKey: ["filterApps", teamId] as const,
-    queryFn: async () => {
-      const r = await fetchAppsFromServer(teamId!);
-      if (
-        r.status !== AppsApiStatus.Success &&
-        r.status !== AppsApiStatus.NoApps
-      ) {
-        throw new Error("Failed to fetch apps");
-      }
-      return { status: r.status, data: (r.data as App[] | null) ?? [] };
-    },
+    queryFn: () => fetchAppsFromServer(teamId!),
     enabled: !!teamId,
   });
 }
 
-export type FilterOptionsQueryResult = {
-  status: FiltersApiStatus;
-  data: FilterOptionsData | null;
-};
+/**
+ * The parsed form of FilterOptionsResult. It has the same four outcomes, and
+ * the raw server response becomes the option lists that the store holds.
+ */
+export type ParsedFilterOptionsResult =
+  | { kind: "options"; data: FilterOptionsData }
+  | { kind: "no-data" }
+  | { kind: "not-onboarded" }
+  | { kind: "no-builds" };
 
 export function useFilterOptionsQuery(
   app: App | null | undefined,
   filterSource: FilterSource,
 ) {
-  return useQuery<FilterOptionsQueryResult>({
+  return useQuery<ParsedFilterOptionsResult>({
     queryKey: [
       "filterOptions",
       app?.id,
@@ -239,53 +167,30 @@ export function useFilterOptionsQuery(
       app?.onboarded ?? false,
     ] as const,
     queryFn: async () => {
-      // Fast path: never-onboarded apps return NotOnboarded for every
-      // event-derived filterSource, skipping the network round-trip. Builds
-      // can be uploaded before an app is onboarded, so the Builds source
+      // An app that is not onboarded has no events, so every event-derived
+      // filterSource is empty. This code therefore skips the request. The
+      // user can upload a build before onboarding, so the Builds source
       // always asks the server.
       if (!app!.onboarded && filterSource !== FilterSource.Builds) {
-        return { status: FiltersApiStatus.NotOnboarded, data: null };
+        return { kind: "not-onboarded" };
       }
-      const r = await fetchFiltersFromServer(app!, filterSource);
-      if (
-        r.status !== FiltersApiStatus.Success &&
-        r.status !== FiltersApiStatus.NotOnboarded &&
-        r.status !== FiltersApiStatus.NoData &&
-        r.status !== FiltersApiStatus.NoBuilds
-      ) {
-        throw new Error("Failed to fetch filters");
+      const result = await fetchFiltersFromServer(app!, filterSource);
+      if (result.kind !== "options") {
+        return result;
       }
-      const parsed = r.data ? parseFilterResponse(r.data) : null;
-      return { status: r.status, data: parsed };
+      return { kind: "options", data: parseFilterResponse(result.data) };
     },
     enabled: !!app,
   });
 }
 
-export type RootSpanNamesQueryResult = {
-  status: RootSpanNamesApiStatus;
-  data: string[] | null;
-};
-
 export function useRootSpanNamesQuery(
   app: App | null | undefined,
   filterSource: FilterSource,
 ) {
-  return useQuery<RootSpanNamesQueryResult>({
+  return useQuery<string[] | null>({
     queryKey: ["rootSpanNames", app?.id] as const,
-    queryFn: async () => {
-      const r = await fetchRootSpanNamesFromServer(app!);
-      if (
-        r.status !== RootSpanNamesApiStatus.Success &&
-        r.status !== RootSpanNamesApiStatus.NoData
-      ) {
-        throw new Error("Failed to fetch root span names");
-      }
-      return {
-        status: r.status,
-        data: (r.data?.results as string[] | null) ?? null,
-      };
-    },
+    queryFn: () => fetchRootSpanNamesFromServer(app!),
     enabled: !!app && filterSource === FilterSource.Spans,
   });
 }
@@ -388,7 +293,10 @@ export enum RootSpanMetricsQuantile {
 // ─── Shared helpers ──────────────────────────────────────────────────────
 
 /** Standard plot transformation: datetime/instances → x/y */
-function mapPlotData(data: any[]) {
+function mapPlotData(data: any[] | null) {
+  if (data === null) {
+    return null;
+  }
   return data.map((item: any) => ({
     id: item.id,
     data: item.data.map((d: any) => ({ x: d.datetime, y: d.instances })),
@@ -456,6 +364,9 @@ function formatOsVersionKey(key: string): string {
 }
 
 function parseDistributionPlot(resultData: any) {
+  if (resultData === null) {
+    return null;
+  }
   const plotKeys: string[] = [];
   const plot = Object.entries(resultData).map(([attribute, values]) => {
     const transformedValues: { [key: string]: number } = {};
@@ -490,13 +401,7 @@ export function useMetricsQuery() {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["metrics", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result = await fetchMetricsFromServer(filters);
-      if (result.status !== MetricsApiStatus.Success) {
-        throw new Error("Failed to fetch metrics");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchMetricsFromServer(filters),
     enabled: filters.ready,
   });
 }
@@ -504,13 +409,7 @@ export function useMetricsQuery() {
 export function useAppThresholdPrefsQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["appThresholdPrefs", appId] as const,
-    queryFn: async () => {
-      const result = await fetchAppThresholdPrefsFromServer(appId!);
-      if (result.status !== FetchAppThresholdPrefsApiStatus.Success) {
-        throw new Error("Failed to fetch threshold prefs");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchAppThresholdPrefsFromServer(appId!),
     enabled: !!appId,
   });
 }
@@ -529,16 +428,7 @@ export function useJourneyQuery(
       bidirectional,
       filters.serialisedFilters,
     ] as const,
-    queryFn: async () => {
-      const result = await fetchJourneyFromServer(bidirectional, filters);
-      if (result.status === JourneyApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== JourneyApiStatus.Success) {
-        throw new Error("Failed to fetch journey");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchJourneyFromServer(bidirectional, filters),
     enabled: filters.ready,
   });
 }
@@ -551,13 +441,7 @@ export function useNetworkDomainsQuery() {
     queryKey: ["networkDomains", filters.serialisedFilters] as const,
     queryFn: async () => {
       const result = await fetchNetworkDomainsFromServer(filters.app!, filters);
-      if (result.status === NetworkDomainsApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkDomainsApiStatus.Success) {
-        throw new Error("Failed to fetch domains");
-      }
-      return result.data.results as string[];
+      return (result?.results ?? null) as string[] | null;
     },
     enabled: filters.ready && !!filters.app,
   });
@@ -579,13 +463,7 @@ export function useNetworkPathsQuery(domain: string, searchPattern: string) {
         searchPattern,
         filters,
       );
-      if (result.status === NetworkPathsApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkPathsApiStatus.Success) {
-        throw new Error("Failed to fetch paths");
-      }
-      return result.data.results as string[];
+      return (result?.results ?? null) as string[] | null;
     },
     enabled: filters.ready && !!filters.app && domain !== "",
   });
@@ -595,17 +473,7 @@ export function useNetworkStatusPlotQuery() {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkStatusPlot", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result =
-        await fetchNetworkOverviewStatusCodesPlotFromServer(filters);
-      if (result.status === NetworkOverviewStatusCodesPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkOverviewStatusCodesPlotApiStatus.Success) {
-        throw new Error("Failed to fetch status plot");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchNetworkOverviewStatusCodesPlotFromServer(filters),
     enabled: filters.ready && !!filters.app,
   });
 }
@@ -614,16 +482,7 @@ export function useNetworkTimelineQuery() {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkTimeline", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result = await fetchNetworkTimelinePlotFromServer(filters, 10);
-      if (result.status === NetworkTimelinePlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkTimelinePlotApiStatus.Success) {
-        throw new Error("Failed to fetch timeline");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchNetworkTimelinePlotFromServer(filters, 10),
     enabled: filters.ready && !!filters.app,
   });
 }
@@ -639,20 +498,8 @@ export function useNetworkEndpointLatencyQuery(domain: string, path: string) {
       domain,
       path,
     ] as const,
-    queryFn: async () => {
-      const result = await fetchNetworkEndpointLatencyPlotFromServer(
-        filters,
-        domain,
-        path,
-      );
-      if (result.status === NetworkEndpointLatencyPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkEndpointLatencyPlotApiStatus.Success) {
-        throw new Error("Failed to fetch latency");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchNetworkEndpointLatencyPlotFromServer(filters, domain, path),
     enabled: filters.ready && domain !== "" && path !== "",
   });
 }
@@ -669,20 +516,8 @@ export function useNetworkEndpointStatusCodesQuery(
       domain,
       path,
     ] as const,
-    queryFn: async () => {
-      const result = await fetchNetworkEndpointStatusCodesPlotFromServer(
-        filters,
-        domain,
-        path,
-      );
-      if (result.status === NetworkEndpointStatusCodesPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkEndpointStatusCodesPlotApiStatus.Success) {
-        throw new Error("Failed to fetch status codes");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchNetworkEndpointStatusCodesPlotFromServer(filters, domain, path),
     enabled: filters.ready && domain !== "" && path !== "",
   });
 }
@@ -696,20 +531,8 @@ export function useNetworkEndpointTimelineQuery(domain: string, path: string) {
       domain,
       path,
     ] as const,
-    queryFn: async () => {
-      const result = await fetchNetworkEndpointTimelinePlotFromServer(
-        filters,
-        domain,
-        path,
-      );
-      if (result.status === NetworkEndpointTimelinePlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkEndpointTimelinePlotApiStatus.Success) {
-        throw new Error("Failed to fetch endpoint timeline");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchNetworkEndpointTimelinePlotFromServer(filters, domain, path),
     enabled: filters.ready && domain !== "" && path !== "",
   });
 }
@@ -720,16 +543,7 @@ export function useNetworkTrendsQuery(active: boolean) {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["networkTrends", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result = await fetchNetworkTrendsFromServer(filters, 15);
-      if (result.status === NetworkTrendsApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== NetworkTrendsApiStatus.Success) {
-        throw new Error("Failed to fetch trends");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchNetworkTrendsFromServer(filters, 15),
     enabled: filters.ready && active,
   });
 }
@@ -742,13 +556,7 @@ export function useBugReportsOverviewPlotQuery() {
     queryKey: ["bugReportsOverviewPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
       const result = await fetchBugReportsOverviewPlotFromServer(filters);
-      if (result.status === BugReportsOverviewPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== BugReportsOverviewPlotApiStatus.Success) {
-        throw new Error("Failed to fetch bug reports plot");
-      }
-      return mapPlotData(result.data);
+      return mapPlotData(result);
     },
     enabled: filters.ready,
   });
@@ -763,13 +571,7 @@ export function useSessionTimelinesOverviewPlotQuery() {
     ] as const,
     queryFn: async () => {
       const result = await fetchSessionTimelinesOverviewPlotFromServer(filters);
-      if (result.status === SessionTimelinesOverviewPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== SessionTimelinesOverviewPlotApiStatus.Success) {
-        throw new Error("Failed to fetch session timelines plot");
-      }
-      return mapPlotData(result.data);
+      return mapPlotData(result);
     },
     enabled: filters.ready,
   });
@@ -779,16 +581,7 @@ export function useAppHealthPlotQuery() {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["appHealthPlot", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result = await fetchAppHealthPlotFromServer(filters);
-      if (result.status === AppHealthPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== AppHealthPlotApiStatus.Success) {
-        throw new Error("Failed to fetch app health plot");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchAppHealthPlotFromServer(filters),
     enabled: filters.ready,
   });
 }
@@ -799,16 +592,7 @@ export function useSpanMetricsPlotQuery(quantile: RootSpanMetricsQuantile) {
   const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: ["spanMetricsPlot", filters.serialisedFilters] as const,
-    queryFn: async () => {
-      const result = await fetchSpanMetricsPlotFromServer(filters);
-      if (result.status === SpanMetricsPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== SpanMetricsPlotApiStatus.Success) {
-        throw new Error("Failed to fetch span metrics plot");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchSpanMetricsPlotFromServer(filters),
     select: (rawData) =>
       rawData ? transformSpanMetricsPlotData(rawData, quantile) : null,
     enabled: filters.ready,
@@ -828,17 +612,8 @@ export function useAlertsOverviewQuery(paginationOffset: number) {
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchAlertsOverviewFromServer(
-        filters,
-        ALERTS_LIMIT,
-        paginationOffset,
-      );
-      if (result.status !== AlertsOverviewApiStatus.Success) {
-        throw new Error("Failed to fetch alerts");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchAlertsOverviewFromServer(filters, ALERTS_LIMIT, paginationOffset),
     enabled: filters.ready,
   });
 }
@@ -856,17 +631,12 @@ export function useBugReportsOverviewQuery(paginationOffset: number) {
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchBugReportsOverviewFromServer(
+    queryFn: () =>
+      fetchBugReportsOverviewFromServer(
         filters,
         BUG_REPORTS_LIMIT,
         paginationOffset,
-      );
-      if (result.status !== BugReportsOverviewApiStatus.Success) {
-        throw new Error("Failed to fetch bug reports");
-      }
-      return result.data;
-    },
+      ),
     enabled: filters.ready,
   });
 }
@@ -880,17 +650,8 @@ export function useBuildsQuery(paginationOffset: number) {
   return useQuery({
     queryKey: ["builds", filters.serialisedFilters, paginationOffset] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchBuildsFromServer(
-        filters,
-        BUILDS_LIMIT,
-        paginationOffset,
-      );
-      if (result.status !== BuildsApiStatus.Success) {
-        throw new Error("Failed to fetch builds");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchBuildsFromServer(filters, BUILDS_LIMIT, paginationOffset),
     enabled: filters.ready,
   });
 }
@@ -904,17 +665,8 @@ export function useSpansQuery(paginationOffset: number) {
   return useQuery({
     queryKey: ["spans", filters.serialisedFilters, paginationOffset] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchSpansFromServer(
-        filters,
-        TRACES_LIMIT,
-        paginationOffset,
-      );
-      if (result.status !== SpansApiStatus.Success) {
-        throw new Error("Failed to fetch spans");
-      }
-      return result.data;
-    },
+    queryFn: () =>
+      fetchSpansFromServer(filters, TRACES_LIMIT, paginationOffset),
     enabled: filters.ready,
   });
 }
@@ -932,17 +684,12 @@ export function useSessionTimelinesOverviewQuery(paginationOffset: number) {
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchSessionTimelinesOverviewFromServer(
+    queryFn: () =>
+      fetchSessionTimelinesOverviewFromServer(
         filters,
         SESSION_TIMELINES_LIMIT,
         paginationOffset,
-      );
-      if (result.status !== SessionTimelinesOverviewApiStatus.Success) {
-        throw new Error("Failed to fetch session timelines");
-      }
-      return result.data;
-    },
+      ),
     enabled: filters.ready,
   });
 }
@@ -961,17 +708,12 @@ export function useErrorsOverviewQuery(paginationOffset: number) {
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchErrorsOverviewFromServer(
+    queryFn: () =>
+      fetchErrorsOverviewFromServer(
         filters,
         ERRORS_OVERVIEW_LIMIT,
         paginationOffset,
-      );
-      if (result.status !== ErrorsOverviewApiStatus.Success) {
-        throw new Error("Failed to fetch errors overview");
-      }
-      return result.data;
-    },
+      ),
     enabled: filters.ready,
   });
 }
@@ -982,13 +724,7 @@ export function useErrorsOverviewPlotQuery() {
     queryKey: ["errorsOverviewPlot", filters.serialisedFilters] as const,
     queryFn: async () => {
       const result = await fetchErrorsOverviewPlotFromServer(filters);
-      if (result.status === ErrorsOverviewPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== ErrorsOverviewPlotApiStatus.Success) {
-        throw new Error("Failed to fetch errors plot");
-      }
-      return mapPlotData(result.data);
+      return mapPlotData(result);
     },
     enabled: filters.ready,
   });
@@ -1007,18 +743,13 @@ export function useErrorsDetailsQuery(
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const result = await fetchErrorsDetailsFromServer(
+    queryFn: () =>
+      fetchErrorsDetailsFromServer(
         errorGroupId,
         paginationOffset,
         filters,
         ERRORS_DETAILS_LIMIT,
-      );
-      if (result.status !== ErrorsDetailsApiStatus.Success) {
-        throw new Error("Failed to fetch error details");
-      }
-      return result.data;
-    },
+      ),
     enabled: filters.ready && errorGroupId !== "",
   });
 }
@@ -1036,13 +767,7 @@ export function useErrorsDetailsPlotQuery(errorGroupId: string) {
         errorGroupId,
         filters,
       );
-      if (result.status === ErrorsDetailsPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== ErrorsDetailsPlotApiStatus.Success) {
-        throw new Error("Failed to fetch error details plot");
-      }
-      return mapPlotData(result.data);
+      return mapPlotData(result);
     },
     enabled: filters.ready && errorGroupId !== "",
   });
@@ -1061,13 +786,7 @@ export function useErrorsDistributionPlotQuery(errorGroupId: string) {
         errorGroupId,
         filters,
       );
-      if (result.status === ErrorsDistributionPlotApiStatus.NoData) {
-        return null;
-      }
-      if (result.status !== ErrorsDistributionPlotApiStatus.Success) {
-        throw new Error("Failed to fetch error distribution plot");
-      }
-      return parseDistributionPlot(result.data);
+      return parseDistributionPlot(result);
     },
     enabled: filters.ready && errorGroupId !== "",
   });
@@ -1082,10 +801,7 @@ export function useErrorGroupCommonPathQuery(errorGroupId: string) {
         errorGroupId,
         filters,
       );
-      if (result.status !== ErrorGroupCommonPathApiStatus.Success) {
-        throw new Error("Failed to fetch error group common path");
-      }
-      return result.data as ExceptionGroupCommonPath;
+      return result as ExceptionGroupCommonPath;
     },
     enabled: !!filters.app && !!errorGroupId,
   });
@@ -1096,13 +812,7 @@ export function useErrorGroupCommonPathQuery(errorGroupId: string) {
 export function useTeamsQuery() {
   return useQuery({
     queryKey: ["teams"] as const,
-    queryFn: async () => {
-      const result = await fetchTeamsFromServer();
-      if (result.status !== TeamsApiStatus.Success) {
-        throw new Error("Failed to fetch teams");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchTeamsFromServer(),
   });
 }
 
@@ -1111,13 +821,7 @@ export function useTeamsQuery() {
 export function useTraceQuery(appId: string, traceId: string) {
   return useQuery({
     queryKey: ["trace", appId, traceId] as const,
-    queryFn: async () => {
-      const result = await fetchTraceFromServer(appId, traceId);
-      if (result.status !== TraceApiStatus.Success) {
-        throw new Error("Failed to fetch trace");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchTraceFromServer(appId, traceId),
     enabled: !!appId && !!traceId,
   });
 }
@@ -1127,13 +831,7 @@ export function useTraceQuery(appId: string, traceId: string) {
 export function useSessionTimelineQuery(appId: string, sessionId: string) {
   return useQuery({
     queryKey: ["sessionTimeline", appId, sessionId] as const,
-    queryFn: async () => {
-      const result = await fetchSessionTimelineFromServer(appId, sessionId);
-      if (result.status !== SessionTimelineApiStatus.Success) {
-        throw new Error("Failed to fetch session timeline");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchSessionTimelineFromServer(appId, sessionId),
     enabled: !!appId && !!sessionId,
   });
 }
@@ -1143,13 +841,7 @@ export function useSessionTimelineQuery(appId: string, sessionId: string) {
 export function useBugReportQuery(appId: string, bugReportId: string) {
   return useQuery({
     queryKey: ["bugReport", appId, bugReportId] as const,
-    queryFn: async () => {
-      const result = await fetchBugReportFromServer(appId, bugReportId);
-      if (result.status !== BugReportApiStatus.Success) {
-        throw new Error("Failed to fetch bug report");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchBugReportFromServer(appId, bugReportId),
     enabled: !!appId && !!bugReportId,
   });
 }
@@ -1161,14 +853,11 @@ export function useToggleBugReportStatusMutation() {
       bugReportId: string;
       newStatus: number;
     }) => {
-      const result = await updateBugReportStatusFromServer(
+      await updateBugReportStatusFromServer(
         params.appId,
         params.bugReportId,
         params.newStatus,
       );
-      if (result.status !== UpdateBugReportStatusApiStatus.Success) {
-        throw new Error("Failed to update bug report status");
-      }
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1184,21 +873,19 @@ export function useToggleBugReportStatusMutation() {
 export function useNotifPrefsQuery() {
   return useQuery({
     queryKey: ["notifPrefs"] as const,
-    queryFn: async () => {
-      const result = await fetchNotifPrefsFromServer();
-      if (result.status !== FetchNotifPrefsApiStatus.Success) {
-        throw new Error("Failed to fetch notification preferences");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchNotifPrefsFromServer(),
   });
 }
 
 export function useSaveNotifPrefsMutation() {
   return useMutation({
     mutationFn: async (params: { notifPrefs: typeof emptyNotifPrefs }) => {
-      const result = await updateNotifPrefsFromServer(params.notifPrefs);
-      if (result.status !== UpdateNotifPrefsApiStatus.Success) {
+      try {
+        await updateNotifPrefsFromServer(params.notifPrefs);
+      } catch {
+        // The preferences page shows this message below its own heading.
+        // The message therefore names the user's task, and does not repeat
+        // the server's words for the same failure.
         throw new Error("Failed to save notification preferences");
       }
     },
@@ -1212,16 +899,8 @@ export function useSaveNotifPrefsMutation() {
 
 export function useCreateAppMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string; appName: string }) => {
-      const result = await createAppFromServer(params.teamId, params.appName);
-      if (result.status === CreateAppApiStatus.Error) {
-        throw new Error(result.error ?? "Failed to create app");
-      }
-      if (result.status !== CreateAppApiStatus.Success) {
-        throw new Error("Failed to create app");
-      }
-      return result.data;
-    },
+    mutationFn: (params: { teamId: string; appName: string }) =>
+      createAppFromServer(params.teamId, params.appName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] });
     },
@@ -1234,13 +913,7 @@ export function useCreateTeamMutation() {
   return useMutation({
     mutationFn: async (params: { teamName: string }) => {
       const result = await createTeamFromServer(params.teamName);
-      if (result.status === CreateTeamApiStatus.Error) {
-        throw new Error(result.error ?? "Failed to create team");
-      }
-      if (result.status !== CreateTeamApiStatus.Success) {
-        throw new Error("Failed to create team");
-      }
-      return result.data as Team;
+      return result as Team;
     },
     onSuccess: (newTeam) => {
       queryClient.setQueryData<Team[]>(["teams"], (old) =>
@@ -1256,13 +929,7 @@ export function useCreateTeamMutation() {
 export function useAuthzAndMembersQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["authzAndMembers", teamId] as const,
-    queryFn: async () => {
-      const result = await fetchAuthzAndMembersFromServer(teamId!);
-      if (result.status !== AuthzAndMembersApiStatus.Success) {
-        throw new Error("Failed to fetch authz and members");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchAuthzAndMembersFromServer(teamId!),
     enabled: !!teamId,
   });
 }
@@ -1270,13 +937,7 @@ export function useAuthzAndMembersQuery(teamId: string | undefined) {
 export function useAppRetentionQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["appRetention", appId] as const,
-    queryFn: async () => {
-      const result = await fetchAppRetentionFromServer(appId!);
-      if (result.status !== FetchAppRetentionApiStatus.Success) {
-        throw new Error("Failed to fetch app retention");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchAppRetentionFromServer(appId!),
     enabled: !!appId,
   });
 }
@@ -1284,20 +945,12 @@ export function useAppRetentionQuery(appId: string | undefined) {
 export function useSdkConfigQuery(appId: string | undefined) {
   return useQuery({
     queryKey: ["sdkConfig", appId] as const,
-    queryFn: async () => {
-      const result = await fetchSdkConfigFromServer(appId!);
-      if (result.status !== SdkConfigApiStatus.Success) {
-        throw new Error("Failed to fetch SDK config");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchSdkConfigFromServer(appId!),
     enabled: !!appId,
   });
 }
 
-type BillingInfoData = Awaited<
-  ReturnType<typeof fetchBillingInfoFromServer>
->["data"];
+type BillingInfoData = Awaited<ReturnType<typeof fetchBillingInfoFromServer>>;
 
 type RefetchInterval =
   | number
@@ -1310,13 +963,7 @@ export function useBillingInfoQuery(
 ) {
   return useQuery({
     queryKey: ["billingInfo", teamId] as const,
-    queryFn: async () => {
-      const result = await fetchBillingInfoFromServer(teamId!);
-      if (result.status !== FetchBillingInfoApiStatus.Success) {
-        throw new Error("Failed to fetch billing info");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchBillingInfoFromServer(teamId!),
     enabled: !!teamId,
     refetchInterval: opts?.refetchInterval,
   });
@@ -1330,13 +977,7 @@ export function useUpdateAppRetentionMutation() {
       appId: string;
       retention: typeof emptyAppRetention;
     }) => {
-      const result = await updateAppRetentionFromServer(
-        params.appId,
-        params.retention,
-      );
-      if (result.status !== UpdateAppRetentionApiStatus.Success) {
-        throw new Error("Failed to update app retention");
-      }
+      await updateAppRetentionFromServer(params.appId, params.retention);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1349,13 +990,7 @@ export function useUpdateAppRetentionMutation() {
 export function useChangeAppNameMutation() {
   return useMutation({
     mutationFn: async (params: { appId: string; appName: string }) => {
-      const result = await changeAppNameFromServer(
-        params.appId,
-        params.appName,
-      );
-      if (result.status !== AppNameChangeApiStatus.Success) {
-        throw new Error("Failed to change app name");
-      }
+      await changeAppNameFromServer(params.appId, params.appName);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] });
@@ -1366,10 +1001,7 @@ export function useChangeAppNameMutation() {
 export function useChangeAppApiKeyMutation() {
   return useMutation({
     mutationFn: async (params: { appId: string }) => {
-      const result = await changeAppApiKeyFromServer(params.appId);
-      if (result.status !== AppApiKeyChangeApiStatus.Success) {
-        throw new Error("Failed to change app API key");
-      }
+      await changeAppApiKeyFromServer(params.appId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] });
@@ -1383,13 +1015,7 @@ export function useUpdateAppThresholdPrefsMutation() {
       appId: string;
       prefs: typeof defaultAppThresholdPrefs;
     }) => {
-      const result = await updateAppThresholdPrefsFromServer(
-        params.appId,
-        params.prefs,
-      );
-      if (result.status !== UpdateAppThresholdPrefsApiStatus.Success) {
-        throw new Error("Failed to update threshold prefs");
-      }
+      await updateAppThresholdPrefsFromServer(params.appId, params.prefs);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1403,19 +1029,8 @@ export function useUpdateAppThresholdPrefsMutation() {
 
 export function useSaveSdkConfigMutation() {
   return useMutation({
-    mutationFn: async (params: {
-      appId: string;
-      config: Partial<SdkConfig>;
-    }) => {
-      const result = await updateSdkConfigFromServer(
-        params.appId,
-        params.config,
-      );
-      if (result.status !== UpdateSdkConfigApiStatus.Success) {
-        throw new Error("Failed to save SDK config");
-      }
-      return result.data;
-    },
+    mutationFn: (params: { appId: string; config: Partial<SdkConfig> }) =>
+      updateSdkConfigFromServer(params.appId, params.config),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["sdkConfig", variables.appId],
@@ -1429,13 +1044,7 @@ export function useSaveSdkConfigMutation() {
 export function usePendingInvitesQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["pendingInvites", teamId] as const,
-    queryFn: async () => {
-      const result = await fetchPendingInvitesFromServer(teamId!);
-      if (result.status !== PendingInvitesApiStatus.Success) {
-        throw new Error("Failed to fetch pending invites");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchPendingInvitesFromServer(teamId!),
     enabled: !!teamId,
   });
 }
@@ -1448,10 +1057,7 @@ export function useTeamSlackConnectUrlQuery(
     queryKey: ["teamSlackConnectUrl", teamId] as const,
     queryFn: async () => {
       const result = await fetchTeamSlackConnectUrlFromServer(teamId!);
-      if (result.status !== FetchTeamSlackConnectUrlApiStatus.Success) {
-        throw new Error("Failed to fetch Slack connect URL");
-      }
-      return result.data.url as string;
+      return result.url as string;
     },
     enabled: !!teamId && enabled,
   });
@@ -1460,13 +1066,7 @@ export function useTeamSlackConnectUrlQuery(
 export function useTeamSlackStatusQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["teamSlackStatus", teamId] as const,
-    queryFn: async () => {
-      const result = await fetchTeamSlackStatusFromServer(teamId!);
-      if (result.status !== FetchTeamSlackStatusApiStatus.Success) {
-        throw new Error("Failed to fetch Slack status");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchTeamSlackStatusFromServer(teamId!),
     enabled: !!teamId,
   });
 }
@@ -1476,13 +1076,7 @@ export function useTeamSlackStatusQuery(teamId: string | undefined) {
 export function useChangeTeamNameMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; newName: string }) => {
-      const result = await changeTeamNameFromServer(
-        params.teamId,
-        params.newName,
-      );
-      if (result.status !== TeamNameChangeApiStatus.Success) {
-        throw new Error("Failed to change team name");
-      }
+      await changeTeamNameFromServer(params.teamId, params.newName);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] });
@@ -1497,14 +1091,7 @@ export function useInviteMemberMutation() {
       email: string;
       role: string;
     }) => {
-      const result = await inviteMemberFromServer(
-        params.teamId,
-        params.email,
-        params.role,
-      );
-      if (result.status !== InviteMemberApiStatus.Success) {
-        throw new Error("Failed to invite member");
-      }
+      await inviteMemberFromServer(params.teamId, params.email, params.role);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1520,13 +1107,7 @@ export function useInviteMemberMutation() {
 export function useRemoveMemberMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; memberId: string }) => {
-      const result = await removeMemberFromServer(
-        params.teamId,
-        params.memberId,
-      );
-      if (result.status !== RemoveMemberApiStatus.Success) {
-        throw new Error("Failed to remove member");
-      }
+      await removeMemberFromServer(params.teamId, params.memberId);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1539,13 +1120,7 @@ export function useRemoveMemberMutation() {
 export function useResendPendingInviteMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; inviteId: string }) => {
-      const result = await resendPendingInviteFromServer(
-        params.teamId,
-        params.inviteId,
-      );
-      if (result.status !== ResendPendingInviteApiStatus.Success) {
-        throw new Error("Failed to resend invite");
-      }
+      await resendPendingInviteFromServer(params.teamId, params.inviteId);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1558,13 +1133,7 @@ export function useResendPendingInviteMutation() {
 export function useRemovePendingInviteMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; inviteId: string }) => {
-      const result = await removePendingInviteFromServer(
-        params.teamId,
-        params.inviteId,
-      );
-      if (result.status !== RemovePendingInviteApiStatus.Success) {
-        throw new Error("Failed to remove invite");
-      }
+      await removePendingInviteFromServer(params.teamId, params.inviteId);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1581,14 +1150,11 @@ export function useChangeRoleMutation() {
       newRole: string;
       memberId: string;
     }) => {
-      const result = await changeRoleFromServer(
+      await changeRoleFromServer(
         params.teamId,
         params.newRole,
         params.memberId,
       );
-      if (result.status !== RoleChangeApiStatus.Success) {
-        throw new Error("Failed to change role");
-      }
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1601,13 +1167,7 @@ export function useChangeRoleMutation() {
 export function useUpdateSlackStatusMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string; status: boolean }) => {
-      const result = await updateTeamSlackStatusFromServer(
-        params.teamId,
-        params.status,
-      );
-      if (result.status !== UpdateTeamSlackStatusApiStatus.Success) {
-        throw new Error("Failed to update Slack status");
-      }
+      await updateTeamSlackStatusFromServer(params.teamId, params.status);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
@@ -1620,10 +1180,7 @@ export function useUpdateSlackStatusMutation() {
 export function useRemoveTeamSlackMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
-      const result = await removeTeamSlackFromServer(params.teamId);
-      if (result.status !== RemoveTeamSlackApiStatus.Success) {
-        throw new Error("Failed to remove Slack integration");
-      }
+      await removeTeamSlackFromServer(params.teamId);
     },
     // Settled, not just success: a failed remove can mean the integration is
     // already gone (removed from another session) or that the response was
@@ -1640,13 +1197,7 @@ export function useRemoveTeamSlackMutation() {
 export function useTestSlackAlertMutation() {
   return useMutation({
     mutationFn: async (params: { teamId: string }) => {
-      const result = await sendTestSlackAlertFromServer(params.teamId);
-      if (result.status === TestSlackAlertApiStatus.Error) {
-        throw new Error(result.error ?? "Failed to send test Slack alert");
-      }
-      if (result.status !== TestSlackAlertApiStatus.Success) {
-        throw new Error("Failed to send test Slack alert");
-      }
+      await sendTestSlackAlertFromServer(params.teamId);
     },
   });
 }
@@ -1656,16 +1207,7 @@ export function useTestSlackAlertMutation() {
 export function useUsageQuery(teamId: string | undefined) {
   return useQuery({
     queryKey: ["usage", teamId] as const,
-    queryFn: async () => {
-      const result = await fetchUsageFromServer(teamId!);
-      if (result.status === FetchUsageApiStatus.NoApps) {
-        return null;
-      }
-      if (result.status !== FetchUsageApiStatus.Success) {
-        throw new Error("Failed to fetch usage");
-      }
-      return result.data;
-    },
+    queryFn: () => fetchUsageFromServer(teamId!),
     enabled: !!teamId,
   });
 }
@@ -1675,10 +1217,7 @@ export function useUsagePermissionsQuery(teamId: string | undefined) {
     queryKey: ["usagePermissions", teamId] as const,
     queryFn: async () => {
       const result = await fetchAuthzAndMembersFromServer(teamId!);
-      if (result.status !== AuthzAndMembersApiStatus.Success) {
-        throw new Error("Failed to fetch usage permissions");
-      }
-      return { canChangePlan: result.data.can_change_billing === true };
+      return { canChangePlan: result.can_change_billing === true };
     },
     enabled: !!teamId,
   });
@@ -1688,16 +1227,8 @@ export function useUsagePermissionsQuery(teamId: string | undefined) {
 
 export function useHandleUpgradeMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string; successUrl: string }) => {
-      const result = await fetchCheckoutSessionFromServer(
-        params.teamId,
-        params.successUrl,
-      );
-      if (result.status !== FetchCheckoutSessionApiStatus.Success) {
-        throw new Error("Failed to create checkout session");
-      }
-      return result.data;
-    },
+    mutationFn: (params: { teamId: string; successUrl: string }) =>
+      fetchCheckoutSessionFromServer(params.teamId, params.successUrl),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["billingInfo", variables.teamId],
@@ -1708,13 +1239,8 @@ export function useHandleUpgradeMutation() {
 
 export function useDowngradeToFreeMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string }) => {
-      const result = await downgradeToFreeFromServer(params.teamId);
-      if (result.status !== DowngradeToFreeApiStatus.Success) {
-        throw new Error("Failed to downgrade to free");
-      }
-      return result.data;
-    },
+    mutationFn: (params: { teamId: string }) =>
+      downgradeToFreeFromServer(params.teamId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["billingInfo", variables.teamId],
@@ -1725,13 +1251,8 @@ export function useDowngradeToFreeMutation() {
 
 export function useUndoDowngradeMutation() {
   return useMutation({
-    mutationFn: async (params: { teamId: string }) => {
-      const result = await undoDowngradeFromServer(params.teamId);
-      if (result.status !== UndoDowngradeApiStatus.Success) {
-        throw new Error("Failed to undo cancellation");
-      }
-      return result.data;
-    },
+    mutationFn: (params: { teamId: string }) =>
+      undoDowngradeFromServer(params.teamId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["billingInfo", variables.teamId],
@@ -1744,17 +1265,16 @@ export async function fetchCustomerPortalUrl(
   teamId: string,
   returnUrl: string,
 ): Promise<{ redirect?: string; error?: string }> {
-  const result = await fetchCustomerPortalUrlFromServer(teamId, returnUrl);
-
-  switch (result.status) {
-    case FetchCustomerPortalUrlApiStatus.Success:
-      if (result.data?.url) {
-        return { redirect: result.data.url };
-      }
-      return { error: "No portal URL returned." };
-    case FetchCustomerPortalUrlApiStatus.Error:
+  try {
+    const result = await fetchCustomerPortalUrlFromServer(teamId, returnUrl);
+    if (result?.url) {
+      return { redirect: result.url };
+    }
+    return { error: "No portal URL returned." };
+  } catch (e) {
+    if (e instanceof ApiError) {
       return { error: "Please try again." };
-    default:
-      return { error: "Request was cancelled." };
+    }
+    return { error: "Request was cancelled." };
   }
 }

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -2,17 +2,14 @@ import { queryClient, SHORT_CODE_STALE_TIME } from "@/app/query/query_client";
 import { createStore } from "zustand/vanilla";
 import {
   App,
-  AppsApiStatus,
   AppVersion,
   BugReportStatus,
   buildShortFiltersPostBody,
   defaultFilters,
   Filters,
-  FiltersApiStatus,
   FilterSource,
   HttpMethod,
   OsVersion,
-  RootSpanNamesApiStatus,
   saveListFiltersToServer,
   SessionType,
   SpanStatus,
@@ -327,14 +324,37 @@ function serializeUrlFilters(
 
 export { urlFiltersKeyMap };
 
+/**
+ * How far the apps query has got. A team with no apps still resolves the
+ * query, so "no-apps" is an answer of its own. It is not a loaded state that
+ * holds an empty list.
+ */
+export type AppsState = "pending" | "error" | "loaded" | "no-apps";
+
+/**
+ * How far the filter options query has got. The three empty outcomes stay
+ * apart, because each page explains them differently. A page that does not
+ * explain an outcome treats it as loaded.
+ */
+export type FilterOptionsState =
+  | "pending"
+  | "error"
+  | "loaded"
+  | "no-data"
+  | "not-onboarded"
+  | "no-builds";
+
+/** How far the root span names query has got. Only the Spans source runs it. */
+export type RootSpanNamesState = "pending" | "error" | "loaded" | "no-data";
+
 interface FiltersStoreState {
   filters: Filters;
 
   config: FilterConfig | null;
 
-  appsApiStatus: AppsApiStatus;
-  filtersApiStatus: FiltersApiStatus;
-  rootSpanNamesApiStatus: RootSpanNamesApiStatus;
+  appsState: AppsState;
+  filterOptionsState: FilterOptionsState;
+  rootSpanNamesState: RootSpanNamesState;
 
   apps: App[];
   versions: AppVersion[];
@@ -384,14 +404,14 @@ interface FiltersStoreState {
 interface FiltersStoreActions {
   setConfig: (config: FilterConfig) => void;
 
-  setApps: (apps: App[], status: AppsApiStatus) => void;
+  setApps: (apps: App[], state: AppsState) => void;
   setFilterOptions: (
     data: FilterOptionsData | null,
-    status: FiltersApiStatus,
+    state: FilterOptionsState,
   ) => void;
   setRootSpanNames: (
     rootSpanNames: string[] | null,
-    status: RootSpanNamesApiStatus,
+    state: RootSpanNamesState,
   ) => void;
   setCurrentTeamId: (teamId: string) => void;
 
@@ -435,9 +455,9 @@ const initialState: FiltersStoreState = {
   filters: defaultFilters,
   config: null,
 
-  appsApiStatus: AppsApiStatus.Loading,
-  filtersApiStatus: FiltersApiStatus.Loading,
-  rootSpanNamesApiStatus: RootSpanNamesApiStatus.Loading,
+  appsState: "pending",
+  filterOptionsState: "pending",
+  rootSpanNamesState: "pending",
 
   apps: [],
   versions: [],
@@ -483,29 +503,27 @@ function computeFilters(state: FiltersStoreState): Filters {
   if (!state.config || !state.selectedApp) {
     return {
       ...defaultFilters,
-      loading: state.appsApiStatus === AppsApiStatus.Loading,
+      loading: state.appsState === "pending",
     };
   }
 
   const config = state.config;
 
-  // A filter options status counts toward ready when it is Success, or an
-  // empty state the page does not surface (its show* flag is false).
-  // Surfaced empty states hold ready back so the page renders the
-  // explanation instead of an empty view.
+  // A filter options state counts toward ready when the options loaded. An
+  // empty outcome also counts, but only when the page does not show it (its
+  // show* flag is false). A shown empty outcome keeps ready false, so the
+  // page shows the explanation and not an empty view.
   const filtersReady =
-    state.filtersApiStatus === FiltersApiStatus.Success ||
-    (!config.showNoData &&
-      state.filtersApiStatus === FiltersApiStatus.NoData) ||
+    state.filterOptionsState === "loaded" ||
+    (!config.showNoData && state.filterOptionsState === "no-data") ||
     (!config.showNotOnboarded &&
-      state.filtersApiStatus === FiltersApiStatus.NotOnboarded) ||
-    (!config.showNoBuilds &&
-      state.filtersApiStatus === FiltersApiStatus.NoBuilds);
+      state.filterOptionsState === "not-onboarded") ||
+    (!config.showNoBuilds && state.filterOptionsState === "no-builds");
 
   const ready =
-    state.appsApiStatus === AppsApiStatus.Success &&
+    state.appsState === "loaded" &&
     ((config.filterSource === FilterSource.Spans &&
-      state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Success) ||
+      state.rootSpanNamesState === "loaded") ||
       config.filterSource !== FilterSource.Spans) &&
     filtersReady;
 
@@ -554,13 +572,12 @@ function computeFilters(state: FiltersStoreState): Filters {
   };
 
   const loading =
-    state.appsApiStatus === AppsApiStatus.Loading ||
-    (state.appsApiStatus === AppsApiStatus.Success &&
-      state.filtersApiStatus === FiltersApiStatus.Loading) ||
-    (state.appsApiStatus === AppsApiStatus.Success &&
-      state.filtersApiStatus === FiltersApiStatus.Success &&
+    state.appsState === "pending" ||
+    (state.appsState === "loaded" && state.filterOptionsState === "pending") ||
+    (state.appsState === "loaded" &&
+      state.filterOptionsState === "loaded" &&
       config.filterSource === FilterSource.Spans &&
-      state.rootSpanNamesApiStatus === RootSpanNamesApiStatus.Loading);
+      state.rootSpanNamesState === "pending");
 
   return {
     ready,
@@ -979,15 +996,15 @@ export function createFiltersStore() {
         });
       },
 
-      setApps: (apps, status) => set({ apps, appsApiStatus: status }),
+      setApps: (apps, state) => set({ apps, appsState: state }),
 
-      setFilterOptions: (data, status) => {
+      setFilterOptions: (data, state) => {
         if (data === null) {
-          set({ filtersApiStatus: status });
+          set({ filterOptionsState: state });
           return;
         }
         set({
-          filtersApiStatus: status,
+          filterOptionsState: state,
           versions: data.versions,
           osVersions: data.osVersions,
           countries: data.countries,
@@ -1002,12 +1019,12 @@ export function createFiltersStore() {
         });
       },
 
-      setRootSpanNames: (rootSpanNames, status) => {
+      setRootSpanNames: (rootSpanNames, state) => {
         if (rootSpanNames === null) {
-          set({ rootSpanNamesApiStatus: status });
+          set({ rootSpanNamesState: state });
           return;
         }
-        set({ rootSpanNamesApiStatus: status, rootSpanNames });
+        set({ rootSpanNamesState: state, rootSpanNames });
       },
 
       setCurrentTeamId: (teamId) => set({ currentTeamId: teamId }),
@@ -1019,7 +1036,7 @@ export function createFiltersStore() {
         if (prevApp !== null && app !== null && prevApp.id !== app.id) {
           set({
             selectedApp: app,
-            filtersApiStatus: FiltersApiStatus.Loading,
+            filterOptionsState: "pending",
             selectedVersions: [],
             selectedOsVersions: [],
           });


### PR DESCRIPTION
# Description

Deletes the *ApiStatus enums. Fetchers now call a single request helper that throws ApiError on a non-ok response and RequestError on a network or parse failure, and returns the parsed body otherwise. Empty results come back as null, an empty array, or a discriminated union.

Query hooks no longer translate statuses by hand, which is what caused the crash fixed in #4097. The filters store keeps its own load state as string unions.

## Related issue
Closes #4096



