### PR TITLE
fix(backend): report auth infra failures as 500 not 401

### DIFF
--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -70,8 +70,6 @@ func (h Handlers) ValidateAPIKey() gin.HandlerFunc {
 				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
 				return
 			}
-			// lookup failures are infrastructure, a 401 would send callers to rotate a
-			// key that was never wrong.
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate api key"})
 			return
 		}

--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -66,7 +66,13 @@ func (h Handlers) ValidateAPIKey() gin.HandlerFunc {
 		appId, err := measure.DecodeAPIKey(c, deps.PgPool, key)
 		if err != nil {
 			fmt.Println("api key decode failed:", err)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
+			if errors.Is(err, measure.ErrInvalidAPIKey) {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
+				return
+			}
+			// lookup failures are infrastructure, a 401 would send callers to rotate a
+			// key that was never wrong.
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate api key"})
 			return
 		}
 
@@ -269,7 +275,14 @@ func (h Handlers) SigninGitHub(c *gin.Context) {
 		githubToken, err := authsession.ExchangeCodeForToken(deps.Config.SiteOrigin, deps.Config.OAuthGitHubKey, deps.Config.OAuthGitHubSecret, authCode.Code)
 		if err != nil {
 			fmt.Println(msg, err)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			if errors.Is(err, authsession.ErrInvalidOAuthCode) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error":   msg,
+					"details": err.Error(),
+				})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 				"error":   msg,
 				"details": err.Error(),
 			})
@@ -475,7 +488,14 @@ func (h Handlers) SigninGoogle(c *gin.Context) {
 		)
 		if err != nil {
 			fmt.Println(msg, err)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			if errors.Is(err, authsession.ErrInvalidOAuthCode) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error":   msg,
+					"details": err.Error(),
+				})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 				"error":   msg,
 				"details": err.Error(),
 			})
@@ -697,6 +717,14 @@ func (h Handlers) RefreshToken(c *gin.Context) {
 		})
 		return
 	}
+	if err != nil {
+		msg := "failed to look up session"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
 
 	msg := `failed to refresh session`
 
@@ -799,6 +827,14 @@ func (h Handlers) GetAuthSession(c *gin.Context) {
 		})
 		return
 	}
+	if err != nil {
+		msg := "failed to look up session"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
 
 	ownTeam, err := measure.EnsureDefaultTeam(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), user)
 	if err != nil {
@@ -829,7 +865,7 @@ func (h Handlers) GetAuthSession(c *gin.Context) {
 		avatarUrl = userMeta["picture"].(string)
 	} else {
 		msg := "invalid oauth provider: " + session.OAuthProvider
-		fmt.Println(msg, err)
+		fmt.Println(msg)
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error": msg,
 		})

