### PR TITLE
fix: name attachments with their extension across sdks

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/BugReportCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/BugReportCollector.kt
@@ -189,7 +189,10 @@ internal class BugReportCollectorImpl internal constructor(
                             activity.runOnUiThread { onError() }
                             return@submit
                         }
-                        val parcelableAttachment = ParcelableAttachment(name = id, path = path)
+                        val parcelableAttachment = ParcelableAttachment(
+                            name = "screenshot.${compressedBitmap.first}",
+                            path = path,
+                        )
                         activity.runOnUiThread { onSuccess(parcelableAttachment) }
                     }
                 } catch (_: RejectedExecutionException) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/bugreport/BugReportCollectorImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/bugreport/BugReportCollectorImplTest.kt
@@ -89,6 +89,22 @@ class BugReportCollectorImplTest {
     }
 
     @Test
+    fun `attachments sharing a name stay distinct`() {
+        val files = createTestFiles(count = 2)
+        val attachments = mutableSetOf(
+            ParcelableAttachment(name = "screenshot.webp", path = files[0].path),
+            ParcelableAttachment(name = "screenshot.webp", path = files[1].path),
+        )
+        assertEquals(2, attachments.size)
+
+        attachments.remove(
+            ParcelableAttachment(name = "screenshot.webp", path = files[0].path),
+        )
+        assertEquals(1, attachments.size)
+        assertEquals(files[1].path, attachments.first().path)
+    }
+
+    @Test
     fun `valid bug report has at least 1 attachment or 1 character`() {
         val invalid = bugReportCollector.validateBugReport(0, 0)
         assertFalse(invalid)

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -59,6 +59,9 @@ type blob struct {
 	// name is the filename with extension
 	// from SDK
 	name string
+	// attachmentType is the SDK's attachment type, it
+	// settles the mime type when the filename can't
+	attachmentType string
 	// key is the s3-like object storage key
 	key string
 	// location is the fully qualified URL
@@ -177,8 +180,11 @@ func (e *eventreq) uploadAttachments() error {
 		})
 
 		eventAttachment := event.Attachment{
-			ID:   id,
-			Name: key,
+			ID: id,
+			// the SDK filename, only a hint, the key drops all
+			// but the last suffix
+			Name: attachment.name,
+			Type: attachment.attachmentType,
 			Key:  key,
 		}
 
@@ -379,8 +385,9 @@ func (e *eventreq) readMultipartRequest(c *gin.Context) error {
 		// see https://github.com/measure-sh/measure/issues/1736
 		for _, attachment := range ev.Attachments {
 			e.attachments[attachment.ID] = &blob{
-				id:   attachment.ID,
-				name: attachment.Name,
+				id:             attachment.ID,
+				name:           attachment.Name,
+				attachmentType: attachment.Type,
 			}
 		}
 

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -53,13 +53,35 @@ type PreSignConfig struct {
 
 // attachment types the SDKs send.
 const (
-	attachmentTypeScreenshot         = "screenshot"
+	// attachmentTypeScreenshot is a raster image of the screen as the user
+	// saw it, encoded as webp, jpeg or png.
+	attachmentTypeScreenshot = "screenshot"
+
+	// attachmentTypeAndroidMethodTrace is a binary trace of every Java/Kotlin
+	// method entry & exit.
+	//
+	// Deprecated: Will be removed in future.
 	attachmentTypeAndroidMethodTrace = "android_method_trace"
-	attachmentTypeLayoutSnapshot     = "layout_snapshot"
+
+	// attachmentTypeLayoutSnapshot is a wireframe of the view hierarchy,
+	// drawn as an SVG on some SDKs & a raster on others.
+	attachmentTypeLayoutSnapshot = "layout_snapshot"
+
+	// attachmentTypeLayoutSnapshotJSON is the view hierarchy as gzipped JSON,
+	// replayed as a wireframe in the dashboard.
 	attachmentTypeLayoutSnapshotJSON = "layout_snapshot_json"
-	attachmentTypePerfettoTrace      = "perfetto_trace"
-	attachmentTypeHeapDump           = "heap_dump"
-	attachmentTypeHeapProfile        = "heap_profile"
+
+	// attachmentTypePerfettoTrace is a protobuf trace of system & app
+	// activity, written by the OS profiler.
+	attachmentTypePerfettoTrace = "perfetto_trace"
+
+	// attachmentTypeHeapDump is a snapshot of every live object on the Java
+	// heap, in HPROF binary format.
+	attachmentTypeHeapDump = "heap_dump"
+
+	// attachmentTypeHeapProfile is a sample of native & Java allocations,
+	// carried in a protobuf trace.
+	attachmentTypeHeapProfile = "heap_profile"
 )
 
 // contentTypeBinary is the fallback for opaque or unrecognized bytes.

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -187,7 +187,7 @@ func contentTypeFor(attachmentType, name string, head []byte) (contentType strin
 		return fixed
 	}
 
-	// extension first, DetectContentType reports svg as text/xml
+	// extension first, sniffing reports svg as plain text
 	if contentType = mime.TypeByExtension(filepath.Ext(name)); contentType != "" {
 		return
 	}

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"backend/libs/objstore"
@@ -52,8 +51,30 @@ type PreSignConfig struct {
 	Origin                     string
 }
 
+// attachment types the SDKs send.
+const (
+	attachmentTypeScreenshot         = "screenshot"
+	attachmentTypeAndroidMethodTrace = "android_method_trace"
+	attachmentTypeLayoutSnapshot     = "layout_snapshot"
+	attachmentTypeLayoutSnapshotJSON = "layout_snapshot_json"
+	attachmentTypePerfettoTrace      = "perfetto_trace"
+	attachmentTypeHeapDump           = "heap_dump"
+	attachmentTypeHeapProfile        = "heap_profile"
+)
+
+// contentTypeBinary is the fallback for opaque or unrecognized bytes.
+const contentTypeBinary = "application/octet-stream"
+
 // attachmentTypes is a list of all valid attachment types.
-var attachmentTypes = []string{"screenshot", "android_method_trace", "layout_snapshot", "layout_snapshot_json", "perfetto_trace", "heap_dump", "heap_profile"}
+var attachmentTypes = []string{
+	attachmentTypeScreenshot,
+	attachmentTypeAndroidMethodTrace,
+	attachmentTypeLayoutSnapshot,
+	attachmentTypeLayoutSnapshotJSON,
+	attachmentTypePerfettoTrace,
+	attachmentTypeHeapDump,
+	attachmentTypeHeapProfile,
+}
 
 // isNotFound checks if error is a googleapi
 // not found error.
@@ -109,60 +130,84 @@ func (a Attachment) Validate() error {
 // gzipMagic prefixes every gzip stream.
 var gzipMagic = []byte{0x1f, 0x8b}
 
-// sniffEncoding detects gzip content from the leading bytes, then rewinds.
+// sniffLen is the window http.DetectContentType reads.
+const sniffLen = 512
+
+// sniffBody reads the leading bytes for content detection, then rewinds.
 //
-// SDKs compress some attachments before upload, so the encoding has to be
-// read off the bytes. A filename can't carry it & can't be trusted.
+// Both the encoding & the mime type are read off the bytes because filenames
+// are unreliable. SDKs have shipped bare UUIDs, fixed literals & double
+// extensions, & released SDKs keep sending all of them.
 //
 // The reader is rewound rather than wrapped because the S3 client seeks the
 // body to compute its payload hash. Wrapping it fails every upload.
 //
-// ponytail: non-seekable bodies skip the sniff & claim no encoding, the
-// only upload path opens a seekable multipart file
-func sniffEncoding(r io.Reader) (encoding string, err error) {
+// ponytail: non-seekable bodies skip the sniff, the only upload path opens a
+// seekable multipart file
+func sniffBody(r io.Reader) (head []byte, encoding string, err error) {
 	seeker, ok := r.(io.Seeker)
 	if !ok {
 		return
 	}
 
-	// a read failure leaves n short, so no encoding gets claimed & the
-	// upload surfaces the error itself
-	head := make([]byte, len(gzipMagic))
-	n, _ := io.ReadFull(r, head)
+	// a read failure leaves n short, so nothing gets claimed & the upload
+	// surfaces the error itself
+	buf := make([]byte, sniffLen)
+	n, _ := io.ReadFull(r, buf)
 
 	if _, err = seeker.Seek(0, io.SeekStart); err != nil {
 		return
 	}
 
-	if bytes.Equal(head[:n], gzipMagic) {
+	head = buf[:n]
+	if bytes.HasPrefix(head, gzipMagic) {
 		encoding = "gzip"
 	}
 
 	return
 }
 
-// contentTypeOf derives the mime type from the original filename, ignoring
-// any compression suffix since encoding is tracked separately.
-func contentTypeOf(name string) (contentType string) {
-	base := strings.TrimSuffix(name, ".gz")
-	contentType = mime.TypeByExtension(filepath.Ext(base))
-	if contentType == "" {
-		contentType = "application/octet-stream"
+// fixedContentTypes maps attachment types whose mime type the bytes can't
+// reveal. Compressed payloads report their wrapper & traces are opaque.
+var fixedContentTypes = map[string]string{
+	attachmentTypeLayoutSnapshotJSON: "application/json",
+	attachmentTypePerfettoTrace:      contentTypeBinary,
+	attachmentTypeHeapDump:           contentTypeBinary,
+	attachmentTypeHeapProfile:        contentTypeBinary,
+	attachmentTypeAndroidMethodTrace: contentTypeBinary,
+}
+
+// contentTypeFor resolves the mime type from the attachment type, falling back
+// to the filename then the bytes for the types the type alone can't settle.
+// layout_snapshot is an SVG wireframe on some SDKs & a raster on others.
+//
+// name is only a hint, it may be a bare UUID or a fixed literal.
+func contentTypeFor(attachmentType, name string, head []byte) (contentType string) {
+	if fixed, ok := fixedContentTypes[attachmentType]; ok {
+		return fixed
 	}
 
-	return
+	// extension first, DetectContentType reports svg as text/xml
+	if contentType = mime.TypeByExtension(filepath.Ext(name)); contentType != "" {
+		return
+	}
+
+	if len(head) > 0 {
+		return http.DetectContentType(head)
+	}
+
+	return contentTypeBinary
 }
 
 // Upload uploads raw file bytes to an S3 compatible storage system.
 func (a *Attachment) Upload(ctx context.Context, config UploadConfig) (err error) {
-	// derive from the name, the key only retains the last suffix
-	contentType := contentTypeOf(a.Name)
-
-	contentEncoding, errSniff := sniffEncoding(a.Reader)
+	head, contentEncoding, errSniff := sniffBody(a.Reader)
 	if errSniff != nil {
 		err = errSniff
 		return
 	}
+
+	contentType := contentTypeFor(a.Type, a.Name, head)
 
 	metadata := map[string]string{
 		"original_file_name": a.Name,

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -60,7 +60,7 @@ const (
 	// attachmentTypeAndroidMethodTrace is a binary trace of every Java/Kotlin
 	// method entry & exit.
 	//
-	// Deprecated: Will be removed in future.
+	// Deprecated: No SDK produces this, kept for older clients.
 	attachmentTypeAndroidMethodTrace = "android_method_trace"
 
 	// attachmentTypeLayoutSnapshot is a wireframe of the view hierarchy,

--- a/backend/libs/event/attachment.go
+++ b/backend/libs/event/attachment.go
@@ -183,6 +183,8 @@ var fixedContentTypes = map[string]string{
 //
 // name is only a hint, it may be a bare UUID or a fixed literal.
 func contentTypeFor(attachmentType, name string, head []byte) (contentType string) {
+	// type first, a compressed payload's extension resolves to the wrapper,
+	// so ".gz" would win over the json it holds
 	if fixed, ok := fixedContentTypes[attachmentType]; ok {
 		return fixed
 	}

--- a/backend/libs/event/attachment_test.go
+++ b/backend/libs/event/attachment_test.go
@@ -150,7 +150,7 @@ func TestContentTypeFor(t *testing.T) {
 		// layout_snapshot_json, the type settles it, the bytes are gzip &
 		// the name varies wildly across SDKs
 		{
-			name:           "android gzipped snapshot",
+			name:           "gzipped snapshot resolves by type not extension",
 			attachmentType: "layout_snapshot_json",
 			filename:       "snapshot.json.gz",
 			head:           gzippedJSON,

--- a/backend/libs/event/attachment_test.go
+++ b/backend/libs/event/attachment_test.go
@@ -208,11 +208,13 @@ func TestContentTypeFor(t *testing.T) {
 			expected:       "image/png",
 		},
 		{
-			name:           "unregistered image extension falls back to bytes",
+			// a synthetic extension, real ones like .heic resolve only on
+			// hosts whose mime files define them
+			name:           "unregistered extension falls back to bytes",
 			attachmentType: "screenshot",
-			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c.heic",
-			head:           []byte("\x00\x00\x00\x20ftypheic"),
-			expected:       "application/octet-stream",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c.msrunknown",
+			head:           webpBytes,
+			expected:       "image/webp",
 		},
 		{
 			name:           "bare uuid screenshot falls back to bytes",

--- a/backend/libs/event/attachment_test.go
+++ b/backend/libs/event/attachment_test.go
@@ -194,6 +194,27 @@ func TestContentTypeFor(t *testing.T) {
 			expected:       "image/webp",
 		},
 		{
+			name:           "flutter gallery jpeg screenshot",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c.jpg",
+			head:           []byte{0xff, 0xd8, 0xff, 0xe0},
+			expected:       "image/jpeg",
+		},
+		{
+			name:           "flutter gallery png screenshot",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c.png",
+			head:           pngBytes,
+			expected:       "image/png",
+		},
+		{
+			name:           "unregistered image extension falls back to bytes",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c.heic",
+			head:           []byte("\x00\x00\x00\x20ftypheic"),
+			expected:       "application/octet-stream",
+		},
+		{
 			name:           "bare uuid screenshot falls back to bytes",
 			attachmentType: "screenshot",
 			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c",

--- a/backend/libs/event/attachment_test.go
+++ b/backend/libs/event/attachment_test.go
@@ -23,7 +23,13 @@ func gzipBytes(t *testing.T, b []byte) []byte {
 	return buf.Bytes()
 }
 
-func TestSniffEncoding(t *testing.T) {
+// webpBytes is a minimal RIFF/WEBP header, enough for content detection.
+var webpBytes = []byte("RIFF\x00\x00\x00\x00WEBPVP8 ")
+
+// pngBytes is the png signature.
+var pngBytes = []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+
+func TestSniffBody(t *testing.T) {
 	gzipped := gzipBytes(t, []byte(`{"hello":"world"}`))
 
 	tests := []struct {
@@ -42,8 +48,8 @@ func TestSniffEncoding(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "png bytes",
-			input:    []byte{0x89, 0x50, 0x4e, 0x47},
+			name:     "webp bytes",
+			input:    webpBytes,
 			expected: "",
 		},
 		{
@@ -56,6 +62,11 @@ func TestSniffEncoding(t *testing.T) {
 			input:    []byte{},
 			expected: "",
 		},
+		{
+			name:     "larger than sniff window",
+			input:    gzipBytes(t, bytes.Repeat([]byte("a"), sniffLen*3)),
+			expected: "gzip",
+		},
 	}
 
 	for _, test := range tests {
@@ -63,13 +74,21 @@ func TestSniffEncoding(t *testing.T) {
 			// multipart.File is a ReadSeeker, mirror that here
 			reader := bytes.NewReader(test.input)
 
-			encoding, err := sniffEncoding(reader)
+			head, encoding, err := sniffBody(reader)
 			if err != nil {
-				t.Fatalf("failed to sniff encoding: %v", err)
+				t.Fatalf("failed to sniff body: %v", err)
 			}
 
 			if encoding != test.expected {
 				t.Errorf("expected encoding %q, got %q", test.expected, encoding)
+			}
+
+			if len(head) > sniffLen {
+				t.Errorf("expected head of at most %d bytes, got %d", sniffLen, len(head))
+			}
+
+			if !bytes.HasPrefix(test.input, head) {
+				t.Error("head is not a prefix of the body")
 			}
 
 			// the body must be rewound, uploads read it from the start
@@ -85,20 +104,24 @@ func TestSniffEncoding(t *testing.T) {
 	}
 }
 
-// TestSniffEncodingNonSeekable covers the degraded path, no encoding is
-// claimed & the body stays untouched.
-func TestSniffEncodingNonSeekable(t *testing.T) {
+// TestSniffBodyNonSeekable covers the degraded path, nothing is claimed & the
+// body stays untouched.
+func TestSniffBodyNonSeekable(t *testing.T) {
 	gzipped := gzipBytes(t, []byte(`{"hello":"world"}`))
 	// a bare Reader hides the Seek method
 	body := struct{ io.Reader }{bytes.NewReader(gzipped)}
 
-	encoding, err := sniffEncoding(body)
+	head, encoding, err := sniffBody(body)
 	if err != nil {
-		t.Fatalf("failed to sniff encoding: %v", err)
+		t.Fatalf("failed to sniff body: %v", err)
 	}
 
 	if encoding != "" {
 		t.Errorf("expected no encoding, got %q", encoding)
+	}
+
+	if len(head) != 0 {
+		t.Errorf("expected no head, got %d bytes", len(head))
 	}
 
 	got, err := io.ReadAll(body)
@@ -111,52 +134,146 @@ func TestSniffEncodingNonSeekable(t *testing.T) {
 	}
 }
 
-func TestContentTypeOf(t *testing.T) {
+// TestContentTypeFor covers every attachment naming convention the SDKs have
+// shipped. Released SDKs keep sending all of them, so each must resolve
+// correctly regardless of how the file is named.
+func TestContentTypeFor(t *testing.T) {
+	gzippedJSON := gzipBytes(t, []byte(`{"hello":"world"}`))
+
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name           string
+		attachmentType string
+		filename       string
+		head           []byte
+		expected       string
 	}{
+		// layout_snapshot_json, the type settles it, the bytes are gzip &
+		// the name varies wildly across SDKs
 		{
-			name:     "gzipped json",
-			input:    "snapshot.json.gz",
-			expected: "application/json",
+			name:           "android gzipped snapshot",
+			attachmentType: "layout_snapshot_json",
+			filename:       "snapshot.json.gz",
+			head:           gzippedJSON,
+			expected:       "application/json",
 		},
 		{
-			name:     "plain json",
-			input:    "snapshot.json",
-			expected: "application/json",
+			name:           "ios bare uuid snapshot",
+			attachmentType: "layout_snapshot_json",
+			filename:       "fa496759-113e-4900-92ed-b3c422c8d7b5",
+			head:           gzippedJSON,
+			expected:       "application/json",
 		},
 		{
-			name:     "webp screenshot",
-			input:    "screenshot.webp",
-			expected: "image/webp",
+			name:           "future ios snapshot with extension",
+			attachmentType: "layout_snapshot_json",
+			filename:       "fa496759-113e-4900-92ed-b3c422c8d7b5.json.gz",
+			head:           gzippedJSON,
+			expected:       "application/json",
+		},
+
+		// screenshots, the name is a hint & the bytes are the fallback
+		{
+			name:           "android screenshot literal",
+			attachmentType: "screenshot",
+			filename:       "screenshot.webp",
+			head:           webpBytes,
+			expected:       "image/webp",
 		},
 		{
-			name:     "svg layout snapshot",
-			input:    "snapshot.svg",
-			expected: "image/svg+xml",
+			name:           "ios uuid screenshot",
+			attachmentType: "screenshot",
+			filename:       "fa496759-113e-4900-92ed-b3c422c8d7b5.webp",
+			head:           webpBytes,
+			expected:       "image/webp",
 		},
 		{
-			name:     "no extension",
-			input:    "0191f3f9-8e0a-7000-8000-000000000000",
-			expected: "application/octet-stream",
+			name:           "ios gallery screenshot literal",
+			attachmentType: "screenshot",
+			filename:       "galleryImage.webp",
+			head:           webpBytes,
+			expected:       "image/webp",
 		},
 		{
-			name:     "unregistered extension",
-			input:    "trace.perfetto",
-			expected: "application/octet-stream",
+			name:           "bare uuid screenshot falls back to bytes",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c",
+			head:           webpBytes,
+			expected:       "image/webp",
 		},
 		{
-			name:     "empty",
-			input:    "",
-			expected: "application/octet-stream",
+			name:           "bare uuid png screenshot falls back to bytes",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c",
+			head:           pngBytes,
+			expected:       "image/png",
+		},
+
+		// layout_snapshot, svg on some SDKs & raster on others
+		{
+			name:           "android legacy svg snapshot",
+			attachmentType: "layout_snapshot",
+			filename:       "snapshot.svg",
+			head:           []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`),
+			expected:       "image/svg+xml",
+		},
+		{
+			name:           "ios legacy svg snapshot",
+			attachmentType: "layout_snapshot",
+			filename:       "layoutSnapshot.svg",
+			head:           []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`),
+			expected:       "image/svg+xml",
+		},
+		{
+			name:           "raster layout snapshot",
+			attachmentType: "layout_snapshot",
+			filename:       "layoutSnapshot.webp",
+			head:           webpBytes,
+			expected:       "image/webp",
+		},
+
+		// opaque payloads, always octet-stream
+		{
+			name:           "perfetto trace",
+			attachmentType: "perfetto_trace",
+			filename:       "profile_trigger-type-2_2026-07-13-18-52-49.perfetto-trace",
+			head:           []byte{0x0a, 0x00, 0x00, 0x00},
+			expected:       "application/octet-stream",
+		},
+		{
+			name:           "heap dump",
+			attachmentType: "heap_dump",
+			filename:       "profile.hprof",
+			head:           []byte("JAVA PROFILE 1.0.3"),
+			expected:       "application/octet-stream",
+		},
+		{
+			name:           "heap profile",
+			attachmentType: "heap_profile",
+			filename:       "profile.heapprofd",
+			head:           []byte{0x0a, 0x00},
+			expected:       "application/octet-stream",
+		},
+
+		// degraded inputs
+		{
+			name:           "unknown type with no name or bytes",
+			attachmentType: "",
+			filename:       "",
+			head:           nil,
+			expected:       "application/octet-stream",
+		},
+		{
+			name:           "screenshot with no bytes to sniff",
+			attachmentType: "screenshot",
+			filename:       "93ce9654-844a-4e8f-ac1b-ca0fc479008c",
+			head:           nil,
+			expected:       "application/octet-stream",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := contentTypeOf(test.input)
+			got := contentTypeFor(test.attachmentType, test.filename, test.head)
 
 			// mime types may carry a charset param depending on host tables
 			if got != test.expected && !bytes.HasPrefix([]byte(got), []byte(test.expected+";")) {

--- a/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/bug_report_collector.dart
@@ -10,6 +10,7 @@ import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/method_channel/msr_method_channel.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
+import 'package:measure_flutter/src/utils/file_extension.dart';
 import 'package:measure_flutter/src/utils/id_provider.dart';
 
 import '../../measure_flutter.dart';
@@ -77,7 +78,9 @@ class BugReportCollector {
 
         final File? file;
         final int sizeBytes;
+        final String fileExtension;
         if (attachment.hasRawPixels) {
+          fileExtension = 'webp';
           final webp = await _methodChannel.encodeWebP(
             pixels: bytes,
             width: attachment.width!,
@@ -90,6 +93,7 @@ class BugReportCollector {
           file = await _fileStorage.writeFile(webp, uuid);
           sizeBytes = webp.length;
         } else {
+          fileExtension = fileExtensionOf(attachment.name);
           file = await _fileStorage.writeFile(bytes, uuid);
           sizeBytes = bytes.length;
         }
@@ -105,7 +109,7 @@ class BugReportCollector {
         );
         storedAttachments.add(
           MsrAttachment(
-            name: uuid,
+            name: fileExtension.isEmpty ? uuid : '$uuid.$fileExtension',
             path: file.path,
             type: attachment.type,
             id: uuid,

--- a/flutter/packages/measure_flutter/lib/src/bug_report/ui/image_picker.dart
+++ b/flutter/packages/measure_flutter/lib/src/bug_report/ui/image_picker.dart
@@ -3,6 +3,7 @@ import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/logger/log_level.dart';
 import 'package:measure_flutter/src/logger/logger.dart';
 
+import '../../utils/file_extension.dart';
 import '../../utils/id_provider.dart';
 
 class ImagePickerWrapper {
@@ -34,6 +35,7 @@ class ImagePickerWrapper {
           type: AttachmentType.screenshot,
           size: size,
           uuid: _idProvider.uuid(),
+          fileExtension: fileExtensionOf(image.path),
         );
         attachments.add(attachment);
       }

--- a/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
+++ b/flutter/packages/measure_flutter/lib/src/events/msr_attachment.dart
@@ -57,6 +57,11 @@ class MsrAttachment {
   bool get hasRawPixels =>
       bytes != null && bytesFormat == AttachmentBytesFormat.rawRgba8888;
 
+  static String _nameFor(String uuid, String? fileExtension) =>
+      (fileExtension == null || fileExtension.isEmpty)
+          ? uuid
+          : '$uuid.$fileExtension';
+
   /// Creates an [MsrAttachment] from encoded image bytes (PNG/JPEG/WebP/etc.).
   ///
   /// Use this factory when you have file content as bytes, such as a
@@ -91,9 +96,10 @@ class MsrAttachment {
     required int height,
     required AttachmentType type,
     required String uuid,
+    String? fileExtension,
   }) {
     return MsrAttachment(
-      name: uuid,
+      name: _nameFor(uuid, fileExtension),
       id: uuid,
       type: type,
       size: bytes.length,
@@ -118,9 +124,10 @@ class MsrAttachment {
     required AttachmentType type,
     required int size,
     required String uuid,
+    String? fileExtension,
   }) {
     return MsrAttachment(
-      name: uuid,
+      name: _nameFor(uuid, fileExtension),
       size: size,
       id: uuid,
       type: type,

--- a/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
@@ -166,6 +166,7 @@ class GestureCollector {
         type: AttachmentType.layoutSnapshotJson,
         size: fileSize,
         uuid: uuid,
+        fileExtension: 'json.gz',
       );
     } catch (e) {
       _logger.log(

--- a/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/screenshot/screenshot_collector.dart
@@ -89,6 +89,7 @@ class DefaultScreenshotCollector extends ScreenshotCollector {
         height: height,
         type: AttachmentType.screenshot,
         uuid: idProvider.uuid(),
+        fileExtension: 'webp',
       );
     } catch (e) {
       logger.log(

--- a/flutter/packages/measure_flutter/lib/src/utils/file_extension.dart
+++ b/flutter/packages/measure_flutter/lib/src/utils/file_extension.dart
@@ -1,0 +1,14 @@
+/// Returns the file extension of [pathOrName] without the leading dot, or an
+/// empty string when there is none.
+String fileExtensionOf(String pathOrName) {
+  final separator = pathOrName.lastIndexOf(RegExp(r'[/\\]'));
+  final basename =
+      separator == -1 ? pathOrName : pathOrName.substring(separator + 1);
+
+  final dot = basename.lastIndexOf('.');
+  if (dot <= 0 || dot == basename.length - 1) {
+    return '';
+  }
+
+  return basename.substring(dot + 1);
+}

--- a/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/bug_report/bug_report_collector_test.dart
@@ -247,7 +247,7 @@ void main() {
 
       if (event.attachments?.isNotEmpty == true) {
         final storedAttachment = event.attachments!.first;
-        expect(storedAttachment.name, equals('uuid-1'));
+        expect(storedAttachment.name, equals('uuid-1.png'));
         expect(storedAttachment.id, equals('uuid-1'));
         expect(storedAttachment.path, contains('uuid-1'));
         expect(storedAttachment.type, equals(AttachmentType.screenshot));

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
@@ -56,6 +56,7 @@ void main() {
       expect(result, isNotNull);
       expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
       expect(result.id, equals('uuid-1'));
+      expect(result.name, equals('uuid-1.json.gz'));
       expect(result.path, contains('uuid-1'));
       expect(result.size, greaterThan(0));
     });

--- a/flutter/packages/measure_flutter/test/utils/file_extension_test.dart
+++ b/flutter/packages/measure_flutter/test/utils/file_extension_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/utils/file_extension.dart';
+
+void main() {
+  group('fileExtensionOf', () {
+    test('returns the extension without the leading dot', () {
+      expect(fileExtensionOf('screenshot.webp'), equals('webp'));
+    });
+
+    test('returns the last segment of a double extension', () {
+      expect(fileExtensionOf('snapshot.json.gz'), equals('gz'));
+    });
+
+    test('returns empty when there is no dot', () {
+      expect(fileExtensionOf('0191f3f9-8e0a-7000-8000-000000000000'),
+          equals(''));
+    });
+
+    test('returns empty for a dotfile', () {
+      expect(fileExtensionOf('.gitignore'), equals(''));
+    });
+
+    test('returns empty for a trailing dot', () {
+      expect(fileExtensionOf('screenshot.'), equals(''));
+    });
+
+    test('returns empty when only a directory segment has a dot', () {
+      expect(fileExtensionOf('/tmp/my.dir/screenshot'), equals(''));
+    });
+
+    test('reads the extension off a full path', () {
+      expect(fileExtensionOf('/tmp/my.dir/screenshot.jpg'), equals('jpg'));
+    });
+
+    test('handles windows separators', () {
+      expect(fileExtensionOf(r'C:\images\screenshot.png'), equals('png'));
+    });
+
+    test('returns empty for an empty string', () {
+      expect(fileExtensionOf(''), equals(''));
+    });
+  });
+}

--- a/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/AttachmentProcessor.swift
@@ -35,7 +35,7 @@ final class BaseAttachmentProcessor: AttachmentProcessor {
         let attachmentName: String = {
             switch attachmentType {
             case .layoutSnapshot: return "\(uuid).svg"
-            case .layoutSnapshotJson: return "\(uuid)"
+            case .layoutSnapshotJson: return "\(uuid).json.gz"
             default: return "\(uuid).webp"
             }
         }()

--- a/ios/Tests/MeasureSDKTests/Event/AttachmentProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Event/AttachmentProcessorTests.swift
@@ -60,6 +60,23 @@ final class AttachmentProcessorTests: XCTestCase {
         XCTAssertNil(attachment?.bytes)
     }
 
+    func test_attachmentName_carriesExtensionDescribingBytes() {
+        let screenshot = sut.getAttachmentObject(for: Data("image".utf8),
+                                                 storageType: .data,
+                                                 attachmentType: .screenshot)
+        XCTAssertEqual(screenshot?.name, "test-uuid.webp")
+
+        let snapshotJson = sut.getAttachmentObject(for: Data("snapshot".utf8),
+                                                   storageType: .gzip,
+                                                   attachmentType: .layoutSnapshotJson)
+        XCTAssertEqual(snapshotJson?.name, "test-uuid.json.gz")
+
+        let snapshot = sut.getAttachmentObject(for: Data("<svg/>".utf8),
+                                               storageType: .data,
+                                               attachmentType: .layoutSnapshot)
+        XCTAssertEqual(snapshot?.name, "test-uuid.svg")
+    }
+
     func test_gzip_returnsBytesAndNilPath() {
         let attachment = sut.getAttachmentObject(for: Data("snapshot".utf8),
                                                   storageType: .gzip,


### PR DESCRIPTION
## Summary

This PR aligns attachment filenames across the SDKs & makes the backend resolve content type from data that is always present. Android's bug report screenshot, iOS's `layout_snapshot_json` & every Flutter attachment carried a bare UUID as their name, so those objects were stored as `application/octet-stream`. Android now names the screenshot `screenshot.<ext>`, iOS names the snapshot `<uuid>.json.gz` & Flutter applies the same extensions to its screenshot & snapshot attachments. The backend resolves `Content-Type` from the attachment `type` first, then the filename, then a byte sniff, so every naming convention released SDKs send resolves correctly. Existing objects stay in place.

## Tasks

- [x] Name Android bug report screenshot with its actual extension
- [x] Name iOS layout snapshot JSON attachment with its extension
- [x] Name Flutter screenshot & layout snapshot attachments with their extension
- [x] Resolve backend attachment content type from type & bytes, with filename as a hint only
- [x] Thread the SDK filename & attachment type through into `event.Attachment` on upload

## See also

- fixes #4212
