### PR TITLE
fix: publish ingest batch before responding to client

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exporter/Exporter.kt
@@ -54,7 +54,7 @@ internal class ExporterImpl(
         // Upper bound on the serialized size of a single batch's upload payload.
         // Batches are split so that no batch exceeds this size, keeping each export
         // request small enough to upload reliably.
-        private const val MAX_BATCH_PAYLOAD_SIZE_BYTES = 10 * 1024 * 1024
+        private const val MAX_BATCH_PAYLOAD_SIZE_BYTES = 9_000_000
 
         // Rough estimate of a single signal's (event or span) serialized size, used to
         // convert the payload size limit into a maximum number of signals per batch.

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exporter/ExporterTest.kt
@@ -201,26 +201,26 @@ internal class ExporterTest {
     @Test
     fun `caps batch size at payload limit when config limit is larger`() {
         whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
-        // Payload limit: 10 MB / 1 KB estimated per signal = 10_240 signals per batch.
+        // Payload limit: 9 MB / 1 KB estimated per signal = 8_789 signals per batch.
         // The config limit is set higher, so the payload limit should take effect.
         configProvider.maxEventsInBatch = 20_000
 
         insertSessionInDb("session1")
-        insertEventsInDb("session1", count = 10_241)
+        insertEventsInDb("session1", count = 8_790)
 
         exporter.export()
 
-        // 10_241 events split into batches of 10_240 and 1.
+        // 8_790 events split into batches of 8_789 and 1.
         val eventsCaptor = argumentCaptor<List<EventPacket>>()
         verify(networkClient, times(2)).execute(any(), eventsCaptor.capture(), any())
         val batchSizes = eventsCaptor.allValues.map { it.size }.sortedDescending()
-        assertEquals(listOf(10_240, 1), batchSizes)
+        assertEquals(listOf(8_789, 1), batchSizes)
     }
 
     @Test
     fun `uses config limit when smaller than payload limit`() {
         whenever(networkClient.execute(any(), any(), any())).thenReturn(HttpResponse.Success())
-        // Config limit (5) is smaller than the payload limit (10_240), so it wins.
+        // Config limit (5) is smaller than the payload limit (8_789), so it wins.
         configProvider.maxEventsInBatch = 5
 
         insertSessionInDb("session1")

--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -1269,7 +1269,6 @@ func processIngestBatchSync(ctx context.Context, batch IngestBatch) error {
 			eventReq.symbolicateEvents[eventReq.events[i].ID] = i
 		}
 		if eventReq.events[i].IsException() {
-			fmt.Println("processing exception: ", eventReq.events[i].ID)
 			eventReq.exceptionIds = append(eventReq.exceptionIds, i)
 		}
 		if eventReq.events[i].IsANR() {

--- a/backend/ingest/measure/apikey.go
+++ b/backend/ingest/measure/apikey.go
@@ -18,6 +18,10 @@ import (
 
 const APIKeyPrefix = "msrsh"
 
+// ErrInvalidAPIKey means the key is malformed or fails checksum. Distinct from
+// a lookup failure, which is infrastructure.
+var ErrInvalidAPIKey = errors.New("invalid api key")
+
 type APIKey struct {
 	appId     uuid.UUID
 	keyPrefix string
@@ -57,16 +61,14 @@ func updateLastSeenForApiKey(ctx context.Context, apiKeyId uuid.UUID) error {
 }
 
 func DecodeAPIKey(ctx context.Context, key string) (*uuid.UUID, error) {
-	defaultErr := errors.New("invalid api key")
-
 	if len(key) < 1 {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	parts := strings.Split(key, "_")
 
 	if len(parts) != 3 {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	prefix := parts[0]
@@ -74,7 +76,7 @@ func DecodeAPIKey(ctx context.Context, key string) (*uuid.UUID, error) {
 	checksum := parts[2]
 
 	if prefix != APIKeyPrefix {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	computedChecksum, err := cipher.ComputeChecksum([]byte(value))
@@ -83,7 +85,7 @@ func DecodeAPIKey(ctx context.Context, key string) (*uuid.UUID, error) {
 	}
 
 	if checksum != *computedChecksum {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	stmt := sqlf.PostgreSQL.

--- a/backend/ingest/measure/auth.go
+++ b/backend/ingest/measure/auth.go
@@ -1,6 +1,7 @@
 package measure
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -44,7 +45,13 @@ func ValidateAPIKey() gin.HandlerFunc {
 		appId, err := DecodeAPIKey(c, key)
 		if err != nil {
 			fmt.Println("api key decode failed:", err)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
+			if errors.Is(err, ErrInvalidAPIKey) {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
+				return
+			}
+			// lookup failures are infrastructure, a 401 would make SDKs discard
+			// the batch instead of retrying.
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate api key"})
 			return
 		}
 

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -2,6 +2,7 @@ package measure
 
 import (
 	"backend/ingest/server"
+	"backend/libs/bus"
 	"backend/libs/event"
 	"backend/libs/objstore"
 	"backend/libs/span"
@@ -30,8 +31,10 @@ import (
 )
 
 // maxBatchSize is the maximum allowed payload
-// size of event request in bytes.
-var maxBatchSize = 10 * 1024 * 1024
+// size of event request in bytes. Kept under the bus
+// per-message cap of 10,000,000 bytes to leave headroom
+// for the IngestBatch wrapper & JSON re-encoding.
+var maxBatchSize = 9_900_000
 
 var ingestBatchPublishCount metric.Int64Counter
 
@@ -1015,16 +1018,6 @@ func PutEvents(c *gin.Context) {
 		genSignedURLsSpan.End()
 	}
 
-	if eventReq.json {
-		c.JSON(http.StatusOK, IngestResponse{
-			AttachmentUploadInfo: eventReq.attachmentUploadInfos,
-		})
-	} else {
-		c.JSON(http.StatusAccepted, gin.H{"ok": "accepted"})
-	}
-
-	ingestReqSpan.End()
-
 	batch := IngestBatch{
 		BatchID:  eventReq.id.String(),
 		AppID:    eventReq.appId.String(),
@@ -1038,13 +1031,35 @@ func PutEvents(c *gin.Context) {
 
 	payload, err := json.Marshal(batch)
 	if err != nil {
-		fmt.Println("failed to marshal ingest batch for publish:", err)
+		msg := "failed to marshal ingest batch for publish"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return
 	}
 
+	// publish before responding, a failure after the response would silently
+	// drop the batch while the SDK deletes its copy. Detached from the request
+	// context so a client disconnect does not abort a publish about to land.
 	if err := server.Server.BusProducer.Publish(context.Background(), payload); err != nil {
-		fmt.Println("failed to publish ingest batch:", err)
-	} else {
-		ingestBatchPublishCount.Add(c.Request.Context(), 1)
+		msg := "failed to publish ingest batch"
+		fmt.Println(msg, err)
+		if bus.IsOversized(err) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "batch too large to publish"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
 	}
+
+	ingestBatchPublishCount.Add(c.Request.Context(), 1)
+
+	if eventReq.json {
+		c.JSON(http.StatusOK, IngestResponse{
+			AttachmentUploadInfo: eventReq.attachmentUploadInfos,
+		})
+	} else {
+		c.JSON(http.StatusAccepted, gin.H{"ok": "accepted"})
+	}
+
+	ingestReqSpan.End()
 }

--- a/backend/ingest/measure/event.go
+++ b/backend/ingest/measure/event.go
@@ -34,7 +34,7 @@ import (
 // size of event request in bytes. Kept under the bus
 // per-message cap of 10,000,000 bytes to leave headroom
 // for the IngestBatch wrapper & JSON re-encoding.
-var maxBatchSize = 9_900_000
+var maxBatchSize = 9_000_000
 
 var ingestBatchPublishCount metric.Int64Counter
 

--- a/backend/ingest/server/server.go
+++ b/backend/ingest/server/server.go
@@ -357,7 +357,12 @@ func Init(config *ServerConfig) {
 
 	var busProducer bus.Producer
 	if config.CloudEnv {
-		p, err := bus.NewPubSubProducer(ctx, "ingest-batch", bus.WithPubSubPublishSettings(pubsub.PublishSettings{EnableCompression: true}))
+		p, err := bus.NewPubSubProducer(ctx, "ingest-batch", bus.WithPubSubPublishSettings(func(s *pubsub.PublishSettings) {
+			s.EnableCompression = true
+			// one message per request & the handler blocks on it, so bundling
+			// only adds DelayThreshold to the request. Flush on every add.
+			s.CountThreshold = 1
+		}))
 		if err != nil {
 			log.Printf("failed to create Pub/Sub producer: %v\n", err)
 		} else {

--- a/backend/libs/bus/bus.go
+++ b/backend/libs/bus/bus.go
@@ -2,10 +2,12 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"cloud.google.com/go/pubsub/v2"
 	iggcon "github.com/apache/iggy/foreign/go/contracts"
+	ierror "github.com/apache/iggy/foreign/go/errors"
 )
 
 // DefaultStreamName is the global stream for all message streaming operations.
@@ -27,6 +29,16 @@ type Producer interface {
 	Close() error
 }
 
+// IsOversized reports whether a Publish error means the payload exceeded the
+// backend per-message limit. Permanent, the same payload always fails, so
+// callers should reject it rather than retry. Both backends cap at 10,000,000
+// bytes but report it with their own error, so the taxonomy lives here rather
+// than leaking a transport sentinel into callers.
+func IsOversized(err error) bool {
+	return errors.Is(err, pubsub.ErrOversizedMessage) ||
+		errors.Is(err, ierror.ErrTooBigMessagePayload)
+}
+
 // Consumer receives messages from a topic/stream.
 type Consumer interface {
 	// Listen blocks until ctx is cancelled or a fatal error occurs.
@@ -43,9 +55,9 @@ type PubSubOption func(*pubSubConfig)
 type pubSubConfig struct {
 	// projectID is the GCP project ID. Empty means auto-detect from the metadata server.
 	projectID string
-	// publishSettings configures publish behaviour (producer-only).
-	// If nil, the publisher's default settings are used.
-	publishSettings *pubsub.PublishSettings
+	// publishSettings mutates publish behaviour (producer-only).
+	// If nil, pubsub.DefaultPublishSettings is used unchanged.
+	publishSettings func(*pubsub.PublishSettings)
 	// receiveSettings configures receive behaviour (consumer-only).
 	// If nil, the subscriber's default settings are used.
 	receiveSettings *pubsub.ReceiveSettings
@@ -68,11 +80,13 @@ func WithPubSubReceiveSettings(s pubsub.ReceiveSettings) PubSubOption {
 	}
 }
 
-// WithPublishSettings sets the PublishSettings for the Pub/Sub producer.
-// If not provided, pubsub.DefaultPublishSettings is used.
-func WithPubSubPublishSettings(s pubsub.PublishSettings) PubSubOption {
+// WithPubSubPublishSettings mutates pubsub.DefaultPublishSettings for the
+// producer. It takes a mutator rather than a struct because a struct literal
+// cannot express "leave this field alone", so every field the caller omitted
+// would silently be zeroed.
+func WithPubSubPublishSettings(fn func(*pubsub.PublishSettings)) PubSubOption {
 	return func(c *pubSubConfig) {
-		c.publishSettings = &s
+		c.publishSettings = fn
 	}
 }
 

--- a/backend/libs/bus/bus_test.go
+++ b/backend/libs/bus/bus_test.go
@@ -301,13 +301,23 @@ func TestWithPubSubReceiveSettings(t *testing.T) {
 
 func TestWithPubSubPublishSettings(t *testing.T) {
 	cfg := &pubSubConfig{}
-	WithPubSubPublishSettings(pubsub.PublishSettings{CountThreshold: 25})(cfg)
+	WithPubSubPublishSettings(func(s *pubsub.PublishSettings) {
+		s.CountThreshold = 25
+	})(cfg)
 
 	if cfg.publishSettings == nil {
 		t.Fatal("publishSettings is nil, want non-nil")
 	}
-	if cfg.publishSettings.CountThreshold != 25 {
-		t.Errorf("CountThreshold = %d, want 25", cfg.publishSettings.CountThreshold)
+
+	settings := pubsub.DefaultPublishSettings
+	cfg.publishSettings(&settings)
+
+	if settings.CountThreshold != 25 {
+		t.Errorf("CountThreshold = %d, want 25", settings.CountThreshold)
+	}
+	// fields the caller left alone keep their defaults rather than zeroing.
+	if settings.Timeout != pubsub.DefaultPublishSettings.Timeout {
+		t.Errorf("Timeout = %v, want %v", settings.Timeout, pubsub.DefaultPublishSettings.Timeout)
 	}
 }
 

--- a/backend/libs/bus/oversized_test.go
+++ b/backend/libs/bus/oversized_test.go
@@ -1,0 +1,45 @@
+package bus
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/pubsub/v2"
+	ierror "github.com/apache/iggy/foreign/go/errors"
+)
+
+func TestIsOversized(t *testing.T) {
+	// each case mirrors the wrap the matching producer applies. If a producer
+	// ever stops using %w, oversized batches stop being classified & callers
+	// retry a payload that can never succeed.
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "pubsub oversized",
+			err:  fmt.Errorf("bus: pubsub publish failed: %w", pubsub.ErrOversizedMessage),
+			want: true,
+		},
+		{
+			name: "iggy oversized",
+			err:  fmt.Errorf("bus: failed to create Iggy message: %w", ierror.ErrTooBigMessagePayload),
+			want: true,
+		},
+		{
+			name: "transient",
+			err:  errors.New("context deadline exceeded"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsOversized(test.err); got != test.want {
+				t.Errorf("IsOversized() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/backend/libs/bus/pubsub_producer.go
+++ b/backend/libs/bus/pubsub_producer.go
@@ -43,9 +43,12 @@ func NewPubSubProducer(ctx context.Context, topic string, opts ...PubSubOption) 
 	topicName := fmt.Sprintf("projects/%s/topics/%s", projectID, topic)
 	publisher := client.Publisher(topicName)
 
+	settings := pubsub.DefaultPublishSettings
 	if cfg.publishSettings != nil {
-		publisher.PublishSettings = *cfg.publishSettings
+		cfg.publishSettings(&settings)
 	}
+	publisher.PublishSettings = settings
+
 	// The client rejects keyed messages (PublishOrdered) unless ordering is
 	// enabled up front; keyless publishes are unaffected by the flag, so it
 	// is always on rather than another option.

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -60,8 +60,7 @@ paths:
 
         Usage notes:
 
-        - Maximum size of one request must not exceed **10 MiB**. This limit includes
-          the combination of events and blob data.
+        - Maximum size of one request must not exceed **9 MB**. The limit includes the combination of events and blob data.
         - Each request must contain a unique UUIDv4 id, set as the header `msr-req-id`.
           If a request fails, the client must retry the same payload with the same
           `msr-req-id` to ensure idempotency.
@@ -1730,8 +1729,8 @@ paths:
                     ok: accepted, known event request
         "400":
           description: >
-            Request body is malformed or does not meet one or more acceptance
-            criteria. Check the `error` field for more details.
+            Request body is malformed or does not meet one or more acceptance criteria. Check the `error` field for more
+            details.
           content:
             application/json:
               schema:

--- a/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
@@ -28,7 +28,7 @@ final class BaseExporter: Exporter {
     private let isExporting = AtomicBool(false)
     private let systemFileManager: SystemFileManager
     private var backgroundTaskId: UIBackgroundTaskIdentifier = .invalid
-    private static let maxBatchPayloadSizeBytes = 10 * 1024 * 1024
+    private static let maxBatchPayloadSizeBytes = 9_000_000
     private static let estimatedEventSizeBytes = 1024
 
     init(

--- a/ios/Tests/MeasureSDKTests/Exporter/ExporterTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/ExporterTests.swift
@@ -427,12 +427,12 @@ final class BaseExporterTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
 
-    func testPayloadLimitOf10MBSplitsBatchWhenConfigLimitIsLarger() {
-        // payload limit: 10 MB / 1 KB = 10_240 events per batch
+    func testPayloadLimitSplitsBatchWhenConfigLimitIsLarger() {
+        // payload limit: 9 MB / 1 KB = 8_789 events per batch
         config.maxEventsInBatch = 20_000
         network.executeResponse = .success(body: nil, eTag: nil)
 
-        for i in 0..<10_241 {
+        for i in 0..<8_790 {
             eventStore.insertEvent(event: makeEvent(id: "e\(i)", sessionId: "s1"))
         }
 
@@ -442,7 +442,7 @@ final class BaseExporterTests: XCTestCase {
 
         DispatchQueue.main.async {
             XCTAssertEqual(self.network.executedEventCounts.count, 2)
-            XCTAssertEqual(self.network.executedEventCounts[0], 10_240)
+            XCTAssertEqual(self.network.executedEventCounts[0], 8_789)
             XCTAssertEqual(self.network.executedEventCounts[1], 1)
             exp.fulfill()
         }
@@ -451,7 +451,7 @@ final class BaseExporterTests: XCTestCase {
     }
 
     func testUsesConfigLimitWhenSmallerThanPayloadLimit() {
-        // config limit (5) < payload limit (10_240), so config wins
+        // config limit (5) < payload limit (8_789), so config wins
         config.maxEventsInBatch = 5
         network.executeResponse = .success(body: nil, eTag: nil)
 


### PR DESCRIPTION
## Summary

This PR makes the ingest response reflect what actually happened to a batch. `PutEvents` published to the bus after writing the response, so a publish failure was only logged while the SDK saw a success status & deleted its local copy. Publishing now happens first & the failure is classified: an oversized payload returns `400` so SDKs drop it, everything else returns `500` so SDKs retry. Request latency is unchanged, the handler already blocked on publish before returning. The same reasoning applies to API key validation, where a Postgres lookup failure returned `401` & made SDKs discard the batch. The server's `maxBatchSize` is lowered from 9,900,000 to 9,000,000 bytes to keep real headroom under the bus per-message cap, & the Android & iOS SDKs plus the public API docs are updated to match this 9 MB limit.

## Tasks

- [x] Publish the batch to the bus before sending the HTTP response in `PutEvents`
- [x] Return `400` on oversized payloads & `500` on other publish failures
- [x] Lower `maxBatchSize` to `9_000_000` bytes to fit under the bus per-message cap
- [x] Add `bus.IsOversized` to detect oversize errors from Pub/Sub & Iggy
- [x] Change `WithPubSubPublishSettings` to a mutator over default publish settings
- [x] Add `ErrInvalidAPIKey` so lookup failures return `500` instead of `401`
- [x] Add test coverage for oversize classification across both bus backends
- [x] Align Android `MAX_BATCH_PAYLOAD_SIZE_BYTES` & iOS `maxBatchPayloadSizeBytes` to 9 MB, matching the server limit
- [x] Update Android & iOS exporter tests for the new derived batch cap of 8,789 signals
- [x] Update the `PUT /events` OpenAPI description in `frontend/dashboard/content/openapi/sdk.yaml` from 10 MiB to 9 MB
