### PR TITLE
fix(backend): fail ingest boot when the bus producer is unavailable

### DIFF
--- a/backend/ingest/server/server.go
+++ b/backend/ingest/server/server.go
@@ -359,10 +359,9 @@ func Init(config *ServerConfig) {
 	if config.CloudEnv {
 		p, err := bus.NewPubSubProducer(ctx, "ingest-batch", bus.WithPubSubPublishSettings(pubsub.PublishSettings{EnableCompression: true}))
 		if err != nil {
-			log.Printf("failed to create Pub/Sub producer: %v\n", err)
-		} else {
-			busProducer = p
+			log.Fatalf("failed to create Pub/Sub producer: %v", err)
 		}
+		busProducer = p
 	} else {
 		p, err := bus.NewIggyProducer(
 			config.IG.Addr,
@@ -373,10 +372,9 @@ func Init(config *ServerConfig) {
 			"ingest-batch",
 		)
 		if err != nil {
-			log.Printf("failed to create Iggy producer: %v\n", err)
-		} else {
-			busProducer = p
+			log.Fatalf("failed to create Iggy producer: %v", err)
 		}
+		busProducer = p
 	}
 
 	Server = &server{

--- a/self-host/compose.yml
+++ b/self-host/compose.yml
@@ -352,6 +352,7 @@ services:
         libs: ../backend/libs
       args:
         TARGETTYPE: debug
+    restart: unless-stopped
     ports:
       - "8085:8085"
     secrets:


### PR DESCRIPTION
## Summary

This PR makes the ingest service fail its boot when the bus producer cannot be constructed, instead of serving traffic that panics on a nil producer.

## Tasks

- [x] `log.Fatalf` on Pub/Sub producer construction failure
- [x] `log.Fatalf` on Iggy producer construction failure
- [x] Add `restart: unless-stopped` to the self-host `ingest` service
