### PR TITLE
chore(backend): update daily summary email & slack message

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
+	"strconv"
 	"time"
 
 	"backend/alerts/server"
 	"backend/alerts/slack"
 	"backend/libs/autumn"
 	"backend/libs/email"
+	"backend/libs/numeric"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -44,38 +47,26 @@ const (
 )
 
 type DailySummaryRow struct {
-	AppID                uuid.UUID
-	Date                 time.Time
-	SessionsValue        string
-	SessionsLabel        string
-	SessionsSubtitle     string
-	SessionsHasWarning   bool
-	SessionsHasError     bool
-	CrashFreeValue       string
-	CrashFreeLabel       string
-	CrashFreeSubtitle    string
-	CrashFreeHasWarning  bool
-	CrashFreeHasError    bool
-	ANRFreeValue         string
-	ANRFreeLabel         string
-	ANRFreeSubtitle      string
-	ANRFreeHasWarning    bool
-	ANRFreeHasError      bool
-	ColdLaunchValue      string
-	ColdLaunchLabel      string
-	ColdLaunchSubtitle   string
-	ColdLaunchHasWarning bool
-	ColdLaunchHasError   bool
-	WarmLaunchValue      string
-	WarmLaunchLabel      string
-	WarmLaunchSubtitle   string
-	WarmLaunchHasWarning bool
-	WarmLaunchHasError   bool
-	HotLaunchValue       string
-	HotLaunchLabel       string
-	HotLaunchSubtitle    string
-	HotLaunchHasWarning  bool
-	HotLaunchHasError    bool
+	AppID uuid.UUID
+	Date  time.Time
+
+	SessionsToday     uint64
+	SessionsYesterday uint64
+
+	CrashSessionsToday     uint64
+	CrashSessionsYesterday uint64
+
+	ANRSessionsToday     uint64
+	ANRSessionsYesterday uint64
+
+	ColdLaunchTodayMs     float64
+	ColdLaunchYesterdayMs float64
+
+	WarmLaunchTodayMs     float64
+	WarmLaunchYesterdayMs float64
+
+	HotLaunchTodayMs     float64
+	HotLaunchYesterdayMs float64
 }
 
 const errorSpikeTimePeriod = time.Hour
@@ -400,6 +391,60 @@ func getAppNameByID(ctx context.Context, appID uuid.UUID) (string, error) {
 	return appName, nil
 }
 
