### PR TITLE
chore(backend): correct documentation accuracy

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -589,7 +589,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_journey
 		newTool(&mcpsdk.Tool{
 			Name:        "get_journey",
-			Description: "Get user navigation journey graph with session counts between screens. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
+			Description: "Get an app's journey as a graph of event types. Each link is one observed transition between consecutive events. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
 			InputSchema: mcpMustInferSchema[mcpGetJourneyInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetJourneyInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetJourney(ctx, in)

--- a/frontend/dashboard/content/docs/mcp.mdx
+++ b/frontend/dashboard/content/docs/mcp.mdx
@@ -127,4 +127,4 @@ Get alerts for an app, ordered by most recent first.
 
 ### `get_journey`
 
-Get user navigation journey graph with session counts between screens.
+Get an app's journey as a graph of event types. Each link is one observed transition between consecutive events.

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -393,13 +393,13 @@ paths:
         - name: versions
           in: query
           required: false
-          description: List of comma separated version identifier strings to return only matching crashes.
+          description: List of comma separated version identifier strings to return only matching issues.
           schema:
             type: string
         - name: version_codes
           in: query
           required: false
-          description: List of comma separated version codes to return only matching crashes.
+          description: List of comma separated version codes to return only matching issues.
           schema:
             type: string
         - name: bigraph
@@ -1182,13 +1182,13 @@ paths:
         - Errors
       summary: Fetch an app's error overview
       description: |
-        Fetch an app's error overview. Returns fatal exceptions, handled
-        exceptions, and ANRs unified into a single list.
+        Fetch an app's error overview. Returns fatal, unhandled & handled
+        errors plus ANRs unified into a single list.
 
         Both `versions` & `version_codes` should be present if any one of them
         is present. When neither `type` nor `severity` is set, all sources
-        (fatal exceptions, nonfatal exceptions, ANRs) are returned.
-        `custom=true` filters exceptions to custom-tracked only and does not
+        (fatal errors, nonfatal errors, ANRs) are returned.
+        `custom=true` filters errors to custom-tracked only & does not
         suppress ANRs. To exclude ANRs explicitly, use `type=error`.
       parameters:
         - name: id

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -389,9 +389,9 @@ paths:
                             type: boolean
                             deprecated: true
                             description: >
-                              Do not use. Prefer using `severity` for new
-                              integrations; `handled` is retained for backwards
-                              compatibility.
+                              Do not use. `severity` is the field consumed when
+                              present; `handled` is only read when `severity`
+                              is absent.
                           severity:
                             type: string
                             enum:


### PR DESCRIPTION
## Summary

This PR fixes four doc inaccuracies found by auditing the docs against the code: the `get_journey` tool description, the journey version params, the error overview wording & the SDK `handled` deprecation note. Prose only, plus one Go string that serves as the LLM-facing tool description.

## Tasks

- [x] Describe `get_journey` as a graph of event types
- [x] Correct the journey version params to filter issues
- [x] Reword the error overview to say errors & name all three severities
- [x] State that `severity` is consumed & `handled` is read only when absent