### PR TITLE
fix(frontend): wrap long text inside dialogs

### DIFF
--- a/frontend/dashboard/__tests__/components/__snapshots__/alert_dialog_test.tsx.snap
+++ b/frontend/dashboard/__tests__/components/__snapshots__/alert_dialog_test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Alert Dialog renders correctly in opened state 1`] = `
     <div
       aria-describedby="radix-_r_2_"
       aria-labelledby="radix-_r_1_"
-      class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg"
+      class="fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg"
       data-state="open"
       id="radix-_r_0_"
       role="dialog"
@@ -99,23 +99,23 @@ exports[`Alert Dialog renders correctly in opened state 1`] = `
       tabindex="-1"
     >
       <div
-        class="flex flex-col space-y-1.5 text-center sm:text-left"
+        class="flex flex-col space-y-1.5 text-left"
       >
         <h2
-          class="text-lg font-semibold leading-none tracking-tight font-display"
+          class="text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere font-display"
           id="radix-_r_1_"
         >
           SOME TITLE TEXT
         </h2>
       </div>
       <p
-        class="text-sm text-muted-foreground"
+        class="text-sm text-muted-foreground wrap-anywhere"
         id="radix-_r_2_"
       >
         SOME BODY TEXT
       </p>
       <div
-        class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end"
       >
         <button
           class="relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 dark:focus-visible:border-ring dark:focus-visible:ring-ring/50 dark:focus-visible:ring-[3px] h-9 px-4 py-2 has-[>svg]:px-3 font-display border border-black select-none"

--- a/frontend/dashboard/__tests__/components/__snapshots__/confirmation_dialog_test.tsx.snap
+++ b/frontend/dashboard/__tests__/components/__snapshots__/confirmation_dialog_test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Confirmation Dialog renders correctly in closed state 1`] = `
     <div
       aria-describedby="radix-_r_5_"
       aria-labelledby="radix-_r_4_"
-      class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
+      class="fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
       data-state="open"
       id="radix-_r_3_"
       role="dialog"
@@ -36,23 +36,23 @@ exports[`Confirmation Dialog renders correctly in closed state 1`] = `
       tabindex="-1"
     >
       <div
-        class="flex flex-col space-y-1.5 text-center sm:text-left"
+        class="flex flex-col space-y-1.5 text-left"
       >
         <h2
-          class="text-lg font-semibold leading-none tracking-tight font-display"
+          class="text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere font-display"
           id="radix-_r_4_"
         >
           Are you sure?
         </h2>
       </div>
       <p
-        class="text-sm text-muted-foreground"
+        class="text-sm text-muted-foreground wrap-anywhere"
         id="radix-_r_5_"
       >
         SOME BODY TEXT
       </p>
       <div
-        class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end"
       >
         <button
           class="relative font-display select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3"
@@ -192,7 +192,7 @@ exports[`Confirmation Dialog renders correctly in opened state 1`] = `
     <div
       aria-describedby="radix-_r_2_"
       aria-labelledby="radix-_r_1_"
-      class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
+      class="fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
       data-state="open"
       id="radix-_r_0_"
       role="dialog"
@@ -200,23 +200,23 @@ exports[`Confirmation Dialog renders correctly in opened state 1`] = `
       tabindex="-1"
     >
       <div
-        class="flex flex-col space-y-1.5 text-center sm:text-left"
+        class="flex flex-col space-y-1.5 text-left"
       >
         <h2
-          class="text-lg font-semibold leading-none tracking-tight font-display"
+          class="text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere font-display"
           id="radix-_r_1_"
         >
           Are you sure?
         </h2>
       </div>
       <p
-        class="text-sm text-muted-foreground"
+        class="text-sm text-muted-foreground wrap-anywhere"
         id="radix-_r_2_"
       >
         SOME BODY TEXT
       </p>
       <div
-        class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end"
       >
         <button
           class="relative font-display select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3"

--- a/frontend/dashboard/__tests__/components/__snapshots__/danger_confirmation_dialog_test.tsx.snap
+++ b/frontend/dashboard/__tests__/components/__snapshots__/danger_confirmation_dialog_test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Danger Confirmation Dialog renders correctly in closed state 1`] = `
     <div
       aria-describedby="radix-_r_5_"
       aria-labelledby="radix-_r_4_"
-      class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
+      class="fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
       data-state="open"
       id="radix-_r_3_"
       role="dialog"