+// formatUnit rounds a measured value to two decimal places, drops trailing
+// zeros, and appends the unit, so a rate reads as 99.5% and a duration as
+// 892.35ms.
+func formatUnit(x float64, unit string) string {
+	return strconv.FormatFloat(math.Round(x*100)/100, 'f', -1, 64) + unit
+}
+
+// freeRate returns the share of sessions that saw no crash (or no ANR) as a
+// percentage. affected must not exceed total.
+func freeRate(total, affected uint64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(total-affected) * 100.0 / float64(total)
+}
+
+// comparison renders the line printed under a metric value, specifying yesterday's
+// figure. Callers pass both days already formatted, so a change too small to survive
+// rounding reads as no change rather than pairing "Up from" with a number identical
+// to the one on the card above it.
+func comparison(todayText, yesterdayText string, up bool) string {
+	if todayText == yesterdayText {
+		return "No change from yesterday"
+	}
+	if up {
+		return fmt.Sprintf("Up from %s yesterday", yesterdayText)
+	}
+	return fmt.Sprintf("Down from %s yesterday", yesterdayText)
+}
+
+// launchMetric builds one of the three launch cards. A day with no launch
+// events of that kind leaves the merged quantile as NaN, which is an absent
+// measurement, so the card says "No Data" and just writes yesterday's
+// duration without "Up" or "Down"
+func launchMetric(label string, todayMs, yesterdayMs float64) email.MetricData {
+	hasYesterday := !math.IsNaN(yesterdayMs) && yesterdayMs != 0
+
+	if math.IsNaN(todayMs) || todayMs == 0 {
+		subtitle := "No previous day data"
+		if hasYesterday {
+			subtitle = fmt.Sprintf("Was %s yesterday", formatUnit(yesterdayMs, "ms"))
+		}
+		return email.MetricData{Value: "No Data", Label: label, Subtitle: subtitle}
+	}
+
+	value := formatUnit(todayMs, "ms")
+	subtitle := "No previous day data"
+	if hasYesterday {
+		subtitle = comparison(value, formatUnit(yesterdayMs, "ms"), todayMs > yesterdayMs)
+	}
+
+	return email.MetricData{Value: value, Label: label, Subtitle: subtitle}
+}
+
 func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]email.MetricData, error) {
 	appThresholdPrefs, err := getAppThresholdPrefs(ctx, app.ID)
 	if err != nil {
@@ -420,9 +465,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
                     toDate(timestamp) AS date,
                     uniqMerge(unique_sessions) AS total_sessions,
                     uniqMerge(crash_sessions) AS crash_sessions,
-                    uniqMerge(perceived_crash_sessions) AS perceived_crash_sessions,
                     uniqMerge(anr_sessions) AS anr_sessions,
-                    uniqMerge(perceived_anr_sessions) AS perceived_anr_sessions,
                     quantileMerge(0.95)(cold_launch_p95) AS cold_launch_p95_ms,
                     quantileMerge(0.95)(warm_launch_p95) AS warm_launch_p95_ms,
                     quantileMerge(0.95)(hot_launch_p95) AS hot_launch_p95_ms
@@ -445,210 +488,111 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
             cd.app_id,
             cd.date,
 
-            -- Sessions
-            toString(cd.total_sessions) AS sessions_value,
-            'Sessions' AS sessions_label,
-            CASE
-                WHEN pd.total_sessions IS NULL OR pd.total_sessions = 0 THEN 'No previous day data'
-                WHEN cd.total_sessions > pd.total_sessions THEN concat(toString(cd.total_sessions - pd.total_sessions), ' greater than yesterday')
-                WHEN cd.total_sessions < pd.total_sessions THEN concat(toString(pd.total_sessions - cd.total_sessions), ' less than yesterday')
-                ELSE 'No change from yesterday'
-            END AS sessions_subtitle,
-            0 AS sessions_has_warning,
-            0 AS sessions_has_error,
+            cd.total_sessions,
+            pd.total_sessions,
 
-            -- Crash-free sessions
-            CASE
-                WHEN cd.total_sessions = 0 THEN '0%'
-                ELSE concat(toString(round((cd.total_sessions - cd.crash_sessions) * 100.0 / cd.total_sessions, 2)), '%')
-            END AS crash_free_value,
-            'Crash free sessions' AS crash_free_label,
-            CASE
-                WHEN pd.total_sessions = 0 OR pd.total_sessions IS NULL THEN 'No previous day data'
-                WHEN (cd.crash_sessions * 1.0 / nullIf(cd.total_sessions, 0)) < (pd.crash_sessions * 1.0 / nullIf(pd.total_sessions, 0)) THEN concat(toString(if(isNaN(round(
-                    ((cd.total_sessions - cd.crash_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.crash_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2)), 0, round(
-                    ((cd.total_sessions - cd.crash_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.crash_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2))), 'x better than yesterday')
-                WHEN (cd.crash_sessions * 1.0 / nullIf(cd.total_sessions, 0)) > (pd.crash_sessions * 1.0 / nullIf(pd.total_sessions, 0)) THEN concat(toString(if(isNaN(round(
-                    ((cd.total_sessions - cd.crash_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.crash_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2)), 0, round(
-                    ((cd.total_sessions - cd.crash_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.crash_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2))), 'x worse than yesterday')
-                ELSE 'No change from yesterday'
-            END AS crash_free_subtitle,
-            (cd.total_sessions != 0 AND (cd.total_sessions - cd.crash_sessions) * 100.0 / cd.total_sessions <= ?) AS crash_free_has_warning,
-            (cd.total_sessions != 0 AND (cd.total_sessions - cd.crash_sessions) * 100.0 / cd.total_sessions <= ?) AS crash_free_has_error,
+            cd.crash_sessions,
+            pd.crash_sessions,
 
-            -- ANR-free sessions
-            CASE
-                WHEN cd.total_sessions = 0 THEN '0%'
-                ELSE concat(toString(round((cd.total_sessions - cd.anr_sessions) * 100.0 / cd.total_sessions, 2)), '%')
-            END AS anr_free_value,
-            'ANR free sessions' AS anr_free_label,
-            CASE
-                WHEN pd.total_sessions = 0 OR pd.total_sessions IS NULL THEN 'No previous day data'
-                WHEN (cd.anr_sessions * 1.0 / nullIf(cd.total_sessions, 0)) < (pd.anr_sessions * 1.0 / nullIf(pd.total_sessions, 0)) THEN concat(toString(if(isNaN(round(
-                    ((cd.total_sessions - cd.anr_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.anr_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2)), 0, round(
-                    ((cd.total_sessions - cd.anr_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.anr_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2))), 'x better than yesterday')
-                WHEN (cd.anr_sessions * 1.0 / nullIf(cd.total_sessions, 0)) > (pd.anr_sessions * 1.0 / nullIf(pd.total_sessions, 0)) THEN concat(toString(if(isNaN(round(
-                    ((cd.total_sessions - cd.anr_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.anr_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2)), 0, round(
-                    ((cd.total_sessions - cd.anr_sessions) * 1.0 / nullIf(cd.total_sessions, 0)) /
-                    nullIf((pd.total_sessions - pd.anr_sessions) * 1.0 / nullIf(pd.total_sessions, 0), 0), 2))), 'x worse than yesterday')
-                ELSE 'No change from yesterday'
-            END AS anr_free_subtitle,
-            (cd.total_sessions != 0 AND (cd.total_sessions - cd.anr_sessions) * 100.0 / cd.total_sessions <= ?) AS anr_free_has_warning,
-            (cd.total_sessions != 0 AND (cd.total_sessions - cd.anr_sessions) * 100.0 / cd.total_sessions <= ?) AS anr_free_has_error,
+            cd.anr_sessions,
+            pd.anr_sessions,
 
-            -- Cold Launch
-            CASE
-                WHEN isNaN(cd.cold_launch_p95_ms) OR cd.cold_launch_p95_ms = 0 THEN '0ms'
-                ELSE concat(toString(round(cd.cold_launch_p95_ms, 2)), 'ms')
-            END AS cold_launch_value,
-            'Cold launch time' AS cold_launch_label,
-            CASE
-                WHEN pd.cold_launch_p95_ms IS NULL OR pd.cold_launch_p95_ms = 0 THEN 'No previous day data'
-                WHEN cd.cold_launch_p95_ms < pd.cold_launch_p95_ms THEN concat(toString(round(cd.cold_launch_p95_ms / pd.cold_launch_p95_ms, 2)), 'x better than yesterday')
-                WHEN cd.cold_launch_p95_ms > pd.cold_launch_p95_ms THEN concat(toString(round(cd.cold_launch_p95_ms / pd.cold_launch_p95_ms, 2)), 'x worse than yesterday')
-                ELSE 'No change from yesterday'
-            END AS cold_launch_subtitle,
-            0 AS cold_launch_has_warning,
-            0 AS cold_launch_has_error,
+            cd.cold_launch_p95_ms,
+            pd.cold_launch_p95_ms,
 
-            -- Warm Launch
-            CASE
-                WHEN isNaN(cd.warm_launch_p95_ms) OR cd.warm_launch_p95_ms = 0 THEN '0ms'
-                ELSE concat(toString(round(cd.warm_launch_p95_ms, 2)), 'ms')
-            END AS warm_launch_value,
-            'Warm launch time' AS warm_launch_label,
-            CASE
-                WHEN pd.warm_launch_p95_ms IS NULL OR pd.warm_launch_p95_ms = 0 THEN 'No previous day data'
-                WHEN cd.warm_launch_p95_ms < pd.warm_launch_p95_ms THEN concat(toString(round(cd.warm_launch_p95_ms / pd.warm_launch_p95_ms, 2)), 'x better than yesterday')
-                WHEN cd.warm_launch_p95_ms > pd.warm_launch_p95_ms THEN concat(toString(round(cd.warm_launch_p95_ms / pd.warm_launch_p95_ms, 2)), 'x worse than yesterday')
-                ELSE 'No change from yesterday'
-            END AS warm_launch_subtitle,
-            0 AS warm_launch_has_warning,
-            0 AS warm_launch_has_error,
+            cd.warm_launch_p95_ms,
+            pd.warm_launch_p95_ms,
 
-            -- Hot Launch
-            CASE
-                WHEN isNaN(cd.hot_launch_p95_ms) OR cd.hot_launch_p95_ms = 0 THEN '0ms'
-                ELSE concat(toString(round(cd.hot_launch_p95_ms, 2)), 'ms')
-            END AS hot_launch_value,
-            'Hot launch time' AS hot_launch_label,
-            CASE
-                WHEN pd.hot_launch_p95_ms IS NULL OR pd.hot_launch_p95_ms = 0 THEN 'No previous day data'
-                WHEN cd.hot_launch_p95_ms < pd.hot_launch_p95_ms THEN concat(toString(round(cd.hot_launch_p95_ms / pd.hot_launch_p95_ms, 2)), 'x better than yesterday')
-                WHEN cd.hot_launch_p95_ms > pd.hot_launch_p95_ms THEN concat(toString(round(cd.hot_launch_p95_ms / pd.hot_launch_p95_ms, 2)), 'x worse than yesterday')
-                ELSE 'No change from yesterday'
-            END AS hot_launch_subtitle,
-            0 AS hot_launch_has_warning,
-            0 AS hot_launch_has_error
-
+            cd.hot_launch_p95_ms,
+            pd.hot_launch_p95_ms
 
         FROM current_day cd
         LEFT JOIN previous_day pd ON cd.app_id = pd.app_id
         ORDER BY cd.app_id
 	`
-	row := server.Server.ChPool.QueryRow(
-		ctx,
-		query,
-		date,
-		app.TeamID,
-		app.ID,
-		appThresholdPrefs.ErrorGoodThreshold,
-		appThresholdPrefs.ErrorCautionThreshold,
-		appThresholdPrefs.ErrorGoodThreshold,
-		appThresholdPrefs.ErrorCautionThreshold,
-	)
+	row := server.Server.ChPool.QueryRow(ctx, query, date, app.TeamID, app.ID)
 
 	var summary DailySummaryRow
 	err = row.Scan(
 		&summary.AppID,
 		&summary.Date,
-		&summary.SessionsValue,
-		&summary.SessionsLabel,
-		&summary.SessionsSubtitle,
-		&summary.SessionsHasWarning,
-		&summary.SessionsHasError,
-		&summary.CrashFreeValue,
-		&summary.CrashFreeLabel,
-		&summary.CrashFreeSubtitle,
-		&summary.CrashFreeHasWarning,
-		&summary.CrashFreeHasError,
-		&summary.ANRFreeValue,
-		&summary.ANRFreeLabel,
-		&summary.ANRFreeSubtitle,
-		&summary.ANRFreeHasWarning,
-		&summary.ANRFreeHasError,
-		&summary.ColdLaunchValue,
-		&summary.ColdLaunchLabel,
-		&summary.ColdLaunchSubtitle,
-		&summary.ColdLaunchHasWarning,
-		&summary.ColdLaunchHasError,
-		&summary.WarmLaunchValue,
-		&summary.WarmLaunchLabel,
-		&summary.WarmLaunchSubtitle,
-		&summary.WarmLaunchHasWarning,
-		&summary.WarmLaunchHasError,
-		&summary.HotLaunchValue,
-		&summary.HotLaunchLabel,
-		&summary.HotLaunchSubtitle,
-		&summary.HotLaunchHasWarning,
-		&summary.HotLaunchHasError,
+		&summary.SessionsToday,
+		&summary.SessionsYesterday,
+		&summary.CrashSessionsToday,
+		&summary.CrashSessionsYesterday,
+		&summary.ANRSessionsToday,
+		&summary.ANRSessionsYesterday,
+		&summary.ColdLaunchTodayMs,
+		&summary.ColdLaunchYesterdayMs,
+		&summary.WarmLaunchTodayMs,
+		&summary.WarmLaunchYesterdayMs,
+		&summary.HotLaunchTodayMs,
+		&summary.HotLaunchYesterdayMs,
 	)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan daily summary: %w", err)
 	}
 
+	// A previous day with no sessions at all is what a missing row from the
+	// LEFT JOIN looks like, so the session-based cards have nothing to compare
+	// against.
+	hasYesterday := summary.SessionsYesterday > 0
+
+	sessionsValue := numeric.FormatKMB(int64(summary.SessionsToday))
+	sessionsSubtitle := "No previous day data"
+	if hasYesterday {
+		sessionsSubtitle = comparison(sessionsValue, numeric.FormatKMB(int64(summary.SessionsYesterday)), summary.SessionsToday > summary.SessionsYesterday)
+	}
+
+	crashFreeToday := freeRate(summary.SessionsToday, summary.CrashSessionsToday)
+	crashFreeValue := formatUnit(crashFreeToday, "%")
+	crashFreeSubtitle := "No previous day data"
+	if hasYesterday {
+		crashFreeYesterday := freeRate(summary.SessionsYesterday, summary.CrashSessionsYesterday)
+		crashFreeSubtitle = comparison(crashFreeValue, formatUnit(crashFreeYesterday, "%"), crashFreeToday > crashFreeYesterday)
+	}
+
 	metrics := []email.MetricData{
 		{
-			Value:      summary.SessionsValue,
-			Label:      summary.SessionsLabel,
-			HasWarning: summary.SessionsHasWarning,
-			HasError:   summary.SessionsHasError,
-			Subtitle:   summary.SessionsSubtitle,
+			Value:    sessionsValue,
+			Label:    "Sessions",
+			Subtitle: sessionsSubtitle,
 		},
 		{
-			Value:      summary.CrashFreeValue,
-			Label:      summary.CrashFreeLabel,
-			HasWarning: summary.CrashFreeHasWarning,
-			HasError:   summary.CrashFreeHasError,
-			Subtitle:   summary.CrashFreeSubtitle,
-		},
-		{
-			Value:      summary.ANRFreeValue,
-			Label:      summary.ANRFreeLabel,
-			HasWarning: summary.ANRFreeHasWarning,
-			HasError:   summary.ANRFreeHasError,
-			Subtitle:   summary.ANRFreeSubtitle,
-		},
-		{
-			Value:      summary.ColdLaunchValue,
-			Label:      summary.ColdLaunchLabel,
-			HasWarning: summary.ColdLaunchHasWarning,
-			HasError:   summary.ColdLaunchHasError,
-			Subtitle:   summary.ColdLaunchSubtitle,
-		},
-		{
-			Value:      summary.WarmLaunchValue,
-			Label:      summary.WarmLaunchLabel,
-			HasWarning: summary.WarmLaunchHasWarning,
-			HasError:   summary.WarmLaunchHasError,
-			Subtitle:   summary.WarmLaunchSubtitle,
-		},
-		{
-			Value:      summary.HotLaunchValue,
-			Label:      summary.HotLaunchLabel,
-			HasWarning: summary.HotLaunchHasWarning,
-			HasError:   summary.HotLaunchHasError,
-			Subtitle:   summary.HotLaunchSubtitle,
+			Value:      crashFreeValue,
+			Label:      "Crash free sessions",
+			Subtitle:   crashFreeSubtitle,
+			HasWarning: summary.SessionsToday != 0 && crashFreeToday <= appThresholdPrefs.ErrorGoodThreshold,
+			HasError:   summary.SessionsToday != 0 && crashFreeToday <= appThresholdPrefs.ErrorCautionThreshold,
 		},
 	}
+
+	// ANR card is only shown if once an ANR has
+	// been recorded on either day to prevent permanent ANR card with no data in iOS.
+	if summary.ANRSessionsToday > 0 || summary.ANRSessionsYesterday > 0 {
+		anrFreeToday := freeRate(summary.SessionsToday, summary.ANRSessionsToday)
+		anrFreeValue := formatUnit(anrFreeToday, "%")
+		anrFreeSubtitle := "No previous day data"
+		if hasYesterday {
+			anrFreeYesterday := freeRate(summary.SessionsYesterday, summary.ANRSessionsYesterday)
+			anrFreeSubtitle = comparison(anrFreeValue, formatUnit(anrFreeYesterday, "%"), anrFreeToday > anrFreeYesterday)
+		}
+
+		metrics = append(metrics, email.MetricData{
+			Value:      anrFreeValue,
+			Label:      "ANR free sessions",
+			Subtitle:   anrFreeSubtitle,
+			HasWarning: summary.SessionsToday != 0 && anrFreeToday <= appThresholdPrefs.ErrorGoodThreshold,
+			HasError:   summary.SessionsToday != 0 && anrFreeToday <= appThresholdPrefs.ErrorCautionThreshold,
+		})
+	}
+
+	metrics = append(metrics,
+		launchMetric("Cold launch p95", summary.ColdLaunchTodayMs, summary.ColdLaunchYesterdayMs),
+		launchMetric("Warm launch p95", summary.WarmLaunchTodayMs, summary.WarmLaunchYesterdayMs),
+		launchMetric("Hot launch p95", summary.HotLaunchTodayMs, summary.HotLaunchYesterdayMs),
+	)
 
 	bugReportCountQuery := `
 		WITH toDate(?) AS target_date
@@ -666,19 +610,13 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
 		return nil, fmt.Errorf("failed to scan bug report count: %w", err)
 	}
 	if todayBugReportCount > 0 {
+		bugValue := numeric.FormatKMB(int64(todayBugReportCount))
 		bugSubtitle := "No previous day data"
 		if yesterdayBugReportCount > 0 {
-			switch {
-			case todayBugReportCount > yesterdayBugReportCount:
-				bugSubtitle = fmt.Sprintf("%d greater than yesterday", todayBugReportCount-yesterdayBugReportCount)
-			case todayBugReportCount < yesterdayBugReportCount:
-				bugSubtitle = fmt.Sprintf("%d less than yesterday", yesterdayBugReportCount-todayBugReportCount)
-			default:
-				bugSubtitle = "No change from yesterday"
-			}
+			bugSubtitle = comparison(bugValue, numeric.FormatKMB(int64(yesterdayBugReportCount)), todayBugReportCount > yesterdayBugReportCount)
 		}
 		metrics = append(metrics, email.MetricData{
-			Value:    fmt.Sprintf("%d", todayBugReportCount),
+			Value:    bugValue,
 			Label:    "Bug reports",
 			Subtitle: bugSubtitle,
 		})

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -890,10 +890,43 @@ func TestCreateBugReportAlerts(t *testing.T) {
 //	[0] Sessions
 //	[1] Crash-free sessions
 //	[2] ANR-free sessions
-//	[3] Cold launch time (p95)
-//	[4] Warm launch time (p95)
-//	[5] Hot launch time (p95)
+//	[3] Cold launch p95
+//	[4] Warm launch p95
+//	[5] Hot launch p95
 //	[6] Bug reports (only present when count > 0)
+//
+// card returns the summary card carrying the given label. Cards for ANR free
+// sessions and bug reports are only included on days that have something to
+// report, so a card's position in the slice is not fixed and the label is the
+// only reliable way to find it.
+func card(t *testing.T, metrics []email.MetricData, label string) email.MetricData {
+	t.Helper()
+	for _, metric := range metrics {
+		if metric.Label == label {
+			return metric
+		}
+	}
+	t.Fatalf("no card labelled %q among %v", label, cardLabels(metrics))
+	return email.MetricData{}
+}
+
+func cardLabels(metrics []email.MetricData) []string {
+	labels := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		labels = append(labels, metric.Label)
+	}
+	return labels
+}
+
+func hasCard(metrics []email.MetricData, label string) bool {
+	for _, metric := range metrics {
+		if metric.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
 func TestGetDailySummaryMetrics(t *testing.T) {
 	// makeApp builds an App value from pre-seeded string IDs.
 	makeApp := func(teamID, appID string) App {
@@ -942,16 +975,16 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[0].Value != "5" {
-			t.Errorf("sessions value: want %q, got %q", "5", metrics[0].Value)
+		if card(t, metrics, "Sessions").Value != "5" {
+			t.Errorf("sessions value: want %q, got %q", "5", card(t, metrics, "Sessions").Value)
 		}
-		if metrics[0].Label != "Sessions" {
-			t.Errorf("sessions label: want %q, got %q", "Sessions", metrics[0].Label)
+		if card(t, metrics, "Sessions").Label != "Sessions" {
+			t.Errorf("sessions label: want %q, got %q", "Sessions", card(t, metrics, "Sessions").Label)
 		}
-		if metrics[0].HasWarning {
+		if card(t, metrics, "Sessions").HasWarning {
 			t.Error("sessions should never have warning")
 		}
-		if metrics[0].HasError {
+		if card(t, metrics, "Sessions").HasError {
 			t.Error("sessions should never have error")
 		}
 	})
@@ -974,8 +1007,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[0].Subtitle != "No previous day data" {
-			t.Errorf("sessions subtitle: want %q, got %q", "No previous day data", metrics[0].Subtitle)
+		if card(t, metrics, "Sessions").Subtitle != "No previous day data" {
+			t.Errorf("sessions subtitle: want %q, got %q", "No previous day data", card(t, metrics, "Sessions").Subtitle)
 		}
 	})
 
@@ -999,8 +1032,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[0].Subtitle != "2 greater than yesterday" {
-			t.Errorf("sessions subtitle: want %q, got %q", "2 greater than yesterday", metrics[0].Subtitle)
+		if card(t, metrics, "Sessions").Subtitle != "Up from 5 yesterday" {
+			t.Errorf("sessions subtitle: want %q, got %q", "Up from 5 yesterday", card(t, metrics, "Sessions").Subtitle)
 		}
 	})
 
@@ -1024,8 +1057,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[0].Subtitle != "2 less than yesterday" {
-			t.Errorf("sessions subtitle: want %q, got %q", "2 less than yesterday", metrics[0].Subtitle)
+		if card(t, metrics, "Sessions").Subtitle != "Down from 5 yesterday" {
+			t.Errorf("sessions subtitle: want %q, got %q", "Down from 5 yesterday", card(t, metrics, "Sessions").Subtitle)
 		}
 	})
 
@@ -1049,8 +1082,36 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[0].Subtitle != "No change from yesterday" {
-			t.Errorf("sessions subtitle: want %q, got %q", "No change from yesterday", metrics[0].Subtitle)
+		if card(t, metrics, "Sessions").Subtitle != "No change from yesterday" {
+			t.Errorf("sessions subtitle: want %q, got %q", "No change from yesterday", card(t, metrics, "Sessions").Subtitle)
+		}
+	})
+
+	t.Run("sessions: counts above a thousand are abbreviated the way the dashboard abbreviates them", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.Add(-25 * time.Hour)
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 1000, 0, 0)
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2500, 0, 0)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "Sessions").Value != "2.5K" {
+			t.Errorf("sessions value: want %q, got %q", "2.5K", card(t, metrics, "Sessions").Value)
+		}
+		if card(t, metrics, "Sessions").Subtitle != "Up from 1K yesterday" {
+			t.Errorf("sessions subtitle: want %q, got %q", "Up from 1K yesterday", card(t, metrics, "Sessions").Subtitle)
 		}
 	})
 
@@ -1074,13 +1135,13 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Value != "100%" {
-			t.Errorf("crash-free value: want %q, got %q", "100%", metrics[1].Value)
+		if card(t, metrics, "Crash free sessions").Value != "100%" {
+			t.Errorf("crash-free value: want %q, got %q", "100%", card(t, metrics, "Crash free sessions").Value)
 		}
-		if metrics[1].HasWarning {
+		if card(t, metrics, "Crash free sessions").HasWarning {
 			t.Error("crash-free should have no warning at 100%")
 		}
-		if metrics[1].HasError {
+		if card(t, metrics, "Crash free sessions").HasError {
 			t.Error("crash-free should have no error at 100%")
 		}
 	})
@@ -1105,13 +1166,13 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Value != "90%" {
-			t.Errorf("crash-free value: want %q, got %q", "90%", metrics[1].Value)
+		if card(t, metrics, "Crash free sessions").Value != "90%" {
+			t.Errorf("crash-free value: want %q, got %q", "90%", card(t, metrics, "Crash free sessions").Value)
 		}
-		if !metrics[1].HasWarning {
+		if !card(t, metrics, "Crash free sessions").HasWarning {
 			t.Error("crash-free should have warning at 90%")
 		}
-		if metrics[1].HasError {
+		if card(t, metrics, "Crash free sessions").HasError {
 			t.Error("crash-free should not have error at 90%")
 		}
 	})
@@ -1136,13 +1197,13 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Value != "80%" {
-			t.Errorf("crash-free value: want %q, got %q", "80%", metrics[1].Value)
+		if card(t, metrics, "Crash free sessions").Value != "80%" {
+			t.Errorf("crash-free value: want %q, got %q", "80%", card(t, metrics, "Crash free sessions").Value)
 		}
-		if !metrics[1].HasWarning {
+		if !card(t, metrics, "Crash free sessions").HasWarning {
 			t.Error("crash-free should have warning at 80%")
 		}
-		if !metrics[1].HasError {
+		if !card(t, metrics, "Crash free sessions").HasError {
 			t.Error("crash-free should have error at 80%")
 		}
 	})
@@ -1165,8 +1226,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Subtitle != "No previous day data" {
-			t.Errorf("crash-free subtitle: want %q, got %q", "No previous day data", metrics[1].Subtitle)
+		if card(t, metrics, "Crash free sessions").Subtitle != "No previous day data" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "No previous day data", card(t, metrics, "Crash free sessions").Subtitle)
 		}
 	})
 
@@ -1184,8 +1245,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		yesterday := now.Add(-25 * time.Hour)
 		// Yesterday: 4 sessions, 2 crashes → 50% crash-free
 		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 2, 2, 0)
-		// Today: 4 sessions, 0 crashes → 100% crash-free
-		// ratio = today_rate / yesterday_rate = 1.0 / 0.5 = 2.0 → "2x better than yesterday"
+		// Today: 4 sessions, 0 crashes → crash rate 0, a 100% drop
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 4, 0, 0)
 
 		app := makeApp(teamID, appID)
@@ -1193,8 +1253,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Subtitle != "2x better than yesterday" {
-			t.Errorf("crash-free subtitle: want %q, got %q", "2x better than yesterday", metrics[1].Subtitle)
+		if card(t, metrics, "Crash free sessions").Subtitle != "Up from 50% yesterday" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "Up from 50% yesterday", card(t, metrics, "Crash free sessions").Subtitle)
 		}
 	})
 
@@ -1210,10 +1270,9 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 
 		now := time.Now().UTC()
 		yesterday := now.Add(-25 * time.Hour)
-		// Yesterday: 4 sessions, 0 crashes → 100% crash-free
-		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 4, 0, 0)
-		// Today: 4 sessions, 2 crashes → 50% crash-free
-		// ratio = today_rate / yesterday_rate = 0.5 / 1.0 = 0.5 → "0.5x worse than yesterday"
+		// Yesterday: 4 sessions, 1 crash → crash rate 0.25
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 3, 1, 0)
+		// Today: 4 sessions, 2 crashes → crash rate 0.5, a 100% rise
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 2, 0)
 
 		app := makeApp(teamID, appID)
@@ -1221,8 +1280,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Subtitle != "0.5x worse than yesterday" {
-			t.Errorf("crash-free subtitle: want %q, got %q", "0.5x worse than yesterday", metrics[1].Subtitle)
+		if card(t, metrics, "Crash free sessions").Subtitle != "Down from 75% yesterday" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "Down from 75% yesterday", card(t, metrics, "Crash free sessions").Subtitle)
 		}
 	})
 
@@ -1247,14 +1306,12 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[1].Subtitle != "No change from yesterday" {
-			t.Errorf("crash-free subtitle: want %q, got %q", "No change from yesterday", metrics[1].Subtitle)
+		if card(t, metrics, "Crash free sessions").Subtitle != "No change from yesterday" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "No change from yesterday", card(t, metrics, "Crash free sessions").Subtitle)
 		}
 	})
 
