### PR TITLE
fix(backend): escape user-supplied values in email HTML

### DIFF
--- a/backend/api/handlers/team.go
+++ b/backend/api/handlers/team.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"backend/libs/email"
 	"backend/libs/measure"
@@ -16,14 +17,22 @@ import (
 
 const maxInvitees = 25
 
+// maxTeamNameLen matches the varchar(256) width of measure.teams.name, so an
+// oversized name is rejected with a 400 here instead of failing in Postgres.
+const maxTeamNameLen = 256
+
 // normalizeTeamName trims a bound team name and reports whether it is usable.
-// A missing field (nil) or a value that is blank after trimming is rejected.
+// A missing field (nil), a value that is blank after trimming, or one longer
+// than the column allows is rejected.
 func normalizeTeamName(name *string) (string, bool) {
 	if name == nil {
 		return "", false
 	}
 	trimmed := strings.TrimSpace(*name)
-	return trimmed, trimmed != ""
+	if trimmed == "" || utf8.RuneCountInString(trimmed) > maxTeamNameLen {
+		return "", false
+	}
+	return trimmed, true
 }
 
 func (h Handlers) CreateTeam(c *gin.Context) {
@@ -45,7 +54,7 @@ func (h Handlers) CreateTeam(c *gin.Context) {
 
 	name, ok := normalizeTeamName(newTeam.Name)
 	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "team name cannot be empty"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("team name cannot be empty or longer than %d characters", maxTeamNameLen)})
 		return
 	}
 	*newTeam.Name = name
@@ -787,7 +796,7 @@ func (h Handlers) RenameTeam(c *gin.Context) {
 
 	name, ok := normalizeTeamName(payload.Name)
 	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "team name cannot be empty"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("team name cannot be empty or longer than %d characters", maxTeamNameLen)})
 		return
 	}
 

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -2,13 +2,23 @@ package email
 
 import (
 	"fmt"
+	"html"
 	"time"
 )
