### PR TITLE
feat(rn): collect expo update attributes for events and spans

### DIFF
--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -501,6 +501,15 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 			Set(`attribute.app_unique_id`, e.events[i].Attribute.AppUniqueID).
 			Set(`attribute.patch_id`, e.events[i].Attribute.PatchID).
 			Set(`attribute.patch_version`, strings.TrimSpace(e.events[i].Attribute.PatchVersion)).
+			Set(`attribute.expo_update_id`, e.events[i].Attribute.ExpoUpdateID).
+			Set(`attribute.expo_runtime_version`, strings.TrimSpace(e.events[i].Attribute.ExpoRuntimeVersion)).
+			Set(`attribute.is_expo_embedded_launch`, e.events[i].Attribute.IsExpoEmbeddedLaunch).
+			Set(`attribute.is_expo_using_embedded_assets`, e.events[i].Attribute.IsExpoUsingEmbeddedAssets).
+			Set(`attribute.expo_automatic_update_policy`, strings.TrimSpace(e.events[i].Attribute.ExpoAutomaticUpdatePolicy)).
+			Set(`attribute.expo_execution_environment`, strings.TrimSpace(e.events[i].Attribute.ExpoExecutionEnvironment)).
+			Set(`attribute.expo_version`, strings.TrimSpace(e.events[i].Attribute.ExpoVersion)).
+			Set(`attribute.expo_sdk_version`, strings.TrimSpace(e.events[i].Attribute.ExpoSDKVersion)).
+			Set(`attribute.expo_eas_project_id`, strings.TrimSpace(e.events[i].Attribute.ExpoEASProjectID)).
 			Set(`attribute.measure_sdk_version`, e.events[i].Attribute.MeasureSDKVersion).
 			Set(`attribute.thread_name`, e.events[i].Attribute.ThreadName).
 			Set(`attribute.user_id`, e.events[i].Attribute.UserID).