-	// ---------- ANR-free sessions ----------
-
-	t.Run("anr-free: 100% with no ANRs, no warning or error", func(t *testing.T) {
+	t.Run("crash-free: subtitle compares against a yesterday that had no crashes", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)
 		defer cleanupAll(ctx, t)
@@ -1265,6 +1322,70 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedApp(ctx, t, appID, teamID, "A", 30)
 
 		now := time.Now().UTC()
+		yesterday := now.Add(-25 * time.Hour)
+		// Yesterday: 4 sessions, 0 crashes → 100% crash-free
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 4, 0, 0)
+		// Today: 4 sessions, 2 crashes → crash rate 0.5
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 2, 0)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "Crash free sessions").Subtitle != "Down from 100% yesterday" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "Down from 100% yesterday", card(t, metrics, "Crash free sessions").Subtitle)
+		}
+	})
+
+	t.Run("crash-free: subtitle reports real movement when both days are near 100% crash-free", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.Add(-25 * time.Hour)
+		// Yesterday: 400 sessions, 1 crash → 99.75% crash-free
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 399, 1, 0)
+		// Today: 400 sessions, 2 crashes → 99.5% crash-free. The crash rate
+		// doubled, but the two crash-free rates differ by a quarter of a
+		// percentage point, which is what an earlier crash-free ratio rounded
+		// away into "1x worse than yesterday".
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 398, 2, 0)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "Crash free sessions").Value != "99.5%" {
+			t.Errorf("crash-free value: want %q, got %q", "99.5%", card(t, metrics, "Crash free sessions").Value)
+		}
+		if card(t, metrics, "Crash free sessions").Subtitle != "Down from 99.75% yesterday" {
+			t.Errorf("crash-free subtitle: want %q, got %q", "Down from 99.75% yesterday", card(t, metrics, "Crash free sessions").Subtitle)
+		}
+	})
+
+	// ---------- ANR-free sessions ----------
+
+	t.Run("anr-free: card is absent when neither day recorded an ANR", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.AddDate(0, 0, -1)
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 10, 0, 0)
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 0, 0)
 
 		app := makeApp(teamID, appID)
