### PR TITLE
fix(backend): distinguish absent `num_code` from a sent zero

### DIFF
--- a/backend/ingest-worker/measure/event.go
+++ b/backend/ingest-worker/measure/event.go
@@ -423,6 +423,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 		attachments := "[]"
 		binaryImages := "[]"
 		errorMeta := "{}"
+		var numCode int32
 
 		if e.events[i].IsANR() {
 			marshalledExceptions, err := json.Marshal(e.events[i].ANR.Exceptions)
@@ -469,6 +470,10 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 					return err
 				}
 				errorMeta = string(metaBytes)
+			}
+
+			if e.events[i].Exception.NumCode != nil {
+				numCode = *e.events[i].Exception.NumCode
 			}
 		}
 
@@ -568,7 +573,8 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				Set(`exception.foreground`, e.events[i].Exception.Foreground).
 				Set(`exception.binary_images`, binaryImages).
 				Set(`exception.framework`, e.events[i].Exception.GetFramework()).
-				Set(`exception.num_code`, e.events[i].Exception.NumCode).
+				Set(`exception.num_code`, numCode).
+				Set(`exception.has_num_code`, e.events[i].Exception.NumCode != nil).
 				Set(`exception.code`, e.events[i].Exception.Code).
 				Set(`exception.meta`, errorMeta).
 				Set(`exception.severity`, e.events[i].Exception.GetSeverity()).
