### PR TITLE
fix(backend): count only fatal exceptions in metrics & filters

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -10,6 +10,7 @@ import (
 	"backend/alerts/server"
 	"backend/alerts/slack"
 	"backend/libs/autumn"
+	"backend/libs/config"
 	"backend/libs/email"
 
 	"github.com/google/uuid"
@@ -1041,13 +1042,13 @@ func formatDailySummarySlackMessage(appName, dashboardURL string, date time.Time
 func createCrashAlertsForApp(ctx context.Context, team Team, app App, from, to time.Time, sessionCount uint64, prefs AppThresholdPrefs) {
 	crashGroupStmt := sqlf.
 		From("events final").
-		Select("exception.fingerprint, count() as crash_count").
+		Select("`exception.fingerprint`, count() as crash_count").
 		Where("team_id = toUUID(?)", team.ID).
 		Where("app_id = toUUID(?)", app.ID).
 		Where("type = 'exception'").
-		Where("exception.handled = false").
+		Where(config.FatalExceptionExpr).
 		Where("timestamp >= ? and timestamp <= ?", from, to).
-		GroupBy("exception.fingerprint")
+		GroupBy("`exception.fingerprint`")
 
 	defer crashGroupStmt.Close()
 
@@ -1163,12 +1164,12 @@ func createCrashAlertsForApp(ctx context.Context, team Team, app App, from, to t
 
 func createAnrAlertsForApp(ctx context.Context, team Team, app App, from, to time.Time, sessionCount uint64, prefs AppThresholdPrefs) {
 	anrGroupStmt := sqlf.From("events final").
-		Select("anr.fingerprint, count() as anr_count").
+		Select("`anr.fingerprint`, count() as anr_count").
 		Where("team_id = toUUID(?)", team.ID).
 		Where("app_id = toUUID(?)", app.ID).
 		Where("type = 'anr'").
 		Where("timestamp >= ? and timestamp <= ?", from, to).
-		GroupBy("anr.fingerprint")
+		GroupBy("`anr.fingerprint`")
 
 	defer anrGroupStmt.Close()
 

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -131,6 +131,36 @@ func TestCreateCrashAndAnrAlerts(t *testing.T) {
 		}
 	})
 
+	t.Run("handled exceptions do not trigger a crash spike alert", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		appID := uuid.New().String()
+		userID := uuid.New().String()
+
+		th.SeedTeam(ctx, t, teamID, "Handled Team")
+		th.SeedUser(ctx, t, userID, "owner@example.com")
+		th.SeedTeamMembership(ctx, t, teamID, userID, "owner")
+		th.SeedApp(ctx, t, appID, teamID, "Handled App", 30)
+
+		now := time.Now().UTC()
+		th.SeedGenericEvents(ctx, t, teamID, appID, 200, now.Add(-30*time.Minute))
+		// 110 realistic new-SDK handled (non-fatal) exceptions, past both the
+		// count & rate thresholds. crash_count must exclude them.
+		for i := 0; i < 110; i++ {
+			th.SeedIssueEventWithSeverity(ctx, t, teamID, appID, testCrashFingerprint, "handled", now.Add(-5*time.Minute))
+		}
+		th.SeedExceptionGroup(ctx, t, teamID, appID, testCrashFingerprint)
+
+		CreateCrashAndAnrAlerts(ctx)
+
+		if got := countAlertsOfType(ctx, t, string(AlertTypeCrashSpike)); got != 0 {
+			t.Errorf("want 0 crash spike alerts for handled exceptions, got %d", got)
+		}
+	})
+
 	t.Run("anr spike fires when count and rate thresholds are both met", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)

--- a/backend/libs/config/query.go
+++ b/backend/libs/config/query.go
@@ -20,3 +20,10 @@ const AppMetricsTable = "app_metrics final"
 // EventsTable is the name of the table for app's
 // raw events.
 const EventsTable = "events"
+
+// FatalExceptionExpr is the SQL predicate for a fatal exception on the events
+// table. Bridges legacy rows written before the severity column, where only
+// the deprecated handled flag expressed fatality. Must be paired with a
+// type = 'exception' gate: non-exception rows carry empty severity &
+// handled=false, so they satisfy it on their own.
+const FatalExceptionExpr = "(`exception.severity` = 'fatal' OR (`exception.severity` = '' AND `exception.handled` = false))"

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -2614,7 +2614,7 @@ func (a App) GetIssueFreeMetrics(
 		}
 
 		if perceivedCrashFreeUnselected != 0 {
-			crashFree.Delta = numeric.RoundTwoDecimalsFloat64(perceivedCrashFree.CrashFreeSessions / perceivedCrashFreeUnselected)
+			perceivedCrashFree.Delta = numeric.RoundTwoDecimalsFloat64(perceivedCrashFree.CrashFreeSessions / perceivedCrashFreeUnselected)
 		} else {
 			perceivedCrashFree.Delta = 1
 		}

--- a/backend/libs/measure/app_health.go
+++ b/backend/libs/measure/app_health.go
@@ -101,12 +101,11 @@ func (a App) GetHealthPlotInstances(ctx context.Context, rch driver.Conn, af *fi
 			"log_comment": lc.MustPut(logcomment.Root, logcomment.Health).String(),
 		}
 		ectx := chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "plots_instances"))