@@ -1272,13 +1393,38 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Value != "100%" {
-			t.Errorf("anr-free value: want %q, got %q", "100%", metrics[2].Value)
+		if hasCard(metrics, "ANR free sessions") {
+			t.Errorf("anr-free card should be absent, got cards %v", cardLabels(metrics))
 		}
-		if metrics[2].HasWarning {
+	})
+
+	t.Run("anr-free: card is present at 100% when only yesterday recorded an ANR", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.AddDate(0, 0, -1)
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 9, 0, 1)
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 0, 0)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "ANR free sessions").Value != "100%" {
+			t.Errorf("anr-free value: want %q, got %q", "100%", card(t, metrics, "ANR free sessions").Value)
+		}
+		if card(t, metrics, "ANR free sessions").HasWarning {
 			t.Error("anr-free should have no warning at 100%")
 		}
-		if metrics[2].HasError {
+		if card(t, metrics, "ANR free sessions").HasError {
 			t.Error("anr-free should have no error at 100%")
 		}
 	})
@@ -1303,13 +1449,13 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Value != "90%" {
-			t.Errorf("anr-free value: want %q, got %q", "90%", metrics[2].Value)
+		if card(t, metrics, "ANR free sessions").Value != "90%" {
+			t.Errorf("anr-free value: want %q, got %q", "90%", card(t, metrics, "ANR free sessions").Value)
 		}
-		if !metrics[2].HasWarning {
+		if !card(t, metrics, "ANR free sessions").HasWarning {
 			t.Error("anr-free should have warning at 90%")
 		}
-		if metrics[2].HasError {
+		if card(t, metrics, "ANR free sessions").HasError {
 			t.Error("anr-free should not have error at 90%")
 		}
 	})
@@ -1334,13 +1480,13 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Value != "80%" {
-			t.Errorf("anr-free value: want %q, got %q", "80%", metrics[2].Value)
+		if card(t, metrics, "ANR free sessions").Value != "80%" {
+			t.Errorf("anr-free value: want %q, got %q", "80%", card(t, metrics, "ANR free sessions").Value)
 		}
-		if !metrics[2].HasWarning {
+		if !card(t, metrics, "ANR free sessions").HasWarning {
 			t.Error("anr-free should have warning at 80%")
 		}
-		if !metrics[2].HasError {
+		if !card(t, metrics, "ANR free sessions").HasError {
 			t.Error("anr-free should have error at 80%")
 		}
 	})
@@ -1359,8 +1505,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		yesterday := now.Add(-25 * time.Hour)
 		// Yesterday: 4 sessions, 2 ANRs → 50% ANR-free
 		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 2, 0, 2)
-		// Today: 4 sessions, 0 ANRs → 100% ANR-free
-		// ratio = 1.0 / 0.5 = 2.0 → "2x better than yesterday"
+		// Today: 4 sessions, 0 ANRs → ANR rate 0, a 100% drop
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 4, 0, 0)
 
 		app := makeApp(teamID, appID)
