### PR TITLE
chore(frontend): noindex markdown twins & thin api reference pages

### DIFF
--- a/frontend/dashboard/__tests__/docs/docs_links_test.ts
+++ b/frontend/dashboard/__tests__/docs/docs_links_test.ts
@@ -19,6 +19,7 @@ import { docsRouteFromFile } from "@/scripts/generate_sitemap";
 const ROOT = path.resolve(__dirname, "..", "..");
 const APP_DIR = path.join(ROOT, "app");
 const CONTENT_DOCS_DIR = path.join(ROOT, "content", "docs");
+const CONTENT_BLOG_DIR = path.join(ROOT, "content", "blog");
 const PUBLIC_DIR = path.join(ROOT, "public");
 const REPO_ROOT = path.resolve(ROOT, "..", "..");
 
@@ -39,6 +40,14 @@ function walkFiles(dir: string, suffix: string): string[] {
 
 function docsPageFiles(): string[] {
   return walkFiles(CONTENT_DOCS_DIR, ".mdx");
+}
+
+/** Blog posts are not part of the docs page tree, so only their links are checked. */
+function blogPostFiles(): string[] {
+  if (!fs.existsSync(CONTENT_BLOG_DIR)) {
+    return [];
+  }
+  return walkFiles(CONTENT_BLOG_DIR, ".mdx");
 }
 
 /** The /docs route of a content file. */
@@ -175,7 +184,7 @@ function extractLinks(mdxFile: string): DocLink[] {
     /!?\[[^\]]*\]\(([^()\s]+)(?:\s+"[^"]*")?\)/g,
   )) {
     links.push({
-      file: path.relative(CONTENT_DOCS_DIR, mdxFile),
+      file: path.relative(ROOT, mdxFile),
       line: content.slice(0, match.index).split("\n").length,
       target: match[1],
     });
@@ -184,7 +193,8 @@ function extractLinks(mdxFile: string): DocLink[] {
 }
 
 describe("docs internal links", () => {
-  const allLinks = docsPageFiles().flatMap(extractLinks);
+  const allLinks = docsPageFiles().flatMap((file) => extractLinks(file));
+  const blogLinks = blogPostFiles().flatMap((file) => extractLinks(file));
 
   function describeLink(link: DocLink, reason: string): string {
     return `${link.file}:${link.line} -> ${link.target} (${reason})`;
@@ -194,15 +204,18 @@ describe("docs internal links", () => {
     expect(allLinks.length).toBeGreaterThan(0);
   });
 
-  it("uses only absolute, anchor, or external targets", () => {
+  it("uses only absolute, anchor, or external targets (docs & blog)", () => {
     // Docs pages are routed from a virtual page tree: relative links have
     // no file tree to resolve against, so every link must be a /docs
-    // route, a root-relative asset, an anchor, or an external URL.
+    // route, a root-relative asset, an anchor, or an external URL. Blog
+    // posts render from the file directly, but relative links still 404
+    // once the site rewrites file paths into post URLs, so they get the
+    // same check even though they are not part of the docs page tree.
     const failures: string[] = [];
 
-    for (const link of allLinks) {
+    for (const link of [...allLinks, ...blogLinks]) {
       if (!/^(https?:|mailto:|#|\/)/.test(link.target)) {
-        failures.push(describeLink(link, "relative link in MDX docs"));
+        failures.push(describeLink(link, "relative link in MDX"));
       }
     }
 
@@ -292,7 +305,7 @@ describe("docs internal links", () => {
 
       let targetFile: string | null;
       if (targetPath === "") {
-        targetFile = path.join(CONTENT_DOCS_DIR, link.file);
+        targetFile = path.join(ROOT, link.file);
       } else if (targetPath.startsWith("/docs")) {
         targetFile = mdxFileForSlug(targetPath.replace(/\/$/, ""));
       } else {

--- a/frontend/dashboard/__tests__/scripts/generate_sitemap_test.ts
+++ b/frontend/dashboard/__tests__/scripts/generate_sitemap_test.ts
@@ -210,6 +210,17 @@ describe("isExcluded", () => {
     expect(isExcluded("/docs")).toBe(false);
     expect(isExcluded("/docs/features/feature-example")).toBe(false);
   });
+
+  it("returns true for generated OpenAPI operation pages", () => {
+    expect(isExcluded("/docs/api/dashboard/teams/getTeamSlack")).toBe(true);
+    expect(isExcluded("/docs/api/sdk/events/postEvents")).toBe(true);
+  });
+
+  it("returns false for the API reference entry points", () => {
+    expect(isExcluded("/docs/api")).toBe(false);
+    expect(isExcluded("/docs/api/dashboard")).toBe(false);
+    expect(isExcluded("/docs/api/sdk")).toBe(false);
+  });
 });
 
 // ─── walk ───────────────────────────────────────────────────────────────────
@@ -365,17 +376,26 @@ describe("main", () => {
     expect(writtenContent).not.toContain(`${SITE_URL}/auth/login`);
   });
 
-  it("includes every docs page", () => {
+  it("includes every non-excluded docs page", () => {
     main();
 
     // getDocsRoutes derives routes from the content/docs sources on disk;
     // the derivation itself is covered by the getDocsRoutes tests, so this
-    // only asserts that every derived route lands in the sitemap.
-    const routes = getDocsRoutes();
+    // only asserts that every derived, non-excluded route lands in the
+    // sitemap.
+    const routes = getDocsRoutes().filter((route) => !isExcluded(route));
     expect(routes.length).toBeGreaterThan(0);
     for (const route of routes) {
       expect(writtenContent).toContain(`<loc>${SITE_URL}${route}</loc>`);
     }
+  });
+
+  it("excludes generated OpenAPI operation pages but keeps their section index", () => {
+    main();
+
+    expect(writtenContent).not.toContain(`${SITE_URL}/docs/api/dashboard/`);
+    expect(writtenContent).not.toContain(`${SITE_URL}/docs/api/sdk/`);
+    expect(writtenContent).toContain(`<loc>${SITE_URL}/docs/api</loc>`);
   });
 
   it("includes every blog post and tag page", () => {

--- a/frontend/dashboard/next.config.mjs
+++ b/frontend/dashboard/next.config.mjs
@@ -351,8 +351,8 @@ const nextConfig = {
         destination: "/docs/performance-tracing/profiling",
         permanent: true,
       },
-      // MCP and Performance tracing moved out of features/ into their own
-      // top-level pages. Forward the old URLs.
+      // MCP, Performance tracing, Agent & Logs moved out of features/ into
+      // their own top-level pages. Forward the old URLs.
       {
         source: "/docs/features/feature-mcp",
         destination: "/docs/mcp",
@@ -361,6 +361,61 @@ const nextConfig = {
       {
         source: "/docs/features/feature-performance-tracing",
         destination: "/docs/performance-tracing",
+        permanent: true,
+      },
+      {
+        source: "/docs/features/feature-agent",
+        destination: "/docs/agent",
+        permanent: true,
+      },
+      {
+        source: "/docs/features/feature-logs",
+        destination: "/docs/logs",
+        permanent: true,
+      },
+      // The sdk-upgrade-guides/ folder was deleted with no redirects. Forward
+      // each guide & the older flat URL form to its platform's getting
+      // started page.
+      {
+        source: "/docs/sdk-upgrade-guides/android-v0.16.0",
+        destination: "/docs/getting-started/android",
+        permanent: true,
+      },
+      {
+        source: "/docs/sdk-upgrade-guides/ios-v0.9.0",
+        destination: "/docs/getting-started/ios",
+        permanent: true,
+      },
+      {
+        source: "/docs/sdk-upgrade-guides/measure_flutter-v0.4.0",
+        destination: "/docs/getting-started/flutter",
+        permanent: true,
+      },
+      {
+        source: "/docs/android-v0.16.0",
+        destination: "/docs/getting-started/android",
+        permanent: true,
+      },
+      {
+        source: "/docs/ios-v0.9.0",
+        destination: "/docs/getting-started/ios",
+        permanent: true,
+      },
+      // The section index has no page of its own. Temporary, like the
+      // /docs/getting-started & /docs/api/* folder entries above, so it
+      // isn't hard-cached if the folder gains a page later.
+      {
+        source: "/docs/sdk-upgrade-guides",
+        destination: "/docs",
+        permanent: false,
+      },
+      // "measre" is misspelled, not a typo in this repo (file was
+      // measure_flutter-v0.4.0.mdx). It is an inbound link on someone else's
+      // site. Keep the misspelling as-is, do not "fix" it, that would drop
+      // the redirect.
+      {
+        source: "/docs/sdk-upgrade-guides/measre_flutter-v0.4.0",
+        destination: "/docs/getting-started/flutter",
         permanent: true,
       },
     ];

--- a/frontend/dashboard/next.config.mjs
+++ b/frontend/dashboard/next.config.mjs
@@ -1,6 +1,28 @@
 import { createMDX } from "fumadocs-mdx/next";
 import { withPostHogConfig } from "@posthog/nextjs-config";
 
+// These sources are markdown/plain-text alternates of canonical HTML pages.
+// They stay crawlable on purpose, X-Robots-Tag: noindex keeps them out of
+// the search index without blocking access.
+const NOINDEX_SOURCES = [
+  "/docs.md",
+  "/docs/:path*.md",
+  "/blog.md",
+  "/blog/:path*.md",
+  "/llms.docs",
+  "/llms.docs/:path*",
+  "/llms.blog",
+  "/llms.blog/:path*",
+  "/llms.txt",
+  "/llms-full.txt",
+  "/llms-docs-full.txt",
+  "/llms-blogs-full.txt",
+  "/llms-pages-full.txt",
+  "/page-md/:path*",
+  "/docs/api/dashboard/:path*",
+  "/docs/api/sdk/:path*",
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Standalone output exists for the self-hosted Docker image, which copies
@@ -329,6 +351,18 @@ const nextConfig = {
         destination: "/docs/performance-tracing/profiling",
         permanent: true,
       },
+      // MCP and Performance tracing moved out of features/ into their own
+      // top-level pages. Forward the old URLs.
+      {
+        source: "/docs/features/feature-mcp",
+        destination: "/docs/mcp",
+        permanent: true,
+      },
+      {
+        source: "/docs/features/feature-performance-tracing",
+        destination: "/docs/performance-tracing",
+        permanent: true,
+      },
     ];
   },
   async headers() {
@@ -370,6 +404,15 @@ const nextConfig = {
           },
         ],
       },
+      ...NOINDEX_SOURCES.map((source) => ({
+        source,
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      })),
     ];
   },
 };

--- a/frontend/dashboard/next.config.mjs
+++ b/frontend/dashboard/next.config.mjs
@@ -1,9 +1,6 @@
 import { createMDX } from "fumadocs-mdx/next";
 import { withPostHogConfig } from "@posthog/nextjs-config";
 
-// These sources are markdown/plain-text alternates of canonical HTML pages.
-// They stay crawlable on purpose, X-Robots-Tag: noindex keeps them out of
-// the search index without blocking access.
 const NOINDEX_SOURCES = [
   "/docs.md",
   "/docs/:path*.md",
@@ -351,8 +348,6 @@ const nextConfig = {
         destination: "/docs/performance-tracing/profiling",
         permanent: true,
       },
-      // MCP, Performance tracing, Agent & Logs moved out of features/ into
-      // their own top-level pages. Forward the old URLs.
       {
         source: "/docs/features/feature-mcp",
         destination: "/docs/mcp",
@@ -373,9 +368,6 @@ const nextConfig = {
         destination: "/docs/logs",
         permanent: true,
       },
-      // The sdk-upgrade-guides/ folder was deleted with no redirects. Forward
-      // each guide & the older flat URL form to its platform's getting
-      // started page.
       {
         source: "/docs/sdk-upgrade-guides/android-v0.16.0",
         destination: "/docs/getting-started/android",
@@ -401,18 +393,11 @@ const nextConfig = {
         destination: "/docs/getting-started/ios",
         permanent: true,
       },
-      // The section index has no page of its own. Temporary, like the
-      // /docs/getting-started & /docs/api/* folder entries above, so it
-      // isn't hard-cached if the folder gains a page later.
       {
         source: "/docs/sdk-upgrade-guides",
         destination: "/docs",
         permanent: false,
       },
-      // "measre" is misspelled, not a typo in this repo (file was
-      // measure_flutter-v0.4.0.mdx). It is an inbound link on someone else's
-      // site. Keep the misspelling as-is, do not "fix" it, that would drop
-      // the redirect.
       {
         source: "/docs/sdk-upgrade-guides/measre_flutter-v0.4.0",
         destination: "/docs/getting-started/flutter",

--- a/frontend/dashboard/scripts/generate_sitemap.js
+++ b/frontend/dashboard/scripts/generate_sitemap.js
@@ -101,7 +101,11 @@ function isDynamic(route) {
   return /\[.+?\]/.test(route);
 }
 
-const EXCLUDED_PREFIXES = ["/auth/"];
+// The generated OpenAPI operation pages under these prefixes are thin
+// near-duplicates (no description, body is a JSX component) and are
+// noindexed in next.config.mjs. Keep them out of the sitemap too. Trailing
+// slash keeps /docs/api itself, the reference entry point, in the sitemap.
+const EXCLUDED_PREFIXES = ["/auth/", "/docs/api/dashboard/", "/docs/api/sdk/"];
 
 function isExcluded(route) {
   return EXCLUDED_PREFIXES.some((prefix) => route.startsWith(prefix));
@@ -146,6 +150,7 @@ function main() {
   }
 
   for (const route of getDocsRoutes()) {
+    if (isExcluded(route)) continue;
     routes.add(route);
   }
 


### PR DESCRIPTION
## Summary

This PR clears two Search Console reports. Markdown twins & generated API reference pages are now noindexed while staying crawlable, so AI agents keep fetching them. Docs URLs that moved or were deleted now redirect to their live equivalents.

## Tasks

- [x] Noindex the markdown twins & generated API reference pages
- [x] Drop the generated API pages from the sitemap
- [x] Redirect docs URLs reported as 404