@@ -36,23 +36,23 @@ exports[`Danger Confirmation Dialog renders correctly in closed state 1`] = `
       tabindex="-1"
     >
       <div
-        class="flex flex-col space-y-1.5 text-center sm:text-left"
+        class="flex flex-col space-y-1.5 text-left"
       >
         <h2
-          class="text-lg font-semibold leading-none tracking-tight font-display text-red-600 dark:text-red-400"
+          class="text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere font-display text-red-600 dark:text-red-400"
           id="radix-_r_4_"
         >
           Are you sure?
         </h2>
       </div>
       <p
-        class="text-sm text-muted-foreground"
+        class="text-sm text-muted-foreground wrap-anywhere"
         id="radix-_r_5_"
       >
         SOME BODY TEXT
       </p>
       <div
-        class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end"
       >
         <button
           class="relative font-display select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-destructive text-destructive-foreground hover:bg-destructive/90 dark:hover:bg-destructive/70 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/80 h-9 px-4 py-2 has-[>svg]:px-3"
@@ -192,7 +192,7 @@ exports[`Danger Confirmation Dialog renders correctly in opened state 1`] = `
     <div
       aria-describedby="radix-_r_2_"
       aria-labelledby="radix-_r_1_"
-      class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
+      class="fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg bg-background text-foreground"
       data-state="open"
       id="radix-_r_0_"
       role="dialog"
