### PR TITLE
fix(backend): disallow crawling on public services

### DIFF
--- a/backend/agent/main.go
+++ b/backend/agent/main.go
@@ -171,6 +171,11 @@ func main() {
 		c.String(http.StatusOK, "pong")
 	})
 
+	// ask well-behaved crawlers not to fetch any route in this service
+	r.GET("/robots.txt", func(c *gin.Context) {
+		c.String(http.StatusOK, "User-agent: *\nDisallow: /\n")
+	})
+
 	// Attachment URLs in tool results point at this service's origin only
 	// outside cloud; in cloud PreSignURL returns direct GCS signed URLs, so
 	// the read proxy is registered for self-host only.

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -79,6 +79,11 @@ func main() {
 		c.String(http.StatusOK, "pong")
 	})
 
+	// ask well-behaved crawlers not to fetch any route in this service
+	r.GET("/robots.txt", func(c *gin.Context) {
+		c.String(http.StatusOK, "User-agent: *\nDisallow: /\n")
+	})
+
 	// SDK routes
 	r.PUT("/events", hdl.ValidateAPIKey(), hdl.PutEvents)
 	r.PUT("/builds", hdl.ValidateAPIKey(), hdl.PutBuilds)

--- a/backend/ingest/main.go
+++ b/backend/ingest/main.go
@@ -58,6 +58,11 @@ func main() {
 		c.String(http.StatusOK, "pong")
 	})
 
+	// ask well-behaved crawlers not to fetch any route in this service
+	r.GET("/robots.txt", func(c *gin.Context) {
+		c.String(http.StatusOK, "User-agent: *\nDisallow: /\n")
+	})
+
 	// SDK routes
 	r.PUT("/events", measure.ValidateAPIKey(), measure.PutEvents)
 	r.PUT("/builds", measure.ValidateAPIKey(), measure.PutBuilds)


### PR DESCRIPTION
## Summary

This PR adds a `GET /robots.txt` route to the `api`, `ingest` & `agent` services, disallowing all crawling. These services previously returned 404 for `/robots.txt`, which crawlers treat as no restrictions, causing them to repeatedly hit authenticated routes with no valid case for indexing.

## Tasks

- [x] Add unauthenticated `/robots.txt` route next to `/ping` in `api`
- [x] Add unauthenticated `/robots.txt` route next to `/ping` in `ingest`
- [x] Add unauthenticated `/robots.txt` route next to `/ping` in `agent`

## See also

- fixes #4249