@@ -1368,8 +1513,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Subtitle != "2x better than yesterday" {
-			t.Errorf("anr-free subtitle: want %q, got %q", "2x better than yesterday", metrics[2].Subtitle)
+		if card(t, metrics, "ANR free sessions").Subtitle != "Up from 50% yesterday" {
+			t.Errorf("anr-free subtitle: want %q, got %q", "Up from 50% yesterday", card(t, metrics, "ANR free sessions").Subtitle)
 		}
 	})
 
@@ -1385,10 +1530,9 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 
 		now := time.Now().UTC()
 		yesterday := now.Add(-25 * time.Hour)
-		// Yesterday: 4 sessions, 0 ANRs → 100% ANR-free
-		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 4, 0, 0)
-		// Today: 4 sessions, 2 ANRs → 50% ANR-free
-		// ratio = 0.5 / 1.0 = 0.5 → "0.5x worse than yesterday"
+		// Yesterday: 4 sessions, 1 ANR → ANR rate 0.25
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 3, 0, 1)
+		// Today: 4 sessions, 2 ANRs → ANR rate 0.5, a 100% rise
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 0, 2)
 
 		app := makeApp(teamID, appID)
@@ -1396,8 +1540,35 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Subtitle != "0.5x worse than yesterday" {
-			t.Errorf("anr-free subtitle: want %q, got %q", "0.5x worse than yesterday", metrics[2].Subtitle)
+		if card(t, metrics, "ANR free sessions").Subtitle != "Down from 75% yesterday" {
+			t.Errorf("anr-free subtitle: want %q, got %q", "Down from 75% yesterday", card(t, metrics, "ANR free sessions").Subtitle)
+		}
+	})
+
+	t.Run("anr-free: subtitle compares against a yesterday that had no ANRs", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.Add(-25 * time.Hour)
+		// Yesterday: 4 sessions, 0 ANRs → 100% ANR-free
+		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 4, 0, 0)
+		// Today: 4 sessions, 2 ANRs → ANR rate 0.5
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 0, 2)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "ANR free sessions").Subtitle != "Down from 100% yesterday" {
+			t.Errorf("anr-free subtitle: want %q, got %q", "Down from 100% yesterday", card(t, metrics, "ANR free sessions").Subtitle)
 		}
 	})
 
@@ -1420,8 +1591,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Subtitle != "No previous day data" {
-			t.Errorf("anr-free subtitle: want %q, got %q", "No previous day data", metrics[2].Subtitle)
+		if card(t, metrics, "ANR free sessions").Subtitle != "No previous day data" {
+			t.Errorf("anr-free subtitle: want %q, got %q", "No previous day data", card(t, metrics, "ANR free sessions").Subtitle)
 		}
 	})
 
@@ -1446,8 +1617,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[2].Subtitle != "No change from yesterday" {
-			t.Errorf("anr-free subtitle: want %q, got %q", "No change from yesterday", metrics[2].Subtitle)
+		if card(t, metrics, "ANR free sessions").Subtitle != "No change from yesterday" {
+			t.Errorf("anr-free subtitle: want %q, got %q", "No change from yesterday", card(t, metrics, "ANR free sessions").Subtitle)
 		}
 	})
 
@@ -1500,11 +1671,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		}
 
 		// With custom thresholds good=99, caution=97, 98% should be warning and not error.
-		if !metrics[1].HasWarning || metrics[1].HasError {
-			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", metrics[1].HasWarning, metrics[1].HasError)
+		if !card(t, metrics, "Crash free sessions").HasWarning || card(t, metrics, "Crash free sessions").HasError {
+			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "Crash free sessions").HasWarning, card(t, metrics, "Crash free sessions").HasError)
 		}
-		if !metrics[2].HasWarning || metrics[2].HasError {
-			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", metrics[2].HasWarning, metrics[2].HasError)
+		if !card(t, metrics, "ANR free sessions").HasWarning || card(t, metrics, "ANR free sessions").HasError {
+			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "ANR free sessions").HasWarning, card(t, metrics, "ANR free sessions").HasError)
 		}
 	})
 
@@ -1530,11 +1701,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !metrics[1].HasWarning || metrics[1].HasError {
-			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", metrics[1].HasWarning, metrics[1].HasError)
+		if !card(t, metrics, "Crash free sessions").HasWarning || card(t, metrics, "Crash free sessions").HasError {
+			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "Crash free sessions").HasWarning, card(t, metrics, "Crash free sessions").HasError)
 		}
-		if !metrics[2].HasWarning || metrics[2].HasError {
-			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", metrics[2].HasWarning, metrics[2].HasError)
+		if !card(t, metrics, "ANR free sessions").HasWarning || card(t, metrics, "ANR free sessions").HasError {
+			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "ANR free sessions").HasWarning, card(t, metrics, "ANR free sessions").HasError)
 		}
 	})
 
@@ -1560,11 +1731,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !metrics[1].HasWarning || !metrics[1].HasError {
-			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,true)", metrics[1].HasWarning, metrics[1].HasError)
+		if !card(t, metrics, "Crash free sessions").HasWarning || !card(t, metrics, "Crash free sessions").HasError {
+			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,true)", card(t, metrics, "Crash free sessions").HasWarning, card(t, metrics, "Crash free sessions").HasError)
 		}
-		if !metrics[2].HasWarning || !metrics[2].HasError {
-			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,true)", metrics[2].HasWarning, metrics[2].HasError)
+		if !card(t, metrics, "ANR free sessions").HasWarning || !card(t, metrics, "ANR free sessions").HasError {
+			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,true)", card(t, metrics, "ANR free sessions").HasWarning, card(t, metrics, "ANR free sessions").HasError)
 		}
 	})
 
@@ -1590,11 +1761,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !metrics[1].HasWarning || metrics[1].HasError {
-			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", metrics[1].HasWarning, metrics[1].HasError)
+		if !card(t, metrics, "Crash free sessions").HasWarning || card(t, metrics, "Crash free sessions").HasError {
+			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "Crash free sessions").HasWarning, card(t, metrics, "Crash free sessions").HasError)
 		}