+
+// escape turns a value that came from a person into text the mail client
+// renders literally instead of parsing as markup. Team names, roles and
+// email addresses all reach these builders as raw input, so a team named
+// `<img src=...>` would otherwise place that tag inside the HTML body of
+// every invite and membership email sent about the team.
+func escape(s string) string {
+	return html.EscapeString(s)
+}
 
 // AddedToTeamEmail builds the email sent when a user is added to a team.
 func AddedToTeamEmail(teamName, role, addedByEmail, siteOrigin, teamId string) (subject, body string) {
 	subject = "Added to Measure team"
-	msg := fmt.Sprintf("You have been added to team <b>%s</b> as <b>%s</b> by <b>%s</b>", teamName, role, addedByEmail)
+	msg := fmt.Sprintf("You have been added to team <b>%s</b> as <b>%s</b> by <b>%s</b>", escape(teamName), escape(role), escape(addedByEmail))
 	url := siteOrigin + "/" + teamId + "/overview"
 	body = RenderEmailBody(subject, MessageContent(msg), "Go to Dashboard", url)
 	return
@@ -21,7 +31,7 @@ func InviteNewUserEmail(inviterEmail, role, teamName string, validityDays int, s
 	if validityDays != 1 {
 		dayStr = "days"
 	}
-	msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>! <br/><br/>This invite is valid for <b>%d %s</b>.", inviterEmail, role, teamName, validityDays, dayStr)
+	msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>! <br/><br/>This invite is valid for <b>%d %s</b>.", escape(inviterEmail), escape(role), escape(teamName), validityDays, dayStr)
 	url := siteOrigin + "/auth/login?inviteId=" + inviteId
 	body = RenderEmailBody(subject, MessageContent(msg), "Join Team", url)
 	return
@@ -30,7 +40,7 @@ func InviteNewUserEmail(inviterEmail, role, teamName string, validityDays int, s
 // InviteExistingUserEmail builds the email sent when an existing user is invited to a team.
 func InviteExistingUserEmail(inviterEmail, role, teamName, siteOrigin string) (subject, body string) {
 	subject = "Invitation to join Measure"
-	msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>!", inviterEmail, role, teamName)
+	msg := fmt.Sprintf("You have been invited by <b>%s</b> as <b>%s</b> in team <b>%s</b>!", escape(inviterEmail), escape(role), escape(teamName))
 	url := siteOrigin + "/auth/login"
 	body = RenderEmailBody(subject, MessageContent(msg), "Join Team", url)
 	return
@@ -41,7 +51,7 @@ func InviteExistingUserEmail(inviterEmail, role, teamName, siteOrigin string) (s
 // when the member has no team left, which links to the dashboard root.
 func RemovedFromTeamEmail(teamName, removedByEmail, siteOrigin, memberTeamId string) (subject, body string) {
 	subject = "Removed from Measure team"
-	msg := fmt.Sprintf("You have been removed from team <b>%s</b> by <b>%s</b>", teamName, removedByEmail)
+	msg := fmt.Sprintf("You have been removed from team <b>%s</b> by <b>%s</b>", escape(teamName), escape(removedByEmail))
 	url := siteOrigin
 	if memberTeamId != "" {
 		url = siteOrigin + "/" + memberTeamId + "/overview"
@@ -53,7 +63,7 @@ func RemovedFromTeamEmail(teamName, removedByEmail, siteOrigin, memberTeamId str
 // RoleChangedEmail builds the email sent when a user's role is changed.
 func RoleChangedEmail(newRole, changedByEmail, teamName, siteOrigin, teamId string) (subject, body string) {
 	subject = "Role changed in Measure team"
-	msg := fmt.Sprintf("Your role has been changed to <b>%s</b> by <b>%s</b> in team <b>%s</b>", newRole, changedByEmail, teamName)
+	msg := fmt.Sprintf("Your role has been changed to <b>%s</b> by <b>%s</b> in team <b>%s</b>", escape(newRole), escape(changedByEmail), escape(teamName))
 	url := siteOrigin + "/" + teamId + "/overview"
 	body = RenderEmailBody(subject, MessageContent(msg), "Go to Dashboard", url)
 	return
@@ -94,14 +104,14 @@ func AnrAlertURL(siteOrigin, teamId, appId, fingerprint, anrType, fileName strin
 // CrashSpikeAlertEmail builds the crash spike alert email.
 func CrashSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - Crash Spike Alert"
-	body = RenderEmailBody(subject, MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
 // AnrSpikeAlertEmail builds the ANR spike alert email.
 func AnrSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - ANR Spike Alert"
-	body = RenderEmailBody(subject, MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
@@ -123,7 +133,7 @@ func BugReportAlertURL(siteOrigin, teamId, appId, bugReportId string) string {
 // BugReportAlertEmail builds the bug report alert email.
 func BugReportAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - New Bug Report"
-	body = RenderEmailBody(subject, MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
@@ -131,7 +141,7 @@ func BugReportAlertEmail(appName, alertMsg, alertURL string) (subject, body stri
 func DailySummaryEmail(appName string, date time.Time, metrics []MetricData, siteOrigin, teamId, appId string) (subject, body string) {
 	subject = appName + " Daily Summary"
 	dashboardURL := fmt.Sprintf("%s/%s/overview?a=%s", siteOrigin, teamId, appId)
-	body = RenderEmailBody(subject, DailySummaryContent(appName, date, metrics), "View Full Dashboard", dashboardURL)
+	body = RenderEmailBody(escape(subject), DailySummaryContent(appName, date, metrics), "View Full Dashboard", dashboardURL)
 	return
 }
 
@@ -146,12 +156,12 @@ func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int) (subjec
 	case 100:
 		subject = fmt.Sprintf("%s - Usage Limit Reached", teamName)
 		title = "Usage Limit Reached"
-		message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Upgrade to Measure Pro to resume.`, teamName)
+		message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Upgrade to Measure Pro to resume.`, escape(teamName))
 		ctaText = "Upgrade to Measure Pro"
 	default:
 		subject = fmt.Sprintf("%s - %d%% of Usage Limit Reached", teamName, threshold)
 		title = fmt.Sprintf("%d%% Usage Limit Reached", threshold)
-		message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Consider upgrading to Measure Pro for unlimited usage!`, teamName, threshold)
+		message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Consider upgrading to Measure Pro for unlimited usage!`, escape(teamName), threshold)
 		ctaText = "Upgrade to Measure Pro"
 	}
 
@@ -164,7 +174,7 @@ func UpgradeEmail(teamName, teamId, siteOrigin string) (subject, body string) {
 	subject = fmt.Sprintf("%s - Upgraded to Measure Pro", teamName)
 	title := "Upgraded to Measure Pro"
 	dashboardURL := fmt.Sprintf("%s/%s/usage", siteOrigin, teamId)
-	message := fmt.Sprintf(`Your team <strong>%s</strong> has been upgraded to Measure Pro!`, teamName)
+	message := fmt.Sprintf(`Your team <strong>%s</strong> has been upgraded to Measure Pro!`, escape(teamName))
 	body = RenderEmailBody(title, MessageContent(message), "Go to Dashboard", dashboardURL)
 	return
 }
@@ -174,7 +184,7 @@ func ManualDowngradeEmail(teamName, teamId, siteOrigin string) (subject, body st
 	subject = fmt.Sprintf("%s - Downgraded to Free Plan", teamName)
 	title := "Downgraded to Free Plan"
 	dashboardURL := fmt.Sprintf("%s/%s/usage", siteOrigin, teamId)
-	message := fmt.Sprintf(`Your team <strong>%s</strong> has been downgraded to the free plan.<br><br>Check your dashboard for the new usage and retention limits.`, teamName)
+	message := fmt.Sprintf(`Your team <strong>%s</strong> has been downgraded to the free plan.<br><br>Check your dashboard for the new usage and retention limits.`, escape(teamName))
 	body = RenderEmailBody(title, MessageContent(message), "Go to Dashboard", dashboardURL)
 	return
 }

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -667,3 +667,55 @@ func TestRemovedFromTeamEmail(t *testing.T) {
 		}
 	})
 }
+
+// Anyone who can name a team controls a string that several emails place in
+// their HTML body, so markup in a name has to arrive as visible text rather
+// than as tags the mail client parses.
+func TestTeamNameMarkupIsEscaped(t *testing.T) {
+	const payload = `evil<img src="x" onerror="alert(1)">`
+	const escaped = `evil&lt;img src=&#34;x&#34; onerror=&#34;alert(1)&#34;&gt;`
+
+	bodies := map[string]string{}
+
+	_, bodies["AddedToTeamEmail"] = AddedToTeamEmail(payload, "admin", "attacker@example.com", "https://measure.sh", "team-abc")
+	_, bodies["InviteNewUserEmail"] = InviteNewUserEmail("attacker@example.com", "admin", payload, 7, "https://measure.sh", "invite-abc")
+	_, bodies["InviteExistingUserEmail"] = InviteExistingUserEmail("attacker@example.com", "admin", payload, "https://measure.sh")
+	_, bodies["RemovedFromTeamEmail"] = RemovedFromTeamEmail(payload, "attacker@example.com", "https://measure.sh", "team-abc")
+	_, bodies["RoleChangedEmail"] = RoleChangedEmail("admin", "attacker@example.com", payload, "https://measure.sh", "team-abc")
+	_, bodies["UsageLimitEmail"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 90)
+	_, bodies["UsageLimitEmail(100)"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 100)
+	_, bodies["UpgradeEmail"] = UpgradeEmail(payload, "team-abc", "https://measure.sh")
+	_, bodies["ManualDowngradeEmail"] = ManualDowngradeEmail(payload, "team-abc", "https://measure.sh")
+
+	for name, body := range bodies {
+		if strings.Contains(body, payload) {
+			t.Errorf("%s: body contains unescaped team name markup", name)
+		}
+		if !strings.Contains(body, escaped) {
+			t.Errorf("%s: body missing escaped team name", name)
+		}
+	}
+}
+
+// App names reach the email header through the subject line, which
+// RenderEmailBody places inside <title> and <h1>.
+func TestAppNameMarkupIsEscapedInTitle(t *testing.T) {
+	const payload = `evil<img src=x>`
+	const escaped = `evil&lt;img src=x&gt;`
+
+	bodies := map[string]string{}
+
+	_, bodies["CrashSpikeAlertEmail"] = CrashSpikeAlertEmail(payload, "spiking", "https://measure.sh")
+	_, bodies["AnrSpikeAlertEmail"] = AnrSpikeAlertEmail(payload, "spiking", "https://measure.sh")
+	_, bodies["BugReportAlertEmail"] = BugReportAlertEmail(payload, "a bug", "https://measure.sh")
+	_, bodies["DailySummaryEmail"] = DailySummaryEmail(payload, time.Now(), nil, "https://measure.sh", "team-abc", "app-abc")
+
+	for name, body := range bodies {
+		if strings.Contains(body, payload) {
+			t.Errorf("%s: body contains unescaped app name markup", name)
+		}
+		if !strings.Contains(body, escaped) {
+			t.Errorf("%s: body missing escaped app name", name)
+		}
+	}
+}


### PR DESCRIPTION
# Description

Team names, roles, actor emails and app names reached the HTML body of transactional emails unescaped, so a team named with markup could deliver that markup to any address invited to the team. Builders now escape caller-supplied values, and team names are capped at 256 characters.



