### PR TITLE
ci(ios): resolve KSCrash includes in frank archive builds

### DIFF
--- a/samples/frank/ios/Podfile
+++ b/samples/frank/ios/Podfile
@@ -209,9 +209,13 @@ post_install do |installer|
     # Compiling those modules resolves includes across KSCrash targets (the
     # KSCrashRecording headers pull in KSCrashNamespace.h from KSCrashCore),
     # so the checkout's include dirs must be on the header search path too.
-    kscrash_sources = '$(OBJROOT)/../../SourcePackages/checkouts/KSCrash/Sources'
-    include_dirs = %w[KSCrashCore KSCrashRecordingCore KSCrashRecording]
-      .map { |t| "#{kscrash_sources}/#{t}/include" }
+    # OBJROOT sits deeper in an archive than in a build, so try both depths.
+    derived_data_roots = ['$(OBJROOT)/../..', '$(OBJROOT)/../../../../..']
+    include_dirs = derived_data_roots.flat_map do |root|
+      %w[KSCrashCore KSCrashRecordingCore KSCrashRecording].map do |t|
+        "#{root}/SourcePackages/checkouts/KSCrash/Sources/#{t}/include"
+      end
+    end
     measure_rn.build_configurations.each do |config|
       flags = Array(config.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)')
       module_maps.each { |map| flags.push('-Xcc', "-fmodule-map-file=#{map}") }


### PR DESCRIPTION
KSCrash 2.6.0 broke the frank iOS archive on main. One of its public headers now imports a header from a different module, and the CocoaPods target that bridges React Native to the Measure SDK cannot resolve it.

The Podfile already passes the include paths this needs, but derives them from a location that only resolves during a normal build. An archive nests that location deeper, so the paths silently pointed at nothing. This passes both.

Verified by temporarily archiving on this PR: the archive resolved KSCrash 2.6.0 and succeeded.

Solves CI failure: https://github.com/measure-sh/measure/actions/runs/31377384954/job/93419622178