### PR TITLE
feat: show patch version on the builds page

### DIFF
--- a/backend/agent/mcp/test_helpers_test.go
+++ b/backend/agent/mcp/test_helpers_test.go
@@ -126,7 +126,7 @@ func seedEventWithSession(ctx context.Context, t *testing.T, teamID, appID, sess
 }
 
 func seedBuildMappingRow(ctx context.Context, t *testing.T, mappingID, appID, versionName, versionCode, mappingType string, lastUpdated time.Time) {
-	th.SeedBuildMappingRow(ctx, t, mappingID, appID, versionName, versionCode, mappingType, "test/"+mappingID, uuid.Nil.String(), lastUpdated)
+	th.SeedBuildMappingRow(ctx, t, mappingID, appID, versionName, versionCode, mappingType, "test/"+mappingID, uuid.Nil.String(), "", lastUpdated)
 }
 
 // --------------------------------------------------------------------------

--- a/backend/api/handlers/build_test.go
+++ b/backend/api/handlers/build_test.go
@@ -21,7 +21,7 @@ import (
 // non-empty storage key.
 func seedBuildMappingRow(ctx context.Context, t *testing.T, mappingID, appID uuid.UUID, versionName, versionCode, mappingType string, lastUpdated time.Time) {
 	t.Helper()
-	th.SeedBuildMappingRow(ctx, t, mappingID.String(), appID.String(), versionName, versionCode, mappingType, "test/"+mappingID.String(), uuid.Nil.String(), lastUpdated)
+	th.SeedBuildMappingRow(ctx, t, mappingID.String(), appID.String(), versionName, versionCode, mappingType, "test/"+mappingID.String(), uuid.Nil.String(), "", lastUpdated)
 }
 
 // configureSymbolsStore uploads the given objects into a fresh
@@ -277,7 +277,7 @@ func TestDownloadBuildFile(t *testing.T) {
 		seedApp(ctx, t, appID, teamID, 90)
 
 		pendingUpload := uuid.New()
-		th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "proguard", "", uuid.Nil.String(), time.Now().UTC())
+		th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "proguard", "", uuid.Nil.String(), "", time.Now().UTC())
 
 		w := downloadRequest(t, userID, appID.String(), pendingUpload.String())
 		if w.Code != http.StatusNotFound {

--- a/backend/libs/measure/build.go
+++ b/backend/libs/measure/build.go
@@ -29,28 +29,31 @@ import (
 // belongs to; they stay out of JSON because the builds list nests
 // files inside their build, which already carries them.
 type BuildFile struct {
-	ID          uuid.UUID `json:"id"`
-	VersionName string    `json:"-"`
-	VersionCode string    `json:"-"`
-	PatchID     uuid.UUID `json:"-"`
-	MappingType string    `json:"mapping_type"`
-	Key         string    `json:"-"`
-	DownloadURL string    `json:"download_url"`
-	FileSize    int64     `json:"filesize"`
-	LastUpdated time.Time `json:"last_updated"`
+	ID           uuid.UUID `json:"id"`
+	VersionName  string    `json:"-"`
+	VersionCode  string    `json:"-"`
+	PatchID      uuid.UUID `json:"-"`
+	PatchVersion string    `json:"-"`
+	MappingType  string    `json:"mapping_type"`
+	Key          string    `json:"-"`
+	DownloadURL  string    `json:"download_url"`
+	FileSize     int64     `json:"filesize"`
+	LastUpdated  time.Time `json:"last_updated"`
 }
 
 // Build represents one build of an app: the mapping files uploaded
 // for a (version_name, version_code, patch_id) group, keeping the
 // latest file of each mapping type. PatchID is empty for regular
 // builds; Over-The-Air patch uploads carry a patch id and empty
-// version columns.
+// version columns. PatchVersion is the version the SDK named the
+// patch, which uploads made before it was collected leave empty.
 type Build struct {
-	VersionName string      `json:"version_name"`
-	VersionCode string      `json:"version_code"`
-	PatchID     string      `json:"patch_id,omitempty"`
-	LastUpdated time.Time   `json:"last_updated"`
-	Files       []BuildFile `json:"files"`
+	VersionName  string      `json:"version_name"`
+	VersionCode  string      `json:"version_code"`
+	PatchID      string      `json:"patch_id,omitempty"`
+	PatchVersion string      `json:"patch_version,omitempty"`
+	LastUpdated  time.Time   `json:"last_updated"`
+	Files        []BuildFile `json:"files"`
 }
 
 // BuildFileDownloadConfig is the storage configuration
@@ -353,6 +356,7 @@ func GetBuildsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 		Select("version_name").
 		Select("version_code").
 		Select("patch_id").
+		Select("patch_version").
 		Select("mapping_type").
 		Select("key").
 		Select("file_size").
@@ -398,6 +402,7 @@ func GetBuildsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 		Select("latest.version_name").
 		Select("latest.version_code").
 		Select("latest.patch_id").
+		Select("latest.patch_version").
 		Select("latest.mapping_type").
 		Select("latest.key").
 		Select("latest.file_size").
@@ -419,6 +424,7 @@ func GetBuildsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 			&file.VersionName,
 			&file.VersionCode,
 			&file.PatchID,
+			&file.PatchVersion,
 			&file.MappingType,
 			&file.Key,
 			&file.FileSize,
@@ -439,9 +445,10 @@ func GetBuildsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 			builds[len(builds)-1].VersionCode != file.VersionCode ||
 			builds[len(builds)-1].PatchID != patch {
 			builds = append(builds, Build{
-				VersionName: file.VersionName,
-				VersionCode: file.VersionCode,
-				PatchID:     patch,
+				VersionName:  file.VersionName,
+				VersionCode:  file.VersionCode,
+				PatchID:      patch,
+				PatchVersion: file.PatchVersion,
 			})
 		}
 

--- a/backend/libs/measure/build_test.go
+++ b/backend/libs/measure/build_test.go
@@ -483,9 +483,9 @@ func TestGetBuildFile(t *testing.T) {
 	patchFileID := uuid.New()
 	pendingUpload := uuid.New()
 	patchID := uuid.New()
-	seedBuildMappingRow(ctx, t, fileID, appID, "1.0.0", "100", "proguard", noPatch, base)
-	seedBuildMappingRow(ctx, t, patchFileID, appID, "", "", "jsbundle", patchID.String(), base)
-	th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "dsym", "", noPatch, base)
+	seedBuildMappingRow(ctx, t, fileID, appID, "1.0.0", "100", "proguard", noPatch, "", base)
+	seedBuildMappingRow(ctx, t, patchFileID, appID, "", "", "jsbundle", patchID.String(), "", base)
+	th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "dsym", "", noPatch, "", base)
 
 	t.Run("reads one file row", func(t *testing.T) {
 		file, err := GetBuildFile(ctx, deps.PgPool, appID, fileID)
@@ -560,16 +560,16 @@ func TestGetBuildsWithFilterPackagesFilesIntoBuilds(t *testing.T) {
 
 	// version 1.0.0 has a superseded proguard file, its replacement
 	// and an elf_debug file
-	seedBuildMappingRow(ctx, t, oldProguard, appID, "1.0.0", "100", "proguard", noPatch, base)
-	seedBuildMappingRow(ctx, t, newProguard, appID, "1.0.0", "100", "proguard", noPatch, base.Add(10*time.Minute))
-	seedBuildMappingRow(ctx, t, elfDebug, appID, "1.0.0", "100", "elf_debug", noPatch, base.Add(20*time.Minute))
+	seedBuildMappingRow(ctx, t, oldProguard, appID, "1.0.0", "100", "proguard", noPatch, "", base)
+	seedBuildMappingRow(ctx, t, newProguard, appID, "1.0.0", "100", "proguard", noPatch, "", base.Add(10*time.Minute))
+	seedBuildMappingRow(ctx, t, elfDebug, appID, "1.0.0", "100", "elf_debug", noPatch, "", base.Add(20*time.Minute))
 
 	// a file whose upload has not finished processing has an empty
 	// key and stays out of the list
-	th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "jsbundle", "", noPatch, base.Add(30*time.Minute))
+	th.SeedBuildMappingRow(ctx, t, pendingUpload.String(), appID.String(), "1.0.0", "100", "jsbundle", "", noPatch, "", base.Add(30*time.Minute))
 
 	// version 2.0.0 has the newest file and sorts first
-	seedBuildMappingRow(ctx, t, v2Proguard, appID, "2.0.0", "200", "proguard", noPatch, base.Add(40*time.Minute))
+	seedBuildMappingRow(ctx, t, v2Proguard, appID, "2.0.0", "200", "proguard", noPatch, "", base.Add(40*time.Minute))
 
 	af := &filter.AppFilter{
 		AppID: appID,
@@ -633,13 +633,15 @@ func TestGetBuildsWithFilterGroupsPatchesSeparately(t *testing.T) {
 	patchOne := uuid.New().String()
 	patchTwo := uuid.New().String()
 
-	seedBuildMappingRow(ctx, t, regular, appID, "1.0.0", "100", "proguard", noPatch, base)
+	seedBuildMappingRow(ctx, t, regular, appID, "1.0.0", "100", "proguard", noPatch, "", base)
 
-	// OTA patch uploads carry a patch id and no version; a re-upload
-	// of the same patch id inserts a new row and the latest one wins
-	seedBuildMappingRow(ctx, t, patchOneOld, appID, "", "", "jsbundle", patchOne, base.Add(10*time.Minute))
-	seedBuildMappingRow(ctx, t, patchOneNew, appID, "", "", "jsbundle", patchOne, base.Add(20*time.Minute))
-	seedBuildMappingRow(ctx, t, patchTwoFile, appID, "", "", "jsbundle", patchTwo, base.Add(30*time.Minute))
+	// OTA patch uploads carry a patch id and no app version; a
+	// re-upload of the same patch id inserts a new row and the latest
+	// one wins. Naming the patch version is optional, so patch two
+	// has an id and no version.
+	seedBuildMappingRow(ctx, t, patchOneOld, appID, "", "", "jsbundle", patchOne, "3.0.9", base.Add(10*time.Minute))
+	seedBuildMappingRow(ctx, t, patchOneNew, appID, "", "", "jsbundle", patchOne, "3.1.0", base.Add(20*time.Minute))
+	seedBuildMappingRow(ctx, t, patchTwoFile, appID, "", "", "jsbundle", patchTwo, "", base.Add(30*time.Minute))
 
 	af := &filter.AppFilter{
 		AppID: appID,
@@ -654,13 +656,15 @@ func TestGetBuildsWithFilterGroupsPatchesSeparately(t *testing.T) {
 		t.Fatalf("want 3 builds, got %d: %+v", len(builds), builds)
 	}
 
-	if builds[0].PatchID != patchTwo || len(builds[0].Files) != 1 || builds[0].Files[0].ID != patchTwoFile {
-		t.Errorf("want patch %s build first with file %s, got %+v", patchTwo, patchTwoFile, builds[0])
+	if builds[0].PatchID != patchTwo || builds[0].PatchVersion != "" || len(builds[0].Files) != 1 || builds[0].Files[0].ID != patchTwoFile {
+		t.Errorf("want patch %s build first with file %s and no patch version, got %+v", patchTwo, patchTwoFile, builds[0])
 	}
-	if builds[1].PatchID != patchOne || len(builds[1].Files) != 1 || builds[1].Files[0].ID != patchOneNew {
-		t.Errorf("want patch %s build with only its latest file %s, got %+v", patchOne, patchOneNew, builds[1])
+	// a build takes its patch version from the same rows its files
+	// came from, so the re-upload's version arrives with its file
+	if builds[1].PatchID != patchOne || builds[1].PatchVersion != "3.1.0" || len(builds[1].Files) != 1 || builds[1].Files[0].ID != patchOneNew {
+		t.Errorf("want patch %s build with only its latest file %s and patch version 3.1.0, got %+v", patchOne, patchOneNew, builds[1])
 	}
-	if builds[2].VersionName != "1.0.0" || builds[2].PatchID != "" {
+	if builds[2].VersionName != "1.0.0" || builds[2].PatchID != "" || builds[2].PatchVersion != "" {
 		t.Errorf("want regular build 1.0.0 last, got %+v", builds[2])
 	}
 }
@@ -681,8 +685,8 @@ func TestGetBuildsWithFilterPaginatesBuilds(t *testing.T) {
 	// not files
 	versions := []string{"1.0.0", "2.0.0", "3.0.0"}
 	for i, v := range versions {
-		seedBuildMappingRow(ctx, t, uuid.New(), appID, v, "100", "proguard", noPatch, base.Add(time.Duration(i)*10*time.Minute))
-		seedBuildMappingRow(ctx, t, uuid.New(), appID, v, "100", "elf_debug", noPatch, base.Add(time.Duration(i)*10*time.Minute+5*time.Minute))
+		seedBuildMappingRow(ctx, t, uuid.New(), appID, v, "100", "proguard", noPatch, "", base.Add(time.Duration(i)*10*time.Minute))
+		seedBuildMappingRow(ctx, t, uuid.New(), appID, v, "100", "elf_debug", noPatch, "", base.Add(time.Duration(i)*10*time.Minute+5*time.Minute))
 	}
 
 	af := &filter.AppFilter{
@@ -732,8 +736,8 @@ func TestGetBuildsWithFilterTimeRange(t *testing.T) {
 	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
 	noPatch := uuid.Nil.String()
 
-	seedBuildMappingRow(ctx, t, uuid.New(), appID, "1.0.0", "100", "proguard", noPatch, base)
-	seedBuildMappingRow(ctx, t, uuid.New(), appID, "2.0.0", "200", "proguard", noPatch, base.Add(30*time.Minute))
+	seedBuildMappingRow(ctx, t, uuid.New(), appID, "1.0.0", "100", "proguard", noPatch, "", base)
+	seedBuildMappingRow(ctx, t, uuid.New(), appID, "2.0.0", "200", "proguard", noPatch, "", base.Add(30*time.Minute))
 
 	af := &filter.AppFilter{
 		AppID: appID,

--- a/backend/libs/measure/test_helpers_test.go
+++ b/backend/libs/measure/test_helpers_test.go
@@ -149,10 +149,10 @@ func seedBuildMappingRow(
 	ctx context.Context,
 	t *testing.T,
 	mappingID, appID uuid.UUID,
-	versionName, versionCode, mappingType, patchID string,
+	versionName, versionCode, mappingType, patchID, patchVersion string,
 	lastUpdated time.Time,
 ) {
-	th.SeedBuildMappingRow(ctx, t, mappingID.String(), appID.String(), versionName, versionCode, mappingType, fmt.Sprintf("test/%s", mappingID), patchID, lastUpdated)
+	th.SeedBuildMappingRow(ctx, t, mappingID.String(), appID.String(), versionName, versionCode, mappingType, fmt.Sprintf("test/%s", mappingID), patchID, patchVersion, lastUpdated)
 }
 
 func seedGenericEvents(ctx context.Context, t *testing.T, teamID, appID string, count int, ts time.Time) {

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -151,20 +151,20 @@ func (h *TestHelper) SeedApp(ctx context.Context, t *testing.T, appID, teamID, a
 }
 
 // SeedBuildMappingRow inserts a single build mapping row with an
-// explicit key and patch id. Only the table row is written; no
-// mapping file object is uploaded. The zero UUID patch id marks a
-// regular build upload; OTA patch uploads carry a patch id and empty
-// version columns. An empty key marks a file whose upload has not
-// finished processing.
-func (h *TestHelper) SeedBuildMappingRow(ctx context.Context, t *testing.T, mappingID, appID, versionName, versionCode, mappingType, key, patchID string, lastUpdated time.Time) {
+// explicit key, patch id and patch version. Only the table row is
+// written; no mapping file object is uploaded. The zero UUID patch id
+// marks a regular build upload; OTA patch uploads carry a patch id and
+// empty version columns, plus a patch version when the SDK sends one.
+// An empty key marks a file whose upload has not finished processing.
+func (h *TestHelper) SeedBuildMappingRow(ctx context.Context, t *testing.T, mappingID, appID, versionName, versionCode, mappingType, key, patchID, patchVersion string, lastUpdated time.Time) {
 	t.Helper()
 
 	_, err := h.PgPool.Exec(ctx,
-		`INSERT INTO build_mappings (id, app_id, version_name, version_code, mapping_type, key, location, fnv1_hash, file_size, patch_id, last_updated)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		`INSERT INTO build_mappings (id, app_id, version_name, version_code, mapping_type, key, location, fnv1_hash, file_size, patch_id, patch_version, last_updated)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		mappingID, appID, versionName, versionCode, mappingType, key,
 		fmt.Sprintf("http://minio.test:9000/msr-symbols-test/%s", key),
-		"0xtesthash", 100, patchID, lastUpdated)
+		"0xtesthash", 100, patchID, patchVersion, lastUpdated)
 	if err != nil {
 		t.Fatalf("seed build mapping row: %v", err)
 	}

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -259,7 +259,7 @@ describe("Builds Component", () => {
     );
   });
 
-  it("renders single and multi file builds for version, patch and version+patch variants", async () => {
+  it("renders single and multi file builds for version and patch variants", async () => {
     const file = (id: string, mappingType: string) => ({
       id,
       mapping_type: mappingType,
@@ -290,6 +290,7 @@ describe("Builds Component", () => {
             version_name: "",
             version_code: "",
             patch_id: "3f0e7c3e-9c31-4d9d-9a4e-2f6a3d0f5b21",
+            patch_version: "3.1.0",
             last_updated: "2020-01-01T00:00:00Z",
             files: [
               file("mapping-4", "jsbundle"),
@@ -302,23 +303,6 @@ describe("Builds Component", () => {
             patch_id: "b2c4e6a8-0d1f-4357-9b8c-2e4a6c8e0a1b",
             last_updated: "2020-01-01T00:00:00Z",
             files: [file("mapping-6", "jsbundle")],
-          },
-          {
-            version_name: "2.4.1",
-            version_code: "2401",
-            patch_id: "9b1de2a7-5c44-4f8e-8a3d-6f2e91c07b55",
-            last_updated: "2020-01-01T00:00:00Z",
-            files: [
-              file("mapping-7", "jsbundle"),
-              file("mapping-8", "elf_debug"),
-            ],
-          },
-          {
-            version_name: "2.4.0",
-            version_code: "2400",
-            patch_id: "d4f6a8b0-2c3e-4579-8d9e-4a6c8e0b2d3f",
-            last_updated: "2020-01-01T00:00:00Z",
-            files: [file("mapping-9", "jsbundle")],
           },
         ],
         meta: { previous: false, next: false },
@@ -338,38 +322,32 @@ describe("Builds Component", () => {
       });
     });
 
-    // Six builds render as six rows, one per group.
-    expect(screen.getAllByTestId("build-row")).toHaveLength(6);
+    // Four builds render as four rows, one per group.
+    expect(screen.getAllByTestId("build-row")).toHaveLength(4);
 
     // Every file shows its mapping type, its own date and a download;
     // the builds themselves carry no date.
     expect(screen.getAllByText("proguard")).toHaveLength(3);
-    expect(screen.getAllByText("elf_debug")).toHaveLength(2);
-    expect(screen.getAllByText("jsbundle")).toHaveLength(4);
-    expect(screen.getAllByText("1 Jan, 2020, 12:00:00 AM")).toHaveLength(9);
-    expect(screen.getAllByRole("link", { name: "Download" })).toHaveLength(9);
+    expect(screen.getAllByText("elf_debug")).toHaveLength(1);
+    expect(screen.getAllByText("jsbundle")).toHaveLength(2);
+    expect(screen.getAllByText("1 Jan, 2020, 12:00:00 AM")).toHaveLength(6);
+    expect(screen.getAllByRole("link", { name: "Download" })).toHaveLength(6);
 
-    // Version-only builds title by version.
+    // Builds uploaded against an app version title by that version.
     expect(screen.getByText("1.0.2 (2)")).toBeInTheDocument();
     expect(screen.getByText("1.0.1 (1)")).toBeInTheDocument();
 
-    // Patch-only builds title by patch id.
+    // A patch that was named by the SDK titles by that name and shows
+    // its id underneath.
+    expect(screen.getByText("patch_version: 3.1.0")).toBeInTheDocument();
     expect(
-      screen.getByText("Patch: 3f0e7c3e-9c31-4d9d-9a4e-2f6a3d0f5b21"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Patch: b2c4e6a8-0d1f-4357-9b8c-2e4a6c8e0a1b"),
+      screen.getByText("patch_id: 3f0e7c3e-9c31-4d9d-9a4e-2f6a3d0f5b21"),
     ).toBeInTheDocument();
 
-    // Builds carrying a version and a patch id keep the version as
-    // the title and show the patch id as a subtitle.
-    expect(screen.getByText("2.4.1 (2401)")).toBeInTheDocument();
+    // A patch with no name falls back to titling by its id, with
+    // nothing underneath.
     expect(
-      screen.getByText("Patch: 9b1de2a7-5c44-4f8e-8a3d-6f2e91c07b55"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("2.4.0 (2400)")).toBeInTheDocument();
-    expect(
-      screen.getByText("Patch: d4f6a8b0-2c3e-4579-8d9e-4a6c8e0b2d3f"),
+      screen.getByText("patch_id: b2c4e6a8-0d1f-4357-9b8c-2e4a6c8e0a1b"),
     ).toBeInTheDocument();
   });
 

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -28,6 +28,28 @@ import { use, useEffect, useRef, useState } from "react";
 
 const PAGINATION_LIMIT = 10;
 
+// A build is titled by the app version it was uploaded against. An
+// Over-The-Air patch has no app version. If patch version is present, that
+// becomes the title and patch id is subtitle. If no patch version exists,
+// patch id is the title.
+const describeBuild = (
+  build: any,
+): { title: string; subtitle: string | null } => {
+  if (build.version_name) {
+    return {
+      title: `${build.version_name} (${build.version_code})`,
+      subtitle: null,
+    };
+  }
+  if (build.patch_version) {
+    return {
+      title: `patch_version: ${build.patch_version}`,
+      subtitle: `patch_id: ${build.patch_id}`,
+    };
+  }
+  return { title: `patch_id: ${build.patch_id}`, subtitle: null };
+};
+
 export default function Builds(props: { params: Promise<{ teamId: string }> }) {
   const params = use(props.params);
   const router = useRouter();
@@ -143,31 +165,32 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {builds.results?.map(
-                ({ version_name, version_code, patch_id, files }: any) => (
+              {builds.results?.map((build: any) => {
+                const { title, subtitle } = describeBuild(build);
+                return (
                   <TableRow
-                    key={JSON.stringify([version_name, version_code, patch_id])}
+                    key={JSON.stringify([
+                      build.version_name,
+                      build.version_code,
+                      build.patch_id,
+                    ])}
                     data-testid="build-row"
                     className="font-body"
                   >
                     <TableCell className="w-[60%] align-top">
-                      <p className="truncate select-none">
-                        {version_name
-                          ? version_name + " (" + version_code + ")"
-                          : "Patch: " + patch_id}
-                      </p>
-                      {version_name && patch_id && (
+                      <p className="truncate select-none">{title}</p>
+                      {subtitle && (
                         <>
                           <div className="py-0.5" />
                           <p className="text-xs truncate text-muted-foreground select-none">
-                            {"Patch: " + patch_id}
+                            {subtitle}
                           </p>
                         </>
                       )}
                     </TableCell>
                     <TableCell className="w-[40%] align-top">
                       <div className="flex flex-col items-end gap-2">
-                        {files?.map((file: any) => (
+                        {build.files?.map((file: any) => (
                           <div
                             key={file.id}
                             className="flex items-center gap-4 py-0.5"
@@ -199,8 +222,8 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
                       </div>
                     </TableCell>
                   </TableRow>
-                ),
-              )}
+                );
+              })}
             </TableBody>
           </Table>
         </div>

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -490,6 +490,7 @@ export const emptyBuildsResponse = {
     version_name: string;
     version_code: string;
     patch_id?: string;
+    patch_version?: string;
     last_updated: string;
     files: {
       id: string;


### PR DESCRIPTION
# Description

- return patch_version from GET /apps/:id/builds
- title patch builds by their patch version, with the patch id below
- fall back to titling by patch id when no patch version exists
- drop the version+patch_id subtitle branch, unreachable since #3968

## Related issue
Closes #4042



