### PR TITLE
fix(backend): remove redundant version sql sort

### DIFF
--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -995,8 +995,7 @@ func (af AppFilter) getAppVersions(ctx context.Context, rch driver.Conn) (versio
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", af.AppID).
 		GroupBy("version").
-		GroupBy("code").
-		OrderBy("code::UInt32 desc, version")
+		GroupBy("code")
 
 	defer stmt.Close()
 

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -995,7 +995,11 @@ func (af AppFilter) getAppVersions(ctx context.Context, rch driver.Conn) (versio
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", af.AppID).
 		GroupBy("version").
-		GroupBy("code")
+		GroupBy("code").
+		// string sort only, codes are free-form text. real
+		// ordering happens in Versions.Sort, this just keeps
+		// the input deterministic for its stable sort.
+		OrderBy("code desc, version desc")
 
 	defer stmt.Close()
 


### PR DESCRIPTION
## Summary

This PR fixes a 500 on `GET /apps/:id/filters` caused by an unsafe `UInt32` cast on the app build number in the `getAppVersions` ClickHouse query. `code` is stored as a free-form `LowCardinality(String)` & iOS `CFBundleVersion` values like `3.7.96` aren't numeric, so the cast threw & the dashboard showed "Error fetching filters" (Android was unaffected since `versionCode` is always an integer). The fix switches the `ORDER BY` to a plain string sort on `code` & `version`, which cannot throw; actual version ordering already happens in Go via `Versions.Sort()`, so the SQL sort only needs to provide a deterministic input order for that stable sort.

## See also

- fixes #4204
