### PR TITLE
feat(backend): send single daily summary per team

### DIFF
--- a/backend/agent/agent/slack.go
+++ b/backend/agent/agent/slack.go
@@ -364,7 +364,7 @@ func (c *Config) slackReply(ctx context.Context, ev slack.AgentEvent, teamID uui
 	}
 
 	question := strings.TrimSpace(slackMentionRE.ReplaceAllString(ev.Text, ""))
-	question = slackUnescaper.Replace(question)
+	question = slack.UnescapeMrkdwn(question)
 	if question == "" {
 		return "Hey! I can help you debug your app, from crashes and errors to slow sessions and network issues. What are you looking into?", nil
 	}
@@ -669,17 +669,6 @@ func noAppsReply(dashboard string) string {
 // slackMentionRE matches user mentions like <@U12345> in message text.
 var slackMentionRE = regexp.MustCompile(`<@[^>]+>`)
 
-// slackUnescaper undoes the HTML escaping Slack applies to message text on
-// the way in, so the model reads ">" where the user typed it instead of
-// "&gt;".
-var slackUnescaper = strings.NewReplacer("&lt;", "<", "&gt;", ">", "&amp;", "&")
-
-// slackEscaper escapes the three characters Slack parses as markup. Replies
-// pass through it so text the model echoes (a "<!channel>" planted in the
-// question, a literal "<30s") renders as text instead of executing with
-// the bot's authority or breaking the message.
-var slackEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
-
 var (
 	mdHeading = regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`)
 	mdBold    = regexp.MustCompile(`\*\*(.+?)\*\*`)
@@ -714,12 +703,12 @@ func stripCellMarkup(s string) string {
 // first, so the angle brackets the link rewrite emits survive it.
 func toMrkdwn(text string) string {
 	text, tables := extractTables(text)
-	text = slackEscaper.Replace(text)
+	text = slack.EscapeMrkdwn(text)
 	text = mdHeading.ReplaceAllString(text, "*$1*")
 	text = mdBold.ReplaceAllString(text, "*$1*")
 	text = mdLink.ReplaceAllString(text, "<$2|$1>")
 	for i, tbl := range tables {
-		fenced := "```\n" + slackEscaper.Replace(tbl) + "\n```"
+		fenced := "```\n" + slack.EscapeMrkdwn(tbl) + "\n```"
 		text = strings.Replace(text, tablePlaceholder(i), fenced, 1)
 	}
 	return text
@@ -1084,7 +1073,7 @@ func selectContextMessages(msgs []slack.Message, botUserID, mentionTS, through s
 func renderSlackContext(msgs []slack.Message) string {
 	var b strings.Builder
 	for _, m := range msgs {
-		text := strings.TrimSpace(slackUnescaper.Replace(m.Text))
+		text := strings.TrimSpace(slack.UnescapeMrkdwn(m.Text))
 		if text == "" {
 			continue
 		}

--- a/backend/agent/agent/slack_test.go
+++ b/backend/agent/agent/slack_test.go
@@ -166,7 +166,7 @@ func TestSlackUnescaper(t *testing.T) {
 	// see what the user typed.
 	in := "crash rate &gt; 2% in Food &amp; Drink?"
 	want := "crash rate > 2% in Food & Drink?"
-	if got := slackUnescaper.Replace(in); got != want {
+	if got := slack.UnescapeMrkdwn(in); got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
 }

--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -18,6 +18,7 @@ import (
 	"backend/libs/config"
 	"backend/libs/email"
 	"backend/libs/numeric"
+	libslack "backend/libs/slack"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -870,6 +871,14 @@ func formatSlackAlertMessage(title, message, url string) slack.SlackMessage {
 		},
 	}
 
+	// The message is shared with the email path and arrives formatted for
+	// HTML, with <br> marking line breaks and app-generated text (a crash
+	// message like "<init>", a user-typed bug report description) left as is.
+	// Rewrite the breaks as newlines, then escape the characters Slack parses
+	// as markup so the text renders literally.
+	message = strings.ReplaceAll(message, "<br>", "\n")
+	message = libslack.EscapeMrkdwn(message)
+
 	blocks = append(blocks, slack.SlackSectionBlock{
 		Type: "section",
 		Text: &slack.SlackText{
@@ -909,17 +918,6 @@ func formatSlackAlertMessage(title, message, url string) slack.SlackMessage {
 	return slack.SlackMessage{
 		Blocks: blocks,
 	}
-}
-
-// escapeSlackMrkdwn replaces &, <, and > with their HTML entities. Slack
-// parses these three characters as control characters in mrkdwn text (< and >
-// delimit links and mentions, & starts an entity), so an app named
-// "<Foo & Bar>" would otherwise render wrongly or drop text.
-func escapeSlackMrkdwn(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	return s
 }
 
 // slackHeaderTextLimit is the maximum number of characters Slack accepts in
@@ -997,7 +995,7 @@ func formatTeamDailySummarySlackMessage(teamName, dashboardURL string, date time
 				Type: "section",
 				Text: &slack.SlackText{
 					Type: "mrkdwn",
-					Text: fmt.Sprintf("*%s*", escapeSlackMrkdwn(app.AppName)),
+					Text: fmt.Sprintf("*%s*", libslack.EscapeMrkdwn(app.AppName)),
 				},
 			},
 			slack.SlackSectionBlock{

--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -1,12 +1,15 @@
 package alerts
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"math"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"backend/alerts/server"
@@ -23,12 +26,14 @@ import (
 
 type Team struct {
 	ID               uuid.UUID
+	Name             string
 	AutumnCustomerID *string
 }
 
 type App struct {
 	ID     uuid.UUID
 	TeamID uuid.UUID
+	Name   string
 }
 
 type Alert struct {
@@ -179,12 +184,6 @@ func CreateBugReportAlerts(ctx context.Context) {
 				continue
 			}
 
-			appName, err := getAppNameByID(ctx, app.ID)
-			if err != nil {
-				fmt.Printf("Error fetching app name for app %v: %v\n", app.ID, err)
-				continue
-			}
-
 			for bugReportRows.Next() {
 				var bugReportId string
 				var description string
@@ -248,8 +247,8 @@ func CreateBugReportAlerts(ctx context.Context) {
 					Type:     string(AlertTypeBugReport),
 				}
 
-				scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, appName)
-				scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, appName)
+				scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, app.Name)
+				scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, app.Name)
 			}
 
 			if bugReportRows != nil {
@@ -278,31 +277,61 @@ func CreateDailySummary(ctx context.Context) {
 			continue
 		}
 
+		entries := []appSummaryWithSessions{}
 		for _, app := range apps {
-			appName, err := getAppNameByID(ctx, app.ID)
-			if err != nil {
-				fmt.Printf("Error fetching app name for app %v: %v\n", app.ID, err)
-				continue
-			}
-
-			metrics, err := getDailySummaryMetrics(ctx, date, &app)
+			metrics, sessionsToday, err := getDailySummaryMetrics(ctx, date, &app)
 			if err != nil {
 				fmt.Printf("Error fetching daily summary data for app %v: %v\n", app.ID, err)
 				continue
 			}
 
-			_, dailySummaryEmailBody := email.DailySummaryEmail(appName, date, metrics, server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String())
-			scheduleDailySummaryEmailForteamMembers(ctx, team.ID, app.ID, dailySummaryEmailBody, appName)
-			dashboardURL := fmt.Sprintf("%s/%s/overview?a=%s", server.Server.Config.SiteOrigin, team.ID, app.ID)
-			scheduleDailySummarySlackMessageForTeamChannels(ctx, team.ID, app.ID, dashboardURL, appName, date, metrics)
+			entries = append(entries, appSummaryWithSessions{
+				Summary:       email.AppDailySummary{AppName: app.Name, Metrics: metrics},
+				SessionsToday: sessionsToday,
+			})
 		}
+
+		// An app whose metrics query returns no rows is left out. Teams with all apps in this
+		// state don't get email or slack message
+		if len(entries) == 0 {
+			continue
+		}
+
+		appSummaries := sortedAppSummaries(entries)
+
+		subject, body := email.TeamDailySummaryEmail(team.Name, date, appSummaries, server.Server.Config.SiteOrigin, team.ID.String())
+		scheduleDailySummaryEmailForTeamMembers(ctx, team.ID, subject, body)
+
+		dashboardURL := fmt.Sprintf("%s/%s/overview", server.Server.Config.SiteOrigin, team.ID)
+		scheduleDailySummarySlackMessageForTeamChannels(ctx, team.ID, team.Name, dashboardURL, date, appSummaries)
 	}
+}
+
+type appSummaryWithSessions struct {
+	Summary       email.AppDailySummary
+	SessionsToday uint64
+}
+
+func sortedAppSummaries(entries []appSummaryWithSessions) []email.AppDailySummary {
+	slices.SortStableFunc(entries, func(a, b appSummaryWithSessions) int {
+		if a.SessionsToday != b.SessionsToday {
+			return cmp.Compare(b.SessionsToday, a.SessionsToday)
+		}
+		return cmp.Compare(a.Summary.AppName, b.Summary.AppName)
+	})
+
+	summaries := make([]email.AppDailySummary, 0, len(entries))
+	for _, entry := range entries {
+		summaries = append(summaries, entry.Summary)
+	}
+	return summaries
 }
 
 func getActiveTeams(ctx context.Context) ([]Team, error) {
 	teams := []Team{}
 	stmt := sqlf.PostgreSQL.
 		Select("id").
+		Select("name").
 		Select("autumn_customer_id").
 		From("teams")
 
@@ -315,7 +344,7 @@ func getActiveTeams(ctx context.Context) ([]Team, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var t Team
-		if err := rows.Scan(&t.ID, &t.AutumnCustomerID); err != nil {
+		if err := rows.Scan(&t.ID, &t.Name, &t.AutumnCustomerID); err != nil {
 			return nil, err
 		}
 		teams = append(teams, t)
@@ -356,6 +385,7 @@ func getAppsForTeam(ctx context.Context, teamID uuid.UUID) ([]App, error) {
 	stmt := sqlf.PostgreSQL.
 		Select("id").
 		Select("team_id").
+		Select("app_name").
 		From("apps").
 		Where("team_id = ?", teamID)
 
@@ -368,28 +398,12 @@ func getAppsForTeam(ctx context.Context, teamID uuid.UUID) ([]App, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var a App
-		if err := rows.Scan(&a.ID, &a.TeamID); err != nil {
+		if err := rows.Scan(&a.ID, &a.TeamID, &a.Name); err != nil {
 			return nil, err
 		}
 		apps = append(apps, a)
 	}
 	return apps, nil
-}
-
-func getAppNameByID(ctx context.Context, appID uuid.UUID) (string, error) {
-	appNameStmt := sqlf.PostgreSQL.
-		Select("app_name").
-		From("apps").
-		Where("id = ?", appID)
-
-	defer appNameStmt.Close()
-
-	var appName string
-	err := server.Server.PgPool.QueryRow(ctx, appNameStmt.String(), appNameStmt.Args()...).Scan(&appName)
-	if err != nil {
-		return "", err
-	}
-	return appName, nil
 }
 
 // formatUnit rounds a measured value to two decimal places, drops trailing
@@ -446,7 +460,7 @@ func launchMetric(label string, todayMs, yesterdayMs float64) email.MetricData {
 	return email.MetricData{Value: value, Label: label, Subtitle: subtitle}
 }
 
-func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]email.MetricData, error) {
+func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) (metrics []email.MetricData, sessionsToday uint64, err error) {
 	appThresholdPrefs, err := getAppThresholdPrefs(ctx, app.ID)
 	if err != nil {
 		fmt.Printf("Error fetching app threshold prefs for app %v, using defaults: %v\n", app.ID, err)
@@ -532,7 +546,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan daily summary: %w", err)
+		return nil, 0, fmt.Errorf("failed to scan daily summary: %w", err)
 	}
 
 	// A previous day with no sessions at all is what a missing row from the
@@ -554,7 +568,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
 		crashFreeSubtitle = comparison(crashFreeValue, formatUnit(crashFreeYesterday, "%"), crashFreeToday > crashFreeYesterday)
 	}
 
-	metrics := []email.MetricData{
+	metrics = []email.MetricData{
 		{
 			Value:    sessionsValue,
 			Label:    "Sessions",
@@ -608,7 +622,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
 	var todayBugReportCount, yesterdayBugReportCount uint64
 	bugCountRow := server.Server.ChPool.QueryRow(ctx, bugReportCountQuery, date, app.ID)
 	if err := bugCountRow.Scan(&todayBugReportCount, &yesterdayBugReportCount); err != nil {
-		return nil, fmt.Errorf("failed to scan bug report count: %w", err)
+		return nil, 0, fmt.Errorf("failed to scan bug report count: %w", err)
 	}
 	if todayBugReportCount > 0 {
 		bugValue := numeric.FormatKMB(int64(todayBugReportCount))
@@ -623,7 +637,7 @@ func getDailySummaryMetrics(ctx context.Context, date time.Time, app *App) ([]em
 		})
 	}
 
-	return metrics, nil
+	return metrics, summary.SessionsToday, nil
 }
 
 func getAppThresholdPrefs(ctx context.Context, appID uuid.UUID) (AppThresholdPrefs, error) {
@@ -772,20 +786,20 @@ func scheduleSlackAlertsForTeamChannels(ctx context.Context, alert Alert, messag
 	}
 }
 
-func scheduleDailySummaryEmailForteamMembers(ctx context.Context, teamId uuid.UUID, appId uuid.UUID, emailBody, appName string) {
+func scheduleDailySummaryEmailForTeamMembers(ctx context.Context, teamId uuid.UUID, subject, body string) {
 	pendingEmail := email.EmailInfo{
 		From:        server.Server.Config.TxEmailAddress,
-		Subject:     appName + " Daily Summary",
+		Subject:     subject,
 		ContentType: "text/html",
-		Body:        emailBody,
+		Body:        body,
 		AlertType:   "daily_summary",
 	}
-	if err := email.QueueEmailForTeam(ctx, server.Server.PgPool, nil, teamId, appId, pendingEmail); err != nil {
+	if err := email.QueueEmailForTeam(ctx, server.Server.PgPool, nil, teamId, nil, pendingEmail); err != nil {
 		fmt.Printf("Error queueing daily summary emails for team %v: %v\n", teamId, err)
 	}
 }
 
-func scheduleDailySummarySlackMessageForTeamChannels(ctx context.Context, teamId uuid.UUID, appId uuid.UUID, dashboardURL, appName string, date time.Time, metrics []email.MetricData) {
+func scheduleDailySummarySlackMessageForTeamChannels(ctx context.Context, teamId uuid.UUID, teamName, dashboardURL string, date time.Time, apps []email.AppDailySummary) {
 	teamSlackStmt := `
     SELECT bot_token, channel_ids, is_active
     FROM team_slack
@@ -810,7 +824,7 @@ func scheduleDailySummarySlackMessageForTeamChannels(ctx context.Context, teamId
 		return
 	}
 
-	slackMessage := formatDailySummarySlackMessage(appName, dashboardURL, date, metrics)
+	slackMessage := formatTeamDailySummarySlackMessage(teamName, dashboardURL, date, apps)
 
 	for _, channelId := range channelIds {
 		slackData := slack.SlackMessageData{
@@ -829,7 +843,7 @@ func scheduleDailySummarySlackMessageForTeamChannels(ctx context.Context, teamId
 			InsertInto("pending_alert_messages").
 			Set("id", uuid.New()).
 			Set("team_id", teamId).
-			Set("app_id", appId).
+			Set("app_id", nil).
 			Set("channel", "slack").
 			SetExpr("data", "?::jsonb", string(dataJson)).
 			Set("created_at", time.Now()).
@@ -851,7 +865,7 @@ func formatSlackAlertMessage(title, message, url string) slack.SlackMessage {
 			Type: "header",
 			Text: &slack.SlackText{
 				Type: "plain_text",
-				Text: fmt.Sprintf("🚨 %s", title),
+				Text: truncateSlackHeader(fmt.Sprintf("🚨 %s", title)),
 			},
 		},
 	}
@@ -897,20 +911,64 @@ func formatSlackAlertMessage(title, message, url string) slack.SlackMessage {
 	}
 }
 
-func formatDailySummarySlackMessage(appName, dashboardURL string, date time.Time, metrics []email.MetricData) slack.SlackMessage {
+// escapeSlackMrkdwn replaces &, <, and > with their HTML entities. Slack
+// parses these three characters as control characters in mrkdwn text (< and >
+// delimit links and mentions, & starts an entity), so an app named
+// "<Foo & Bar>" would otherwise render wrongly or drop text.
+func escapeSlackMrkdwn(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+// slackHeaderTextLimit is the maximum number of characters Slack accepts in
+// a header block's text.
+const slackHeaderTextLimit = 150
+
+func truncateSlackHeader(text string) string {
+	runes := []rune(text)
+	if len(runes) <= slackHeaderTextLimit {
+		return text
+	}
+	return string(runes[:slackHeaderTextLimit-1]) + "…"
+}
+
+// slackBlockLimit is the maximum number of blocks Slack accepts in a single
+// chat.postMessage call; longer messages are rejected outright.
+const slackBlockLimit = 50
+
+// slackBlocksPerApp is the number of blocks each app adds to the team daily
+// summary message: a section naming the app, a section with its metric lines,
+// and a trailing divider.
+const slackBlocksPerApp = 3
+
+// formatTeamDailySummarySlackMessage builds one Slack message summarizing the
+// day's metrics for every app in apps, in the given order. When the apps do
+// not all fit under Slack's block limit, the trailing apps are dropped and a
+// context line reports how many were left out.
+func formatTeamDailySummarySlackMessage(teamName, dashboardURL string, date time.Time, apps []email.AppDailySummary) slack.SlackMessage {
 	formattedDate := date.Format("January 2, 2006")
 
+	// The header, date section, and leading divider open the message and the
+	// actions block closes it, so four blocks are always present. When apps
+	// are dropped, the context line reporting the omission takes a fifth,
+	// leaving less room for app blocks.
+	shownApps := len(apps)
+	if shownApps > (slackBlockLimit-4)/slackBlocksPerApp {
+		shownApps = (slackBlockLimit - 5) / slackBlocksPerApp
+	}
+	omitted := len(apps) - shownApps
+
 	blocks := []slack.SlackBlock{
-		// Title
 		slack.SlackHeaderBlock{
 			Type: "header",
 			Text: &slack.SlackText{
 				Type: "plain_text",
-				Text: fmt.Sprintf("%s — Daily Summary", appName),
+				Text: truncateSlackHeader(fmt.Sprintf("%s — Daily Summary", teamName)),
 			},
 		},
 
-		// Date subtitle
 		slack.SlackSectionBlock{
 			Type: "section",
 			Text: &slack.SlackText{
@@ -922,42 +980,50 @@ func formatDailySummarySlackMessage(appName, dashboardURL string, date time.Time
 		slack.SlackDividerBlock{Type: "divider"},
 	}
 
-	for _, metric := range metrics {
-		status := "🟢"
-		if metric.HasError {
-			status = "🔴"
-		} else if metric.HasWarning {
-			status = "🟡"
+	for _, app := range apps[:shownApps] {
+		lines := make([]string, 0, len(app.Metrics))
+		for _, metric := range app.Metrics {
+			status := "🟢"
+			if metric.HasError {
+				status = "🔴"
+			} else if metric.HasWarning {
+				status = "🟡"
+			}
+			lines = append(lines, fmt.Sprintf("%s *%s*  %s · _%s_", status, metric.Label, metric.Value, metric.Subtitle))
 		}
 
 		blocks = append(blocks,
 			slack.SlackSectionBlock{
 				Type: "section",
-				Fields: []slack.SlackText{
-					{
-						Type: "mrkdwn",
-						Text: fmt.Sprintf("*%s*", metric.Label),
-					},
-					{
-						Type: "mrkdwn",
-						Text: fmt.Sprintf("%s *%s*\n_%s_", status, metric.Value, metric.Subtitle),
-					},
+				Text: &slack.SlackText{
+					Type: "mrkdwn",
+					Text: fmt.Sprintf("*%s*", escapeSlackMrkdwn(app.AppName)),
 				},
 			},
-			// Spacer between rows
-			slack.SlackContextBlock{
-				Type: "context",
-				Elements: []slack.SlackText{
-					{Type: "mrkdwn", Text: " "},
+			slack.SlackSectionBlock{
+				Type: "section",
+				Text: &slack.SlackText{
+					Type: "mrkdwn",
+					Text: strings.Join(lines, "\n"),
 				},
 			},
+			slack.SlackDividerBlock{Type: "divider"},
 		)
 	}
 
-	// Divider before button
-	blocks = append(blocks, slack.SlackDividerBlock{Type: "divider"})
+	if omitted > 0 {
+		noun := "apps"
+		if omitted == 1 {
+			noun = "app"
+		}
+		blocks = append(blocks, slack.SlackContextBlock{
+			Type: "context",
+			Elements: []slack.SlackText{
+				{Type: "mrkdwn", Text: fmt.Sprintf("+%d more %s not shown", omitted, noun)},
+			},
+		})
+	}
 
-	// Button
 	blocks = append(blocks, slack.SlackActionsBlock{
 		Type: "actions",
 		Elements: []slack.SlackElement{
@@ -1076,12 +1142,6 @@ func createCrashAlertsForApp(ctx context.Context, team Team, app App, from, to t
 				continue
 			}
 
-			appName, err := getAppNameByID(ctx, app.ID)
-			if err != nil {
-				fmt.Printf("Error fetching app name for app %v: %v\n", app.ID, err)
-				continue
-			}
-
 			alert := Alert{
 				ID:       alertID,
 				TeamID:   team.ID,
@@ -1090,8 +1150,8 @@ func createCrashAlertsForApp(ctx context.Context, team Team, app App, from, to t
 				Type:     string(AlertTypeCrashSpike),
 			}
 
-			scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, appName)
-			scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, appName)
+			scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, app.Name)
+			scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, app.Name)
 		}
 	}
 
@@ -1196,12 +1256,6 @@ func createAnrAlertsForApp(ctx context.Context, team Team, app App, from, to tim
 				continue
 			}
 
-			appName, err := getAppNameByID(ctx, app.ID)
-			if err != nil {
-				fmt.Printf("Error fetching app name for app %v: %v\n", app.ID, err)
-				continue
-			}
-
 			alert := Alert{
 				ID:       alertID,
 				TeamID:   team.ID,
@@ -1210,8 +1264,8 @@ func createAnrAlertsForApp(ctx context.Context, team Team, app App, from, to tim
 				Type:     string(AlertTypeAnrSpike),
 			}
 
-			scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, appName)
-			scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, appName)
+			scheduleEmailAlertsForteamMembers(ctx, alert, alertMsg, alertUrl, app.Name)
+			scheduleSlackAlertsForTeamChannels(ctx, alert, alertMsg, alertUrl, app.Name)
 		}
 	}
 

--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -981,13 +981,13 @@ func formatTeamDailySummarySlackMessage(teamName, dashboardURL string, date time
 	for _, app := range apps[:shownApps] {
 		lines := make([]string, 0, len(app.Metrics))
 		for _, metric := range app.Metrics {
-			status := "🟢"
+			line := fmt.Sprintf("• *%s*  %s · _%s_", metric.Label, metric.Value, metric.Subtitle)
 			if metric.HasError {
-				status = "🔴"
+				line += " `poor`"
 			} else if metric.HasWarning {
-				status = "🟡"
+				line += " `caution`"
 			}
-			lines = append(lines, fmt.Sprintf("%s *%s*  %s · _%s_", status, metric.Label, metric.Value, metric.Subtitle))
+			lines = append(lines, line)
 		}
 
 		blocks = append(blocks,

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -2532,8 +2532,8 @@ func TestCreateDailySummary(t *testing.T) {
 			t.Fatalf("unmarshal slack payload: %v", err)
 		}
 		payloadJSON, _ := json.Marshal(payload)
-		if !strings.Contains(string(payloadJSON), "🟡") {
-			t.Fatalf("expected slack payload to include warning status icon for custom thresholds")
+		if !strings.Contains(string(payloadJSON), "`caution`") {
+			t.Fatalf("expected slack payload to include the caution status tag for custom thresholds")
 		}
 	})
 
@@ -2599,8 +2599,8 @@ func TestCreateDailySummary(t *testing.T) {
 			t.Fatalf("unmarshal slack payload: %v", err)
 		}
 		payloadJSON, _ := json.Marshal(payload)
-		if !strings.Contains(string(payloadJSON), "🔴") {
-			t.Fatalf("expected slack payload to include error status icon for custom thresholds")
+		if !strings.Contains(string(payloadJSON), "`poor`") {
+			t.Fatalf("expected slack payload to include the poor status tag for custom thresholds")
 		}
 	})
 
@@ -2889,14 +2889,14 @@ func TestFormatTeamDailySummarySlackMessage(t *testing.T) {
 		if len(checkoutLines) != 3 {
 			t.Fatalf("got %d metric lines for Checkout, want 3", len(checkoutLines))
 		}
-		if checkoutLines[0] != "🟢 *Sessions*  1.2K · _Up from 1K yesterday_" {
-			t.Errorf("healthy metric line = %q", checkoutLines[0])
+		if checkoutLines[0] != "• *Sessions*  1.2K · _Up from 1K yesterday_" {
+			t.Errorf("healthy metric line = %q, want no status tag", checkoutLines[0])
 		}
-		if !strings.HasPrefix(checkoutLines[1], "🟡 ") {
-			t.Errorf("warning metric line = %q, want a 🟡 prefix", checkoutLines[1])
+		if !strings.HasSuffix(checkoutLines[1], " `caution`") {
+			t.Errorf("warning metric line = %q, want a trailing `caution` tag", checkoutLines[1])
 		}
-		if !strings.HasPrefix(checkoutLines[2], "🔴 ") {
-			t.Errorf("error metric line = %q, want a 🔴 prefix (error outranks warning)", checkoutLines[2])
+		if !strings.HasSuffix(checkoutLines[2], " `poor`") {
+			t.Errorf("error metric line = %q, want a trailing `poor` tag (error outranks warning)", checkoutLines[2])
 		}
 
 		if got := sectionText(t, msg.Blocks[6]); got != "*Storefront*" {

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"backend/alerts/server"
+	"backend/alerts/slack"
 	"backend/libs/autumn"
 	autumntest "backend/libs/autumn/testhelpers"
 	"backend/libs/email"
@@ -979,7 +980,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedApp(ctx, t, appID, teamID, "A", 30)
 
 		app := makeApp(teamID, appID)
-		_, err := getDailySummaryMetrics(ctx, time.Now().UTC(), &app)
+		_, _, err := getDailySummaryMetrics(ctx, time.Now().UTC(), &app)
 		if err == nil {
 			t.Error("expected error when no data, got nil")
 		}
@@ -1001,7 +1002,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 5, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1033,7 +1034,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 5, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1058,7 +1059,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 5, 0, 0) // yesterday: 5
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1083,7 +1084,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 5, 0, 0) // yesterday: 5
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1108,7 +1109,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, yesterday, 5, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1133,7 +1134,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2500, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1161,7 +1162,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1192,7 +1193,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 9, 1, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1223,7 +1224,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 8, 2, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1252,7 +1253,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 9, 1, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1279,7 +1280,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 4, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1306,7 +1307,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 2, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1332,7 +1333,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 9, 1, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1359,7 +1360,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 2, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1389,7 +1390,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 398, 2, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1419,7 +1420,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1444,7 +1445,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1475,7 +1476,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 90, 0, 10)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1506,7 +1507,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 8, 0, 2)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1539,7 +1540,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 4, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1566,7 +1567,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 0, 2)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1593,7 +1594,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 2, 0, 2)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1617,7 +1618,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 9, 0, 1)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1643,7 +1644,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 9, 0, 1)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1695,7 +1696,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 48, 1, 1)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1726,7 +1727,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 96, 2, 2)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1756,7 +1757,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 10, 10, 10)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1786,7 +1787,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 96, 2, 2)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1816,7 +1817,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 90, 5, 5)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1845,7 +1846,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 5, 0, 0) // generic only, no launch events
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1877,7 +1878,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedAppMetrics(ctx, t, teamID, appID, now, 5, 0, 0)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1905,7 +1906,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "hot_launch", 100, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1936,7 +1937,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "hot_launch", 100, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1964,7 +1965,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 500, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1990,7 +1991,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 1000, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2016,7 +2017,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "cold_launch", 500, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2041,7 +2042,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		th.SeedLaunchEvent(ctx, t, teamID, appID, "hot_launch", 5000, now)
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2075,7 +2076,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		}
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2114,7 +2115,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		// No bug reports seeded
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2145,7 +2146,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		}
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2179,7 +2180,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		}
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2213,7 +2214,7 @@ func TestGetDailySummaryMetrics(t *testing.T) {
 		}
 
 		app := makeApp(teamID, appID)