@@ -1068,6 +1077,15 @@ func (e eventreq) ingestSpans(ctx context.Context) error {
 			Set(`attribute.app_unique_id`, e.spans[i].Attributes.AppUniqueID).
 			Set(`attribute.patch_id`, e.spans[i].Attributes.PatchID).
 			Set(`attribute.patch_version`, strings.TrimSpace(e.spans[i].Attributes.PatchVersion)).
+			Set(`attribute.expo_update_id`, e.spans[i].Attributes.ExpoUpdateID).
+			Set(`attribute.expo_runtime_version`, strings.TrimSpace(e.spans[i].Attributes.ExpoRuntimeVersion)).
+			Set(`attribute.is_expo_embedded_launch`, e.spans[i].Attributes.IsExpoEmbeddedLaunch).
+			Set(`attribute.is_expo_using_embedded_assets`, e.spans[i].Attributes.IsExpoUsingEmbeddedAssets).
+			Set(`attribute.expo_automatic_update_policy`, strings.TrimSpace(e.spans[i].Attributes.ExpoAutomaticUpdatePolicy)).
+			Set(`attribute.expo_execution_environment`, strings.TrimSpace(e.spans[i].Attributes.ExpoExecutionEnvironment)).
+			Set(`attribute.expo_version`, strings.TrimSpace(e.spans[i].Attributes.ExpoVersion)).
+			Set(`attribute.expo_sdk_version`, strings.TrimSpace(e.spans[i].Attributes.ExpoSDKVersion)).
+			Set(`attribute.expo_eas_project_id`, strings.TrimSpace(e.spans[i].Attributes.ExpoEASProjectID)).
 			Set(`attribute.installation_id`, e.spans[i].Attributes.InstallationID).
 			Set(`attribute.user_id`, e.spans[i].Attributes.UserID).
 			Set(`attribute.measure_sdk_version`, e.spans[i].Attributes.MeasureSDKVersion).

--- a/backend/libs/event/attribute.go
+++ b/backend/libs/event/attribute.go
@@ -36,6 +36,47 @@ type Attribute struct {
 	// optional. Not used for symbolication.
 	PatchVersion string `json:"patch_version"`
 
+	// ExpoUpdateID is the id of the Expo OTA update the
+	// app is running. Optional UUID, reported only by Expo
+	// apps using expo-updates. Independent of PatchID.
+	//
+	// Absent values must be omitted from the payload
+	// entirely — an empty or malformed string fails to
+	// unmarshal and rejects the whole batch.
+	ExpoUpdateID uuid.UUID `json:"expo_update_id"`
+
+	// ExpoRuntimeVersion is the runtime version of the Expo
+	// update. Depending on the app's runtime version policy
+	// this may be a version string or a fingerprint hash.
+	ExpoRuntimeVersion string `json:"expo_runtime_version"`
+
+	// IsExpoEmbeddedLaunch is true if the app launched from
+	// the bundle embedded in the binary rather than a
+	// downloaded update.
+	IsExpoEmbeddedLaunch bool `json:"is_expo_embedded_launch"`
+
+	// IsExpoUsingEmbeddedAssets is true if the app is using
+	// the assets embedded in the binary.
+	IsExpoUsingEmbeddedAssets bool `json:"is_expo_using_embedded_assets"`
+
+	// ExpoAutomaticUpdatePolicy is the policy configured for
+	// Expo automatic updates. One of on_load,
+	// on_error_recovery, wifi_only or never.
+	ExpoAutomaticUpdatePolicy string `json:"expo_automatic_update_policy"`
+
+	// ExpoExecutionEnvironment describes where the app is
+	// running. One of storeClient, standalone or bare.
+	ExpoExecutionEnvironment string `json:"expo_execution_environment"`
+
+	// ExpoVersion is the Expo client version.
+	ExpoVersion string `json:"expo_version"`
+
+	// ExpoSDKVersion is the Expo SDK version.
+	ExpoSDKVersion string `json:"expo_sdk_version"`
+
+	// ExpoEASProjectID is the EAS project identifier.
+	ExpoEASProjectID string `json:"expo_eas_project_id"`
+
 	// MeasureSDKVersion is the measure sdk version
 	// identifier.
 	MeasureSDKVersion string `json:"measure_sdk_version" binding:"required"`
@@ -134,24 +175,30 @@ type Attribute struct {
 // Validate validates an event's attributes.
 func (a Attribute) Validate() error {
 	const (
-		maxThreadNameChars         = 128
-		maxUserIDChars             = 128
-		maxDeviceNameChars         = 32
-		maxDeviceModelChars        = 32
-		maxDeviceManufacturerChars = 256
-		maxDeviceTypeChars         = 32
-		maxOSNameChars             = 32
-		maxOSVersionChars          = 32
-		maxAppVersionChars         = 128
-		maxAppBuildChars           = 32
-		maxAppUniqueIDChars        = 128
-		maxPatchVersionChars       = 256
-		maxMeasureSDKVersion       = 16
-		maxNetworkTypeChars        = 16
-		maxNetworkGenerationChars  = 8
-		maxNetworkProviderChars    = 64
-		maxDeviceLocaleChars       = 64
-		maxDeviceCPUArchChars      = 16
+		maxThreadNameChars                = 128
+		maxUserIDChars                    = 128
+		maxDeviceNameChars                = 32
+		maxDeviceModelChars               = 32
+		maxDeviceManufacturerChars        = 256
+		maxDeviceTypeChars                = 32
+		maxOSNameChars                    = 32
+		maxOSVersionChars                 = 32
+		maxAppVersionChars                = 128
+		maxAppBuildChars                  = 32
+		maxAppUniqueIDChars               = 128
+		maxPatchVersionChars              = 256
+		maxMeasureSDKVersion              = 16
+		maxNetworkTypeChars               = 16
+		maxNetworkGenerationChars         = 8
+		maxNetworkProviderChars           = 64
+		maxDeviceLocaleChars              = 64
+		maxDeviceCPUArchChars             = 16
+		maxExpoRuntimeVersionChars        = 128
+		maxExpoAutomaticUpdatePolicyChars = 32
+		maxExpoExecutionEnvironmentChars  = 32
+		maxExpoVersionChars               = 32
+		maxExpoSDKVersionChars            = 32
+		maxExpoEASProjectIDChars          = 64
 	)
 
 	if len(a.OSName) > maxOSNameChars {
@@ -195,10 +242,28 @@ func (a Attribute) Validate() error {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_build`, maxAppBuildChars)
 	}
 	if len(a.AppUniqueID) > maxAppUniqueIDChars {
-		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attrubute.app_unique_id`, maxAppUniqueIDChars)
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.app_unique_id`, maxAppUniqueIDChars)
 	}
 	if len(a.PatchVersion) > maxPatchVersionChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.patch_version`, maxPatchVersionChars)
+	}
+	if len(a.ExpoRuntimeVersion) > maxExpoRuntimeVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_runtime_version`, maxExpoRuntimeVersionChars)
+	}
+	if len(a.ExpoAutomaticUpdatePolicy) > maxExpoAutomaticUpdatePolicyChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_automatic_update_policy`, maxExpoAutomaticUpdatePolicyChars)
+	}
+	if len(a.ExpoExecutionEnvironment) > maxExpoExecutionEnvironmentChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_execution_environment`, maxExpoExecutionEnvironmentChars)
+	}
+	if len(a.ExpoVersion) > maxExpoVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_version`, maxExpoVersionChars)
+	}
+	if len(a.ExpoSDKVersion) > maxExpoSDKVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_sdk_version`, maxExpoSDKVersionChars)
+	}
+	if len(a.ExpoEASProjectID) > maxExpoEASProjectIDChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.expo_eas_project_id`, maxExpoEASProjectIDChars)
 	}
 	if len(a.MeasureSDKVersion) > maxMeasureSDKVersion {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attribute.measure_sdk_version`, maxMeasureSDKVersion)

--- a/backend/libs/span/span.go
+++ b/backend/libs/span/span.go
@@ -53,25 +53,31 @@ var ValidNetworkGenerations = []string{
 }
 
 const (
-	maxSpanNameChars           = 64
-	maxCheckpointNameChars     = 64
-	maxNumberOfCheckpoints     = 100
-	maxThreadNameChars         = 128
-	maxUserIDChars             = 128
-	maxDeviceNameChars         = 32
-	maxDeviceModelChars        = 32
-	maxDeviceManufacturerChars = 32
-	maxOSNameChars             = 32
-	maxOSVersionChars          = 32
-	maxAppVersionChars         = 128
-	maxAppBuildChars           = 32
-	maxAppUniqueIDChars        = 128
-	maxPatchVersionChars       = 256
-	maxMeasureSDKVersion       = 16
-	maxNetworkTypeChars        = 16
-	maxNetworkGenerationChars  = 8
-	maxNetworkProviderChars    = 64
-	maxDeviceLocaleChars       = 64
+	maxSpanNameChars                  = 64
+	maxCheckpointNameChars            = 64
+	maxNumberOfCheckpoints            = 100
+	maxThreadNameChars                = 128
+	maxUserIDChars                    = 128
+	maxDeviceNameChars                = 32
+	maxDeviceModelChars               = 32
+	maxDeviceManufacturerChars        = 32
+	maxOSNameChars                    = 32
+	maxOSVersionChars                 = 32
+	maxAppVersionChars                = 128
+	maxAppBuildChars                  = 32
+	maxAppUniqueIDChars               = 128
+	maxPatchVersionChars              = 256
+	maxMeasureSDKVersion              = 16
+	maxExpoRuntimeVersionChars        = 128
+	maxExpoAutomaticUpdatePolicyChars = 32
+	maxExpoExecutionEnvironmentChars  = 32
+	maxExpoVersionChars               = 32
+	maxExpoSDKVersionChars            = 32
+	maxExpoEASProjectIDChars          = 64
+	maxNetworkTypeChars               = 16
+	maxNetworkGenerationChars         = 8
+	maxNetworkProviderChars           = 64
+	maxDeviceLocaleChars              = 64
 )
 
 type CheckPointField struct {
@@ -80,28 +86,37 @@ type CheckPointField struct {
 }
 
 type SpanAttributes struct {
-	AppUniqueID              string    `json:"app_unique_id" binding:"required"`
-	InstallationID           uuid.UUID `json:"installation_id" binding:"required"`
-	PatchID                  uuid.UUID `json:"patch_id"`
-	PatchVersion             string    `json:"patch_version"`
-	UserID                   string    `json:"user_id"`
-	MeasureSDKVersion        string    `json:"measure_sdk_version" binding:"required"`
-	AppVersion               string    `json:"app_version" binding:"required"`
-	AppBuild                 string    `json:"app_build" binding:"required"`
-	OSName                   string    `json:"os_name" binding:"required"`
-	OSVersion                string    `json:"os_version" binding:"required"`
-	ThreadName               string    `json:"thread_name"`
-	CountryCode              string    `json:"inet_country_code"`
-	NetworkType              string    `json:"network_type"`
-	NetworkProvider          string    `json:"network_provider"`
-	NetworkGeneration        string    `json:"network_generation"`
-	DeviceName               string    `json:"device_name"`
-	DeviceModel              string    `json:"device_model"`
-	DeviceManufacturer       string    `json:"device_manufacturer"`
-	DeviceLocale             string    `json:"device_locale"`
-	LowPowerModeEnabled      bool      `json:"device_low_power_mode"`
-	ThermalThrottlingEnabled bool      `json:"device_thermal_throttling_enabled"`
-	SessionStartTime         time.Time `json:"session_start_time"`
+	AppUniqueID               string    `json:"app_unique_id" binding:"required"`
+	InstallationID            uuid.UUID `json:"installation_id" binding:"required"`
+	PatchID                   uuid.UUID `json:"patch_id"`
+	PatchVersion              string    `json:"patch_version"`
+	ExpoUpdateID              uuid.UUID `json:"expo_update_id"`
+	ExpoRuntimeVersion        string    `json:"expo_runtime_version"`
+	IsExpoEmbeddedLaunch      bool      `json:"is_expo_embedded_launch"`
+	IsExpoUsingEmbeddedAssets bool      `json:"is_expo_using_embedded_assets"`
+	ExpoAutomaticUpdatePolicy string    `json:"expo_automatic_update_policy"`
+	ExpoExecutionEnvironment  string    `json:"expo_execution_environment"`
+	ExpoVersion               string    `json:"expo_version"`
+	ExpoSDKVersion            string    `json:"expo_sdk_version"`
+	ExpoEASProjectID          string    `json:"expo_eas_project_id"`
+	UserID                    string    `json:"user_id"`
+	MeasureSDKVersion         string    `json:"measure_sdk_version" binding:"required"`
+	AppVersion                string    `json:"app_version" binding:"required"`
+	AppBuild                  string    `json:"app_build" binding:"required"`
+	OSName                    string    `json:"os_name" binding:"required"`
+	OSVersion                 string    `json:"os_version" binding:"required"`
+	ThreadName                string    `json:"thread_name"`
+	CountryCode               string    `json:"inet_country_code"`
+	NetworkType               string    `json:"network_type"`
+	NetworkProvider           string    `json:"network_provider"`
+	NetworkGeneration         string    `json:"network_generation"`
+	DeviceName                string    `json:"device_name"`
+	DeviceModel               string    `json:"device_model"`
+	DeviceManufacturer        string    `json:"device_manufacturer"`
+	DeviceLocale              string    `json:"device_locale"`
+	LowPowerModeEnabled       bool      `json:"device_low_power_mode"`
+	ThermalThrottlingEnabled  bool      `json:"device_thermal_throttling_enabled"`
+	SessionStartTime          time.Time `json:"session_start_time"`
 }
 
 type RootSpanDisplay struct {
@@ -287,6 +302,30 @@ func (s *SpanField) Validate(opts ...ingest.ValidationOptions) error {
 
 	if len(s.Attributes.PatchVersion) > maxPatchVersionChars {
 		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.patch_version`, maxPatchVersionChars)
