### PR TITLE
fix(backend): set correct content type & encoding for multipart uploads

### DIFF
--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"backend/libs/objstore"
@@ -104,13 +106,62 @@ func (a Attachment) Validate() error {
 	return nil
 }
 
+// gzipMagic prefixes every gzip stream.
+var gzipMagic = []byte{0x1f, 0x8b}
+
+// sniffEncoding detects gzip content from the leading bytes, then rewinds.
+//
+// SDKs compress some attachments before upload, so the encoding has to be
+// read off the bytes. A filename can't carry it & can't be trusted.
+//
+// The reader is rewound rather than wrapped because the S3 client seeks the
+// body to compute its payload hash. Wrapping it fails every upload.
+//
+// ponytail: non-seekable bodies skip the sniff & claim no encoding, the
+// only upload path opens a seekable multipart file
+func sniffEncoding(r io.Reader) (encoding string, err error) {
+	seeker, ok := r.(io.Seeker)
+	if !ok {
+		return
+	}
+
+	// a read failure leaves n short, so no encoding gets claimed & the
+	// upload surfaces the error itself
+	head := make([]byte, len(gzipMagic))
+	n, _ := io.ReadFull(r, head)
+
+	if _, err = seeker.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+
+	if bytes.Equal(head[:n], gzipMagic) {
+		encoding = "gzip"
+	}
+
+	return
+}
+
+// contentTypeOf derives the mime type from the original filename, ignoring
+// any compression suffix since encoding is tracked separately.
+func contentTypeOf(name string) (contentType string) {
+	base := strings.TrimSuffix(name, ".gz")
+	contentType = mime.TypeByExtension(filepath.Ext(base))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return
+}
+
 // Upload uploads raw file bytes to an S3 compatible storage system.
 func (a *Attachment) Upload(ctx context.Context, config UploadConfig) (err error) {
-	// set mime type from extension
-	ext := filepath.Ext(a.Key)
-	contentType := "application/octet-stream"
-	if ext != "" {
-		contentType = mime.TypeByExtension(ext)
+	// derive from the name, the key only retains the last suffix
+	contentType := contentTypeOf(a.Name)
+
+	contentEncoding, errSniff := sniffEncoding(a.Reader)
+	if errSniff != nil {
+		err = errSniff
+		return
 	}
 
 	metadata := map[string]string{
@@ -152,6 +203,7 @@ func (a *Attachment) Upload(ctx context.Context, config UploadConfig) (err error
 
 		writer := obj.NewWriter(ctx)
 		writer.ContentType = contentType
+		writer.ContentEncoding = contentEncoding
 		writer.Metadata = metadata
 
 		if _, err = io.Copy(writer, a.Reader); err != nil {
@@ -175,6 +227,11 @@ func (a *Attachment) Upload(ctx context.Context, config UploadConfig) (err error
 		Body:        a.Reader,
 		Metadata:    metadata,
 		ContentType: aws.String(contentType),
+	}
+
+	// leave unset for uncompressed bytes, an empty header would mislabel them
+	if contentEncoding != "" {
+		putObjectInput.ContentEncoding = aws.String(contentEncoding)
 	}
 
 	// ignore the putObjectOutput, don't need

--- a/backend/libs/event/attachment_test.go
+++ b/backend/libs/event/attachment_test.go
@@ -1,0 +1,167 @@
+package event
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+)
+
+// gzipBytes compresses b so tests assert against a real gzip stream.
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		t.Fatalf("failed to write gzip: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+func TestSniffEncoding(t *testing.T) {
+	gzipped := gzipBytes(t, []byte(`{"hello":"world"}`))
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "gzip stream",
+			input:    gzipped,
+			expected: "gzip",
+		},
+		{
+			name:     "plain json",
+			input:    []byte(`{"hello":"world"}`),
+			expected: "",
+		},
+		{
+			name:     "png bytes",
+			input:    []byte{0x89, 0x50, 0x4e, 0x47},
+			expected: "",
+		},
+		{
+			name:     "shorter than magic",
+			input:    []byte{0x1f},
+			expected: "",
+		},
+		{
+			name:     "empty",
+			input:    []byte{},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// multipart.File is a ReadSeeker, mirror that here
+			reader := bytes.NewReader(test.input)
+
+			encoding, err := sniffEncoding(reader)
+			if err != nil {
+				t.Fatalf("failed to sniff encoding: %v", err)
+			}
+
+			if encoding != test.expected {
+				t.Errorf("expected encoding %q, got %q", test.expected, encoding)
+			}
+
+			// the body must be rewound, uploads read it from the start
+			got, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatalf("failed to read body: %v", err)
+			}
+
+			if !bytes.Equal(got, test.input) {
+				t.Errorf("expected body of %d bytes, got %d", len(test.input), len(got))
+			}
+		})
+	}
+}
+
+// TestSniffEncodingNonSeekable covers the degraded path, no encoding is
+// claimed & the body stays untouched.
+func TestSniffEncodingNonSeekable(t *testing.T) {
+	gzipped := gzipBytes(t, []byte(`{"hello":"world"}`))
+	// a bare Reader hides the Seek method
+	body := struct{ io.Reader }{bytes.NewReader(gzipped)}
+
+	encoding, err := sniffEncoding(body)
+	if err != nil {
+		t.Fatalf("failed to sniff encoding: %v", err)
+	}
+
+	if encoding != "" {
+		t.Errorf("expected no encoding, got %q", encoding)
+	}
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	if !bytes.Equal(got, gzipped) {
+		t.Errorf("expected body of %d bytes, got %d", len(gzipped), len(got))
+	}
+}
+
+func TestContentTypeOf(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "gzipped json",
+			input:    "snapshot.json.gz",
+			expected: "application/json",
+		},
+		{
+			name:     "plain json",
+			input:    "snapshot.json",
+			expected: "application/json",
+		},
+		{
+			name:     "webp screenshot",
+			input:    "screenshot.webp",
+			expected: "image/webp",
+		},
+		{
+			name:     "svg layout snapshot",
+			input:    "snapshot.svg",
+			expected: "image/svg+xml",
+		},
+		{
+			name:     "no extension",
+			input:    "0191f3f9-8e0a-7000-8000-000000000000",
+			expected: "application/octet-stream",
+		},
+		{
+			name:     "unregistered extension",
+			input:    "trace.perfetto",
+			expected: "application/octet-stream",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "application/octet-stream",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := contentTypeOf(test.input)
+
+			// mime types may carry a charset param depending on host tables
+			if got != test.expected && !bytes.HasPrefix([]byte(got), []byte(test.expected+";")) {
+				t.Errorf("expected content type %q, got %q", test.expected, got)
+			}
+		})
+	}
+}

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -394,6 +394,8 @@ services:
       watch:
         - path: ../backend/ingest
           action: rebuild
