### PR TITLE
docs(rn): update link in upload build script

### DIFF
--- a/react-native/scripts/upload_build_phase.sh
+++ b/react-native/scripts/upload_build_phase.sh
@@ -15,7 +15,7 @@
 # code and images" build phase:
 #   export SOURCEMAP_FILE="$(pwd)/main.jsbundle.map"
 #
-# See https://github.com/measure-sh/measure/blob/main/docs/features/feature-upload-symbols.md#react-native
+# See https://measure.sh/docs/error-monitoring/upload-symbols
 
 if [ "$#" -lt 2 ]; then
   echo "Usage: $0 <api_url> <api_key>"


### PR DESCRIPTION
## Summary

This PR updates an outdated link the React Native build upload script.

## Tasks

- [x] Fixes an outdated link in `upload_build_phase.sh` script