### PR TITLE
chore(frontend): switch to canvas rendering for all line plots

### DIFF
--- a/frontend/dashboard/__tests__/components/app_health_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/app_health_plot_test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from "@testing-library/react";
 let lastLineProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -189,26 +189,9 @@ describe("AppHealthPlot", () => {
     render(<AppHealthPlot />);
     expect(screen.getByTestId("line-mock")).toBeInTheDocument();
 
-    const tooltip = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "a1",
-            seriesId: "ANRs",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 1 },
-          },
-          {
-            id: "s1",
-            seriesId: "Sessions",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 10 },
-          },
-          {
-            id: "c1",
-            seriesId: "Crashes",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 2 },
-          },
-        ],
-      },
+    const datum = lastLineProps.data[0].data[0];
+    const tooltip = lastLineProps.tooltip({
+      point: { data: { ...datum, xFormatted: "2026-02-01T01:00:00" } },
     });
 
     const { container } = render(tooltip);
@@ -232,21 +215,9 @@ describe("AppHealthPlot", () => {
     });
     render(<AppHealthPlot />);
 
-    const tooltip = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "a1",
-            seriesId: "ANRs",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 1 },
-          },
-          {
-            id: "s1",
-            seriesId: "Sessions",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 10 },
-          },
-        ],
-      },
+    const datum = lastLineProps.data[0].data[0];
+    const tooltip = lastLineProps.tooltip({
+      point: { data: { ...datum, xFormatted: "2026-02-01T01:00:00" } },
     });
 
     const { container } = render(tooltip);

--- a/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 let lastLineProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -184,28 +184,20 @@ describe("BugReportsOverviewPlot", () => {
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    const one = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p1",
-            seriesColor: "#111",
-            seriesId: "v1",
-            data: { xFormatted: "2025-02-01", yFormatted: 1 },
-          },
-        ],
+    const one = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2025-02-01",
+          siblings: [{ id: "v1", y: 1, color: "#111" }],
+        },
       },
     });
-    const many = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p2",
-            seriesColor: "#111",
-            seriesId: "v1",
-            data: { xFormatted: "2025-02-01", yFormatted: 3 },
-          },
-        ],
+    const many = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2025-02-01",
+          siblings: [{ id: "v1", y: 3, color: "#111" }],
+        },
       },
     });
     const r1 = render(one);

--- a/frontend/dashboard/__tests__/components/errors_details_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/errors_details_plot_test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from "@testing-library/react";
 let lastLineProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -161,28 +161,20 @@ describe("ErrorsDetailsPlot", () => {
     });
     render(<ErrorsDetailsPlot errorGroupId="g1" />);
 
-    const many = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p1",
-            seriesColor: "#111",
-            seriesId: "3.1.0",
-            data: { xFormatted: "2026-02-01T01:00:00", y: 5, yFormatted: 5 },
-          },
-        ],
+    const many = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-01T01:00:00",
+          siblings: [{ id: "3.1.0", y: 5, color: "#111" }],
+        },
       },
     });
-    const one = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p2",
-            seriesColor: "#111",
-            seriesId: "3.1.0",
-            data: { xFormatted: "2026-02-01T01:00:00", y: 1, yFormatted: 1 },
-          },
-        ],
+    const one = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-01T01:00:00",
+          siblings: [{ id: "3.1.0", y: 1, color: "#111" }],
+        },
       },
     });
 

--- a/frontend/dashboard/__tests__/components/errors_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/errors_overview_plot_test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from "@testing-library/react";
 let lastLineProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -172,28 +172,20 @@ describe("ErrorsOverviewPlot", () => {
     });
     render(<ErrorsOverviewPlot />);
 
-    const many = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p1",
-            seriesColor: "#111",
-            seriesId: "3.1.0",
-            data: { xFormatted: "2026-02-01T01:00:00", y: 5, yFormatted: 5 },
-          },
-        ],
+    const many = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-01T01:00:00",
+          siblings: [{ id: "3.1.0", y: 5, color: "#111" }],
+        },
       },
     });
-    const one = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p2",
-            seriesColor: "#111",
-            seriesId: "3.1.0",
-            data: { xFormatted: "2026-02-01T01:00:00", y: 1, yFormatted: 1 },
-          },
-        ],
+    const one = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-01T01:00:00",
+          siblings: [{ id: "3.1.0", y: 1, color: "#111" }],
+        },
       },
     });
 

