### PR TITLE
chore(frontend): make filter component flags optional

### DIFF
--- a/frontend/dashboard/app/[teamId]/alerts/page.tsx
+++ b/frontend/dashboard/app/[teamId]/alerts/page.tsx
@@ -87,25 +87,7 @@ export default function AlertsOverview(props: {
         teamId={params.teamId}
         filterSource={FilterSource.Events}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-        showNoData={true}
-        showNotOnboarded={true}
-        showAppSelector={true}
         showAppVersions={false}
-        showDates={true}
-        showSessionTypes={false}
-        showOsVersions={false}
-        showCountries={false}
-        showNetworkTypes={false}
-        showNetworkProviders={false}
-        showNetworkGenerations={false}
-        showLocales={false}
-        showDeviceManufacturers={false}
-        showDeviceNames={false}
-        showBugReportStatus={false}
-        showHttpMethods={false}
-        showUdAttrs={false}
-        showFreeText={false}
-        freeTextPlaceholder="Search User ID, Session Id, Bug Report ID or description.."
       />
       <div className="py-4" />
 

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -288,22 +288,8 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
           appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
           showNoData={false}
           showNotOnboarded={hasNoApps}
-          showAppSelector={true}
           showAppVersions={false}
           showDates={false}
-          showSessionTypes={false}
-          showOsVersions={false}
-          showCountries={false}
-          showNetworkTypes={false}
-          showNetworkProviders={false}
-          showNetworkGenerations={false}
-          showLocales={false}
-          showDeviceManufacturers={false}
-          showDeviceNames={false}
-          showBugReportStatus={false}
-          showHttpMethods={false}
-          showUdAttrs={false}
-          showFreeText={false}
         />
 
         {!hasNoApps && (

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -92,12 +92,6 @@ export default function BugReportsOverview(props: {
         teamId={params.teamId}
         filterSource={FilterSource.Events}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showNoData={true}
-        showNotOnboarded={true}
-        showAppSelector={true}
-        showAppVersions={true}
-        showDates={true}
-        showSessionTypes={false}
         showOsVersions={true}
         showCountries={true}
         showNetworkTypes={true}
@@ -107,7 +101,6 @@ export default function BugReportsOverview(props: {
         showDeviceManufacturers={true}
         showDeviceNames={true}
         showBugReportStatus={true}
-        showHttpMethods={false}
         showUdAttrs={true}
         showFreeText={true}
         freeTextPlaceholder="Search User ID, Session Id, Bug Report ID or description.."

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -110,22 +110,7 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
         showNoData={false}
         showNotOnboarded={false}
         showNoBuilds={true}
-        showAppSelector={true}
         showAppVersions={false}
-        showDates={true}
-        showSessionTypes={false}
-        showOsVersions={false}
-        showCountries={false}
-        showNetworkTypes={false}
-        showNetworkProviders={false}
-        showNetworkGenerations={false}
-        showLocales={false}
-        showDeviceManufacturers={false}
-        showDeviceNames={false}
-        showBugReportStatus={false}
-        showHttpMethods={false}
-        showUdAttrs={false}
-        showFreeText={false}
       />
       <div className="py-4" />
 

--- a/frontend/dashboard/app/[teamId]/session_replays/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_replays/page.tsx
@@ -116,11 +116,6 @@ export default function SessionReplayOverview(props: {
         teamId={params.teamId}
         filterSource={FilterSource.Events}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showNoData={true}
-        showNotOnboarded={true}
-        showAppSelector={true}
-        showAppVersions={true}
-        showDates={true}
         showSessionTypes={true}
         showOsVersions={true}
         showCountries={true}
@@ -130,8 +125,6 @@ export default function SessionReplayOverview(props: {
         showLocales={true}
         showDeviceManufacturers={true}
         showDeviceNames={true}
-        showBugReportStatus={false}
-        showHttpMethods={false}
         showUdAttrs={true}
         showFreeText={true}
         freeTextPlaceholder="Search User/Session ID, Logs, Event Type, Target View ID, File/Class name or Exception Traces..."

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -87,12 +87,6 @@ export default function TracesOverview(props: {
         teamId={params.teamId}
         filterSource={FilterSource.Spans}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showNoData={true}
-        showNotOnboarded={true}
-        showAppSelector={true}
-        showAppVersions={true}
-        showDates={true}
-        showSessionTypes={false}
         showOsVersions={true}
         showCountries={true}
         showNetworkTypes={true}
@@ -101,10 +95,7 @@ export default function TracesOverview(props: {
         showLocales={true}
         showDeviceManufacturers={true}
         showDeviceNames={true}
-        showBugReportStatus={false}
-        showHttpMethods={false}
         showUdAttrs={true}
-        showFreeText={false}
       />
       <div className="py-4" />
 

--- a/frontend/dashboard/app/components/errors_details.tsx
+++ b/frontend/dashboard/app/components/errors_details.tsx
@@ -341,12 +341,7 @@ export const ErrorsDetails: React.FC<ErrorsDetailsProps> = ({
           appId={appId}
           filterSource={FilterSource.Errors}
           appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-          showNoData={true}
-          showNotOnboarded={true}
           showAppSelector={false}
-          showAppVersions={true}
-          showDates={true}
-          showSessionTypes={false}
           showOsVersions={true}
           showCountries={true}
           showNetworkTypes={true}
@@ -355,10 +350,7 @@ export const ErrorsDetails: React.FC<ErrorsDetailsProps> = ({
           showLocales={true}
           showDeviceManufacturers={true}
           showDeviceNames={true}
-          showBugReportStatus={false}
-          showHttpMethods={false}
           showUdAttrs={true}
-          showFreeText={false}
         />
       )}
 

--- a/frontend/dashboard/app/components/errors_overview.tsx
+++ b/frontend/dashboard/app/components/errors_overview.tsx
@@ -84,12 +84,6 @@ export const ErrorsOverview: React.FC<ErrorsOverviewProps> = ({ teamId }) => {
         teamId={teamId}
         filterSource={FilterSource.Errors}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showNoData={true}
-        showNotOnboarded={true}
-        showAppSelector={true}
-        showAppVersions={true}
-        showDates={true}
-        showSessionTypes={false}
         showOsVersions={true}
         showCountries={true}
         showNetworkTypes={true}
@@ -98,10 +92,7 @@ export const ErrorsOverview: React.FC<ErrorsOverviewProps> = ({ teamId }) => {
         showLocales={true}
         showDeviceManufacturers={true}
         showDeviceNames={true}
-        showBugReportStatus={false}
-        showHttpMethods={false}
         showUdAttrs={true}
-        showFreeText={false}
         showErrorType={true}
         showSeverity={true}
         showCustomErrors={true}

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -81,25 +81,29 @@ interface FiltersProps {
   appId?: string;
   filterSource: FilterSource;
   appVersionsInitialSelectionType: AppVersionsInitialSelectionType;
-  showNoData: boolean;
-  showNotOnboarded: boolean;
+  // Every show* flag is optional and defaults to the value most pages want: the
+  // app selector, date range and app version filters are on, as are the no-data
+  // and not-onboarded states; every other filter is off. A page only uses
+  // the flags where it differs from that baseline.
+  showNoData?: boolean;
+  showNotOnboarded?: boolean;
   showNoBuilds?: boolean;
-  showAppSelector: boolean;
-  showDates: boolean;
-  showAppVersions: boolean;
-  showOsVersions: boolean;
-  showSessionTypes: boolean;
-  showCountries: boolean;
-  showNetworkProviders: boolean;
-  showNetworkTypes: boolean;
-  showNetworkGenerations: boolean;
-  showLocales: boolean;
-  showDeviceManufacturers: boolean;
-  showDeviceNames: boolean;
-  showBugReportStatus: boolean;
-  showHttpMethods: boolean;
-  showUdAttrs: boolean;
-  showFreeText: boolean;
+  showAppSelector?: boolean;
+  showDates?: boolean;
+  showAppVersions?: boolean;
+  showOsVersions?: boolean;
+  showSessionTypes?: boolean;
+  showCountries?: boolean;
+  showNetworkProviders?: boolean;
+  showNetworkTypes?: boolean;
+  showNetworkGenerations?: boolean;
+  showLocales?: boolean;
+  showDeviceManufacturers?: boolean;
+  showDeviceNames?: boolean;
+  showBugReportStatus?: boolean;
+  showHttpMethods?: boolean;
+  showUdAttrs?: boolean;
+  showFreeText?: boolean;
   showErrorType?: boolean;
   showSeverity?: boolean;
   showCustomErrors?: boolean;
@@ -500,25 +504,25 @@ const FiltersComponent = forwardRef<
       appId,
       filterSource,
       appVersionsInitialSelectionType,
-      showNoData,
-      showNotOnboarded,
+      showNoData = true,
+      showNotOnboarded = true,
       showNoBuilds = false,
-      showAppSelector,
-      showDates,
-      showAppVersions,
-      showOsVersions,
-      showSessionTypes,
-      showCountries,
-      showNetworkTypes,
-      showNetworkProviders,
-      showNetworkGenerations,
-      showLocales,
-      showDeviceManufacturers,
-      showDeviceNames,
-      showBugReportStatus,
-      showHttpMethods,
-      showUdAttrs,
-      showFreeText,
+      showAppSelector = true,
+      showDates = true,
+      showAppVersions = true,
+      showOsVersions = false,
+      showSessionTypes = false,
+      showCountries = false,
+      showNetworkTypes = false,
+      showNetworkProviders = false,
+      showNetworkGenerations = false,
+      showLocales = false,
+      showDeviceManufacturers = false,
+      showDeviceNames = false,
+      showBugReportStatus = false,
+      showHttpMethods = false,
+      showUdAttrs = false,
+      showFreeText = false,
       showErrorType = false,
       showSeverity = false,
       showCustomErrors = false,

--- a/frontend/dashboard/app/components/network_details.tsx
+++ b/frontend/dashboard/app/components/network_details.tsx
@@ -91,11 +91,6 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
         filterSource={FilterSource.Events}
         appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
         showNoData={false}
-        showNotOnboarded={true}
-        showAppSelector={true}
-        showAppVersions={true}
-        showDates={true}
-        showSessionTypes={false}
         showOsVersions={true}
         showCountries={true}
         showNetworkTypes={true}
@@ -104,10 +99,7 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
         showLocales={true}
         showDeviceManufacturers={true}
         showDeviceNames={true}
-        showBugReportStatus={false}
         showHttpMethods={true}
-        showUdAttrs={false}
-        showFreeText={false}
       />
 
       <div className="py-4" />

--- a/frontend/dashboard/app/components/network_overview.tsx
+++ b/frontend/dashboard/app/components/network_overview.tsx
@@ -332,23 +332,7 @@ export default function NetworkOverview({
           filterSource={FilterSource.Events}
           appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
           showNoData={false}
-          showNotOnboarded={true}
-          showAppSelector={true}
           showAppVersions={false}
-          showDates={true}
-          showSessionTypes={false}
-          showOsVersions={false}
-          showCountries={false}
-          showNetworkTypes={false}
-          showNetworkProviders={false}
-          showNetworkGenerations={false}
-          showLocales={false}
-          showDeviceManufacturers={false}
-          showDeviceNames={false}
-          showBugReportStatus={false}
-          showHttpMethods={false}
-          showUdAttrs={false}
-          showFreeText={false}
         />
       )}
 

--- a/frontend/dashboard/app/components/overview.tsx
+++ b/frontend/dashboard/app/components/overview.tsx
@@ -49,24 +49,6 @@ export default function Overview({
           appVersionsInitialSelectionType={
             AppVersionsInitialSelectionType.Latest
           }
-          showNoData={true}
-          showNotOnboarded={true}
-          showAppSelector={true}
-          showAppVersions={true}
-          showDates={true}
-          showSessionTypes={false}
-          showOsVersions={false}
-          showCountries={false}
-          showNetworkTypes={false}
-          showNetworkProviders={false}
-          showNetworkGenerations={false}
-          showLocales={false}
-          showDeviceManufacturers={false}
-          showDeviceNames={false}
-          showBugReportStatus={false}
-          showHttpMethods={false}
-          showFreeText={false}
-          showUdAttrs={false}
         />
       )}
 

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -65,24 +65,6 @@ export default function UserJourneys({
           appVersionsInitialSelectionType={
             AppVersionsInitialSelectionType.Latest
           }
-          showNoData={true}
-          showNotOnboarded={true}
-          showAppSelector={true}
-          showAppVersions={true}
-          showDates={true}
-          showSessionTypes={false}
-          showOsVersions={false}
-          showCountries={false}
-          showNetworkTypes={false}
-          showNetworkProviders={false}
-          showNetworkGenerations={false}
-          showLocales={false}
-          showDeviceManufacturers={false}
-          showDeviceNames={false}
-          showBugReportStatus={false}
-          showHttpMethods={false}
-          showFreeText={false}
-          showUdAttrs={false}
         />
       )}
 


### PR DESCRIPTION
# Description

Filter component show* flags were required and every page was repeating default values needlessly. This commit makes them optional with app selector, date range, app versions, no data and not-onboarded states on (which most pages use) and the rest off.

Pages now use the flags only when they differ from the baseline.

## Related issue
Closes #4016



