### PR TITLE
refactor(backend): build alert messages as channel-neutral plain text

### DIFF
--- a/backend/alerts/alerts/alerts.go
+++ b/backend/alerts/alerts/alerts.go
@@ -14,6 +14,7 @@ import (
 
 	"backend/alerts/server"
 	"backend/alerts/slack"
+	"backend/libs/alertmsg"
 	"backend/libs/autumn"
 	"backend/libs/config"
 	"backend/libs/email"
@@ -215,8 +216,8 @@ func CreateBugReportAlerts(ctx context.Context) {
 					continue
 				}
 
-				alertMsg := email.BugReportAlertMessage(description)
-				alertUrl := email.BugReportAlertURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), bugReportId)
+				alertMsg := alertmsg.BugReportMessage(description)
+				alertUrl := alertmsg.BugReportURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), bugReportId)
 
 				fmt.Printf("Inserting alert for bug report %s\n", bugReportId)
 
@@ -703,7 +704,7 @@ func scheduleEmailAlertsForteamMembers(ctx context.Context, alert Alert, message
 		subject, body = email.BugReportAlertEmail(appName, message, url)
 	} else {
 		subject = appName + " - Alert"
-		body = email.RenderEmailBody(subject, email.MessageContent(message), "View in Dashboard", url)
+		body = email.RenderEmailBody(subject, email.PlainTextContent(message), "View in Dashboard", url)
 	}
 
 	pendingEmail := email.EmailInfo{
@@ -871,12 +872,9 @@ func formatSlackAlertMessage(title, message, url string) slack.SlackMessage {
 		},
 	}
 
-	// The message is shared with the email path and arrives formatted for
-	// HTML, with <br> marking line breaks and app-generated text (a crash
-	// message like "<init>", a user-typed bug report description) left as is.
-	// Rewrite the breaks as newlines, then escape the characters Slack parses
-	// as markup so the text renders literally.
-	message = strings.ReplaceAll(message, "<br>", "\n")
+	// The message carries app-generated text as is (a crash message like
+	// "<init>", a user-typed bug report description), so the characters
+	// Slack parses as markup are escaped for the text to render literally.
 	message = libslack.EscapeMrkdwn(message)
 
 	blocks = append(blocks, slack.SlackSectionBlock{
@@ -1115,8 +1113,8 @@ func createCrashAlertsForApp(ctx context.Context, team Team, app App, from, to t
 			if method == "" {
 				method = "unknown_method"
 			}
-			alertMsg := email.CrashAlertMessage(file, method, message)
-			alertUrl := email.CrashAlertURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), fingerprint, crashType, fileName)
+			alertMsg := alertmsg.CrashSpikeMessage(file, method, message)
+			alertUrl := alertmsg.CrashSpikeURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), fingerprint, crashType, fileName)
 
 			fmt.Printf("Inserting alert for crash group %s\n", fingerprint)
 
@@ -1229,8 +1227,8 @@ func createAnrAlertsForApp(ctx context.Context, team Team, app App, from, to tim
 			if method == "" {
 				method = "unknown_method"
 			}
-			alertMsg := email.AnrAlertMessage(file, method, message)
-			alertUrl := email.AnrAlertURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), fingerprint, crashType, fileName)
+			alertMsg := alertmsg.AnrSpikeMessage(file, method, message)
+			alertUrl := alertmsg.AnrSpikeURL(server.Server.Config.SiteOrigin, team.ID.String(), app.ID.String(), fingerprint, crashType, fileName)
 
 			fmt.Printf("Inserting alert for anr group %s\n", fingerprint)
 