--- a/frontend/dashboard/__tests__/components/network_endpoint_status_codes_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/network_endpoint_status_codes_plot_test.tsx
@@ -25,7 +25,7 @@ jest.mock("@/app/utils/time_utils", () => ({
 }));
 
 jest.mock("@/app/utils/shared_styles", () => ({
-  useChartForeground: () => "#222222",
+  useChartCanvasTheme: () => ({}),
   useChartColor: () => ({
     blue: "#38bdf8",
     green: "#34d399",
@@ -133,8 +133,6 @@ describe("NetworkEndpointStatusCodesPlot", () => {
       />,
     );
 
-    // The canvas tooltip receives one nearest point; the full breakdown
-    // comes from the datum's source datapoint.
     const tooltip = lastLineProps.tooltip({
       point: {
         seriesId: "200",

--- a/frontend/dashboard/__tests__/components/session_replay_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_replay_overview_plot_test.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 let lastLineProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -208,16 +208,12 @@ describe("SessionReplayOverviewPlot", () => {
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    const tooltip = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p1",
-            seriesColor: "#111",
-            seriesId: "1.0.0",
-            data: { xFormatted: "2026-02-23T01:00:00", yFormatted: 2 },
-          },
-        ],
+    const tooltip = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-23T01:00:00",
+          siblings: [{ id: "1.0.0", y: 2, color: "#111" }],
+        },
       },
     });
     const { container } = render(tooltip);

--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -11,7 +11,7 @@ let lastLineProps: any = null;
 let lastTabSelectProps: any = null;
 
 jest.mock("@nivo/line", () => ({
-  ResponsiveLine: (props: any) => {
+  ResponsiveLineCanvas: (props: any) => {
     lastLineProps = props;
     return <div data-testid="line-mock" />;
   },
@@ -191,16 +191,12 @@ describe("SpanMetricsPlot", () => {
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    const tooltip = lastLineProps.sliceTooltip({
-      slice: {
-        points: [
-          {
-            id: "p1",
-            seriesColor: "#111",
-            seriesId: "v1",
-            data: { xFormatted: "2026-02-01T01:00:00", yFormatted: 30 },
-          },
-        ],
+    const tooltip = lastLineProps.tooltip({
+      point: {
+        data: {
+          xFormatted: "2026-02-01T01:00:00",
+          siblings: [{ id: "v1", y: 30, color: "#111" }],
+        },
       },
     });
     const { container } = render(tooltip);

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -68,9 +68,8 @@ jest.mock("next/image", () => ({
   default: (props: any) => <img {...props} />,
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
       {data?.map((s: any) => (
         <span key={s.id} data-testid={`chart-series-${s.id}`}>
@@ -78,8 +77,13 @@ jest.mock("@nivo/line", () => ({
         </span>
       ))}
     </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 // --- MSW ---
 import {

--- a/frontend/dashboard/__tests__/integration/errors_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/errors_msw_test.tsx
@@ -94,9 +94,8 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
       {data?.map((s: any) => (
         <span key={s.id} data-testid={`chart-series-${s.id}`}>
@@ -104,8 +103,13 @@ jest.mock("@nivo/line", () => ({
         </span>
       ))}
     </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 jest.mock("@nivo/bar", () => ({
   __esModule: true,

--- a/frontend/dashboard/__tests__/integration/filter_persistence_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/filter_persistence_msw_test.tsx
@@ -50,10 +50,14 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: () => <div data-testid="nivo-line-chart" />,
-}));
+jest.mock("@nivo/line", () => {
+  const LineChartStub = () => <div data-testid="nivo-line-chart" />;
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 import { server } from "../msw/server";
 

--- a/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
@@ -87,11 +87,6 @@ jest.mock("@nivo/sankey", () => ({
   ),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: () => <div data-testid="nivo-line-chart" />,
-}));
-
 // --- MSW ---
 import {
   makeAppFixture,

--- a/frontend/dashboard/__tests__/integration/network_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/network_msw_test.tsx
@@ -72,9 +72,6 @@ jest.mock("next-themes", () => ({
 }));
 
 jest.mock("@nivo/line", () => {
-  // The overview status plot renders with ResponsiveLineCanvas while the
-  // endpoint detail plots still use ResponsiveLine; both get the same stub
-  // so assertions can address any line chart through one set of testids.
   const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
       {data?.map((s: any) => (

--- a/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
@@ -68,10 +68,14 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: () => <div data-testid="nivo-line-chart" />,
-}));
+jest.mock("@nivo/line", () => {
+  const LineChartStub = () => <div data-testid="nivo-line-chart" />;
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 // --- MSW + fixtures ---
 

--- a/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/overview_msw_test.tsx
@@ -54,20 +54,22 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-// Nivo charts need a real DOM layout engine which jsdom doesn't have.
-// Stub ResponsiveLine to render a testable placeholder with the data prop.
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
-      {data?.map((series: any) => (
-        <span key={series.id} data-testid={`chart-series-${series.id}`}>
-          {series.id}: {series.data?.length ?? 0} points
+      {data?.map((s: any) => (
+        <span key={s.id} data-testid={`chart-series-${s.id}`}>
+          {s.id}: {s.data?.length ?? 0} points
         </span>
       ))}
     </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 // --- Restore real fetch (jest config sets globals.fetch to a no-op) ---
 // MSW needs the real fetch/Request to intercept. jsdom provides them.

--- a/frontend/dashboard/__tests__/integration/session_replay_overview_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/session_replay_overview_msw_test.tsx
@@ -58,23 +58,22 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
-      {data?.map((series: any) => (
-        <span key={series.id} data-testid={`chart-series-${series.id}`}>
-          {series.id}: {series.data?.length ?? 0} points
+      {data?.map((s: any) => (
+        <span key={s.id} data-testid={`chart-series-${s.id}`}>
+          {s.id}: {s.data?.length ?? 0} points
         </span>
       ))}
     </div>
-  ),
-  ResponsiveLineCanvas: ({ data }: any) => (
-    <div data-testid="nivo-line-canvas">
-      {JSON.stringify(data?.length ?? 0)} series
-    </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 // --- MSW ---
 import {

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -60,9 +60,8 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@nivo/line", () => ({
-  __esModule: true,
-  ResponsiveLine: ({ data }: any) => (
+jest.mock("@nivo/line", () => {
+  const LineChartStub = ({ data }: any) => (
     <div data-testid="nivo-line-chart">
       {data?.map((s: any) => (
         <span key={s.id} data-testid={`chart-series-${s.id}`}>
@@ -70,8 +69,13 @@ jest.mock("@nivo/line", () => ({
         </span>
       ))}
     </div>
-  ),
-}));
+  );
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
 
 // --- MSW ---
 import {

--- a/frontend/dashboard/app/components/app_health_plot.tsx
+++ b/frontend/dashboard/app/components/app_health_plot.tsx
@@ -2,18 +2,23 @@
 
 import { useAppHealthPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { DateTime } from "luxon";
 import { useTheme } from "next-themes";
-import React from "react";
+import React, { useMemo } from "react";
 import { numberToKMB } from "../utils/number_utils";
-import { chartTheme, useChartColor } from "../utils/shared_styles";
+import { useChartCanvasTheme, useChartColor } from "../utils/shared_styles";
 import {
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
 const demoDataDate = DateTime.now();
@@ -144,13 +149,28 @@ const AppHealthPlot: React.FC<AppHealthPlotProps> = ({ demo = false }) => {
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
   const effectiveStatus = demo ? "success" : status;
-  const plot = demo ? demoPlot : queryPlot;
+  const rawPlot = demo ? demoPlot : queryPlot;
 
-  const colorMap = {
-    Sessions: chartColor.blue,
-    Crashes: chartColor.red,
-    ANRs: chartColor.amber,
-  } as const;
+  const colorMap = useMemo(
+    () =>
+      ({
+        Sessions: chartColor.blue,
+        Crashes: chartColor.red,
+        ANRs: chartColor.amber,
+      }) as const,
+    [chartColor],
+  );
+
+  const canvasTheme = useChartCanvasTheme();
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (id) => colorMap[id as keyof typeof colorMap] || "#888",
+    );
+  }, [rawPlot, colorMap]);
 
   const labelMap = {
     Sessions: "Sessions",
@@ -172,10 +192,10 @@ const AppHealthPlot: React.FC<AppHealthPlotProps> = ({ demo = false }) => {
       )}
       {effectiveStatus === "success" && plot !== null && plot !== undefined && (
         <div className="size-full">
-          <ResponsiveLine
+          <ResponsiveLineCanvas
             data={plot}
             curve="monotoneX"
-            theme={chartTheme}
+            theme={canvasTheme}
             enableArea={true}
             areaOpacity={0.05}
             colors={({ id }) => colorMap[id as keyof typeof colorMap] || "#888"}
@@ -217,38 +237,36 @@ const AppHealthPlot: React.FC<AppHealthPlotProps> = ({ demo = false }) => {
             pointBorderColor={({ seriesId }: { seriesId: string }) =>
               colorMap[seriesId as keyof typeof colorMap] || "#888"
             }
-            pointLabelYOffset={-12}
-            useMesh={true}
             enableGridX={false}
             enableGridY={false}
-            enableSlices="x"
-            sliceTooltip={({ slice }) => {
+            tooltip={({ point }) => {
+              const pointData = point.data as unknown as {
+                xFormatted: string;
+                siblings: SiblingPoint[];
+              };
               const order = ["Sessions", "Crashes", "ANRs"] as const;
-              const pointsById: Record<string, (typeof slice.points)[number]> =
-                Object.fromEntries(slice.points.map((p) => [p.seriesId, p]));
+              const siblingsById: Record<string, SiblingPoint> =
+                Object.fromEntries(pointData.siblings.map((s) => [s.id, s]));
               return (
                 <PlotTooltipShell>
                   <p className="p-2">
                     Date:{" "}
                     {formatPlotTooltipDate(
-                      slice.points[0].data.xFormatted.toString(),
+                      pointData.xFormatted.toString(),
                       plotTimeGroup,
                     )}
                   </p>
                   {order.map((key) => {
-                    const point = pointsById[key];
-                    if (!point) return null;
+                    const sibling = siblingsById[key];
+                    if (!sibling) return null;
                     return (
-                      <div
-                        className="flex flex-row items-center p-2"
-                        key={point.id}
-                      >
-                        <PlotTooltipSwatch color={colorMap[key]} />
+                      <div className="flex flex-row items-center p-2" key={key}>
+                        <PlotTooltipSwatch color={sibling.color} />
                         <div className="px-2" />
                         <p>{labelMap[key]} - </p>
                         <div className="px-2" />
                         <p>
-                          {point.data.yFormatted} {labelMap[key]}
+                          {sibling.y.toLocaleString()} {labelMap[key]}
                         </p>
                       </div>
                     );

--- a/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
+++ b/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
@@ -2,28 +2,44 @@
 
 import { useBugReportsOverviewPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
-import React from "react";
-import { chartTheme, useChartColors } from "../utils/shared_styles";
+import React, { useMemo } from "react";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import {
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
 const BugReportsOverviewPlot: React.FC = () => {
   const filters = useFiltersStore((state) => state.filters);
-  const { data: plot, status } = useBugReportsOverviewPlotQuery();
+  const { data: rawPlot, status } = useBugReportsOverviewPlotQuery();
   const { theme } = useTheme();
   const chartColors = useChartColors();
+  const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
     filters.startDate,
     filters.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
+
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (_, index) => chartColors[index % chartColors.length],
+    );
+  }, [rawPlot, chartColors]);
 
   return (
     <div
@@ -47,10 +63,10 @@ const BugReportsOverviewPlot: React.FC = () => {
       )}
       {status === "success" && plot !== null && plot !== undefined && (
         <div data-testid="bug-reports-plot-data" className="size-full">
-          <ResponsiveLine
+          <ResponsiveLineCanvas
             data={plot}
             curve="monotoneX"
-            theme={chartTheme}
+            theme={canvasTheme}
             enableArea={true}
             areaOpacity={0.1}
             colors={chartColors}
@@ -97,35 +113,34 @@ const BugReportsOverviewPlot: React.FC = () => {
               from: "seriesColor",
               modifiers: [["darker", 0.3]],
             }}
-            pointLabelYOffset={-12}
-            useMesh={true}
             enableGridX={false}
             enableGridY={false}
-            enableSlices="x"
-            sliceTooltip={({ slice }) => {
+            tooltip={({ point }) => {
+              const pointData = point.data as unknown as {
+                xFormatted: string;
+                siblings: SiblingPoint[];
+              };
               return (
                 <PlotTooltipShell>
                   <p className="p-2">
                     Date:{" "}
                     {formatPlotTooltipDate(
-                      slice.points[0].data.xFormatted.toString(),
+                      pointData.xFormatted.toString(),
                       plotTimeGroup,
                     )}
                   </p>
-                  {slice.points.map((point) => (
+                  {pointData.siblings.map((sibling) => (
                     <div
                       className="flex flex-row items-center p-2"
-                      key={point.id}
+                      key={sibling.id}
                     >
-                      <PlotTooltipSwatch color={point.seriesColor} />
+                      <PlotTooltipSwatch color={sibling.color} />
                       <div className="px-2" />
-                      <p>{point.seriesId.toString()} - </p>
+                      <p>{sibling.id} - </p>
                       <div className="px-2" />
                       <p>
-                        {point.data.yFormatted}{" "}
-                        {(point.data.yFormatted as number) > 1
-                          ? "Bug Reports"
-                          : "Bug Report"}
+                        {sibling.y.toLocaleString()}{" "}
+                        {sibling.y > 1 ? "Bug Reports" : "Bug Report"}
                       </p>
                     </div>
                   ))}

--- a/frontend/dashboard/app/components/errors_details_plot.tsx
+++ b/frontend/dashboard/app/components/errors_details_plot.tsx
@@ -2,18 +2,23 @@
 
 import { useErrorsDetailsPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { DateTime } from "luxon";
 import { useTheme } from "next-themes";
-import React from "react";
+import React, { useMemo } from "react";
 import { numberToKMB } from "../utils/number_utils";
-import { chartTheme, useChartColors } from "../utils/shared_styles";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import {
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
 const demoDataDate = DateTime.now();
@@ -93,6 +98,11 @@ type ErrorsDetailsPlotData = {
   }[];
 }[];
 
+const demoPlot: ErrorsDetailsPlotData = demoData.map((item: any) => ({
+  id: item.id,
+  data: item.data.map((d: any) => ({ x: d.datetime, y: d.instances })),
+}));
+
 const ErrorsDetailsPlot: React.FC<ErrorsDetailsPlotProps> = ({
   errorGroupId,
   demo = false,
@@ -101,18 +111,25 @@ const ErrorsDetailsPlot: React.FC<ErrorsDetailsPlotProps> = ({
   const { data: queryPlot, status } = useErrorsDetailsPlotQuery(errorGroupId);
   const { theme } = useTheme();
   const chartColors = useChartColors();
+  const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
     filters.startDate,
     filters.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
-  const demoPlot: ErrorsDetailsPlotData = demoData.map((item: any) => ({
-    id: item.id,
-    data: item.data.map((d: any) => ({ x: d.datetime, y: d.instances })),
-  }));
   const effectiveStatus = demo ? "success" : status;
-  const plot = demo ? demoPlot : queryPlot;
+  const rawPlot = demo ? demoPlot : queryPlot;
+
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (_, index) => chartColors[index % chartColors.length],
+    );
+  }, [rawPlot, chartColors]);
 
   return (
     <div
@@ -136,10 +153,10 @@ const ErrorsDetailsPlot: React.FC<ErrorsDetailsPlotProps> = ({
       )}
       {effectiveStatus === "success" && plot !== null && plot !== undefined && (
         <div data-testid="exception-detail-plot-data" className="size-full">
-          <ResponsiveLine
+          <ResponsiveLineCanvas
             data={plot}
             curve="monotoneX"
-            theme={chartTheme}
+            theme={canvasTheme}
             enableArea={true}
             areaOpacity={0.1}
             colors={chartColors}
@@ -187,35 +204,34 @@ const ErrorsDetailsPlot: React.FC<ErrorsDetailsPlotProps> = ({
               from: "seriesColor",
               modifiers: [["darker", 0.3]],
             }}
-            pointLabelYOffset={-12}
-            useMesh={true}
             enableGridX={false}
             enableGridY={false}
-            enableSlices="x"
-            sliceTooltip={({ slice }) => {
+            tooltip={({ point }) => {
+              const pointData = point.data as unknown as {
+                xFormatted: string;
+                siblings: SiblingPoint[];
+              };
               return (
                 <PlotTooltipShell>
                   <p className="p-2">
                     Date:{" "}
                     {formatPlotTooltipDate(
-                      slice.points[0].data.xFormatted.toString(),
+                      pointData.xFormatted.toString(),
                       plotTimeGroup,
                     )}
                   </p>
-                  {slice.points.map((point) => (
+                  {pointData.siblings.map((sibling) => (
                     <div
                       className="flex flex-row items-center p-2"
-                      key={point.id}
+                      key={sibling.id}
                     >
-                      <PlotTooltipSwatch color={point.seriesColor} />
+                      <PlotTooltipSwatch color={sibling.color} />
                       <div className="px-2" />
-                      <p>{point.seriesId.toString()} - </p>
+                      <p>{sibling.id} - </p>
                       <div className="px-2" />
                       <p>
-                        {point.data.y.toString()}{" "}
-                        {(point.data.y.valueOf() as number) > 1
-                          ? "instances"
-                          : "instance"}
+                        {sibling.y.toLocaleString()}{" "}
+                        {sibling.y > 1 ? "instances" : "instance"}
                       </p>
                     </div>
                   ))}

--- a/frontend/dashboard/app/components/errors_overview_plot.tsx
+++ b/frontend/dashboard/app/components/errors_overview_plot.tsx
@@ -2,28 +2,44 @@
 
 import { useErrorsOverviewPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
-import React from "react";
-import { chartTheme, useChartColors } from "../utils/shared_styles";
+import React, { useMemo } from "react";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import {
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
 const ErrorsOverviewPlot: React.FC = () => {
   const filters = useFiltersStore((state) => state.filters);
-  const { data: plot, status } = useErrorsOverviewPlotQuery();
+  const { data: rawPlot, status } = useErrorsOverviewPlotQuery();
   const { theme } = useTheme();
   const chartColors = useChartColors();
+  const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
     filters.startDate,
     filters.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
+
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (_, index) => chartColors[index % chartColors.length],
+    );
+  }, [rawPlot, chartColors]);
 
   return (
     <div
@@ -51,10 +67,10 @@ const ErrorsOverviewPlot: React.FC = () => {
       )}
       {status === "success" && plot !== null && plot !== undefined && (
         <div data-testid="exceptions-plot-data" className="size-full">
-          <ResponsiveLine
+          <ResponsiveLineCanvas
             data={plot}
             curve="monotoneX"
-            theme={chartTheme}
+            theme={canvasTheme}
             enableArea={true}
             areaOpacity={0.1}
             colors={chartColors}
@@ -101,35 +117,34 @@ const ErrorsOverviewPlot: React.FC = () => {
               from: "seriesColor",
               modifiers: [["darker", 0.3]],
             }}
-            pointLabelYOffset={-12}
-            useMesh={true}
             enableGridX={false}
             enableGridY={false}
-            enableSlices="x"
-            sliceTooltip={({ slice }) => {
+            tooltip={({ point }) => {
+              const pointData = point.data as unknown as {
+                xFormatted: string;
+                siblings: SiblingPoint[];
+              };
               return (
                 <PlotTooltipShell>
                   <p className="p-2">
                     Date:{" "}
                     {formatPlotTooltipDate(
-                      slice.points[0].data.xFormatted.toString(),
+                      pointData.xFormatted.toString(),
                       plotTimeGroup,
                     )}
                   </p>
-                  {slice.points.map((point) => (
+                  {pointData.siblings.map((sibling) => (
                     <div
                       className="flex flex-row items-center p-2"
-                      key={point.id}
+                      key={sibling.id}
                     >
-                      <PlotTooltipSwatch color={point.seriesColor} />
+                      <PlotTooltipSwatch color={sibling.color} />
                       <div className="px-2" />
-                      <p>{point.seriesId.toString()} - </p>
+                      <p>{sibling.id} - </p>
                       <div className="px-2" />
                       <p>
-                        {point.data.y.toString()}{" "}
-                        {(point.data.y.valueOf() as number) > 1
-                          ? "instances"
-                          : "instance"}
+                        {sibling.y.toLocaleString()}{" "}
+                        {sibling.y > 1 ? "instances" : "instance"}
                       </p>
                     </div>
                   ))}

--- a/frontend/dashboard/app/components/network_endpoint_status_codes_plot.tsx
+++ b/frontend/dashboard/app/components/network_endpoint_status_codes_plot.tsx
@@ -4,7 +4,7 @@ import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo } from "react";
 import { numberToKMB } from "../utils/number_utils";
-import { useChartColor, useChartForeground } from "../utils/shared_styles";
+import { useChartCanvasTheme, useChartColor } from "../utils/shared_styles";
 import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
 import {
   formatPlotTooltipDate,
@@ -27,16 +27,7 @@ const NetworkEndpointStatusCodesPlot: React.FC<Props> = ({
   const chartColor = useChartColor();
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
-  const foreground = useChartForeground();
-  const canvasTheme = useMemo(
-    () => ({
-      text: { fill: foreground },
-      axis: { ticks: { text: { fill: foreground } } },
-      legends: { text: { fill: foreground } },
-      crosshair: { line: { stroke: foreground, strokeWidth: 1 } },
-    }),
-    [foreground],
-  );
+  const canvasTheme = useChartCanvasTheme();
 
   const bucketColors: Record<number, string> = {
     2: chartColor.green,
@@ -51,9 +42,6 @@ const NetworkEndpointStatusCodesPlot: React.FC<Props> = ({
     if (!data || data.length === 0 || !statusCodes || statusCodes.length === 0)
       return undefined;
 
-    // Every datum carries its source datapoint so the nearest-point tooltip
-    // can list the counts of all status codes at that datetime, not only the
-    // hovered series.
     return statusCodes.map((code) => ({
       id: String(code),
       data: data.map((d) => ({

--- a/frontend/dashboard/app/components/network_latency_plot.tsx
+++ b/frontend/dashboard/app/components/network_latency_plot.tsx
@@ -3,7 +3,7 @@
 import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo, useState } from "react";
-import { useChartColors, useChartForeground } from "../utils/shared_styles";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
 import {
   formatMillisToHumanReadable,
@@ -53,16 +53,7 @@ const NetworkLatencyPlot: React.FC<NetworkLatencyPlotProps> = ({
   const chartColors = useChartColors();
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
-  const foreground = useChartForeground();
-  const canvasTheme = useMemo(
-    () => ({
-      text: { fill: foreground },
-      axis: { ticks: { text: { fill: foreground } } },
-      legends: { text: { fill: foreground } },
-      crosshair: { line: { stroke: foreground, strokeWidth: 1 } },
-    }),
-    [foreground],
-  );
+  const canvasTheme = useChartCanvasTheme();
 
   const plot = useMemo<PlotData | undefined>(() => {
     if (!data) return undefined;

--- a/frontend/dashboard/app/components/network_status_distribution_plot.tsx
+++ b/frontend/dashboard/app/components/network_status_distribution_plot.tsx
@@ -4,7 +4,7 @@ import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo } from "react";
 import { numberToKMB } from "../utils/number_utils";
-import { useChartColor, useChartForeground } from "../utils/shared_styles";
+import { useChartCanvasTheme, useChartColor } from "../utils/shared_styles";
 import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
 import {
   formatPlotTooltipDate,
@@ -53,16 +53,7 @@ const NetworkStatusDistributionPlot: React.FC<
   const chartColor = useChartColor();
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
-  const foreground = useChartForeground();
-  const canvasTheme = useMemo(
-    () => ({
-      text: { fill: foreground },
-      axis: { ticks: { text: { fill: foreground } } },
-      legends: { text: { fill: foreground } },
-      crosshair: { line: { stroke: foreground, strokeWidth: 1 } },
-    }),
-    [foreground],
-  );
+  const canvasTheme = useChartCanvasTheme();
 
   const colorMap = {
     "2xx": chartColor.green,
@@ -74,9 +65,6 @@ const NetworkStatusDistributionPlot: React.FC<
   const plot = useMemo<PlotData | undefined>(() => {
     if (!data) return undefined;
 
-    // Every datum carries all four status counts so the nearest-point
-    // tooltip can list the full breakdown at that datetime, not only the
-    // hovered series.
     return seriesConfig.map(({ key, id }) => ({
       id,
       data: data.map((d) => ({

--- a/frontend/dashboard/app/components/network_timeline_plot.tsx
+++ b/frontend/dashboard/app/components/network_timeline_plot.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Slider } from "@/app/components/slider";
-import { useChartForeground } from "@/app/utils/shared_styles";
+import { useChartCanvasTheme } from "@/app/utils/shared_styles";
 import { formatMillisToHumanReadable } from "@/app/utils/time_utils";
 import { PlotTooltipShell } from "@/app/components/plot_tooltip";
 import { ResponsiveHeatMapCanvas } from "@nivo/heatmap";
@@ -26,17 +26,8 @@ interface Props {
 
 const NetworkTimelinePlot: React.FC<Props> = ({ data }) => {
   const { theme } = useTheme();
-  const foreground = useChartForeground();
   const interval = data.interval;
-
-  const canvasTheme = useMemo(
-    () => ({
-      text: { fill: foreground },
-      axis: { ticks: { text: { fill: foreground } } },
-      legends: { text: { fill: foreground } },
-    }),
-    [foreground],
-  );
+  const canvasTheme = useChartCanvasTheme();
 
   const { endpointOrder, bucketMap, minBucket, maxBucket } = useMemo(() => {
     // Group by endpoint and bucket (already aligned from backend), and order

--- a/frontend/dashboard/app/components/plot_tooltip.tsx
+++ b/frontend/dashboard/app/components/plot_tooltip.tsx
@@ -29,3 +29,38 @@ export function PlotTooltipSwatch({ color }: { color: string }) {
     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
   );
 }
+
+export interface SiblingPoint {
+  id: string;
+  y: number;
+  color: string;
+}
+
+// Canvas line charts have no x-slice tooltip, only a nearest-point one, so
+// each datum carries the values of every series at its x position for the
+// tooltip to list the full breakdown. Series are matched by their x value;
+// a series with no datum at that x is absent from the list.
+export function embedSiblingPoints<
+  D extends { x: string; y: number },
+  S extends { id: string; data: D[] },
+>(
+  plot: S[],
+  colorFor: (id: string, index: number) => string,
+): (Omit<S, "data"> & { data: (D & { siblings: SiblingPoint[] })[] })[] {
+  const byX = new Map<string, SiblingPoint[]>();
+  plot.forEach((series, index) => {
+    const color = colorFor(series.id, index);
+    for (const d of series.data) {
+      let list = byX.get(d.x);
+      if (!list) {
+        list = [];
+        byX.set(d.x, list);
+      }
+      list.push({ id: series.id, y: d.y, color });
+    }
+  });
+  return plot.map((series) => ({
+    ...series,
+    data: series.data.map((d) => ({ ...d, siblings: byX.get(d.x) ?? [] })),
+  }));
+}

--- a/frontend/dashboard/app/components/session_replay_overview_plot.tsx
+++ b/frontend/dashboard/app/components/session_replay_overview_plot.tsx
@@ -2,28 +2,44 @@
 
 import { useSessionReplayOverviewPlotQuery } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
-import React from "react";
-import { chartTheme, useChartColors } from "../utils/shared_styles";
+import React, { useMemo } from "react";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import {
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
 const SessionReplayOverviewPlot: React.FC = () => {
   const filters = useFiltersStore((state) => state.filters);
-  const { data: plot, status } = useSessionReplayOverviewPlotQuery();
+  const { data: rawPlot, status } = useSessionReplayOverviewPlotQuery();
   const { theme } = useTheme();
   const chartColors = useChartColors();
+  const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
     filters.startDate,
     filters.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
+
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (_, index) => chartColors[index % chartColors.length],
+    );
+  }, [rawPlot, chartColors]);
 
   return (
     <div className="flex font-body items-center justify-center w-full h-144">
@@ -39,10 +55,10 @@ const SessionReplayOverviewPlot: React.FC = () => {
       )}
       {status === "success" && plot !== null && plot !== undefined && (
         <div className="size-full">
-          <ResponsiveLine
+          <ResponsiveLineCanvas
             data={plot}
             curve="monotoneX"
-            theme={chartTheme}
+            theme={canvasTheme}
             enableArea={true}
             areaOpacity={0.1}
             colors={chartColors}
@@ -89,31 +105,32 @@ const SessionReplayOverviewPlot: React.FC = () => {
               from: "seriesColor",
               modifiers: [["darker", 0.3]],
             }}
-            pointLabelYOffset={-12}
-            useMesh={true}
             enableGridX={false}
             enableGridY={false}
-            enableSlices="x"
-            sliceTooltip={({ slice }) => {
+            tooltip={({ point }) => {
+              const pointData = point.data as unknown as {
+                xFormatted: string;
+                siblings: SiblingPoint[];
+              };
               return (
                 <PlotTooltipShell>
                   <p className="p-2">
                     Date:{" "}
                     {formatPlotTooltipDate(
-                      slice.points[0].data.xFormatted.toString(),
+                      pointData.xFormatted.toString(),
                       plotTimeGroup,
                     )}
                   </p>
-                  {slice.points.map((point) => (
+                  {pointData.siblings.map((sibling) => (
                     <div
                       className="flex flex-row items-center p-2"
-                      key={point.id}
+                      key={sibling.id}
                     >
-                      <PlotTooltipSwatch color={point.seriesColor} />
+                      <PlotTooltipSwatch color={sibling.color} />
                       <div className="px-2" />
-                      <p>{point.seriesId.toString()} - </p>
+                      <p>{sibling.id} - </p>
                       <div className="px-2" />
-                      <p>{point.data.yFormatted} session replays</p>
+                      <p>{sibling.y.toLocaleString()} session replays</p>
                     </div>
                   ))}
                 </PlotTooltipShell>

--- a/frontend/dashboard/app/components/span_metrics_plot.tsx
+++ b/frontend/dashboard/app/components/span_metrics_plot.tsx
@@ -5,17 +5,22 @@ import {
   useSpanMetricsPlotQuery,
 } from "@/app/query/hooks";
 import { useFiltersStore } from "@/app/stores/provider";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
-import React, { useState } from "react";
-import { chartTheme, useChartColors } from "../utils/shared_styles";
+import React, { useMemo, useState } from "react";
+import { useChartCanvasTheme, useChartColors } from "../utils/shared_styles";
 import {
   formatMillisToHumanReadable,
   formatPlotTooltipDate,
   getPlotTimeGroupForRange,
   getPlotTimeGroupNivoConfig,
 } from "../utils/time_utils";
-import { PlotTooltipShell, PlotTooltipSwatch } from "./plot_tooltip";
+import {
+  embedSiblingPoints,
+  PlotTooltipShell,
+  PlotTooltipSwatch,
+  SiblingPoint,
+} from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 import TabSelect from "./tab_select";
 
@@ -24,14 +29,25 @@ const SpanMetricsPlot: React.FC = () => {
   const [quantile, setQuantile] = useState<RootSpanMetricsQuantile>(
     RootSpanMetricsQuantile.p50,
   );
-  const { data: plot, status } = useSpanMetricsPlotQuery(quantile);
+  const { data: rawPlot, status } = useSpanMetricsPlotQuery(quantile);
   const { theme } = useTheme();
   const chartColors = useChartColors();
+  const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
     filters.startDate,
     filters.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
+
+  const plot = useMemo(() => {
+    if (!rawPlot) {
+      return rawPlot;
+    }
+    return embedSiblingPoints(
+      rawPlot,
+      (_: string, index: number) => chartColors[index % chartColors.length],
+    );
+  }, [rawPlot, chartColors]);
 
   function mapQuantileStringToQuantile(quantile: string) {
     switch (quantile) {
@@ -72,10 +88,10 @@ const SpanMetricsPlot: React.FC = () => {
             />
           </div>
           <div className="size-full">
-            <ResponsiveLine
+            <ResponsiveLineCanvas
               data={plot}
               curve="monotoneX"
-              theme={chartTheme}
+              theme={canvasTheme}
               enableArea={true}
               areaOpacity={0.1}
               colors={chartColors}
@@ -121,35 +137,33 @@ const SpanMetricsPlot: React.FC = () => {
                 from: "seriesColor",
                 modifiers: [["darker", 0.3]],
               }}
-              pointLabelYOffset={-12}
-              useMesh={true}
               enableGridX={false}
               enableGridY={false}
-              enableSlices="x"
-              sliceTooltip={({ slice }) => {
+              tooltip={({ point }) => {
+                const pointData = point.data as unknown as {
+                  xFormatted: string;
+                  siblings: SiblingPoint[];
+                };
                 return (
                   <PlotTooltipShell>
                     <p className="p-2">
                       Date:{" "}
                       {formatPlotTooltipDate(
-                        slice.points[0].data.xFormatted.toString(),
+                        pointData.xFormatted.toString(),
                         plotTimeGroup,
                       )}
                     </p>
-                    {slice.points.map((point) => (
+                    {pointData.siblings.map((sibling) => (
                       <div
                         className="flex flex-row items-center p-2"
-                        key={point.id}
+                        key={sibling.id}
                       >
-                        <PlotTooltipSwatch color={point.seriesColor} />
+                        <PlotTooltipSwatch color={sibling.color} />
                         <div className="px-2" />
-                        <p>{point.seriesId.toString()} - </p>
+                        <p>{sibling.id} - </p>
                         <div className="px-2" />
                         <p>
-                          {formatMillisToHumanReadable(
-                            Number(point.data.yFormatted),
-                          )}{" "}
-                          ({quantile})
+                          {formatMillisToHumanReadable(sibling.y)} ({quantile})
                         </p>
                       </div>
                     ))}

--- a/frontend/dashboard/app/utils/shared_styles.tsx
+++ b/frontend/dashboard/app/utils/shared_styles.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "next-themes";
+import { useMemo } from "react";
 
 // Mirrors the docs prose links (fumadocs typography plus our fd-primary
 // override in globals.css): same decoration pair, thickness, offset, weight
@@ -46,13 +47,22 @@ export function useChartColors() {
   return chartColors;
 }
 
-// Concrete foreground for canvas-rendered charts. Canvas fillStyle cannot
-// resolve the `var(--foreground)` that chartTheme uses for SVG charts, so
-// canvas renderers need the `--foreground` token values from globals.css as
-// hex; keep the two in sync.
-export function useChartForeground() {
+// chartTheme rebuilt with concrete colors for canvas renderers. Canvas
+// fillStyle cannot resolve the `var(--foreground)` that chartTheme uses for
+// SVG charts, so this uses the `--foreground` token values from globals.css
+// as hex; keep the two in sync.
+export function useChartCanvasTheme() {
   const { theme } = useTheme();
-  return theme === "dark" ? "#fafafa" : "#222222";
+  const foreground = theme === "dark" ? "#fafafa" : "#222222";
+  return useMemo(
+    () => ({
+      text: { fill: foreground },
+      axis: { ticks: { text: { fill: foreground } } },
+      legends: { text: { fill: foreground } },
+      crosshair: { line: { stroke: foreground, strokeWidth: 1 } },
+    }),
+    [foreground],
+  );
 }
 
 export const chartTheme = {


### PR DESCRIPTION
# Description

Convert the remaining SVG ResponsiveLine plots (app health, errors overview, error group details, session replays, bug reports, span metrics) to ResponsiveLineCanvas. These queries share the same minute bucketing as the network plots, so a range of 24 hours or less returns up to 1,440 buckets per series and the SVG renderer blocked the main thread for seconds. The canvas plots render much faster (usually under 300ms).

Canvas charts have no x-slice tooltip, so a shared embedSiblingPoints helper stores every series' value on each datum and the nearest-point tooltip lists the full breakdown. The colour canvas theme moves into a shared useChartCanvasTheme hook, used by the network plots as well.



