### PR TITLE
fix(backend): serialize empty thread frames & threads as arrays

### DIFF
--- a/backend/libs/event/issue.go
+++ b/backend/libs/event/issue.go
@@ -67,9 +67,10 @@ func (e *EventANR) ComputeView() {
 		Message:    e.ANR.GetMessage(),
 	}
 
+	e.Threads = []ThreadView{}
+
 	for i := range e.ANR.Threads {
-		var tv ThreadView
-		tv.Name = e.ANR.Threads[i].Name
+		tv := ThreadView{Name: e.ANR.Threads[i].Name, Frames: []string{}}
 		for j := range e.ANR.Threads[i].Frames {
 			tv.Frames = append(tv.Frames, e.ANR.Threads[i].Frames[j].String(FrameworkJVM))
 		}
@@ -91,10 +92,11 @@ func (e *EventException) ComputeView() {
 	var buf bytes.Buffer
 	w := &buf
 
+	e.Threads = []ThreadView{}
+
 	for i := range e.Exception.Threads {
-		var tv ThreadView
+		tv := ThreadView{Name: e.Exception.Threads[i].Name, Frames: []string{}}
 		t := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		tv.Name = e.Exception.Threads[i].Name
 
 		for j := range e.Exception.Threads[i].Frames {
 			frame := e.Exception.Threads[i].Frames[j]

--- a/backend/libs/event/issue_test.go
+++ b/backend/libs/event/issue_test.go
@@ -1,0 +1,93 @@
+package event
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestComputeViewThreadsFrames(t *testing.T) {
+	const wantWithThread = `[{"name":"main","frames":[]}]`
+	const wantEmpty = `[]`
+
+	tests := []struct {
+		name string
+		want string
+		run  func() []ThreadView
+	}{
+		{
+			name: "exception apple framework",
+			want: wantWithThread,
+			run: func() []ThreadView {
+				e := EventException{
+					Exception: Exception{
+						Framework:  FrameworkApple,
+						Exceptions: ExceptionUnits{{Type: "SIGSEGV", ExceptionUnitiOS: &ExceptionUnitiOS{Signal: "SIGSEGV"}}},
+						Threads:    Threads{{Name: "main", Frames: Frames{}}},
+					},
+				}
+				e.ComputeView()
+				return e.Threads
+			},
+		},
+		{
+			name: "exception default framework",
+			want: wantWithThread,
+			run: func() []ThreadView {
+				e := EventException{
+					Exception: Exception{
+						Exceptions: ExceptionUnits{{Type: "NullPointerException"}},
+						Threads:    Threads{{Name: "main", Frames: Frames{}}},
+					},
+				}
+				e.ComputeView()
+				return e.Threads
+			},
+		},
+		{
+			name: "anr",
+			want: wantWithThread,
+			run: func() []ThreadView {
+				e := EventANR{
+					ANR: ANR{
+						Exceptions: ExceptionUnits{{Type: "ANR"}},
+						Threads:    Threads{{Name: "main", Frames: Frames{}}},
+					},
+				}
+				e.ComputeView()
+				return e.Threads
+			},
+		},
+		{
+			name: "exception zero threads",
+			want: wantEmpty,
+			run: func() []ThreadView {
+				e := EventException{
+					Exception: Exception{Exceptions: ExceptionUnits{{Type: "NullPointerException"}}},
+				}
+				e.ComputeView()
+				return e.Threads
+			},
+		},
+		{
+			name: "anr zero threads",
+			want: wantEmpty,
+			run: func() []ThreadView {
+				e := EventANR{ANR: ANR{Exceptions: ExceptionUnits{{Type: "ANR"}}}}
+				e.ComputeView()
+				return e.Threads
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.run())
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("json.Marshal() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR makes the thread payload always serialize as an array. `ComputeView` built `Frames` & `Threads` by appending to a nil slice, so empty ones returned `null` & broke clients treating them as lists. Both are now seeded, for exception & ANR views alike.

## Tasks

- [x] Seed `ThreadView.Frames` so a zero-frame thread returns `[]`
- [x] Seed `e.Threads` so an event with no threads returns `[]`
- [x] Apply to both exception & ANR thread views
- [x] Cover zero-frame & zero-thread cases with tests

## See also

- fixes #4260
