### PR TITLE
fix(backend): double close panic in cleanup service

### DIFF
--- a/backend/cleanup/cleanup/cleanup.go
+++ b/backend/cleanup/cleanup/cleanup.go
@@ -577,9 +577,8 @@ func deleteEventsAndAttachments(ctx context.Context, retentions []AppRetention) 
 			From("events final").
 			Where("team_id = toUUID(?)", retention.TeamID).
 			Where("app_id = toUUID(?)", retention.AppID).
-			Where("timestamp < ?", retention.Threshold)
-
-		defer fetchAttachmentsStmt.Close()
+			Where("timestamp < ?", retention.Threshold).
+			Where("attachments not in ('', '[]')")
 
 		attachmentRows, err := server.Server.ChPool.Query(ctx, fetchAttachmentsStmt.String(), fetchAttachmentsStmt.Args()...)
 		if err != nil {
@@ -608,6 +607,9 @@ func deleteEventsAndAttachments(ctx context.Context, retentions []AppRetention) 
 				staleAttachments = append(staleAttachments, attachments...)
 			}
 		}
+
+		attachmentRows.Close()
+		fetchAttachmentsStmt.Close()
 
 		// Delete attachments from object storage
 		if err := deleteAttachments(ctx, staleAttachments); err != nil {

--- a/backend/cleanup/cleanup/cleanup_test.go
+++ b/backend/cleanup/cleanup/cleanup_test.go
@@ -1,0 +1,83 @@
+package cleanup
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// sqlf's Close is not idempotent. It nils the statement buffer then hands it
+// to bytebufferpool, so a second Close faults on the nil buffer. Closing a
+// statement both with a defer & explicitly on an error branch is exactly that
+// double Close, since a defer inside a loop body does not run per iteration,
+// it piles up & fires at function return.
+func TestNoDeferredAndExplicitClose(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "cleanup.go", nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse cleanup.go: %v", err)
+	}
+
+	var funcs int
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+
+		funcs++
+
+		deferred := map[string]bool{}
+		explicit := map[string]bool{}
+
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			// a defer inside a nested func literal has its own scope
+			if _, ok := n.(*ast.FuncLit); ok {
+				return false
+			}
+
+			switch stmt := n.(type) {
+			case *ast.DeferStmt:
+				if name, ok := closeTarget(stmt.Call); ok {
+					deferred[name] = true
+				}
+			case *ast.ExprStmt:
+				call, ok := stmt.X.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if name, ok := closeTarget(call); ok {
+					explicit[name] = true
+				}
+			}
+
+			return true
+		})
+
+		for name := range deferred {
+			if explicit[name] {
+				t.Errorf("%s: %s is closed by both a defer & an explicit call, sqlf Close is not idempotent", fn.Name.Name, name)
+			}
+		}
+	}
+
+	if funcs == 0 {
+		t.Fatal("found no functions in cleanup.go, the check is not looking at what it thinks it is")
+	}
+}
+
+// closeTarget returns the receiver name of an x.Close() call.
+func closeTarget(call *ast.CallExpr) (name string, ok bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Close" {
+		return "", false
+	}
+
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+
+	return ident.Name, true
+}

--- a/backend/cleanup/main.go
+++ b/backend/cleanup/main.go
@@ -65,7 +65,9 @@ func main() {
 }
 
 func initCron(ctx context.Context) *cron.Cron {
-	cron := cron.New()
+	// recover panics so one failed step doesn't kill the process
+	// & skip every step sequenced after it
+	cron := cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger)))
 
 	// run at 2 AM UTC every day
 	if _, err := cron.AddFunc("0 2 * * *", func() { cleanup.DeleteStaleData(ctx) }); err != nil {


### PR DESCRIPTION
## Summary

This PR fixes a nil-pointer panic in the `cleanup` service cron job. `sqlf.Stmt.Close()` is not idempotent & `deleteEventsAndAttachments` closed the same statement twice, once via a `defer` stacked inside a loop & once explicitly on an error branch. The second close handed a nil buffer to `bytebufferpool` & faulted, terminating the process before the remaining cleanup steps ran.

## Tasks

- [x] Close the fetch statement & ClickHouse rows explicitly after the row loop
- [x] Push an `attachments not in ('', '[]')` filter into the ClickHouse query so scans skip rows with nothing to delete
- [x] Wrap the cron scheduler with `cron.Recover` so a panic stays logged & contained to that run
- [x] Add an AST based test that fails when a variable in `cleanup.go` is closed by both a defer & an explicit call

## See also

- fixes #4218