-		metrics, err := getDailySummaryMetrics(ctx, now, &app)
+		metrics, _, err := getDailySummaryMetrics(ctx, now, &app)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2321,7 +2322,7 @@ func TestCreateDailySummary(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple apps each get their own daily summary email", func(t *testing.T) {
+	t.Run("multiple apps are combined into one team summary email", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)
 		defer cleanupAll(ctx, t)
@@ -2343,8 +2344,79 @@ func TestCreateDailySummary(t *testing.T) {
 
 		CreateDailySummary(ctx)
 
-		if got := countPendingByChannel(ctx, t, "email"); got != 2 {
-			t.Errorf("want 2 daily summary emails (one per app), got %d", got)
+		if got := countPendingByChannel(ctx, t, "email"); got != 1 {
+			t.Fatalf("want 1 team daily summary email covering both apps, got %d", got)
+		}
+
+		var data []byte
+		if err := th.PgPool.QueryRow(ctx,
+			"SELECT data FROM pending_alert_messages WHERE channel = 'email'").Scan(&data); err != nil {
+			t.Fatalf("read queued email: %v", err)
+		}
+		var info email.EmailInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if info.Subject != "Multi App Team Daily Summary" {
+			t.Errorf("Subject = %q, want %q", info.Subject, "Multi App Team Daily Summary")
+		}
+		for _, appName := range []string{"App One", "App Two"} {
+			if !strings.Contains(info.Body, appName) {
+				t.Errorf("email body does not mention %q", appName)
+			}
+		}
+	})
+
+	t.Run("apps without data are left out and busier apps come first", func(t *testing.T) {
+		ctx := context.Background()
+		setupAlertsTest(ctx, t)
+		defer cleanupAll(ctx, t)
+
+		teamID := uuid.New().String()
+		busyApp := uuid.New().String()
+		quietApp := uuid.New().String()
+		emptyApp := uuid.New().String()
+		userID := uuid.New().String()
+
+		th.SeedTeam(ctx, t, teamID, "Ordered Team")
+		th.SeedUser(ctx, t, userID, "owner@example.com")
+		th.SeedTeamMembership(ctx, t, teamID, userID, "owner")
+		// Seeded so alphabetical order disagrees with session order: the app
+		// named last has the most sessions and must still come first.
+		th.SeedApp(ctx, t, busyApp, teamID, "Zebra App", 30)
+		th.SeedApp(ctx, t, quietApp, teamID, "Alpha App", 30)
+		th.SeedApp(ctx, t, emptyApp, teamID, "Empty App", 30)
+
+		summaryDate := time.Now().UTC().AddDate(0, 0, -1)
+		th.SeedGenericEvents(ctx, t, teamID, busyApp, 8, summaryDate)
+		th.SeedGenericEvents(ctx, t, teamID, quietApp, 3, summaryDate)
+
+		CreateDailySummary(ctx)
+
+		if got := countPendingByChannel(ctx, t, "email"); got != 1 {
+			t.Fatalf("want 1 team daily summary email, got %d", got)
+		}
+
+		var data []byte
+		if err := th.PgPool.QueryRow(ctx,
+			"SELECT data FROM pending_alert_messages WHERE channel = 'email'").Scan(&data); err != nil {
+			t.Fatalf("read queued email: %v", err)
+		}
+		var info email.EmailInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if strings.Contains(info.Body, "Empty App") {
+			t.Error("email body mentions the app with no data")
+		}
+		zebraAt := strings.Index(info.Body, "Zebra App")
+		alphaAt := strings.Index(info.Body, "Alpha App")
+		if zebraAt < 0 || alphaAt < 0 {
+			t.Fatalf("email body is missing an app section: zebra=%d alpha=%d", zebraAt, alphaAt)
+		}
+		if zebraAt > alphaAt {
+			t.Error("app with more sessions should appear before the quieter app")
 		}
 	})
 
@@ -2432,10 +2504,10 @@ func TestCreateDailySummary(t *testing.T) {
 		err := th.PgPool.QueryRow(ctx, `
 			SELECT data->>'body'
 			FROM pending_alert_messages
-			WHERE team_id = $1::uuid AND app_id = $2::uuid AND channel = 'email'
+			WHERE team_id = $1::uuid AND app_id IS NULL AND channel = 'email'
 			ORDER BY created_at DESC
 			LIMIT 1
-		`, teamID, appID).Scan(&emailBody)
+		`, teamID).Scan(&emailBody)
 		if err != nil {
 			t.Fatalf("query daily summary email body: %v", err)
 		}
@@ -2447,10 +2519,10 @@ func TestCreateDailySummary(t *testing.T) {
 		err = th.PgPool.QueryRow(ctx, `
 			SELECT data::text
 			FROM pending_alert_messages
-			WHERE team_id = $1::uuid AND app_id = $2::uuid AND channel = 'slack'
+			WHERE team_id = $1::uuid AND app_id IS NULL AND channel = 'slack'
 			ORDER BY created_at DESC
 			LIMIT 1
-		`, teamID, appID).Scan(&slackRaw)
+		`, teamID).Scan(&slackRaw)
 		if err != nil {
 			t.Fatalf("query daily summary slack payload: %v", err)
 		}
@@ -2499,10 +2571,10 @@ func TestCreateDailySummary(t *testing.T) {
 		err := th.PgPool.QueryRow(ctx, `
 			SELECT data->>'body'
 			FROM pending_alert_messages
-			WHERE team_id = $1::uuid AND app_id = $2::uuid AND channel = 'email'
+			WHERE team_id = $1::uuid AND app_id IS NULL AND channel = 'email'
 			ORDER BY created_at DESC
 			LIMIT 1
-		`, teamID, appID).Scan(&emailBody)
+		`, teamID).Scan(&emailBody)
 		if err != nil {
 			t.Fatalf("query daily summary email body: %v", err)
 		}
@@ -2514,10 +2586,10 @@ func TestCreateDailySummary(t *testing.T) {
 		err = th.PgPool.QueryRow(ctx, `
 			SELECT data::text
 			FROM pending_alert_messages
-			WHERE team_id = $1::uuid AND app_id = $2::uuid AND channel = 'slack'
+			WHERE team_id = $1::uuid AND app_id IS NULL AND channel = 'slack'
 			ORDER BY created_at DESC
 			LIMIT 1
-		`, teamID, appID).Scan(&slackRaw)
+		`, teamID).Scan(&slackRaw)
 		if err != nil {
 			t.Fatalf("query daily summary slack payload: %v", err)
 		}
@@ -2713,6 +2785,258 @@ func TestCreateDailySummary(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// Tests — team daily summary Slack formatting and app ordering
+// --------------------------------------------------------------------------
+
+// slackBlockType reads the type string out of any of the concrete Slack block
+// structs, which share no interface beyond the empty one.
+func slackBlockType(t *testing.T, block slack.SlackBlock) string {
+	t.Helper()
+	switch b := block.(type) {
+	case slack.SlackHeaderBlock:
+		return b.Type
+	case slack.SlackSectionBlock:
+		return b.Type
+	case slack.SlackDividerBlock:
+		return b.Type
+	case slack.SlackContextBlock:
+		return b.Type
+	case slack.SlackActionsBlock:
+		return b.Type
+	default:
+		t.Fatalf("unexpected block type %T", block)
+		return ""
+	}
+}
+
+// sectionText returns the mrkdwn text of a section block, failing the test if
+// the block is not a section or carries no text.
+func sectionText(t *testing.T, block slack.SlackBlock) string {
+	t.Helper()
+	section, ok := block.(slack.SlackSectionBlock)
+	if !ok {
+		t.Fatalf("block is %T, want a section", block)
+	}
+	if section.Text == nil {
+		t.Fatal("section block has no text")
+	}
+	return section.Text.Text
+}
+
+// summaryApps builds n app summaries, each with one healthy metric, named so
+// their order in the message is easy to assert on.
+func summaryApps(n int) []email.AppDailySummary {
+	apps := make([]email.AppDailySummary, 0, n)
+	for i := range n {
+		apps = append(apps, email.AppDailySummary{
+			AppName: fmt.Sprintf("App %03d", i+1),
+			Metrics: []email.MetricData{{Label: "Sessions", Value: "10", Subtitle: "No previous day data"}},
+		})
+	}
+	return apps
+}
+
+func TestFormatTeamDailySummarySlackMessage(t *testing.T) {
+	date := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+
+	t.Run("multi-app input produces the expected block sequence", func(t *testing.T) {
+		apps := []email.AppDailySummary{
+			{
+				AppName: "Checkout",
+				Metrics: []email.MetricData{
+					{Label: "Sessions", Value: "1.2K", Subtitle: "Up from 1K yesterday"},
+					{Label: "Crash free sessions", Value: "97%", Subtitle: "Down from 99% yesterday", HasWarning: true},
+					{Label: "ANR free sessions", Value: "80%", Subtitle: "Down from 95% yesterday", HasWarning: true, HasError: true},
+				},
+			},
+			{
+				AppName: "Storefront",
+				Metrics: []email.MetricData{
+					{Label: "Sessions", Value: "300", Subtitle: "No change from yesterday"},
+				},
+			},
+		}
+
+		msg := formatTeamDailySummarySlackMessage("Acme", "https://test.measure.sh/team-1/overview", date, apps)
+
+		wantTypes := []string{
+			"header", "section", "divider",
+			"section", "section", "divider",
+			"section", "section", "divider",
+			"actions",
+		}
+		if len(msg.Blocks) != len(wantTypes) {
+			t.Fatalf("got %d blocks, want %d", len(msg.Blocks), len(wantTypes))
+		}
+		for i, want := range wantTypes {
+			if got := slackBlockType(t, msg.Blocks[i]); got != want {
+				t.Errorf("block %d type = %q, want %q", i, got, want)
+			}
+		}
+
+		header := msg.Blocks[0].(slack.SlackHeaderBlock)
+		if header.Text.Text != "Acme — Daily Summary" {
+			t.Errorf("header = %q, want %q", header.Text.Text, "Acme — Daily Summary")
+		}
+		if got := sectionText(t, msg.Blocks[1]); got != "*August 18, 2026*  _(last 24 hours)_" {
+			t.Errorf("date section = %q", got)
+		}
+
+		if got := sectionText(t, msg.Blocks[3]); got != "*Checkout*" {
+			t.Errorf("first app name section = %q, want %q", got, "*Checkout*")
+		}
+		checkoutLines := strings.Split(sectionText(t, msg.Blocks[4]), "\n")
+		if len(checkoutLines) != 3 {
+			t.Fatalf("got %d metric lines for Checkout, want 3", len(checkoutLines))
+		}
+		if checkoutLines[0] != "🟢 *Sessions*  1.2K · _Up from 1K yesterday_" {
+			t.Errorf("healthy metric line = %q", checkoutLines[0])
+		}
+		if !strings.HasPrefix(checkoutLines[1], "🟡 ") {
+			t.Errorf("warning metric line = %q, want a 🟡 prefix", checkoutLines[1])
+		}
+		if !strings.HasPrefix(checkoutLines[2], "🔴 ") {
+			t.Errorf("error metric line = %q, want a 🔴 prefix (error outranks warning)", checkoutLines[2])
+		}
+
+		if got := sectionText(t, msg.Blocks[6]); got != "*Storefront*" {
+			t.Errorf("second app name section = %q, want %q", got, "*Storefront*")
+		}
+
+		actions := msg.Blocks[len(msg.Blocks)-1].(slack.SlackActionsBlock)
+		if len(actions.Elements) != 1 || actions.Elements[0].URL != "https://test.measure.sh/team-1/overview" {
+			t.Errorf("actions block = %+v, want one button pointing at the team overview", actions)
+		}
+	})
+
+	t.Run("app names with mrkdwn control characters are escaped", func(t *testing.T) {
+		apps := []email.AppDailySummary{
+			{
+				AppName: "<Foo & Bar>",
+				Metrics: []email.MetricData{{Label: "Sessions", Value: "10", Subtitle: "No previous day data"}},
+			},
+		}
+
+		msg := formatTeamDailySummarySlackMessage("Team <A&B>", "https://test.measure.sh/team-1/overview", date, apps)
+
+		if got := sectionText(t, msg.Blocks[3]); got != "*&lt;Foo &amp; Bar&gt;*" {
+			t.Errorf("app name section = %q, want %q", got, "*&lt;Foo &amp; Bar&gt;*")
+		}
+		// The header is plain_text, which Slack renders verbatim, so the team
+		// name must stay unescaped there.
+		header := msg.Blocks[0].(slack.SlackHeaderBlock)
+		if header.Text.Text != "Team <A&B> — Daily Summary" {
+			t.Errorf("header = %q, want the unescaped team name", header.Text.Text)
+		}
+	})
+
+	t.Run("a team whose apps all fit gets no omission context block", func(t *testing.T) {
+		msg := formatTeamDailySummarySlackMessage("Acme", "https://test.measure.sh/team-1/overview", date, summaryApps(15))
+
+		// 3 leading blocks + 15 apps * 3 blocks + 1 actions block.
+		if len(msg.Blocks) != 49 {
+			t.Errorf("got %d blocks, want 49", len(msg.Blocks))
+		}
+		for i, block := range msg.Blocks {
+			if slackBlockType(t, block) == "context" {
+				t.Errorf("block %d is a context block, want none when every app fits", i)
+			}
+		}
+	})
+
+	t.Run("more apps than fit are capped at 50 blocks with an omission context block", func(t *testing.T) {
+		msg := formatTeamDailySummarySlackMessage("Acme", "https://test.measure.sh/team-1/overview", date, summaryApps(20))
+
+		if len(msg.Blocks) > 50 {
+			t.Fatalf("got %d blocks, slack rejects more than 50", len(msg.Blocks))
+		}
+		if len(msg.Blocks) != 50 {
+			t.Errorf("got %d blocks, want exactly 50 (15 apps shown plus overhead)", len(msg.Blocks))
+		}
+
+		var joined strings.Builder
+		for _, block := range msg.Blocks {
+			if section, ok := block.(slack.SlackSectionBlock); ok && section.Text != nil {
+				joined.WriteString(section.Text.Text)
+				joined.WriteString("\n")
+			}
+		}
+		if !strings.Contains(joined.String(), "*App 015*") {
+			t.Error("fifteenth app should still be shown")
+		}
+		if strings.Contains(joined.String(), "*App 016*") {
+			t.Error("sixteenth app should be dropped")
+		}
+
+		contextBlock, ok := msg.Blocks[len(msg.Blocks)-2].(slack.SlackContextBlock)
+		if !ok {
+			t.Fatalf("second-to-last block is %T, want the omission context block", msg.Blocks[len(msg.Blocks)-2])
+		}
+		if len(contextBlock.Elements) != 1 || contextBlock.Elements[0].Text != "+5 more apps not shown" {
+			t.Errorf("context block = %+v, want a single \"+5 more apps not shown\" line", contextBlock)
+		}
+		if got := slackBlockType(t, msg.Blocks[len(msg.Blocks)-1]); got != "actions" {
+			t.Errorf("last block type = %q, want actions after the context block", got)
+		}
+	})
+
+	t.Run("a team name over Slack's header limit is truncated with an ellipsis", func(t *testing.T) {
+		longName := strings.Repeat("x", 256)
+		apps := []email.AppDailySummary{
+			{AppName: "Checkout", Metrics: []email.MetricData{{Label: "Sessions", Value: "1", Subtitle: "No previous day data"}}},
+		}
+
+		msg := formatTeamDailySummarySlackMessage(longName, "https://test.measure.sh/team-1/overview", date, apps)
+
+		header := msg.Blocks[0].(slack.SlackHeaderBlock)
+		headerRunes := []rune(header.Text.Text)
+		if len(headerRunes) != slackHeaderTextLimit {
+			t.Errorf("header length = %d runes, want %d", len(headerRunes), slackHeaderTextLimit)
+		}
+		if headerRunes[len(headerRunes)-1] != '…' {
+			t.Errorf("header = %q, want an ellipsis at the end", header.Text.Text)
+		}
+		if !strings.HasPrefix(header.Text.Text, "xxx") {
+			t.Errorf("header = %q, want it to start with the team name", header.Text.Text)
+		}
+	})
+
+	t.Run("a team name within Slack's header limit is kept whole", func(t *testing.T) {
+		apps := []email.AppDailySummary{
+			{AppName: "Checkout", Metrics: []email.MetricData{{Label: "Sessions", Value: "1", Subtitle: "No previous day data"}}},
+		}
+
+		msg := formatTeamDailySummarySlackMessage("Acme", "https://test.measure.sh/team-1/overview", date, apps)
+
+		header := msg.Blocks[0].(slack.SlackHeaderBlock)
+		if header.Text.Text != "Acme — Daily Summary" {
+			t.Errorf("header = %q, want %q", header.Text.Text, "Acme — Daily Summary")
+		}
+	})
+}
+
+func TestSortedAppSummaries(t *testing.T) {
+	entries := []appSummaryWithSessions{
+		{Summary: email.AppDailySummary{AppName: "Bravo"}, SessionsToday: 5},
+		{Summary: email.AppDailySummary{AppName: "Alpha"}, SessionsToday: 5},
+		{Summary: email.AppDailySummary{AppName: "Zulu"}, SessionsToday: 50},
+		{Summary: email.AppDailySummary{AppName: "Quiet"}, SessionsToday: 0},
+	}
+
+	got := sortedAppSummaries(entries)
+
+	want := []string{"Zulu", "Alpha", "Bravo", "Quiet"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d summaries, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].AppName != name {
+			t.Errorf("position %d = %q, want %q (sessions descending, name ascending on ties)", i, got[i].AppName, name)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
 // Tests — internal helper coverage
 // --------------------------------------------------------------------------
 
@@ -2788,25 +3112,23 @@ func TestScheduleInternalHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("scheduleDailySummaryEmailForteamMembers sets daily_summary AlertType", func(t *testing.T) {
+	t.Run("scheduleDailySummaryEmailForTeamMembers sets daily_summary AlertType and passes the subject through", func(t *testing.T) {
 		ctx := context.Background()
 		setupAlertsTest(ctx, t)
 		defer cleanupAll(ctx, t)
 
 		teamID := uuid.New().String()
-		appID := uuid.New().String()
 		userID := uuid.New().String()
 
 		th.SeedTeam(ctx, t, teamID, "Test Team")
 		th.SeedUser(ctx, t, userID, "owner@example.com")
 		th.SeedTeamMembership(ctx, t, teamID, userID, "owner")
-		th.SeedApp(ctx, t, appID, teamID, "Test App", 30)
 
-		scheduleDailySummaryEmailForteamMembers(ctx, uuid.MustParse(teamID), uuid.MustParse(appID), "<p>Summary</p>", "Test App")
+		scheduleDailySummaryEmailForTeamMembers(ctx, uuid.MustParse(teamID), "Test Team Daily Summary", "<p>Summary</p>")
 
 		var data []byte
 		err := th.PgPool.QueryRow(ctx,
-			"SELECT data FROM pending_alert_messages WHERE channel = 'email'").Scan(&data)
+			"SELECT data FROM pending_alert_messages WHERE channel = 'email' AND app_id IS NULL").Scan(&data)
 		if err != nil {
 			t.Fatalf("read queued email: %v", err)
 		}
@@ -2817,6 +3139,9 @@ func TestScheduleInternalHelpers(t *testing.T) {
 		}
 		if info.AlertType != "daily_summary" {
 			t.Errorf("AlertType = %q, want %q", info.AlertType, "daily_summary")
+		}
+		if info.Subject != "Test Team Daily Summary" {
+			t.Errorf("Subject = %q, want %q", info.Subject, "Test Team Daily Summary")
 		}
 	})
 }

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -3015,6 +3015,33 @@ func TestFormatTeamDailySummarySlackMessage(t *testing.T) {
 	})
 }
 
+func TestFormatSlackAlertMessage(t *testing.T) {
+	// The message comes from the shared email builders: <br> marks line
+	// breaks and app-generated text carries raw mrkdwn control characters.
+	msg := formatSlackAlertMessage(
+		"Checkout - Crash Spike Alert",
+		"Crashes are spiking at:<br><br>Foo.kt: <init>() - x < 1",
+		"https://test.measure.sh/dashboard",
+	)
+
+	got := sectionText(t, msg.Blocks[1])
+	want := "Crashes are spiking at:\n\n" +
+		"Foo.kt: &lt;init&gt;() - x &lt; 1"
+	if got != want {
+		t.Errorf("section text = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "<br>") {
+		t.Errorf("section text = %q, want no <br> remnants", got)
+	}
+
+	// The header is plain_text, which Slack renders verbatim, so the title
+	// must stay unescaped there.
+	header := msg.Blocks[0].(slack.SlackHeaderBlock)
+	if header.Text.Text != "🚨 Checkout - Crash Spike Alert" {
+		t.Errorf("header = %q, want the unescaped title", header.Text.Text)
+	}
+}
+
 func TestSortedAppSummaries(t *testing.T) {
 	entries := []appSummaryWithSessions{
 		{Summary: email.AppDailySummary{AppName: "Bravo"}, SessionsToday: 5},

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -137,11 +137,12 @@ func BugReportAlertEmail(appName, alertMsg, alertURL string) (subject, body stri
 	return
 }
 
-// DailySummaryEmail builds the daily summary email for an app.
-func DailySummaryEmail(appName string, date time.Time, metrics []MetricData, siteOrigin, teamId, appId string) (subject, body string) {
-	subject = appName + " Daily Summary"
-	dashboardURL := fmt.Sprintf("%s/%s/overview?a=%s", siteOrigin, teamId, appId)
-	body = RenderEmailBody(escape(subject), DailySummaryContent(appName, date, metrics), "View Full Dashboard", dashboardURL)
+// TeamDailySummaryEmail builds the daily summary email for a team,
+// covering all of the team's apps that recorded data.
+func TeamDailySummaryEmail(teamName string, date time.Time, apps []AppDailySummary, siteOrigin, teamId string) (subject, body string) {
+	subject = teamName + " Daily Summary"
+	dashboardURL := fmt.Sprintf("%s/%s/overview", siteOrigin, teamId)
+	body = RenderEmailBody(escape(subject), TeamDailySummaryContent(date, apps), "View Full Dashboard", dashboardURL)
 	return
 }
 

--- a/backend/libs/email/cmd/preview/main.go
+++ b/backend/libs/email/cmd/preview/main.go
@@ -126,7 +126,9 @@ func main() {
 	_, body = email.ManualDowngradeEmail("Acme Corp", "team-abc", "https://measure.sh")
 	add("12-downgraded-to-free.html", body)
 
-	// --- Alerts: Daily Summary ---
+	// --- Alerts: Team Daily Summary ---
+
+	summaryDate := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
 
 	healthyMetrics := []email.MetricData{
 		{Value: "12.85K", Label: "Sessions", Subtitle: "Up from 11.65K yesterday", HasWarning: false, HasError: false},
@@ -137,8 +139,6 @@ func main() {
 		{Value: "98ms", Label: "Hot launch p95", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
 		{Value: "7", Label: "Bug reports", Subtitle: "Down from 10 yesterday", HasWarning: false, HasError: false},
 	}
-	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), healthyMetrics, "https://measure.sh", "team-abc", "app-123")
-	add("14-daily-summary-healthy.html", body)
 
 	warningMetrics := []email.MetricData{
 		{Value: "8.42K", Label: "Sessions", Subtitle: "Down from 11.62K yesterday", HasWarning: false, HasError: false},
@@ -149,8 +149,6 @@ func main() {
 		{Value: "145ms", Label: "Hot launch p95", Subtitle: "Up from 98ms yesterday", HasWarning: false, HasError: false},
 		{Value: "18", Label: "Bug reports", Subtitle: "Up from 12 yesterday", HasWarning: false, HasError: false},
 	}
-	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), warningMetrics, "https://measure.sh", "team-abc", "app-123")
-	add("15-daily-summary-warnings.html", body)
 
 	errorMetrics := []email.MetricData{
 		{Value: "3.1K", Label: "Sessions", Subtitle: "Down from 12.6K yesterday", HasWarning: false, HasError: false},
@@ -160,36 +158,6 @@ func main() {
 		{Value: "890ms", Label: "Warm launch p95", Subtitle: "Up from 366ms yesterday", HasWarning: false, HasError: false},
 		{Value: "312ms", Label: "Hot launch p95", Subtitle: "Up from 98ms yesterday", HasWarning: false, HasError: false},
 	}
-	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), errorMetrics, "https://measure.sh", "team-abc", "app-123")
-	add("16-daily-summary-errors.html", body)
-
-	customThresholdMetrics := []email.MetricData{
-		{Value: "7.89K", Label: "Sessions", Subtitle: "Down from 8.43K yesterday", HasWarning: false, HasError: false},
-		{Value: "91.2%", Label: "Crash free sessions", Subtitle: "Down from 93.6% yesterday", HasWarning: false, HasError: false},
-		{Value: "88.6%", Label: "ANR free sessions", Subtitle: "Down from 90.1% yesterday", HasWarning: false, HasError: false},
-		{Value: "1120ms", Label: "Cold launch p95", Subtitle: "Up from 940ms yesterday", HasWarning: false, HasError: false},
-		{Value: "498ms", Label: "Warm launch p95", Subtitle: "Up from 421ms yesterday", HasWarning: false, HasError: false},
-		{Value: "132ms", Label: "Hot launch p95", Subtitle: "Up from 111ms yesterday", HasWarning: false, HasError: false},
-	}
-	_, body = email.DailySummaryEmail(
-		"MyApp",
-		time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
-		applyDailySummaryThresholds(customThresholdMetrics, 98, 90),
-		"https://measure.sh",
-		"team-abc",
-		"app-123",
-	)
-	add("17-daily-summary-custom-thresholds-strict.html", body)
-
-	_, body = email.DailySummaryEmail(
-		"MyApp",
-		time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
-		applyDailySummaryThresholds(customThresholdMetrics, 92, 85),
-		"https://measure.sh",
-		"team-abc",
-		"app-123",
-	)
-	add("18-daily-summary-custom-thresholds-lenient.html", body)
 
 	noDataMetrics := []email.MetricData{
 		{Value: "412", Label: "Sessions", Subtitle: "Down from 1.2K yesterday", HasWarning: false, HasError: false},
@@ -199,8 +167,6 @@ func main() {
 		{Value: "No Data", Label: "Warm launch p95", Subtitle: "Was 366ms yesterday", HasWarning: false, HasError: false},
 		{Value: "No Data", Label: "Hot launch p95", Subtitle: "No previous day data", HasWarning: false, HasError: false},
 	}
-	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), noDataMetrics, "https://measure.sh", "team-abc", "app-123")
-	add("19-daily-summary-no-data.html", body)
 
 	noANRMetrics := []email.MetricData{
 		{Value: "6.31K", Label: "Sessions", Subtitle: "Up from 5.98K yesterday", HasWarning: false, HasError: false},
@@ -209,8 +175,48 @@ func main() {
 		{Value: "412ms", Label: "Warm launch p95", Subtitle: "Down from 455ms yesterday", HasWarning: false, HasError: false},
 		{Value: "121ms", Label: "Hot launch p95", Subtitle: "No change from yesterday", HasWarning: false, HasError: false},
 	}
-	_, body = email.DailySummaryEmail("MyApp", time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), noANRMetrics, "https://measure.sh", "team-abc", "app-123")
-	add("20-daily-summary-no-anr-card.html", body)
+
+	multiAppSummary := []email.AppDailySummary{
+		{AppName: "Storefront Android", Metrics: healthyMetrics},
+		{AppName: "Storefront iOS", Metrics: warningMetrics},
+		{AppName: "Courier Android", Metrics: errorMetrics},
+		{AppName: "Warehouse Scanner", Metrics: noDataMetrics},
+		{AppName: "Kiosk iOS", Metrics: noANRMetrics},
+	}
+	_, body = email.TeamDailySummaryEmail("Acme Corp", summaryDate, multiAppSummary, "https://measure.sh", "team-abc")
+	add("14-team-daily-summary-multi-app.html", body)
+
+	customThresholdMetrics := []email.MetricData{
+		{Value: "7.89K", Label: "Sessions", Subtitle: "Down from 8.43K yesterday", HasWarning: false, HasError: false},
+		{Value: "91.2%", Label: "Crash free sessions", Subtitle: "Down from 93.6% yesterday", HasWarning: false, HasError: false},
+		{Value: "88.6%", Label: "ANR free sessions", Subtitle: "Down from 90.1% yesterday", HasWarning: false, HasError: false},
+		{Value: "1120ms", Label: "Cold launch p95", Subtitle: "Up from 940ms yesterday", HasWarning: false, HasError: false},
+		{Value: "498ms", Label: "Warm launch p95", Subtitle: "Up from 421ms yesterday", HasWarning: false, HasError: false},
+		{Value: "132ms", Label: "Hot launch p95", Subtitle: "Up from 111ms yesterday", HasWarning: false, HasError: false},
+	}
+	_, body = email.TeamDailySummaryEmail(
+		"Acme Corp",
+		summaryDate,
+		[]email.AppDailySummary{{AppName: "Storefront Android", Metrics: applyDailySummaryThresholds(customThresholdMetrics, 98, 90)}},
+		"https://measure.sh",
+		"team-abc",
+	)
+	add("15-team-daily-summary-custom-thresholds-strict.html", body)
+
+	_, body = email.TeamDailySummaryEmail(
+		"Acme Corp",
+		summaryDate,
+		[]email.AppDailySummary{{AppName: "Storefront Android", Metrics: applyDailySummaryThresholds(customThresholdMetrics, 92, 85)}},
+		"https://measure.sh",
+		"team-abc",
+	)
+	add("16-team-daily-summary-custom-thresholds-lenient.html", body)
+
+	singleAppSummary := []email.AppDailySummary{
+		{AppName: "Storefront Android", Metrics: healthyMetrics},
+	}
+	_, body = email.TeamDailySummaryEmail("Acme Corp", summaryDate, singleAppSummary, "https://measure.sh", "team-abc")
+	add("17-team-daily-summary-single-app.html", body)
 
 	for _, e := range emails {
 		path := filepath.Join(dir, e.name)

--- a/backend/libs/email/email.go
+++ b/backend/libs/email/email.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,6 +31,13 @@ type MetricData struct {
 	HasWarning bool
 	HasError   bool
 	Subtitle   string
+}
+
+// AppDailySummary is one app's section in the team daily summary:
+// the app's name and its metric cards for the reported day.
+type AppDailySummary struct {
+	AppName string
+	Metrics []MetricData
 }
 
 // SendEmail sends an email immediately using the provided mail client.
@@ -77,16 +85,11 @@ func QueueEmail(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, teamID, appI
 		InsertInto("pending_alert_messages").
 		Set("id", uuid.New()).
 		Set("team_id", teamID).
+		Set("app_id", appID).
 		Set("channel", "email").
 		SetExpr("data", "?::jsonb", string(dataJson)).
 		Set("created_at", time.Now()).
 		Set("updated_at", time.Now())
-
-	if appID == nil {
-		insertStmt.SetExpr("app_id", "NULL")
-	} else {
-		insertStmt.Set("app_id", appID)
-	}
 
 	if tx != nil {
 		_, err = tx.Exec(ctx, insertStmt.String(), insertStmt.Args()...)
@@ -265,15 +268,31 @@ func getProgressBarColor(threshold int) string {
 	}
 }
 
-// DailySummaryContent renders the date header and metrics grid
-// for daily summary emails.
-func DailySummaryContent(appName string, date time.Time, metrics []MetricData) string {
+func TeamDailySummaryContent(date time.Time, apps []AppDailySummary) string {
 	formattedDate := date.Format("January 2, 2006")
 	formattedDateShort := date.Format("Jan 2, 2006")
 	comparisonDateShort := date.AddDate(0, 0, -1).Format("Jan 2, 2006")
 
-	metricsHTML := ""
-	for _, metric := range metrics {
+	var appsHTML strings.Builder
+	for i, app := range apps {
+		appsHTML.WriteString(appDailySummarySection(app, i == 0))
+	}
+
+	return fmt.Sprintf(`
+            <!-- Date Header -->
+            <div style="text-align: center; margin-bottom: 32px;">
+                <h2 style="margin: 0; font-size: 18px; color: #2d3748; font-family: 'Josefin Sans', sans-serif; font-weight: 600;">
+                    Summary for %s
+                </h2>
+                <p style="margin: 8px 0 0 0; font-size: 12px; color: #718096;">
+                    Comparisons are between %s (12:00 AM UTC to 11:59 PM UTC) and %s (12:00 AM UTC to 11:59 PM UTC).
+                </p>
+            </div>%s`, formattedDate, formattedDateShort, comparisonDateShort, appsHTML.String())
+}
+
+func appDailySummarySection(app AppDailySummary, first bool) string {
+	var metricsHTML strings.Builder
+	for _, metric := range app.Metrics {
 		icon := ""
 		if metric.HasError {
 			icon = `<div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background-color: #e7000b; border-radius: 50%;">
@@ -293,10 +312,10 @@ func DailySummaryContent(appName string, date time.Time, metrics []MetricData) s
 					</div>`
 		}
 
-		metricsHTML += fmt.Sprintf(`
+		fmt.Fprintf(&metricsHTML, `
 			<div style="background-color: #ffffff; border-radius: 8px; padding: 20px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); border: 1px solid #e2e8f0; position: relative; min-height: 80px;">
 				%s
-				<div style="font-size: 28px; font-weight: 700; color: #1a202c; margin-bottom: 8px; font-family: 'Space Mono', monospace;">
+				<div style="font-size: 22px; font-weight: 700; color: #1a202c; margin-bottom: 8px; font-family: 'Space Mono', monospace;">
 					%s
 				</div>
 				<div style="font-size: 14px; color: #4a5568; font-weight: 500;">
@@ -308,19 +327,23 @@ func DailySummaryContent(appName string, date time.Time, metrics []MetricData) s
 			</div>`, icon, metric.Value, metric.Label, metric.Subtitle)
 	}
 
+	// The date header above the app sections already ends with a 32px bottom
+	// margin, so the first app heading uses a smaller top margin to avoid a
+	// large blank band while later headings keep the wider separation.
+	topMargin := "64px"
+	if first {
+		topMargin = "48px"
+	}
+
 	return fmt.Sprintf(`
-            <!-- Date Header -->
-            <div style="text-align: center; margin-bottom: 32px;">
-                <h2 style="margin: 0; font-size: 18px; color: #2d3748; font-family: 'Josefin Sans', sans-serif; font-weight: 600;">
-                    Summary for %s
-                </h2>
-                <p style="margin: 8px 0 0 0; font-size: 12px; color: #718096;">
-                    Comparisons are between %s (12:00 AM UTC to 11:59 PM UTC) and %s (12:00 AM UTC to 11:59 PM UTC).
-                </p>
-            </div>
+
+            <!-- App Name -->
+            <h3 style="margin: %s 0 16px 0; font-size: 24px; color: #1a202c; font-family: 'Josefin Sans', sans-serif; font-weight: 600; text-align: left;">
+                %s
+            </h3>
 
             <!-- Metrics Grid -->
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; margin-bottom: 32px;">
                 %s
-            </div>`, formattedDate, formattedDateShort, comparisonDateShort, metricsHTML)
+            </div>`, topMargin, escape(app.AppName), metricsHTML.String())
 }

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -92,15 +92,26 @@ func TestUsageLimitContent(t *testing.T) {
 	}
 }
 
-func TestDailySummaryContent(t *testing.T) {
+func TestTeamDailySummaryContent(t *testing.T) {
 	date := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
-	metrics := []MetricData{
-		{Value: "1,234", Label: "Sessions", Subtitle: "Last 24h", HasWarning: false, HasError: false},
-		{Value: "99.5%", Label: "Crash Free", Subtitle: "Target: 99%", HasWarning: true, HasError: false},
-		{Value: "98.0%", Label: "ANR Free", Subtitle: "Target: 99%", HasWarning: false, HasError: true},
+	apps := []AppDailySummary{
+		{
+			AppName: "MyApp",
+			Metrics: []MetricData{
+				{Value: "1,234", Label: "Sessions", Subtitle: "Last 24h", HasWarning: false, HasError: false},
+				{Value: "99.5%", Label: "Crash Free", Subtitle: "Target: 99%", HasWarning: true, HasError: false},
+				{Value: "98.0%", Label: "ANR Free", Subtitle: "Target: 99%", HasWarning: false, HasError: true},
+			},
+		},
+		{
+			AppName: "OtherApp",
+			Metrics: []MetricData{
+				{Value: "5,678", Label: "Sessions", Subtitle: "Last 24h", HasWarning: false, HasError: false},
+			},
+		},
 	}
 
-	content := DailySummaryContent("MyApp", date, metrics)
+	content := TeamDailySummaryContent(date, apps)
 
 	checks := []struct {
 		name    string
@@ -109,6 +120,8 @@ func TestDailySummaryContent(t *testing.T) {
 		{"date", "February 15, 2026"},
 		{"summary label", "Summary for February 15, 2026"},
 		{"comparison label", "Comparisons are between Feb 15, 2026 (12:00 AM UTC to 11:59 PM UTC) and Feb 14, 2026 (12:00 AM UTC to 11:59 PM UTC)."},
+		{"first app name", "MyApp"},
+		{"second app name", "OtherApp"},
 		{"sessions value", "1,234"},
 		{"sessions label", "Sessions"},
 		{"crash free value", "99.5%"},
@@ -124,15 +137,35 @@ func TestDailySummaryContent(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("apps render in order with their metrics under them", func(t *testing.T) {
+		firstApp := strings.Index(content, "MyApp")
+		firstAppMetric := strings.Index(content, "1,234")
+		secondApp := strings.Index(content, "OtherApp")
+		secondAppMetric := strings.Index(content, "5,678")
+
+		if firstApp == -1 || firstAppMetric == -1 || secondApp == -1 || secondAppMetric == -1 {
+			t.Fatal("content should contain both app names and both apps' metrics")
+		}
+		if !(firstApp < firstAppMetric && firstAppMetric < secondApp && secondApp < secondAppMetric) {
+			t.Errorf("expected order: MyApp (%d) < 1,234 (%d) < OtherApp (%d) < 5,678 (%d)",
+				firstApp, firstAppMetric, secondApp, secondAppMetric)
+		}
+	})
 }
 
-func TestDailySummaryContentNoWarnings(t *testing.T) {
+func TestTeamDailySummaryContentNoWarnings(t *testing.T) {
 	date := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	metrics := []MetricData{
-		{Value: "500", Label: "Sessions", Subtitle: "All good"},
+	apps := []AppDailySummary{
+		{
+			AppName: "App",
+			Metrics: []MetricData{
+				{Value: "500", Label: "Sessions", Subtitle: "All good"},
+			},
+		},
 	}
 
-	content := DailySummaryContent("App", date, metrics)
+	content := TeamDailySummaryContent(date, apps)
 
 	if strings.Contains(content, "#e7000b") {
 		t.Error("should not contain error color when no errors")
@@ -708,7 +741,9 @@ func TestAppNameMarkupIsEscapedInTitle(t *testing.T) {
 	_, bodies["CrashSpikeAlertEmail"] = CrashSpikeAlertEmail(payload, "spiking", "https://measure.sh")
 	_, bodies["AnrSpikeAlertEmail"] = AnrSpikeAlertEmail(payload, "spiking", "https://measure.sh")
 	_, bodies["BugReportAlertEmail"] = BugReportAlertEmail(payload, "a bug", "https://measure.sh")
-	_, bodies["DailySummaryEmail"] = DailySummaryEmail(payload, time.Now(), nil, "https://measure.sh", "team-abc", "app-abc")
+	// The team summary places the team name in the subject and each app
+	// name in a section heading, so the payload is exercised in both spots.
+	_, bodies["TeamDailySummaryEmail"] = TeamDailySummaryEmail(payload, time.Now(), []AppDailySummary{{AppName: payload}}, "https://measure.sh", "team-abc")
 
 	for name, body := range bodies {
 		if strings.Contains(body, payload) {

--- a/backend/libs/slack/escaper.go
+++ b/backend/libs/slack/escaper.go
@@ -1,0 +1,26 @@
+package slack
+
+import "strings"
+
+// mrkdwnEscaper rewrites the three characters Slack parses as markup in
+// mrkdwn text into their HTML entities. The & rule comes first so a literal
+// "&lt;" in the input escapes its ampersand instead of being matched by a
+// later rule.
+var mrkdwnEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// mrkdwnUnescaper is the inverse of mrkdwnEscaper.
+var mrkdwnUnescaper = strings.NewReplacer("&lt;", "<", "&gt;", ">", "&amp;", "&")
+
+// EscapeMrkdwn escapes the characters Slack parses as markup in mrkdwn text:
+// < and > delimit links and mentions, and & starts an entity. Without
+// escaping, text like "<init>" disappears from the rendered message, and a
+// planted "<!channel>" would ping the channel with the bot's authority.
+func EscapeMrkdwn(s string) string {
+	return mrkdwnEscaper.Replace(s)
+}
+
+// UnescapeMrkdwn undoes the entity encoding Slack applies to message text on
+// the way in, so a reader gets ">" where the user typed it instead of "&gt;".
+func UnescapeMrkdwn(s string) string {
+	return mrkdwnUnescaper.Replace(s)
+}

--- a/backend/libs/slack/escaper_test.go
+++ b/backend/libs/slack/escaper_test.go
@@ -1,0 +1,40 @@
+package slack
+
+import "testing"
+
+func TestEscapeMrkdwn(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ampersand", "Food & Drink", "Food &amp; Drink"},
+		{"less than", "x < 1", "x &lt; 1"},
+		{"greater than", "rate > 2%", "rate &gt; 2%"},
+		{"angle bracket pair", "<init>", "&lt;init&gt;"},
+		{"already encoded entity keeps its ampersand escaped", "&lt;", "&amp;lt;"},
+		{"no control characters", "plain text", "plain text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EscapeMrkdwn(tc.in); got != tc.want {
+				t.Fatalf("EscapeMrkdwn(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnescapeMrkdwn(t *testing.T) {
+	in := "crash rate &gt; 2% in Food &amp; Drink, &lt;init&gt;"
+	want := "crash rate > 2% in Food & Drink, <init>"
+	if got := UnescapeMrkdwn(in); got != want {
+		t.Fatalf("UnescapeMrkdwn(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestEscapeUnescapeRoundTrip(t *testing.T) {
+	in := "<Foo & Bar> says x < 1 && y > 2"
+	if got := UnescapeMrkdwn(EscapeMrkdwn(in)); got != in {
+		t.Fatalf("round trip changed the text: got %q, want %q", got, in)
+	}
+}

--- a/frontend/dashboard/content/docs/alerts.mdx
+++ b/frontend/dashboard/content/docs/alerts.mdx
@@ -18,11 +18,11 @@ Once an issue triggers an alert, the same issue won't trigger another one for 7 
 
 ### Bug reports
 
-Every new [bug report](/docs/bug-reports) triggers an alert with the report's description and a link to it on the dashboard. There are no thresholds or cooldowns. Each report alerts exactly once.
+Every new [bug report](/docs/bug-reports) triggers an alert with the report's description and a link to it on the dashboard. 
 
 ### Daily summary
 
-Once a day, you get a summary of the previous day's core metrics: sessions, crash-free sessions, ANR-free sessions, and cold, warm, and hot launch times. Each metric is compared with the day before. The summary catches slow drifts that would never trip a spike alert.
+Once a day, you get a summary for your team covering the previous day's core metrics for each of your apps: sessions, crash-free sessions, ANR-free sessions, and cold, warm, and hot launch times. Each metric is compared with the day before, and apps are ordered by session count so the busiest ones come first. Apps that recorded no data that day are left out.
 
 ## Channels
 


### PR DESCRIPTION
# Description

- one email and one Slack message per team, covering all its apps
- email keeps the metric cards, grouped under a heading per app
- subject is "{Team name} Daily Summary", single CTA to team overview
- Slack uses a compact one-line-per-metric layout, capped at Slack's 50-block limit with a note for omitted apps
- apps ordered by session count, busiest first
- apps with no data that day are left out; a team with no data at all gets no summary

## Related issue
Closes #4223