-		if !metrics[2].HasWarning || metrics[2].HasError {
-			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", metrics[2].HasWarning, metrics[2].HasError)
+		if !card(t, metrics, "ANR free sessions").HasWarning || card(t, metrics, "ANR free sessions").HasError {
+			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,false)", card(t, metrics, "ANR free sessions").HasWarning, card(t, metrics, "ANR free sessions").HasError)
 		}
 	})
 
@@ -1620,17 +1791,17 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !metrics[1].HasWarning || !metrics[1].HasError {
-			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,true)", metrics[1].HasWarning, metrics[1].HasError)
+		if !card(t, metrics, "Crash free sessions").HasWarning || !card(t, metrics, "Crash free sessions").HasError {
+			t.Fatalf("crash-free flags = (warning=%v, error=%v), want (true,true)", card(t, metrics, "Crash free sessions").HasWarning, card(t, metrics, "Crash free sessions").HasError)
 		}
-		if !metrics[2].HasWarning || !metrics[2].HasError {
-			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,true)", metrics[2].HasWarning, metrics[2].HasError)
+		if !card(t, metrics, "ANR free sessions").HasWarning || !card(t, metrics, "ANR free sessions").HasError {
+			t.Fatalf("anr-free flags = (warning=%v, error=%v), want (true,true)", card(t, metrics, "ANR free sessions").HasWarning, card(t, metrics, "ANR free sessions").HasError)
 		}
 	})
 
 	// ---------- Launch times ----------
 
-	t.Run("launch: all values are 0ms when no launch events seeded", func(t *testing.T) {
+	t.Run("launch: values are No Data when no launch events seeded", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)
 		defer cleanupAll(ctx, t)
@@ -1648,10 +1819,43 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for i, name := range []string{"cold", "warm", "hot"} {
-			if metrics[3+i].Value != "0ms" {
-				t.Errorf("%s launch value: want %q, got %q", name, "0ms", metrics[3+i].Value)
+		for _, label := range []string{"Cold launch p95", "Warm launch p95", "Hot launch p95"} {
+			if card(t, metrics, label).Value != "No Data" {
+				t.Errorf("%s launch value: want %q, got %q", label, "No Data", card(t, metrics, label).Value)
 			}
+			if card(t, metrics, label).Subtitle != "No previous day data" {
+				t.Errorf("%s launch subtitle: want %q, got %q", label, "No previous day data", card(t, metrics, label).Subtitle)
+			}
+		}
+	})
+
+	t.Run("launch: unmeasured today names yesterday's duration without a direction", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		th.SeedTeam(ctx, t, teamID, "T")
+		th.SeedApp(ctx, t, appID, teamID, "A", 30)
+
+		now := time.Now().UTC()
+		yesterday := now.Add(-25 * time.Hour)
+		// Yesterday recorded a cold launch, today recorded none, so today has no
+		// duration to compare against yesterday's.
+		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 900, yesterday)
+		th.SeedAppMetrics(ctx, t, teamID, appID, now, 5, 0, 0)
+
+		app := makeApp(teamID, appID)
+		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if card(t, metrics, "Cold launch p95").Value != "No Data" {
+			t.Errorf("cold launch value: want %q, got %q", "No Data", card(t, metrics, "Cold launch p95").Value)
+		}
+		if card(t, metrics, "Cold launch p95").Subtitle != "Was 900ms yesterday" {
+			t.Errorf("cold launch subtitle: want %q, got %q", "Was 900ms yesterday", card(t, metrics, "Cold launch p95").Subtitle)
 		}
 	})
 
@@ -1675,14 +1879,14 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[3].Value != "500ms" {
-			t.Errorf("cold launch value: want %q, got %q", "500ms", metrics[3].Value)
+		if card(t, metrics, "Cold launch p95").Value != "500ms" {
+			t.Errorf("cold launch value: want %q, got %q", "500ms", card(t, metrics, "Cold launch p95").Value)
 		}
-		if metrics[4].Value != "200ms" {
-			t.Errorf("warm launch value: want %q, got %q", "200ms", metrics[4].Value)
+		if card(t, metrics, "Warm launch p95").Value != "200ms" {
+			t.Errorf("warm launch value: want %q, got %q", "200ms", card(t, metrics, "Warm launch p95").Value)
 		}
-		if metrics[5].Value != "100ms" {
-			t.Errorf("hot launch value: want %q, got %q", "100ms", metrics[5].Value)
+		if card(t, metrics, "Hot launch p95").Value != "100ms" {
+			t.Errorf("hot launch value: want %q, got %q", "100ms", card(t, metrics, "Hot launch p95").Value)
 		}
 	})
 
@@ -1706,9 +1910,9 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for i, name := range []string{"cold", "warm", "hot"} {
-			if metrics[3+i].Subtitle != "No previous day data" {
-				t.Errorf("%s launch subtitle: want %q, got %q", name, "No previous day data", metrics[3+i].Subtitle)
+		for _, label := range []string{"Cold launch p95", "Warm launch p95", "Hot launch p95"} {
+			if card(t, metrics, label).Subtitle != "No previous day data" {
+				t.Errorf("%s launch subtitle: want %q, got %q", label, "No previous day data", card(t, metrics, label).Subtitle)
 			}
 		}
 	})
@@ -1725,8 +1929,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 
 		now := time.Now().UTC()
 		yesterday := now.Add(-25 * time.Hour)
-		// Yesterday: cold_launch 1000ms; today: 500ms
-		// ratio = round(500 / 1000, 2) = 0.5 → "0.5x better than yesterday"
+		// Yesterday: cold_launch 1000ms; today: 500ms → 500ms faster
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 1000, yesterday)
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 500, now)
 
@@ -1735,8 +1938,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[3].Subtitle != "0.5x better than yesterday" {
-			t.Errorf("cold launch subtitle: want %q, got %q", "0.5x better than yesterday", metrics[3].Subtitle)
+		if card(t, metrics, "Cold launch p95").Subtitle != "Down from 1000ms yesterday" {
+			t.Errorf("cold launch subtitle: want %q, got %q", "Down from 1000ms yesterday", card(t, metrics, "Cold launch p95").Subtitle)
 		}
 	})
 
@@ -1752,8 +1955,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 
 		now := time.Now().UTC()
 		yesterday := now.Add(-25 * time.Hour)
-		// Yesterday: cold_launch 500ms; today: 1000ms
-		// ratio = round(1000 / 500, 2) = 2 → "2x worse than yesterday"
+		// Yesterday: cold_launch 500ms; today: 1000ms → 500ms slower
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 500, yesterday)
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 1000, now)
 
@@ -1762,8 +1964,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[3].Subtitle != "2x worse than yesterday" {
-			t.Errorf("cold launch subtitle: want %q, got %q", "2x worse than yesterday", metrics[3].Subtitle)
+		if card(t, metrics, "Cold launch p95").Subtitle != "Up from 500ms yesterday" {
+			t.Errorf("cold launch subtitle: want %q, got %q", "Up from 500ms yesterday", card(t, metrics, "Cold launch p95").Subtitle)
 		}
 	})
 
@@ -1788,8 +1990,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if metrics[3].Subtitle != "No change from yesterday" {
-			t.Errorf("cold launch subtitle: want %q, got %q", "No change from yesterday", metrics[3].Subtitle)
+		if card(t, metrics, "Cold launch p95").Subtitle != "No change from yesterday" {
+			t.Errorf("cold launch subtitle: want %q, got %q", "No change from yesterday", card(t, metrics, "Cold launch p95").Subtitle)
 		}
 	})
 