@@ -200,23 +200,23 @@ exports[`Danger Confirmation Dialog renders correctly in opened state 1`] = `
       tabindex="-1"
     >
       <div
-        class="flex flex-col space-y-1.5 text-center sm:text-left"
+        class="flex flex-col space-y-1.5 text-left"
       >
         <h2
-          class="text-lg font-semibold leading-none tracking-tight font-display text-red-600 dark:text-red-400"
+          class="text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere font-display text-red-600 dark:text-red-400"
           id="radix-_r_1_"
         >
           Are you sure?
         </h2>
       </div>
       <p
-        class="text-sm text-muted-foreground"
+        class="text-sm text-muted-foreground wrap-anywhere"
         id="radix-_r_2_"
       >
         SOME BODY TEXT
       </p>
       <div
-        class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end"
       >
         <button
           class="relative font-display select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-destructive text-destructive-foreground hover:bg-destructive/90 dark:hover:bg-destructive/70 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/80 h-9 px-4 py-2 has-[>svg]:px-3"

--- a/frontend/dashboard/app/components/dialog.tsx
+++ b/frontend/dashboard/app/components/dialog.tsx
@@ -37,7 +37,12 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // The single grid column is capped at minmax(0,1fr) because a grid
+        // track otherwise grows to its min-content width, so one long word in
+        // the title or body (an app name, an email) would push the whole
+        // dialog wider than max-w-lg. Tall content scrolls inside the dialog
+        // instead of running off the top and bottom of the screen.
+        "fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -57,10 +62,7 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className,
-    )}
+    className={cn("flex flex-col space-y-1.5 text-left", className)}
     {...props}
   />
 );
@@ -72,7 +74,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end",
       className,
     )}
     {...props}
@@ -87,7 +89,10 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      // pr-6 keeps a long title clear of the close button pinned to the top
+      // right corner, and wrap-anywhere breaks a word with no spaces in it
+      // rather than letting it run past the edge of the dialog.
+      "text-lg font-semibold leading-snug tracking-tight pr-6 wrap-anywhere",
       className,
     )}
     {...props}
@@ -101,7 +106,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-muted-foreground wrap-anywhere", className)}
     {...props}
   />
 ));

--- a/frontend/dashboard/app/dialog-test/page.tsx
+++ b/frontend/dashboard/app/dialog-test/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import AlertDialog from "@/app/components/alert_dialog";
+import { Button } from "@/app/components/button";
+import ConfirmationDialog from "@/app/components/confirmation_dialog";
+import DangerConfirmationDialog from "@/app/components/danger_confirmation_dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/components/dialog";
+import { Input } from "@/app/components/input";
+
+// A name with no spaces in it, which is what a user can actually type into an
+// app or team name field, and the case that used to push the dialog wider than
+// its own box instead of wrapping.
+const LONG_NAME =
+  "SuperCalifragilisticExpialidociousApplicationNameThatKeepsGoingAndGoing";
+const LONG_EMAIL =
+  "a.very.long.person.name.with.many.dots@an-extremely-long-company-domain-name.example.com";
+
+export default function DialogTestPage() {
+  const [open, setOpen] = useState<string | null>(null);
+  const close = () => setOpen(null);
+
+  const cases: { id: string; label: string }[] = [
+    { id: "danger-long-name", label: "Danger: long app name" },
+    { id: "danger-long-email", label: "Danger: long email" },
+    { id: "danger-long-buttons", label: "Danger: long button labels" },
+    { id: "confirm-long", label: "Confirmation: long body" },
+    { id: "alert-long-title", label: "Alert: long title" },
+    { id: "alert-list", label: "Alert: list body" },
+    { id: "form-long-title", label: "Form dialog (create app style)" },
+    { id: "wide-tall", label: "Wide dialog with very tall body" },
+  ];
+
+  return (
+    <main className="p-8 flex flex-col gap-4 items-start">
+      <h1 className="font-display text-2xl">Dialog overflow test</h1>
+      <div className="flex flex-row flex-wrap gap-2">
+        {cases.map((c) => (
+          <Button key={c.id} variant="outline" onClick={() => setOpen(c.id)}>
+            {c.label}
+          </Button>
+        ))}
+      </div>
+
+      <DangerConfirmationDialog
+        open={open === "danger-long-name"}
+        body={
+          <p className="font-body">
+            Are you sure you want to rename app{" "}
+            <span className="font-display font-bold">{LONG_NAME}</span> to{" "}
+            <span className="font-display font-bold">{LONG_NAME}V2Final</span>?
+          </p>
+        }
+        affirmativeText="Yes, I'm sure"
+        cancelText="Cancel"
+        onAffirmativeAction={close}
+        onCancelAction={close}
+      />
+
+      <DangerConfirmationDialog
+        open={open === "danger-long-email"}
+        body={
+          <p className="font-body">
+            Are you sure you want to remove pending invite for{" "}
+            <span className="font-display font-bold">{LONG_EMAIL}</span>?
+          </p>
+        }
+        affirmativeText="Yes, I'm sure"
+        cancelText="Cancel"
+        onAffirmativeAction={close}
+        onCancelAction={close}
+      />
+
+      <DangerConfirmationDialog
+        open={open === "danger-long-buttons"}
+        body={
+          <p className="font-body">
+            Are you sure you want to rotate the API key for app{" "}
+            <span className="font-display font-bold">{LONG_NAME}</span>?
+          </p>
+        }
+        affirmativeText="Yes, rotate the API key for this app right now"
+        cancelText="No, keep the existing API key unchanged"
+        onAffirmativeAction={close}
+        onCancelAction={close}
+      />
+
+      <ConfirmationDialog
+        open={open === "confirm-long"}
+        body={
+          <p className="font-body">
+            Are you sure you want to change the role of{" "}
+            <span className="font-display font-bold">{LONG_EMAIL}</span> from{" "}
+            <span className="font-display font-bold">developer</span> to{" "}
+            <span className="font-display font-bold">owner</span>? The URL for
+            this change is
+            https://app.measure.sh/teams/00000000-0000-0000-0000-000000000000/members/00000000-0000-0000-0000-000000000000/role
+          </p>
+        }
+        affirmativeText="Yes, I'm sure"
+        cancelText="Cancel"
+        onAffirmativeAction={close}
+        onCancelAction={close}
+      />
+
+      <AlertDialog
+        open={open === "alert-long-title"}
+        title={`Could not update ${LONG_NAME}`}
+        body={
+          <p className="font-body">
+            The server rejected the request with
+            ERR_VALIDATION_FAILED_ON_FIELD_APP_NAME_BECAUSE_IT_EXCEEDS_THE_MAXIMUM_LENGTH.
+            Try a shorter name.
+          </p>
+        }
+        affirmativeText="Ok"
+        onAffirmativeAction={close}
+      />
+
+      <AlertDialog
+        open={open === "alert-list"}
+        title="Downgrade to Free"
+        body={
+          <div className="font-body">
+            <p>
+              Downgrading affects{" "}
+              <span className="font-display font-bold">{LONG_NAME}</span>:
+            </p>
+            <ul className="list-disc list-inside pt-2 text-sm">
+              <li>
+                Pro stays active until the end of the current billing cycle
+              </li>
+              <li>
+                App retention resets to 30 days for
+                {" " + LONG_NAME}
+              </li>
+              <li>Alerts configured for {LONG_EMAIL} stop being delivered</li>
+            </ul>
+          </div>
+        }
+        affirmativeText="Ok"
+        onAffirmativeAction={close}
+      />
+
+      <Dialog
+        open={open === "form-long-title"}
+        onOpenChange={(next) => {
+          if (!next) close();
+        }}
+      >
+        <DialogContent className="bg-background text-foreground">
+          <DialogHeader>
+            <DialogTitle className="font-display">
+              Add new app to {LONG_NAME}
+            </DialogTitle>
+            <DialogDescription>
+              Create a new app for team {LONG_NAME}, owned by {LONG_EMAIL}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col w-5/6">
+            <Input
+              placeholder="Enter app name"
+              className="w-96 font-body"
+              defaultValue={LONG_NAME}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={close}>
+              Create App
+            </Button>
+            <Button variant="outline" onClick={close}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={open === "wide-tall"}
+        onOpenChange={(next) => {
+          if (!next) close();
+        }}
+      >
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="font-display">More filters</DialogTitle>
+            <DialogDescription className="font-body">
+              Narrow down results with additional filters for {LONG_NAME}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="font-body text-sm flex flex-col gap-2">
+            {Array.from({ length: 40 }, (_, i) => (
+              <p key={i}>
+                Row {i + 1}: {LONG_EMAIL}
+              </p>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={close}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}


### PR DESCRIPTION
# Description

Long app names, team names, and emails ran past the edge of the dialog instead of wrapping. Also scrolls tall bodies inside the dialog, wraps footer buttons, and left aligns the header at all widths.


