### PR TITLE
fix(frontend): use canvas chart for network status distribution plot

### DIFF
--- a/frontend/dashboard/__tests__/integration/network_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/network_msw_test.tsx
@@ -71,9 +71,11 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  // The overview status plot renders with ResponsiveLineCanvas while the
+  // endpoint detail plots still use ResponsiveLine; both get the same stub
+  // so assertions can address any line chart through one set of testids.
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
       {data?.map((s: any) => (
         <span key={s.id} data-testid={`chart-series-${s.id}`}>
@@ -81,8 +83,13 @@ jest.mock("@nivo/line", () => ({
         </span>
       ))}
     </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 jest.mock("@nivo/heatmap", () => ({
   __esModule: true,

--- a/frontend/dashboard/app/components/network_status_distribution_plot.tsx
+++ b/frontend/dashboard/app/components/network_status_distribution_plot.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo } from "react";
 import { numberToKMB } from "../utils/number_utils";
-import { chartTheme, useChartColor } from "../utils/shared_styles";
+import { useChartColor, useChartForeground } from "../utils/shared_styles";
 import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
 import {
   formatPlotTooltipDate,
@@ -53,6 +53,19 @@ const NetworkStatusDistributionPlot: React.FC<
   const chartColor = useChartColor();
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
+  // The canvas renderer cannot resolve CSS variables like the shared
+  // chartTheme uses, so the theme needs concrete colors per app theme.
+  const foreground = useChartForeground();
+  const canvasTheme = useMemo(
+    () => ({
+      text: { fill: foreground },
+      axis: { ticks: { text: { fill: foreground } } },
+      legends: { text: { fill: foreground } },
+      crosshair: { line: { stroke: foreground, strokeWidth: 1 } },
+    }),
+    [foreground],
+  );
+
   const colorMap = {
     "2xx": chartColor.green,
     "3xx": chartColor.blue,
@@ -88,10 +101,10 @@ const NetworkStatusDistributionPlot: React.FC<
   return (
     <div className="flex font-body items-center justify-center w-full h-144">
       <div className="size-full">
-        <ResponsiveLine
+        <ResponsiveLineCanvas
           data={plot}
           curve="monotoneX"
-          theme={chartTheme}
+          theme={canvasTheme}
           enableArea={true}
           areaOpacity={0.1}
           colors={({ id }) => colorMap[id as keyof typeof colorMap] || "#888"}
@@ -136,13 +149,10 @@ const NetworkStatusDistributionPlot: React.FC<
           pointBorderColor={({ seriesId }: { seriesId: string }) =>
             colorMap[seriesId as keyof typeof colorMap] || "#888"
           }
-          pointLabelYOffset={-12}
-          useMesh={true}
           enableGridX={false}
           enableGridY={false}
-          enableSlices="x"
-          sliceTooltip={({ slice }) => {
-            const pointData = slice.points[0]?.data as unknown as {
+          tooltip={({ point }) => {
+            const pointData = point.data as unknown as {
               xFormatted: string;
               total_count: number;
               count_2xx: number;
@@ -150,39 +160,31 @@ const NetworkStatusDistributionPlot: React.FC<
               count_4xx: number;
               count_5xx: number;
             };
-            const total = pointData?.total_count ?? 0;
+            const total = pointData.total_count ?? 0;
             const pct = (count: number) =>
               total > 0 ? ((count / total) * 100).toFixed(1) : "0.0";
             return (
               <PlotTooltipShell>
                 <p className="p-2 font-semibold">
                   {formatPlotTooltipDate(
-                    slice.points[0].data.xFormatted.toString(),
+                    pointData.xFormatted.toString(),
                     plotTimeGroup,
                   )}
                 </p>
                 <p className="px-2 pb-1">Total: {total.toLocaleString()}</p>
-                {/* nivo orders points by y-value, sort to maintain 2xx, 3xx, 4xx, 5xx order */}
-                {[...slice.points]
-                  .sort((a, b) =>
-                    a.seriesId.toString().localeCompare(b.seriesId.toString()),
-                  )
-                  .map((point) => {
-                    const count = Number(point.data.y);
-                    return (
-                      <div
-                        className="flex flex-row items-center px-2 py-0.5"
-                        key={point.id}
-                      >
-                        <PlotTooltipSwatch color={point.seriesColor} />
-                        <div className="px-1" />
-                        <p>
-                          {point.seriesId}: {count.toLocaleString()} (
-                          {pct(count)}%)
-                        </p>
-                      </div>
-                    );
-                  })}
+                {seriesConfig.map(({ key, id }) => (
+                  <div
+                    className="flex flex-row items-center px-2 py-0.5"
+                    key={id}
+                  >
+                    <PlotTooltipSwatch color={colorMap[id]} />
+                    <div className="px-1" />
+                    <p>
+                      {id}: {pointData[key].toLocaleString()} (
+                      {pct(pointData[key])}%)
+                    </p>
+                  </div>
+                ))}
               </PlotTooltipShell>
             );
           }}

--- a/frontend/dashboard/app/components/network_timeline_plot.tsx
+++ b/frontend/dashboard/app/components/network_timeline_plot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Slider } from "@/app/components/slider";
+import { useChartForeground } from "@/app/utils/shared_styles";
 import { formatMillisToHumanReadable } from "@/app/utils/time_utils";
 import { PlotTooltipShell } from "@/app/components/plot_tooltip";
 import { ResponsiveHeatMapCanvas } from "@nivo/heatmap";
@@ -25,7 +26,7 @@ interface Props {
 
 const NetworkTimelinePlot: React.FC<Props> = ({ data }) => {
   const { theme } = useTheme();
-  const foreground = theme === "dark" ? "#ffffff" : "#000000";
+  const foreground = useChartForeground();
   const interval = data.interval;
 
   const canvasTheme = useMemo(

--- a/frontend/dashboard/app/utils/shared_styles.tsx
+++ b/frontend/dashboard/app/utils/shared_styles.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from "next-themes";
+
 // Mirrors the docs prose links (fumadocs typography plus our fd-primary
 // override in globals.css): same decoration pair, thickness, offset, weight
 // and fade-on-hover, so links look the same on marketing and docs pages.
@@ -42,6 +44,15 @@ export function useChartColor() {
 
 export function useChartColors() {
   return chartColors;
+}
+
+// Concrete foreground for canvas-rendered charts. Canvas fillStyle cannot
+// resolve the `var(--foreground)` that chartTheme uses for SVG charts, so
+// canvas renderers need the `--foreground` token values from globals.css as
+// hex; keep the two in sync.
+export function useChartForeground() {
+  const { theme } = useTheme();
+  return theme === "dark" ? "#fafafa" : "#222222";
 }
 
 export const chartTheme = {


### PR DESCRIPTION
# Description

NetworkStatusDistributionPlot used ResponsiveLine which renders many SVG nodes and caused the page to hang when data has many points. This commit switches it to canvas renderer which fixes the issue along with updating the misconfigured theme colours for both status distribution and timeline plots.



