### PR TITLE
fix(frontend): disallow crawling on non-canonical deployments

### DIFF
--- a/frontend/dashboard/__tests__/app/robots_test.ts
+++ b/frontend/dashboard/__tests__/app/robots_test.ts
@@ -1,0 +1,53 @@
+import { afterAll, describe, expect, it, jest } from "@jest/globals";
+import type { MetadataRoute } from "next";
+
+const ORIGINAL = process.env.NEXT_PUBLIC_SITE_URL;
+
+async function robotsFor(siteUrl?: string): Promise<MetadataRoute.Robots> {
+  jest.resetModules();
+  if (siteUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SITE_URL = siteUrl;
+  }
+  const robots = (await import("@/app/robots")).default;
+  return robots();
+}
+
+afterAll(() => {
+  process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL;
+});
+
+describe("robots", () => {
+  it("allows crawling and advertises a sitemap on the canonical site", async () => {
+    const r = await robotsFor("https://measure.sh");
+    const rule = Array.isArray(r.rules) ? r.rules[0] : r.rules;
+
+    expect(rule.allow).toBe("/");
+    expect(rule.disallow).toContain("/auth/");
+    expect(rule.disallow).toContain("/api/");
+    expect(rule.disallow).toContain("/yrtmlt/");
+    expect(r.sitemap).toBe("https://measure.sh/sitemap.xml");
+    expect(r.host).toBe("https://measure.sh");
+  });
+
+  it("disallows all crawling on non-canonical hosts", async () => {
+    const r = await robotsFor("https://staging.measure.sh");
+    const rule = Array.isArray(r.rules) ? r.rules[0] : r.rules;
+
+    expect(rule.disallow).toBe("/");
+    expect(rule.allow).toBeUndefined();
+    expect(r.sitemap).toBeUndefined();
+    expect(r.host).toBeUndefined();
+  });
+
+  it("disallows all crawling when NEXT_PUBLIC_SITE_URL is unset", async () => {
+    const r = await robotsFor(undefined);
+    const rule = Array.isArray(r.rules) ? r.rules[0] : r.rules;
+
+    expect(rule.disallow).toBe("/");
+    expect(rule.allow).toBeUndefined();
+    expect(r.sitemap).toBeUndefined();
+    expect(r.host).toBeUndefined();
+  });
+});

--- a/frontend/dashboard/app/robots.ts
+++ b/frontend/dashboard/app/robots.ts
@@ -1,6 +1,21 @@
 import type { MetadataRoute } from "next";
 
+const CANONICAL_URL = "https://measure.sh";
+const isCanonical = process.env.NEXT_PUBLIC_SITE_URL === CANONICAL_URL;
+
 export default function robots(): MetadataRoute.Robots {
+  // Staging, self-host & local builds stay out of search entirely.
+  if (!isCanonical) {
+    return {
+      rules: [
+        {
+          userAgent: "*",
+          disallow: "/",
+        },
+      ],
+    };
+  }
+
   return {
     rules: [
       {
@@ -9,7 +24,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/auth/", "/api/", "/yrtmlt/"],
       },
     ],
-    sitemap: "https://measure.sh/sitemap.xml",
-    host: "https://measure.sh",
+    sitemap: `${CANONICAL_URL}/sitemap.xml`,
+    host: CANONICAL_URL,
   };
 }


### PR DESCRIPTION
## Summary

This PR gates `robots.ts` on the canonical site host so non-canonical deployments & self-hosted installs stop advertising themselves for crawling. Previously the sitemap URL, host & an unconditional `allow: "/"` were hardcoded to production, so every deployment served the production robots.txt. Non-canonical or unset `NEXT_PUBLIC_SITE_URL` now serves `Disallow: /` with no sitemap or host, matching how `generate_sitemap.js` already behaves.

## Tasks

- [x] Gate `robots.ts` on `NEXT_PUBLIC_SITE_URL` matching the canonical host
- [x] Serve `Disallow: /` with no sitemap/host when not canonical or unset
- [x] Add tests covering canonical, non-canonical & unset cases

## See also

- fixes #4251
