### PR TITLE
ci(backend): merge build & test jobs across service workflows

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -27,8 +27,8 @@ env:
   IMAGE_NAME: measure-sh/agent
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/agent
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/agent/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test -tags=integration ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,40 +48,19 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/alerts
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/alerts/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
-        run: go test ./...
+        run: go test -tags=integration ./...
 
   push:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -27,8 +27,8 @@ env:
   IMAGE_NAME: measure-sh/api
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/api
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/api/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test -tags=integration ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/cleanup
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/cleanup/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ingest-worker.yml
+++ b/.github/workflows/ingest-worker.yml
@@ -27,8 +27,8 @@ env:
   IMAGE_NAME: measure-sh/ingest-worker
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/ingest-worker
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/ingest-worker/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test -tags=integration ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -7,7 +7,6 @@ on:
       - backend/ingest/**/*.go
       - backend/ingest/**/*.mod
       - backend/ingest/**/*.sum
-      - backend/ingest/**/*.go
   push:
     branches:
       - "main"
@@ -17,7 +16,6 @@ on:
       - backend/ingest/**/*.go
       - backend/ingest/**/*.mod
       - backend/ingest/**/*.sum
-      - backend/ingest/**/*.go
     tags:
       - "v*"
 
@@ -29,8 +27,8 @@ env:
   IMAGE_NAME: measure-sh/ingest
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,40 +48,19 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/ingest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/ingest/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
-        run: go test ./...
+        run: go test -tags=integration ./...
 
   push:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,30 +47,5 @@ jobs:
         run: go build -v ./...
       - name: Vet with ${{ matrix.go-version }}
         run: go vet ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/libs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/libs/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go mod download
-      # Integration tagged tests are skipped, they need containers & resolve
-      # backend/testinfra only through the workspace.
       - name: Test with ${{ matrix.go-version }}
-        run: go test ./...
+        run: go test -tags=integration ./...

--- a/.github/workflows/migrator.yml
+++ b/.github/workflows/migrator.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/migrator
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/migrator/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/symboloader.yml
+++ b/.github/workflows/symboloader.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,32 +48,11 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install dependencies
-        run: go get .
+        run: go mod download
       - name: Build with ${{ matrix.go-version }}
         run: go build -v ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25.x", "1.26.x"]
-    defaults:
-      run:
-        working-directory: backend/symboloader
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-          cache-dependency-path: backend/symboloader/go.sum
-      - name: Display go version
-        run: go version
-      - name: Install dependencies
-        run: go get .
+      - name: Vet with ${{ matrix.go-version }}
+        run: go vet ./...
       - name: Test with ${{ matrix.go-version }}
         run: go test ./...
 
@@ -81,7 +60,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test]
+    needs: [build-test]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

This PR merges the `build` & `test` jobs into a single `build-test` job across the nine per-service backend workflows, halving the job count per workflow. The install step standardizes on `go mod download`, `go vet ./...` runs everywhere & `-tags=integration` is enabled for alerts, ingest & libs so their integration tests run in CI.

## Tasks

- [x] Merge `build`/`test` into a single `build-test` job per workflow
- [x] Replace `go get .` with `go mod download` for the install step
- [x] Add `go vet ./...` to all nine workflows
- [x] Enable `-tags=integration` in alerts, ingest & libs
- [x] Drop the stale skip-integration comment in `libs.yml`
- [x] Point the image `push` job `needs` at `build-test`