+	}
+
+	if len(s.Attributes.ExpoRuntimeVersion) > maxExpoRuntimeVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_runtime_version`, maxExpoRuntimeVersionChars)
+	}
+
+	if len(s.Attributes.ExpoAutomaticUpdatePolicy) > maxExpoAutomaticUpdatePolicyChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_automatic_update_policy`, maxExpoAutomaticUpdatePolicyChars)
+	}
+
+	if len(s.Attributes.ExpoExecutionEnvironment) > maxExpoExecutionEnvironmentChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_execution_environment`, maxExpoExecutionEnvironmentChars)
+	}
+
+	if len(s.Attributes.ExpoVersion) > maxExpoVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_version`, maxExpoVersionChars)
+	}
+
+	if len(s.Attributes.ExpoSDKVersion) > maxExpoSDKVersionChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_sdk_version`, maxExpoSDKVersionChars)
+	}
+
+	if len(s.Attributes.ExpoEASProjectID) > maxExpoEASProjectIDChars {
+		return fmt.Errorf(`%q exceeds maximum allowed characters of %d`, `attributes.expo_eas_project_id`, maxExpoEASProjectIDChars)
 	}
 
 	if len(s.Attributes.UserID) > maxUserIDChars {

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		52B7F1352D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */; };
 		52B7F1362D757F81001498BC /* InstallationIdAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */; };
 		52B7F1372D757F81001498BC /* UserAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */; };
+		CFE1A0022FD000010000AA02 /* ExpoAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE1A0012FD000010000AA01 /* ExpoAttributeTests.swift */; };
 		52B7F1382D757F81001498BC /* BaseConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E32D757F81001498BC /* BaseConfigProviderTests.swift */; };
 		52B7F1392D757F81001498BC /* BatchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E52D757F81001498BC /* BatchStoreTests.swift */; };
 		52B7F13A2D757F81001498BC /* DataCleanupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E62D757F81001498BC /* DataCleanupServiceTests.swift */; };
@@ -498,6 +499,7 @@
 		52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComputeOnceAttributeProcessorTests.swift; sourceTree = "<group>"; };
 		52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstallationIdAttributeProcessorTests.swift; sourceTree = "<group>"; };
 		52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAttributeProcessorTests.swift; sourceTree = "<group>"; };
+		CFE1A0012FD000010000AA01 /* ExpoAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpoAttributeTests.swift; sourceTree = "<group>"; };
 		52B7F0E32D757F81001498BC /* BaseConfigProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseConfigProviderTests.swift; sourceTree = "<group>"; };
 		52B7F0E52D757F81001498BC /* BatchStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchStoreTests.swift; sourceTree = "<group>"; };
 		52B7F0E62D757F81001498BC /* DataCleanupServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCleanupServiceTests.swift; sourceTree = "<group>"; };
@@ -1104,6 +1106,7 @@
 				CF12A68F2E97B0A9001C8112 /* AttributeValueValidatorTests.swift */,
 				CF123F872FAA11FE0053856F /* BaseAttributeTransformerTests.swift */,
 				52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */,
+				CFE1A0012FD000010000AA01 /* ExpoAttributeTests.swift */,
 				52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */,
 				52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */,
 			);
@@ -2000,6 +2003,7 @@
 				CF7CAE582D95344100E15CDB /* HttpEventValidatorTests.swift in Sources */,
 				CF1A2B3D2FC0000100564FDA /* URLSessionTaskInterceptorTests.swift in Sources */,
 				52B7F1342D757F81001498BC /* AttributeProcessorTests.swift in Sources */,
+				CFE1A0022FD000010000AA02 /* ExpoAttributeTests.swift in Sources */,
 				CFB838212DAFEF780023592B /* SpanProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/Attribute.swift
@@ -59,6 +59,15 @@ class Attributes: Codable {
     var deviceLowPowerMode: Bool?
     var osPageSize: UInt8?
     var sessionStartTime: String?
+    var expoUpdateId: String?
+    var expoRuntimeVersion: String?
+    var isExpoEmbeddedLaunch: Bool?
+    var isExpoUsingEmbeddedAssets: Bool?
+    var expoAutomaticUpdatePolicy: String?
+    var expoExecutionEnvironment: String?
+    var expoVersion: String?
+    var expoSdkVersion: String?
+    var expoEasProjectId: String?
 
     enum CodingKeys: String, CodingKey {
         case threadName = "thread_name"
@@ -91,6 +100,15 @@ class Attributes: Codable {
         case deviceThermalThrottlingEnabled = "device_thermal_throttling_enabled"
         case deviceLowPowerMode = "device_low_power_mode"
         case sessionStartTime = "session_start_time"
+        case expoUpdateId = "expo_update_id"
+        case expoRuntimeVersion = "expo_runtime_version"
+        case isExpoEmbeddedLaunch = "is_expo_embedded_launch"
+        case isExpoUsingEmbeddedAssets = "is_expo_using_embedded_assets"
+        case expoAutomaticUpdatePolicy = "expo_automatic_update_policy"
+        case expoExecutionEnvironment = "expo_execution_environment"
+        case expoVersion = "expo_version"
+        case expoSdkVersion = "expo_sdk_version"
+        case expoEasProjectId = "expo_eas_project_id"
     }
 
     init(
@@ -123,7 +141,16 @@ class Attributes: Codable {
         deviceThermalThrottlingEnabled: Bool? = nil,
         deviceLowPowerMode: Bool? = nil,
         osPageSize: UInt8? = nil,
-        sessionStartTime: String? = nil) {
+        sessionStartTime: String? = nil,
+        expoUpdateId: String? = nil,
+        expoRuntimeVersion: String? = nil,
+        isExpoEmbeddedLaunch: Bool? = nil,
+        isExpoUsingEmbeddedAssets: Bool? = nil,
+        expoAutomaticUpdatePolicy: String? = nil,
+        expoExecutionEnvironment: String? = nil,
+        expoVersion: String? = nil,
+        expoSdkVersion: String? = nil,
+        expoEasProjectId: String? = nil) {
            self.threadName = threadName
            self.deviceName = deviceName
            self.deviceModel = deviceModel
@@ -154,6 +181,15 @@ class Attributes: Codable {
            self.deviceLowPowerMode = deviceLowPowerMode
            self.osPageSize = osPageSize
            self.sessionStartTime = sessionStartTime
+           self.expoUpdateId = expoUpdateId
+           self.expoRuntimeVersion = expoRuntimeVersion
+           self.isExpoEmbeddedLaunch = isExpoEmbeddedLaunch
+           self.isExpoUsingEmbeddedAssets = isExpoUsingEmbeddedAssets
+           self.expoAutomaticUpdatePolicy = expoAutomaticUpdatePolicy
+           self.expoExecutionEnvironment = expoExecutionEnvironment
+           self.expoVersion = expoVersion
+           self.expoSdkVersion = expoSdkVersion
+           self.expoEasProjectId = expoEasProjectId
     }
 
     init(dict: [String: Any?]) {
@@ -187,5 +223,14 @@ class Attributes: Codable {
         self.deviceLowPowerMode = dict["device_low_power_mode"] as? Bool
         self.osPageSize = dict["os_page_size"] as? UInt8
         self.sessionStartTime = dict["session_start_time"] as? String
+        self.expoUpdateId = dict["expo_update_id"] as? String
+        self.expoRuntimeVersion = dict["expo_runtime_version"] as? String
+        self.isExpoEmbeddedLaunch = dict["is_expo_embedded_launch"] as? Bool
+        self.isExpoUsingEmbeddedAssets = dict["is_expo_using_embedded_assets"] as? Bool
+        self.expoAutomaticUpdatePolicy = dict["expo_automatic_update_policy"] as? String
+        self.expoExecutionEnvironment = dict["expo_execution_environment"] as? String
+        self.expoVersion = dict["expo_version"] as? String
+        self.expoSdkVersion = dict["expo_sdk_version"] as? String
+        self.expoEasProjectId = dict["expo_eas_project_id"] as? String
     }
 }

--- a/ios/Tests/MeasureSDKTests/Attribute/ExpoAttributeTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/ExpoAttributeTests.swift
@@ -1,0 +1,120 @@
+//
+//  ExpoAttributeTests.swift
+//  MeasureSDKTests
+//
+//  Created by Adwin Ross on 29/07/26.
+//
+
+import XCTest
+@testable import Measure
+
+final class ExpoAttributeTests: XCTestCase {
+    private let expoDict: [String: Any?] = [
+        "expo_update_id": "0f8fad5b-d9cb-469f-a165-70867728950e",
+        "expo_runtime_version": "2.0.0",
+        "is_expo_embedded_launch": false,
+        "is_expo_using_embedded_assets": true,
+        "expo_automatic_update_policy": "on_load",
+        "expo_execution_environment": "standalone",
+        "expo_version": "56.0.9",
+        "expo_sdk_version": "56.0.0",
+        "expo_eas_project_id": "eas-project-id"
+    ]
+
+    func testReadsExpoAttributesFromDictionary() {
+        let attributes = Attributes(dict: expoDict)
+
+        XCTAssertEqual(attributes.expoUpdateId, "0f8fad5b-d9cb-469f-a165-70867728950e")
+        XCTAssertEqual(attributes.expoRuntimeVersion, "2.0.0")
+        XCTAssertEqual(attributes.isExpoEmbeddedLaunch, false)
+        XCTAssertEqual(attributes.isExpoUsingEmbeddedAssets, true)
+        XCTAssertEqual(attributes.expoAutomaticUpdatePolicy, "on_load")
+        XCTAssertEqual(attributes.expoExecutionEnvironment, "standalone")
+        XCTAssertEqual(attributes.expoVersion, "56.0.9")
+        XCTAssertEqual(attributes.expoSdkVersion, "56.0.0")
+        XCTAssertEqual(attributes.expoEasProjectId, "eas-project-id")
+    }
+
+    func testExpoAttributesAreNilWhenAbsentFromDictionary() {
+        let attributes = Attributes(dict: ["device_name": "iPhone 14"])
+
+        XCTAssertNil(attributes.expoUpdateId)
+        XCTAssertNil(attributes.expoRuntimeVersion)
+        XCTAssertNil(attributes.isExpoEmbeddedLaunch)
+        XCTAssertNil(attributes.isExpoUsingEmbeddedAssets)
+        XCTAssertNil(attributes.expoAutomaticUpdatePolicy)
+        XCTAssertNil(attributes.expoExecutionEnvironment)
+        XCTAssertNil(attributes.expoVersion)
+        XCTAssertNil(attributes.expoSdkVersion)
+        XCTAssertNil(attributes.expoEasProjectId)
+    }
+
+    func testEncodesExpoAttributesWithSnakeCaseKeys() throws {
+        let attributes = Attributes(dict: expoDict)
+
+        let data = try JSONEncoder().encode(attributes)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["expo_update_id"] as? String, "0f8fad5b-d9cb-469f-a165-70867728950e")
+        XCTAssertEqual(json["expo_runtime_version"] as? String, "2.0.0")
+        XCTAssertEqual(json["is_expo_embedded_launch"] as? Bool, false)
+        XCTAssertEqual(json["is_expo_using_embedded_assets"] as? Bool, true)
+        XCTAssertEqual(json["expo_automatic_update_policy"] as? String, "on_load")
+        XCTAssertEqual(json["expo_execution_environment"] as? String, "standalone")
+        XCTAssertEqual(json["expo_version"] as? String, "56.0.9")
+        XCTAssertEqual(json["expo_sdk_version"] as? String, "56.0.0")
+        XCTAssertEqual(json["expo_eas_project_id"] as? String, "eas-project-id")
+    }
+
+    func testOmitsExpoAttributesFromPayloadWhenNil() throws {
+        let attributes = Attributes(dict: ["device_name": "iPhone 14"])
+
+        let data = try JSONEncoder().encode(attributes)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNil(json["expo_update_id"])
+        XCTAssertNil(json["expo_runtime_version"])
+        XCTAssertNil(json["is_expo_embedded_launch"])
+        XCTAssertNil(json["is_expo_using_embedded_assets"])
+        XCTAssertNil(json["expo_automatic_update_policy"])
+        XCTAssertNil(json["expo_execution_environment"])
+        XCTAssertNil(json["expo_version"])
+        XCTAssertNil(json["expo_sdk_version"])
+        XCTAssertNil(json["expo_eas_project_id"])
+    }
+
+    func testDecodesExpoAttributesFromEncodedPayload() throws {
+        let data = try JSONEncoder().encode(Attributes(dict: expoDict))
+
+        let decoded = try JSONDecoder().decode(Attributes.self, from: data)
+
+        XCTAssertEqual(decoded.expoUpdateId, "0f8fad5b-d9cb-469f-a165-70867728950e")
+        XCTAssertEqual(decoded.isExpoEmbeddedLaunch, false)
+        XCTAssertEqual(decoded.expoAutomaticUpdatePolicy, "on_load")
+        XCTAssertEqual(decoded.expoEasProjectId, "eas-project-id")
+    }
+
+    func testReadsBooleansBridgedFromReactNativeAsNSNumber() {
+        let bridged: NSDictionary = [
+            "expo_update_id": "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "is_expo_embedded_launch": false,
+            "is_expo_using_embedded_assets": true
+        ]
+
+        let attributes = Attributes(dict: bridged as? [String: Any?] ?? [:])
+
+        XCTAssertEqual(attributes.expoUpdateId, "0f8fad5b-d9cb-469f-a165-70867728950e")
+        XCTAssertEqual(attributes.isExpoEmbeddedLaunch, false)
+        XCTAssertEqual(attributes.isExpoUsingEmbeddedAssets, true)
+    }
+
+    func testExpoUpdateIdIsIndependentOfPatchId() {
+        var dict = expoDict
+        dict["patch_id"] = "patch-id"
+
+        let attributes = Attributes(dict: dict)
+
+        XCTAssertEqual(attributes.patchId, "patch-id")
+        XCTAssertEqual(attributes.expoUpdateId, "0f8fad5b-d9cb-469f-a165-70867728950e")
+    }
+}

--- a/react-native/example/rnExample/ios/Podfile
+++ b/react-native/example/rnExample/ios/Podfile
@@ -27,6 +27,7 @@ end
 
 target 'rnExample' do
   config = use_native_modules!
+  $MeasureDisableSPM = true
 
   pod 'MeasureReactNative', :path => '../../..'
   pod 'measure-sh', :path => '../../../..'

--- a/react-native/example/rnExample/ios/rnExample/AppDelegate.mm
+++ b/react-native/example/rnExample/ios/rnExample/AppDelegate.mm
@@ -13,7 +13,7 @@
   // They will be passed down to the ViewController used by React Native.
   MSRConfig *config = [[MSRConfig alloc] initWithEnableLogging:YES
                                                      autoStart:YES
-                                      enableFullCollectionMode:NO
+                                      enableFullCollectionMode:YES
                                         requestHeadersProvider:NULL
                                               maxDiskUsageInMb:@300
                                           enableDiagnosticMode:YES

--- a/react-native/example/rnExample/metro.config.js
+++ b/react-native/example/rnExample/metro.config.js
@@ -21,4 +21,14 @@ const config = withMetroConfig(defaultConfig, {
 
 config.resolver.unstable_enablePackageExports = true;
 
+const expoModulesBlockList = [
+  /[/\\]node_modules[/\\]expo-updates[/\\].*/,
+  /[/\\]node_modules[/\\]expo-constants[/\\].*/,
+];
+
+config.resolver.blockList = [
+  ...[config.resolver.blockList ?? []].flat(),
+  ...expoModulesBlockList,
+];
+
 module.exports = config;

--- a/react-native/src/__tests__/events/signalProcessor.test.ts
+++ b/react-native/src/__tests__/events/signalProcessor.test.ts
@@ -1,0 +1,130 @@
+import { SignalProcessor } from '../../events/signalProcessor';
+import { trackEvent, trackSpan } from '../../native/measureBridge';
+import type { SpanData } from '../../tracing/spanData';
+
+jest.mock('../../native/measureBridge', () => ({
+  trackEvent: jest.fn(() => Promise.resolve()),
+  trackSpan: jest.fn(() => Promise.resolve()),
+}));
+
+const ATTRIBUTES_ARG_INDEX = 3;
+
+function makeSpanData(attributes?: Record<string, any>): SpanData {
+  return {
+    name: 'span',
+    traceId: 'trace-id',
+    spanId: 'span-id',
+    startTime: 1,
+    endTime: 2,
+    duration: 1,
+    status: 0 as any,
+    attributes,
+    checkpoints: [],
+    hasEnded: true,
+    isSampled: true,
+  };
+}
+
+describe('SignalProcessor framework attributes', () => {
+  let logger: { log: jest.Mock; internalLog: jest.Mock };
+  let processor: SignalProcessor;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = { log: jest.fn(), internalLog: jest.fn() };
+    processor = new SignalProcessor(logger as any);
+  });
+
+  it('passes attributes through untouched when none are set', async () => {
+    await processor.trackEvent({}, 'custom', 1, { existing: 'value' });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(
+      (trackEvent as jest.Mock).mock.calls[0][ATTRIBUTES_ARG_INDEX]
+    ).toEqual({ existing: 'value' });
+  });
+
+  it('merges framework attributes into every tracked event', async () => {
+    processor.setFrameworkAttributes({
+      expo_update_id: 'update-id',
+      is_expo_embedded_launch: false,
+      patch_id: 'patch-id',
+    });
+
+    await processor.trackEvent({}, 'custom', 1, { existing: 'value' });
+
+    expect(
+      (trackEvent as jest.Mock).mock.calls[0][ATTRIBUTES_ARG_INDEX]
+    ).toEqual({
+      existing: 'value',
+      expo_update_id: 'update-id',
+      is_expo_embedded_launch: false,
+      patch_id: 'patch-id',
+    });
+  });
+
+  it('merges framework attributes into every tracked span', async () => {
+    processor.setFrameworkAttributes({ expo_sdk_version: '56.0.0' });
+
+    await processor.trackSpan(makeSpanData({ existing: 'value' }));
+
+    expect(trackSpan).toHaveBeenCalledTimes(1);
+    // trackSpan receives attributes as its 9th positional argument.
+    expect((trackSpan as jest.Mock).mock.calls[0][8]).toEqual({
+      existing: 'value',
+      expo_sdk_version: '56.0.0',
+    });
+  });
+
+  it('applies framework attributes to spans with no attributes of their own', async () => {
+    processor.setFrameworkAttributes({ expo_sdk_version: '56.0.0' });
+
+    await processor.trackSpan(makeSpanData(undefined));
+
+    expect((trackSpan as jest.Mock).mock.calls[0][8]).toEqual({
+      expo_sdk_version: '56.0.0',
+    });
+  });
+
+  it('lets framework attributes take precedence over per-signal attributes', async () => {
+    processor.setFrameworkAttributes({ patch_id: 'framework-patch' });
+
+    await processor.trackEvent({}, 'custom', 1, { patch_id: 'signal-patch' });
+
+    expect(
+      (trackEvent as jest.Mock).mock.calls[0][ATTRIBUTES_ARG_INDEX].patch_id
+    ).toBe('framework-patch');
+  });
+
+  it('does not mutate the caller-supplied attributes object', async () => {
+    processor.setFrameworkAttributes({ expo_version: '56.0.9' });
+    const attributes = { existing: 'value' };
+
+    await processor.trackEvent({}, 'custom', 1, attributes);
+
+    expect(attributes).toEqual({ existing: 'value' });
+  });
+
+  it('replaces previously set framework attributes', async () => {
+    processor.setFrameworkAttributes({ expo_update_id: 'first' });
+    processor.setFrameworkAttributes({ expo_update_id: 'second' });
+
+    await processor.trackEvent({}, 'custom', 1);
+
+    expect(
+      (trackEvent as jest.Mock).mock.calls[0][ATTRIBUTES_ARG_INDEX]
+    ).toEqual({ expo_update_id: 'second' });
+  });
+
+  it('keeps a copy so later mutations of the source map are ignored', async () => {
+    const source: Record<string, any> = { expo_version: '56.0.9' };
+    processor.setFrameworkAttributes(source);
+    source.expo_version = 'mutated';
+
+    await processor.trackEvent({}, 'custom', 1);
+
+    expect(
+      (trackEvent as jest.Mock).mock.calls[0][ATTRIBUTES_ARG_INDEX].expo_version
+    ).toBe('56.0.9');
+  });
+});

--- a/react-native/src/__tests__/expoUpdates/expoAttributes.test.ts
+++ b/react-native/src/__tests__/expoUpdates/expoAttributes.test.ts
@@ -1,0 +1,326 @@
+/**
+ * The collector only requires `expo-updates` / `expo-constants` after finding
+ * the package's native module, so these tests drive both the native module
+ * registry (`globalThis.expo.modules`) and the JS modules themselves.
+ *
+ * Jest resolves modules eagerly, so each state is set up with `jest.doMock`
+ * inside `jest.isolateModules`. An uninstalled package is simulated by making
+ * the module factory throw, matching Metro's runtime behaviour for an
+ * unresolved optional dependency.
+ */
+
+const UPDATES = 'expo-updates';
+const CONSTANTS = 'expo-constants';
+const UPDATES_NATIVE_MODULE = 'ExpoUpdates';
+const CONSTANTS_NATIVE_MODULE = 'ExponentConstants';
+
+function loadCollector() {
+  return require('../../expoUpdates/expoAttributes').collectExpoAttributes();
+}
+
+/** Registers the given Expo native modules, as expo-modules-core would. */
+function installNativeModules(...names: string[]) {
+  (globalThis as any).expo = {
+    modules: Object.fromEntries(names.map((name) => [name, {}])),
+  };
+}
+
+/**
+ * Mocks a module as uninstalled. Metro leaves an unresolved optional dependency
+ * out of the bundle, so requiring it throws.
+ */
+function mockAbsent(name: string) {
+  const factory = jest.fn(() => {
+    throw new Error(`Requiring unknown module "884".`);
+  });
+  jest.doMock(name, factory, { virtual: true });
+  return factory;
+}
+
+function mockModule(name: string, value: unknown) {
+  jest.doMock(name, () => value, { virtual: true });
+}
+
+function mockEsModuleWithDefault(name: string, value: unknown) {
+  jest.doMock(name, () => ({ __esModule: true, default: value }), {
+    virtual: true,
+  });
+}
+
+function collectWith(
+  setup: () => void
+): Record<string, string | boolean> | undefined {
+  let result: Record<string, string | boolean> | undefined;
+  jest.isolateModules(() => {
+    setup();
+    result = loadCollector();
+  });
+  return result;
+}
+
+describe('collectExpoAttributes', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete (globalThis as any).expo;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).expo;
+  });
+
+  it('returns no attributes when neither Expo package is installed', () => {
+    const attrs = collectWith(() => {
+      mockAbsent(UPDATES);
+      mockAbsent(CONSTANTS);
+    });
+
+    expect(attrs).toEqual({});
+  });
+
+  it('never requires expo-updates when its native module is absent', () => {
+    let factory: jest.Mock | undefined;
+    const attrs = collectWith(() => {
+      factory = mockAbsent(UPDATES);
+      mockAbsent(CONSTANTS);
+    });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(attrs).toEqual({});
+  });
+
+  it('never requires expo-constants when its native module is absent', () => {
+    let factory: jest.Mock | undefined;
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE);
+      mockModule(UPDATES, { updateId: 'update-id' });
+      factory = mockAbsent(CONSTANTS);
+    });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(attrs).toEqual({ expo_update_id: 'update-id' });
+  });
+
+  it('collects expo-constants attributes when expo-updates is absent', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(CONSTANTS_NATIVE_MODULE);
+      mockAbsent(UPDATES);
+      mockEsModuleWithDefault(CONSTANTS, {
+        executionEnvironment: 'standalone',
+        expoVersion: '56.0.9',
+        expoConfig: { sdkVersion: '56.0.0', runtimeVersion: '1.0.0' },
+        easConfig: { projectId: 'eas-project-id' },
+      });
+    });
+
+    expect(attrs).toEqual({
+      expo_execution_environment: 'standalone',
+      expo_version: '56.0.9',
+      expo_sdk_version: '56.0.0',
+      expo_eas_project_id: 'eas-project-id',
+      expo_runtime_version: '1.0.0',
+    });
+  });
+
+  it('collects the full set when both packages are present and updates are enabled', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, {
+        isEnabled: true,
+        updateId: '0f8fad5b-d9cb-469f-a165-70867728950e',
+        runtimeVersion: '2.0.0',
+        isEmbeddedLaunch: false,
+        isUsingEmbeddedAssets: false,
+        checkAutomatically: 'ON_LOAD',
+      });
+      mockEsModuleWithDefault(CONSTANTS, {
+        executionEnvironment: 'standalone',
+        expoVersion: '56.0.9',
+        expoConfig: { sdkVersion: '56.0.0', runtimeVersion: '1.0.0' },
+        easConfig: { projectId: 'eas-project-id' },
+      });
+    });
+
+    expect(attrs).toEqual({
+      expo_update_id: '0f8fad5b-d9cb-469f-a165-70867728950e',
+      expo_runtime_version: '2.0.0',
+      is_expo_embedded_launch: false,
+      is_expo_using_embedded_assets: false,
+      expo_automatic_update_policy: 'on_load',
+      expo_execution_environment: 'standalone',
+      expo_version: '56.0.9',
+      expo_sdk_version: '56.0.0',
+      expo_eas_project_id: 'eas-project-id',
+    });
+  });
+
+  it('falls back to the NativeModules proxy for older Expo versions', () => {
+    const attrs = collectWith(() => {
+      // No globalThis.expo — the module is only on the proxy.
+      jest.doMock('react-native', () => ({
+        NativeModules: { [UPDATES_NATIVE_MODULE]: {} },
+      }));
+      mockModule(UPDATES, { updateId: 'update-id' });
+      mockAbsent(CONSTANTS);
+    });
+
+    expect(attrs).toEqual({ expo_update_id: 'update-id' });
+  });
+
+  it('reads expo-constants values from the default export', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(CONSTANTS_NATIVE_MODULE);
+      mockAbsent(UPDATES);
+      mockEsModuleWithDefault(CONSTANTS, {
+        executionEnvironment: 'standalone',
+        expoVersion: '56.0.9',
+        expoConfig: { sdkVersion: '56.0.0' },
+        easConfig: { projectId: 'eas-project-id' },
+      });
+    });
+
+    expect(attrs).toEqual({
+      expo_execution_environment: 'standalone',
+      expo_version: '56.0.9',
+      expo_sdk_version: '56.0.0',
+      expo_eas_project_id: 'eas-project-id',
+    });
+  });
+
+  it('reads expo-constants values from the namespace when there is no default', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(CONSTANTS_NATIVE_MODULE);
+      mockAbsent(UPDATES);
+      mockModule(CONSTANTS, {
+        executionEnvironment: 'bare',
+        expoConfig: { sdkVersion: '56.0.0' },
+      });
+    });
+
+    expect(attrs).toEqual({
+      expo_execution_environment: 'bare',
+      expo_sdk_version: '56.0.0',
+    });
+  });
+
+  it('prefers the runtime version from expo-updates over the app config', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, { runtimeVersion: '2.0.0' });
+      mockEsModuleWithDefault(CONSTANTS, {
+        expoConfig: { runtimeVersion: '1.0.0' },
+      });
+    });
+
+    expect(attrs?.expo_runtime_version).toBe('2.0.0');
+  });
+
+  it('omits update attributes when expo-updates is installed but disabled', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, {
+        isEnabled: false,
+        updateId: null,
+        runtimeVersion: null,
+        isEmbeddedLaunch: null,
+        isUsingEmbeddedAssets: null,
+        checkAutomatically: null,
+      });
+      mockEsModuleWithDefault(CONSTANTS, {
+        executionEnvironment: 'bare',
+        expoConfig: { sdkVersion: '56.0.0' },
+      });
+    });
+
+    expect(attrs).toEqual({
+      expo_execution_environment: 'bare',
+      expo_sdk_version: '56.0.0',
+    });
+  });
+
+  it('lowercases the automatic update policy', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE);
+      mockAbsent(CONSTANTS);
+      mockModule(UPDATES, { checkAutomatically: 'ON_ERROR_RECOVERY' });
+    });
+
+    expect(attrs?.expo_automatic_update_policy).toBe('on_error_recovery');
+  });
+
+  it('keeps false booleans, which are meaningful values', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE);
+      mockAbsent(CONSTANTS);
+      mockModule(UPDATES, {
+        isEmbeddedLaunch: false,
+        isUsingEmbeddedAssets: false,
+      });
+    });
+
+    expect(attrs).toEqual({
+      is_expo_embedded_launch: false,
+      is_expo_using_embedded_assets: false,
+    });
+  });
+
+  it('drops empty strings rather than reporting them as values', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(CONSTANTS_NATIVE_MODULE);
+      mockAbsent(UPDATES);
+      mockEsModuleWithDefault(CONSTANTS, {
+        executionEnvironment: '',
+        expoVersion: '',
+        expoConfig: { sdkVersion: '' },
+      });
+    });
+
+    expect(attrs).toEqual({});
+  });
+
+  it('falls back to expoConfig.extra.eas for the project id', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(CONSTANTS_NATIVE_MODULE);
+      mockAbsent(UPDATES);
+      mockEsModuleWithDefault(CONSTANTS, {
+        expoConfig: { extra: { eas: { projectId: 'extra-project-id' } } },
+      });
+    });
+
+    expect(attrs?.expo_eas_project_id).toBe('extra-project-id');
+  });
+
+  it('still collects expo-updates attributes when expo-constants throws', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, { updateId: 'update-id' });
+      mockEsModuleWithDefault(CONSTANTS, {
+        get expoConfig(): never {
+          throw new Error('Constants.manifest is null, must be an object.');
+        },
+      });
+    });
+
+    expect(attrs).toEqual({ expo_update_id: 'update-id' });
+  });
+
+  it('does not throw when a require resolves to undefined', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, undefined);
+      mockModule(CONSTANTS, undefined);
+    });
+
+    expect(attrs).toEqual({});
+  });
+
+  it('does not throw when a module resolves to null', () => {
+    const attrs = collectWith(() => {
+      installNativeModules(UPDATES_NATIVE_MODULE, CONSTANTS_NATIVE_MODULE);
+      mockModule(UPDATES, null);
+      mockModule(CONSTANTS, null);
+    });
+
+    expect(attrs).toEqual({});
+  });
+});

--- a/react-native/src/__tests__/measureInternal.test.ts
+++ b/react-native/src/__tests__/measureInternal.test.ts
@@ -1,3 +1,4 @@
+import { collectExpoAttributes } from '../expoUpdates/expoAttributes';
 import { MeasureInternal } from '../measureInternal';
 import * as measureBridge from '../native/measureBridge';
 
@@ -17,9 +18,14 @@ jest.mock('../exception/errorReportingManager', () => ({
   })),
 }));
 
+jest.mock('../expoUpdates/expoAttributes', () => ({
+  collectExpoAttributes: jest.fn(() => ({})),
+}));
+
 function makeMockInitializer() {
   return {
     logger: { internalLog: jest.fn(), log: jest.fn() },
+    signalProcessor: { setFrameworkAttributes: jest.fn() },
     configLoader: { loadDynamicConfig: jest.fn(() => Promise.resolve(null)) },
     configProvider: { setDynamicConfig: jest.fn() },
     spanProcessor: { onConfigLoaded: jest.fn() },
@@ -202,5 +208,134 @@ describe('MeasureInternal.init with autoStart', () => {
     expect(initializer.customEventCollector.register).not.toHaveBeenCalled();
     expect(measureBridge.enableNativeModule).not.toHaveBeenCalled();
     expect(measureBridge.start).not.toHaveBeenCalled();
+  });
+});
+
+describe('MeasureInternal.init framework attributes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (collectExpoAttributes as jest.Mock).mockReturnValue({});
+    delete (global as any).__measurePatchId;
+  });
+
+  afterEach(() => {
+    delete (global as any).__measurePatchId;
+  });
+
+  it('does not set framework attributes when there are none', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ config: { autoStart: false } as any });
+
+    expect(
+      initializer.signalProcessor.setFrameworkAttributes
+    ).not.toHaveBeenCalled();
+  });
+
+  it('forwards the collected Expo attributes', async () => {
+    (collectExpoAttributes as jest.Mock).mockReturnValue({
+      expo_update_id: 'update-id',
+      is_expo_embedded_launch: false,
+    });
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ config: { autoStart: false } as any });
+
+    expect(
+      initializer.signalProcessor.setFrameworkAttributes
+    ).toHaveBeenCalledWith({
+      expo_update_id: 'update-id',
+      is_expo_embedded_launch: false,
+    });
+  });
+
+  it('combines Expo attributes with the OTA patch identifiers', async () => {
+    (collectExpoAttributes as jest.Mock).mockReturnValue({
+      expo_update_id: 'update-id',
+    });
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({
+      config: {
+        autoStart: false,
+        patchId: 'patch-id',
+        patchVersion: 'v1.0.3-hotfix',
+      } as any,
+    });
+
+    expect(
+      initializer.signalProcessor.setFrameworkAttributes
+    ).toHaveBeenCalledWith({
+      expo_update_id: 'update-id',
+      patch_id: 'patch-id',
+      patch_version: 'v1.0.3-hotfix',
+    });
+  });
+
+  it('keeps expo_update_id and patch_id separate', async () => {
+    (collectExpoAttributes as jest.Mock).mockReturnValue({
+      expo_update_id: 'update-id',
+    });
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({
+      config: { autoStart: false, patchId: 'patch-id' } as any,
+    });
+
+    const attributes = (
+      initializer.signalProcessor.setFrameworkAttributes as jest.Mock
+    ).mock.calls[0][0];
+    expect(attributes.expo_update_id).toBe('update-id');
+    expect(attributes.patch_id).toBe('patch-id');
+  });
+
+  it('falls back to the Metro-injected patch id', async () => {
+    (global as any).__measurePatchId = 'metro-patch-id';
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ config: { autoStart: false } as any });
+
+    expect(
+      initializer.signalProcessor.setFrameworkAttributes
+    ).toHaveBeenCalledWith({ patch_id: 'metro-patch-id' });
+  });
+
+  it('prefers config.patchId over the Metro-injected patch id', async () => {
+    (global as any).__measurePatchId = 'metro-patch-id';
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({
+      config: { autoStart: false, patchId: 'config-patch-id' } as any,
+    });
+
+    expect(
+      initializer.signalProcessor.setFrameworkAttributes
+    ).toHaveBeenCalledWith({ patch_id: 'config-patch-id' });
+  });
+
+  it('sets framework attributes before starting the native SDK', async () => {
+    (collectExpoAttributes as jest.Mock).mockReturnValue({
+      expo_update_id: 'update-id',
+    });
+    const initializer = makeMockInitializer();
+    const order: string[] = [];
+    (
+      initializer.signalProcessor.setFrameworkAttributes as jest.Mock
+    ).mockImplementation(() => order.push('setFrameworkAttributes'));
+    (measureBridge.start as jest.Mock).mockImplementation(() => {
+      order.push('start');
+      return Promise.resolve();
+    });
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ config: { autoStart: true } as any });
+
+    expect(order).toEqual(['setFrameworkAttributes', 'start']);
   });
 });

--- a/react-native/src/events/signalProcessor.ts
+++ b/react-native/src/events/signalProcessor.ts
@@ -2,19 +2,17 @@ import { trackEvent, trackSpan } from '../native/measureBridge';
 import type { SpanData } from '../tracing/spanData';
 import type { Logger } from '../utils/logger';
 
-const PATCH_ID_KEY = 'patch_id';
-const PATCH_VERSION_KEY = 'patch_version';
-
 /**
  * Protocol for processing events and spans.
  */
 export interface ISignalProcessor {
   /**
-   * Sets the OTA patch identifiers to attach to every event and span tracked
-   * by the React Native SDK. Scoping the attributes here ensures they are only
+   * Sets the framework level attributes to attach to every event and span
+   * tracked by the React Native SDK, such as the OTA patch identifiers and the
+   * Expo update metadata. Scoping the attributes here ensures they are only
    * added to RN-originated signals and not to native events.
    */
-  setPatchInfo(patchId?: string, patchVersion?: string): void;
+  setFrameworkAttributes(attributes: Record<string, any>): void;
 
   /**
    * Tracks a completed span's data.
@@ -41,32 +39,24 @@ export interface ISignalProcessor {
 
 export class SignalProcessor implements ISignalProcessor {
   private logger: Logger;
-  private patchId?: string;
-  private patchVersion?: string;
+  private frameworkAttributes: Record<string, any> = {};
 
   constructor(logger: Logger) {
     this.logger = logger;
   }
 
-  setPatchInfo(patchId?: string, patchVersion?: string): void {
-    this.patchId = patchId;
-    this.patchVersion = patchVersion;
+  setFrameworkAttributes(attributes: Record<string, any>): void {
+    this.frameworkAttributes = { ...attributes };
   }
 
-  private withPatchAttributes(
+  private withFrameworkAttributes(
     attributes: Record<string, any>
   ): Record<string, any> {
-    if (!this.patchId && !this.patchVersion) {
+    const keys = Object.keys(this.frameworkAttributes);
+    if (keys.length === 0) {
       return attributes;
     }
-    const merged = { ...attributes };
-    if (this.patchId) {
-      merged[PATCH_ID_KEY] = this.patchId;
-    }
-    if (this.patchVersion) {
-      merged[PATCH_VERSION_KEY] = this.patchVersion;
-    }
-    return merged;
+    return { ...attributes, ...this.frameworkAttributes };
   }
 
   async trackSpan(spanData: SpanData): Promise<any> {
@@ -78,7 +68,9 @@ export class SignalProcessor implements ISignalProcessor {
         { duration: spanData.duration }
       );
 
-      const attributes = this.withPatchAttributes(spanData.attributes ?? {});
+      const attributes = this.withFrameworkAttributes(
+        spanData.attributes ?? {}
+      );
       const userDefinedAttrs = spanData.userDefinedAttrs ?? {};
 
       const checkpointsDict = (spanData.checkpoints || []).reduce(
@@ -126,7 +118,7 @@ export class SignalProcessor implements ISignalProcessor {
       data,
       type,
       timestamp,
-      this.withPatchAttributes(attributes),
+      this.withFrameworkAttributes(attributes),
       userDefinedAttrs,
       userTriggered,
       sessionId,

--- a/react-native/src/expoUpdates/expoAttributes.ts
+++ b/react-native/src/expoUpdates/expoAttributes.ts
@@ -1,0 +1,185 @@
+import { NativeModules } from 'react-native';
+
+export const EXPO_UPDATE_ID_KEY = 'expo_update_id';
+export const EXPO_RUNTIME_VERSION_KEY = 'expo_runtime_version';
+export const IS_EXPO_EMBEDDED_LAUNCH_KEY = 'is_expo_embedded_launch';
+export const IS_EXPO_USING_EMBEDDED_ASSETS_KEY =
+  'is_expo_using_embedded_assets';
+export const EXPO_AUTOMATIC_UPDATE_POLICY_KEY = 'expo_automatic_update_policy';
+export const EXPO_EXECUTION_ENVIRONMENT_KEY = 'expo_execution_environment';
+export const EXPO_VERSION_KEY = 'expo_version';
+export const EXPO_SDK_VERSION_KEY = 'expo_sdk_version';
+export const EXPO_EAS_PROJECT_ID_KEY = 'expo_eas_project_id';
+
+export type ExpoAttributes = Record<string, string | boolean>;
+
+interface ExpoUpdatesModule {
+  isEnabled?: boolean;
+  updateId?: string | null;
+  runtimeVersion?: string | null;
+  isEmbeddedLaunch?: boolean | null;
+  isUsingEmbeddedAssets?: boolean | null;
+  checkAutomatically?: string | null;
+}
+
+interface ExpoConstantsModule {
+  executionEnvironment?: string | null;
+  expoVersion?: string | null;
+  expoConfig?: {
+    sdkVersion?: string | null;
+    runtimeVersion?: string | null;
+    extra?: { eas?: { projectId?: string | null } | null } | null;
+  } | null;
+  easConfig?: { projectId?: string | null } | null;
+}
+
+/** Expo module name registered by `expo-updates`. */
+const EXPO_UPDATES_NATIVE_MODULE = 'ExpoUpdates';
+
+/** Expo module name registered by `expo-constants`. */
+const EXPO_CONSTANTS_NATIVE_MODULE = 'ExponentConstants';
+
+/**
+ * Reports whether an Expo native module is registered in this app.
+ *
+ * Mirrors `requireOptionalNativeModule` from `expo-modules-core`, but without
+ * depending on it — that package is itself absent in bare React Native apps.
+ * `expo-constants` detects `expo-updates` the same way.
+ */
+function hasNativeModule(name: string): boolean {
+  try {
+    const expoModules = (globalThis as any).expo?.modules;
+    if (expoModules?.[name]) {
+      return true;
+    }
+    // Fallback for Expo versions that expose modules through the proxy.
+    return !!(NativeModules as Record<string, unknown> | undefined)?.[name];
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Unwraps a transpiled ES module's default export.
+ *
+ * `expo-constants` ends in `export default constants`, so `require()` returns
+ * the module namespace and the values live on `.default`. `expo-updates` only
+ * uses named exports, so its values are on the namespace itself. Handling both
+ * keeps this working whichever shape a package ships.
+ */
+function interopDefault<T>(module: any): T | undefined {
+  return (module?.default ?? module) as T | undefined;
+}
+
+/**
+ * Adds `key` to `target` when `value` is a usable string or boolean.
+ *
+ * Null, undefined and empty strings are dropped so absent metadata stays absent
+ * rather than being reported as an empty value.
+ */
+function put(
+  target: ExpoAttributes,
+  key: string,
+  value: string | boolean | null | undefined
+): void {
+  if (typeof value === 'boolean') {
+    target[key] = value;
+    return;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    target[key] = value;
+  }
+}
+
+/**
+ * Collects attributes exposed by `expo-updates`.
+ */
+function collectUpdatesAttributes(target: ExpoAttributes): void {
+  if (!hasNativeModule(EXPO_UPDATES_NATIVE_MODULE)) {
+    return;
+  }
+
+  try {
+    // The require must remain the first statement inside this try block for
+    // Metro to treat it as an optional dependency.
+    const updates = interopDefault<ExpoUpdatesModule>(require('expo-updates'));
+    if (!updates) {
+      return;
+    }
+
+    put(target, EXPO_UPDATE_ID_KEY, updates.updateId);
+    put(target, EXPO_RUNTIME_VERSION_KEY, updates.runtimeVersion);
+    put(target, IS_EXPO_EMBEDDED_LAUNCH_KEY, updates.isEmbeddedLaunch);
+    put(
+      target,
+      IS_EXPO_USING_EMBEDDED_ASSETS_KEY,
+      updates.isUsingEmbeddedAssets
+    );
+    put(
+      target,
+      EXPO_AUTOMATIC_UPDATE_POLICY_KEY,
+      updates.checkAutomatically?.toLowerCase()
+    );
+  } catch {
+    // expo-updates is not installed, or reading it failed. Both are expected.
+  }
+}
+
+/**
+ * Collects attributes exposed by `expo-constants`.
+ */
+function collectConstantsAttributes(target: ExpoAttributes): void {
+  if (!hasNativeModule(EXPO_CONSTANTS_NATIVE_MODULE)) {
+    return;
+  }
+
+  try {
+    const constants = interopDefault<ExpoConstantsModule>(
+      require('expo-constants')
+    );
+    if (!constants) {
+      return;
+    }
+
+    put(target, EXPO_EXECUTION_ENVIRONMENT_KEY, constants.executionEnvironment);
+    put(target, EXPO_VERSION_KEY, constants.expoVersion);
+    put(target, EXPO_SDK_VERSION_KEY, constants.expoConfig?.sdkVersion);
+    put(
+      target,
+      EXPO_EAS_PROJECT_ID_KEY,
+      constants.easConfig?.projectId ??
+        constants.expoConfig?.extra?.eas?.projectId
+    );
+
+    // expo-updates reports the runtime version of the running update, which is
+    // the more accurate value. Fall back to the app config when it is absent.
+    if (!(EXPO_RUNTIME_VERSION_KEY in target)) {
+      put(
+        target,
+        EXPO_RUNTIME_VERSION_KEY,
+        constants.expoConfig?.runtimeVersion
+      );
+    }
+  } catch {
+    // expo-constants is not installed, or reading it failed. Both are expected.
+  }
+}
+
+/**
+ * Returns the Expo attributes available in this app.
+ *
+ * Returns an empty object for bare React Native apps. Never throws a failure
+ * to read Expo metadata must not prevent the SDK from initializing.
+ */
+export function collectExpoAttributes(): ExpoAttributes {
+  const attributes: ExpoAttributes = {};
+
+  try {
+    collectUpdatesAttributes(attributes);
+    collectConstantsAttributes(attributes);
+  } catch {
+    return attributes;
+  }
+
+  return attributes;
+}

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -1,6 +1,7 @@
 import { MeasureConfig } from './config/measureConfig';
 import type { MsrAttachment } from './events/msrAttachment';
 import type { LogSeverity } from './events/logSeverity';
+import { collectExpoAttributes } from './expoUpdates/expoAttributes';
 import { ErrorReportingManager } from './exception/errorReportingManager';
 import { buildExceptionPayload } from './exception/exceptionBuilder';
 import type { MeasureInitializer } from './measureInitializer';
@@ -15,6 +16,9 @@ import {
 import type { Span } from './tracing/span';
 import type { SpanBuilder } from './tracing/spanBuilder';
 import type { ValidAttributeValue } from './utils/attributeValueValidator';
+
+export const PATCH_ID_KEY = 'patch_id';
+export const PATCH_VERSION_KEY = 'patch_version';
 
 export class MeasureInternal {
   private measureInitializer: MeasureInitializer;
@@ -70,16 +74,24 @@ export class MeasureInternal {
         this.measureInitializer.spanProcessor.onConfigLoaded();
       });
 
+    // Framework level attributes are attached to every RN-originated event and
+    // span by the signal processor, keeping them scoped to the React Native
+    // layer.
+    //
     // config.patchId takes priority (manual / CodePush approach).
     // Falls back to global.__measurePatchId injected by withMeasureConfig()
     // in metro.config.js (automated approach).
-    // The patch identifiers are attached to every RN-originated event and span
-    // by the signal processor, keeping them scoped to the React Native layer.
+    const frameworkAttributes: Record<string, any> = collectExpoAttributes();
     const patchId = config?.patchId ?? (global as any).__measurePatchId;
-    if (patchId || config?.patchVersion) {
-      this.measureInitializer.signalProcessor.setPatchInfo(
-        patchId,
-        config?.patchVersion
+    if (patchId) {
+      frameworkAttributes[PATCH_ID_KEY] = patchId;
+    }
+    if (config?.patchVersion) {
+      frameworkAttributes[PATCH_VERSION_KEY] = config.patchVersion;
+    }
+    if (Object.keys(frameworkAttributes).length > 0) {
+      this.measureInitializer.signalProcessor.setFrameworkAttributes(
+        frameworkAttributes
       );
     }
 

--- a/self-host/clickhouse/20260731061500_alter_events_table.sql
+++ b/self-host/clickhouse/20260731061500_alter_events_table.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+alter table events
+    add column if not exists `attribute.expo_update_id` UUID comment 'uuid of the currently running expo ota update' CODEC(ZSTD(3)) after `attribute.patch_version`,
+    add column if not exists `attribute.expo_runtime_version` LowCardinality(String) comment 'runtime version of the expo update' CODEC(ZSTD(3)) after `attribute.expo_update_id`,
+    add column if not exists `attribute.is_expo_embedded_launch` Bool comment 'true if the app launched from the embedded bundle' CODEC(ZSTD(3)) after `attribute.expo_runtime_version`,
+    add column if not exists `attribute.is_expo_using_embedded_assets` Bool comment 'true if the app is using embedded assets' CODEC(ZSTD(3)) after `attribute.is_expo_embedded_launch`,
+    add column if not exists `attribute.expo_automatic_update_policy` LowCardinality(String) comment 'policy set for expo automatic updates' CODEC(ZSTD(3)) after `attribute.is_expo_using_embedded_assets`,
+    add column if not exists `attribute.expo_execution_environment` LowCardinality(String) comment 'where the app is running - storeClient, standalone or bare' CODEC(ZSTD(3)) after `attribute.expo_automatic_update_policy`,
+    add column if not exists `attribute.expo_version` LowCardinality(String) comment 'expo client version' CODEC(ZSTD(3)) after `attribute.expo_execution_environment`,
+    add column if not exists `attribute.expo_sdk_version` LowCardinality(String) comment 'expo sdk version' CODEC(ZSTD(3)) after `attribute.expo_version`,
+    add column if not exists `attribute.expo_eas_project_id` LowCardinality(String) comment 'eas project identifier' CODEC(ZSTD(3)) after `attribute.expo_sdk_version`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table events
+    drop column if exists `attribute.expo_update_id`,
+    drop column if exists `attribute.expo_runtime_version`,
+    drop column if exists `attribute.is_expo_embedded_launch`,
+    drop column if exists `attribute.is_expo_using_embedded_assets`,
+    drop column if exists `attribute.expo_automatic_update_policy`,
+    drop column if exists `attribute.expo_execution_environment`,
+    drop column if exists `attribute.expo_version`,
+    drop column if exists `attribute.expo_sdk_version`,
+    drop column if exists `attribute.expo_eas_project_id`
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260731061530_alter_spans_table.sql
+++ b/self-host/clickhouse/20260731061530_alter_spans_table.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+alter table spans
+    add column if not exists `attribute.expo_update_id` UUID comment 'uuid of the currently running expo ota update' CODEC(ZSTD(3)) after `attribute.patch_version`,
+    add column if not exists `attribute.expo_runtime_version` LowCardinality(String) comment 'runtime version of the expo update' CODEC(ZSTD(3)) after `attribute.expo_update_id`,
+    add column if not exists `attribute.is_expo_embedded_launch` Bool comment 'true if the app launched from the embedded bundle' CODEC(ZSTD(3)) after `attribute.expo_runtime_version`,
+    add column if not exists `attribute.is_expo_using_embedded_assets` Bool comment 'true if the app is using embedded assets' CODEC(ZSTD(3)) after `attribute.is_expo_embedded_launch`,
+    add column if not exists `attribute.expo_automatic_update_policy` LowCardinality(String) comment 'policy set for expo automatic updates' CODEC(ZSTD(3)) after `attribute.is_expo_using_embedded_assets`,
+    add column if not exists `attribute.expo_execution_environment` LowCardinality(String) comment 'where the app is running - storeClient, standalone or bare' CODEC(ZSTD(3)) after `attribute.expo_automatic_update_policy`,
+    add column if not exists `attribute.expo_version` LowCardinality(String) comment 'expo client version' CODEC(ZSTD(3)) after `attribute.expo_execution_environment`,
+    add column if not exists `attribute.expo_sdk_version` LowCardinality(String) comment 'expo sdk version' CODEC(ZSTD(3)) after `attribute.expo_version`,
+    add column if not exists `attribute.expo_eas_project_id` LowCardinality(String) comment 'eas project identifier' CODEC(ZSTD(3)) after `attribute.expo_sdk_version`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table spans
+    drop column if exists `attribute.expo_update_id`,
+    drop column if exists `attribute.expo_runtime_version`,
+    drop column if exists `attribute.is_expo_embedded_launch`,
+    drop column if exists `attribute.is_expo_using_embedded_assets`,
+    drop column if exists `attribute.expo_automatic_update_policy`,
+    drop column if exists `attribute.expo_execution_environment`,
+    drop column if exists `attribute.expo_version`,
+    drop column if exists `attribute.expo_sdk_version`,
+    drop column if exists `attribute.expo_eas_project_id`
+settings mutations_sync = 2;


### PR DESCRIPTION
# Description

- Collect Expo OTA attributes on RN events and spans.
- Read expo-updates and expo-constants in JS, gated on native module.
- Add typed Attributes fields on iOS
- Add ClickHouse columns, Go struct fields, ingest-worker writes
- Scoped to RN events and spans, natively collected events do not contain these attributes.

## Related issue
Closes #3923 