--- a/backend/api/handlers/auth_test.go
+++ b/backend/api/handlers/auth_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestValidateAPIKey(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("malformed key returns unauthorized", func(t *testing.T) {
+		c, w := newTestGinContext(http.MethodGet, "/apps", nil)
+		c.Request.Header.Set("Authorization", "Bearer not-a-valid-key")
+
+		h.ValidateAPIKey()(c)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+		wantJSON(t, w, "error", "invalid api key")
+	})
+
+	t.Run("lookup failure returns internal server error", func(t *testing.T) {
+		cfg := deps.PgPool.Config().Copy()
+		broken, err := pgxpool.NewWithConfig(ctx, cfg)
+		if err != nil {
+			t.Fatalf("failed to create pool: %v", err)
+		}
+		broken.Close()
+
+		brokenDeps := *deps
+		brokenDeps.PgPool = broken
+		brokenH := New(&brokenDeps)
+
+		raw := mustRawAPIKey(t, "some-value")
+		c, w := newTestGinContext(http.MethodGet, "/apps", nil)
+		c.Request.Header.Set("Authorization", "Bearer "+raw)
+
+		brokenH.ValidateAPIKey()(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+		wantJSON(t, w, "error", "failed to validate api key")
+	})
+}

--- a/backend/libs/measure/apikey.go
+++ b/backend/libs/measure/apikey.go
@@ -21,6 +21,10 @@ import (
 
 const APIKeyPrefix = "msrsh"
 
+// ErrInvalidAPIKey means the key is malformed or fails checksum. Distinct from
+// a lookup failure, which is infrastructure.
+var ErrInvalidAPIKey = errors.New("invalid api key")
+
 type APIKey struct {
 	appId     uuid.UUID
 	keyPrefix string
@@ -128,16 +132,14 @@ func (a App) RotateAPIKey(pg *pgxpool.Pool) (*APIKey, error) {
 }
 
 func DecodeAPIKey(ctx context.Context, pg *pgxpool.Pool, key string) (*uuid.UUID, error) {
-	defaultErr := errors.New("invalid api key")
-
 	if len(key) < 1 {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	parts := strings.Split(key, "_")
 
 	if len(parts) != 3 {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	prefix := parts[0]
@@ -145,7 +147,7 @@ func DecodeAPIKey(ctx context.Context, pg *pgxpool.Pool, key string) (*uuid.UUID
 	checksum := parts[2]
 
 	if prefix != APIKeyPrefix {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	computedChecksum, err := cipher.ComputeChecksum([]byte(value))
@@ -154,7 +156,7 @@ func DecodeAPIKey(ctx context.Context, pg *pgxpool.Pool, key string) (*uuid.UUID
 	}
 
 	if checksum != *computedChecksum {
-		return nil, defaultErr
+		return nil, ErrInvalidAPIKey
 	}
 
 	stmt := sqlf.PostgreSQL.

--- a/backend/libs/measure/apikey.go
+++ b/backend/libs/measure/apikey.go
@@ -21,7 +21,6 @@ import (
 
 const APIKeyPrefix = "msrsh"
 
-// ErrInvalidAPIKey means the key is malformed or fails checksum.
 var ErrInvalidAPIKey = errors.New("invalid api key")
 
 type APIKey struct {

--- a/backend/libs/measure/apikey.go
+++ b/backend/libs/measure/apikey.go
@@ -21,8 +21,7 @@ import (
 
 const APIKeyPrefix = "msrsh"
 
-// ErrInvalidAPIKey means the key is malformed or fails checksum. Distinct from
-// a lookup failure, which is infrastructure.
+// ErrInvalidAPIKey means the key is malformed or fails checksum.
 var ErrInvalidAPIKey = errors.New("invalid api key")
 
 type APIKey struct {

--- a/backend/libs/measure/apikey_test.go
+++ b/backend/libs/measure/apikey_test.go
@@ -5,6 +5,7 @@ package measure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"backend/libs/cipher"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func mustRawAPIKey(t *testing.T, value string) string {
@@ -279,6 +281,31 @@ func TestDecodeAPIKey(t *testing.T) {
 		_, err := DecodeAPIKey(ctx, deps.PgPool, "badprefix_value_12345678")
 		if err == nil {
 			t.Fatalf("expected error for wrong prefix")
+		}
+	})
+
+	t.Run("malformed key returns ErrInvalidAPIKey", func(t *testing.T) {
+		_, err := DecodeAPIKey(ctx, deps.PgPool, "not-a-valid-key")
+		if !errors.Is(err, ErrInvalidAPIKey) {
+			t.Fatalf("err = %v, want ErrInvalidAPIKey", err)
+		}
+	})
+
+	t.Run("lookup failure is not ErrInvalidAPIKey", func(t *testing.T) {
+		cfg := deps.PgPool.Config().Copy()
+		broken, err := pgxpool.NewWithConfig(ctx, cfg)
+		if err != nil {
+			t.Fatalf("failed to create pool: %v", err)
+		}
+		broken.Close()
+
+		raw := mustRawAPIKey(t, "some-value")
+		_, err = DecodeAPIKey(ctx, broken, raw)
+		if err == nil {
+			t.Fatalf("expected error from closed pool")
+		}
+		if errors.Is(err, ErrInvalidAPIKey) {
+			t.Fatalf("err = %v, want not ErrInvalidAPIKey", err)
 		}
 	})
 }

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -111,7 +111,7 @@ paths:
                     user_id: 835283a5-cddc-472b-84ad-5ea3319efeed
                     own_team_id: e47ac49d-0697-4e85-8607-1a34536c04e3
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: GitHub rejected the sign-in. The authorization code is invalid, already used or expired.
         "429":
@@ -181,7 +181,7 @@ paths:
                     user_id: 835283a5-cddc-472b-84ad-5ea3319efeed
                     own_team_id: e47ac49d-0697-4e85-8607-1a34536c04e3
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Google rejected the sign-in. The authorization code is invalid, already used or expired.
         "429":
@@ -227,7 +227,7 @@ paths:
                   value:
                     valid: true
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "410":
           description: Invite has expired.
         "429":
@@ -263,8 +263,6 @@ paths:
                   value:
                     access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDUyMjU2NTl9.XzbpImWw9GXFlIXHCu92QNsA1D8m_Y9ZFVDEDqG_wtM
                     refresh_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDU4Mjg2NTl9.MeMIsk1KEHvPa2AAbDBQWqeKJwQcxbk1lXb7Mhcz-uQ
-        "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's refresh token is invalid or has expired.
         "403":
@@ -323,8 +321,6 @@ paths:
                       last_sign_in_at: "2024-06-19T22:14:49.77Z"
                       created_at: "2024-06-19T22:14:49.77Z"
                       updated_at: "2024-06-19T22:14:49.77Z"
-        "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's access token is invalid or has expired.
         "403":
@@ -360,8 +356,6 @@ paths:
                 response:
                   value:
                     ok: true
-        "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's refresh token is invalid or has expired.
         "403":
@@ -5927,7 +5921,7 @@ paths:
                     id: 269362f4-27a5-4eac-84f8-b2291515edd3
                     name: acme-team
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's access token is invalid or has expired.
         "403":
@@ -5967,8 +5961,6 @@ paths:
                     - id: 823f0g9c-2gg7-32mp-x6cj-v368geb129d0
                       name: Team 2
                       role: admin
-        "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's access token is invalid or has expired.
         "403":
@@ -7201,7 +7193,7 @@ paths:
                     created_at: "2024-01-01T00:00:00Z"
                     updated_at: "2024-01-01T00:00:00Z"
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's access token is invalid or has expired.
         "403":
@@ -7260,7 +7252,7 @@ paths:
                   value:
                     ok: done
         "400":
-          description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
+          description: Request is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
           description: Either the user's access token is invalid or has expired.
         "403":


### PR DESCRIPTION
## Summary

This PR fixes four auth paths in the dashboard API that reported infrastructure failures as client errors. Invalid input keeps its 4xx, everything else returns 500, so callers retry instead of discarding data. Mirrors the same fix already made in the ingest service.

## Tasks

- [x] Add `ErrInvalidAPIKey` sentinel to `DecodeAPIKey` in `apikey.go`
- [x] Return 401 only for malformed API keys & 500 for lookup failures in `ValidateAPIKey`
- [x] Guard non-`ErrNoRows` session lookup errors in `RefreshToken` & `GetAuthSession`
- [x] Return 400 for `ErrInvalidOAuthCode` & 500 for other errors in GitHub & Google OAuth code exchange
- [x] Add tests covering API key error classification
- [x] Updates OpenAPI spec accordingly
