### PR TITLE
chore(backend): drop unused postgres tables

### DIFF
--- a/self-host/postgres/20260812143333_drop_user_attribution_table.sql
+++ b/self-host/postgres/20260812143333_drop_user_attribution_table.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+drop table if exists measure.user_attribution;
+
+-- migrate:down
+create table if not exists measure.user_attribution (
+    user_id uuid primary key references measure.users(id) on delete cascade,
+    ga_client_id text null,
+    gclid text null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+comment on table measure.user_attribution is 'Marketing attribution identifiers captured at signup. 1:1 with users; row exists only when at least one identifier was captured.';

--- a/self-host/postgres/20260812144140_drop_event_reqs_table.sql
+++ b/self-host/postgres/20260812144140_drop_event_reqs_table.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+drop table if exists measure.event_reqs;
+
+-- migrate:down
+create table if not exists measure.event_reqs (
+    id uuid primary key not null,
+    app_id uuid references measure.apps(id) on delete cascade,
+    event_count int default 0,
+    attachment_count int default 0,
+    session_count int default 0,
+    bytes_in int default 0,
+    symbolication_attempts_count int default 0,
+    created_at timestamptz not null default now(),
+    status int default 0,
+    span_count int default 0
+);
+
+comment on column measure.event_reqs.id is 'id of the event request';
+comment on column measure.event_reqs.app_id is 'id of the associated app';
+comment on column measure.event_reqs.event_count is 'number of events in the event request';
+comment on column measure.event_reqs.attachment_count is 'number of attachments in the event request';
+comment on column measure.event_reqs.session_count is 'number of sessions in the event request';
+comment on column measure.event_reqs.bytes_in is 'total payload size of the request';
+comment on column measure.event_reqs.symbolication_attempts_count is 'number of times symbolication was attempted for this event request';
+comment on column measure.event_reqs.created_at is 'utc timestamp at the time of record creation';
+comment on column measure.event_reqs.status is 'status of event request: 0 is pending, 1 is done';
+comment on column measure.event_reqs.span_count is 'number of spans in the event request';


### PR DESCRIPTION
## Summary

This PR drops two unused Postgres tables, `measure.user_attribution` & `measure.event_reqs` via dbmate migrations. Both migrations include down-migrations that recreate the original table & column definitions.

## Tasks

- [x] Drop `measure.user_attribution` table
- [x] Drop `measure.event_reqs` table