@@ -583,6 +589,7 @@ func (e eventreq) ingestEvents(ctx context.Context) error {
 				Set(`exception.binary_images`, nil).
 				Set(`exception.framework`, nil).
 				Set(`exception.num_code`, nil).
+				Set(`exception.has_num_code`, nil).
 				Set(`exception.code`, nil).
 				Set(`exception.meta`, nil).
 				Set(`exception.severity`, nil).

--- a/backend/libs/event/event.go
+++ b/backend/libs/event/event.go
@@ -403,7 +403,9 @@ type Exception struct {
 	// Deprecated: Use Code, NumCode & Meta instead.
 	Error *Error `json:"error"`
 	// NumCode represents the numeric error code.
-	NumCode int32 `json:"num_code"`
+	//
+	// Nil means the SDK did not send it, distinct from a sent 0.
+	NumCode *int32 `json:"num_code"`
 	// Code represents the string error code.
 	Code string `json:"code"`
 	// Meta represents arbitrary metadata
@@ -1611,7 +1613,7 @@ func (e Exception) HasJSFrames() bool {
 // An AppleFamily Exception may optionally have
 // an associated Error.
 func (e Exception) HasError() bool {
-	return e.Code != "" || e.NumCode != 0 || len(e.Meta) != 0 || (e.Error.hasData())
+	return e.Code != "" || e.NumCode != nil || len(e.Meta) != 0 || (e.Error.hasData())
 }
 
 // GetMetaBytes returns the meta bytes of the exception.

--- a/backend/libs/event/event_test.go
+++ b/backend/libs/event/event_test.go
@@ -225,8 +225,23 @@ func TestHasError(t *testing.T) {
 		}
 	}
 	{
+		numCode := int32(47)
 		e := Exception{
-			NumCode: 47,
+			NumCode: &numCode,
+		}
+		expected := true
+		got := e.HasError()
+
+		if expected != got {
+			t.Errorf("Expected %v, but got %v", expected, got)
+		}
+	}
+
+	// NumCode sent as zero is still present, not absent
+	{
+		numCode := int32(0)
+		e := Exception{
+			NumCode: &numCode,
 		}
 		expected := true
 		got := e.HasError()

--- a/backend/libs/event/issue.go
+++ b/backend/libs/event/issue.go
@@ -43,7 +43,7 @@ type EventException struct {
 	Attribute            Attribute          `json:"attribute"`
 	Exception            Exception          `json:"-"`
 	ExceptionView        ExceptionView      `json:"exception"`
-	NumCode              int32              `json:"num_code"`
+	NumCode              *int32             `json:"num_code"`
 	Code                 string             `json:"code"`
 	Meta                 map[string]any     `json:"meta"`
 	Severity             Severity           `json:"severity"`

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -1063,7 +1063,7 @@ func (a App) GetErrorsWithFilter(ctx context.Context, rch driver.Conn, fingerpri
 			Select("exception.exceptions as exceptions").
 			Select("exception.threads as threads").
 			Select("exception.framework as framework").
-			Select("exception.num_code as num_code").
+			Select("if(exception.has_num_code OR exception.num_code != 0, exception.num_code, NULL) as num_code").
 			Select("exception.code as code").
 			Select("exception.meta as meta").
 			Select("if(exception.severity = '', if(exception.handled, 'handled', 'fatal'), exception.severity) as severity").
@@ -3622,7 +3622,7 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 		`gesture_scroll.end_x`,
 		`gesture_scroll.end_y`,
 		`gesture_scroll.direction`,
-		`exception.num_code`,
+		`if(exception.has_num_code OR exception.num_code != 0, exception.num_code, NULL) as num_code`,
 		`exception.code`,
 		`exception.meta`,
 		`exception.is_custom`,

--- a/backend/libs/timeline/critical.go
+++ b/backend/libs/timeline/critical.go
@@ -19,7 +19,7 @@ type Exception struct {
 	GroupId       string              `json:"group_id"`
 	Severity      string              `json:"severity"`
 	IsCustom      bool                `json:"is_custom"`
-	NumCode       int32               `json:"num_code"`
+	NumCode       *int32              `json:"num_code"`
 	Code          string              `json:"code"`
 	Meta          map[string]any      `json:"meta"`
 	Type          string              `json:"type"`

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -1722,7 +1722,10 @@ paths:
                         severity:
                           type: string
                         num_code:
-                          type: number
+                          type:
+                            - number
+                            - "null"
+                          description: Numeric error code. Null when the SDK did not report one.
                         code:
                           type: string
                         meta:
@@ -1792,7 +1795,7 @@ paths:
                           stacktrace: "java.lang.NullPointerException: Attempt to invoke virtual method\n\tat com.example.MainActivity.onClick(MainActivity.kt:42)"
                           message: Attempt to invoke virtual method on a null object reference
                         severity: fatal
-                        num_code: 0
+                        num_code: null
                         code: ""
                         meta: null
                         user_defined_attribute:

--- a/self-host/clickhouse/20260820060000_alter_events_table.sql
+++ b/self-host/clickhouse/20260820060000_alter_events_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+alter table events
+    add column if not exists `exception.has_num_code` Bool comment 'true if the sdk sent exception.num_code' CODEC(ZSTD(3)) after `exception.num_code`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table events
+    drop column if exists `exception.has_num_code`
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260820060100_alter_sessions_mv.sql
+++ b/self-host/clickhouse/20260820060100_alter_sessions_mv.sql
@@ -1,0 +1,229 @@
+-- migrate:up
+alter table sessions_mv
+modify query
+select
+    session_id,
+    team_id,
+    app_id,
+    minSimpleState(timestamp) as first_event_timestamp,
+    maxSimpleState(timestamp) as last_event_timestamp,
+    (attribute.app_version, attribute.app_build) as app_version,
+    (attribute.os_name, attribute.os_version) as os_version,
+    groupUniqArrayArraySimpleState(if(inet.country_code != '', [inet.country_code], [])) as country_codes,
+    groupUniqArrayArraySimpleState(if(attribute.network_provider != '', [attribute.network_provider], [])) as network_providers,
+    groupUniqArrayArraySimpleState(if(attribute.network_type != '', [attribute.network_type], [])) as network_types,
+    groupUniqArrayArraySimpleState(if(attribute.network_generation != '', [attribute.network_generation], [])) as network_generations,
+    groupUniqArrayArraySimpleState([attribute.device_locale]) as device_locales,
+    argMax(attribute.device_name, timestamp) as device_name,
+    argMax(attribute.device_manufacturer, timestamp) as device_manufacturer,
+    argMax(attribute.device_model, timestamp) as device_model,
+    groupUniqArrayArraySimpleState(if(attribute.user_id != '', [attribute.user_id], [])) as user_ids,
+    groupUniqArrayArraySimpleState([type]) as unique_types,
+    groupUniqArrayArraySimpleState(if(type = 'custom', [custom.name], [])) as unique_custom_type_names,
+    groupUniqArrayArraySimpleState(if(`string.string` != '', [`string.string`], [])) as unique_strings,
+    groupUniqArrayArraySimpleState(if(`log.body` != '', [`log.body`], [])) as unique_logs,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_activity') and (lifecycle_activity.class_name != ''), [lifecycle_activity.class_name], [])) as unique_view_classnames,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_fragment') and (lifecycle_fragment.class_name != ''), [lifecycle_fragment.class_name], [])) as unique_subview_classnames,
+    -- fatal: severity='fatal' or (severity='' and handled=0)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_fatal_exceptions,
+    -- handled: severity='handled' or (severity='' and handled=1)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_handled_exceptions,
+    -- nonfatal unhandled: strictly new, severity='unhandled' only
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_unhandled_exceptions,
+    groupUniqArrayArraySimpleState(if(
+        (type = 'exception') and (
+            exception.has_num_code or exception.num_code != 0 or
+            (exception.code != '' and exception.code != '{}') or
+            (exception.meta != '' and exception.meta != '{}')
+        ),
+        [concat(
+            '{"num_code":', if(exception.has_num_code OR exception.num_code != 0, toString(exception.num_code), 'null'),
+            ',"code":', toJSONString(exception.code),
+            ',"meta":', if(exception.meta = '' or exception.meta = '{}', '{}', exception.meta),
+            '}'
+        )],
+        []
+    )) as unique_errors,
+    groupUniqArrayArraySimpleState(if(type = 'anr', [(simpleJSONExtractString(`anr.exceptions`, 'type'), simpleJSONExtractString(`anr.exceptions`, 'message'), simpleJSONExtractString(`anr.exceptions`, 'file_name'), simpleJSONExtractString(`anr.exceptions`, 'class_name'), simpleJSONExtractString(`anr.exceptions`, 'method_name'))], [])) as unique_anrs,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_click', [(gesture_click.target, gesture_click.target_id)], [])) as unique_click_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_long_click', [(gesture_long_click.target, gesture_long_click.target_id)], [])) as unique_longclick_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_scroll', [(gesture_scroll.target, gesture_scroll.target_id)], [])) as unique_scroll_targets,
+    sumSimpleState(toUInt64(1)) as event_count,
+    -- fatal count: legacy handled=0 or new severity='fatal'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as fatal_exception_count,
+    -- handled count: legacy handled=1 or new severity='handled'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as handled_exception_count,
+    -- nonfatal unhandled count: strictly new
+    sumSimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        toUInt64(1), toUInt64(0)
+    )) as unhandled_exception_count,
+    sumSimpleState(if(type = 'anr', toUInt64(1), toUInt64(0))) as anr_count,
+    sumSimpleState(if(type = 'bug_report', toUInt64(1), toUInt64(0))) as bug_report_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'background'), toUInt64(1), toUInt64(0))) as background_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'foreground'), toUInt64(1), toUInt64(0))) as foreground_count,
+    sumMapSimpleState(map(type, toUInt64(1))) as event_type_counts
+from events
+group by
+    team_id,
+    app_id,
+    session_id,
+    app_version,
+    os_version;
+
+-- migrate:down
+alter table sessions_mv
+modify query
+select
+    session_id,
+    team_id,
+    app_id,
+    minSimpleState(timestamp) as first_event_timestamp,
+    maxSimpleState(timestamp) as last_event_timestamp,
+    (attribute.app_version, attribute.app_build) as app_version,
+    (attribute.os_name, attribute.os_version) as os_version,
+    groupUniqArrayArraySimpleState(if(inet.country_code != '', [inet.country_code], [])) as country_codes,
+    groupUniqArrayArraySimpleState(if(attribute.network_provider != '', [attribute.network_provider], [])) as network_providers,
+    groupUniqArrayArraySimpleState(if(attribute.network_type != '', [attribute.network_type], [])) as network_types,
+    groupUniqArrayArraySimpleState(if(attribute.network_generation != '', [attribute.network_generation], [])) as network_generations,
+    groupUniqArrayArraySimpleState([attribute.device_locale]) as device_locales,
+    argMax(attribute.device_name, timestamp) as device_name,
+    argMax(attribute.device_manufacturer, timestamp) as device_manufacturer,
+    argMax(attribute.device_model, timestamp) as device_model,
+    groupUniqArrayArraySimpleState(if(attribute.user_id != '', [attribute.user_id], [])) as user_ids,
+    groupUniqArrayArraySimpleState([type]) as unique_types,
+    groupUniqArrayArraySimpleState(if(type = 'custom', [custom.name], [])) as unique_custom_type_names,
+    groupUniqArrayArraySimpleState(if(`string.string` != '', [`string.string`], [])) as unique_strings,
+    groupUniqArrayArraySimpleState(if(`log.body` != '', [`log.body`], [])) as unique_logs,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_activity') and (lifecycle_activity.class_name != ''), [lifecycle_activity.class_name], [])) as unique_view_classnames,
+    groupUniqArrayArraySimpleState(if((type = 'lifecycle_fragment') and (lifecycle_fragment.class_name != ''), [lifecycle_fragment.class_name], [])) as unique_subview_classnames,
+    -- fatal: severity='fatal' or (severity='' and handled=0)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_fatal_exceptions,
+    -- handled: severity='handled' or (severity='' and handled=1)
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_handled_exceptions,
+    -- nonfatal unhandled: strictly new, severity='unhandled' only
+    groupUniqArrayArraySimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        [(simpleJSONExtractString(`exception.exceptions`, 'type'),
+          simpleJSONExtractString(`exception.exceptions`, 'message'),
+          simpleJSONExtractString(`exception.exceptions`, 'file_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'class_name'),
+          simpleJSONExtractString(`exception.exceptions`, 'method_name'))],
+        []
+    )) as unique_unhandled_exceptions,
+    groupUniqArrayArraySimpleState(if(
+        (type = 'exception') and (
+            exception.num_code != 0 or
+            (exception.code != '' and exception.code != '{}') or
+            (exception.meta != '' and exception.meta != '{}')
+        ),
+        [concat(
+            '{"num_code":', toString(exception.num_code),
+            ',"code":', toJSONString(exception.code),
+            ',"meta":', if(exception.meta = '' or exception.meta = '{}', '{}', exception.meta),
+            '}'
+        )],
+        []
+    )) as unique_errors,
+    groupUniqArrayArraySimpleState(if(type = 'anr', [(simpleJSONExtractString(`anr.exceptions`, 'type'), simpleJSONExtractString(`anr.exceptions`, 'message'), simpleJSONExtractString(`anr.exceptions`, 'file_name'), simpleJSONExtractString(`anr.exceptions`, 'class_name'), simpleJSONExtractString(`anr.exceptions`, 'method_name'))], [])) as unique_anrs,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_click', [(gesture_click.target, gesture_click.target_id)], [])) as unique_click_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_long_click', [(gesture_long_click.target, gesture_long_click.target_id)], [])) as unique_longclick_targets,
+    groupUniqArrayArraySimpleState(if(type = 'gesture_scroll', [(gesture_scroll.target, gesture_scroll.target_id)], [])) as unique_scroll_targets,
+    sumSimpleState(toUInt64(1)) as event_count,
+    -- fatal count: legacy handled=0 or new severity='fatal'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'fatal' or
+            (exception.severity = '' and exception.handled = 0)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as fatal_exception_count,
+    -- handled count: legacy handled=1 or new severity='handled'
+    sumSimpleState(if(
+        type = 'exception' and (
+            exception.severity = 'handled' or
+            (exception.severity = '' and exception.handled = 1)
+        ),
+        toUInt64(1), toUInt64(0)
+    )) as handled_exception_count,
+    -- nonfatal unhandled count: strictly new
+    sumSimpleState(if(
+        type = 'exception' and exception.severity = 'unhandled',
+        toUInt64(1), toUInt64(0)
+    )) as unhandled_exception_count,
+    sumSimpleState(if(type = 'anr', toUInt64(1), toUInt64(0))) as anr_count,
+    sumSimpleState(if(type = 'bug_report', toUInt64(1), toUInt64(0))) as bug_report_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'background'), toUInt64(1), toUInt64(0))) as background_count,
+    sumSimpleState(if((type = 'lifecycle_app') and (lifecycle_app.type = 'foreground'), toUInt64(1), toUInt64(0))) as foreground_count,
+    sumMapSimpleState(map(type, toUInt64(1))) as event_type_counts
+from events
+group by
+    team_id,
+    app_id,
+    session_id,
+    app_version,
+    os_version;


### PR DESCRIPTION
## Summary

This PR lets `num_code` distinguish an absent value from an intentionally sent zero, so exception events report `null` when the SDK sent no code.

## Tasks

- [x] Add `has_num_code` column to the events table via migration
- [x] Update `sessions_mv` materialized view for the new column
- [x] Make `NumCode` a pointer across ingest & API response structs
- [x] Update OpenAPI docs for the dashboard API

## See also

- fixes #4272