@@ -1813,12 +2015,12 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for i, name := range []string{"cold", "warm", "hot"} {
-			if metrics[3+i].HasWarning {
-				t.Errorf("%s launch should never have warning", name)
+		for _, label := range []string{"Cold launch p95", "Warm launch p95", "Hot launch p95"} {
+			if card(t, metrics, label).HasWarning {
+				t.Errorf("%s should never have warning", label)
 			}
-			if metrics[3+i].HasError {
-				t.Errorf("%s launch should never have error", name)
+			if card(t, metrics, label).HasError {
+				t.Errorf("%s should never have error", label)
 			}
 		}
 	})
@@ -1847,22 +2049,22 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(metrics) != 7 {
-			t.Fatalf("want 7 metrics (6 standard + bug reports), got %d", len(metrics))
+		if !hasCard(metrics, "Bug reports") {
+			t.Fatalf("bug reports card should be present, got cards %v", cardLabels(metrics))
 		}
-		if metrics[6].Value != "3" {
-			t.Errorf("bug report count: want %q, got %q", "3", metrics[6].Value)
+		if card(t, metrics, "Bug reports").Value != "3" {
+			t.Errorf("bug report count: want %q, got %q", "3", card(t, metrics, "Bug reports").Value)
 		}
-		if metrics[6].Label != "Bug reports" {
-			t.Errorf("bug report label: want %q, got %q", "Bug reports", metrics[6].Label)
+		if card(t, metrics, "Bug reports").Label != "Bug reports" {
+			t.Errorf("bug report label: want %q, got %q", "Bug reports", card(t, metrics, "Bug reports").Label)
 		}
-		if metrics[6].Subtitle != "No previous day data" {
-			t.Errorf("bug report subtitle: want %q, got %q", "No previous day data", metrics[6].Subtitle)
+		if card(t, metrics, "Bug reports").Subtitle != "No previous day data" {
+			t.Errorf("bug report subtitle: want %q, got %q", "No previous day data", card(t, metrics, "Bug reports").Subtitle)
 		}
-		if metrics[6].HasWarning {
+		if card(t, metrics, "Bug reports").HasWarning {
 			t.Error("bug report metric should not have warning")
 		}
-		if metrics[6].HasError {
+		if card(t, metrics, "Bug reports").HasError {
 			t.Error("bug report metric should not have error")
 		}
 	})
@@ -1886,8 +2088,8 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(metrics) != 6 {
-			t.Errorf("want 6 metrics when no bug reports today, got %d", len(metrics))
+		if hasCard(metrics, "Bug reports") {
+			t.Errorf("bug reports card should be absent, got cards %v", cardLabels(metrics))
 		}
 	})
 
@@ -1917,11 +2119,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(metrics) != 7 {
-			t.Fatalf("want 7 metrics, got %d", len(metrics))
+		if !hasCard(metrics, "Bug reports") {
+			t.Fatalf("bug reports card should be present, got cards %v", cardLabels(metrics))
 		}
-		if metrics[6].Subtitle != "2 greater than yesterday" {
-			t.Errorf("bug report subtitle: want %q, got %q", "2 greater than yesterday", metrics[6].Subtitle)
+		if card(t, metrics, "Bug reports").Subtitle != "Up from 3 yesterday" {
+			t.Errorf("bug report subtitle: want %q, got %q", "Up from 3 yesterday", card(t, metrics, "Bug reports").Subtitle)
 		}
 	})
 
@@ -1951,11 +2153,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(metrics) != 7 {
-			t.Fatalf("want 7 metrics, got %d", len(metrics))
+		if !hasCard(metrics, "Bug reports") {
+			t.Fatalf("bug reports card should be present, got cards %v", cardLabels(metrics))
 		}
-		if metrics[6].Subtitle != "2 less than yesterday" {
-			t.Errorf("bug report subtitle: want %q, got %q", "2 less than yesterday", metrics[6].Subtitle)
+		if card(t, metrics, "Bug reports").Subtitle != "Down from 5 yesterday" {
+			t.Errorf("bug report subtitle: want %q, got %q", "Down from 5 yesterday", card(t, metrics, "Bug reports").Subtitle)
 		}
 	})
 
@@ -1985,11 +2187,11 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(metrics) != 7 {
-			t.Fatalf("want 7 metrics, got %d", len(metrics))
+		if !hasCard(metrics, "Bug reports") {
+			t.Fatalf("bug reports card should be present, got cards %v", cardLabels(metrics))
 		}
-		if metrics[6].Subtitle != "No change from yesterday" {
-			t.Errorf("bug report subtitle: want %q, got %q", "No change from yesterday", metrics[6].Subtitle)
+		if card(t, metrics, "Bug reports").Subtitle != "No change from yesterday" {
+			t.Errorf("bug report subtitle: want %q, got %q", "No change from yesterday", card(t, metrics, "Bug reports").Subtitle)
 		}
 	})
 }

--- a/backend/libs/email/cmd/preview/main.go
+++ b/backend/libs/email/cmd/preview/main.go
@@ -129,47 +129,47 @@ func main() {
 	// --- Alerts: Daily Summary ---
 
 	healthyMetrics := []email.MetricData{
-		{Value: "12,847", Label: "Sessions", Subtitle: "1,203 greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "99.72%", Label: "Crash free sessions", Subtitle: "1.01x better than yesterday", HasWarning: false, HasError: false},
+		{Value: "12.85K", Label: "Sessions", Subtitle: "Up from 11.65K yesterday", HasWarning: false, HasError: false},
+		{Value: "99.72%", Label: "Crash free sessions", Subtitle: "Up from 99.69% yesterday", HasWarning: false, HasError: false},
 		{Value: "99.85%", Label: "ANR free sessions", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
-		{Value: "892ms", Label: "Cold launch p95", Subtitle: "45ms less than yesterday", HasWarning: false, HasError: false},
-		{Value: "234ms", Label: "Warm launch p95", Subtitle: "12ms greater than yesterday", HasWarning: false, HasError: false},
+		{Value: "892.35ms", Label: "Cold launch p95", Subtitle: "Down from 937.53ms yesterday", HasWarning: false, HasError: false},
+		{Value: "234ms", Label: "Warm launch p95", Subtitle: "Up from 222ms yesterday", HasWarning: false, HasError: false},
 		{Value: "98ms", Label: "Hot launch p95", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
-		{Value: "7", Label: "Bug reports", Subtitle: "3 less than yesterday", HasWarning: false, HasError: false},
+		{Value: "7", Label: "Bug reports", Subtitle: "Down from 10 yesterday", HasWarning: false, HasError: false},
 	}
 	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), healthyMetrics, "https://measure.sh", "team-abc", "app-123")
 	add("14-daily-summary-healthy.html", body)
 
 	warningMetrics := []email.MetricData{
-		{Value: "8,421", Label: "Sessions", Subtitle: "3,200 less than yesterday", HasWarning: false, HasError: false},
-		{Value: "93.1%", Label: "Crash free sessions", Subtitle: "0.95x worse than yesterday", HasWarning: true, HasError: false},
-		{Value: "99.2%", Label: "ANR free sessions", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
-		{Value: "1,450ms", Label: "Cold launch p95", Subtitle: "320ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "567ms", Label: "Warm launch p95", Subtitle: "201ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "145ms", Label: "Hot launch p95", Subtitle: "47ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "18", Label: "Bug reports", Subtitle: "6 greater than yesterday", HasWarning: false, HasError: false},
+		{Value: "8.42K", Label: "Sessions", Subtitle: "Down from 11.62K yesterday", HasWarning: false, HasError: false},
+		{Value: "93.1%", Label: "Crash free sessions", Subtitle: "Down from 95.16% yesterday", HasWarning: true, HasError: false},
+		{Value: "99.2%", Label: "ANR free sessions", Subtitle: "Down from 100% yesterday", HasWarning: false, HasError: false},
+		{Value: "1450.6ms", Label: "Cold launch p95", Subtitle: "Up from 1130.46ms yesterday", HasWarning: false, HasError: false},
+		{Value: "567ms", Label: "Warm launch p95", Subtitle: "Up from 366ms yesterday", HasWarning: false, HasError: false},
+		{Value: "145ms", Label: "Hot launch p95", Subtitle: "Up from 98ms yesterday", HasWarning: false, HasError: false},
+		{Value: "18", Label: "Bug reports", Subtitle: "Up from 12 yesterday", HasWarning: false, HasError: false},
 	}
 	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), warningMetrics, "https://measure.sh", "team-abc", "app-123")
 	add("15-daily-summary-warnings.html", body)
 
 	errorMetrics := []email.MetricData{
-		{Value: "3,102", Label: "Sessions", Subtitle: "9,500 less than yesterday", HasWarning: false, HasError: false},
-		{Value: "87.3%", Label: "Crash free sessions", Subtitle: "0.89x worse than yesterday", HasWarning: false, HasError: true},
-		{Value: "82.1%", Label: "ANR free sessions", Subtitle: "0.84x worse than yesterday", HasWarning: false, HasError: true},
-		{Value: "2,340ms", Label: "Cold launch p95", Subtitle: "1,100ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "890ms", Label: "Warm launch p95", Subtitle: "524ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "312ms", Label: "Hot launch p95", Subtitle: "214ms greater than yesterday", HasWarning: false, HasError: false},
+		{Value: "3.1K", Label: "Sessions", Subtitle: "Down from 12.6K yesterday", HasWarning: false, HasError: false},
+		{Value: "87.3%", Label: "Crash free sessions", Subtitle: "Down from 94.02% yesterday", HasWarning: false, HasError: true},
+		{Value: "82.1%", Label: "ANR free sessions", Subtitle: "Down from 90.88% yesterday", HasWarning: false, HasError: true},
+		{Value: "2340ms", Label: "Cold launch p95", Subtitle: "Up from 1240ms yesterday", HasWarning: false, HasError: false},
+		{Value: "890ms", Label: "Warm launch p95", Subtitle: "Up from 366ms yesterday", HasWarning: false, HasError: false},
+		{Value: "312ms", Label: "Hot launch p95", Subtitle: "Up from 98ms yesterday", HasWarning: false, HasError: false},
 	}
 	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), errorMetrics, "https://measure.sh", "team-abc", "app-123")
 	add("16-daily-summary-errors.html", body)
 
 	customThresholdMetrics := []email.MetricData{
-		{Value: "7,890", Label: "Sessions", Subtitle: "540 less than yesterday", HasWarning: false, HasError: false},
-		{Value: "91.2%", Label: "Crash free sessions", Subtitle: "0.96x worse than yesterday", HasWarning: false, HasError: false},
-		{Value: "88.6%", Label: "ANR free sessions", Subtitle: "0.92x worse than yesterday", HasWarning: false, HasError: false},
-		{Value: "1,120ms", Label: "Cold launch p95", Subtitle: "180ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "498ms", Label: "Warm launch p95", Subtitle: "77ms greater than yesterday", HasWarning: false, HasError: false},
-		{Value: "132ms", Label: "Hot launch p95", Subtitle: "21ms greater than yesterday", HasWarning: false, HasError: false},
+		{Value: "7.89K", Label: "Sessions", Subtitle: "Down from 8.43K yesterday", HasWarning: false, HasError: false},
+		{Value: "91.2%", Label: "Crash free sessions", Subtitle: "Down from 93.6% yesterday", HasWarning: false, HasError: false},
+		{Value: "88.6%", Label: "ANR free sessions", Subtitle: "Down from 90.1% yesterday", HasWarning: false, HasError: false},
+		{Value: "1120ms", Label: "Cold launch p95", Subtitle: "Up from 940ms yesterday", HasWarning: false, HasError: false},
+		{Value: "498ms", Label: "Warm launch p95", Subtitle: "Up from 421ms yesterday", HasWarning: false, HasError: false},
+		{Value: "132ms", Label: "Hot launch p95", Subtitle: "Up from 111ms yesterday", HasWarning: false, HasError: false},
 	}
 	_, body = email.DailySummaryEmail(
 		"MyApp",
@@ -190,6 +190,27 @@ func main() {
 		"app-123",
 	)
 	add("18-daily-summary-custom-thresholds-lenient.html", body)
+
+	noDataMetrics := []email.MetricData{
+		{Value: "412", Label: "Sessions", Subtitle: "Down from 1.2K yesterday", HasWarning: false, HasError: false},
+		{Value: "100%", Label: "Crash free sessions", Subtitle: "Up from 99.42% yesterday", HasWarning: false, HasError: false},
+		{Value: "100%", Label: "ANR free sessions", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
+		{Value: "1024ms", Label: "Cold launch p95", Subtitle: "Up from 998.5ms yesterday", HasWarning: false, HasError: false},
+		{Value: "No Data", Label: "Warm launch p95", Subtitle: "Was 366ms yesterday", HasWarning: false, HasError: false},
+		{Value: "No Data", Label: "Hot launch p95", Subtitle: "No previous day data", HasWarning: false, HasError: false},
+	}
+	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), noDataMetrics, "https://measure.sh", "team-abc", "app-123")
+	add("19-daily-summary-no-data.html", body)
+
+	noANRMetrics := []email.MetricData{
+		{Value: "6.31K", Label: "Sessions", Subtitle: "Up from 5.98K yesterday", HasWarning: false, HasError: false},
+		{Value: "99.81%", Label: "Crash free sessions", Subtitle: "Down from 99.9% yesterday", HasWarning: false, HasError: false},
+		{Value: "1180ms", Label: "Cold launch p95", Subtitle: "Up from 1102.4ms yesterday", HasWarning: false, HasError: false},
+		{Value: "412ms", Label: "Warm launch p95", Subtitle: "Down from 455ms yesterday", HasWarning: false, HasError: false},
+		{Value: "121ms", Label: "Hot launch p95", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
+	}
+	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), noANRMetrics, "https://measure.sh", "team-abc", "app-123")
+	add("20-daily-summary-no-anr-card.html", body)
 
 	for _, e := range emails {
 		path := filepath.Join(dir, e.name)

--- a/backend/libs/email/email.go
+++ b/backend/libs/email/email.go
@@ -170,6 +170,12 @@ func RenderEmailBody(title, contentHTML, ctaText, ctaURL string) string {
     <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;600&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
     <style>
         :root { color-scheme: light dark; supported-color-schemes: light dark; }
+        /* Every colour in this email is a hardcoded light one, but declaring
+           dark support above makes a dark-mode browser pick its dark highlight
+           for selected text, which reads as grey on the white panels, so we set
+           our own selection colour here. */
+        ::selection { background-color: #000000; color: #ffffff; }
+        ::-moz-selection { background-color: #000000; color: #ffffff; }
     </style>
     <title>%s</title>
 </head>

--- a/backend/libs/numeric/numeric.go
+++ b/backend/libs/numeric/numeric.go
@@ -1,6 +1,10 @@
 package numeric
 
-import "math"
+import (
+	"math"
+	"strconv"
+	"strings"
+)
 
 // AbsInt returns the absolute
 // value of int n.
@@ -21,4 +25,45 @@ func AbsInt(n int) int {
 // part of a float64 value to 2 decimals.
 func RoundTwoDecimalsFloat64(x float64) float64 {
 	return math.Ceil(x*100) / 100
+}
+
+func FormatKMB(n int64) string {
+	sign := ""
+	v := float64(n)
+
+	if v < 0 {
+		sign = "-"
+		v = -v
+	}
+
+	var divisor float64
+	var suffix string
+
+	switch {
+	case v >= 1e9:
+		divisor, suffix = 1e9, "B"
+	case v >= 1e6:
+		divisor, suffix = 1e6, "M"
+	case v >= 1e3:
+		divisor, suffix = 1e3, "K"
+	default:
+		return strconv.FormatInt(n, 10)
+	}
+
+	rounded := math.Round(v/divisor*100) / 100
+
+	// Promote after rounding, e.g. 999.999K → 1M.
+	if rounded >= 1000 {
+		switch suffix {
+		case "K":
+			rounded, suffix = rounded/1000, "M"
+		case "M":
+			rounded, suffix = rounded/1000, "B"
+		}
+	}
+
+	s := strconv.FormatFloat(rounded, 'f', 2, 64)
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+
+	return sign + s + suffix
 }

--- a/backend/libs/numeric/numeric_test.go
+++ b/backend/libs/numeric/numeric_test.go
@@ -1,0 +1,51 @@
+package numeric
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFormatKMB(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"zero", 0, "0"},
+		{"single digit", 1, "1"},
+		{"just below the first suffix", 999, "999"},
+
+		{"exactly a thousand", 1_000, "1K"},
+		{"one decimal place needed", 1_100, "1.1K"},
+		{"two decimal places needed", 1_050, "1.05K"},
+		{"half a thousand", 1_500, "1.5K"},
+		{"rounded down to two places", 1_234, "1.23K"},
+		{"rounded up past the suffix boundary", 1_999, "2K"},
+		{"five figures", 12_345, "12.35K"},
+		{"just below a million promotes to the next suffix", 999_999, "1M"},
+
+		{"exactly a million", 1_000_000, "1M"},
+		{"half a million", 1_500_000, "1.5M"},
+		{"eight figures", 12_345_678, "12.35M"},
+		{"just below a billion promotes to the next suffix", 999_999_999, "1B"},
+
+		{"exactly a billion", 1_000_000_000, "1B"},
+		{"two and a half billion", 2_500_000_000, "2.5B"},
+		{"eleven figures", 12_345_678_901, "12.35B"},
+		{"largest int64", math.MaxInt64, "9223372036.85B"},
+
+		{"negative single digit", -1, "-1"},
+		{"negative just below the first suffix", -999, "-999"},
+		{"negative thousand", -1_000, "-1K"},
+		{"negative million", -1_500_000, "-1.5M"},
+		{"smallest int64", math.MinInt64, "-9223372036.85B"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FormatKMB(c.in); got != c.want {
+				t.Errorf("FormatKMB(%d) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

- replace ratio and delta comparisons with yesterday's value, e.g. "Up from 99.69% yesterday"; direction is derived from the formatted strings, so a change too small to render no longer prints "1x worse than yesterday"
- return raw values for both days from the query and build every card in Go, removing the CASE expressions, ratio arithmetic, divide-by-zero guards and NaN branches
- rename launch labels to "Cold/Warm/Hot launch p95"
- add numeric.FormatKMB with tests and use it for session and bug report counts, so they read as 12.85K like the dashboard
- show "No Data" with "Was 366ms yesterday" for a day with no launch events, replacing "0ms" with "No change from yesterday"
- correct the preview fixtures, which carried invented thousands separators and labels that had drifted from the query, and add a no-data preview

## Related issue
Fixes #4229, References #3533