-		const fatalExpr = "(`exception.severity` = 'fatal' OR (`exception.severity` = '' AND `exception.handled` = false))"
 
 		stmt := sqlf.From("events final").
 			Select(groupExpr.BucketExpr+" as datetime_bucket", af.Timezone).
 			Select("formatDateTime(datetime_bucket, ?) as datetime", groupExpr.DatetimeFormat).
-			Select("countIf(type = ? and "+fatalExpr+") as crashes", event.TypeException).
+			Select("countIf(type = ? and "+config.FatalExceptionExpr+") as crashes", event.TypeException).
 			Select("countIf(type = ?) as anrs", event.TypeANR).
 			Where("team_id = toUUID(?)", a.TeamId).
 			Where("app_id = toUUID(?)", a.ID).

--- a/backend/libs/measure/metrics_test.go
+++ b/backend/libs/measure/metrics_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package measure
+
+import (
+	"testing"
+	"time"
+
+	"backend/libs/filter"
+	"backend/testinfra"
+)
+
+// GetIssueFreeMetrics must compute both crashFree.Delta & perceivedCrashFree.Delta
+// as ratios against their own unselected baselines.
+func TestGetIssueFreeMetricsDeltas(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	// Selected version v1: 8 plain sessions + 1 fatal crash -> 9 sessions, 1 crash.
+	seedEventRows(f.ctx, t, team, app, 8, testinfra.EventRow{AppVersion: "v1", AppBuild: "1", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 1, testinfra.EventRow{Type: "exception", AppVersion: "v1", AppBuild: "1", Severity: "fatal", Timestamp: ts})
+
+	// Unselected version v2 with a different crash rate: 8 plain + 2 fatal crashes -> 10 sessions, 2 crashes.
+	seedEventRows(f.ctx, t, team, app, 8, testinfra.EventRow{AppVersion: "v2", AppBuild: "2", Timestamp: ts})
+	seedEventRows(f.ctx, t, team, app, 2, testinfra.EventRow{Type: "exception", AppVersion: "v2", AppBuild: "2", Severity: "fatal", Timestamp: ts})
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	af.Versions = []string{"v1"}
+	af.VersionCodes = []string{"1"}
+
+	var unselected filter.Versions
+	unselected.Add("v2", "2")
+
+	crashFree, perceivedCrashFree, _, _, err := f.app.GetIssueFreeMetrics(f.ctx, deps.RchPool, af, unselected)
+	if err != nil {
+		t.Fatalf("GetIssueFreeMetrics: %v", err)
+	}
+
+	// selected: (1 - 1/9) * 100 = 88.89, unselected: (1 - 2/10) * 100 = 80.
+	// RoundTwoDecimalsFloat64 rounds up (math.Ceil), so
+	// delta = ceil(88.89 / 80 * 100) / 100 = 1.12.
+	const wantCrashFree = 88.89
+	const wantDelta = 1.12
+
+	if crashFree.CrashFreeSessions != wantCrashFree {
+		t.Errorf("crashFree.CrashFreeSessions = %v, want %v", crashFree.CrashFreeSessions, wantCrashFree)
+	}
+	if crashFree.Delta != wantDelta {
+		t.Errorf("crashFree.Delta = %v, want %v", crashFree.Delta, wantDelta)
+	}
+
+	// Seeds hardcode exception.foreground=true, so perceived values equal
+	// non-perceived ones here.
+	if perceivedCrashFree.Delta != wantDelta {
+		t.Errorf("perceivedCrashFree.Delta = %v, want %v", perceivedCrashFree.Delta, wantDelta)
+	}
+}

--- a/backend/libs/measure/mv_severity_test.go
+++ b/backend/libs/measure/mv_severity_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package measure
+
+import (
+	"testing"
+	"time"
+
+	"backend/libs/ambient"
+	"backend/libs/event"
+	"backend/libs/filter"
+)
+
+// These tests drive the real app_filters_mv & app_metrics_mv by seeding raw
+// events, not by inserting into the target tables, so they cover the MV SQL
+// predicates themselves.
+
+// crash_sessions counts fatal exceptions only: severity='fatal', or legacy
+// rows with empty severity & handled=false. Unhandled, handled, legacy
+// handled=true & non-exception rows must not contribute. ANR & generic rows
+// also carry empty severity & handled=false, so they guard the
+// type='exception' gate.
+func TestAppMetricsMVCrashSessionsCountsOnlyFatal(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	// New-SDK severity-tagged exceptions, each its own session.
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "fatal", ts)     // crash
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "unhandled", ts) // not a crash
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "handled", ts)   // not a crash
+	// Legacy exceptions without severity: handled decides fatality.
+	seedIssueEvent(f.ctx, t, team, app, "exception", "", false, ts) // crash (legacy fatal)
+	seedIssueEvent(f.ctx, t, team, app, "exception", "", true, ts)  // not a crash (legacy handled)
+	// Non-exception rows: empty severity & handled=false would satisfy the
+	// bridge on their own, so these guard the type='exception' gate itself.
+	seedIssueEvent(f.ctx, t, team, app, "anr", "", false, ts) // not an exception
+	seedGenericEvents(f.ctx, t, team, app, 1, ts)             // not an exception
+
+	var crashSessions uint64
+	row := deps.RchPool.QueryRow(f.ctx,
+		`select uniqMerge(crash_sessions) from app_metrics final where team_id = toUUID(?) and app_id = toUUID(?)`,
+		team, app)
+	if err := row.Scan(&crashSessions); err != nil {
+		t.Fatalf("query app_metrics: %v", err)
+	}
+	if crashSessions != 2 {
+		t.Errorf("crash_sessions = %d, want 2 (severity=fatal + legacy handled=false)", crashSessions)
+	}
+}
+
+// app_filters_mv's exception flag must be reachable for an attribute combo
+// whose only exception is a legacy handled one (empty severity, handled=1),
+// since the column now means "any exception" rather than "fatal exception
+// only". The old predicate (handled=0) excluded exactly this row.
+func TestAppFiltersMVExceptionFlagIncludesHandled(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	seedIssueEventWithFullAttributes(f.ctx, t, team, app, "", true, ts)
+
+	ctx := ambient.WithTeamId(f.ctx, f.teamID)
+	af := filter.AppFilter{
+		AppID:      f.appID,
+		ErrorTypes: []event.ErrorType{event.ErrorTypeError},
+	}
+
+	var fl filter.FilterList
+	if err := af.GetGenericFilters(ctx, deps.RchPool, &fl, false, false); err != nil {
+		t.Fatalf("GetGenericFilters: %v", err)
+	}
+	if len(fl.Versions) == 0 {
+		t.Fatalf("expected version options for handled-only exception, got none")
+	}
+}
+
+// GetIssueFreeMetrics must exclude handled exceptions from crash_free_sessions,
+// counting only fatal ones as crashes.
+func TestGetIssueFreeMetricsExcludesHandled(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+
+	// 8 plain sessions, 1 fatal crash, 1 handled (non-crash).
+	seedGenericEvents(f.ctx, t, team, app, 8, ts)
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "fatal", ts)
+	seedIssueEventWithSeverity(f.ctx, t, team, app, "", "handled", ts)
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
+	af.Versions = []string{"v1"}
+	af.VersionCodes = []string{"1"}
+
+	crashFree, _, _, _, err := f.app.GetIssueFreeMetrics(f.ctx, deps.RchPool, af, filter.Versions{})
+	if err != nil {
+		t.Fatalf("GetIssueFreeMetrics: %v", err)
+	}
+	// 10 total sessions (8 generic + 1 fatal + 1 handled), 1 crash.
+	if want := 90.0; crashFree.CrashFreeSessions != want {
+		t.Errorf("crash_free_sessions = %v, want %v (handled exception must not count as a crash)", crashFree.CrashFreeSessions, want)
+	}
+}