+        - path: ../backend/libs
+          action: rebuild
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8085/ping"]
       interval: 5s
@@ -456,6 +458,8 @@ services:
       watch:
         - path: ../backend/cleanup
           action: rebuild
+        - path: ../backend/libs
+          action: rebuild
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8081/ping"]
       interval: 5s
@@ -512,6 +516,8 @@ services:
     develop:
       watch:
         - path: ../backend/alerts
+          action: rebuild
+        - path: ../backend/libs
           action: rebuild
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8082/ping"]
@@ -605,6 +611,8 @@ services:
     develop:
       watch:
         - path: ../backend/migrator
+          action: rebuild
+        - path: ../backend/libs
           action: rebuild
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

This PR fixes session replay showing "Error loading captures here" for sessions ingested via the multipart route (`sessionator ingest`). Gzipped `layout_snapshot_json` attachments were stored labeled `application/json`, so the dashboard received raw gzip bytes where it expected JSON. `Attachment.Upload` now sniffs the gzip magic number to set `ContentEncoding` & derives `Content-Type` from the original filename instead of the storage key. Existing objects keep their bytes & stay valid as-is. Also adds `backend/libs` to `docker compose watch` for `ingest`, `cleanup`, `alerts` & `migrator` so libs changes rebuild those services.

## Tasks

- [x] Sniff gzip magic bytes to set `ContentEncoding` on attachment uploads
- [x] Derive `Content-Type` from filename instead of storage key
- [x] Fall back to `application/octet-stream` for unknown extensions
- [x] Add tests for `sniffEncoding` & `contentTypeOf`
- [x] Watch `backend/libs` for `ingest`, `cleanup`, `alerts` & `migrator` in self-host compose

## See also

- fixes #4196