--- a/backend/alerts/alerts/alerts_test.go
+++ b/backend/alerts/alerts/alerts_test.go
@@ -3016,11 +3016,12 @@ func TestFormatTeamDailySummarySlackMessage(t *testing.T) {
 }
 
 func TestFormatSlackAlertMessage(t *testing.T) {
-	// The message comes from the shared email builders: <br> marks line
-	// breaks and app-generated text carries raw mrkdwn control characters.
+	// The message mimics the alertmsg builders' output, with app-generated
+	// text carrying raw mrkdwn control characters, so only the mrkdwn
+	// escaping should alter it.
 	msg := formatSlackAlertMessage(
 		"Checkout - Crash Spike Alert",
-		"Crashes are spiking at:<br><br>Foo.kt: <init>() - x < 1",
+		"Crashes are spiking at:\n\nFoo.kt: <init>() - x < 1",
 		"https://test.measure.sh/dashboard",
 	)
 
@@ -3029,9 +3030,6 @@ func TestFormatSlackAlertMessage(t *testing.T) {
 		"Foo.kt: &lt;init&gt;() - x &lt; 1"
 	if got != want {
 		t.Errorf("section text = %q, want %q", got, want)
-	}
-	if strings.Contains(got, "<br>") {
-		t.Errorf("section text = %q, want no <br> remnants", got)
 	}
 
 	// The header is plain_text, which Slack renders verbatim, so the title

--- a/backend/libs/alertmsg/alertmsg.go
+++ b/backend/libs/alertmsg/alertmsg.go
@@ -1,0 +1,56 @@
+// Package alertmsg builds the plain text messages and dashboard URLs
+// for crash spike, ANR spike, and bug report alerts. The alerts service
+// stores each message in the alerts table and hands the same string to
+// the email and Slack channels, so the builders emit no markup: each
+// channel applies its own formatting, email by escaping the text into
+// HTML and Slack by escaping mrkdwn control characters.
+package alertmsg
+
+import "fmt"
+
+// CrashSpikeMessage builds the plain text message for a crash spike alert.
+func CrashSpikeMessage(file, method, message string) string {
+	return fmt.Sprintf("Crashes are spiking at:\n\n%s: %s() - %s", file, method, message)
+}
+
+// AnrSpikeMessage builds the plain text message for an ANR spike alert.
+func AnrSpikeMessage(file, method, message string) string {
+	return fmt.Sprintf("ANRs are spiking at:\n\n%s: %s() - %s", file, method, message)
+}
+
+// BugReportMessage builds the plain text message for a bug report alert.
+// An empty description is replaced with a placeholder so the alert never
+// reads as truncated.
+func BugReportMessage(description string) string {
+	if description == "" {
+		description = "No description provided."
+	}
+	return fmt.Sprintf("A new bug report has been submitted:\n\n%s", description)
+}
+
+// CrashSpikeURL builds the dashboard URL for a crash spike alert. A
+// non-empty fileName joins the crash type with "@" to form the error
+// group name segment of the dashboard route.
+func CrashSpikeURL(siteOrigin, teamId, appId, fingerprint, crashType, fileName string) string {
+	suffix := ""
+	if fileName != "" {
+		suffix = "@" + fileName
+	}
+	return fmt.Sprintf("%s/%s/errors/%s/%s/%s%s", siteOrigin, teamId, appId, fingerprint, crashType, suffix)
+}
+
+// AnrSpikeURL builds the dashboard URL for an ANR spike alert. A
+// non-empty fileName joins the ANR type with "@" to form the error
+// group name segment of the dashboard route.
+func AnrSpikeURL(siteOrigin, teamId, appId, fingerprint, anrType, fileName string) string {
+	suffix := ""
+	if fileName != "" {
+		suffix = "@" + fileName
+	}
+	return fmt.Sprintf("%s/%s/errors/%s/%s/%s%s", siteOrigin, teamId, appId, fingerprint, anrType, suffix)
+}
+
+// BugReportURL builds the dashboard URL for a bug report alert.
+func BugReportURL(siteOrigin, teamId, appId, bugReportId string) string {
+	return fmt.Sprintf("%s/%s/bug_reports/%s/%s", siteOrigin, teamId, appId, bugReportId)
+}

--- a/backend/libs/alertmsg/alertmsg_test.go
+++ b/backend/libs/alertmsg/alertmsg_test.go
@@ -1,0 +1,81 @@
+package alertmsg
+
+import "testing"
+
+func TestCrashSpikeMessage(t *testing.T) {
+	got := CrashSpikeMessage("Foo.kt", "<init>", "x < 1")
+	want := "Crashes are spiking at:\n\nFoo.kt: <init>() - x < 1"
+	if got != want {
+		t.Errorf("CrashSpikeMessage = %q, want %q", got, want)
+	}
+}
+
+func TestAnrSpikeMessage(t *testing.T) {
+	got := AnrSpikeMessage("Bar.kt", "run", "Input dispatching timed out")
+	want := "ANRs are spiking at:\n\nBar.kt: run() - Input dispatching timed out"
+	if got != want {
+		t.Errorf("AnrSpikeMessage = %q, want %q", got, want)
+	}
+}
+
+func TestBugReportMessage(t *testing.T) {
+	t.Run("carries the description through unchanged", func(t *testing.T) {
+		got := BugReportMessage("Login button <b>does nothing</b>")
+		want := "A new bug report has been submitted:\n\nLogin button <b>does nothing</b>"
+		if got != want {
+			t.Errorf("BugReportMessage = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("replaces an empty description with a placeholder", func(t *testing.T) {
+		got := BugReportMessage("")
+		want := "A new bug report has been submitted:\n\nNo description provided."
+		if got != want {
+			t.Errorf("BugReportMessage = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestCrashSpikeURL(t *testing.T) {
+	t.Run("appends the file name after the crash type", func(t *testing.T) {
+		got := CrashSpikeURL("https://measure.sh", "team-1", "app-1", "fp-1", "java.lang.NullPointerException", "Foo.kt")
+		want := "https://measure.sh/team-1/errors/app-1/fp-1/java.lang.NullPointerException@Foo.kt"
+		if got != want {
+			t.Errorf("CrashSpikeURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("omits the suffix without a file name", func(t *testing.T) {
+		got := CrashSpikeURL("https://measure.sh", "team-1", "app-1", "fp-1", "java.lang.NullPointerException", "")
+		want := "https://measure.sh/team-1/errors/app-1/fp-1/java.lang.NullPointerException"
+		if got != want {
+			t.Errorf("CrashSpikeURL = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestAnrSpikeURL(t *testing.T) {
+	t.Run("appends the file name after the ANR type", func(t *testing.T) {
+		got := AnrSpikeURL("https://measure.sh", "team-1", "app-1", "fp-2", "AnrError", "Bar.kt")
+		want := "https://measure.sh/team-1/errors/app-1/fp-2/AnrError@Bar.kt"
+		if got != want {
+			t.Errorf("AnrSpikeURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("omits the suffix without a file name", func(t *testing.T) {
+		got := AnrSpikeURL("https://measure.sh", "team-1", "app-1", "fp-2", "AnrError", "")
+		want := "https://measure.sh/team-1/errors/app-1/fp-2/AnrError"
+		if got != want {
+			t.Errorf("AnrSpikeURL = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestBugReportURL(t *testing.T) {
+	got := BugReportURL("https://measure.sh", "team-1", "app-1", "bug-1")
+	want := "https://measure.sh/team-1/bug_reports/app-1/bug-1"
+	if got != want {
+		t.Errorf("BugReportURL = %q, want %q", got, want)
+	}
+}

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -69,71 +69,27 @@ func RoleChangedEmail(newRole, changedByEmail, teamName, siteOrigin, teamId stri
 	return
 }
 
-// CrashAlertMessage builds the alert message string for crash spike alerts.
-// This message is shared across email, DB storage, and Slack notifications.
-func CrashAlertMessage(file, method, crashMessage string) string {
-	return fmt.Sprintf("Crashes are spiking at:<br><br>%s: %s() - %s", file, method, crashMessage)
-}
-
-// AnrAlertMessage builds the alert message string for ANR spike alerts.
-// This message is shared across email, DB storage, and Slack notifications.
-func AnrAlertMessage(file, method, anrMessage string) string {
-	return fmt.Sprintf("ANRs are spiking at:<br><br>%s: %s() - %s", file, method, anrMessage)
-}
-
-// CrashAlertURL builds the dashboard URL for a crash spike alert.
-// This URL is shared across email, DB storage, and Slack notifications.
-func CrashAlertURL(siteOrigin, teamId, appId, fingerprint, crashType, fileName string) string {
-	suffix := ""
-	if fileName != "" {
-		suffix = "@" + fileName
-	}
-	return fmt.Sprintf("%s/%s/errors/%s/%s/%s%s", siteOrigin, teamId, appId, fingerprint, crashType, suffix)
-}
-
-// AnrAlertURL builds the dashboard URL for an ANR spike alert.
-// This URL is shared across email, DB storage, and Slack notifications.
-func AnrAlertURL(siteOrigin, teamId, appId, fingerprint, anrType, fileName string) string {
-	suffix := ""
-	if fileName != "" {
-		suffix = "@" + fileName
-	}
-	return fmt.Sprintf("%s/%s/errors/%s/%s/%s%s", siteOrigin, teamId, appId, fingerprint, anrType, suffix)
-}
-
-// CrashSpikeAlertEmail builds the crash spike alert email.
+// CrashSpikeAlertEmail builds the crash spike alert email from the plain
+// text alert message.
 func CrashSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - Crash Spike Alert"
-	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
-// AnrSpikeAlertEmail builds the ANR spike alert email.
+// AnrSpikeAlertEmail builds the ANR spike alert email from the plain
+// text alert message.
 func AnrSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - ANR Spike Alert"
-	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
-// BugReportAlertMessage builds the alert message string for bug report alerts.
-// This message is shared across email and Slack notifications.
-func BugReportAlertMessage(description string) string {
-	if description == "" {
-		description = "No description provided."
-	}
-	return fmt.Sprintf("A new bug report has been submitted:<br><br>%s", description)
-}
-
-// BugReportAlertURL builds the dashboard URL for a bug report alert.
-// This URL is shared across email and Slack notifications.
-func BugReportAlertURL(siteOrigin, teamId, appId, bugReportId string) string {
-	return fmt.Sprintf("%s/%s/bug_reports/%s/%s", siteOrigin, teamId, appId, bugReportId)
-}
-
-// BugReportAlertEmail builds the bug report alert email.
+// BugReportAlertEmail builds the bug report alert email from the plain
+// text alert message.
 func BugReportAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - New Bug Report"
-	body = RenderEmailBody(escape(subject), MessageContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 

--- a/backend/libs/email/cmd/preview/main.go
+++ b/backend/libs/email/cmd/preview/main.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"backend/libs/alertmsg"
 	"backend/libs/email"
 )
 
@@ -82,28 +83,28 @@ func main() {
 
 	// --- Alerts: Crash & ANR ---
 
-	alertMsg := email.CrashAlertMessage(
+	alertMsg := alertmsg.CrashSpikeMessage(
 		"com.example.myapp.MainActivity.java",
 		"onCreate",
 		"NullPointerException: Attempt to invoke virtual method on a null object reference",
 	)
-	alertURL := email.CrashAlertURL("https://measure.sh", "team-abc", "app-123", "fingerprint-456", "java.lang.NullPointerException", "")
+	alertURL := alertmsg.CrashSpikeURL("https://measure.sh", "team-abc", "app-123", "fingerprint-456", "java.lang.NullPointerException", "")
 	_, body = email.CrashSpikeAlertEmail("MyApp", alertMsg, alertURL)
 	add("06-crash-spike-alert.html", body)
 
-	alertMsg = email.AnrAlertMessage(
+	alertMsg = alertmsg.AnrSpikeMessage(
 		"com.example.myapp.NetworkService.java",
 		"fetchData",
 		"Application Not Responding: Input dispatching timed out",
 	)
-	alertURL = email.AnrAlertURL("https://measure.sh", "team-abc", "app-123", "fingerprint-789", "ANR", "")
+	alertURL = alertmsg.AnrSpikeURL("https://measure.sh", "team-abc", "app-123", "fingerprint-789", "ANR", "")
 	_, body = email.AnrSpikeAlertEmail("MyApp", alertMsg, alertURL)
 	add("07-anr-spike-alert.html", body)
 
 	// --- Alerts: Bug Report ---
 
-	alertMsg = email.BugReportAlertMessage("The app crashes when I click the login button after entering a very long password.")
-	alertURL = email.BugReportAlertURL("https://measure.sh", "team-abc", "app-123", "bug-report-456")
+	alertMsg = alertmsg.BugReportMessage("The app crashes when I click the login button after entering a very long password.")
+	alertURL = alertmsg.BugReportURL("https://measure.sh", "team-abc", "app-123", "bug-report-456")
 	_, body = email.BugReportAlertEmail("MyApp", alertMsg, alertURL)
 	add("07b-bug-report-alert.html", body)
 

--- a/backend/libs/email/email.go
+++ b/backend/libs/email/email.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"strings"
 	"time"
 
@@ -228,14 +229,26 @@ func RenderEmailBody(title, contentHTML, ctaText, ctaURL string) string {
 </html>`, title, title, contentHTML, ctaURL, ctaText)
 }
 
-// MessageContent wraps a plain text/HTML message in the standard
-// styled content div. Used for simple notification emails.
+// MessageContent wraps a message in the standard styled content div.
+// The message is trusted as HTML and placed in the email body verbatim,
+// so callers must only pass markup they built themselves; text from
+// outside the codebase belongs in PlainTextContent instead.
 func MessageContent(message string) string {
 	return fmt.Sprintf(`
             <!-- Message -->
             <div style="margin-bottom: 32px; font-size: 16px; line-height: 1.6; color: #4a5568;">
                 %s
             </div>`, message)
+}
+
+// PlainTextContent wraps an untrusted plain text message in the standard
+// styled content div. Unlike MessageContent, which trusts its input as
+// HTML, this escapes the message first and then renders its newlines as
+// <br>, so a crash message or a user-typed bug report description cannot
+// place markup inside the email body.
+func PlainTextContent(message string) string {
+	escaped := html.EscapeString(message)
+	return MessageContent(strings.ReplaceAll(escaped, "\n", "<br>"))
 }
 
 // UsageLimitContent renders a percent-only usage progress bar and message.

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -754,3 +754,47 @@ func TestAppNameMarkupIsEscapedInTitle(t *testing.T) {
 		}
 	}
 }
+
+// Alert messages carry crash strings and user-typed bug report
+// descriptions, so markup in them must render as visible text.
+func TestPlainTextContentEscapesMarkupAndRendersNewlines(t *testing.T) {
+	const payload = "Crashes are spiking at:\n\nFoo.kt: <init>() - evil<img src=\"x\" onerror=\"alert(1)\">"
+
+	content := PlainTextContent(payload)
+
+	if strings.Contains(content, `<img`) {
+		t.Error("content contains an unescaped img tag")
+	}
+	if !strings.Contains(content, `evil&lt;img src=&#34;x&#34; onerror=&#34;alert(1)&#34;&gt;`) {
+		t.Error("content missing the escaped markup as visible text")
+	}
+	if !strings.Contains(content, "Foo.kt: &lt;init&gt;() -") {
+		t.Error("content missing the escaped crash frame")
+	}
+	if !strings.Contains(content, "Crashes are spiking at:<br><br>Foo.kt:") {
+		t.Error("content missing <br> line breaks for the message newlines")
+	}
+}
+
+// The alert email builders receive the plain text alert message, so a crash
+// string or bug description with markup must reach the rendered body only
+// in escaped form.
+func TestAlertMessageMarkupIsEscapedInBody(t *testing.T) {
+	const payload = `spiking at <img src=x onerror=alert(1)>`
+	const escaped = `spiking at &lt;img src=x onerror=alert(1)&gt;`
+
+	bodies := map[string]string{}
+
+	_, bodies["CrashSpikeAlertEmail"] = CrashSpikeAlertEmail("MyApp", payload, "https://measure.sh")
+	_, bodies["AnrSpikeAlertEmail"] = AnrSpikeAlertEmail("MyApp", payload, "https://measure.sh")
+	_, bodies["BugReportAlertEmail"] = BugReportAlertEmail("MyApp", payload, "https://measure.sh")
+
+	for name, body := range bodies {
+		if strings.Contains(body, payload) {
+			t.Errorf("%s: body contains unescaped alert message markup", name)
+		}
+		if !strings.Contains(body, escaped) {
+			t.Errorf("%s: body missing escaped alert message", name)
+		}
+	}
+}

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -4447,7 +4447,7 @@ paths:
                         app_id: 19e26d60-2ad8-4ef7-8aab-333e1f5377fc
                         entity_id: 09ef78940bd258030ebe3937bf1e32a2
                         type: anr_spike
-                        message: "ANRs are spiking at CpuUsageCollector: run() - Application Not Responding for at least 5s"
+                        message: "ANRs are spiking at:\n\nCpuUsageCollector: run() - Application Not Responding for at least 5s"
                         url: http://localhost:3000/29f0f5b2-f03f-4dbe-bd18-acf163b91965/anrs/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/09ef78940bd258030ebe3937bf1e32a2/sh.measure.android.anr.AnrError@CpuUsageCollector
                         created_at: "2025-07-10T11:35:48.069383Z"
                         updated_at: "2025-07-10T11:35:48.069383Z"
@@ -4456,7 +4456,7 @@ paths:
                         app_id: 19e26d60-2ad8-4ef7-8aab-333e1f5377fc
                         entity_id: f94859bc4b47fbf05b4eec2a300de0a4
                         type: crash_spike
-                        message: "Crashes are spiking at ExceptionDemoActivity: onClick() - This is a nested custom exception"
+                        message: "Crashes are spiking at:\n\nExceptionDemoActivity: onClick() - This is a nested custom exception"
                         url: http://localhost:3000/29f0f5b2-f03f-4dbe-bd18-acf163b91965/crashes/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/f94859bc4b47fbf05b4eec2a300de0a4/sh.measure.sample.CustomException@ExceptionDemoActivity
                         created_at: "2025-07-10T11:35:48.057192Z"
                         updated_at: "2025-07-10T11:35:48.057192Z"


### PR DESCRIPTION
# Description

- new backend/libs/alertmsg package holds the crash spike, ANR spike, and bug report message and URL builders; messages are plain text with newlines, moved out of the email package
- each sink formats for itself: email escapes then converts newlines to <br> via the new PlainTextContent (closing a path where crash strings and bug descriptions reached email HTML unescaped), Slack escapes mrkdwn only, the alerts table stores the neutral text
- dashboard alerts page and MCP get_alerts stop showing literal <br> for new alerts; old rows age out via retention
- the <br>-to-newline shim in the Slack formatter is removed
- OpenAPI alert message examples refreshed