--- a/backend/libs/measure/test_helpers_test.go
+++ b/backend/libs/measure/test_helpers_test.go
@@ -186,6 +186,16 @@ func seedIssueEventWithSeverity(
 	th.SeedIssueEventWithSeverity(ctx, t, teamID, appID, fingerprint, severity, ts)
 }
 
+func seedIssueEventWithFullAttributes(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, severity string,
+	handled bool,
+	ts time.Time,
+) {
+	th.SeedIssueEventWithFullAttributes(ctx, t, teamID, appID, severity, handled, ts)
+}
+
 func seedExceptionGroup(ctx context.Context, t *testing.T, teamID, appID, fingerprint string) {
 	th.SeedExceptionGroup(ctx, t, teamID, appID, fingerprint)
 }

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -239,6 +239,19 @@ type EventRow struct {
 	Severity       string
 	ExceptionsJSON string
 	IsCustom       bool
+
+	// Device/network attributes, written only when OSName is non-empty.
+	// app_filters_mv requires all nine of these non-empty to emit a row, so
+	// set every field together when a test needs to reach that view.
+	OSName             string
+	OSVersion          string
+	CountryCode        string
+	NetworkProvider    string
+	NetworkType        string
+	NetworkGeneration  string
+	DeviceLocale       string
+	DeviceManufacturer string
+	DeviceName         string
 }
 
 func (r EventRow) filled() EventRow {
@@ -317,6 +330,17 @@ func (h *TestHelper) SeedEventRows(ctx context.Context, t *testing.T, teamID, ap
 			cols = append(cols, "`exception.is_custom`")
 			vals = append(vals, "true")
 		}
+	}
+
+	if row.OSName != "" {
+		cols = append(cols,
+			"`attribute.os_name`", "`attribute.os_version`", "`inet.country_code`",
+			"`attribute.network_provider`", "`attribute.network_type`", "`attribute.network_generation`",
+			"`attribute.device_locale`", "`attribute.device_manufacturer`", "`attribute.device_name`")
+		vals = append(vals,
+			quote(row.OSName), quote(row.OSVersion), quote(row.CountryCode),
+			quote(row.NetworkProvider), quote(row.NetworkType), quote(row.NetworkGeneration),
+			quote(row.DeviceLocale), quote(row.DeviceManufacturer), quote(row.DeviceName))
 	}
 
 	query := fmt.Sprintf("INSERT INTO measure.events (%s) SELECT %s FROM numbers(%d)",
@@ -506,9 +530,9 @@ func (h *TestHelper) SeedIssueEventWithDataInSession(
 }
 
 // SeedIssueEventWithSeverity inserts an exception event with an explicit
-// exception.severity column value, mimicking new-SDK ingestion. The handled
-// bool is set consistently with severity ("handled" → true, others → false).
-// Use this to test the new-data path of severity-aware queries.
+// exception.severity value, mimicking new-SDK ingestion. Handled is always
+// false: no current SDK sends the deprecated handled field, so ingest
+// zero-values it whatever the severity.
 func (h *TestHelper) SeedIssueEventWithSeverity(
 	ctx context.Context,
 	t *testing.T,
@@ -520,8 +544,38 @@ func (h *TestHelper) SeedIssueEventWithSeverity(
 		Type:        "exception",
 		Fingerprint: fingerprint,
 		Severity:    severity,
-		Handled:     severity == "handled",
+		Handled:     false,
 		Timestamp:   ts,
+	})
+}
+
+// SeedIssueEventWithFullAttributes inserts an exception event with an explicit
+// severity, a handled flag & every device/network attribute app_filters_mv
+// requires non-empty to emit a row. Use it to reach that view instead of the
+// SeedAppFilters direct-insert bypass. severity="" with handled=true models a
+// legacy pre-severity handled exception, the row the old predicate excluded.
+func (h *TestHelper) SeedIssueEventWithFullAttributes(
+	ctx context.Context,
+	t *testing.T,
+	teamID, appID, severity string,
+	handled bool,
+	ts time.Time,
+) {
+	t.Helper()
+	h.SeedEventRows(ctx, t, teamID, appID, 1, EventRow{
+		Type:               "exception",
+		Severity:           severity,
+		Handled:            handled,
+		Timestamp:          ts,
+		OSName:             "Android",
+		OSVersion:          "14",
+		CountryCode:        "US",
+		NetworkProvider:    "carrier",
+		NetworkType:        "wifi",
+		NetworkGeneration:  "4g",
+		DeviceLocale:       "en-US",
+		DeviceManufacturer: "TestCo",
+		DeviceName:         "pixel",
 	})
 }
 
@@ -725,7 +779,8 @@ func (h *TestHelper) SeedAnrGroup(ctx context.Context, t *testing.T, teamID, app
 // a unique session_id, so:
 //
 //	total_sessions = genericCount + crashCount + anrCount
-//	crash_sessions = crashCount   (type="exception", exception.handled=false)
+//	crash_sessions = crashCount   (type="exception", fatal: severity="fatal"
+//	                 or (severity="" and exception.handled=false))
 //	anr_sessions   = anrCount     (type="anr")
 func (h *TestHelper) SeedAppMetrics(ctx context.Context, t *testing.T, teamID, appID string, ts time.Time, genericCount, crashCount, anrCount int) {
 	t.Helper()

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -502,8 +502,7 @@ paths:
         Both `versions` & `version_codes` should be present if any one of them
         is present, and the number of items in each must be the same. `from` &
         `to` values must be ISO 8601 UTC strings in milliseconds precision and
-        default to a last 7 days time range if not supplied. Only the first
-        version in `versions` & `version_codes` is used to query at the moment.
+        default to a last 7 days time range if not supplied.
 
         `nan` can be true in the response if some computed values result in a
         division by zero error.
@@ -520,13 +519,13 @@ paths:
         - name: versions
           in: query
           required: false
-          description: Comma separated version identifiers. Only the first version will be used to query at the moment.
+          description: Comma separated version identifiers.
           schema:
             type: string
         - name: version_codes
           in: query
           required: false
-          description: Comma separated version codes. Only the first version will be used to query at the moment.
+          description: Comma separated version codes.
           schema:
             type: string
       responses:
@@ -807,6 +806,9 @@ paths:
         `builds=1` to return version filters computed from uploaded build
         mappings instead of event data. If `type`, `span` and `builds` are
         omitted, filters are computed from all events.
+
+        `severity` is not honoured on this endpoint and is ignored if passed.
+        Use it on the errorGroups endpoints instead.
       parameters:
         - name: id
           in: path

--- a/self-host/clickhouse/20260819120000_alter_app_metrics_mv.sql
+++ b/self-host/clickhouse/20260819120000_alter_app_metrics_mv.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+alter table app_metrics_mv modify query
+select
+    team_id,
+    app_id,
+    toStartOfFifteenMinutes(timestamp)                                                                           as timestamp,
+    (attribute.app_version, attribute.app_build)                                                                 as app_version,
+    uniqState(session_id)                                                                                        as unique_sessions,
+    uniqStateIf(session_id, (type = 'exception') and (
+        exception.severity = 'fatal' or (exception.severity = '' and exception.handled = 0)
+    ))                                                                                       as crash_sessions,
+    uniqStateIf(session_id, (type = 'exception') and (
+        exception.severity = 'fatal' or (exception.severity = '' and exception.handled = 0)
+    ) and (exception.foreground = 1))                                                        as perceived_crash_sessions,
+    uniqStateIf(session_id, type = 'anr')                                                                       as anr_sessions,
+    uniqStateIf(session_id, (type = 'anr') and (anr.foreground = 1))                                            as perceived_anr_sessions,
+    quantileStateIf(0.95)(cold_launch.duration, (type = 'cold_launch') and (cold_launch.duration > 0) and (cold_launch.duration <= 30000)) as cold_launch_p95,
+    quantileStateIf(0.95)(warm_launch.duration, (type = 'warm_launch') and (warm_launch.duration > 0) and (warm_launch.duration <= 10000)) as warm_launch_p95,
+    quantileStateIf(0.95)(hot_launch.duration, (type = 'hot_launch') and (hot_launch.duration > 0))             as hot_launch_p95
+from events
+group by
+    team_id,
+    app_id,
+    timestamp,
+    app_version;
+
+-- migrate:down
+alter table app_metrics_mv modify query
+select
+    team_id,
+    app_id,
+    toStartOfFifteenMinutes(timestamp)                                                                           as timestamp,
+    (attribute.app_version, attribute.app_build)                                                                 as app_version,
+    uniqState(session_id)                                                                                        as unique_sessions,
+    uniqStateIf(session_id, (type = 'exception') and (exception.handled = 0))                                    as crash_sessions,
+    uniqStateIf(session_id, (type = 'exception') and (exception.handled = 0) and (exception.foreground = 1))    as perceived_crash_sessions,
+    uniqStateIf(session_id, type = 'anr')                                                                       as anr_sessions,
+    uniqStateIf(session_id, (type = 'anr') and (anr.foreground = 1))                                            as perceived_anr_sessions,
+    quantileStateIf(0.95)(cold_launch.duration, (type = 'cold_launch') and (cold_launch.duration > 0) and (cold_launch.duration <= 30000)) as cold_launch_p95,
+    quantileStateIf(0.95)(warm_launch.duration, (type = 'warm_launch') and (warm_launch.duration > 0) and (warm_launch.duration <= 10000)) as warm_launch_p95,
+    quantileStateIf(0.95)(hot_launch.duration, (type = 'hot_launch') and (hot_launch.duration > 0))             as hot_launch_p95
+from events
+group by
+    team_id,
+    app_id,
+    timestamp,
+    app_version;

--- a/self-host/clickhouse/20260819120100_alter_app_filters_mv.sql
+++ b/self-host/clickhouse/20260819120100_alter_app_filters_mv.sql
@@ -1,0 +1,85 @@
+-- migrate:up
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max(type = 'exception')                               as exception,
+    max(type = 'anr')                                     as anr,
+    attribute.patch_version                               as patch_version
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    patch_version;
+
+-- migrate:down
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max((type = 'exception') and (exception.handled = 0)) as exception,
+    max(type = 'anr')                                     as anr,
+    attribute.patch_version                               as patch_version
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    patch_version;


### PR DESCRIPTION
## Summary

This PR moves `app_filters_mv` & `app_metrics_mv` onto the fatal/non-fatal severity model, the last two consumers still classifying exceptions by the deprecated `exception.handled` flag. No current SDK sends that field, so it zero-values to `false` on ingest & the old predicate matched every exception whatever its severity, counting handled & custom-tracked errors as crashes. `crash_sessions` now counts fatal exceptions only, `app_filters.exception` marks any exception so `type=error` covers fatal + non-fatal as documented & the fatal predicate is shared from one place. Crash spike alerts had the same flaw & are now limited to fatal exceptions. Also corrects `perceived_crash_free_sessions.delta`, which took the crash-free field's assignment.

## Tasks

- [x] Move `app_metrics_mv` & `app_filters_mv` to the severity model
- [x] Count only fatal exceptions as crashes
- [x] Treat `app_filters.exception` as any exception
- [x] Share the fatal predicate via `config.FatalExceptionExpr`
- [x] Limit crash spike alerts to fatal exceptions
- [x] Set `perceived_crash_free_sessions.delta` from its own baseline
- [x] Seed exceptions the way current SDKs send them
- [x] Cover the materialized view predicates with tests
- [x] Update metrics & filters API docs

## See also

- fixes #4256
