### PR TITLE
feat: migrate spans to use expression filters

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -4,6 +4,7 @@ import (
 	"backend/agent/server"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 	"backend/libs/ambient"
 	"backend/libs/chquery"
 	"backend/libs/event"
+	"backend/libs/exprfilter"
 	"backend/libs/filter"
 	"backend/libs/group"
 	"backend/libs/measure"
@@ -415,6 +417,24 @@ func commonTools(cfg *Config) []Tool {
 			return cfg.mcpGetFilters(ctx, in)
 		}),
 
+		// get_filter_keys
+		newTool(&mcpsdk.Tool{
+			Name:        "get_filter_keys",
+			Description: "List the filter keys of an entity (spans or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
+			InputSchema: mcpMustInferSchema[mcpGetFilterKeysInput](),
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFilterKeysInput) (*mcpsdk.CallToolResult, any, error) {
+			return cfg.mcpGetFilterKeys(ctx, in)
+		}),
+
+		// get_filter_values
+		newTool(&mcpsdk.Tool{
+			Name:        "get_filter_values",
+			Description: "List the values a filter key can be set to for an app, for use in a filter_expr, optionally narrowed by a search string. truncated in the result says more values matched. get_filter_keys lists the keys; a key whose value_suggestion_mode is none takes typed values and has no list.",
+			InputSchema: mcpMustInferSchema[mcpGetFilterValuesInput](),
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFilterValuesInput) (*mcpsdk.CallToolResult, any, error) {
+			return cfg.mcpGetFilterValues(ctx, in)
+		}),
+
 		// get_metrics
 		newTool(&mcpsdk.Tool{
 			Name:        "get_metrics",
@@ -553,8 +573,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_instances
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_instances",
-			Description: "Get span instances for a root span name. Covers all app versions unless versions/version_codes narrow it; get_filters with span=true lists the versions seen in span data.",
-			InputSchema: mcpMustInferSchema[mcpGetSpanInstancesInput](),
+			Description: "Get span instances for a root span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanInstancesInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanInstancesInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanInstances(ctx, in)
 		}),
@@ -562,8 +582,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_metrics_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_metrics_over_time",
-			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers all app versions unless versions/version_codes narrow it; get_filters with span=true lists the versions seen in span data.",
-			InputSchema: mcpMustInferSchema[mcpGetSpanMetricsOverTimeInput](),
+			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanMetricsOverTimeInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanMetricsOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanMetricsOverTime(ctx, in)
 		}),
@@ -678,6 +698,36 @@ func commonTools(cfg *Config) []Tool {
 	}
 }
 
+// mcpFilterExprToolsHint tells the client where the vocabulary of a
+// filter_expr comes from. It is shared by every tool that takes one.
+const mcpFilterExprToolsHint = "get_filter_keys with entity spans lists the keys and operators a filter_expr may use, get_filter_values lists a key's suggested values"
+
+// mcpFilterExprGrammar is the filter_expr grammar, condensed from
+// backend/libs/exprfilter/parse.go, shared as the field's schema description
+// by every tool that takes one.
+const mcpFilterExprGrammar = "Filter expression narrowing the spans. A condition is key:operator:value or key:operator:[v1,v2]; a no-value operator like is_set is written key:operator. Conditions join with AND / OR, parentheses group, and AND binds tighter than OR. A value holding a space, comma, bracket, colon or quote is written in double quotes. Example: version_name:in:[1.2.0,1.1.9] AND span_status:in:error. User-defined span attribute keys appear under the Custom key group and carry the custom. prefix, as in custom.is_premium:eq:true. " + mcpFilterExprToolsHint
+
+// mcpMustInferFilterExprSchema infers a JSON schema from a Go type and sets
+// the shared grammar text as the description of its "filter_expr" property.
+// A struct tag cannot hold a constant, so the description is set here. Used
+// by tools whose input carries a filter_expr field.
+func mcpMustInferFilterExprSchema[T any]() json.RawMessage {
+	schema, err := jsonschema.For[T](nil)
+	if err != nil {
+		panic("mcp: failed to infer schema: " + err.Error())
+	}
+	p, ok := schema.Properties["filter_expr"]
+	if !ok {
+		panic("mcp: schema has no filter_expr property")
+	}
+	p.Description = mcpFilterExprGrammar
+	data, err := schema.MarshalJSON()
+	if err != nil {
+		panic("mcp: failed to marshal schema: " + err.Error())
+	}
+	return json.RawMessage(data)
+}
+
 // mcpMustInferSchema infers a JSON schema from a Go type.
 func mcpMustInferSchema[T any]() json.RawMessage {
 	schema, err := jsonschema.For[T](nil)
@@ -751,6 +801,18 @@ type mcpGetFiltersInput struct {
 	ErrorTypes []string `json:"error_types,omitempty" jsonschema:"Narrow the event-derived options to errors of these types: 'error' (exceptions) and/or 'anr'. Mutually exclusive with span and builds. Omitted, options cover all events, not only errors"`
 	Span       bool     `json:"span,omitempty" jsonschema:"Scope filter options to span data. Required for span-relevant options; omitted, options derive from event data, not spans. Mutually exclusive with error_types and builds"`
 	Builds     bool     `json:"builds,omitempty" jsonschema:"Scope filter options to uploaded builds. Required for build-relevant versions; omitted, versions derive from event data, not build mappings. Mutually exclusive with span and error_types"`
+}
+type mcpGetFilterKeysInput struct {
+	AppID  string   `json:"app_id" jsonschema:"UUID of the app to query"`
+	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans or builds"`
+	Keys   []string `json:"keys,omitempty" jsonschema:"Key names you already know, for example from the user's request, to include in the result even when the listing is truncated"`
+}
+type mcpGetFilterValuesInput struct {
+	AppID   string `json:"app_id" jsonschema:"UUID of the app to query"`
+	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans or builds"`
+	KeyName string `json:"key_name" jsonschema:"Name of the filter key to list values for, as get_filter_keys returns it"`
+	Search  string `json:"search,omitempty" jsonschema:"Return only values containing this text"`
+	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum number of values to return (default: 50, max: 200)"`
 }
 type mcpGetMetricsInput struct {
 	mcpCommonFilters
@@ -830,16 +892,20 @@ type mcpGetRootSpanNamesInput struct {
 	AppID string `json:"app_id" jsonschema:"UUID of the app"`
 }
 type mcpGetSpanInstancesInput struct {
-	mcpCommonFilters
+	AppID        string `json:"app_id" jsonschema:"UUID of the app to query"`
 	RootSpanName string `json:"root_span_name" jsonschema:"Name of the root span to query"`
-	SpanStatuses []int  `json:"span_statuses,omitempty" jsonschema:"Filter by span status: 0=Unset, 1=Ok, 2=Error"`
+	From         string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To           string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr   string `json:"filter_expr,omitempty"`
 	Limit        int    `json:"limit,omitempty" jsonschema:"Maximum number of spans to return (default: 10)"`
 	Offset       int    `json:"offset,omitempty" jsonschema:"Number of spans to skip for pagination (default: 0)"`
 }
 type mcpGetSpanMetricsOverTimeInput struct {
-	mcpCommonFilters
+	AppID        string `json:"app_id" jsonschema:"UUID of the app to query"`
 	RootSpanName string `json:"root_span_name" jsonschema:"Name of the root span to query"`
-	SpanStatuses []int  `json:"span_statuses,omitempty" jsonschema:"Filter by span status: 0=Unset, 1=Ok, 2=Error"`
+	From         string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To           string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr   string `json:"filter_expr,omitempty"`
 	Timezone     string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
 }
 type mcpGetTraceInput struct {
@@ -1062,6 +1128,56 @@ func (c *Config) mcpBuildAppFilter(ctx context.Context, appID uuid.UUID, cf mcpC
 	return af, nil
 }
 
+// mcpSpanExprFilter builds the exprfilter.ExprFilter the span query tools pass
+// to the spans queries, parsing the tool's filter_expr input into the filter
+// tree. The caller still sets Limit, Offset and Timezone, then runs Validate.
+func mcpSpanExprFilter(appID, teamID uuid.UUID, fromStr, toStr, filterExpr string) (*exprfilter.ExprFilter, error) {
+	from, to, err := mcpParseTimeRangeStrings(fromStr, toStr)
+	if err != nil {
+		return nil, err
+	}
+
+	ef := &exprfilter.ExprFilter{
+		AppID:      appID,
+		TeamID:     teamID,
+		Entity:     exprfilter.SpansEntity,
+		From:       from,
+		To:         to,
+		Limit:      exprfilter.DefaultPaginationLimit,
+		FilterExpr: filterExpr,
+	}
+
+	if err := ef.BuildExprTree(); err != nil {
+		return nil, mcpFilterExprError(err)
+	}
+
+	return ef, nil
+}
+
+// mcpFilterExprError renders a filter_expr parse or validation failure as one
+// error whose text names each problem and where in the expression it is, so
+// the model can correct the expression and call again. Other errors pass
+// through unchanged.
+func mcpFilterExprError(err error) error {
+	var parseErr *exprfilter.ParseError
+	var invalid *exprfilter.ValidationError
+	switch {
+	case errors.As(err, &parseErr):
+		return fmt.Errorf("filter_expr could not be parsed: %s at position %d", parseErr.Message, parseErr.Position)
+	case errors.As(err, &invalid):
+		messages := make([]string, len(invalid.Issues))
+		for i, issue := range invalid.Issues {
+			if issue.Span != nil {
+				messages[i] = fmt.Sprintf("%s (characters %d-%d)", issue.Message, issue.Span.Start, issue.Span.End)
+			} else {
+				messages[i] = issue.Message
+			}
+		}
+		return fmt.Errorf("filter_expr is invalid: %s", strings.Join(messages, "; "))
+	}
+	return err
+}
+
 // mcpApplyErrorFilters validates and applies the error-scoping filters onto an
 // AppFilter. Empty fields leave the filter unscoped (all error sources).
 func mcpApplyErrorFilters(af *filter.AppFilter, ef mcpErrorFilters) error {
@@ -1228,6 +1344,83 @@ func (c *Config) mcpGetFilters(ctx context.Context, in mcpGetFiltersInput) (*mcp
 		return nil, nil, fmt.Errorf("failed to get filters: %v", err)
 	}
 	data, _ := json.Marshal(fl)
+	return mcpTextResult(string(data)), nil, nil
+}
+
+func (c *Config) mcpGetFilterKeys(ctx context.Context, in mcpGetFilterKeysInput) (*mcpsdk.CallToolResult, any, error) {
+	entity, err := exprfilter.FindByName(in.Entity)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx = exprfilter.WithFilterQuerySettings(ctx, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode, "filter_keys")
+	keys, keysTruncated, err := entity.ListKeys(ctx, c.Deps.PgPool, c.Deps.RchPool, teamID, appID, in.Keys)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get filter keys: %v", err)
+	}
+
+	result := map[string]any{
+		"keys":           keys,
+		"key_groups":     exprfilter.ListKeyGroups(keys),
+		"keys_truncated": keysTruncated,
+	}
+	data, _ := json.Marshal(result)
+	return mcpTextResult(string(data)), nil, nil
+}
+
+func (c *Config) mcpGetFilterValues(ctx context.Context, in mcpGetFilterValuesInput) (*mcpsdk.CallToolResult, any, error) {
+	deps := c.Deps
+	entity, err := exprfilter.FindByName(in.Entity)
+	if err != nil {
+		return nil, nil, err
+	}
+	if in.KeyName == "" {
+		return nil, nil, fmt.Errorf("key_name is required")
+	}
+
+	limit := in.Limit
+	if limit <= 0 {
+		limit = exprfilter.DefaultValueLimit
+	}
+	if limit > exprfilter.MaxValueLimit {
+		return nil, nil, fmt.Errorf("limit cannot be more than %d", exprfilter.MaxValueLimit)
+	}
+
+	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx = exprfilter.WithFilterQuerySettings(ctx, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode, "filter_values")
+	key, found, err := entity.FindKey(ctx, deps.RchPool, teamID, appID, in.KeyName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get filter values: %v", err)
+	}
+	if !found {
+		return nil, nil, fmt.Errorf("entity %q has no key %q", entity.Name, in.KeyName)
+	}
+	if key.ValueSuggestionMode == exprfilter.ValueSuggestionModeNone {
+		return nil, nil, fmt.Errorf("key %q takes typed values only and has no value list", key.Name)
+	}
+
+	valueList, err := entity.SuggestKeyValues(ctx, deps.PgPool, deps.RchPool, teamID, appID, key, exprfilter.ValueRequest{
+		Search: in.Search,
+		Limit:  limit,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get filter values: %v", err)
+	}
+
+	result := map[string]any{
+		"values":    valueList.Values,
+		"truncated": valueList.Truncated,
+	}
+	data, _ := json.Marshal(result)
 	return mcpTextResult(string(data)), nil, nil
 }
 
@@ -1752,7 +1945,7 @@ func (c *Config) mcpGetSpanInstances(ctx context.Context, in mcpGetSpanInstances
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildAppFilter(ctx, appID, in.mcpCommonFilters)
+	ef, err := mcpSpanExprFilter(appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1764,21 +1957,20 @@ func (c *Config) mcpGetSpanInstances(ctx context.Context, in mcpGetSpanInstances
 	if limit > 30 {
 		limit = 30
 	}
-	af.Limit = limit
-	af.Offset = in.Offset
-	af.Span = true
+	ef.Limit = limit
+	ef.Offset = in.Offset
 
-	if len(in.SpanStatuses) > 0 {
-		statuses := make([]int8, len(in.SpanStatuses))
-		for i, s := range in.SpanStatuses {
-			statuses[i] = int8(s)
-		}
-		af.SpanStatuses = statuses
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
+	}
+
+	if err := ef.Validate(); err != nil {
+		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
 	spanCtx := ambient.WithTeamId(ctx, teamID)
-	spans, _, _, spanErr := app.GetSpansForSpanNameWithFilter(spanCtx, deps.RchPool, in.RootSpanName, af)
+	spans, _, _, spanErr := app.GetSpansForSpanNameWithFilter(spanCtx, deps.RchPool, in.RootSpanName, ef)
 	if spanErr != nil {
 		return nil, nil, fmt.Errorf("failed to get span instances: %v", spanErr)
 	}
@@ -1800,25 +1992,23 @@ func (c *Config) mcpGetSpanMetricsOverTime(ctx context.Context, in mcpGetSpanMet
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildAppFilter(ctx, appID, in.mcpCommonFilters)
+	ef, err := mcpSpanExprFilter(appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}
-	af.Timezone = in.Timezone
-	af.Limit = filter.DefaultPaginationLimit
-	af.Span = true
+	ef.Timezone = in.Timezone
 
-	if len(in.SpanStatuses) > 0 {
-		statuses := make([]int8, len(in.SpanStatuses))
-		for i, s := range in.SpanStatuses {
-			statuses[i] = int8(s)
-		}
-		af.SpanStatuses = statuses
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
+	}
+
+	if err := ef.Validate(); err != nil {
+		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
 	plotCtx := ambient.WithTeamId(ctx, teamID)
-	instances, plotErr := app.GetMetricsPlotForSpanNameWithFilter(plotCtx, deps.RchPool, in.RootSpanName, af)
+	instances, plotErr := app.GetMetricsPlotForSpanNameWithFilter(plotCtx, deps.RchPool, in.RootSpanName, ef)
 	if plotErr != nil {
 		return nil, nil, fmt.Errorf("failed to get span metrics plot: %v", plotErr)
 	}

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -13,13 +13,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"backend/testinfra"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -1591,7 +1595,7 @@ func TestMCPToolsList(t *testing.T) {
 	}
 
 	expectedTools := []string{
-		"list_apps", "get_filters", "get_metrics",
+		"list_apps", "get_filters", "get_filter_keys", "get_filter_values", "get_metrics",
 		"get_app_health_over_time",
 		"get_errors", "get_error",
 		"get_errors_over_time", "get_error_over_time", "get_error_distribution",
@@ -2412,6 +2416,324 @@ func TestMCPGetFilters(t *testing.T) {
 	})
 }
 
+func TestMCPGetFilterKeys(t *testing.T) {
+	ctx := context.Background()
+	setupToolTest := func(t *testing.T, email string) (uuid.UUID, string) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), email)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, email+" team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_" + email
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+		return appID, rawToken
+	}
+
+	t.Run("unknown entity", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "fkeys1@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_keys", map[string]any{"app_id": appID.String(), "entity": "bogus"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unknown entity")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "bogus") {
+			t.Errorf("error text %q should name the unknown entity", text)
+		}
+	})
+	t.Run("spans keys", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "fkeys2@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_keys", map[string]any{"app_id": appID.String(), "entity": "spans"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+
+		var result struct {
+			Keys []struct {
+				Name                string   `json:"name"`
+				Label               string   `json:"label"`
+				KeyGroup            string   `json:"key_group"`
+				ValueType           string   `json:"value_type"`
+				Operators           []string `json:"operators"`
+				ValueSuggestionMode string   `json:"value_suggestion_mode"`
+			} `json:"keys"`
+			KeyGroups []string `json:"key_groups"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+			t.Fatalf("parse filter keys response: %v", err)
+		}
+
+		keysByName := make(map[string]bool)
+		for _, key := range result.Keys {
+			keysByName[key.Name] = true
+			if key.Label == "" || key.KeyGroup == "" || key.ValueType == "" || len(key.Operators) == 0 || key.ValueSuggestionMode == "" {
+				t.Errorf("key %q is missing fields: %+v", key.Name, key)
+			}
+		}
+		for _, want := range []string{"version_name", "version_code", "span_status", "os_name", "country"} {
+			if !keysByName[want] {
+				t.Errorf("spans keys missing %q", want)
+			}
+		}
+		if len(result.KeyGroups) == 0 {
+			t.Error("want non-empty key_groups")
+		}
+	})
+	t.Run("a user-defined attribute joins the spans keys", func(t *testing.T) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), "fkeys3@mcp.test")
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "fkeys3 team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_fkeys3@mcp.test"
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+
+		seedSpanUDAttr(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "pro"})
+
+		resp := callMCPTool(t, rawToken, "get_filter_keys", map[string]any{"app_id": appID.String(), "entity": "spans"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+
+		var result struct {
+			Keys []struct {
+				Name     string `json:"name"`
+				Label    string `json:"label"`
+				KeyGroup string `json:"key_group"`
+			} `json:"keys"`
+			KeyGroups     []string `json:"key_groups"`
+			KeysTruncated bool     `json:"keys_truncated"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+			t.Fatalf("parse filter keys response: %v", err)
+		}
+
+		found := false
+		for _, key := range result.Keys {
+			if key.Name == "custom.plan" {
+				found = true
+				if key.Label != "plan" || key.KeyGroup != "Custom" {
+					t.Errorf("want the label unprefixed under the Custom group, got %+v", key)
+				}
+			}
+		}
+		if !found {
+			t.Error("want the seeded attribute listed as custom.plan")
+		}
+		if !slices.Contains(result.KeyGroups, "Custom") {
+			t.Errorf("want the Custom group listed, got %v", result.KeyGroups)
+		}
+		if result.KeysTruncated {
+			t.Error("want the listing complete for one attribute")
+		}
+	})
+	t.Run("a key requested through the keys input is included", func(t *testing.T) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), "fkeys4@mcp.test")
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, "fkeys4 team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_fkeys4@mcp.test"
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+
+		seedSpanUDAttr(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "pro"})
+
+		resp := callMCPTool(t, rawToken, "get_filter_keys", map[string]any{
+			"app_id": appID.String(),
+			"entity": "spans",
+			"keys":   []string{"custom.plan", "custom.ghost"},
+		})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+
+		var result struct {
+			Keys []struct {
+				Name string `json:"name"`
+			} `json:"keys"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+			t.Fatalf("parse filter keys response: %v", err)
+		}
+
+		planCount := 0
+		ghostFound := false
+		for _, key := range result.Keys {
+			if key.Name == "custom.plan" {
+				planCount++
+			}
+			if key.Name == "custom.ghost" {
+				ghostFound = true
+			}
+		}
+		if planCount != 1 {
+			t.Errorf("want custom.plan once, got it %d times", planCount)
+		}
+		if ghostFound {
+			t.Error("want a name the app never reported left out")
+		}
+	})
+}
+
+func TestMCPGetFilterValues(t *testing.T) {
+	ctx := context.Background()
+	setupToolTest := func(t *testing.T, email string) (uuid.UUID, uuid.UUID, string) {
+		cleanupAll(ctx, t)
+		userID := uuid.New()
+		seedUser(ctx, t, userID.String(), email)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, email+" team")
+		seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+		appID := uuid.New()
+		seedApp(ctx, t, appID, teamID, 30)
+		rawToken := "msr_" + email
+		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+		return appID, teamID, rawToken
+	}
+	now := time.Now().UTC()
+
+	valueTexts := func(t *testing.T, resp map[string]any) []string {
+		t.Helper()
+		var result struct {
+			Values []struct {
+				Text string `json:"text"`
+			} `json:"values"`
+			Truncated bool `json:"truncated"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+			t.Fatalf("parse filter values response: %v", err)
+		}
+		texts := make([]string, len(result.Values))
+		for i, value := range result.Values {
+			texts[i] = value.Text
+		}
+		return texts
+	}
+
+	t.Run("missing key_name", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvals1@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans"})
+		if !isToolError(resp) {
+			t.Error("want tool error for missing key_name")
+		}
+	})
+	t.Run("unknown key", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvals2@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "bogus_key"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unknown key")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "bogus_key") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+	t.Run("seeded span values", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "fvals3@mcp.test")
+		// The span_filters rollup serving these values keeps only spans
+		// carrying every attribute, so the seeds set them all.
+		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-2*time.Hour),
+			AppVersion: "v1", AppBuild: "1",
+			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
+			NetworkGeneration: "5g", DeviceLocale: "en-US",
+			DeviceManufacturer: "Google", DeviceName: "pixel 4a",
+		})
+		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-time.Hour),
+			AppVersion: "v2", AppBuild: "2",
+			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
+			NetworkGeneration: "5g", DeviceLocale: "en-US",
+			DeviceManufacturer: "Google", DeviceName: "pixel 4a",
+		})
+
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "version_name"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		// Both versions appear in the same month, so the alphabetical
+		// tiebreak orders them.
+		texts := valueTexts(t, resp)
+		if !reflect.DeepEqual(texts, []string{"v1", "v2"}) {
+			t.Errorf("want versions [v1 v2], got %v", texts)
+		}
+	})
+	t.Run("search narrows values", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "fvals4@mcp.test")
+		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-2*time.Hour),
+			AppVersion: "1.2.0", AppBuild: "1",
+			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
+			NetworkGeneration: "5g", DeviceLocale: "en-US",
+			DeviceManufacturer: "Google", DeviceName: "pixel 4a",
+		})
+		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-time.Hour),
+			AppVersion: "2.0.0", AppBuild: "2",
+			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
+			NetworkGeneration: "5g", DeviceLocale: "en-US",
+			DeviceManufacturer: "Google", DeviceName: "pixel 4a",
+		})
+
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "version_name", "search": "1.2"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		texts := valueTexts(t, resp)
+		if !reflect.DeepEqual(texts, []string{"1.2.0"}) {
+			t.Errorf("want [1.2.0], got %v", texts)
+		}
+	})
+	t.Run("enum key lists its full set", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvals5@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "span_status"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		texts := valueTexts(t, resp)
+		if !reflect.DeepEqual(texts, []string{"unset", "ok", "error"}) {
+			t.Errorf("want [unset ok error], got %v", texts)
+		}
+	})
+	t.Run("limit above the maximum", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvals6@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "version_name", "limit": 1000})
+		if !isToolError(resp) {
+			t.Error("want tool error for limit above the maximum")
+		}
+	})
+	t.Run("a user-defined attribute serves its values", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "fvals7@mcp.test")
+		seedSpanUDAttr(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "free", Timestamp: now.Add(-2 * time.Hour)})
+		seedSpanUDAttr(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "pro", Timestamp: now.Add(-time.Hour)})
+
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "custom.plan"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		texts := valueTexts(t, resp)
+		if !reflect.DeepEqual(texts, []string{"pro", "free"}) {
+			t.Errorf("want [pro free] most recent first, got %v", texts)
+		}
+	})
+	t.Run("an unknown user-defined attribute", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvals8@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "spans", "key_name": "custom.nope"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for an attribute the app's spans never reported")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "custom.nope") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+}
+
 func TestMCPGetMetrics(t *testing.T) {
 	ctx := context.Background()
 
@@ -2785,9 +3107,7 @@ func TestMCPGetSessions(t *testing.T) {
 		t.Run("with error filter "+ec.name, func(t *testing.T) {
 			appID, rawToken := setupToolTest(t, "sess"+strings.ReplaceAll(ec.name, " ", "")+"@mcp.test")
 			args := map[string]any{"app_id": appID.String(), "from": from, "to": to}
-			for k, v := range ec.args {
-				args[k] = v
-			}
+			maps.Copy(args, ec.args)
 			resp := callMCPTool(t, rawToken, "get_sessions", args)
 			if isToolError(resp) {
 				t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
@@ -3071,7 +3391,7 @@ func TestMCPGetRootSpanNames(t *testing.T) {
 
 func TestMCPGetSpanInstances(t *testing.T) {
 	ctx := context.Background()
-	setupToolTest := func(t *testing.T, email string) (uuid.UUID, string) {
+	setupToolTest := func(t *testing.T, email string) (uuid.UUID, uuid.UUID, string) {
 		cleanupAll(ctx, t)
 		userID := uuid.New()
 		seedUser(ctx, t, userID.String(), email)
@@ -3082,24 +3402,108 @@ func TestMCPGetSpanInstances(t *testing.T) {
 		seedApp(ctx, t, appID, teamID, 30)
 		rawToken := "msr_" + email
 		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
-		return appID, rawToken
+		return appID, teamID, rawToken
 	}
 	now := time.Now().UTC()
 	from := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
 	to := now.Format(time.RFC3339)
 
 	t.Run("missing root_span_name", func(t *testing.T) {
-		appID, rawToken := setupToolTest(t, "si@mcp.test")
-		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String()})
+		appID, _, rawToken := setupToolTest(t, "si@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "from": from, "to": to})
 		if !isToolError(resp) {
 			t.Error("want tool error for missing root_span_name")
 		}
 	})
 	t.Run("valid call", func(t *testing.T) {
-		appID, rawToken := setupToolTest(t, "si2@mcp.test")
+		appID, _, rawToken := setupToolTest(t, "si2@mcp.test")
 		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "root_span_name": "some-span", "from": from, "to": to})
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+	})
+	t.Run("filter_expr narrows results", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "si3@mcp.test")
+		seedSpan(ctx, t, teamID.String(), appID.String(), "checkout", 1, now.Add(-time.Hour), now.Add(-time.Hour+time.Second), "v1", "1")
+		seedSpan(ctx, t, teamID.String(), appID.String(), "checkout", 1, now.Add(-time.Hour), now.Add(-time.Hour+time.Second), "v2", "2")
+
+		args := map[string]any{"app_id": appID.String(), "root_span_name": "checkout", "from": from, "to": to}
+		resp := callMCPTool(t, rawToken, "get_span_instances", args)
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		var spans []map[string]any
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &spans); err != nil {
+			t.Fatalf("unmarshal spans: %v", err)
+		}
+		if len(spans) != 2 {
+			t.Fatalf("want 2 spans with no filter, got %d", len(spans))
+		}
+
+		args["filter_expr"] = "version_name:in:v1"
+		resp = callMCPTool(t, rawToken, "get_span_instances", args)
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &spans); err != nil {
+			t.Fatalf("unmarshal filtered spans: %v", err)
+		}
+		if len(spans) != 1 {
+			t.Fatalf("want 1 span with version filter, got %d", len(spans))
+		}
+		if spans[0]["app_version"] != "v1" {
+			t.Errorf("filtered span app_version = %v, want v1", spans[0]["app_version"])
+		}
+	})
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "si4@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "root_span_name": "checkout", "from": from, "to": to, "filter_expr": "bogus_key:in:x"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unknown filter key")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "bogus_key") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+	t.Run("unparseable filter_expr returns the parse error", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "si5@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "root_span_name": "checkout", "from": from, "to": to, "filter_expr": "version_name:in:v1 AND"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unparseable filter")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "filter_expr could not be parsed") {
+			t.Errorf("error text %q should report the parse failure", text)
+		}
+	})
+	t.Run("a custom filter_expr narrows results", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "si6@mcp.test")
+		traceOne := seedSpan(ctx, t, teamID.String(), appID.String(), "checkout", 1, now.Add(-time.Hour), now.Add(-time.Hour+time.Second), "v1", "1")
+		seedSpan(ctx, t, teamID.String(), appID.String(), "checkout", 1, now.Add(-time.Hour), now.Add(-time.Hour+time.Second), "v2", "2")
+		seedSpanUDAttr(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{SpanID: traceOne[:16], Key: "plan", Value: "pro", Timestamp: now.Add(-time.Hour)})
+
+		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "root_span_name": "checkout", "from": from, "to": to, "filter_expr": "custom.plan:in:pro"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		var spans []map[string]any
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &spans); err != nil {
+			t.Fatalf("unmarshal spans: %v", err)
+		}
+		if len(spans) != 1 {
+			t.Fatalf("want 1 span with the custom filter, got %d", len(spans))
+		}
+		if spans[0]["app_version"] != "v1" {
+			t.Errorf("filtered span app_version = %v, want v1", spans[0]["app_version"])
+		}
+	})
+	t.Run("an unknown custom key returns the issue", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "si7@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_span_instances", map[string]any{"app_id": appID.String(), "root_span_name": "checkout", "from": from, "to": to, "filter_expr": "custom.nope:in:x"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for an attribute the app's spans never reported")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "custom.nope") {
+			t.Errorf("error text %q should name the unknown key", text)
 		}
 	})
 }
@@ -3140,6 +3544,25 @@ func TestMCPGetSpanMetricsPlot(t *testing.T) {
 		resp := callMCPTool(t, rawToken, "get_span_metrics_over_time", map[string]any{"app_id": appID.String(), "root_span_name": "some-span", "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339)})
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+	})
+	t.Run("valid filter_expr is accepted", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "smplot4@mcp.test")
+		now := time.Now().UTC()
+		resp := callMCPTool(t, rawToken, "get_span_metrics_over_time", map[string]any{"app_id": appID.String(), "root_span_name": "some-span", "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339), "filter_expr": "version_name:in:v1 AND span_status:in:error"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+	})
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "smplot5@mcp.test")
+		now := time.Now().UTC()
+		resp := callMCPTool(t, rawToken, "get_span_metrics_over_time", map[string]any{"app_id": appID.String(), "root_span_name": "some-span", "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339), "filter_expr": "span_status:in:bogus"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for invalid span_status value")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "span_status") || !strings.Contains(text, "bogus") {
+			t.Errorf("error text %q should name the bad value", text)
 		}
 	})
 }
@@ -3587,6 +4010,8 @@ func TestMCPAccessControl(t *testing.T) {
 		args map[string]any
 	}{
 		{"get_filters", map[string]any{"app_id": appA.String()}},
+		{"get_filter_keys", map[string]any{"app_id": appA.String(), "entity": "spans"}},
+		{"get_filter_values", map[string]any{"app_id": appA.String(), "entity": "spans", "key_name": "version_name"}},
 		{"get_metrics", map[string]any{"app_id": appA.String(), "from": from, "to": to}},
 		{"get_app_health_over_time", map[string]any{"app_id": appA.String(), "timezone": "UTC", "from": from, "to": to}},
 		{"get_errors", map[string]any{"app_id": appA.String(), "from": from, "to": to}},
@@ -3632,6 +4057,8 @@ func TestMCPInvalidAppIDFormat(t *testing.T) {
 		args map[string]any
 	}{
 		{"get_filters", map[string]any{"app_id": "not-a-uuid"}},
+		{"get_filter_keys", map[string]any{"app_id": "not-a-uuid", "entity": "spans"}},
+		{"get_filter_values", map[string]any{"app_id": "not-a-uuid", "entity": "spans", "key_name": "version_name"}},
 		{"get_errors", map[string]any{"app_id": "not-a-uuid"}},
 		{"get_sessions", map[string]any{"app_id": "not-a-uuid"}},
 		{"get_metrics", map[string]any{"app_id": "not-a-uuid"}},
@@ -3985,7 +4412,7 @@ func callMCPTool(t *testing.T, rawToken, toolName string, args map[string]any) m
 // The format is "event: message\ndata: {json}\n\n".
 func parseSSEData(t *testing.T, body string) map[string]any {
 	t.Helper()
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(line, "data: ") {
 			var resp map[string]any
 			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &resp); err != nil {

--- a/backend/agent/mcp/test_helpers_test.go
+++ b/backend/agent/mcp/test_helpers_test.go
@@ -121,6 +121,10 @@ func seedSpan(
 	return th.SeedSpan(ctx, t, teamID, appID, spanName, status, startTime, endTime, appVersion, appBuild)
 }
 
+func seedSpanUDAttr(ctx context.Context, t *testing.T, teamID, appID string, row testinfra.SpanUDAttrRow) {
+	th.SeedSpanUDAttrRow(ctx, t, teamID, appID, row)
+}
+
 func seedEventWithSession(ctx context.Context, t *testing.T, teamID, appID, sessionID string, ts time.Time) {
 	th.SeedEventWithSession(ctx, t, teamID, appID, sessionID, ts)
 }

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"sort"
 	"strconv"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"backend/libs/chquery"
 	"backend/libs/config"
 	"backend/libs/event"
+	"backend/libs/exprfilter"
 	"backend/libs/filter"
 	"backend/libs/journey"
 	"backend/libs/logcomment"
@@ -777,7 +777,6 @@ func (h Handlers) GetAppFilters(c *gin.Context) {
 	})
 }
 
-
 func (h Handlers) GetErrorOverview(c *gin.Context) {
 	deps := h.Deps
 	ctx := c.Request.Context()
@@ -1512,7 +1511,6 @@ func (h Handlers) GetErrorDetailAttributeDistribution(c *gin.Context) {
 
 	c.JSON(http.StatusOK, distribution)
 }
-
 
 func (h Handlers) CreateApp(c *gin.Context) {
 	deps := h.Deps
@@ -2772,28 +2770,20 @@ func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 		return
 	}
 
-	rawSpanName := c.Query("span_name")
-	if rawSpanName == "" {
+	spanName := c.Query("span_name")
+	if spanName == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Missing span_name query param",
 		})
 		return
 	}
 
-	spanName, err := url.QueryUnescape(rawSpanName)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid span_name query param",
-		})
-		return
-	}
-
-	af := filter.AppFilter{
+	ef := exprfilter.ExprFilter{
 		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
+		Limit: exprfilter.DefaultPaginationLimit,
 	}
 
-	if err := c.ShouldBindQuery(&af); err != nil {
+	if err := c.ShouldBindQuery(&ef); err != nil {
 		msg := `failed to parse query parameters`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -2803,44 +2793,14 @@ func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 		return
 	}
 
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
+	ef.Entity = exprfilter.SpansEntity
+
+	if err := ef.BuildExprTree(); err != nil {
+		respondFilterError(c, err)
 		return
 	}
 
-	msg := "root spans request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
+	ef.SetDefaultTimeRangeIfUnset()
 
 	app := measure.App{
 		ID: &id,
@@ -2892,6 +2852,7 @@ func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 	}
 
 	app.TeamId = *team.ID
+	ef.TeamID = *team.ID
 
 	lc := logcomment.New(2)
 	settings := clickhouse.Settings{
@@ -2901,7 +2862,21 @@ func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 
 	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "list"))
 
-	spans, next, previous, err := app.GetSpansForSpanNameWithFilter(ctx, deps.RchPool, spanName, &af)
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		msg := "failed to read the filter's custom keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if err := ef.Validate(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	spans, next, previous, err := app.GetSpansForSpanNameWithFilter(ctx, deps.RchPool, spanName, &ef)
 	if err != nil {
 		msg := "failed to get app's root spans"
 		fmt.Println(msg, err)
@@ -2933,28 +2908,20 @@ func (h Handlers) GetMetricsPlotForSpanName(c *gin.Context) {
 		return
 	}
 
-	rawSpanName := c.Query("span_name")
-	if rawSpanName == "" {
+	spanName := c.Query("span_name")
+	if spanName == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Missing span_name query param",
 		})
 		return
 	}
 
-	spanName, err := url.QueryUnescape(rawSpanName)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid span_name query param",
-		})
-		return
-	}
-
-	af := filter.AppFilter{
+	ef := exprfilter.ExprFilter{
 		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
+		Limit: exprfilter.DefaultPaginationLimit,
 	}
 
-	if err := c.ShouldBindQuery(&af); err != nil {
+	if err := c.ShouldBindQuery(&ef); err != nil {
 		msg := `failed to parse query parameters`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -2964,44 +2931,14 @@ func (h Handlers) GetMetricsPlotForSpanName(c *gin.Context) {
 		return
 	}
 
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
+	ef.Entity = exprfilter.SpansEntity
+
+	if err := ef.BuildExprTree(); err != nil {
+		respondFilterError(c, err)
 		return
 	}
 
-	msg := "span plot request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
+	ef.SetDefaultTimeRangeIfUnset()
 
 	app := measure.App{
 		ID: &id,
@@ -3053,6 +2990,7 @@ func (h Handlers) GetMetricsPlotForSpanName(c *gin.Context) {
 	}
 
 	app.TeamId = *team.ID
+	ef.TeamID = *team.ID
 
 	lc := logcomment.New(2)
 	settings := clickhouse.Settings{
@@ -3061,7 +2999,21 @@ func (h Handlers) GetMetricsPlotForSpanName(c *gin.Context) {
 
 	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "plots_metrics"))
 
-	spanMetricsPlotInstances, err := app.GetMetricsPlotForSpanNameWithFilter(ctx, deps.RchPool, spanName, &af)
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		msg := "failed to read the filter's custom keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if err := ef.Validate(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	spanMetricsPlotInstances, err := app.GetMetricsPlotForSpanNameWithFilter(ctx, deps.RchPool, spanName, &ef)
 	if err != nil {
 		msg := "failed to get span's plot"
 		fmt.Println(msg, err)

--- a/backend/api/handlers/build.go
+++ b/backend/api/handlers/build.go
@@ -67,9 +67,7 @@ func (h Handlers) GetBuilds(c *gin.Context) {
 		return
 	}
 
-	if !ef.HasTimeRange() {
-		ef.SetDefaultTimeRange()
-	}
+	ef.SetDefaultTimeRangeIfUnset()
 
 	app := measure.App{
 		ID: &id,

--- a/backend/api/handlers/exprfilter.go
+++ b/backend/api/handlers/exprfilter.go
@@ -34,9 +34,9 @@ func respondFilterError(c *gin.Context, err error) {
 	})
 }
 
-// authorizeAppRead reports whether the caller may read the app. It answers the
-// request itself and returns false when they may not.
-func (h Handlers) authorizeAppRead(c *gin.Context, appID uuid.UUID) bool {
+// authorizeAppRead reports whether the caller may read the app, along with the
+// id of the team owning it. Returns false when they may not.
+func (h Handlers) authorizeAppRead(c *gin.Context, appID uuid.UUID) (teamID uuid.UUID, ok bool) {
 	ctx := c.Request.Context()
 	deps := h.Deps
 
@@ -46,11 +46,11 @@ func (h Handlers) authorizeAppRead(c *gin.Context, appID uuid.UUID) bool {
 		msg := "Failed to get team from app id"
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return false
+		return uuid.Nil, false
 	}
 	if team == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("No team exists for app [%s]", appID)})
-		return false
+		return uuid.Nil, false
 	}
 
 	userId := c.GetString("userId")
@@ -59,7 +59,7 @@ func (h Handlers) authorizeAppRead(c *gin.Context, appID uuid.UUID) bool {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return false
+		return uuid.Nil, false
 	}
 
 	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
@@ -67,18 +67,20 @@ func (h Handlers) authorizeAppRead(c *gin.Context, appID uuid.UUID) bool {
 		msg := `failed to perform authorization`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return false
+		return uuid.Nil, false
 	}
 
 	if !okTeam || !okApp {
 		c.JSON(http.StatusForbidden, gin.H{"error": `you are not authorized to access this app`})
-		return false
+		return uuid.Nil, false
 	}
 
-	return true
+	return *team.ID, true
 }
 
 func (h Handlers) GetFilterKeys(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	appID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": `id invalid or missing`})
@@ -91,15 +93,24 @@ func (h Handlers) GetFilterKeys(c *gin.Context) {
 		return
 	}
 
-	if !h.authorizeAppRead(c, appID) {
+	teamID, ok := h.authorizeAppRead(c, appID)
+	if !ok {
 		return
 	}
 
-	keys := entity.Keys
+	ctx = exprfilter.WithFilterQuerySettings(ctx, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode, "filter_keys")
+	keys, keysTruncated, err := entity.ListKeys(ctx, h.Deps.PgPool, h.Deps.RchPool, teamID, appID, c.QueryArray("key"))
+	if err != nil {
+		msg := "Failed to read the filter keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"keys":       keys,
-		"key_groups": exprfilter.ListKeyGroups(keys),
+		"keys":           keys,
+		"key_groups":     exprfilter.ListKeyGroups(keys),
+		"keys_truncated": keysTruncated,
 	})
 }
 
@@ -141,12 +152,20 @@ func (h Handlers) GetFilterValues(c *gin.Context) {
 		return
 	}
 
-	if !h.authorizeAppRead(c, appID) {
+	teamID, authorized := h.authorizeAppRead(c, appID)
+	if !authorized {
 		return
 	}
 
-	key, ok := exprfilter.IndexKeysByName(entity.Keys)[queryParams.KeyName]
-	if !ok {
+	ctx = exprfilter.WithFilterQuerySettings(ctx, gin.Mode() == gin.ReleaseMode, gin.Mode() == gin.DebugMode, "filter_values")
+	key, found, err := entity.FindKey(ctx, h.Deps.RchPool, teamID, appID, queryParams.KeyName)
+	if err != nil {
+		msg := "Failed to read the filter values"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		return
+	}
+	if !found {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": fmt.Sprintf("Entity %q has no key %q", entity.Name, queryParams.KeyName),
 		})
@@ -160,7 +179,7 @@ func (h Handlers) GetFilterValues(c *gin.Context) {
 		return
 	}
 
-	valueList, err := entity.SuggestKeyValues(ctx, h.Deps.PgPool, h.Deps.ChPool, appID, key, exprfilter.ValueRequest{
+	valueList, err := entity.SuggestKeyValues(ctx, h.Deps.PgPool, h.Deps.RchPool, teamID, appID, key, exprfilter.ValueRequest{
 		Search: queryParams.Search,
 		Limit:  queryParams.Limit,
 	})

--- a/backend/libs/exprfilter/custom.go
+++ b/backend/libs/exprfilter/custom.go
@@ -1,0 +1,202 @@
+package exprfilter
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+// A custom key is a user-defined attribute the app reported, offered as a
+// filter key.
+
+// CustomKeyPrefix marks a filter key as a user-defined attribute. The part
+// after the prefix is the attribute name as the app reported it.
+const CustomKeyPrefix = "custom."
+
+// CustomKeyLimit caps how many user-defined attribute keys a key listing
+// returns.
+const CustomKeyLimit = 500
+
+var customValueTypes = map[string]ValueType{
+	string(ValueTypeString):  ValueTypeString,
+	string(ValueTypeInt64):   ValueTypeInt64,
+	string(ValueTypeFloat64): ValueTypeFloat64,
+	string(ValueTypeBool):    ValueTypeBool,
+}
+
+// CustomKey is the filter key for one user-defined attribute.
+func CustomKey(rawName string, valueType ValueType) Key {
+	// Whether the attribute was set at all is independent of the value's
+	// type, so every custom key offers the presence operators on top of its
+	// type's own set.
+	operators := slices.Clone(AllowedOperatorsFor(valueType))
+	for _, operator := range []Operator{OperatorIsSet, OperatorIsNotSet} {
+		if !slices.Contains(operators, operator) {
+			operators = append(operators, operator)
+		}
+	}
+
+	key := Key{
+		Name:                CustomKeyPrefix + rawName,
+		Label:               rawName,
+		Description:         fmt.Sprintf("The user-defined attribute %q, set by the app.", rawName),
+		KeyGroup:            KeyGroupCustom,
+		ValueType:           valueType,
+		Operators:           operators,
+		ValueSuggestionMode: ValueSuggestionModeNone,
+	}
+
+	switch valueType {
+	case ValueTypeString:
+		key.ValueSuggestionMode = ValueSuggestionModeSample
+	case ValueTypeBool:
+		key.ValueSuggestionMode = ValueSuggestionModeFullList
+		key.EnumValues = []string{"true", "false"}
+	}
+
+	return key
+}
+
+// ListKeys returns the entity's fixed keys followed by the app's custom
+// keys, reporting whether the custom set was cut off at CustomKeyLimit. Any
+// names the caller passes that carry the custom prefix and did not make the
+// listing are resolved by name and appended. The fixed Keys slice is
+// package-level state, so the merge reallocates to leave it untouched.
+func (e Entity) ListKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, names []string) ([]Key, bool, error) {
+	if e.FetchCustomKeys == nil {
+		return e.Keys, false, nil
+	}
+
+	customKeys, truncated, err := e.FetchCustomKeys(ctx, pgPool, chPool, teamID, appID, CustomKeyLimit)
+	if err != nil {
+		return nil, false, err
+	}
+
+	keys := append(slices.Clip(e.Keys), customKeys...)
+
+	listed := IndexKeysByName(keys)
+	missingRawNames := []string{}
+	for _, name := range names {
+		rawName, isCustom := strings.CutPrefix(name, CustomKeyPrefix)
+		if !isCustom {
+			continue
+		}
+		if _, found := listed[name]; found {
+			continue
+		}
+		if !slices.Contains(missingRawNames, rawName) {
+			missingRawNames = append(missingRawNames, rawName)
+		}
+	}
+	if len(missingRawNames) > 0 && e.FetchCustomKeysByName != nil {
+		namedKeys, err := e.FetchCustomKeysByName(ctx, pgPool, chPool, teamID, appID, missingRawNames)
+		if err != nil {
+			return nil, false, err
+		}
+		keys = append(keys, namedKeys...)
+	}
+
+	return keys, truncated, nil
+}
+
+// FindKey resolves one key name to the entity's key definition, fixed or
+// custom.
+func (e Entity) FindKey(ctx context.Context, ch driver.Conn, teamID, appID uuid.UUID, name string) (Key, bool, error) {
+	if key, found := IndexKeysByName(e.Keys)[name]; found {
+		return key, true, nil
+	}
+
+	rawName, isCustom := strings.CutPrefix(name, CustomKeyPrefix)
+	if !isCustom || e.FetchCustomKeysByName == nil {
+		return Key{}, false, nil
+	}
+
+	customKeys, err := e.FetchCustomKeysByName(ctx, nil, ch, teamID, appID, []string{rawName})
+	if err != nil {
+		return Key{}, false, err
+	}
+	if len(customKeys) != 1 {
+		return Key{}, false, nil
+	}
+	return customKeys[0], true, nil
+}
+
+// collectCustomKeyNames lists the user-defined attribute names a filter tree
+// mentions, without their prefix, each name once.
+func collectCustomKeyNames(exprTree *ExprTree) []string {
+	if exprTree == nil {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	rawNames := []string{}
+
+	var walk func(node *ExprTree)
+	walk = func(node *ExprTree) {
+		if node.Condition != nil {
+			rawName, isCustom := strings.CutPrefix(node.Condition.KeyName, CustomKeyPrefix)
+			if isCustom && rawName != "" && !seen[rawName] {
+				seen[rawName] = true
+				rawNames = append(rawNames, rawName)
+			}
+			return
+		}
+		for i := range node.Children {
+			walk(&node.Children[i])
+		}
+	}
+	walk(exprTree)
+
+	return rawNames
+}
+
+// ResolveCustomKeys reads the custom keys the filter expression mentions and
+// extends this request's copy of the entity with them, so validation accepts
+// them and Predicate writes their conditions like any other key's. A
+// mentioned name the app never reported stays out, so validation reports it
+// as an unknown key.
+func (ef *ExprFilter) ResolveCustomKeys(ctx context.Context, chPool driver.Conn) error {
+	rawNames := collectCustomKeyNames(ef.ExprTree)
+	if len(rawNames) == 0 {
+		return nil
+	}
+
+	if ef.Entity.FetchCustomKeysByName == nil || ef.Entity.BindCustomKey == nil {
+		return nil
+	}
+
+	keys, err := ef.Entity.FetchCustomKeysByName(ctx, nil, chPool, ef.TeamID, ef.AppID, rawNames)
+	if err != nil {
+		return err
+	}
+
+	// The entity is this request's own copy, but its Keys slice still shares
+	// the package-level array, so the append must reallocate to leave that
+	// array untouched.
+	ef.Entity.Keys = append(slices.Clip(ef.Entity.Keys), keys...)
+
+	to := ef.To.Add(ef.Entity.MaxTimeBucketWidth)
+
+	// The wrapped binding handles custom keys itself and hands fixed keys to
+	// the original binding. Predicate uses it for conditions not covered by the
+	// override map, so overriding only fixed keys still resolves custom
+	// conditions correctly.
+	customKeyBindings := make(map[string]KeyBinding, len(keys))
+	for _, key := range keys {
+		customKeyBindings[key.Name] = ef.Entity.BindCustomKey(ef.TeamID, ef.AppID, ef.From, to, key)
+	}
+	fixedKeyBinding := ef.Entity.BindKey
+	ef.Entity.BindKey = func(condition Condition) (*sqlf.Stmt, error) {
+		if keyBinding, isCustom := customKeyBindings[condition.KeyName]; isCustom {
+			return keyBinding(condition)
+		}
+		return fixedKeyBinding(condition)
+	}
+	return nil
+}

--- a/backend/libs/exprfilter/custom_test.go
+++ b/backend/libs/exprfilter/custom_test.go
@@ -1,0 +1,354 @@
+package exprfilter
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+func TestCustomKeyMapping(t *testing.T) {
+	tests := []struct {
+		valueType      ValueType
+		suggestionMode ValueSuggestionMode
+		enumValues     []string
+	}{
+		{ValueTypeString, ValueSuggestionModeSample, nil},
+		{ValueTypeInt64, ValueSuggestionModeNone, nil},
+		{ValueTypeFloat64, ValueSuggestionModeNone, nil},
+		{ValueTypeBool, ValueSuggestionModeFullList, []string{"true", "false"}},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.valueType), func(t *testing.T) {
+			key := CustomKey("is_premium", test.valueType)
+
+			if key.Name != "custom.is_premium" {
+				t.Errorf("want the name prefixed, got %q", key.Name)
+			}
+			if key.Label != "is_premium" {
+				t.Errorf("want the label unprefixed, got %q", key.Label)
+			}
+			if key.Description == "" {
+				t.Error("want a description for the picker to draw")
+			}
+			if key.KeyGroup != KeyGroupCustom {
+				t.Errorf("want the Custom group, got %q", key.KeyGroup)
+			}
+			if key.ValueType != test.valueType {
+				t.Errorf("want value type %q, got %q", test.valueType, key.ValueType)
+			}
+			for _, operator := range AllowedOperatorsFor(test.valueType) {
+				if !slices.Contains(key.Operators, operator) {
+					t.Errorf("want the full operator set of %q, missing %q", test.valueType, operator)
+				}
+			}
+			for _, operator := range []Operator{OperatorIsSet, OperatorIsNotSet} {
+				if !slices.Contains(key.Operators, operator) {
+					t.Errorf("want the presence operator %q on every custom key", operator)
+				}
+			}
+			seen := map[Operator]int{}
+			for _, operator := range key.Operators {
+				seen[operator]++
+			}
+			for operator, count := range seen {
+				if count > 1 {
+					t.Errorf("want operator %q offered once, got %d times", operator, count)
+				}
+			}
+			if key.ValueSuggestionMode != test.suggestionMode {
+				t.Errorf("want suggestion mode %q, got %q", test.suggestionMode, key.ValueSuggestionMode)
+			}
+			if !slices.Equal(key.EnumValues, test.enumValues) {
+				t.Errorf("want enum values %v, got %v", test.enumValues, key.EnumValues)
+			}
+		})
+	}
+}
+
+func TestCustomKeyGroupIsInTheOrderTheFilterBarShows(t *testing.T) {
+	if !slices.Contains(keyGroupOrder, KeyGroupCustom) {
+		t.Error("want the Custom group in keyGroupOrder")
+	}
+}
+
+func TestCollectCustomKeyNames(t *testing.T) {
+	t.Run("an empty tree mentions nothing", func(t *testing.T) {
+		if got := collectCustomKeyNames(nil); len(got) != 0 {
+			t.Errorf("want no names, got %v", got)
+		}
+	})
+
+	t.Run("keys without the prefix stay out", func(t *testing.T) {
+		got := collectCustomKeyNames(leafExprTree("version_name", OperatorIn, "1.2.0"))
+		if len(got) != 0 {
+			t.Errorf("want no names, got %v", got)
+		}
+	})
+
+	t.Run("one condition yields its name unprefixed", func(t *testing.T) {
+		got := collectCustomKeyNames(leafExprTree("custom.plan", OperatorIn, "pro"))
+		if !slices.Equal(got, []string{"plan"}) {
+			t.Errorf("want [plan], got %v", got)
+		}
+	})
+
+	t.Run("nested groups yield every name once", func(t *testing.T) {
+		exprTree := &ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
+			*leafExprTree("custom.plan", OperatorIn, "pro"),
+			*leafExprTree("version_name", OperatorIn, "1.2.0"),
+			{LogicalOperator: LogicalOr, Children: []ExprTree{
+				*leafExprTree("custom.is_premium", OperatorEq, "true"),
+				*leafExprTree("custom.plan", OperatorNotIn, "free"),
+			}},
+		}}
+
+		got := collectCustomKeyNames(exprTree)
+		if !slices.Equal(got, []string{"plan", "is_premium"}) {
+			t.Errorf("want [plan is_premium] in first-mention order, got %v", got)
+		}
+	})
+
+	t.Run("the prefix alone names nothing", func(t *testing.T) {
+		if got := collectCustomKeyNames(leafExprTree("custom.", OperatorIsSet)); len(got) != 0 {
+			t.Errorf("want no names, got %v", got)
+		}
+	})
+}
+
+func TestResolveCustomKeysBindsEveryMentionedKey(t *testing.T) {
+	keys := []Key{CustomKey("plan", ValueTypeString), CustomKey("retries", ValueTypeInt64)}
+
+	entity := Entity{
+		Name: "stub",
+		Keys: []Key{versionName},
+		FetchCustomKeysByName: func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
+			if !slices.Equal(rawNames, []string{"plan", "retries"}) {
+				t.Errorf("want the mentioned names fetched, got %v", rawNames)
+			}
+			return keys, nil
+		},
+		BindCustomKey: func(teamID, appID uuid.UUID, from, to time.Time, key Key) KeyBinding {
+			return func(condition Condition) (*sqlf.Stmt, error) {
+				return sqlf.New("bound ?", key.Name), nil
+			}
+		},
+	}
+
+	ef := &ExprFilter{
+		AppID:  uuid.New(),
+		TeamID: uuid.New(),
+		Entity: entity,
+		ExprTree: &ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
+			*leafExprTree("custom.plan", OperatorIn, "pro"),
+			*leafExprTree("custom.retries", OperatorGt, "9"),
+		}},
+	}
+
+	if err := ef.ResolveCustomKeys(context.Background(), nil); err != nil {
+		t.Fatalf("ResolveCustomKeys: %v", err)
+	}
+	byName := IndexKeysByName(ef.Entity.Keys)
+	for _, key := range keys {
+		if _, found := byName[key.Name]; !found {
+			t.Errorf("want %q added to the request's key set", key.Name)
+		}
+		stmt, err := ef.Entity.BindKey(Condition{KeyName: key.Name, Operator: OperatorIn, Values: []Value{{Text: "x"}}})
+		if err != nil {
+			t.Fatalf("bind %q through the entity: %v", key.Name, err)
+		}
+		if stmt.String() != "bound ?" || stmt.Args()[0] != key.Name {
+			t.Errorf("want the custom binding of %q used, got %q %v", key.Name, stmt.String(), stmt.Args())
+		}
+		stmt.Close()
+	}
+}
+
+func TestResolveCustomKeysWithoutCustomKeysResolvesNothing(t *testing.T) {
+	exprTree := leafExprTree("custom.plan", OperatorIn, "pro")
+	ef := &ExprFilter{AppID: uuid.New(), TeamID: uuid.New(), Entity: BuildsEntity, ExprTree: exprTree}
+
+	// A nil connection proves nothing is read: a query would panic on it.
+	if err := ef.ResolveCustomKeys(context.Background(), nil); err != nil {
+		t.Fatalf("ResolveCustomKeys: %v", err)
+	}
+	if _, err := ef.Entity.BindKey(Condition{KeyName: "custom.plan", Operator: OperatorIn, Values: []Value{{Text: "pro"}}}); err == nil {
+		t.Error("want the entity's binding unchanged, still refusing the custom key")
+	}
+}
+
+func TestFindKeyWithoutCustomKeysReportsACustomKeyNotFound(t *testing.T) {
+	// A nil connection proves the lookup reads nothing: a query would panic
+	// on it.
+	key, found, err := BuildsEntity.FindKey(context.Background(), nil, uuid.New(), uuid.New(), "custom.plan")
+	if err != nil {
+		t.Fatalf("FindKey: %v", err)
+	}
+	if found {
+		t.Errorf("want the key reported not found, got %+v", key)
+	}
+}
+
+// bindCustom writes the SQL for one condition on a custom key of the given
+// value type, failing the test on a binding error.
+func bindCustom(t *testing.T, valueType ValueType, operator Operator, texts ...string) (string, []any) {
+	t.Helper()
+
+	key := CustomKey("plan", valueType)
+	binding := SpansEntity.BindCustomKey(uuid.New(), uuid.New(), time.Now().UTC().Add(-time.Hour), time.Now().UTC(), key)
+
+	values := make([]Value, len(texts))
+	for i, text := range texts {
+		values[i] = Value{Text: text}
+	}
+
+	stmt, err := binding(Condition{KeyName: key.Name, Operator: operator, Values: values})
+	if err != nil {
+		t.Fatalf("bind %s %s: %v", valueType, operator, err)
+	}
+	defer stmt.Close()
+
+	// Close recycles the statement's argument slice, so the caller gets a copy.
+	return stmt.String(), slices.Clone(stmt.Args())
+}
+
+const customSubqueryScope = "select span_id from span_user_def_attrs where team_id = toUUID(?) and app_id = toUUID(?) and timestamp >= ? and timestamp <= ? and key = ? and type = ?"
+
+const customPresenceScope = "select span_id from span_user_def_attrs where team_id = toUUID(?) and app_id = toUUID(?) and timestamp >= ? and timestamp <= ? and key = ?"
+
+func TestBindSpanCustomKeyWritesAMembershipSubquery(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueType ValueType
+		operator  Operator
+		texts     []string
+		want      string
+		wantArgs  int
+	}{
+		{
+			name: "string in", valueType: ValueTypeString, operator: OperatorIn, texts: []string{"pro", "free"},
+			want:     "span_id in (" + customSubqueryScope + " and value in ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string not_in negates the membership", valueType: ValueTypeString, operator: OperatorNotIn, texts: []string{"pro"},
+			want:     "span_id not in (" + customSubqueryScope + " and value in ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string contains", valueType: ValueTypeString, operator: OperatorContains, texts: []string{"pro"},
+			want:     "span_id in (" + customSubqueryScope + " and value ilike ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string not_contains negates the membership", valueType: ValueTypeString, operator: OperatorNotContains, texts: []string{"pro"},
+			want:     "span_id not in (" + customSubqueryScope + " and value ilike ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string starts_with", valueType: ValueTypeString, operator: OperatorStartsWith, texts: []string{"pro"},
+			want:     "span_id in (" + customSubqueryScope + " and value ilike ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string ends_with", valueType: ValueTypeString, operator: OperatorEndsWith, texts: []string{"pro"},
+			want:     "span_id in (" + customSubqueryScope + " and value ilike ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "string is_set", valueType: ValueTypeString, operator: OperatorIsSet,
+			want:     "span_id in (" + customPresenceScope + ")",
+			wantArgs: 5,
+		},
+		{
+			name: "string is_not_set", valueType: ValueTypeString, operator: OperatorIsNotSet,
+			want:     "span_id not in (" + customPresenceScope + ")",
+			wantArgs: 5,
+		},
+		{
+			name: "int64 gt casts the value", valueType: ValueTypeInt64, operator: OperatorGt, texts: []string{"9"},
+			want:     "span_id in (" + customSubqueryScope + " and toInt64OrNull(value) > ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "int64 neq negates the membership", valueType: ValueTypeInt64, operator: OperatorNeq, texts: []string{"9"},
+			want:     "span_id not in (" + customSubqueryScope + " and toInt64OrNull(value) = ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "int64 is_not_set", valueType: ValueTypeInt64, operator: OperatorIsNotSet,
+			want:     "span_id not in (" + customPresenceScope + ")",
+			wantArgs: 5,
+		},
+		{
+			name: "float64 lte casts the value", valueType: ValueTypeFloat64, operator: OperatorLte, texts: []string{"1.5"},
+			want:     "span_id in (" + customSubqueryScope + " and toFloat64OrNull(value) <= ?)",
+			wantArgs: 7,
+		},
+		{
+			name: "bool eq", valueType: ValueTypeBool, operator: OperatorEq, texts: []string{"true"},
+			want:     "span_id in (" + customSubqueryScope + " and value = ?)",
+			wantArgs: 7,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, args := bindCustom(t, test.valueType, test.operator, test.texts...)
+			if got != test.want {
+				t.Errorf("\n got %s\nwant %s", got, test.want)
+			}
+			if len(args) != test.wantArgs {
+				t.Errorf("want %d bound arguments, got %d: %v", test.wantArgs, len(args), args)
+			}
+		})
+	}
+}
+
+func TestBindSpanCustomKeyBindsTheRawNameAndStoredType(t *testing.T) {
+	_, args := bindCustom(t, ValueTypeInt64, OperatorGt, "9")
+
+	if got := args[4]; got != "plan" {
+		t.Errorf("want the attribute name bound without its prefix, got %v", got)
+	}
+	if got := args[5]; got != "int64" {
+		t.Errorf("want the stored type name bound, got %v", got)
+	}
+	if got := args[6]; got != int64(9) {
+		t.Errorf("want the value bound as a number, got %v (%T)", got, got)
+	}
+}
+
+func TestBindSpanCustomKeyNormalizesABoolValue(t *testing.T) {
+	_, args := bindCustom(t, ValueTypeBool, OperatorEq, "1")
+	if got := args[6]; got != "true" {
+		t.Errorf("want the stored spelling bound, got %v", got)
+	}
+}
+
+func TestBindSpanCustomKeyEscapesLikeWildcards(t *testing.T) {
+	_, args := bindCustom(t, ValueTypeString, OperatorContains, "100%_a")
+	if got := args[6]; got != `%100\%\_a%` {
+		t.Errorf("want the wildcards turned off, got %v", got)
+	}
+}
+
+func TestBindSpanCustomKeyRefusesAnOperatorTheTypeDoesNotOffer(t *testing.T) {
+	key := CustomKey("retries", ValueTypeInt64)
+	binding := SpansEntity.BindCustomKey(uuid.New(), uuid.New(), time.Now().UTC().Add(-time.Hour), time.Now().UTC(), key)
+
+	_, err := binding(Condition{KeyName: key.Name, Operator: OperatorContains, Values: []Value{{Text: "9"}}})
+	if err == nil {
+		t.Fatal("want a text operator on a number key refused")
+	}
+	if !strings.Contains(err.Error(), "custom.retries") {
+		t.Errorf("want the key named, got %q", err)
+	}
+}

--- a/backend/libs/exprfilter/custom_values_test.go
+++ b/backend/libs/exprfilter/custom_values_test.go
@@ -1,0 +1,311 @@
+//go:build integration
+
+package exprfilter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/testinfra"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func seedSpanUDAttrs(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+	otherAppID = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "custom keys team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "custom keys app", 90)
+	th.SeedApp(ctx, t, otherAppID.String(), teamID.String(), "another app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "free", Timestamp: base})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "pro", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "", Timestamp: base.Add(20 * time.Minute)})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "is_premium", Type: "bool", Value: "true", Timestamp: base})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "retries", Type: "int64", Value: "3", Timestamp: base})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "ratio", Type: "float64", Value: "0.5", Timestamp: base})
+
+	// One key written under two types, the bool row last.
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "flag", Type: "string", Value: "yes", Timestamp: base})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "flag", Type: "bool", Value: "true", Timestamp: base.Add(10 * time.Minute)})
+
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), otherAppID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "enterprise", Timestamp: base})
+
+	return teamID, appID, otherAppID
+}
+
+func customKeyNames(keys []Key) []string {
+	names := make([]string, len(keys))
+	for i, key := range keys {
+		names[i] = key.Name
+	}
+	return names
+}
+
+func TestFetchSpanCustomKeys(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, _ := seedSpanUDAttrs(ctx, t)
+
+	t.Run("every key comes back ordered by name", func(t *testing.T) {
+		keys, truncated, err := SpansEntity.FetchCustomKeys(ctx, pgPool, chConn, teamID, appID, CustomKeyLimit)
+		if err != nil {
+			t.Fatalf("fetch custom keys: %v", err)
+		}
+		if truncated {
+			t.Error("want the whole list for five keys")
+		}
+
+		want := []string{"custom.flag", "custom.is_premium", "custom.plan", "custom.ratio", "custom.retries"}
+		got := customKeyNames(keys)
+		if len(got) != len(want) {
+			t.Fatalf("want %v, got %v", want, got)
+		}
+		for i, name := range want {
+			if got[i] != name {
+				t.Fatalf("want %v, got %v", want, got)
+			}
+		}
+	})
+
+	t.Run("a listing past the limit reports truncation", func(t *testing.T) {
+		keys, truncated, err := SpansEntity.FetchCustomKeys(ctx, pgPool, chConn, teamID, appID, 2)
+		if err != nil {
+			t.Fatalf("fetch custom keys: %v", err)
+		}
+		if !truncated {
+			t.Error("want the listing marked truncated")
+		}
+		got := customKeyNames(keys)
+		if len(got) != 2 || got[0] != "custom.flag" || got[1] != "custom.is_premium" {
+			t.Errorf("want the first two keys by name, got %v", got)
+		}
+	})
+
+	t.Run("each key carries its stored type", func(t *testing.T) {
+		keys, _, err := SpansEntity.FetchCustomKeys(ctx, pgPool, chConn, teamID, appID, CustomKeyLimit)
+		if err != nil {
+			t.Fatalf("fetch custom keys: %v", err)
+		}
+
+		byName := IndexKeysByName(keys)
+		wantTypes := map[string]ValueType{
+			"custom.plan":       ValueTypeString,
+			"custom.is_premium": ValueTypeBool,
+			"custom.retries":    ValueTypeInt64,
+			"custom.ratio":      ValueTypeFloat64,
+		}
+		for name, want := range wantTypes {
+			if got := byName[name].ValueType; got != want {
+				t.Errorf("key %q: want type %q, got %q", name, want, got)
+			}
+		}
+	})
+}
+
+func TestListKeysResolvesRequestedNames(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, _ := seedSpanUDAttrs(ctx, t)
+
+	// The listing is held to the first two custom keys by name, flag and
+	// is_premium, so the other seeded keys stand in for keys past
+	// CustomKeyLimit.
+	entity := SpansEntity
+	entity.FetchCustomKeys = func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
+		return SpansEntity.FetchCustomKeys(ctx, pgPool, chPool, teamID, appID, 2)
+	}
+
+	baseKeys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, nil)
+	if err != nil {
+		t.Fatalf("list keys: %v", err)
+	}
+	if _, listed := IndexKeysByName(baseKeys)["custom.retries"]; listed {
+		t.Fatal("want custom.retries beyond the truncated listing")
+	}
+
+	t.Run("a requested name beyond the listing is appended with its type", func(t *testing.T) {
+		keys, truncated, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.retries"})
+		if err != nil {
+			t.Fatalf("list keys: %v", err)
+		}
+		if !truncated {
+			t.Error("want the listing still marked truncated")
+		}
+		key, found := IndexKeysByName(keys)["custom.retries"]
+		if !found {
+			t.Fatal("want the requested key appended")
+		}
+		if key.ValueType != ValueTypeInt64 {
+			t.Errorf("want type %q, got %q", ValueTypeInt64, key.ValueType)
+		}
+	})
+
+	t.Run("a requested name the app never reported is ignored", func(t *testing.T) {
+		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.nope"})
+		if err != nil {
+			t.Fatalf("list keys: %v", err)
+		}
+		if len(keys) != len(baseKeys) {
+			t.Errorf("want %d keys, got %d", len(baseKeys), len(keys))
+		}
+	})
+
+	t.Run("a requested name already listed is not duplicated", func(t *testing.T) {
+		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.flag"})
+		if err != nil {
+			t.Fatalf("list keys: %v", err)
+		}
+		count := 0
+		for _, key := range keys {
+			if key.Name == "custom.flag" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("want custom.flag once, got it %d times", count)
+		}
+		if len(keys) != len(baseKeys) {
+			t.Errorf("want %d keys, got %d", len(baseKeys), len(keys))
+		}
+	})
+
+	t.Run("a name without the custom prefix is ignored", func(t *testing.T) {
+		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"retries"})
+		if err != nil {
+			t.Fatalf("list keys: %v", err)
+		}
+		if len(keys) != len(baseKeys) {
+			t.Errorf("want %d keys, got %d", len(baseKeys), len(keys))
+		}
+	})
+}
+
+func TestFetchSpanCustomKeysByName(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, _ := seedSpanUDAttrs(ctx, t)
+
+	t.Run("only the requested names come back", func(t *testing.T) {
+		keys, err := SpansEntity.FetchCustomKeysByName(ctx, pgPool, chConn, teamID, appID, []string{"plan", "retries", "nope"})
+		if err != nil {
+			t.Fatalf("fetch custom keys by name: %v", err)
+		}
+		got := customKeyNames(keys)
+		if len(got) != 2 || got[0] != "custom.plan" || got[1] != "custom.retries" {
+			t.Errorf("want [custom.plan custom.retries], got %v", got)
+		}
+	})
+
+	t.Run("no names read nothing", func(t *testing.T) {
+		keys, err := SpansEntity.FetchCustomKeysByName(ctx, pgPool, chConn, teamID, appID, nil)
+		if err != nil {
+			t.Fatalf("fetch custom keys by name: %v", err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("want no keys, got %v", customKeyNames(keys))
+		}
+	})
+
+	t.Run("a key written under two types offers the last one", func(t *testing.T) {
+		keys, err := SpansEntity.FetchCustomKeysByName(ctx, pgPool, chConn, teamID, appID, []string{"flag"})
+		if err != nil {
+			t.Fatalf("fetch custom keys by name: %v", err)
+		}
+		if len(keys) != 1 || keys[0].ValueType != ValueTypeBool {
+			t.Errorf("want one bool key, got %v", keys)
+		}
+	})
+}
+
+func TestCustomSpanKeyValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, otherAppID := seedSpanUDAttrs(ctx, t)
+
+	list := func(t *testing.T, key Key, valueRequest ValueRequest) ([]string, bool) {
+		t.Helper()
+		valueList, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, key, valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		texts := make([]string, len(valueList.Values))
+		for i, value := range valueList.Values {
+			texts[i] = value.Text
+		}
+		return texts, valueList.Truncated
+	}
+
+	plan := CustomKey("plan", ValueTypeString)
+
+	t.Run("string values come back most recently written first", func(t *testing.T) {
+		got, truncated := list(t, plan, ValueRequest{})
+		if truncated {
+			t.Error("want the whole list for two values")
+		}
+		if len(got) != 2 || got[0] != "pro" || got[1] != "free" {
+			t.Errorf("want [pro free], got %v", got)
+		}
+	})
+
+	t.Run("an empty stored value stays out", func(t *testing.T) {
+		got, _ := list(t, plan, ValueRequest{})
+		for _, text := range got {
+			if text == "" {
+				t.Error("want empty values left out of the list")
+			}
+		}
+	})
+
+	t.Run("search narrows the list", func(t *testing.T) {
+		got, _ := list(t, plan, ValueRequest{Search: "fr"})
+		if len(got) != 1 || got[0] != "free" {
+			t.Errorf("want [free], got %v", got)
+		}
+	})
+
+	t.Run("a list past the limit reports truncation", func(t *testing.T) {
+		got, truncated := list(t, plan, ValueRequest{Limit: 1})
+		if !truncated {
+			t.Error("want the list marked truncated")
+		}
+		if len(got) != 1 || got[0] != "pro" {
+			t.Errorf("want [pro], got %v", got)
+		}
+	})
+
+	t.Run("another app's values stay out", func(t *testing.T) {
+		got, _ := list(t, plan, ValueRequest{})
+		for _, text := range got {
+			if text == "enterprise" {
+				t.Error("want another app's value out of this app's list")
+			}
+		}
+		valueList, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, otherAppID, plan, ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		if len(valueList.Values) != 1 || valueList.Values[0].Text != "enterprise" {
+			t.Errorf("want [enterprise] for the other app, got %v", valueList.Values)
+		}
+	})
+
+	t.Run("a bool key lists its fixed set", func(t *testing.T) {
+		got, _ := list(t, CustomKey("is_premium", ValueTypeBool), ValueRequest{})
+		if len(got) != 2 || got[0] != "true" || got[1] != "false" {
+			t.Errorf("want [true false], got %v", got)
+		}
+	})
+
+	t.Run("a number key takes typed-in values only", func(t *testing.T) {
+		_, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, CustomKey("retries", ValueTypeInt64), ValueRequest{})
+		if err == nil {
+			t.Error("want a number key's value list refused")
+		}
+	})
+}

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"backend/libs/chquery"
 	"backend/libs/symbol"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -33,13 +35,34 @@ type Entity struct {
 	// SuggestKeyValues lists what one key can be set to, narrowed by what has been
 	// typed. Both pools are passed because which one an entity reads is its own
 	// choice.
-	SuggestKeyValues func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error)
+	SuggestKeyValues func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error)
+
+	// FetchCustomKeys lists the keys an app's user-defined attributes add to
+	// the entity's fixed set. Nil for an entity whose keys are all fixed.
+	FetchCustomKeys func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error)
+
+	// FetchCustomKeysByName reads the entity's custom keys with the given
+	// names, each name without the custom prefix. A name not present in
+	// user defined attributes yields no key. Nil for an entity whose keys are all fixed.
+	FetchCustomKeysByName func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error)
+
+	// BindCustomKey builds the KeyBinding for one custom key. Nil for an
+	// entity whose keys are all fixed.
+	BindCustomKey func(teamID, appID uuid.UUID, from, to time.Time, key Key) KeyBinding
+
+	// MaxTimeBucketWidth is the widest time bucket used by any of the entity's
+	// tables. Bucketed queries may include rows from this bucket past the range
+	// end, so custom key bindings must be resolved that far past it. Zero means
+	// all tables store raw timestamps.
+	MaxTimeBucketWidth time.Duration
 }
 
 func FindByName(name string) (Entity, error) {
 	switch name {
 	case BuildsEntity.Name:
 		return BuildsEntity, nil
+	case SpansEntity.Name:
+		return SpansEntity, nil
 	}
 
 	return Entity{}, fmt.Errorf("Unknown filter entity %q", name)
@@ -47,12 +70,22 @@ func FindByName(name string) (Entity, error) {
 
 // The groups a key can belong to.
 const (
-	KeyGroupVersion KeyGroup = "Version"
-	KeyGroupBuild   KeyGroup = "Build"
+	KeyGroupVersion  KeyGroup = "Version"
+	KeyGroupBuild    KeyGroup = "Build"
+	KeyGroupSpan     KeyGroup = "Span"
+	KeyGroupOS       KeyGroup = "OS"
+	KeyGroupDevice   KeyGroup = "Device"
+	KeyGroupNetwork  KeyGroup = "Network"
+	KeyGroupLocation KeyGroup = "Location"
+	KeyGroupCustom   KeyGroup = "Custom"
 )
 
 // keyGroupOrder is the order the filter bar shows groups in.
-var keyGroupOrder = []KeyGroup{KeyGroupVersion, KeyGroupBuild}
+var keyGroupOrder = []KeyGroup{
+	KeyGroupVersion, KeyGroupBuild, KeyGroupSpan,
+	KeyGroupOS, KeyGroupDevice, KeyGroupNetwork, KeyGroupLocation,
+	KeyGroupCustom,
+}
 
 // ListKeyGroups lists the groups a set of keys falls into, in the order the
 // filter bar shows them.
@@ -134,6 +167,113 @@ var (
 		ValueSuggestionMode: ValueSuggestionModeFullList,
 		EnumValues:          mappingTypes(),
 	}
+
+	spanStatus = Key{
+		Name:                "span_status",
+		Label:               "Span status",
+		Description:         "Status of the span.",
+		KeyGroup:            KeyGroupSpan,
+		ValueType:           ValueTypeEnum,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeFullList,
+		EnumValues:          []string{"unset", "ok", "error"},
+	}
+
+	osName = Key{
+		Name:                "os_name",
+		Label:               "OS name",
+		Description:         "The name of the operating system.",
+		KeyGroup:            KeyGroupOS,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	osVersion = Key{
+		Name:        "os_version",
+		Label:       "OS version",
+		Description: "The version of the operating system.",
+		KeyGroup:    KeyGroupOS,
+		ValueType:   ValueTypeString,
+		Operators: []Operator{
+			OperatorIn, OperatorNotIn,
+			OperatorContains, OperatorStartsWith,
+		},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	deviceName = Key{
+		Name:        "device_name",
+		Label:       "Device name",
+		Description: "The name of the device.",
+		KeyGroup:    KeyGroupDevice,
+		ValueType:   ValueTypeString,
+		Operators: []Operator{
+			OperatorIn, OperatorNotIn,
+			OperatorContains, OperatorStartsWith,
+		},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	deviceManufacturer = Key{
+		Name:                "device_manufacturer",
+		Label:               "Device manufacturer",
+		Description:         "The manufacturer of the device.",
+		KeyGroup:            KeyGroupDevice,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	locale = Key{
+		Name:                "locale",
+		Label:               "Locale",
+		Description:         "The device locale.",
+		KeyGroup:            KeyGroupDevice,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	networkType = Key{
+		Name:                "network_type",
+		Label:               "Network type",
+		Description:         "The kind of network connection: wifi, cellular and so on.",
+		KeyGroup:            KeyGroupNetwork,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	networkGeneration = Key{
+		Name:                "network_generation",
+		Label:               "Network generation",
+		Description:         "The cellular network generation: 2g, 3g, 4g and so on.",
+		KeyGroup:            KeyGroupNetwork,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	networkProvider = Key{
+		Name:                "network_provider",
+		Label:               "Network provider",
+		Description:         "The name of the network service provider.",
+		KeyGroup:            KeyGroupNetwork,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	country = Key{
+		Name:                "country",
+		Label:               "Country",
+		Description:         "The country the device was in, as a country code.",
+		KeyGroup:            KeyGroupLocation,
+		ValueType:           ValueTypeString,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
 )
 
 func mappingTypes() []string {
@@ -143,6 +283,176 @@ func mappingTypes() []string {
 		names[i] = mappingType.String()
 	}
 	return names
+}
+
+// narrowEnumValues narrows a key's fixed value set by what has been typed. An
+// enum key carries its values itself, so no table is read.
+func narrowEnumValues(key Key, valueRequest ValueRequest) ValueList {
+	values := []Value{}
+	for _, text := range key.EnumValues {
+		if valueRequest.Search != "" && !strings.Contains(strings.ToLower(text), strings.ToLower(valueRequest.Search)) {
+			continue
+		}
+		values = append(values, Value{Text: text})
+	}
+
+	limit := valueRequest.Limit
+	if limit <= 0 {
+		limit = DefaultValueLimit
+	}
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}
+	}
+	return ValueList{Values: values}
+}
+
+func readCustomKeys(ctx context.Context, ch driver.Conn, teamID uuid.UUID, stmt *sqlf.Stmt) ([]Key, error) {
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	rows, err := ch.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+	}
+	defer rows.Close()
+
+	keys := []Key{}
+	for rows.Next() {
+		var rawName, storedType string
+		if err := rows.Scan(&rawName, &storedType); err != nil {
+			return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+		}
+		valueType, ok := customValueTypes[storedType]
+		if !ok {
+			return nil, fmt.Errorf("Attribute %q stores values of unknown type %q", rawName, storedType)
+		}
+		keys = append(keys, CustomKey(rawName, valueType))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+	}
+
+	return keys, nil
+}
+
+var comparisonSQL = map[Operator]string{
+	OperatorEq:  "=",
+	OperatorNeq: "!=",
+	OperatorGt:  ">",
+	OperatorGte: ">=",
+	OperatorLt:  "<",
+	OperatorLte: "<=",
+}
+
+// bindCustomKeyToMembership turns each condition on a user-defined attribute
+// key into an id membership subquery against the given attribute table; every
+// such table stores the same key, type, value and timestamp columns. The
+// value column holds the text form of every type, so a numeric condition
+// compares through a cast, and a row whose text is not numeric casts to null
+// and matches nothing.
+func bindCustomKeyToMembership(table, idColumn string) func(teamID, appID uuid.UUID, from, to time.Time, key Key) KeyBinding {
+	return func(teamID, appID uuid.UUID, from, to time.Time, key Key) KeyBinding {
+		rawName := strings.TrimPrefix(key.Name, CustomKeyPrefix)
+		storedType := string(key.ValueType)
+
+		return func(condition Condition) (*sqlf.Stmt, error) {
+			presence := func(operator string) *sqlf.Stmt {
+				text := idColumn + " " + operator + " (" +
+					"select " + idColumn + " from " + table +
+					" where team_id = toUUID(?) and app_id = toUUID(?)" +
+					" and timestamp >= ? and timestamp <= ?" +
+					" and key = ?)"
+				return sqlf.New(text, teamID, appID, from, to, rawName)
+			}
+			membership := func(operator string, valueComparison string, valueArgs ...any) *sqlf.Stmt {
+				text := idColumn + " " + operator + " (" +
+					"select " + idColumn + " from " + table +
+					" where team_id = toUUID(?) and app_id = toUUID(?)" +
+					" and timestamp >= ? and timestamp <= ?" +
+					" and key = ? and type = ?" +
+					valueComparison +
+					")"
+				args := append([]any{teamID, appID, from, to, rawName, storedType}, valueArgs...)
+				return sqlf.New(text, args...)
+			}
+
+			// An attribute rewritten under a new type keeps its old rows so type is ingnored
+			// by presence operators.
+			switch condition.Operator {
+			case OperatorIsSet:
+				return presence("in"), nil
+			case OperatorIsNotSet:
+				return presence("not in"), nil
+			}
+
+			switch key.ValueType {
+			case ValueTypeString:
+				switch condition.Operator {
+				case OperatorIn:
+					return membership("in", " and value in ?", condition.TextValues()), nil
+				case OperatorNotIn:
+					// A negative condition negates the membership itself, so
+					// a span without the attribute also matches, like a fixed
+					// key's empty column value does.
+					return membership("not in", " and value in ?", condition.TextValues()), nil
+				case OperatorContains:
+					return membership("in", " and value ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+				case OperatorNotContains:
+					return membership("not in", " and value ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+				case OperatorStartsWith:
+					return membership("in", " and value ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
+				case OperatorEndsWith:
+					return membership("in", " and value ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())), nil
+				}
+
+			case ValueTypeInt64:
+				if condition.Operator == OperatorNeq {
+					number, err := condition.IntegerValue()
+					if err != nil {
+						return nil, err
+					}
+					return membership("not in", " and toInt64OrNull(value) = ?", number), nil
+				}
+				if comparison, ok := comparisonSQL[condition.Operator]; ok {
+					number, err := condition.IntegerValue()
+					if err != nil {
+						return nil, err
+					}
+					return membership("in", " and toInt64OrNull(value) "+comparison+" ?", number), nil
+				}
+
+			case ValueTypeFloat64:
+				if condition.Operator == OperatorNeq {
+					number, err := condition.FloatValue()
+					if err != nil {
+						return nil, err
+					}
+					return membership("not in", " and toFloat64OrNull(value) = ?", number), nil
+				}
+				if comparison, ok := comparisonSQL[condition.Operator]; ok {
+					number, err := condition.FloatValue()
+					if err != nil {
+						return nil, err
+					}
+					return membership("in", " and toFloat64OrNull(value) "+comparison+" ?", number), nil
+				}
+
+			case ValueTypeBool:
+				if condition.Operator == OperatorEq {
+					yes, err := condition.BoolValue()
+					if err != nil {
+						return nil, err
+					}
+					text := "false"
+					if yes {
+						text = "true"
+					}
+					return membership("in", " and value = ?", text), nil
+				}
+			}
+
+			return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+		}
+	}
 }
 
 // BuildsEntity is an app's uploaded builds. Both its filtering and its
@@ -230,19 +540,10 @@ func bindBuildsKey(condition Condition) (*sqlf.Stmt, error) {
 // fetchBuildsKeySuggestions lists what one key can be set to, narrowed by what has been
 // typed. It asks for one row past the limit so it can report that more matched
 // without counting them. Builds are read from Postgres only, so the ClickHouse
-// connection is unused here.
-func fetchBuildsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
-	// An enum key carries its values itself, so the search narrows that set here
-	// instead of a column.
+// connection and the team id are unused here.
+func fetchBuildsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
 	if len(key.EnumValues) > 0 {
-		values := []Value{}
-		for _, text := range key.EnumValues {
-			if valueRequest.Search != "" && !strings.Contains(strings.ToLower(text), strings.ToLower(valueRequest.Search)) {
-				continue
-			}
-			values = append(values, Value{Text: text})
-		}
-		return ValueList{Values: values}, nil
+		return narrowEnumValues(key, valueRequest), nil
 	}
 
 	if key.ValueSuggestionMode == ValueSuggestionModeNone {
@@ -289,6 +590,346 @@ func fetchBuildsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool
 	for rows.Next() {
 		var text string
 		var recency any
+		if err := rows.Scan(&text, &recency); err != nil {
+			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+		}
+		values = append(values, Value{Text: text})
+	}
+	if err := rows.Err(); err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}, nil
+	}
+
+	return ValueList{Values: values}, nil
+}
+
+// SpansEntity is an app's performance trace spans. Both its filtering and its
+// value lists read the spans table in ClickHouse. The span_metrics rollup
+// stores the same fields as flat columns, which SpanMetricsKeyBindings maps
+// for queries that aggregate over it.
+var SpansEntity = Entity{
+	Name:                  "spans",
+	Keys:                  spansKeys,
+	BindKey:               bindSpansKeyToColumns(spansTableColumns),
+	SuggestKeyValues:      fetchSpansKeySuggestions,
+	FetchCustomKeys:       fetchSpanCustomKeys,
+	FetchCustomKeysByName: fetchSpanCustomKeysByName,
+	BindCustomKey:         bindCustomKeyToMembership("span_user_def_attrs", "span_id"),
+	// span_metrics groups spans into 15-minute buckets by start time. A query
+	// can therefore include spans whose bucket extends past the range end.
+	MaxTimeBucketWidth: 15 * time.Minute,
+}
+
+var spansKeys = []Key{
+	versionName,
+	versionCode,
+	spanStatus,
+	osName,
+	osVersion,
+	deviceName,
+	deviceManufacturer,
+	locale,
+	networkType,
+	networkGeneration,
+	networkProvider,
+	country,
+}
+
+// The column expression each spans key compares against, per table. The spans
+// table nests device and network attributes in attribute-prefixed columns and
+// the span_metrics rollup stores the same fields as flat columns; both hold
+// the app and os versions as (name, version) tuples.
+var (
+	spansTableColumns = map[string]string{
+		versionName.Name:        "tupleElement(attribute.app_version, 1)",
+		versionCode.Name:        "tupleElement(attribute.app_version, 2)",
+		spanStatus.Name:         "status",
+		osName.Name:             "tupleElement(attribute.os_version, 1)",
+		osVersion.Name:          "tupleElement(attribute.os_version, 2)",
+		deviceName.Name:         "attribute.device_name",
+		deviceManufacturer.Name: "attribute.device_manufacturer",
+		locale.Name:             "attribute.device_locale",
+		networkType.Name:        "attribute.network_type",
+		networkGeneration.Name:  "attribute.network_generation",
+		networkProvider.Name:    "attribute.network_provider",
+		country.Name:            "attribute.country_code",
+	}
+
+	spanFilterColumns = map[string]string{
+		versionName.Name:        "tupleElement(app_version, 1)",
+		versionCode.Name:        "tupleElement(app_version, 2)",
+		osName.Name:             "tupleElement(os_version, 1)",
+		osVersion.Name:          "tupleElement(os_version, 2)",
+		deviceName.Name:         "device_name",
+		deviceManufacturer.Name: "device_manufacturer",
+		locale.Name:             "device_locale",
+		networkType.Name:        "network_type",
+		networkGeneration.Name:  "network_generation",
+		networkProvider.Name:    "network_provider",
+		country.Name:            "country_code",
+	}
+
+	spanMetricsTableColumns = map[string]string{
+		versionName.Name:        "tupleElement(app_version, 1)",
+		versionCode.Name:        "tupleElement(app_version, 2)",
+		spanStatus.Name:         "status",
+		osName.Name:             "tupleElement(os_version, 1)",
+		osVersion.Name:          "tupleElement(os_version, 2)",
+		deviceName.Name:         "device_name",
+		deviceManufacturer.Name: "device_manufacturer",
+		locale.Name:             "device_locale",
+		networkType.Name:        "network_type",
+		networkGeneration.Name:  "network_generation",
+		networkProvider.Name:    "network_provider",
+		country.Name:            "country_code",
+	}
+)
+
+// SpanMetricsKeyBindings maps every fixed spans key onto the flat columns of
+// the span_metrics rollup, as Predicate overrides for queries that read that
+// table.
+func SpanMetricsKeyBindings() map[string]KeyBinding {
+	binding := bindSpansKeyToColumns(spanMetricsTableColumns)
+	overrides := make(map[string]KeyBinding, len(spansKeys))
+	for _, key := range spansKeys {
+		overrides[key.Name] = binding
+	}
+	return overrides
+}
+
+// spanStatusCodes maps the status names a filter carries to the integer codes
+// the status column stores.
+var spanStatusCodes = map[string]int8{
+	"unset": 0,
+	"ok":    1,
+	"error": 2,
+}
+
+// bindSpansKeyToColumns compares one key against the column expression the
+// mapping names for it.
+func bindSpansKeyToColumns(columns map[string]string) KeyBinding {
+	return func(condition Condition) (*sqlf.Stmt, error) {
+		column, ok := columns[condition.KeyName]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrKeyNotSupported, condition.KeyName)
+		}
+
+		if condition.KeyName == spanStatus.Name {
+			return bindSpanStatusCondition(column, condition)
+		}
+
+		switch condition.Operator {
+		case OperatorIn:
+			return sqlf.New(column+" in ?", condition.TextValues()), nil
+		case OperatorNotIn:
+			return sqlf.New(column+" not in ?", condition.TextValues()), nil
+		case OperatorContains:
+			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorStartsWith:
+			return sqlf.New(column+" ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		}
+
+		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+	}
+}
+
+func bindSpanStatusCondition(column string, condition Condition) (*sqlf.Stmt, error) {
+	codes := make([]int8, 0, len(condition.Values))
+	for _, name := range condition.TextValues() {
+		code, ok := spanStatusCodes[name]
+		if !ok {
+			return nil, fmt.Errorf("Key %q has no value %q", condition.KeyName, name)
+		}
+		codes = append(codes, code)
+	}
+
+	switch condition.Operator {
+	case OperatorIn:
+		return sqlf.New(column+" in ?", codes), nil
+	case OperatorNotIn:
+		return sqlf.New(column+" not in ?", codes), nil
+	}
+
+	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+}
+
+// fetchSpansKeySuggestions lists what one key can be set to, narrowed by what
+// has been typed. Values are read from the spans table in ClickHouse, most
+// recently seen first, asking for one row past the limit so it can report that
+// more matched without counting them.
+func fetchSpansKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	if len(key.EnumValues) > 0 {
+		return narrowEnumValues(key, valueRequest), nil
+	}
+
+	if key.ValueSuggestionMode == ValueSuggestionModeNone {
+		return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
+	}
+
+	if strings.HasPrefix(key.Name, CustomKeyPrefix) {
+		return fetchSpanCustomKeySuggestions(ctx, chPool, teamID, appID, key, valueRequest)
+	}
+
+	column, ok := spanFilterColumns[key.Name]
+	if !ok {
+		return ValueList{}, fmt.Errorf("%w: %q", ErrKeyNotSupported, key.Name)
+	}
+
+	limit := valueRequest.Limit
+	if limit <= 0 {
+		limit = DefaultValueLimit
+	}
+
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	// A span that did not carry an attribute holds an empty string in that
+	// column, so those rows are left out. Recency carries month granularity,
+	// so values seen in the same month order alphabetically.
+	stmt := sqlf.
+		From("span_filters").
+		Select(column+" as suggested_value").
+		Select("max(end_of_month) as recency").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		Where(column + " <> ''").
+		GroupBy("suggested_value").
+		OrderBy("recency desc, suggested_value").
+		Limit(limit + 1)
+
+	defer stmt.Close()
+
+	if valueRequest.Search != "" {
+		stmt.Where(column+" ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+	}
+
+	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+	defer rows.Close()
+
+	values := []Value{}
+	for rows.Next() {
+		var text string
+		var recency time.Time
+		if err := rows.Scan(&text, &recency); err != nil {
+			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+		}
+		values = append(values, Value{Text: text})
+	}
+	if err := rows.Err(); err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}, nil
+	}
+
+	return ValueList{Values: values}, nil
+}
+
+// The custom keys of spans are the user-defined attributes an app set on
+// its spans. The span_user_def_attrs table holds one row per span, attribute
+// and value, with the value of every type stored in one String column, and
+// each condition on one becomes a span_id membership subquery against it.
+// The attributes are read from ClickHouse, so the Postgres pool the entity
+// fields carry is unused here.
+
+// fetchSpanCustomKeys lists the filter keys for every user-defined attribute
+// of an app's spans, ordered by name. It asks for one key past the limit so
+// it can report that more exist without counting them.
+func fetchSpanCustomKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
+	stmt := spanCustomKeyQuery(teamID, appID).
+		Limit(limit + 1).
+		// Most granules hold rows of this team and app anyway, so skip
+		// indexes cost analysis without pruning reads.
+		Clause("settings use_skip_indexes = 0")
+
+	defer stmt.Close()
+
+	keys, err := readCustomKeys(ctx, chPool, teamID, stmt)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(keys) > limit {
+		return keys[:limit], true, nil
+	}
+	return keys, false, nil
+}
+
+// fetchSpanCustomKeysByName reads the filter keys for the named user-defined
+// span attributes of one app.
+func fetchSpanCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
+	if len(rawNames) == 0 {
+		return nil, nil
+	}
+
+	stmt := spanCustomKeyQuery(teamID, appID).
+		Where("key in ?", rawNames)
+
+	defer stmt.Close()
+
+	return readCustomKeys(ctx, chPool, teamID, stmt)
+}
+
+// spanCustomKeyQuery reads an app's user-defined span attribute keys with
+// their types. An attribute rewritten under a new type keeps one row per
+// type, so the type written last is the one its key offers.
+func spanCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
+	return sqlf.
+		From("span_user_def_attrs final").
+		Select("key").
+		Select("argMax(type, timestamp) as type").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		GroupBy("key").
+		OrderBy("key")
+}
+
+// fetchSpanCustomKeySuggestions lists what one user-defined attribute has
+// been set to, most recently written first, asking for one row past the limit
+// so it can report that more matched without counting them. Empty ones are left out.
+func fetchSpanCustomKeySuggestions(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	limit := valueRequest.Limit
+	if limit <= 0 {
+		limit = DefaultValueLimit
+	}
+
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	stmt := sqlf.
+		From("span_user_def_attrs").
+		Select("value").
+		Select("max(timestamp) as recency").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		Where("key = ?", strings.TrimPrefix(key.Name, CustomKeyPrefix)).
+		Where("type = ?", string(key.ValueType)).
+		Where("value <> ''").
+		GroupBy("value").
+		OrderBy("recency desc").
+		Limit(limit + 1)
+
+	defer stmt.Close()
+
+	if valueRequest.Search != "" {
+		stmt.Where("value ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+	}
+
+	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+	defer rows.Close()
+
+	values := []Value{}
+	for rows.Next() {
+		var text string
+		var recency time.Time
 		if err := rows.Scan(&text, &recency); err != nil {
 			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
 		}

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var allEntities = []Entity{BuildsEntity}
+var allEntities = []Entity{BuildsEntity, SpansEntity}
 
 func sampleValues(t *testing.T, key Key, operator Operator) []Value {
 	t.Helper()
@@ -213,6 +213,72 @@ func TestBuildsEntityOffersEveryBuildKey(t *testing.T) {
 		if _, ok := byName[name]; !ok {
 			t.Errorf("want a %q key on the builds entity", name)
 		}
+	}
+}
+
+func TestSpansEntityOffersEverySpanKey(t *testing.T) {
+	byName := IndexKeysByName(SpansEntity.Keys)
+
+	wanted := []string{
+		"version_name", "version_code", "span_status",
+		"os_name", "os_version",
+		"device_name", "device_manufacturer", "locale",
+		"network_type", "network_generation", "network_provider",
+		"country",
+	}
+	for _, name := range wanted {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("want a %q key on the spans entity", name)
+		}
+	}
+	if len(SpansEntity.Keys) != len(wanted) {
+		t.Errorf("want %d spans keys, got %d", len(wanted), len(SpansEntity.Keys))
+	}
+}
+
+func TestSpansBindKeyRefusesAKeyTheEntityDoesNotHave(t *testing.T) {
+	_, err := SpansEntity.BindKey(Condition{
+		KeyName:  "mapping_type",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "proguard"}},
+	})
+
+	if err == nil {
+		t.Fatal("want a key the spans entity does not have refused")
+	}
+	if !strings.Contains(err.Error(), "mapping_type") {
+		t.Errorf("want the key named, got %q", err)
+	}
+}
+
+func TestSpanStatusBindsTheColumnCodes(t *testing.T) {
+	stmt, err := SpansEntity.BindKey(Condition{
+		KeyName:  "span_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "unset"}, {Text: "error"}},
+	})
+	if err != nil {
+		t.Fatalf("bind span_status: %v", err)
+	}
+	defer stmt.Close()
+
+	if got := stmt.String(); got != "status in ?" {
+		t.Errorf("want the status column compared, got %q", got)
+	}
+	args := stmt.Args()
+	if len(args) != 1 {
+		t.Fatalf("want one bound argument, got %v", args)
+	}
+	if got, ok := args[0].([]int8); !ok || !slices.Equal(got, []int8{0, 2}) {
+		t.Errorf("want the codes [0 2] bound, got %v", args[0])
+	}
+
+	if _, err := SpansEntity.BindKey(Condition{
+		KeyName:  "span_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "cancelled"}},
+	}); err == nil {
+		t.Error("want a status name the column does not store refused")
 	}
 }
 

--- a/backend/libs/exprfilter/entity_values_test.go
+++ b/backend/libs/exprfilter/entity_values_test.go
@@ -11,31 +11,36 @@ import (
 
 	"backend/testinfra"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 var (
 	pgPool *pgxpool.Pool
+	chConn driver.Conn
 	th     *testinfra.TestHelper
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
-	pool, cleanup := testinfra.SetupPostgres(ctx)
+	pool, pgCleanup := testinfra.SetupPostgres(ctx)
 	pgPool = pool
-	th = testinfra.NewTestHelper(pool, nil, nil)
+	conn, chCleanup := testinfra.SetupClickHouse(ctx)
+	chConn = conn
+	th = testinfra.NewTestHelper(pool, conn, nil)
 
 	code := m.Run()
-	cleanup()
+	chCleanup()
+	pgCleanup()
 	os.Exit(code)
 }
 
-func seedBuilds(ctx context.Context, t *testing.T) (appID, otherAppID uuid.UUID, patchOne, patchTwo uuid.UUID) {
+func seedBuilds(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID, patchOne, patchTwo uuid.UUID) {
 	t.Helper()
 
-	teamID := uuid.New()
+	teamID = uuid.New()
 	appID = uuid.New()
 	otherAppID = uuid.New()
 	patchOne = uuid.New()
@@ -61,18 +66,18 @@ func seedBuilds(ctx context.Context, t *testing.T) (appID, otherAppID uuid.UUID,
 	// Another app's build, which must stay out of this app's lists.
 	th.SeedBuildMappingRow(ctx, t, uuid.NewString(), otherAppID.String(), "9.9.9", "9999", "proguard", "k6", noPatch, "", base)
 
-	return appID, otherAppID, patchOne, patchTwo
+	return teamID, appID, otherAppID, patchOne, patchTwo
 }
 
 func TestBuildsValues(t *testing.T) {
 	ctx := context.Background()
-	appID, otherAppID, patchOne, patchTwo := seedBuilds(ctx, t)
+	teamID, appID, otherAppID, patchOne, patchTwo := seedBuilds(ctx, t)
 
 	byName := IndexKeysByName(BuildsEntity.Keys)
 
 	list := func(t *testing.T, keyName string, valueRequest ValueRequest) ([]Value, bool) {
 		t.Helper()
-		valueList, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, appID, byName[keyName], valueRequest)
+		valueList, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, teamID, appID, byName[keyName], valueRequest)
 		if err != nil {
 			t.Fatalf("fetch values: %v", err)
 		}
@@ -115,7 +120,7 @@ func TestBuildsValues(t *testing.T) {
 			}
 		}
 
-		otherApp, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, otherAppID, byName["version_name"], ValueRequest{})
+		otherApp, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, teamID, otherAppID, byName["version_name"], ValueRequest{})
 		if err != nil {
 			t.Fatalf("fetch values: %v", err)
 		}
@@ -195,7 +200,188 @@ func TestBuildsValues(t *testing.T) {
 	})
 
 	t.Run("an app with no builds has no values", func(t *testing.T) {
-		emptyApp, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, uuid.New(), byName["version_name"], ValueRequest{})
+		emptyApp, err := BuildsEntity.SuggestKeyValues(ctx, pgPool, nil, teamID, uuid.New(), byName["version_name"], ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		if len(emptyApp.Values) != 0 {
+			t.Errorf("want no values, got %v", texts(emptyApp.Values))
+		}
+	})
+}
+
+func seedSpans(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+	otherAppID = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "span values team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "span values app", 90)
+	th.SeedApp(ctx, t, otherAppID.String(), teamID.String(), "another span app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	// The span_filters rollup keeps only spans carrying every attribute, so
+	// the suggestion fixtures set them all.
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		StartTime:          base,
+		OSName:             "Android",
+		OSVersion:          "14",
+		CountryCode:        "US",
+		NetworkProvider:    "T-Mobile",
+		NetworkType:        "cellular",
+		NetworkGeneration:  "5g",
+		DeviceLocale:       "en-US",
+		DeviceManufacturer: "Google",
+		DeviceName:         "pixel 4a",
+	})
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		StartTime:          base.Add(10 * time.Minute),
+		OSName:             "iOS",
+		OSVersion:          "17.4",
+		CountryCode:        "US",
+		NetworkProvider:    "Verizon",
+		NetworkType:        "wifi",
+		NetworkGeneration:  "5g",
+		DeviceLocale:       "en-US",
+		DeviceManufacturer: "Apple",
+		DeviceName:         "iPhone 15",
+	})
+	// A span whose SDK reported no device or country attributes.
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		StartTime: base.Add(20 * time.Minute),
+	})
+
+	// Another app's span, which must stay out of this app's lists.
+	th.SeedSpanRows(ctx, t, teamID.String(), otherAppID.String(), 1, testinfra.SpanRow{
+		StartTime:          base,
+		OSName:             "Android",
+		OSVersion:          "14",
+		CountryCode:        "US",
+		NetworkProvider:    "T-Mobile",
+		NetworkType:        "cellular",
+		NetworkGeneration:  "5g",
+		DeviceLocale:       "en-US",
+		DeviceManufacturer: "Samsung",
+		DeviceName:         "galaxy s24",
+	})
+
+	return teamID, appID, otherAppID
+}
+
+func TestSpansValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, otherAppID := seedSpans(ctx, t)
+
+	byName := IndexKeysByName(SpansEntity.Keys)
+
+	list := func(t *testing.T, keyName string, valueRequest ValueRequest) ([]Value, bool) {
+		t.Helper()
+		valueList, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName[keyName], valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		return valueList.Values, valueList.Truncated
+	}
+
+	texts := func(values []Value) []string {
+		out := make([]string, len(values))
+		for i, value := range values {
+			out[i] = value.Text
+		}
+		return out
+	}
+
+	t.Run("device names order by month seen, then by name", func(t *testing.T) {
+		// Both devices appear in the same month, so the alphabetical
+		// tiebreak orders them.
+		values, truncated := list(t, "device_name", ValueRequest{})
+		if truncated {
+			t.Error("want the whole list for two device names")
+		}
+		got := texts(values)
+		if len(got) != 2 || got[0] != "iPhone 15" || got[1] != "pixel 4a" {
+			t.Errorf("want [iPhone 15, pixel 4a], got %v", got)
+		}
+	})
+
+	t.Run("os names are read from the version tuple", func(t *testing.T) {
+		values, _ := list(t, "os_name", ValueRequest{})
+		got := texts(values)
+		// The span seeded with no attributes still carries the default os
+		// name, so both names are present.
+		if len(got) != 2 {
+			t.Errorf("want [Android iOS] in some order, got %v", got)
+		}
+	})
+
+	t.Run("a span without an attribute contributes no value", func(t *testing.T) {
+		values, _ := list(t, "country", ValueRequest{})
+		if got := texts(values); len(got) != 1 || got[0] != "US" {
+			t.Errorf("want only US, got %v", got)
+		}
+	})
+
+	t.Run("another app's spans stay out", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{})
+		for _, value := range texts(values) {
+			if value == "galaxy s24" {
+				t.Error("want another app's device out of this app's list")
+			}
+		}
+
+		otherApp, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, otherAppID, byName["device_name"], ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		if got := texts(otherApp.Values); len(got) != 1 || got[0] != "galaxy s24" {
+			t.Errorf("want the other app to see only its own device, got %v", got)
+		}
+	})
+
+	t.Run("typing narrows the list without regard to case", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{Search: "PIX"})
+		if got := texts(values); len(got) != 1 || got[0] != "pixel 4a" {
+			t.Errorf("want only pixel 4a, got %v", got)
+		}
+	})
+
+	t.Run("a percent sign is matched as literal text", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{Search: "%"})
+		if len(values) != 0 {
+			t.Errorf("want a literal percent sign to match nothing, got %v", texts(values))
+		}
+	})
+
+	t.Run("a limit reports that more matched", func(t *testing.T) {
+		values, truncated := list(t, "device_name", ValueRequest{Limit: 1})
+		if len(values) != 1 {
+			t.Errorf("want one value, got %v", texts(values))
+		}
+		if !truncated {
+			t.Error("want the picker told the list is partial")
+		}
+	})
+
+	t.Run("span statuses are the fixed set", func(t *testing.T) {
+		values, truncated := list(t, "span_status", ValueRequest{})
+		if truncated {
+			t.Error("want a fixed list reported whole")
+		}
+		if got := texts(values); len(got) != 3 || got[0] != "unset" || got[1] != "ok" || got[2] != "error" {
+			t.Errorf("want [unset ok error], got %v", got)
+		}
+
+		narrowed, _ := list(t, "span_status", ValueRequest{Search: "err"})
+		if got := texts(narrowed); len(got) != 1 || got[0] != "error" {
+			t.Errorf("want error, got %v", got)
+		}
+	})
+
+	t.Run("an app with no spans has no values", func(t *testing.T) {
+		emptyApp, err := SpansEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, uuid.New(), byName["device_name"], ValueRequest{})
 		if err != nil {
 			t.Fatalf("fetch values: %v", err)
 		}

--- a/backend/libs/exprfilter/exprfilter.go
+++ b/backend/libs/exprfilter/exprfilter.go
@@ -1,10 +1,18 @@
 package exprfilter
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
+	"backend/libs/chquery"
+	"backend/libs/config"
+	"backend/libs/logcomment"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 )
 
@@ -13,6 +21,21 @@ const DefaultDuration = time.Hour * 24 * 7
 const DefaultPaginationLimit = 10
 
 const MaxPaginationLimit = 1000
+
+// The granularities a plot endpoint can bucket its time axis by.
+const (
+	PlotTimeGroupMinutes = "minutes"
+	PlotTimeGroupHours   = "hours"
+	PlotTimeGroupDays    = "days"
+	PlotTimeGroupMonths  = "months"
+)
+
+var plotTimeGroups = []string{
+	PlotTimeGroupMinutes,
+	PlotTimeGroupHours,
+	PlotTimeGroupDays,
+	PlotTimeGroupMonths,
+}
 
 type ExprFilter struct {
 	AppID  uuid.UUID
@@ -27,6 +50,10 @@ type ExprFilter struct {
 
 	Limit  int `form:"limit"`
 	Offset int `form:"offset"`
+
+	// PlotTimeGroup is the time bucketing a plot endpoint groups by. Endpoints
+	// that do not plot leave it empty.
+	PlotTimeGroup string `form:"plot_time_group"`
 
 	// FilterExpr is the text form of the filter, as a link or an API request
 	// carries it. ExprTree is the parsed form.
@@ -43,7 +70,12 @@ func (ef *ExprFilter) HasTimeRange() bool {
 	return !ef.From.IsZero() && !ef.To.IsZero()
 }
 
-func (ef *ExprFilter) SetDefaultTimeRange() {
+// SetDefaultTimeRangeIfUnset fills the time range when the request gave neither
+// bound. A request giving only is left alone, so it can be rejected during validation.
+func (ef *ExprFilter) SetDefaultTimeRangeIfUnset() {
+	if !ef.From.IsZero() || !ef.To.IsZero() {
+		return
+	}
 	to := time.Now().UTC()
 	ef.From = to.Add(-DefaultDuration)
 	ef.To = to
@@ -89,6 +121,10 @@ func (ef *ExprFilter) Validate() error {
 		return errors.New("`offset` cannot be negative")
 	}
 
+	if ef.PlotTimeGroup != "" && !slices.Contains(plotTimeGroups, ef.PlotTimeGroup) {
+		return fmt.Errorf("`plot_time_group` must be one of: %s", strings.Join(plotTimeGroups, ", "))
+	}
+
 	if !ef.HasFilterExpr() {
 		return nil
 	}
@@ -98,4 +134,18 @@ func (ef *ExprFilter) Validate() error {
 	}
 
 	return ValidateFilterExpr(ef.ExprTree, IndexKeysByName(ef.Entity.Keys))
+}
+
+// WithFilterQuerySettings carries the ClickHouse settings for filter key and
+// value reads: a log comment specifying the query and, in release mode, a short
+// query cache, since the same lists are asked for on every picker open.
+func WithFilterQuerySettings(ctx context.Context, releaseMode, debugMode bool, queryName string) context.Context {
+	lc := logcomment.New(2)
+	settings := clickhouse.Settings{
+		"log_comment":       lc.MustPut(logcomment.Root, logcomment.Filters).String(),
+		"use_query_cache":   releaseMode,
+		"query_cache_ttl":   int(config.DefaultQueryCacheTTL.Seconds()),
+		"force_primary_key": debugMode,
+	}
+	return chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, queryName))
 }

--- a/backend/libs/exprfilter/exprfilter_test.go
+++ b/backend/libs/exprfilter/exprfilter_test.go
@@ -120,6 +120,23 @@ func TestExprFilterValidate(t *testing.T) {
 			wantErr: "`offset` cannot be negative",
 		},
 		{
+			name: "a valid plot time group",
+			build: func() *ExprFilter {
+				ef := base()
+				ef.PlotTimeGroup = PlotTimeGroupHours
+				return ef
+			},
+		},
+		{
+			name: "an unknown plot time group",
+			build: func() *ExprFilter {
+				ef := base()
+				ef.PlotTimeGroup = "weeks"
+				return ef
+			},
+			wantErr: "`plot_time_group` must be one of",
+		},
+		{
 			name: "a filter with no entity to check it against",
 			build: func() *ExprFilter {
 				ef := base()
@@ -205,7 +222,7 @@ func TestTimeRangeHelpers(t *testing.T) {
 		t.Error("want no range before one is set")
 	}
 
-	ef.SetDefaultTimeRange()
+	ef.SetDefaultTimeRangeIfUnset()
 
 	if !ef.HasTimeRange() {
 		t.Fatal("want a range after the default is set")
@@ -215,6 +232,12 @@ func TestTimeRangeHelpers(t *testing.T) {
 	}
 	if ef.To.After(time.Now().UTC().Add(time.Minute)) {
 		t.Error("want the range to end around now")
+	}
+
+	oneSided := &ExprFilter{From: time.Now().UTC().Add(-time.Hour)}
+	oneSided.SetDefaultTimeRangeIfUnset()
+	if !oneSided.To.IsZero() {
+		t.Error("want a one-sided range kept for Validate, got a default")
 	}
 }
 

--- a/backend/libs/exprfilter/predicate.go
+++ b/backend/libs/exprfilter/predicate.go
@@ -18,8 +18,8 @@ type KeyBinding func(condition Condition) (*sqlf.Stmt, error)
 //	defer predicate.Close()
 //	stmt.Where(predicate.String(), predicate.Args()...)
 //
-// keyBindingOverrides replaces the key binding for specific keys. Pass nil
-// when the entity's own binding should write every condition.
+// keyBindingOverrides replaces the key binding for specific keys; every other
+// key binds through the entity.
 func (ef *ExprFilter) Predicate(keyBindingOverrides map[string]KeyBinding) (*sqlf.Stmt, error) {
 	bindLeaf := func(condition Condition) (*sqlf.Stmt, error) {
 		if keyBinding, overridden := keyBindingOverrides[condition.KeyName]; overridden {

--- a/backend/libs/exprfilter/predicate_test.go
+++ b/backend/libs/exprfilter/predicate_test.go
@@ -56,7 +56,7 @@ func bindTestKey(condition Condition) (*sqlf.Stmt, error) {
 	return nil, fmt.Errorf("key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
 }
 
-func fetchTestKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+func fetchTestKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
 	return ValueList{}, nil
 }
 

--- a/backend/libs/exprfilter/testdata/filter_test_expr_cases.json
+++ b/backend/libs/exprfilter/testdata/filter_test_expr_cases.json
@@ -355,6 +355,40 @@
           }
         ]
       }
+    },
+    {
+      "name": "a user-defined attribute key carries the custom. prefix",
+      "text": "custom.is_premium:eq:true",
+      "tree": {
+        "condition": {
+          "key_name": "custom.is_premium",
+          "operator": "eq",
+          "values": [{ "text": "true" }]
+        }
+      }
+    },
+    {
+      "name": "a custom key beside a built-in key",
+      "text": "custom.plan:in:[pro,free] AND version_name:in:1.2.0",
+      "tree": {
+        "logical_operator": "and",
+        "children": [
+          {
+            "condition": {
+              "key_name": "custom.plan",
+              "operator": "in",
+              "values": [{ "text": "pro" }, { "text": "free" }]
+            }
+          },
+          {
+            "condition": {
+              "key_name": "version_name",
+              "operator": "in",
+              "values": [{ "text": "1.2.0" }]
+            }
+          }
+        ]
+      }
     }
   ],
 
@@ -455,6 +489,17 @@
       "name": "no values",
       "text": "patch_id:is_set",
       "tree": { "condition": { "key_name": "patch_id", "operator": "is_set" } }
+    },
+    {
+      "name": "a custom key keeps its prefix",
+      "text": "custom.is_premium:eq:true",
+      "tree": {
+        "condition": {
+          "key_name": "custom.is_premium",
+          "operator": "eq",
+          "values": [{ "text": "true" }]
+        }
+      }
     },
     {
       "name": "a group",

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -172,10 +172,6 @@ type AppFilter struct {
 	// data.
 	Builds bool `form:"builds"`
 
-	// SpanStatuses represents the list of status of
-	// a span to be filtered on.
-	SpanStatuses []int8 `form:"span_statuses"`
-
 	// BugReportStatuses represents the list of status of
 	// a bug report to be filtered on.
 	BugReportStatuses []int8 `form:"bug_report_statuses"`
@@ -473,12 +469,6 @@ func (af *AppFilter) Validate() error {
 		}
 	}
 
-	for _, status := range af.SpanStatuses {
-		if status < 0 || status > 2 {
-			return fmt.Errorf("`span_statuses` values must be 0 (Unset), 1 (Ok) or 2 (Error)")
-		}
-	}
-
 	if af.HasPlotTimeGroup() {
 		if _, ok := validPlotTimeGroups[af.PlotTimeGroup]; !ok {
 			return fmt.Errorf("`plot_time_group` must be one of: %s, %s, %s, %s", PlotTimeGroupMinutes, PlotTimeGroupHours, PlotTimeGroupDays, PlotTimeGroupMonths)
@@ -640,12 +630,6 @@ func (af *AppFilter) SetDefaultPlotTimeGroup() {
 // keyword was supplied.
 func (af AppFilter) HasFreeText() bool {
 	return af.FreeText != ""
-}
-
-// HasSpanStatuses returns true if at least
-// one span statuses are requested.
-func (af AppFilter) HasSpanStatuses() bool {
-	return len(af.SpanStatuses) > 0
 }
 
 // HasBugReportStatuses returns true if at least

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -14,6 +14,7 @@ import (
 	"backend/libs/chquery"
 	"backend/libs/config"
 	"backend/libs/event"
+	"backend/libs/exprfilter"
 	"backend/libs/filter"
 	"backend/libs/group"
 	"backend/libs/metrics"
@@ -265,7 +266,7 @@ func resolveErrorSources(af *filter.AppFilter) (queryANR, wantHandledTrue, wantH
 
 // applyExceptionSeverityFilter adds a WHERE clause to s restricting events to
 // those matching severities. Bridges new data (exception.severity populated)
-// and legacy data (exception.severity = '', falls back to exception.handled).
+// and legacy data (exception.severity not present, falls back to exception.handled).
 // Legacy mapping: handled=false matches both fatal and unhandled
 // (indistinguishable in legacy data); handled=true matches handled.
 //
@@ -2273,9 +2274,10 @@ func (a App) FetchTracesForSessionId(ctx context.Context, rch driver.Conn, sessi
 	return
 }
 
-// GetSpansForSpanNameWithFilter provides list of spans for the given span name that matches various
-// filter criteria in a paginated fashion.
-func (a App) GetSpansForSpanNameWithFilter(ctx context.Context, rch driver.Conn, spanName string, af *filter.AppFilter) (rootSpans []span.RootSpanDisplay, next, previous bool, err error) {
+// GetSpansForSpanNameWithFilter provides the list of spans for the given
+// span name that matches the filter expression, newest first, in a paginated
+// fashion.
+func (a App) GetSpansForSpanNameWithFilter(ctx context.Context, rch driver.Conn, spanName string, ef *exprfilter.ExprFilter) (rootSpans []span.RootSpanDisplay, next, previous bool, err error) {
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
 	stmt := sqlf.
 		From("spans final").
@@ -2295,95 +2297,29 @@ func (a App) GetSpansForSpanNameWithFilter(ctx context.Context, rch driver.Conn,
 		Where("team_id = toUUID(?)", a.TeamId).
 		Where("app_id = toUUID(?)", a.ID).
 		Where("span_name = ?", spanName).
-		Where("start_time >= ? and end_time <= ?", af.From, af.To)
+		Where("start_time >= ? and end_time <= ?", ef.From, ef.To)
 
-	if af.HasSpanStatuses() {
-		stmt.Where("status").In(af.SpanStatuses)
-	}
+	defer stmt.Close()
 
-	if af.HasVersions() {
-		stmt.Where("`attribute.app_version`.1 in ?", af.Versions)
-		stmt.Where("`attribute.app_version`.2 in ?", af.VersionCodes)
-	}
-
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err != nil {
-			return rootSpans, next, previous, err
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(nil)
+		if errPredicate != nil {
+			err = errPredicate
+			return
 		}
-
-		stmt.Where("attribute.os_version in (?)", selectedOSVersions.Parameterize())
-	}
-
-	if af.HasCountries() {
-		stmt.Where("attribute.country_code in ?", af.Countries)
-	}
-
-	if af.HasNetworkProviders() {
-		stmt.Where("attribute.network_provider in ?", af.NetworkProviders)
-	}
-
-	if af.HasNetworkTypes() {
-		stmt.Where("attribute.network_type in ?", af.NetworkTypes)
-	}
-
-	if af.HasNetworkGenerations() {
-		stmt.Where("attribute.network_generation in ?", af.NetworkGenerations)
-	}
-
-	if af.HasDeviceLocales() {
-		stmt.Where("attribute.device_locale in ?", af.Locales)
-	}
-
-	if af.HasDeviceManufacturers() {
-		stmt.Where("attribute.device_manufacturer in ?", af.DeviceManufacturers)
-	}
-
-	if af.HasDeviceNames() {
-		stmt.Where("attribute.device_name in ?", af.DeviceNames)
-	}
-
-	if af.HasUDExpression() && !af.UDExpression.Empty() {
-		subQuery := sqlf.
-			From("span_user_def_attrs").
-			Select("span_id").
-			Where("team_id = toUUID(?)", a.TeamId).
-			Where("app_id = toUUID(?)", a.ID).
-			Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
-
-		if af.HasVersions() {
-			subQuery.
-				Where("app_version.1 in ?", af.Versions).
-				Where("app_version.2 in ?", af.VersionCodes)
-		}
-
-		if af.HasOSVersions() {
-			selectedOSVersions, errVersions := af.OSVersionPairs()
-			if err != nil {
-				err = errVersions
-				return
-			}
-
-			subQuery.
-				Where("os_version in (?)", selectedOSVersions.Parameterize())
-		}
-
-		af.UDExpression.Augment(subQuery)
-		subQuery.GroupBy("span_id")
-		stmt.SubQuery("span_id in (", ")", subQuery)
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
 	}
 
 	stmt.OrderBy("start_time desc")
 
-	if af.Limit > 0 {
-		stmt.Limit(uint64(af.Limit) + 1)
+	if ef.Limit > 0 {
+		stmt.Limit(uint64(ef.Limit) + 1)
 	}
 
-	if af.Offset >= 0 {
-		stmt.Offset(uint64(af.Offset))
+	if ef.Offset >= 0 {
+		stmt.Offset(uint64(ef.Offset))
 	}
-
-	defer stmt.Close()
 
 	rows, err := rch.Query(ctx, stmt.String(), stmt.Args()...)
 	if err != nil {
@@ -2400,45 +2336,45 @@ func (a App) GetSpansForSpanNameWithFilter(ctx context.Context, rch driver.Conn,
 			return
 		}
 
-		if err = rows.Err(); err != nil {
-			return
-		}
-
 		rootSpan.Duration = time.Duration(rootSpan.EndTime.Sub(rootSpan.StartTime).Milliseconds())
 
 		rootSpans = append(rootSpans, rootSpan)
 	}
 
-	err = rows.Err()
+	if err = rows.Err(); err != nil {
+		return
+	}
 
 	resultLen := len(rootSpans)
 
 	// Set pagination next & previous flags
-	if resultLen > af.Limit {
+	if resultLen > ef.Limit {
 		rootSpans = rootSpans[:resultLen-1]
 		next = true
 	}
-	if af.Offset > 0 {
+	if ef.Offset > 0 {
 		previous = true
 	}
 
 	return
 }
 
-// GetMetricsPlotForSpanNameWithFilter provides p50, p90, p95 and p99 duration metrics
-// for the given span name with the applied filtering criteria
-func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver.Conn, spanName string, af *filter.AppFilter) (spanMetricsPlotInstances []span.SpanMetricsPlotInstance, err error) {
+// GetMetricsPlotForSpanNameWithFilter provides p50, p90, p95 and p99
+// duration metrics for the given span name that matches the filter
+// expression.
+func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver.Conn, spanName string, ef *exprfilter.ExprFilter) (spanMetricsPlotInstances []span.SpanMetricsPlotInstance, err error) {
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
-	if !af.HasTimezone() {
+	if ef.Timezone == "" {
 		err = fmt.Errorf("timezone is required")
 		return
 	}
 
-	if !af.HasPlotTimeGroup() {
-		af.SetDefaultPlotTimeGroup()
+	plotTimeGroup := ef.PlotTimeGroup
+	if plotTimeGroup == "" {
+		plotTimeGroup = exprfilter.PlotTimeGroupDays
 	}
 
-	groupExpr, err := GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	groupExpr, err := GetPlotTimeGroupExpr("timestamp", plotTimeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -2446,7 +2382,7 @@ func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver
 	stmt := sqlf.
 		From("span_metrics").
 		Select("concat(tupleElement(app_version, 1), ' ', '(', tupleElement(app_version, 2), ')') app_version_fmt").
-		Select(groupExpr.BucketExpr+" as datetime_bucket", af.Timezone).
+		Select(groupExpr.BucketExpr+" as datetime_bucket", ef.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", groupExpr.DatetimeFormat).
 		Select("round(quantileMerge(0.50)(p50), 2) as p50").
 		Select("round(quantileMerge(0.90)(p90), 2) as p90").
@@ -2455,88 +2391,21 @@ func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver
 		Where("team_id = toUUID(?)", a.TeamId).
 		Where("app_id = toUUID(?)", a.ID).
 		Where("span_name = ?", spanName).
-		Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
+		Where("timestamp >= ? and timestamp <= ?", ef.From, ef.To)
 
-	if af.HasVersions() {
-		stmt.Where("app_version.1 in ?", af.Versions)
-		stmt.Where("app_version.2 in ?", af.VersionCodes)
-	}
+	defer stmt.Close()
 
-	if af.HasSpanStatuses() {
-		stmt.Where("status").In(af.SpanStatuses)
-	}
-
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err != nil {
-			return nil, err
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(exprfilter.SpanMetricsKeyBindings())
+		if errPredicate != nil {
+			return nil, errPredicate
 		}
-
-		stmt.Where("os_version in (?)", selectedOSVersions.Parameterize())
-	}
-
-	if af.HasCountries() {
-		stmt.Where("country_code in ?", af.Countries)
-	}
-
-	if af.HasNetworkProviders() {
-		stmt.Where("network_provider in ?", af.NetworkProviders)
-	}
-
-	if af.HasNetworkTypes() {
-		stmt.Where("network_type in ?", af.NetworkTypes)
-	}
-
-	if af.HasNetworkGenerations() {
-		stmt.Where("network_generation in ?", af.NetworkGenerations)
-	}
-
-	if af.HasDeviceLocales() {
-		stmt.Where("device_locale in ?", af.Locales)
-	}
-
-	if af.HasDeviceManufacturers() {
-		stmt.Where("device_manufacturer in ?", af.DeviceManufacturers)
-	}
-
-	if af.HasDeviceNames() {
-		stmt.Where("device_name in ?", af.DeviceNames)
-	}
-
-	if af.HasUDExpression() && !af.UDExpression.Empty() {
-		subQuery := sqlf.
-			From("span_user_def_attrs").
-			Select("span_id").
-			Where("team_id = toUUID(?)", a.TeamId).
-			Where("app_id = toUUID(?)", a.ID).
-			Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
-
-		if af.HasVersions() {
-			subQuery.
-				Where("app_version.1 in ?", af.Versions).
-				Where("app_version.2 in ?", af.VersionCodes)
-		}
-
-		if af.HasOSVersions() {
-			selectedOSVersions, errVersions := af.OSVersionPairs()
-			if err != nil {
-				err = errVersions
-				return
-			}
-
-			subQuery.
-				Where("os_version in (?)", selectedOSVersions.Parameterize())
-		}
-
-		af.UDExpression.Augment(subQuery)
-		subQuery.GroupBy("span_id")
-		stmt.SubQuery("span_id in (", ")", subQuery)
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
 	}
 
 	stmt.GroupBy("app_version, datetime_bucket")
 	stmt.OrderBy("datetime_bucket, tupleElement(app_version, 2) desc")
-
-	defer stmt.Close()
 
 	rows, err := rch.Query(ctx, stmt.String(), stmt.Args()...)
 	if err != nil {

--- a/backend/libs/measure/plot_test.go
+++ b/backend/libs/measure/plot_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"backend/libs/exprfilter"
 	"backend/libs/filter"
 	"backend/libs/session"
 	"backend/libs/span"
@@ -57,6 +58,19 @@ func (f plotFixture) appFilter(from, to time.Time, timezone, plotTimeGroup strin
 		af.PlotTimeGroup = plotTimeGroup
 	}
 	return af
+}
+
+func (f plotFixture) spanExprFilter(from, to time.Time, timezone, plotTimeGroup string) *exprfilter.ExprFilter {
+	return &exprfilter.ExprFilter{
+		AppID:         f.appID,
+		TeamID:        f.teamID,
+		Entity:        exprfilter.SpansEntity,
+		From:          from,
+		To:            to,
+		Timezone:      timezone,
+		Limit:         exprfilter.DefaultPaginationLimit,
+		PlotTimeGroup: plotTimeGroup,
+	}
 }
 
 func (f plotFixture) teamIDStr() string { return f.teamID.String() }
@@ -119,7 +133,6 @@ func TestPlotMethodsGroupByPlotTimeGroup(t *testing.T) {
 	}
 
 	for _, tc := range groups {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cleanupAll(f.ctx, t)
 
@@ -144,7 +157,7 @@ func TestPlotMethodsGroupByPlotTimeGroup(t *testing.T) {
 				cleanupAll(f.ctx, t)
 
 				spanTimes := spanMetricTimesForGroup(tc.group)
-				afSpan := f.appFilter(spanTimes[0].Add(-time.Hour), spanTimes[len(spanTimes)-1].Add(time.Hour), "UTC", tc.group)
+				efSpan := f.spanExprFilter(spanTimes[0].Add(-time.Hour), spanTimes[len(spanTimes)-1].Add(time.Hour), "UTC", tc.group)
 				for _, ts := range spanTimes {
 					seedSpan(
 						f.ctx, t, f.teamIDStr(), f.appIDStr(),
@@ -154,7 +167,7 @@ func TestPlotMethodsGroupByPlotTimeGroup(t *testing.T) {
 					)
 				}
 
-				items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", afSpan)
+				items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", efSpan)
 				if err != nil {
 					t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 				}
@@ -196,9 +209,6 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
 			t.Fatalf("expected error for missing timezone in bug report plot")
 		}
-		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af); err == nil {
-			t.Fatalf("expected error for missing timezone in span metrics plot")
-		}
 	})
 
 	t.Run("unsupported plot_time_group returns error", func(t *testing.T) {
@@ -208,9 +218,6 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 		}
 		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
 			t.Fatalf("expected error for unsupported plot_time_group in bug report plot")
-		}
-		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af); err == nil {
-			t.Fatalf("expected error for unsupported plot_time_group in span metrics plot")
 		}
 	})
 
@@ -225,7 +232,7 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 			t.Fatalf("expected empty sessions plot, got %d rows", len(sessions))
 		}
 
-		spans, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+		spans, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", f.spanExprFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupDays))
 		if err != nil {
 			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 		}
@@ -267,8 +274,8 @@ func TestNonExceptionPlotsRespectTimezoneBucketing(t *testing.T) {
 	t.Run("span metrics", func(t *testing.T) {
 		cleanupAll(f.ctx, t)
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, ts, ts.Add(750*time.Millisecond), "v1", "1")
-		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
-		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+		ef := f.spanExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", exprfilter.PlotTimeGroupDays)
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
 		if err != nil {
 			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 		}
@@ -308,8 +315,8 @@ func TestPlotMethodsDefaultToDaysWhenPlotTimeGroupMissing(t *testing.T) {
 		cleanupAll(f.ctx, t)
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, t1, t1.Add(time.Second), "v1", "1")
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, t2, t2.Add(time.Second), "v1", "1")
-		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
-		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+		ef := f.spanExprFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
 		if err != nil {
 			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 		}
@@ -336,30 +343,6 @@ func TestPlotMethodsDefaultToDaysWhenPlotTimeGroupMissing(t *testing.T) {
 func TestPlotMethodsRespectOptionalFilters(t *testing.T) {
 	f := newPlotFixture(t)
 	now := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
-
-	t.Run("span status filter", func(t *testing.T) {
-		cleanupAll(f.ctx, t)
-		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, now, now.Add(time.Second), "v1", "1")
-
-		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
-		af.SpanStatuses = []int8{1}
-		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
-		if err != nil {
-			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
-		}
-		if len(items) == 0 {
-			t.Fatalf("expected non-empty span metrics for matching status")
-		}
-
-		af.SpanStatuses = []int8{2}
-		items, err = f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
-		if err != nil {
-			t.Fatalf("GetMetricsPlotForSpanNameWithFilter mismatch status: %v", err)
-		}
-		if len(items) != 0 {
-			t.Fatalf("expected empty span metrics for non-matching status")
-		}
-	})
 
 	t.Run("bug report status filter", func(t *testing.T) {
 		cleanupAll(f.ctx, t)
@@ -396,14 +379,14 @@ func TestSpanMetricsPlotQuantilesForUniformDurations(t *testing.T) {
 
 	// Same duration for all rows in one bucket/version should make all quantiles
 	// collapse to the same value.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		start := base.Add(time.Duration(i) * time.Minute)
 		end := start.Add(3 * time.Second)
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, end, "v1", "1")
 	}
 
-	af := f.appFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", filter.PlotTimeGroupHours)
-	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+	ef := f.spanExprFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupHours)
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
 	if err != nil {
 		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 	}
@@ -430,20 +413,20 @@ func TestSpanMetricsPlotQuantilesAreMonotonicAndVersionIsolated(t *testing.T) {
 	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
 
 	// Version v1 has lower uniform durations.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		secs := 2
 		start := base.Add(time.Duration(secs) * time.Minute)
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, start.Add(time.Duration(secs)*time.Second), "v1", "1")
 	}
 	// Version v2 has higher uniform durations.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		secs := 8
 		start := base.Add(time.Duration(secs) * time.Minute)
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, start, start.Add(time.Duration(secs)*time.Second), "v2", "2")
 	}
 
-	af := f.appFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", filter.PlotTimeGroupHours)
-	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+	ef := f.spanExprFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupHours)
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
 	if err != nil {
 		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 	}
@@ -498,13 +481,13 @@ func TestSpanMetricsPlotQuantilesForSkewedDistribution(t *testing.T) {
 	// 101 spans with durations 1s..101s in a single version and 15-minute
 	// bucket. Sorted durations are v[Rank] = (Rank+1)*1000ms, and ClickHouse's
 	// quantile lands on v[level*100], giving exact, non-interpolated percentiles.
-	for i := 0; i < 101; i++ {
+	for i := range 101 {
 		dur := time.Duration(i+1) * time.Second
 		seedSpan(f.ctx, t, f.teamIDStr(), f.appIDStr(), "http_request", 1, base, base.Add(dur), "v1", "1")
 	}
 
-	af := f.appFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", filter.PlotTimeGroupHours)
-	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", af)
+	ef := f.spanExprFilter(base.Add(-time.Hour), base.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupHours)
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
 	if err != nil {
 		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
 	}

--- a/backend/libs/measure/span_test.go
+++ b/backend/libs/measure/span_test.go
@@ -1,0 +1,512 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"backend/libs/exprfilter"
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+type spanFixture struct {
+	ctx    context.Context
+	teamID uuid.UUID
+	appID  uuid.UUID
+	app    App
+}
+
+// newSpanFixture seeds two http_request spans for one app: version v1 on
+// an Android Google Pixel with an ok status, and ten minutes later version v2
+// on an iOS Apple iPhone with an error status. A span of another name and a
+// span of another app are seeded too, which every query must leave out.
+func newSpanFixture(t *testing.T) (spanFixture, time.Time) {
+	t.Helper()
+
+	ctx := context.Background()
+	cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	otherAppID := uuid.New()
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		SpanName:           "http_request",
+		Status:             1,
+		StartTime:          base,
+		AppVersion:         "v1",
+		AppBuild:           "1",
+		OSName:             "Android",
+		OSVersion:          "14",
+		CountryCode:        "US",
+		NetworkType:        "wifi",
+		DeviceManufacturer: "Google",
+		DeviceName:         "pixel 4a",
+	})
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		SpanName:           "http_request",
+		Status:             2,
+		StartTime:          base.Add(10 * time.Minute),
+		AppVersion:         "v2",
+		AppBuild:           "2",
+		OSName:             "iOS",
+		OSVersion:          "17.4",
+		CountryCode:        "IN",
+		NetworkType:        "cellular",
+		DeviceManufacturer: "Apple",
+		DeviceName:         "iPhone 15",
+	})
+	th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
+		SpanName:  "db_query",
+		Status:    1,
+		StartTime: base,
+	})
+	th.SeedSpanRows(ctx, t, teamID.String(), otherAppID.String(), 1, testinfra.SpanRow{
+		SpanName:  "http_request",
+		Status:    1,
+		StartTime: base,
+	})
+
+	return spanFixture{
+		ctx:    ctx,
+		teamID: teamID,
+		appID:  appID,
+		app:    App{ID: &appID, TeamId: teamID},
+	}, base
+}
+
+func (f spanFixture) exprFilter(from, to time.Time, exprTree *exprfilter.ExprTree) *exprfilter.ExprFilter {
+	return &exprfilter.ExprFilter{
+		AppID:    f.appID,
+		TeamID:   f.teamID,
+		Entity:   exprfilter.SpansEntity,
+		From:     from,
+		To:       to,
+		Timezone: "UTC",
+		Limit:    10,
+		ExprTree: exprTree,
+	}
+}
+
+func spanVersions(t *testing.T, ef *exprfilter.ExprFilter, f spanFixture) []string {
+	t.Helper()
+	spans, _, _, err := f.app.GetSpansForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+	if err != nil {
+		t.Fatalf("GetSpansForSpanNameWithFilter: %v", err)
+	}
+	versions := make([]string, len(spans))
+	for i, s := range spans {
+		versions[i] = s.AppVersion
+	}
+	return versions
+}
+
+func TestGetSpansForSpanNameWithFilter(t *testing.T) {
+	f, base := newSpanFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	t.Run("no filter returns the named spans newest first", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		got := spanVersions(t, ef, f)
+		if len(got) != 2 || got[0] != "v2" || got[1] != "v1" {
+			t.Fatalf("want [v2 v1], got %v", got)
+		}
+	})
+
+	t.Run("version filter", func(t *testing.T) {
+		exprTree := leaf("version_name", exprfilter.OperatorIn, "v1")
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("status filter translates names to codes", func(t *testing.T) {
+		exprTree := leaf("span_status", exprfilter.OperatorIn, "error")
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("os name filter reads the version tuple", func(t *testing.T) {
+		exprTree := leaf("os_name", exprfilter.OperatorIn, "iOS")
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("device name substring match", func(t *testing.T) {
+		exprTree := leaf("device_name", exprfilter.OperatorContains, "phone")
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("or group matches either side", func(t *testing.T) {
+		exprTree := exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalOr, Children: []exprfilter.ExprTree{
+			leaf("version_name", exprfilter.OperatorIn, "v1"),
+			leaf("span_status", exprfilter.OperatorIn, "error"),
+		}}
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 2 {
+			t.Fatalf("want both spans, got %v", got)
+		}
+	})
+
+	t.Run("a filter matching nothing", func(t *testing.T) {
+		exprTree := leaf("network_type", exprfilter.OperatorIn, "vpn")
+		got := spanVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 0 {
+			t.Fatalf("want no spans, got %v", got)
+		}
+	})
+
+	t.Run("pagination flags", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.Limit = 1
+
+		spans, next, previous, err := f.app.GetSpansForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+		if err != nil {
+			t.Fatalf("GetSpansForSpanNameWithFilter: %v", err)
+		}
+		if len(spans) != 1 || !next || previous {
+			t.Fatalf("want the first page with more to come, got %d spans next=%v previous=%v", len(spans), next, previous)
+		}
+
+		ef.Offset = 1
+		spans, next, previous, err = f.app.GetSpansForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+		if err != nil {
+			t.Fatalf("GetSpansForSpanNameWithFilter: %v", err)
+		}
+		if len(spans) != 1 || next || !previous {
+			t.Fatalf("want the last page with one before it, got %d spans next=%v previous=%v", len(spans), next, previous)
+		}
+	})
+}
+
+func metricsVersions(t *testing.T, ef *exprfilter.ExprFilter, f spanFixture, plotTimeGroup string) map[string]bool {
+	t.Helper()
+	ef.PlotTimeGroup = plotTimeGroup
+	items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+	if err != nil {
+		t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+	}
+	versions := map[string]bool{}
+	for _, item := range items {
+		versions[item.Version] = true
+	}
+	return versions
+}
+
+func TestGetMetricsPlotForSpanNameWithFilter(t *testing.T) {
+	f, base := newSpanFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	t.Run("no filter returns one row per version", func(t *testing.T) {
+		got := metricsVersions(t, f.exprFilter(from, to, nil), f, exprfilter.PlotTimeGroupDays)
+		if len(got) != 2 || !got["v1 (1)"] || !got["v2 (2)"] {
+			t.Fatalf("want v1 (1) and v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("device name filter binds the rollup's flat column", func(t *testing.T) {
+		exprTree := leaf("device_name", exprfilter.OperatorIn, "pixel 4a")
+		got := metricsVersions(t, f.exprFilter(from, to, &exprTree), f, exprfilter.PlotTimeGroupDays)
+		if len(got) != 1 || !got["v1 (1)"] {
+			t.Fatalf("want only v1 (1), got %v", got)
+		}
+	})
+
+	t.Run("os name filter reads the rollup's version tuple", func(t *testing.T) {
+		exprTree := leaf("os_name", exprfilter.OperatorIn, "iOS")
+		got := metricsVersions(t, f.exprFilter(from, to, &exprTree), f, exprfilter.PlotTimeGroupDays)
+		if len(got) != 1 || !got["v2 (2)"] {
+			t.Fatalf("want only v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("status filter translates names to codes", func(t *testing.T) {
+		exprTree := leaf("span_status", exprfilter.OperatorIn, "error")
+		got := metricsVersions(t, f.exprFilter(from, to, &exprTree), f, exprfilter.PlotTimeGroupDays)
+		if len(got) != 1 || !got["v2 (2)"] {
+			t.Fatalf("want only v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("an empty plot time group defaults to days", func(t *testing.T) {
+		got := metricsVersions(t, f.exprFilter(from, to, nil), f, "")
+		if len(got) != 2 {
+			t.Fatalf("want both versions, got %v", got)
+		}
+	})
+
+	t.Run("missing timezone returns an error", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.Timezone = ""
+		ef.PlotTimeGroup = exprfilter.PlotTimeGroupDays
+		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef); err == nil {
+			t.Fatal("want an error for a missing timezone")
+		}
+	})
+
+	t.Run("unsupported plot time group returns an error", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.PlotTimeGroup = "weeks"
+		if _, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef); err == nil {
+			t.Fatal("want an error for an unsupported plot time group")
+		}
+	})
+}
+
+func newCustomKeySpanFixture(t *testing.T) (spanFixture, time.Time) {
+	t.Helper()
+
+	f, base := newSpanFixture(t)
+	spanOne, spanTwo := "1111111111111111", "2222222222222222"
+
+	th.SeedSpanRows(f.ctx, t, f.teamID.String(), f.appID.String(), 1, testinfra.SpanRow{
+		SpanName:   "http_request",
+		SpanID:     spanOne,
+		StartTime:  base,
+		AppVersion: "v1",
+		AppBuild:   "1",
+	})
+	th.SeedSpanRows(f.ctx, t, f.teamID.String(), f.appID.String(), 1, testinfra.SpanRow{
+		SpanName:   "http_request",
+		SpanID:     spanTwo,
+		StartTime:  base.Add(10 * time.Minute),
+		AppVersion: "v2",
+		AppBuild:   "2",
+	})
+
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "plan", Value: "pro", Timestamp: base})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "retries", Type: "int64", Value: "9", Timestamp: base})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "is_premium", Type: "bool", Value: "true", Timestamp: base})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "coupon", Value: "WELCOME", Timestamp: base})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "plan", Value: "free", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "retries", Type: "int64", Value: "10", Timestamp: base.Add(10 * time.Minute)})
+	// The badge attribute changes type over time: the older row is a string,
+	// the newer a bool, so the key resolves as bool.
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "badge", Value: "gold", Timestamp: base})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "badge", Type: "bool", Value: "true", Timestamp: base.Add(10 * time.Minute)})
+
+	return f, base
+}
+
+// resolveCustomKeys runs the same steps a handler does for a filter that may
+// mention user-defined attribute keys: read the mentioned keys, then validate
+// against the widened key set.
+func resolveCustomKeys(t *testing.T, ef *exprfilter.ExprFilter) {
+	t.Helper()
+	if err := ef.ResolveCustomKeys(context.Background(), deps.RchPool); err != nil {
+		t.Fatalf("ResolveCustomKeys: %v", err)
+	}
+	if err := ef.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestGetSpansForSpanNameWithCustomKeys(t *testing.T) {
+	f, base := newCustomKeySpanFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	// The unpinned spans of newSpanFixture carry no attributes, so a custom
+	// condition matching both attributed spans still returns two of the four.
+	listVersions := func(t *testing.T, exprTree exprfilter.ExprTree) []string {
+		t.Helper()
+		ef := f.exprFilter(from, to, &exprTree)
+		resolveCustomKeys(t, ef)
+		spans, _, _, err := f.app.GetSpansForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+		if err != nil {
+			t.Fatalf("GetSpansForSpanNameWithFilter: %v", err)
+		}
+		versions := make([]string, len(spans))
+		for i, s := range spans {
+			versions[i] = s.AppVersion
+		}
+		return versions
+	}
+
+	t.Run("string value narrows to its span", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.plan", exprfilter.OperatorIn, "pro"))
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("a list of string values matches each", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.plan", exprfilter.OperatorIn, "pro", "free"))
+		if len(got) != 2 {
+			t.Fatalf("want both attributed spans, got %v", got)
+		}
+	})
+
+	t.Run("numbers compare as numbers", func(t *testing.T) {
+		// As text, "10" orders before "9"; the cast compares them as numbers.
+		got := listVersions(t, leaf("custom.retries", exprfilter.OperatorGt, "9"))
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+
+		got = listVersions(t, leaf("custom.retries", exprfilter.OperatorGt, "5"))
+		if len(got) != 2 {
+			t.Fatalf("want both attributed spans, got %v", got)
+		}
+	})
+
+	t.Run("bool value narrows to its span", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.is_premium", exprfilter.OperatorEq, "true"))
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("is_set matches spans carrying the attribute", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.coupon", exprfilter.OperatorIsSet))
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("is_not_set matches spans without the attribute", func(t *testing.T) {
+		// Of the four http_request spans, only the attributed v1 span carries
+		// the coupon attribute, so the other three remain: the attributed v2
+		// span and the two unattributed spans of the base fixture.
+		got := listVersions(t, leaf("custom.coupon", exprfilter.OperatorIsNotSet))
+		if len(got) != 3 {
+			t.Fatalf("want the three spans without the attribute, got %v", got)
+		}
+	})
+
+	t.Run("not_in also matches spans without the attribute", func(t *testing.T) {
+		// Of the four http_request spans, only the pro span is excluded: the
+		// free span and the two unattributed spans of the base fixture stay,
+		// like a fixed key's empty column value would.
+		got := listVersions(t, leaf("custom.plan", exprfilter.OperatorNotIn, "pro"))
+		if len(got) != 3 {
+			t.Fatalf("want the three spans without plan pro, got %v", got)
+		}
+	})
+
+	t.Run("is_set matches every type the attribute was written under", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.badge", exprfilter.OperatorIsSet))
+		if len(got) != 2 {
+			t.Fatalf("want the string-typed and bool-typed spans, got %v", got)
+		}
+	})
+
+	t.Run("a custom key beside a built-in key", func(t *testing.T) {
+		got := listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("version_name", exprfilter.OperatorIn, "v1"),
+		}})
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+
+		got = listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("version_name", exprfilter.OperatorIn, "v2"),
+		}})
+		if len(got) != 0 {
+			t.Fatalf("want no spans, got %v", got)
+		}
+	})
+
+	t.Run("a custom key inside an or group", func(t *testing.T) {
+		got := listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalOr, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "free"),
+			leaf("version_name", exprfilter.OperatorIn, "v1"),
+		}})
+		if len(got) != 3 {
+			t.Fatalf("want the free span and both v1 spans, got %v", got)
+		}
+	})
+
+	t.Run("an unknown custom key fails validation", func(t *testing.T) {
+		exprTree := leaf("custom.nope", exprfilter.OperatorIn, "x")
+		ef := f.exprFilter(from, to, &exprTree)
+		if err := ef.ResolveCustomKeys(context.Background(), deps.RchPool); err != nil {
+			t.Fatalf("ResolveCustomKeys: %v", err)
+		}
+		err := ef.Validate()
+		if err == nil {
+			t.Fatal("want validation to refuse a key the app's spans never reported")
+		}
+		if !strings.Contains(err.Error(), "custom.nope") {
+			t.Errorf("want the key named, got %q", err)
+		}
+	})
+}
+
+func TestGetMetricsPlotForSpanNameWithCustomKeys(t *testing.T) {
+	f, base := newCustomKeySpanFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	plotVersions := func(t *testing.T, exprTree exprfilter.ExprTree) map[string]bool {
+		t.Helper()
+		ef := f.exprFilter(from, to, &exprTree)
+		ef.PlotTimeGroup = exprfilter.PlotTimeGroupDays
+		resolveCustomKeys(t, ef)
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		versions := map[string]bool{}
+		for _, item := range items {
+			versions[item.Version] = true
+		}
+		return versions
+	}
+
+	t.Run("an edge span keeps its attributes visible", func(t *testing.T) {
+		// v2 starts 10 minutes after base, so it belongs to the 10:00 bucket.
+		// The query ends 5 minutes after base, before v2's attributes end.
+		// The v2 series should still be included because its bucket overlaps
+		// the plot range.
+		exprTree := leaf("custom.plan", exprfilter.OperatorIn, "free")
+		ef := f.exprFilter(from, base.Add(5*time.Minute), &exprTree)
+		ef.PlotTimeGroup = exprfilter.PlotTimeGroupDays
+		resolveCustomKeys(t, ef)
+		items, err := f.app.GetMetricsPlotForSpanNameWithFilter(f.ctx, deps.RchPool, "http_request", ef)
+		if err != nil {
+			t.Fatalf("GetMetricsPlotForSpanNameWithFilter: %v", err)
+		}
+		if len(items) != 1 || items[0].Version != "v2 (2)" {
+			t.Fatalf("want the edge span's v2 (2) series, got %v", items)
+		}
+	})
+
+	t.Run("string value narrows the rollup by span id", func(t *testing.T) {
+		got := plotVersions(t, leaf("custom.plan", exprfilter.OperatorIn, "pro"))
+		if len(got) != 1 || !got["v1 (1)"] {
+			t.Fatalf("want only v1 (1), got %v", got)
+		}
+	})
+
+	t.Run("numbers compare as numbers", func(t *testing.T) {
+		got := plotVersions(t, leaf("custom.retries", exprfilter.OperatorGt, "9"))
+		if len(got) != 1 || !got["v2 (2)"] {
+			t.Fatalf("want only v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("a custom key beside a built-in key", func(t *testing.T) {
+		got := plotVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "free"),
+			leaf("os_name", exprfilter.OperatorIn, "Android"),
+		}})
+		if len(got) != 1 || !got["v2 (2)"] {
+			t.Fatalf("want only v2 (2), got %v", got)
+		}
+	})
+}

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -365,19 +365,32 @@ func (h *TestHelper) SeedEvents(ctx context.Context, t *testing.T, teamID, appID
 //   - StartTime:  time.Now().UTC()
 //   - EndTime:    StartTime + Duration (Duration defaults to 100ms)
 //   - AppVersion: "v1", AppBuild: "1"
+//   - OSName: "Android", OSVersion: "14"
 //   - SessionID, TraceID, SpanID: fresh per inserted row
+//
+// The device, network and country attributes stay empty strings unless set,
+// as they are for a span whose SDK did not report them.
 type SpanRow struct {
-	SpanName    string
-	SessionID   string
-	TraceID     string
-	SpanID      string
-	Status      uint8
-	StartTime   time.Time
-	EndTime     time.Time
-	Duration    time.Duration
-	AppVersion  string
-	AppBuild    string
-	Checkpoints []string
+	SpanName           string
+	SessionID          string
+	TraceID            string
+	SpanID             string
+	Status             uint8
+	StartTime          time.Time
+	EndTime            time.Time
+	Duration           time.Duration
+	AppVersion         string
+	AppBuild           string
+	OSName             string
+	OSVersion          string
+	CountryCode        string
+	NetworkProvider    string
+	NetworkType        string
+	NetworkGeneration  string
+	DeviceLocale       string
+	DeviceManufacturer string
+	DeviceName         string
+	Checkpoints        []string
 }
 
 func (r SpanRow) filled() SpanRow {
@@ -398,6 +411,12 @@ func (r SpanRow) filled() SpanRow {
 	}
 	if r.AppBuild == "" {
 		r.AppBuild = "1"
+	}
+	if r.OSName == "" {
+		r.OSName = "Android"
+	}
+	if r.OSVersion == "" {
+		r.OSVersion = "14"
 	}
 	return r
 }
@@ -436,6 +455,9 @@ func (h *TestHelper) SeedSpanRows(ctx context.Context, t *testing.T, teamID, app
 		"status", "start_time", "end_time",
 		"`attribute.app_unique_id`", "`attribute.installation_id`",
 		"`attribute.measure_sdk_version`", "`attribute.app_version`", "`attribute.os_version`",
+		"`attribute.country_code`", "`attribute.network_provider`",
+		"`attribute.network_type`", "`attribute.network_generation`",
+		"`attribute.device_locale`", "`attribute.device_manufacturer`", "`attribute.device_name`",
 		"`attribute.device_low_power_mode`", "`attribute.device_thermal_throttling_enabled`",
 	}
 	vals := []string{
@@ -443,7 +465,11 @@ func (h *TestHelper) SeedSpanRows(ctx context.Context, t *testing.T, teamID, app
 		spanExpr, traceExpr, sessionExpr,
 		fmt.Sprintf("%d", row.Status), chTime(row.StartTime), chTime(row.EndTime),
 		"'com.test'", "generateUUIDv4()",
-		"'0.1'", fmt.Sprintf("('%s','%s')", row.AppVersion, row.AppBuild), "('Android','14')",
+		"'0.1'", fmt.Sprintf("('%s','%s')", row.AppVersion, row.AppBuild),
+		fmt.Sprintf("('%s','%s')", row.OSName, row.OSVersion),
+		quote(row.CountryCode), quote(row.NetworkProvider),
+		quote(row.NetworkType), quote(row.NetworkGeneration),
+		quote(row.DeviceLocale), quote(row.DeviceManufacturer), quote(row.DeviceName),
 		"false", "false",
 	}
 
@@ -460,6 +486,75 @@ func (h *TestHelper) SeedSpanRows(ctx context.Context, t *testing.T, teamID, app
 		strings.Join(cols, ", "), strings.Join(vals, ", "), count)
 	if err := h.ChConn.Exec(ctx, query); err != nil {
 		t.Fatalf("seed span (%s): %v", row.SpanName, err)
+	}
+}
+
+// SpanUDAttrRow describes one row to insert into the span_user_def_attrs
+// table: one user-defined attribute of one span. Values of every type are
+// stored as text in the one value column, with Type naming which of
+// "string", "int64", "float64" or "bool" the text holds.
+//
+// Zero-value fields fall back to defaults:
+//   - Type:       "string"
+//   - Timestamp:  time.Now().UTC()
+//   - AppVersion: "v1", AppBuild: "1"
+//   - OSName: "Android", OSVersion: "14"
+//   - SessionID, SpanID: fresh per row
+//
+// Pin SpanID (exactly 16 characters) to attach the attribute to a span seeded
+// with the same id.
+type SpanUDAttrRow struct {
+	SpanID     string
+	SessionID  string
+	Key        string
+	Type       string
+	Value      string
+	Timestamp  time.Time
+	AppVersion string
+	AppBuild   string
+	OSName     string
+	OSVersion  string
+}
+
+// SeedSpanUDAttrRow inserts one row described by row into the
+// span_user_def_attrs table.
+func (h *TestHelper) SeedSpanUDAttrRow(ctx context.Context, t *testing.T, teamID, appID string, row SpanUDAttrRow) {
+	t.Helper()
+
+	if row.SpanID == "" {
+		row.SpanID = strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	}
+	if row.SessionID == "" {
+		row.SessionID = uuid.New().String()
+	}
+	if row.Type == "" {
+		row.Type = "string"
+	}
+	if row.Timestamp.IsZero() {
+		row.Timestamp = time.Now().UTC()
+	}
+	if row.AppVersion == "" {
+		row.AppVersion = "v1"
+	}
+	if row.AppBuild == "" {
+		row.AppBuild = "1"
+	}
+	if row.OSName == "" {
+		row.OSName = "Android"
+	}
+	if row.OSVersion == "" {
+		row.OSVersion = "14"
+	}
+
+	query := fmt.Sprintf(`INSERT INTO measure.span_user_def_attrs
+		(team_id, app_id, span_id, session_id, app_version, os_version, key, type, value, timestamp)
+		VALUES ('%s', '%s', '%s', '%s', ('%s','%s'), ('%s','%s'), '%s', '%s', '%s', toDateTime64('%s', 3, 'UTC'))`,
+		teamID, appID, row.SpanID, row.SessionID,
+		row.AppVersion, row.AppBuild, row.OSName, row.OSVersion,
+		row.Key, row.Type, row.Value,
+		row.Timestamp.UTC().Format("2006-01-02 15:04:05.000"))
+	if err := h.ChConn.Exec(ctx, query); err != nil {
+		t.Fatalf("seed span user-defined attribute (%s): %v", row.Key, err)
 	}
 }
 

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -392,12 +392,6 @@ describe("fetchFiltersFromServer", () => {
     expect(url).toContain("type=error,anr");
   });
 
-  it("appends span=1 for Spans filterSource", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({ versions: [] }));
-    await fetchFiltersFromServer(onboardedApp, FilterSource.Spans);
-    expect(lastFetchUrl()).toContain("span=1");
-  });
-
   it("has no source-specific param for Events", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ versions: [] }));
     await fetchFiltersFromServer(onboardedApp, FilterSource.Events);
@@ -508,28 +502,19 @@ describe("fetch functions that use applyGenericFiltersToUrl", () => {
     expect(lastFetchUrl()).not.toContain("filter_short_code");
   });
 
-  it.each([
-    ["fetchMetricsFromServer", fetchMetricsFromServer],
-    ["fetchSpanMetricsPlotFromServer", fetchSpanMetricsPlotFromServer],
-  ])("%s: returns data, throws on failure", async (_name, fn) => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({ a: 1 }));
-    expect(await (fn as any)(makeFilters())).toEqual({ a: 1 });
+  it.each([["fetchMetricsFromServer", fetchMetricsFromServer]])(
+    "%s: returns data, throws on failure",
+    async (_name, fn) => {
+      mockApiClientFetch.mockResolvedValueOnce(successResponse({ a: 1 }));
+      expect(await (fn as any)(makeFilters())).toEqual({ a: 1 });
 
-    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    await expect((fn as any)(makeFilters())).rejects.toThrow(ApiError);
+      mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+      await expect((fn as any)(makeFilters())).rejects.toThrow(ApiError);
 
-    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    await expect((fn as any)(makeFilters())).rejects.toThrow(RequestError);
-  });
-
-  it("fetchSpansFromServer includes limit/offset in URL", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    await fetchSpansFromServer(makeFilters(), 50, 100);
-    const url = lastFetchUrl();
-    expect(url).toContain("/api/apps/app-a/spans");
-    expect(url).toContain("limit=50");
-    expect(url).toContain("offset=100");
-  });
+      mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+      await expect((fn as any)(makeFilters())).rejects.toThrow(RequestError);
+    },
+  );
 
   it("fetchSessionReplayOverviewFromServer includes limit/offset", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
@@ -898,30 +883,66 @@ describe("sessions, bug reports, alerts", () => {
     expect(lastFetchUrl()).toContain("/api/apps/app-a/alerts");
   });
 
-  it("fetchBuildsFromServer hits /builds with filters and pagination", async () => {
+  it("fetchBuildsFromServer hits /builds with the range, expression and pagination", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
-    await fetchBuildsFromServer(makeFilters(), 10, 20);
+    await fetchBuildsFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      "version_name:in:v1",
+      10,
+      20,
+    );
     const url = lastFetchUrl();
     expect(url).toContain("/api/apps/app-a/builds");
-    expect(url).toContain("filter_short_code=code-123");
     expect(url).toContain("from=");
     expect(url).toContain("to=");
+    expect(url).toContain(
+      `filter_expr=${encodeURIComponent("version_name:in:v1")}`,
+    );
     expect(url).toContain("limit=10");
     expect(url).toContain("offset=20");
   });
 
+  it("fetchBuildsFromServer omits filter_expr when there is none", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await fetchBuildsFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      null,
+      10,
+      0,
+    );
+    expect(lastFetchUrl()).not.toContain("filter_expr");
+  });
+
   it("fetchBuildsFromServer throws on a non-ok response", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    await expect(fetchBuildsFromServer(makeFilters(), 10, 0)).rejects.toThrow(
-      ApiError,
-    );
+    await expect(
+      fetchBuildsFromServer(
+        "app-a",
+        "2026-04-01T00:00:00.000Z",
+        "2026-04-10T00:00:00.000Z",
+        null,
+        10,
+        0,
+      ),
+    ).rejects.toThrow(ApiError);
   });
 
   it("fetchBuildsFromServer throws when the request throws", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("boom"));
-    await expect(fetchBuildsFromServer(makeFilters(), 10, 0)).rejects.toThrow(
-      RequestError,
-    );
+    await expect(
+      fetchBuildsFromServer(
+        "app-a",
+        "2026-04-01T00:00:00.000Z",
+        "2026-04-10T00:00:00.000Z",
+        null,
+        10,
+        0,
+      ),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -1231,7 +1252,7 @@ describe("billing endpoints", () => {
 // ========================================================================
 // applyGenericFiltersToUrl — exercised via any function that uses it.
 // These tests cover the per-field append branches (session types, span
-// statuses, bug report statuses, free text, span name, span filters,
+// statuses, bug report statuses, free text, span filters,
 // http methods) by passing filters with non-default values.
 // ========================================================================
 describe("applyGenericFiltersToUrl filter branches", () => {
@@ -1260,27 +1281,6 @@ describe("applyGenericFiltersToUrl filter branches", () => {
     expect(url).not.toContain("user_interaction=");
     expect(url).not.toContain("foreground=");
     expect(url).not.toContain("background=");
-  });
-
-  it("appends rootSpanName when non-empty", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchMetricsFromServer(makeFilters({ rootSpanName: "my_root_span" }));
-    expect(lastFetchUrl()).toContain("span_name=");
-  });
-
-  it("appends span statuses for each SpanStatus", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchMetricsFromServer(
-      makeFilters({
-        spanStatuses: {
-          all: false,
-          selected: ["Unset", "Ok", "Error"] as any,
-        },
-      }),
-    );
-    const url = lastFetchUrl();
-    // Each status value becomes a span_statuses query param.
-    expect(url.match(/span_statuses=\d/g)?.length).toBe(3);
   });
 
   it("appends bug_report_statuses for Open/Closed", async () => {
@@ -1318,7 +1318,7 @@ describe("applyGenericFiltersToUrl filter branches", () => {
   });
 });
 
-describe("applyHttpMethodsToUrl and applySpanFiltersToUrl", () => {
+describe("applyHttpMethodsToUrl", () => {
   it("appends http_methods params for selected methods", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
     await fetchNetworkEndpointLatencyPlotFromServer(
@@ -1332,23 +1332,108 @@ describe("applyHttpMethodsToUrl and applySpanFiltersToUrl", () => {
     expect(url).toContain("http_methods=get");
     expect(url).toContain("http_methods=post");
   });
+});
 
-  it("appends span filters to fetchSpansFromServer URL", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    await fetchSpansFromServer(
-      makeFilters({
-        rootSpanName: "root",
-        spanStatuses: {
-          all: false,
-          selected: ["Error"] as any,
-        },
-      }),
+// ========================================================================
+// Expression-filter span fetchers
+// ========================================================================
+describe("fetchSpansFromServer", () => {
+  const call = (filterExpr: string | null = null, spanName = "root.a") =>
+    fetchSpansFromServer(
+      "app-a",
+      spanName,
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      filterExpr,
+      5,
       10,
-      0,
     );
-    const url = lastFetchUrl();
-    expect(url).toContain("/api/apps/app-a/spans");
-    expect(url).toContain("span_name=");
+
+  it("sends the span, range, timezone and page in the URL", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await call();
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/spans");
+    expect(url.searchParams.get("span_name")).toBe("root.a");
+    expect(url.searchParams.get("from")).toBe("2026-04-01T00:00:00.000Z");
+    expect(url.searchParams.get("to")).toBe("2026-04-10T00:00:00.000Z");
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    expect(url.searchParams.get("limit")).toBe("5");
+    expect(url.searchParams.get("offset")).toBe("10");
+    expect(url.searchParams.has("filter_expr")).toBe(false);
+  });
+
+  it("carries a span name with reserved characters intact", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await call(null, "load & render 100%");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("span_name")).toBe("load & render 100%");
+  });
+
+  it("sends the filter expression when one is given", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await call("span_status:in:error");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe("span_status:in:error");
+  });
+
+  it("returns data, throws on failure", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ a: 1 }));
+    expect(await call()).toEqual({ a: 1 });
+
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(call()).rejects.toThrow(ApiError);
+
+    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+    await expect(call()).rejects.toThrow(RequestError);
+  });
+});
+
+describe("fetchSpanMetricsPlotFromServer", () => {
+  const call = (filterExpr: string | null = null) =>
+    fetchSpanMetricsPlotFromServer(
+      "app-a",
+      "root.a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      filterExpr,
+    );
+
+  it("sends the span, range, timezone and time group in the URL", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
+    await call();
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/spans/plots/metrics");
+    expect(url.searchParams.get("span_name")).toBe("root.a");
+    expect(url.searchParams.get("from")).toBe("2026-04-01T00:00:00.000Z");
+    expect(url.searchParams.get("to")).toBe("2026-04-10T00:00:00.000Z");
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    // A nine day range buckets by day.
+    expect(url.searchParams.get("plot_time_group")).toBe("days");
+    expect(url.searchParams.has("filter_expr")).toBe(false);
+  });
+
+  it("sends the filter expression when one is given", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
+    await call("span_status:in:ok");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe("span_status:in:ok");
+  });
+
+  it("returns null when response data is null", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
+    expect(await call()).toBeNull();
+  });
+
+  it("returns data, throws on failure", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([{ id: "v1" }]));
+    expect(await call()).toEqual([{ id: "v1" }]);
+
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(call()).rejects.toThrow(ApiError);
+
+    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+    await expect(call()).rejects.toThrow(RequestError);
   });
 });
 
@@ -1358,11 +1443,6 @@ describe("applyHttpMethodsToUrl and applySpanFiltersToUrl", () => {
 // ========================================================================
 describe("fetch functions: failure paths", () => {
   const cases: Array<[string, () => Promise<unknown>]> = [
-    [
-      "fetchSpanMetricsPlotFromServer",
-      () => fetchSpanMetricsPlotFromServer(makeFilters()),
-    ],
-    ["fetchSpansFromServer", () => fetchSpansFromServer(makeFilters(), 10, 0)],
     [
       "fetchJourneyFromServer",
       () => fetchJourneyFromServer(false, makeFilters()),
@@ -1529,39 +1609,15 @@ describe("mutation functions: failure paths", () => {
 });
 
 // ========================================================================
-// Additional branch coverage — NoData paths, all SpanStatus values,
-// all SessionType values via session replay fetches, etc.
+// Additional branch coverage — NoData paths, all SessionType values via
+// session replay fetches, etc.
 // ========================================================================
 describe("additional branch coverage", () => {
-  it("fetchSpanMetricsPlotFromServer returns null when response data is null", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    const r = await fetchSpanMetricsPlotFromServer(makeFilters());
-    expect(r).toBeNull();
-  });
-
   it("fetchAppHealthPlotFromServer throws when the fetch throws", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("network down"));
     await expect(fetchAppHealthPlotFromServer(makeFilters())).rejects.toThrow(
       RequestError,
     );
-  });
-
-  it("appends all span statuses (Unset/Ok/Error) to span endpoint URLs", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    await fetchSpansFromServer(
-      makeFilters({
-        spanStatuses: {
-          all: false,
-          selected: ["Unset", "Ok", "Error"] as any,
-        },
-      }),
-      10,
-      0,
-    );
-    const url = lastFetchUrl();
-    expect(url).toContain("span_statuses=0");
-    expect(url).toContain("span_statuses=1");
-    expect(url).toContain("span_statuses=2");
   });
 
   it("appends all session types via fetchSessionReplayOverviewFromServer", async () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 
 const mockUseAppsQuery = jest.fn();
 const mockUseFilterKeysQuery = jest.fn();
+const mockUseRootSpanNamesQuery = jest.fn();
 const mockToastNegative = jest.fn();
 
 jest.mock("@/app/components/toast", () => ({
@@ -14,8 +15,12 @@ jest.mock("@/app/components/toast", () => ({
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
   useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
-  useFilterKeysQuery: (appId: string | undefined, entity: string) =>
-    mockUseFilterKeysQuery(appId, entity),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: (app: unknown) => mockUseRootSpanNamesQuery(app),
 }));
 
 const { useStore } = jest.requireActual("zustand") as any;
@@ -170,6 +175,28 @@ const versionKey = {
   operators: ["in", "not_in"],
 } as unknown as FilterKey;
 
+// The server serves a user-defined attribute key with a `custom.` prefix on
+// the name and the raw attribute name as the label.
+const customPremiumKey = {
+  name: "custom.is_premium",
+  label: "is_premium",
+  key_group: "Custom",
+  description: "A user-defined attribute",
+  value_type: "bool",
+  value_suggestion_mode: "full_list",
+  operators: ["eq"],
+} as unknown as FilterKey;
+
+const customPlanKey = {
+  name: "custom.plan",
+  label: "plan",
+  key_group: "Custom",
+  description: "A user-defined attribute",
+  value_type: "string",
+  value_suggestion_mode: "sample",
+  operators: ["in", "not_in", "contains"],
+} as unknown as FilterKey;
+
 function appsLoaded(loaded: App[] = apps) {
   mockUseAppsQuery.mockReturnValue({
     status: "success",
@@ -177,9 +204,12 @@ function appsLoaded(loaded: App[] = apps) {
   } as any);
 }
 
-function keysLoaded(keys: FilterKey[] = [mappingTypeKey, versionKey]) {
+function keysLoaded(
+  keys: FilterKey[] = [mappingTypeKey, versionKey],
+  keyGroups: string[] = ["Build", "Version"],
+) {
   mockUseFilterKeysQuery.mockReturnValue({
-    data: { keys, key_groups: ["Build", "Version"] },
+    data: { keys, key_groups: keyGroups },
     isPending: false,
     isError: false,
   } as any);
@@ -264,6 +294,14 @@ describe("FilterBar", () => {
     storeInstance = createFiltersStore();
     appsLoaded();
     keysLoaded();
+    // Most tests leave the root span selector off, so the bar passes null
+    // and the query stays in its disabled pending state.
+    mockUseRootSpanNamesQuery.mockReturnValue({
+      data: undefined,
+      isPending: true,
+      isError: false,
+      isSuccess: false,
+    });
     mockToastNegative.mockClear();
   });
 
@@ -291,11 +329,82 @@ describe("FilterBar", () => {
       expect(lastState(onFilterChange)).toMatchObject({ app: apps[1] });
     });
 
+    it("reports the request as applied when everything asked for is honoured", async () => {
+      const { onFilterChange } = await renderBar({
+        requestedAppId: "app-2",
+        requestedDateRange: {
+          dateRange: "Last Week",
+          startDate: null,
+          endDate: null,
+        },
+      });
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        appliedAsRequested: true,
+      });
+    });
+
     it("keeps the app another page left on the store", async () => {
       storeInstance.getState().setSelectedApp(apps[1]);
       const { onFilterChange } = await renderBar();
 
       expect(lastState(onFilterChange)).toMatchObject({ app: apps[1] });
+    });
+
+    it("toasts when the requested root span name is unknown to the app", async () => {
+      mockUseRootSpanNamesQuery.mockReturnValue({
+        data: ["checkout", "startup"],
+        isPending: false,
+        isError: false,
+        isSuccess: true,
+      });
+      const { onFilterChange } = await renderBar({
+        requestedAppId: "app-1",
+        showRootSpanSelector: true,
+        requestedRootSpanName: "gone",
+      });
+
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        "Some filters were invalid, page reset to defaults",
+      );
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        rootSpanName: "checkout",
+        appliedAsRequested: false,
+      });
+    });
+
+    it("does not toast for a root span name with no requested app", async () => {
+      mockUseRootSpanNamesQuery.mockReturnValue({
+        data: ["checkout", "startup"],
+        isPending: false,
+        isError: false,
+        isSuccess: true,
+      });
+      // The link's name belongs to the app the link asked for; without a
+      // requested app the name is not judged against the selected app's list.
+      await renderBar({
+        showRootSpanSelector: true,
+        requestedRootSpanName: "gone",
+      });
+
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+
+    it("ranks the requested app above the one another page left on the store", async () => {
+      storeInstance.getState().setSelectedApp(apps[1]);
+      const { onFilterChange } = await renderBar({ requestedAppId: "app-1" });
+
+      // Every ready state carries the requested app; a first report built
+      // from the remembered app would overwrite the link's app in the URL.
+      for (const [state] of onFilterChange.mock.calls) {
+        if (state.status === "ready") {
+          expect(state.app).toEqual(apps[0]);
+        }
+      }
+      expect(lastState(onFilterChange)).toMatchObject({ app: apps[0] });
+      expect(storeInstance.getState().selectedApp).toEqual(apps[0]);
     });
 
     it("falls back to the team's first app when the requested one is gone", async () => {
@@ -464,6 +573,33 @@ describe("FilterBar", () => {
       });
     });
 
+    it("keeps a custom key the keys listing left out", async () => {
+      // The app has more custom keys than the listing returns, so the
+      // server serves custom.plan only when the request specifies it.
+      mockUseFilterKeysQuery.mockImplementation(
+        (_appId: string | undefined, _entity: string, keyNames: string[]) => ({
+          data: {
+            keys: keyNames.includes("custom.plan")
+              ? [mappingTypeKey, versionKey, customPlanKey]
+              : [mappingTypeKey, versionKey],
+            key_groups: ["Build", "Version", "Custom"],
+          },
+          isPending: false,
+          isError: false,
+        }),
+      );
+
+      const { onFilterChange } = await renderBar({
+        requestedFilterExpr: "custom.plan:in:pro",
+      });
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        filterExpr: "custom.plan:in:pro",
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+
     it("filters nothing when it names a key this app does not have", async () => {
       const { onFilterChange } = await renderBar({
         requestedFilterExpr: "device_cohort:in:new",
@@ -537,6 +673,20 @@ describe("FilterBar", () => {
 
       expect(lastState(onFilterChange)).toMatchObject({
         filterExpr: "mapping_type:in:dsym",
+      });
+    });
+
+    it("no longer reports the request as applied once the filter is edited", async () => {
+      const { onFilterChange } = await renderBar();
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        appliedAsRequested: true,
+      });
+
+      await addCondition();
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        appliedAsRequested: false,
       });
     });
 
@@ -1083,6 +1233,127 @@ describe("FilterBar", () => {
     });
   });
 
+  describe("a user-defined key", () => {
+    beforeEach(() => {
+      keysLoaded(
+        [mappingTypeKey, versionKey, customPremiumKey, customPlanKey],
+        ["Build", "Version", "Custom"],
+      );
+    });
+
+    it("draws a requested custom condition and filters by it", async () => {
+      const { onFilterChange } = await renderBar({
+        requestedFilterExpr: "custom.is_premium:eq:true",
+      });
+
+      expect(screen.getByTestId("operator-picker")).toBeInTheDocument();
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        filterExpr: "custom.is_premium:eq:true",
+      });
+    });
+
+    it("names the condition by the raw attribute name", async () => {
+      await renderBar();
+
+      await click(
+        wholeFilterPicker().getByTestId("pick-key-custom.is_premium"),
+      );
+
+      // The key control of the new condition takes focus, so the text on it is
+      // what the chip shows for this key.
+      expect(document.activeElement?.textContent).toBe("is_premium");
+    });
+
+    it("serializes a picked custom key under its full dotted name", async () => {
+      const { onFilterChange } = await renderBar();
+
+      await addCondition(wholeFilterPicker(), "custom.plan");
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        filterExpr: "custom.plan:in:dsym",
+      });
+    });
+
+    it("asks the keys query for a custom key typed by hand", async () => {
+      // The app has more custom keys than the listing returns, so the
+      // server serves custom.plan only when the request specifies it.
+      mockUseFilterKeysQuery.mockImplementation(
+        (_appId: string | undefined, _entity: string, keyNames: string[]) => ({
+          data: {
+            keys: keyNames.includes("custom.plan")
+              ? [mappingTypeKey, versionKey, customPlanKey]
+              : [mappingTypeKey, versionKey],
+            key_groups: ["Build", "Version", "Custom"],
+          },
+          isPending: false,
+          isError: false,
+        }),
+      );
+
+      const { onFilterChange } = await renderBar();
+
+      await click(screen.getByLabelText("Edit as text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: { value: "custom.plan:in:pro" },
+        });
+      });
+
+      expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        ["custom.plan"],
+      );
+      expect(screen.queryByTestId("filter-issue")).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.keyDown(screen.getByTestId("filter-text"), { key: "Enter" });
+      });
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        filterExpr: "custom.plan:in:pro",
+      });
+    });
+
+    it("does not ask for a custom key still being typed", async () => {
+      await renderBar();
+
+      await click(screen.getByLabelText("Edit as text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: { value: "custom.pl" },
+        });
+      });
+
+      expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        [],
+      );
+    });
+
+    it("round-trips a typed custom condition through the text editor", async () => {
+      const { onFilterChange } = await renderBar();
+
+      await click(screen.getByLabelText("Edit as text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: {
+            value: "custom.plan:in:pro AND custom.is_premium:eq:true",
+          },
+        });
+      });
+      await click(screen.getByLabelText("Edit as conditions"));
+
+      expect(screen.queryByTestId("filter-issue")).not.toBeInTheDocument();
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
+      expect(lastState(onFilterChange)).toMatchObject({
+        filterExpr: "custom.plan:in:pro AND custom.is_premium:eq:true",
+      });
+    });
+  });
+
   describe("while the keys are on their way", () => {
     it("shows no bar to filter with", async () => {
       mockUseFilterKeysQuery.mockReturnValue({
@@ -1204,11 +1475,17 @@ describe("FilterBar", () => {
     });
 
     it("says so for an expression that cannot be read", async () => {
-      await renderBar({ requestedFilterExpr: "mapping_type:in:" });
+      const { onFilterChange } = await renderBar({
+        requestedFilterExpr: "mapping_type:in:",
+      });
 
       expect(mockToastNegative).toHaveBeenCalledWith(
         "Some filters were invalid, page reset to defaults",
       );
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        appliedAsRequested: false,
+      });
     });
 
     it("says so once, however much was refused", async () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
@@ -69,6 +69,7 @@ import type { FilterKey } from "@/app/api/filter_types";
 import KeyPicker, {
   OperatorPicker,
 } from "@/app/components/filter_bar/key_picker";
+import { operatorLabels as filterBarOperatorLabels } from "@/app/components/filter_bar/operators";
 
 const key = (
   name: string,
@@ -271,6 +272,37 @@ describe("KeyPicker", () => {
 
     expect(screen.getByTestId("lands-here")).toHaveFocus();
   });
+
+  describe("a user-defined key", () => {
+    const customKey = key(
+      "custom.is_premium",
+      "is_premium",
+      "Custom",
+      "A user-defined attribute",
+    );
+    const withCustom = {
+      keys: [...keys, customKey],
+      keyGroups: [...keyGroups, "Custom"],
+    };
+
+    it("shows the Custom tab, and the key by its raw name", () => {
+      openPicker(withCustom);
+
+      fireEvent.click(screen.getByTestId("tab-Custom"));
+
+      expect(screen.getByText("is_premium")).toBeInTheDocument();
+      expect(screen.queryByText("custom.is_premium")).not.toBeInTheDocument();
+    });
+
+    it("reports the key with its full dotted name when picked", () => {
+      const { onSelect } = openPicker(withCustom);
+
+      fireEvent.click(screen.getByTestId("tab-Custom"));
+      fireEvent.click(screen.getByTestId("filter-key-custom.is_premium"));
+
+      expect(onSelect).toHaveBeenCalledWith(customKey);
+    });
+  });
 });
 
 describe("OperatorPicker", () => {
@@ -306,6 +338,52 @@ describe("OperatorPicker", () => {
 
     expect(screen.getByTestId("filter-op-between")).toHaveTextContent(
       "between",
+    );
+  });
+
+  it("has a label for every comparison a number key offers", () => {
+    render(
+      <OperatorPicker
+        operators={["eq", "neq", "gt", "gte", "lt", "lte"]}
+        selected={null}
+        operatorLabels={filterBarOperatorLabels}
+        onSelect={jest.fn()}
+        open
+        trigger={<button>open</button>}
+      />,
+    );
+
+    expect(screen.getByTestId("filter-op-eq")).toHaveTextContent("=");
+    expect(screen.getByTestId("filter-op-neq")).toHaveTextContent("≠");
+    expect(screen.getByTestId("filter-op-gt")).toHaveTextContent(">");
+    expect(screen.getByTestId("filter-op-gte")).toHaveTextContent("≥");
+    expect(screen.getByTestId("filter-op-lt")).toHaveTextContent("<");
+    expect(screen.getByTestId("filter-op-lte")).toHaveTextContent("≤");
+  });
+
+  it("has a label for every match a text key offers", () => {
+    render(
+      <OperatorPicker
+        operators={["contains", "not_contains", "starts_with", "ends_with"]}
+        selected={null}
+        operatorLabels={filterBarOperatorLabels}
+        onSelect={jest.fn()}
+        open
+        trigger={<button>open</button>}
+      />,
+    );
+
+    expect(screen.getByTestId("filter-op-contains")).toHaveTextContent(
+      "contains",
+    );
+    expect(screen.getByTestId("filter-op-not_contains")).toHaveTextContent(
+      "does not contain",
+    );
+    expect(screen.getByTestId("filter-op-starts_with")).toHaveTextContent(
+      "starts with",
+    );
+    expect(screen.getByTestId("filter-op-ends_with")).toHaveTextContent(
+      "ends with",
     );
   });
 

--- a/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
@@ -380,4 +380,63 @@ describe("ValuePicker", () => {
       expect(onOpenChange).not.toHaveBeenCalled();
     });
   });
+
+  describe("a user-defined key", () => {
+    it("lists the fetched values for a bool key and replaces on pick", () => {
+      valuesLoaded([{ text: "true" }, { text: "false" }]);
+      const { onChange, onOpenChange } = renderPicker({
+        keyName: "custom.is_premium",
+        valueType: "bool",
+        valueSuggestionMode: "full_list",
+        takesOneValue: true,
+      });
+
+      expect(mockUseFilterValuesQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        "custom.is_premium",
+        "",
+      );
+      expect(screen.getByTestId("filter-value-true")).toBeInTheDocument();
+      expect(screen.getByTestId("filter-value-false")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("filter-value-true"));
+
+      expect(onChange).toHaveBeenCalledWith([{ text: "true" }]);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("asks for a string key's suggestions under its full dotted name", () => {
+      valuesLoaded([{ text: "pro" }]);
+      renderPicker({
+        keyName: "custom.plan",
+        valueSuggestionMode: "sample",
+      });
+
+      fireEvent.change(screen.getByTestId("value-search"), {
+        target: { value: "fr" },
+      });
+
+      expect(mockUseFilterValuesQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        "custom.plan",
+        "fr",
+      );
+    });
+
+    it("takes a typed whole number, unbounded, for an int64 key", () => {
+      renderPicker({
+        keyName: "custom.launch_count",
+        valueType: "int64",
+        valueSuggestionMode: "none",
+      });
+
+      const input = screen.getByTestId("filter-value-input");
+      expect(input).toHaveAttribute("type", "number");
+      expect(input).toHaveAttribute("step", "1");
+      expect(input).not.toHaveAttribute("min");
+      expect(input).not.toHaveAttribute("max");
+    });
+  });
 });

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -43,13 +43,11 @@ jest.mock("@/app/query/query_client", () => ({
 
 let appsQueryState: any = { status: "pending", data: undefined };
 let filterOptionsQueryState: any = { status: "pending", data: undefined };
-let rootSpanNamesQueryState: any = { status: "pending", data: undefined };
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
   useAppsQuery: () => appsQueryState,
   useFilterOptionsQuery: () => filterOptionsQueryState,
-  useRootSpanNamesQuery: () => rootSpanNamesQueryState,
 }));
 
 jest.mock("@/app/components/dropdown_select", () => ({
@@ -235,35 +233,12 @@ function setFiltersPending() {
   filterOptionsQueryState = { status: "pending", data: undefined };
 }
 
-function setRootSpansSuccess(names = ["root.a", "root.b"]) {
-  rootSpanNamesQueryState = {
-    status: "success",
-    data: names,
-  };
-}
-// An app that has never reported a trace answers with a null list. The
-// fetcher sends the null through, and does not change it to an empty array.
-function setRootSpansNoData() {
-  rootSpanNamesQueryState = { status: "success", data: null };
-}
-function setRootSpansPending() {
-  rootSpanNamesQueryState = { status: "pending", data: undefined };
-}
-function setRootSpansError() {
-  rootSpanNamesQueryState = {
-    status: "error",
-    data: undefined,
-    error: new Error(),
-  };
-}
-
 let sessionStorageData: Record<string, string> = {};
 
 beforeEach(() => {
   storeInstance = createFiltersStore();
   setAppsPending();
   setFiltersPending();
-  setRootSpansPending();
   mockSearchParams = new URLSearchParams();
   mockPathname = "/team-1/overview";
   sessionStorageData = {};
@@ -393,60 +368,6 @@ describe("Filters — filter options states", () => {
   });
 });
 
-describe("Filters — Span filter source", () => {
-  beforeEach(() => {
-    setAppsSuccess([makeApp("a")]);
-    setFiltersSuccess();
-  });
-
-  it("shows the trace name skeleton while root span names load", async () => {
-    setRootSpansPending();
-    await renderFilters({ filterSource: FilterSource.Spans });
-    await waitFor(() => {
-      expect(screen.getAllByTestId("skeleton-mock").length).toBeGreaterThan(0);
-    });
-  });
-
-  it("shows the trace name error when the root span names query fails", async () => {
-    setRootSpansError();
-    await renderFilters({ filterSource: FilterSource.Spans });
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Error fetching traces list/),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("shows the no-traces message when the app has never reported a trace", async () => {
-    setRootSpansNoData();
-    await renderFilters({ filterSource: FilterSource.Spans });
-    await waitFor(() => {
-      expect(
-        screen.getByText(/No traces received for this app yet/),
-      ).toBeInTheDocument();
-    });
-    expect(storeInstance.getState().rootSpanNamesState).toBe("no-data");
-  });
-
-  it("renders the trace name dropdown once root span names load", async () => {
-    setRootSpansSuccess();
-    await renderFilters({ filterSource: FilterSource.Spans });
-    await waitFor(() => {
-      expect(screen.getByTestId("dropdown-Trace Name")).toBeInTheDocument();
-    });
-  });
-
-  it("does not render the trace name dropdown when filterSource is not Spans", async () => {
-    setRootSpansSuccess();
-    await renderFilters({ filterSource: FilterSource.Events });
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("dropdown-Trace Name"),
-      ).not.toBeInTheDocument();
-    });
-  });
-});
-
 describe("Filters — store state after queries resolve", () => {
   it("mirrors apps and statuses into the store on resolve", async () => {
     setAppsSuccess([makeApp("a")]);
@@ -541,18 +462,6 @@ describe("Filters — store state after queries resolve", () => {
       expect(
         storeInstance.getState().selectedVersions.map((v: any) => v.name),
       ).toEqual(["1.0", "2.0", "3.0"]);
-    });
-  });
-
-  it("mirrors root span names into the store and selects the first", async () => {
-    setAppsSuccess([makeApp("a")]);
-    setFiltersSuccess();
-    setRootSpansSuccess(["traceA", "traceB"]);
-    await renderFilters({ filterSource: FilterSource.Spans });
-    await waitFor(() => {
-      const state = storeInstance.getState();
-      expect(state.rootSpanNames).toEqual(["traceA", "traceB"]);
-      expect(state.selectedRootSpanName).toBe("traceA");
     });
   });
 });

--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -1,14 +1,13 @@
 import "@testing-library/jest-dom";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 let lastLineProps: any = null;
 let lastTabSelectProps: any = null;
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
+}));
 
 jest.mock("@nivo/line", () => ({
   ResponsiveLineCanvas: (props: any) => {
@@ -43,113 +42,76 @@ jest.mock("@/app/components/tab_select", () => ({
   },
 }));
 
-const mockUseSpanMetricsPlotQuery = jest.fn(
-  (): { data: any; status: string; error: Error | null } => ({
+import SpanMetricsPlot from "@/app/components/span_metrics_plot";
+
+const filterParams = {
+  appId: "app-1",
+  startDate: "2026-02-01T00:00:00Z",
+  endDate: "2026-02-01T08:00:00Z",
+  filterExpr: null,
+};
+
+function queryWith(overrides: any) {
+  return {
     data: undefined,
     status: "pending",
     error: null,
-  }),
-);
+    ...overrides,
+  } as any;
+}
 
-jest.mock("@/app/query/hooks", () => ({
-  __esModule: true,
-  RootSpanMetricsQuantile: {
-    p50: "p50",
-    p90: "p90",
-    p95: "p95",
-    p99: "p99",
+// One series with every quantile, as the server sends it. The component
+// picks a quantile out of it.
+const rawPlotData = [
+  {
+    id: "v1",
+    data: [
+      { datetime: "2026-02-01T01:00:00", p50: 30, p90: 35, p95: 38, p99: 40 },
+    ],
   },
-  useSpanMetricsPlotQuery: () => mockUseSpanMetricsPlotQuery(),
-}));
-
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: null },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
-});
-
-import SpanMetricsPlot from "@/app/components/span_metrics_plot";
-const { useFiltersStore } = require("@/app/stores/provider") as any;
-
-const defaultFilters = {
-  ready: true,
-  startDate: "2026-02-01T00:00:00Z",
-  endDate: "2026-02-01T08:00:00Z",
-  serialisedFilters: "2026-02-01T00:00:00Z|2026-02-01T08:00:00Z|minutes",
-};
+];
 
 describe("SpanMetricsPlot", () => {
   beforeEach(() => {
     lastLineProps = null;
     lastTabSelectProps = null;
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: null },
-    });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "pending",
-      error: null,
-    });
   });
 
-  it("renders no data state", async () => {
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: null,
-      status: "success",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+  it("renders no data state when the server sends a null plot", async () => {
+    render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ data: null, status: "success" })}
+      />,
+    );
 
     expect(screen.getByText("No Data")).toBeInTheDocument();
   });
 
   it("renders error state", async () => {
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "error",
-      error: new Error("test"),
-    });
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ status: "error", error: new Error("test") })}
+      />,
+    );
     expect(screen.getByText(/Error fetching plot/)).toBeInTheDocument();
   });
 
-  it("does not fetch when filters are not ready", async () => {
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: null },
-    });
-    render(<SpanMetricsPlot />);
-    // Query hook is called but TanStack Query handles the enabled flag internally
-    expect(mockUseSpanMetricsPlotQuery).toHaveBeenCalled();
-  });
-
-  it("renders loading state before request resolves", async () => {
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "pending",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+  it("renders loading state before the request resolves", async () => {
+    render(
+      <SpanMetricsPlot filterParams={filterParams} query={queryWith({})} />,
+    );
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 
   it("maps quantile and updates when tab changes", async () => {
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-01T01:00:00", y: 30 }] },
-    ];
-
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
 
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
@@ -160,33 +122,18 @@ describe("SpanMetricsPlot", () => {
     expect(lastTabSelectProps.items).toEqual(["p50", "p90", "p95", "p99"]);
     expect(lastTabSelectProps.selected).toBe("p50");
 
-    // Change to p99 - this triggers a re-render with new quantile passed to the query hook
-    const plotDataP99 = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-01T01:00:00", y: 40 }] },
-    ];
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotDataP99,
-      status: "success",
-      error: null,
-    });
-
     fireEvent.click(screen.getByTestId("quantile-p99"));
     await waitFor(() => expect(lastLineProps.data[0].data[0].y).toBe(40));
     expect(lastLineProps.axisLeft.legend).toBe("Duration (p99)");
   });
 
   it("renders tooltip with human readable millis", async () => {
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-01T01:00:00", y: 30 }] },
-    ];
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -204,25 +151,19 @@ describe("SpanMetricsPlot", () => {
     expect(container.textContent).toContain("(p50)");
   });
 
-  it("uses hour/day/month axis configuration for larger ranges", async () => {
-    // hours range (5 days)
-    const hoursFilters = {
-      ready: true,
+  it("uses hour axis configuration for multi-day ranges", async () => {
+    const hoursParams = {
+      ...filterParams,
       startDate: "2026-02-01T00:00:00Z",
       endDate: "2026-02-06T00:00:00Z",
-      serialisedFilters: "2026-02-01T00:00:00Z|2026-02-06T00:00:00Z|hours",
     };
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-10T01:00:00", y: 30 }] },
-    ];
 
-    useFiltersStore.setState({ filters: hoursFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={hoursParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -230,23 +171,18 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("uses day axis configuration for medium ranges", async () => {
-    const daysFilters = {
-      ready: true,
+    const daysParams = {
+      ...filterParams,
       startDate: "2026-01-01T00:00:00Z",
       endDate: "2026-03-15T00:00:00Z",
-      serialisedFilters: "2026-01-01T00:00:00Z|2026-03-15T00:00:00Z|days",
     };
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-10T01:00:00", y: 30 }] },
-    ];
 
-    useFiltersStore.setState({ filters: daysFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={daysParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -254,23 +190,18 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("uses month axis configuration for large ranges", async () => {
-    const monthsFilters = {
-      ready: true,
+    const monthsParams = {
+      ...filterParams,
       startDate: "2025-01-01T00:00:00Z",
       endDate: "2026-01-01T00:00:00Z",
-      serialisedFilters: "2025-01-01T00:00:00Z|2026-01-01T00:00:00Z|months",
     };
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-10T01:00:00", y: 30 }] },
-    ];
 
-    useFiltersStore.setState({ filters: monthsFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={monthsParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -278,17 +209,12 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("throws for invalid quantile selection", async () => {
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-01T01:00:00", y: 30 }] },
-    ];
-    useFiltersStore.setState({ filters: defaultFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-
-    render(<SpanMetricsPlot />);
+    render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -303,42 +229,19 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("hides stale chart while new range data is loading", async () => {
-    // First render with success state
-    const plotData = [
-      { id: "v1", data: [{ id: "v1.0", x: "2026-02-10T01:00:00", y: 30 }] },
-    ];
-    const hoursFilters = {
-      ready: true,
-      startDate: "2026-02-01T00:00:00Z",
-      endDate: "2026-02-06T00:00:00Z",
-      serialisedFilters: "2026-02-01T00:00:00Z|2026-02-06T00:00:00Z|hours",
-    };
-    useFiltersStore.setState({ filters: hoursFilters });
-    mockUseSpanMetricsPlotQuery.mockReturnValue({
-      data: plotData,
-      status: "success",
-      error: null,
-    });
-    render(<SpanMetricsPlot />);
+    const { rerender } = render(
+      <SpanMetricsPlot
+        filterParams={filterParams}
+        query={queryWith({ data: rawPlotData, status: "success" })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    // Now change filters and set loading
-    const newFilters = {
-      ready: true,
-      startDate: "2026-02-01T00:00:00Z",
-      endDate: "2026-02-01T08:00:00Z",
-      serialisedFilters: "2026-02-01T00:00:00Z|2026-02-01T08:00:00Z|minutes",
-    };
-    await act(async () => {
-      useFiltersStore.setState({ filters: newFilters });
-      mockUseSpanMetricsPlotQuery.mockReturnValue({
-        data: undefined,
-        status: "pending",
-        error: null,
-      });
-    });
+    rerender(
+      <SpanMetricsPlot filterParams={filterParams} query={queryWith({})} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("loading")).toBeInTheDocument();

--- a/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
@@ -24,12 +24,31 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's query reads the URL, so without this it
+// would never see what the bar settled on.
 let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const mockRouterReplace = jest.fn(
+  (url: string, _options?: { scroll: boolean }) => {
+    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+    searchParamsSubscribers.forEach((notify) => notify());
+  },
+);
 jest.mock("next/navigation", () => ({
   __esModule: true,
   useRouter: () => ({ replace: mockRouterReplace, push: jest.fn() }),
-  useSearchParams: () => mockSearchParams,
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
   usePathname: () => "/test-team/builds",
 }));
 

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -1,10 +1,10 @@
 /**
  * Integration tests for Traces Overview and Detail pages.
  *
- * Overview: paginated spans list with 4 columns (Trace, Start Time,
- * Duration, Status), span metrics plot with quantile selector, and
- * 10 filter types. Uses FilterSource.Spans which adds span_name and
- * span_statuses filters.
+ * Overview: FilterBar-driven spans list with 4 columns (Trace, Start Time,
+ * Duration, Status), a span metrics plot with quantile selector, and a
+ * root span ("Trace Name") selector the FilterBar owns and whose resolved
+ * choice the span queries require.
  *
  * Detail: single trace with pills (User ID, Start Time, Duration,
  * Device, App version, Network type), TraceWaterfall timeline visualization,
@@ -26,6 +26,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 
@@ -36,13 +37,33 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
 const mockRouterPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
+
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's queries read the URL, so without this
+// they would never see what the bar settled on.
+let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const mockRouterReplace = jest.fn(
+  (url: string, _options?: { scroll: boolean }) => {
+    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+    searchParamsSubscribers.forEach((notify) => notify());
+  },
+);
 jest.mock("next/navigation", () => ({
   __esModule: true,
   useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
   usePathname: () => "/test-team/traces",
 }));
 
@@ -76,6 +97,18 @@ jest.mock("@nivo/line", () => {
     ResponsiveLineCanvas: LineChartStub,
   };
 });
+
+// The trace name select and the filter pickers are Radix popovers, which
+// need a resize observer and pointer capture that jsdom does not have.
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn(() => false);
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
 
 // --- MSW ---
 import {
@@ -120,12 +153,16 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
+const appId = makeAppFixture().id;
+
+// What the default root span names handler serves, in order.
+const firstRootSpanName = "checkout_full_display";
+
 beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  filtersStore.getState().reset();
-  for (const key of [...mockSearchParams.keys()]) mockSearchParams.delete(key);
+  mockSearchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -140,137 +177,210 @@ function renderWithProviders(ui: React.ReactElement) {
 // TRACES OVERVIEW
 // ====================================================================
 describe("Traces Overview (MSW integration)", () => {
-  const { AppVersion, OsVersion } = require("@/app/api/api_calls");
-
-  async function renderAndWaitForData() {
-    renderWithProviders(
+  function renderPage() {
+    return renderWithProviders(
       <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
     );
+  }
+
+  function recordSpansRequests() {
+    const sent: URL[] = [];
+    server.use(
+      http.get("*/api/apps/:appId/spans", ({ request }) => {
+        const url = new URL(request.url);
+        if (
+          url.pathname.includes("/plots/") ||
+          url.pathname.includes("/roots/")
+        ) {
+          return;
+        }
+        sent.push(url);
+        return HttpResponse.json(makeSpansOverviewFixture());
+      }),
+    );
+    return sent;
+  }
+
+  async function waitForSpans() {
     await waitFor(
-      () => {
-        // Wait for the trace ID to appear in the table (not span name which also appears in root span names dropdown)
-        expect(screen.getByText("ID: trace-001")).toBeTruthy();
-      },
+      () => expect(screen.getByText("ID: trace-001")).toBeTruthy(),
       { timeout: 5000 },
     );
   }
 
-  // ================================================================
-  // PAGE LOAD
-  // ================================================================
-  describe("page load", () => {
-    it("shows error when spans API returns 500", async () => {
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          return new HttpResponse(null, { status: 500 });
-        }),
-      );
+  describe("opening the page", () => {
+    it("lists the spans the server sent under the plot", async () => {
+      renderPage();
+      await waitForSpans();
 
-      renderWithProviders(
-        <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(/Error fetching list of traces/),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
+      expect(screen.getByText("ID: trace-002")).toBeTruthy();
+      expect(screen.getByTestId("nivo-line-chart")).toBeTruthy();
     });
 
-    it("shows plot error when plot API returns 500", async () => {
+    it("asks for the first root span over the range it settled on", async () => {
+      const sent = recordSpansRequests();
+      renderPage();
+      await waitForSpans();
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].pathname).toBe(`/api/apps/${appId}/spans`);
+      expect(sent[0].searchParams.get("span_name")).toBe(firstRootSpanName);
+      const from = sent[0].searchParams.get("from")!;
+      const to = sent[0].searchParams.get("to")!;
+      expect(from).toMatch(/Z$/);
+      expect(to).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("timezone")).toBeTruthy();
+      expect(sent[0].searchParams.get("limit")).toBe("5");
+      expect(sent[0].searchParams.get("offset")).toBe("0");
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+      expect(sent[0].searchParams.has("filter_short_code")).toBe(false);
+      expect(sent[0].searchParams.has("span_statuses")).toBe(false);
+    });
+
+    it("sends the span and time group in the plot request", async () => {
+      const plotUrls: URL[] = [];
       server.use(
-        http.get("*/api/apps/:appId/spans/plots/metrics", () => {
-          return new HttpResponse(null, { status: 500 });
+        http.get("*/api/apps/:appId/spans/plots/metrics", ({ request }) => {
+          plotUrls.push(new URL(request.url));
+          return HttpResponse.json(makeSpanMetricsPlotFixture());
         }),
       );
+      renderPage();
+      await waitForSpans();
 
-      renderWithProviders(
-        <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
+      await waitFor(() => expect(plotUrls.length).toBeGreaterThan(0));
+      expect(plotUrls[0].searchParams.get("span_name")).toBe(firstRootSpanName);
+      expect(plotUrls[0].searchParams.get("plot_time_group")).toBeTruthy();
+      expect(plotUrls[0].searchParams.has("filter_expr")).toBe(false);
+    });
+
+    it("records the app, range and span name it settled on in the URL", async () => {
+      renderPage();
+      await waitForSpans();
+
+      const written = new URLSearchParams(
+        mockRouterReplace.mock.calls[0][0].slice(1),
       );
-      await waitFor(
-        () => {
-          expect(screen.getByText(/Error fetching plot/)).toBeTruthy();
-        },
-        { timeout: 5000 },
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(written.get("sd")).toBeTruthy();
+      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("po")).toBe("0");
+      expect(written.get("r")).toBe(firstRootSpanName);
+    });
+  });
+
+  describe("root span selection", () => {
+    it("restores the name a link asked for when its app matches", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&a=${appId}&r=api_fetch_payments`,
+      );
+      const sent = recordSpansRequests();
+      renderPage();
+      await waitForSpans();
+
+      expect(sent[0].searchParams.get("span_name")).toBe("api_fetch_payments");
+    });
+
+    it("picking another name refetches for it from page one", async () => {
+      const sent = recordSpansRequests();
+      renderPage();
+      await waitForSpans();
+
+      fireEvent.click(screen.getByRole("button", { name: firstRootSpanName }));
+      const list = within(await screen.findByRole("dialog"));
+      await act(async () => {
+        fireEvent.click(list.getByText("api_fetch_payments"));
+      });
+
+      await waitFor(() => expect(sent.length).toBeGreaterThan(1));
+      const last = sent[sent.length - 1];
+      expect(last.searchParams.get("span_name")).toBe("api_fetch_payments");
+      expect(last.searchParams.get("offset")).toBe("0");
+
+      const written = new URLSearchParams(
+        mockRouterReplace.mock.calls[
+          mockRouterReplace.mock.calls.length - 1
+        ][0].slice(1),
+      );
+      expect(written.get("r")).toBe("api_fetch_payments");
+      expect(written.get("po")).toBe("0");
+    });
+
+    it("falls back to the first name when the link's app is not the selected one", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&a=some-other-app&r=api_fetch_payments`,
+      );
+      const sent = recordSpansRequests();
+      renderPage();
+      await waitForSpans();
+
+      expect(sent[0].searchParams.get("span_name")).toBe(firstRootSpanName);
+    });
+
+    it("falls back to the first name when the link names an unknown span", async () => {
+      mockSearchParams = new URLSearchParams(`po=0&a=${appId}&r=span.gone`);
+      const sent = recordSpansRequests();
+      renderPage();
+      await waitForSpans();
+
+      expect(sent[0].searchParams.get("span_name")).toBe(firstRootSpanName);
+    });
+
+    it("says there is no data when the app never reported a trace", async () => {
+      server.use(
+        http.get("*/api/apps/:appId/spans/roots/names", () => {
+          return HttpResponse.json({ results: null });
+        }),
+      );
+      renderPage();
+
+      expect(
+        await screen.findByText("No traces received for this app yet"),
+      ).toBeTruthy();
+      expect(screen.queryByText("ID: trace-001")).toBeNull();
+    });
+  });
+
+  describe("a link carrying a filter", () => {
+    it("filters the spans and the plot by it", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
+      );
+      const sent = recordSpansRequests();
+      const plotUrls: URL[] = [];
+      server.use(
+        http.get("*/api/apps/:appId/spans/plots/metrics", ({ request }) => {
+          plotUrls.push(new URL(request.url));
+          return HttpResponse.json(makeSpanMetricsPlotFixture());
+        }),
+      );
+      renderPage();
+      await waitForSpans();
+
+      expect(sent[0].searchParams.get("filter_expr")).toBe(
+        "version_name:in:3.1.0",
+      );
+      await waitFor(() => expect(plotUrls.length).toBeGreaterThan(0));
+      expect(plotUrls[0].searchParams.get("filter_expr")).toBe(
+        "version_name:in:3.1.0",
       );
     });
   });
 
-  // ================================================================
-  // PAGINATION
-  // ================================================================
-  describe("pagination", () => {
-    it("clicking Next renders page 2 data, Previous returns to page 1", async () => {
-      const page2Fixture = makeSpansOverviewFixture({
-        meta: { next: false, previous: true },
-        results: [
-          {
-            ...makeSpansOverviewFixture().results[0],
-            span_name: "page2_span_render_ui",
-            trace_id: "trace-page2",
-          },
-        ],
-      });
-
+  describe("deep links", () => {
+    it("with po=5 asks for page 2", async () => {
       server.use(
         http.get("*/api/apps/:appId/spans", ({ request }) => {
           const url = new URL(request.url);
           if (
             url.pathname.includes("/plots/") ||
             url.pathname.includes("/roots/")
-          )
+          ) {
             return;
+          }
           const offset = url.searchParams.get("offset");
-          if (offset === "5") return HttpResponse.json(page2Fixture);
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      expect(screen.getByText("ID: trace-001")).toBeTruthy();
-
-      await act(async () => {
-        fireEvent.click(screen.getByText("Next").closest("button")!);
-      });
-      await waitFor(
-        () => {
-          expect(screen.getByText("ID: trace-page2")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      expect(screen.queryByText("ID: trace-001")).toBeNull();
-
-      await act(async () => {
-        fireEvent.click(screen.getByText("Previous").closest("button")!);
-      });
-      await waitFor(
-        () => {
-          expect(screen.getByText("ID: trace-001")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      expect(screen.queryByText("ID: trace-page2")).toBeNull();
-    });
-
-    it("deep-link with po=5 renders page 2 data", async () => {
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          const offset = url.searchParams.get("offset");
-          if (offset === "5")
+          if (offset === "5") {
             return HttpResponse.json(
               makeSpansOverviewFixture({
                 results: [
@@ -282,14 +392,13 @@ describe("Traces Overview (MSW integration)", () => {
                 ],
               }),
             );
+          }
           return HttpResponse.json(makeSpansOverviewFixture());
         }),
       );
 
-      mockSearchParams.set("po", "5");
-      renderWithProviders(
-        <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
+      mockSearchParams = new URLSearchParams("po=5");
+      renderPage();
       await waitFor(
         () => {
           expect(screen.getByText("ID: trace-deep-link")).toBeTruthy();
@@ -300,383 +409,71 @@ describe("Traces Overview (MSW integration)", () => {
     });
   });
 
-  // ================================================================
-  // FILTERS
-  // ================================================================
-  describe("filters", () => {
-    let shortFilterBodies: any[];
-
-    beforeEach(() => {
-      shortFilterBodies = [];
-      server.use(
-        http.post("*/api/apps/:appId/shortFilters", async ({ request }) => {
-          shortFilterBodies.push(await request.json());
-          return HttpResponse.json({
-            filter_short_code: `code-${shortFilterBodies.length}`,
-          });
-        }),
-      );
-    });
-
-    it.each([
-      [
-        "versions",
-        () =>
-          filtersStore
-            .getState()
-            .setSelectedVersions([new AppVersion("3.0.1", "301")]),
-        ["3.0.1"],
-      ],
-      [
-        "os_names",
-        () =>
-          filtersStore
-            .getState()
-            .setSelectedOsVersions([new OsVersion("android", "14")]),
-        ["android"],
-      ],
-      [
-        "countries",
-        () => filtersStore.getState().setSelectedCountries(["DE"]),
-        ["DE"],
-      ],
-      [
-        "network_providers",
-        () => filtersStore.getState().setSelectedNetworkProviders(["Jio"]),
-        ["Jio"],
-      ],
-      [
-        "network_types",
-        () => filtersStore.getState().setSelectedNetworkTypes(["cellular"]),
-        ["cellular"],
-      ],
-      [
-        "network_generations",
-        () => filtersStore.getState().setSelectedNetworkGenerations(["5g"]),
-        ["5g"],
-      ],
-      [
-        "locales",
-        () => filtersStore.getState().setSelectedLocales(["hi-IN"]),
-        ["hi-IN"],
-      ],
-      [
-        "device_manufacturers",
-        () =>
-          filtersStore.getState().setSelectedDeviceManufacturers(["Samsung"]),
-        ["Samsung"],
-      ],
-      [
-        "device_names",
-        () => filtersStore.getState().setSelectedDeviceNames(["Galaxy S24"]),
-        ["Galaxy S24"],
-      ],
-    ])(
-      "%s filter change is sent in shortFilters POST",
-      async (field, applyFilter, expected) => {
-        await renderAndWaitForData();
-        shortFilterBodies.length = 0;
-        await act(async () => {
-          (applyFilter as () => void)();
-        });
-        await waitFor(
-          () => expect(shortFilterBodies.length).toBeGreaterThan(0),
-          { timeout: 5000 },
-        );
-        expect(
-          shortFilterBodies[shortFilterBodies.length - 1].filters[
-            field as string
-          ],
-        ).toEqual(expected);
-      },
-    );
-
-    it("span status filter sends span_statuses in request URL", async () => {
-      const requestUrls: string[] = [];
+  describe("when the server fails", () => {
+    it("shows the error message", async () => {
       server.use(
         http.get("*/api/apps/:appId/spans", ({ request }) => {
           const url = new URL(request.url);
           if (
             url.pathname.includes("/plots/") ||
             url.pathname.includes("/roots/")
-          )
+          ) {
             return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeSpansOverviewFixture());
+          }
+          return new HttpResponse(null, { status: 500 });
         }),
       );
+      renderPage();
 
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      const { SpanStatus } = require("@/app/api/api_calls");
-      await act(async () => {
-        filtersStore.getState().setSelectedSpanStatuses([SpanStatus.Error]);
-      });
-
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      expect(requestUrls[requestUrls.length - 1]).toContain("span_statuses=2");
+      expect(
+        await screen.findByText(/Error fetching list of traces/),
+      ).toBeTruthy();
     });
 
-    it("multiple span statuses sends multiple params", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      const { SpanStatus } = require("@/app/api/api_calls");
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedSpanStatuses([SpanStatus.Ok, SpanStatus.Error]);
-      });
-
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("span_statuses=1");
-      expect(lastUrl).toContain("span_statuses=2");
-    });
-
-    it("root span name change sends span_name in request URL", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      await act(async () => {
-        filtersStore.getState().setSelectedRootSpanName("api_fetch_payments");
-      });
-
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("span_name=");
-      expect(decodeURIComponent(lastUrl)).toContain("api_fetch_payments");
-    });
-
-    it("root span name is also sent in plot request URL", async () => {
-      const plotUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans/plots/metrics", ({ request }) => {
-          plotUrls.push(new URL(request.url).toString());
-          return HttpResponse.json(makeSpanMetricsPlotFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      plotUrls.length = 0;
-
-      await act(async () => {
-        filtersStore.getState().setSelectedRootSpanName("api_fetch_payments");
-      });
-
-      await waitFor(() => expect(plotUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      expect(decodeURIComponent(plotUrls[plotUrls.length - 1])).toContain(
-        "api_fetch_payments",
-      );
-    });
-  });
-
-  // ================================================================
-  // URL SYNC
-  // ================================================================
-  describe("URL sync", () => {
-    it("serialises filters into URL", async () => {
-      await renderAndWaitForData();
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      expect(url).toContain("a=");
-      expect(url).toContain("sd=");
-      expect(url).toContain("ed=");
-    });
-  });
-
-  // ================================================================
-  // REQUEST URL PARAMS
-  // ================================================================
-  describe("request URL params", () => {
-    it("sends limit=5 and offset in request URL", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-      await renderAndWaitForData();
-      expect(requestUrls[requestUrls.length - 1]).toContain("limit=5");
-      expect(requestUrls[requestUrls.length - 1]).toContain("offset=0");
-    });
-
-    it("request URL contains correct app ID", async () => {
-      const requestPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          requestPaths.push(url.pathname);
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-      await renderAndWaitForData();
-      expect(requestPaths[requestPaths.length - 1]).toContain(
-        `/apps/${makeAppFixture().id}/spans`,
-      );
-    });
-  });
-
-  // ================================================================
-  // API PATH VERIFICATION
-  // ================================================================
-  describe("API paths", () => {
-    it("fetches from /spans path", async () => {
-      const requestPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans", ({ request }) => {
-          const url = new URL(request.url);
-          if (
-            url.pathname.includes("/plots/") ||
-            url.pathname.includes("/roots/")
-          )
-            return;
-          requestPaths.push(url.pathname);
-          return HttpResponse.json(makeSpansOverviewFixture());
-        }),
-      );
-      await renderAndWaitForData();
-      expect(requestPaths.some((p) => p.endsWith("/spans"))).toBe(true);
-    });
-
-    it("plot endpoint uses /spans/plots/metrics", async () => {
-      const plotPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/spans/plots/metrics", ({ request }) => {
-          plotPaths.push(new URL(request.url).pathname);
-          return HttpResponse.json(makeSpanMetricsPlotFixture());
-        }),
-      );
-      await renderAndWaitForData();
-      expect(plotPaths.some((p) => p.includes("/spans/plots/metrics"))).toBe(
-        true,
-      );
-    });
-  });
-
-  // ================================================================
-  // PLOT STORE
-  // ================================================================
-  describe("plot store", () => {
-    it("plot re-fetches on filter change", async () => {
-      let plotFetchCount = 0;
+    it("says so when the plot cannot be fetched", async () => {
       server.use(
         http.get("*/api/apps/:appId/spans/plots/metrics", () => {
-          plotFetchCount++;
-          return HttpResponse.json(makeSpanMetricsPlotFixture());
+          return new HttpResponse(null, { status: 500 });
         }),
       );
-      await renderAndWaitForData();
-      const initial = plotFetchCount;
+      renderPage();
 
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedVersions([new AppVersion("3.0.1", "301")]);
-      });
-      await waitFor(
-        () => {
-          expect(plotFetchCount).toBeGreaterThan(initial);
-        },
-        { timeout: 5000 },
+      expect(await screen.findByText(/Error fetching plot/)).toBeTruthy();
+    });
+
+    it("says so when the root span names cannot be fetched", async () => {
+      server.use(
+        http.get("*/api/apps/:appId/spans/roots/names", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
       );
+      renderPage();
+
+      expect(
+        await screen.findByText(/Error fetching traces list/),
+      ).toBeTruthy();
+    });
+
+    it("says so when the team's apps cannot be fetched", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      renderPage();
+
+      expect(await screen.findByText(/Error fetching apps/)).toBeTruthy();
     });
   });
 
-  // ================================================================
-  // CONCURRENT / RE-RENDER
-  // ================================================================
-  describe("concurrent and re-render", () => {
-    it("rapid filter changes settle on the last one", async () => {
-      await renderAndWaitForData();
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedVersions([new AppVersion("3.0.2", "302")]);
-        filtersStore
-          .getState()
-          .setSelectedVersions([new AppVersion("3.0.1", "301")]);
-        filtersStore
-          .getState()
-          .setSelectedVersions([new AppVersion("3.1.0", "310")]);
-      });
-      await waitFor(() => {
-        expect(filtersStore.getState().selectedVersions[0]?.name).toBe("3.1.0");
-      });
-    });
-
+  describe("re-render", () => {
     it("re-render still shows data", async () => {
-      const { unmount } = renderWithProviders(
-        <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
-      await waitFor(
-        () => {
-          expect(screen.getByText("ID: trace-001")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
+      const { unmount } = renderPage();
+      await waitForSpans();
 
       unmount();
-      renderWithProviders(
-        <TracesOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
-      await waitFor(
-        () => {
-          expect(screen.getByText("ID: trace-001")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
+      renderPage();
+      await waitForSpans();
     });
   });
 });

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -4,12 +4,39 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const replaceMock = jest.fn();
-
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's query reads the URL, so without this it
+// would never see what the bar settled on.
 let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const applyReplaceUrl = (url: string) => {
+  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+  searchParamsSubscribers.forEach((notify) => notify());
+};
+// Holds a replace's URL for the test to apply later, modeling the real
+// router landing a write one render after the call.
+let mockDeferReplace = false;
+let deferredReplaceUrl: string | null = null;
+const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
+  if (mockDeferReplace) {
+    deferredReplaceUrl = url;
+    return;
+  }
+  applyReplaceUrl(url);
+});
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
-  useSearchParams: () => mockSearchParams,
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
 }));
 
 const downloadBuildFileMock = jest.fn();
@@ -53,20 +80,33 @@ const mockReportedDate = {
   endDate: "2026-01-01T06:00:00.000Z",
 };
 
-// Like the real bar, this stub reports an app and a range as it mounts.
+// Makes the stub drop the URL's filter on mount, like the bar discarding
+// a filter it cannot read.
+let mockMountDiscardsFilter = false;
+
+// Only an undiscarded mount report carries appliedAsRequested true; a
+// report from a button models a user edit.
 jest.mock("@/app/components/filter_bar/filter_bar", () => {
   const { useEffect } = require("react");
 
   function FilterBarMock(props: any) {
-    const ready = (filterExpr: string | null) => ({
+    const ready = (
+      filterExpr: string | null,
+      appliedAsRequested: boolean = false,
+    ) => ({
       status: "ready",
       app: mockReportedApp,
       date: mockReportedDate,
       filterExpr,
+      appliedAsRequested,
     });
 
     useEffect(() => {
-      props.onFilterChange(ready(props.requestedFilterExpr));
+      if (mockMountDiscardsFilter) {
+        props.onFilterChange(ready(null, false));
+      } else {
+        props.onFilterChange(ready(props.requestedFilterExpr, true));
+      }
     }, []);
 
     return (
@@ -183,6 +223,9 @@ describe("Builds page", () => {
   beforeEach(() => {
     replaceMock.mockClear();
     downloadBuildFileMock.mockClear();
+    mockMountDiscardsFilter = false;
+    mockDeferReplace = false;
+    deferredReplaceUrl = null;
     mockSearchParams = new URLSearchParams();
     mockUseBuildsQuery.mockReset();
     mockUseBuildsQuery.mockReturnValue({
@@ -229,13 +272,47 @@ describe("Builds page", () => {
 
     expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
       {
-        status: "ready",
-        app: mockReportedApp,
-        date: mockReportedDate,
+        appId: mockReportedApp.id,
+        startDate: mockReportedDate.startDate,
+        endDate: mockReportedDate.endDate,
         filterExpr: "patch_id:is_set",
       },
       20,
     );
+  });
+
+  it("never fetches a filter the bar discarded on mount", async () => {
+    mockMountDiscardsFilter = true;
+    mockDeferReplace = true;
+    mockSearchParams = new URLSearchParams(
+      `po=30&filter_expr=patch_id%3Ais_set&${selectionParams}`,
+    );
+    loaded();
+    renderPage();
+
+    // The write has not landed, so the URL still holds the discarded
+    // filter and the query stays disabled.
+    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 30);
+
+    await act(async () => {
+      applyReplaceUrl(deferredReplaceUrl!);
+    });
+
+    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+      scroll: false,
+    });
+    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
+      {
+        appId: mockReportedApp.id,
+        startDate: mockReportedDate.startDate,
+        endDate: mockReportedDate.endDate,
+        filterExpr: null,
+      },
+      0,
+    );
+    for (const [params] of mockUseBuildsQuery.mock.calls) {
+      expect(params?.filterExpr ?? null).not.toBe("patch_id:is_set");
+    }
   });
 
   it("records what the bar settled on, keeping the page the link asked for", () => {
@@ -478,7 +555,7 @@ describe("Builds page", () => {
 
       // Paging keeps everything else the URL was carrying.
       expect(replaceMock).toHaveBeenLastCalledWith(
-        `?po=10&filter_expr=patch_id%3Ais_set&${selectionParams}`,
+        selectionUrl(10, "filter_expr=patch_id%3Ais_set"),
         { scroll: false },
       );
     });
@@ -494,7 +571,7 @@ describe("Builds page", () => {
         fireEvent.click(screen.getByTestId("prev-button"));
       });
       expect(replaceMock).toHaveBeenLastCalledWith(
-        "?po=0&filter_expr=patch_id%3Ais_set",
+        selectionUrl(0, "filter_expr=patch_id%3Ais_set"),
         { scroll: false },
       );
 
@@ -506,7 +583,7 @@ describe("Builds page", () => {
         fireEvent.click(screen.getAllByTestId("prev-button")[1]);
       });
       expect(replaceMock).toHaveBeenLastCalledWith(
-        "?po=0&filter_expr=patch_id%3Ais_set",
+        selectionUrl(0, "filter_expr=patch_id%3Ais_set"),
         { scroll: false },
       );
     });
@@ -526,6 +603,18 @@ describe("Builds page", () => {
         selectionUrl(0, "filter_expr=mapping_type%3Ain%3Adsym"),
         { scroll: false },
       );
+      // The changed filter and the reset offset reach the query together,
+      // through the URL, so the new filter is never fetched at the page the
+      // old filter was on.
+      expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ filterExpr: "mapping_type:in:dsym" }),
+        0,
+      );
+      for (const [params, offset] of mockUseBuildsQuery.mock.calls) {
+        if (params?.filterExpr === "mapping_type:in:dsym") {
+          expect(offset).toBe(0);
+        }
+      }
     });
 
     it("cannot be used while a refetch is in flight", () => {

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -4,66 +4,193 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-// Global replace mock for router.replace
-const replaceMock = jest.fn();
 const pushMock = jest.fn();
 
-// Mock next/navigation hooks
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's queries read the URL, so without this
+// they would never see what the bar settled on.
+let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const applyReplaceUrl = (url: string) => {
+  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+  searchParamsSubscribers.forEach((notify) => notify());
+};
+// Holds a replace's URL for the test to apply later, modeling the real
+// router landing a write one render after the call.
+let mockDeferReplace = false;
+let deferredReplaceUrl: string | null = null;
+const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
+  if (mockDeferReplace) {
+    deferredReplaceUrl = url;
+    return;
+  }
+  applyReplaceUrl(url);
+});
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-    push: pushMock,
-  }),
-  // By default, return empty search params.
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
 }));
 
-// Mock API calls and constants
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
   emptySpansResponse: {
     meta: { next: false, previous: false },
     results: [],
   },
-  FilterSource: { Spans: "spans" },
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return {
-    __esModule: true,
-    useFiltersStore: filtersStore,
-  };
-});
+jest.mock("@/app/stores/filters_store", () => ({
+  __esModule: true,
+  urlFiltersKeyMap: {
+    appId: "a",
+    dateRange: "d",
+    startDate: "sd",
+    endDate: "ed",
+    rootSpanName: "r",
+  },
+}));
 
-const mockUseSpansQuery = jest.fn(() => ({
+const pendingQueryState = () => ({
   data: undefined as any,
   status: "pending" as string,
   isFetching: true,
   error: null as Error | null,
-}));
+});
+
+const mockUseSpansQuery = jest.fn(
+  (_filter: any, _spanName: string | null, _offset: number) =>
+    pendingQueryState(),
+);
+const mockUseSpanMetricsPlotQuery = jest.fn(
+  (_filter: any, _spanName: string | null) => pendingQueryState(),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useSpansQuery: () => mockUseSpansQuery(),
+  useSpansQuery: (filter: any, spanName: string | null, offset: number) =>
+    mockUseSpansQuery(filter, spanName, offset),
+  useSpanMetricsPlotQuery: (filter: any, spanName: string | null) =>
+    mockUseSpanMetricsPlotQuery(filter, spanName),
   paginationOffsetUrlKey: "po",
 }));
 
-jest.mock("@/app/components/filters", () => ({
+const mockReportedApp = { id: "app-1", name: "Sample" };
+const mockReportedDate = {
+  dateRange: "Last 6 Hours",
+  startDate: "2026-01-01T00:00:00.000Z",
+  endDate: "2026-01-01T06:00:00.000Z",
+};
+
+// Set before render to make the stub open with a trace name of its own in
+// place of the URL's, the way the real bar substitutes a default when the
+// app no longer has the requested name.
+let mockMountSubstitutesName = false;
+
+// Like the real bar, this stub reports an app, a range and a resolved trace
+// name as it mounts, and offers buttons that report a changed filter, a
+// changed trace name, or a failure. Only the mount report carries
+// appliedAsRequested true, and only when nothing was substituted; a report
+// from a button models a user edit.
+jest.mock("@/app/components/filter_bar/filter_bar", () => {
+  const { useEffect } = require("react");
+
+  function FilterBarMock(props: any) {
+    const ready = (
+      filterExpr: string | null,
+      // The real bar restores the URL's name when it can, so the stub
+      // reports it back too and falls back to a first name of its own.
+      rootSpanName: string = props.requestedRootSpanName ?? "span.first",
+      appliedAsRequested: boolean = false,
+    ) => ({
+      status: "ready",
+      app: mockReportedApp,
+      date: mockReportedDate,
+      filterExpr,
+      rootSpanName,
+      appliedAsRequested,
+    });
+
+    useEffect(() => {
+      if (mockMountSubstitutesName) {
+        props.onFilterChange(
+          ready(props.requestedFilterExpr, "span.substitute", false),
+        );
+      } else {
+        props.onFilterChange(ready(props.requestedFilterExpr, undefined, true));
+      }
+    }, []);
+
+    return (
+      <div data-testid="filter-bar-mock">
+        <span data-testid="filter-bar-expr">
+          {props.requestedFilterExpr ?? "none"}
+        </span>
+        <span data-testid="filter-bar-requested-name">
+          {props.requestedRootSpanName ?? "none"}
+        </span>
+        <span data-testid="filter-bar-selector-shown">
+          {String(props.showRootSpanSelector ?? false)}
+        </span>
+        <button
+          data-testid="filter-bar-apply"
+          onClick={() => props.onFilterChange(ready("span_status:in:error"))}
+        >
+          apply
+        </button>
+        <button
+          data-testid="filter-bar-pick-name"
+          onClick={() =>
+            props.onFilterChange(
+              ready(props.requestedFilterExpr, "span.second"),
+            )
+          }
+        >
+          pick name
+        </button>
+        <button
+          data-testid="filter-bar-fail"
+          onClick={() =>
+            props.onFilterChange({
+              status: "error",
+              message: "Error fetching apps, please refresh page to try again",
+            })
+          }
+        >
+          fail
+        </button>
+      </div>
+    );
+  }
+
+  return {
+    __esModule: true,
+    default: FilterBarMock,
+    filterExprUrlKey: "filter_expr",
+  };
+});
+
+jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { All: "all" },
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
 }));
 
-// Mock SpanMetricsPlot component.
-jest.mock("@/app/components/span_metrics_plot", () => () => (
-  <div data-testid="span-metrics-plot-mock">TracesOverviewPlot Rendered</div>
-));
+jest.mock("@/app/components/span_metrics_plot", () => ({
+  __esModule: true,
+  default: () => (
+    <div data-testid="span-metrics-plot-mock">TracesOverviewPlot Rendered</div>
+  ),
+}));
 
-// Updated Paginator mock renders Next and Prev buttons.
 jest.mock("@/app/components/paginator", () => ({
   __esModule: true,
   default: (props: any) => (
@@ -87,19 +214,15 @@ jest.mock("@/app/components/paginator", () => ({
   ),
 }));
 
-// Mock LoadingBar component.
 jest.mock("@/app/components/loading_bar", () => () => (
   <div data-testid="loading-bar-mock">LoadingBar Rendered</div>
 ));
 
-// Mock time utils
 jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableDate: jest.fn(() => "Jan 1, 2020"),
   formatDateToHumanReadableTime: jest.fn(() => "12:00 AM"),
   formatMillisToHumanReadable: jest.fn(() => "5s"),
 }));
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
 
 const mockSpanData = {
   results: [
@@ -123,57 +246,131 @@ const mockSpanData = {
   meta: { previous: true, next: true },
 };
 
-describe("TracesOverview Component", () => {
+function spansLoaded(data: any = mockSpanData) {
+  mockUseSpansQuery.mockReturnValue({
+    data,
+    status: "success",
+    isFetching: false,
+    error: null,
+  });
+}
+
+// What the stub bar reports, as the page writes it into the URL.
+const selectionParams =
+  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+
+// The names in these tests are URL-safe, so they appear in the URL as-is.
+const selectionUrl = (
+  offset: number,
+  spanName = "span.first",
+  filterParam?: string,
+) =>
+  `?po=${offset}&${selectionParams}&r=${spanName}${filterParam ? `&${filterParam}` : ""}`;
+
+function renderPage() {
+  return render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
+}
+
+describe("TracesOverview page", () => {
   beforeEach(() => {
     replaceMock.mockClear();
     pushMock.mockClear();
+    mockMountSubstitutesName = false;
+    mockDeferReplace = false;
+    deferredReplaceUrl = null;
+    mockSearchParams = new URLSearchParams();
     mockUseSpansQuery.mockReset();
-    mockUseSpansQuery.mockReturnValue({
-      data: undefined,
-      status: "pending" as string,
-      isFetching: true,
-      error: null,
-    });
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
+    mockUseSpansQuery.mockReturnValue(pendingQueryState());
+    mockUseSpanMetricsPlotQuery.mockReset();
+    mockUseSpanMetricsPlotQuery.mockReturnValue(pendingQueryState());
   });
 
-  it("renders the Filters component", () => {
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
+  it("renders the filter bar", () => {
+    renderPage();
+    expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
   });
 
-  it("does not render main traces UI when filters are not ready", () => {
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    expect(
-      screen.queryByTestId("span-metrics-plot-mock"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId("paginator-mock")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("loading-bar-mock")).not.toBeInTheDocument();
+  it("asks the bar to show the trace name selector", () => {
+    renderPage();
+    expect(screen.getByTestId("filter-bar-selector-shown")).toHaveTextContent(
+      "true",
+    );
   });
 
-  it("renders main traces UI when filters are ready and data is loaded", async () => {
-    mockUseSpansQuery.mockReturnValue({
-      data: mockSpanData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("hands the bar the filter the URL opened on", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=0&filter_expr=span_status%3Ain%3Aerror",
+    );
+    spansLoaded();
+    renderPage();
 
-    expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-      scroll: false,
-    });
+    expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
+      "span_status:in:error",
+    );
+  });
+
+  it("hands the bar the trace name the URL opened on", () => {
+    mockSearchParams = new URLSearchParams("po=0&a=app-1&r=span.second");
+    spansLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-requested-name")).toHaveTextContent(
+      "span.second",
+    );
+  });
+
+  it("fetches nothing until the bar settles on an app, a range and a name", () => {
+    spansLoaded();
+    renderPage();
+
+    expect(mockUseSpansQuery).toHaveBeenNthCalledWith(1, null, null, 0);
+  });
+
+  it("fetches spans and the plot for the name the bar reported", () => {
+    spansLoaded();
+    renderPage();
+
+    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+      {
+        appId: mockReportedApp.id,
+        startDate: mockReportedDate.startDate,
+        endDate: mockReportedDate.endDate,
+        filterExpr: null,
+      },
+      "span.first",
+      0,
+    );
+    expect(mockUseSpanMetricsPlotQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ appId: mockReportedApp.id }),
+      "span.first",
+    );
+  });
+
+  it("records what the bar settled on, keeping the page the link asked for", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=20&filter_expr=span_status%3Ain%3Aerror",
+    );
+    spansLoaded();
+    renderPage();
+
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).toHaveBeenCalledWith(
+      selectionUrl(20, "span.first", "filter_expr=span_status%3Ain%3Aerror"),
+      { scroll: false },
+    );
+  });
+
+  it("keeps the plot area up with paging disabled while the spans load", () => {
+    renderPage();
+    expect(screen.getByTestId("span-metrics-plot-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeDisabled();
+    expect(screen.getByTestId("prev-button")).toBeDisabled();
+  });
+
+  it("renders the plot, paginator and table headers once ready", async () => {
+    spansLoaded();
+    renderPage();
+
     expect(
       await screen.findByTestId("span-metrics-plot-mock"),
     ).toBeInTheDocument();
@@ -183,23 +380,9 @@ describe("TracesOverview Component", () => {
     expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
-  it("displays span data correctly", async () => {
-    mockUseSpansQuery.mockReturnValue({
-      data: mockSpanData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("displays span data correctly", () => {
+    spansLoaded();
+    renderPage();
 
     expect(screen.getByText("Test Span")).toBeInTheDocument();
     expect(screen.getByText("Jan 1, 2020")).toBeInTheDocument();
@@ -214,26 +397,12 @@ describe("TracesOverview Component", () => {
   it.each([
     [2, "Error"],
     [0, "Unset"],
-  ])("renders status pill %s as %s", async (status, label) => {
-    mockUseSpansQuery.mockReturnValue({
-      data: {
-        ...mockSpanData,
-        results: [{ ...mockSpanData.results[0], status }],
-      },
-      status: "success",
-      isFetching: false,
-      error: null,
+  ])("renders status pill %s as %s", (status, label) => {
+    spansLoaded({
+      ...mockSpanData,
+      results: [{ ...mockSpanData.results[0], status }],
     });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+    renderPage();
 
     expect(screen.getByText(label as string)).toBeInTheDocument();
   });
@@ -250,84 +419,41 @@ describe("TracesOverview Component", () => {
     ["harmonyos", "4", "Huawei", "P60", "1.0(1), harmonyos 4, Huawei P60"],
   ])(
     "renders the %s device string",
-    async (
-      os_name,
-      os_version,
-      device_manufacturer,
-      device_model,
-      expected,
-    ) => {
-      mockUseSpansQuery.mockReturnValue({
-        data: {
-          ...mockSpanData,
-          results: [
-            {
-              ...mockSpanData.results[0],
-              os_name,
-              os_version,
-              device_manufacturer,
-              device_model,
-            },
-          ],
-        },
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
+    (os_name, os_version, device_manufacturer, device_model, expected) => {
+      spansLoaded({
+        ...mockSpanData,
+        results: [
+          {
+            ...mockSpanData.results[0],
+            os_name,
+            os_version,
+            device_manufacturer,
+            device_model,
           },
-        });
+        ],
       });
+      renderPage();
 
       expect(screen.getByText(expected as string)).toBeInTheDocument();
     },
   );
 
-  it("renders an empty table when no spans match", async () => {
-    mockUseSpansQuery.mockReturnValue({
-      data: { results: [], meta: { previous: false, next: false } },
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("renders an empty table when no spans match", () => {
+    spansLoaded({ results: [], meta: { previous: false, next: false } });
+    renderPage();
 
     expect(screen.getByText("Trace")).toBeInTheDocument();
     expect(screen.queryByText(/ID:/)).not.toBeInTheDocument();
   });
 
-  it("shows error message when API returns error status", async () => {
+  it("shows an error message when the spans request fails", () => {
     mockUseSpansQuery.mockReturnValue({
       data: undefined,
       status: "error",
       isFetching: false,
       error: new Error("fail"),
     });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+    renderPage();
 
     expect(
       screen.getByText(/Error fetching list of traces/),
@@ -335,22 +461,8 @@ describe("TracesOverview Component", () => {
   });
 
   it("renders appropriate link for each span", async () => {
-    mockUseSpansQuery.mockReturnValue({
-      data: mockSpanData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+    spansLoaded();
+    renderPage();
 
     const link = screen.getByRole("link", { name: /ID: trace1/i });
     expect(link).toBeInTheDocument();
@@ -368,210 +480,209 @@ describe("TracesOverview Component", () => {
     expect(pushMock).toHaveBeenCalledWith("/123/traces/app1/trace1");
   });
 
-  describe("Pagination", () => {
-    it("renders paginator with correct enabled state", async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
-      });
-
-      const prevButton = screen.getByTestId("prev-button");
-      const nextButton = screen.getByTestId("next-button");
-      expect(prevButton).not.toBeDisabled();
-      expect(nextButton).not.toBeDisabled();
+  describe("a filter the bar could not settle", () => {
+    beforeEach(() => {
+      mockSearchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      spansLoaded();
     });
 
-    it("disables paginator buttons during loading", async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "pending" as string,
-        isFetching: true,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
+    it("is said by the page, in place of the list", async () => {
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
 
-      const prevButton = screen.getByTestId("prev-button");
-      const nextButton = screen.getByTestId("next-button");
-      expect(prevButton).toBeDisabled();
-      expect(nextButton).toBeDisabled();
+      expect(
+        screen.getByText(
+          "Error fetching apps, please refresh page to try again",
+        ),
+      ).toBeInTheDocument();
     });
 
-    it("includes pagination offset in URL", async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
+    it("stops the page fetching anything", async () => {
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
 
-      // Click next to change offset
-      const nextButton = screen.getByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
+      // The name stays readable from the URL, but the null filter keeps the
+      // query disabled.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        null,
+        "span.first",
+        10,
+      );
     });
 
-    it("decrements offset by 5 on Prev click (not below 0)", async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
-      });
-
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
-
-      const prevButton = await screen.findByTestId("prev-button");
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-
-      // Clicking Prev again must not go negative
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-    });
-
-    it("resets pagination offset when filters change", async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
-      });
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
+    it("leaves the URL where the link had it", async () => {
+      renderPage();
+      replaceMock.mockClear();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated2",
-            app: { id: "app-1" },
-          },
-        });
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated2", {
-        scroll: false,
-      });
+
+      expect(replaceMock).not.toHaveBeenCalled();
     });
   });
 
-  it("correctly toggles loading bar visibility", async () => {
+  describe("pagination", () => {
+    it("moves the offset on by the page size when Next is clicked", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&r=span.first&${selectionParams}`,
+      );
+      spansLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("next-button"));
+      });
+
+      // Paging keeps everything else the URL was carrying.
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(5), {
+        scroll: false,
+      });
+    });
+
+    it("moves the offset back when Prev is clicked, and never below zero", async () => {
+      mockSearchParams = new URLSearchParams("po=5&r=span.first&a=app-1");
+      spansLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("prev-button"));
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+        scroll: false,
+      });
+
+      mockSearchParams = new URLSearchParams("po=0&r=span.first&a=app-1");
+      renderPage();
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("prev-button")[1]);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+        scroll: false,
+      });
+    });
+
+    it("goes back to the first page when the filter changes", async () => {
+      mockSearchParams = new URLSearchParams("po=30&a=app-1&r=span.first");
+      spansLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-apply"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl(0, "span.first", "filter_expr=span_status%3Ain%3Aerror"),
+        { scroll: false },
+      );
+    });
+
+    it("goes back to the first page when the bar reports another name", async () => {
+      mockSearchParams = new URLSearchParams(`po=30&${selectionParams}`);
+      spansLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-pick-name"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl(0, "span.second"),
+        { scroll: false },
+      );
+      // The changed name and the reset offset reach the queries together,
+      // through the URL, so the new name is never fetched at the page the
+      // old name was on.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "span.second",
+        0,
+      );
+      for (const [, spanName, offset] of mockUseSpansQuery.mock.calls) {
+        if (spanName === "span.second") {
+          expect(offset).toBe(0);
+        }
+      }
+    });
+
+    it("goes back to the first page when the bar opens on a substituted name", async () => {
+      mockMountSubstitutesName = true;
+      mockDeferReplace = true;
+      mockSearchParams = new URLSearchParams(
+        `po=30&r=span.gone&${selectionParams}`,
+      );
+      spansLoaded();
+      renderPage();
+
+      // The write has not landed, so the URL still holds the dead name
+      // and the queries stay disabled.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, "span.gone", 30);
+
+      await act(async () => {
+        applyReplaceUrl(deferredReplaceUrl!);
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl(0, "span.substitute"),
+        { scroll: false },
+      );
+      // The substituted name is never fetched at the page the URL's name
+      // was on.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "span.substitute",
+        0,
+      );
+      for (const [filter, spanName, offset] of mockUseSpansQuery.mock.calls) {
+        if (spanName === "span.substitute") {
+          expect(offset).toBe(0);
+        }
+        if (spanName === "span.gone") {
+          expect(filter).toBeNull();
+        }
+      }
+    });
+
+    it("cannot be used while a refetch is in flight", () => {
+      mockUseSpansQuery.mockReturnValue({
+        data: mockSpanData,
+        status: "success",
+        isFetching: true,
+        error: null,
+      });
+      renderPage();
+
+      expect(screen.getByTestId("next-button")).toBeDisabled();
+      expect(screen.getByTestId("prev-button")).toBeDisabled();
+    });
+  });
+
+  it("shows the loading bar only while a refetch is in flight", async () => {
     mockUseSpansQuery.mockReturnValue({
-      data: undefined,
-      status: "pending" as string,
+      data: mockSpanData,
+      status: "success",
       isFetching: true,
       error: null,
     });
-    render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
-
-    // Set loading state
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+    const { rerender } = renderPage();
 
     const loadingBarContainer =
       screen.getByTestId("loading-bar-mock").parentElement;
     expect(loadingBarContainer).toHaveClass("visible");
     expect(loadingBarContainer).not.toHaveClass("invisible");
 
-    // Set success state
     await act(async () => {
-      mockUseSpansQuery.mockReturnValue({
-        data: mockSpanData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
+      spansLoaded();
+      rerender(<TracesOverview params={promiseParams({ teamId: "123" })} />);
     });
 
+    await screen.findByText("Test Span");
     expect(loadingBarContainer).not.toHaveClass("visible");
     expect(loadingBarContainer).toHaveClass("invisible");
   });

--- a/frontend/dashboard/__tests__/query/hooks_test.tsx
+++ b/frontend/dashboard/__tests__/query/hooks_test.tsx
@@ -11,9 +11,12 @@ jest.mock("@/app/api/api_calls", () => {
   return {
     ...actual,
     fetchAppsFromServer: jest.fn(),
-    fetchBuildsWithFilter: jest.fn(),
+    fetchBuildsFromServer: jest.fn(),
+    fetchFilterKeys: jest.fn(),
     fetchFiltersFromServer: jest.fn(),
     fetchRootSpanNamesFromServer: jest.fn(),
+    fetchSpansFromServer: jest.fn(),
+    fetchSpanMetricsPlotFromServer: jest.fn(),
     fetchErrorsOverviewFromServer: jest.fn(),
     fetchErrorsOverviewPlotFromServer: jest.fn(),
     fetchErrorsDetailsFromServer: jest.fn(),
@@ -50,15 +53,18 @@ jest.mock("@/app/api/api_client", () => ({
 
 import {
   fetchAppsFromServer,
-  fetchBuildsWithFilter,
+  fetchBuildsFromServer,
   fetchErrorGroupCommonPathFromServer,
   fetchErrorsDetailsFromServer,
   fetchErrorsDetailsPlotFromServer,
   fetchErrorsDistributionPlotFromServer,
   fetchErrorsOverviewFromServer,
   fetchErrorsOverviewPlotFromServer,
+  fetchFilterKeys,
   fetchFiltersFromServer,
   fetchRootSpanNamesFromServer,
+  fetchSpanMetricsPlotFromServer,
+  fetchSpansFromServer,
 } from "@/app/api/api_calls";
 import { apiClient } from "@/app/api/api_client";
 import {
@@ -72,15 +78,21 @@ import {
   useErrorsDistributionPlotQuery,
   useErrorsOverviewPlotQuery,
   useErrorsOverviewQuery,
+  useFilterKeysQuery,
   useFilterOptionsQuery,
   useRootSpanNamesQuery,
   useSessionQuery,
+  useSpanMetricsPlotQuery,
+  useSpansQuery,
 } from "@/app/query/hooks";
 
 const mockFetchApps = fetchAppsFromServer as jest.Mock;
-const mockFetchBuilds = fetchBuildsWithFilter as jest.Mock;
+const mockFetchBuilds = fetchBuildsFromServer as jest.Mock;
+const mockFetchFilterKeys = fetchFilterKeys as jest.Mock;
 const mockFetchFilters = fetchFiltersFromServer as jest.Mock;
 const mockFetchRootSpanNames = fetchRootSpanNamesFromServer as jest.Mock;
+const mockFetchSpans = fetchSpansFromServer as jest.Mock;
+const mockFetchSpanMetricsPlot = fetchSpanMetricsPlotFromServer as jest.Mock;
 const mockFetchErrorsOverview = fetchErrorsOverviewFromServer as jest.Mock;
 const mockFetchErrorsOverviewPlot =
   fetchErrorsOverviewPlotFromServer as jest.Mock;
@@ -325,31 +337,77 @@ describe("useFilterOptionsQuery", () => {
   });
 });
 
-describe("useRootSpanNamesQuery", () => {
-  const app = { id: "a1", name: "App 1", onboarded: true } as any;
-
-  it("is disabled when filterSource is not Spans", () => {
-    const { wrapper } = makeWrapper();
-    const { result } = renderHook(
-      () => useRootSpanNamesQuery(app, FilterSource.Errors),
-      { wrapper },
-    );
-    expect(result.current.fetchStatus).toBe("idle");
-    expect(mockFetchRootSpanNames).not.toHaveBeenCalled();
-  });
-
-  it("fetches when filterSource is Spans and returns the parsed results", async () => {
-    mockFetchRootSpanNames.mockResolvedValueOnce(["root.a", "root.b"]);
+describe("useFilterKeysQuery", () => {
+  it("keeps the last keys while a changed name set refetches", async () => {
+    mockFetchFilterKeys
+      .mockResolvedValueOnce({ keys: [{ name: "k1" }], key_groups: ["g"] })
+      // The second response never arrives, so the hook stays mid-fetch.
+      .mockReturnValueOnce(new Promise(() => {}));
 
     const { wrapper } = makeWrapper();
-    const { result } = renderHook(
-      () => useRootSpanNamesQuery(app, FilterSource.Spans),
-      { wrapper },
+    const { result, rerender } = renderHook(
+      ({ names }: { names: string[] }) =>
+        useFilterKeysQuery("app-1", "builds", names),
+      { wrapper, initialProps: { names: [] as string[] } },
     );
 
     await waitFor(() => expect(result.current.status).toBe("success"));
 
+    rerender({ names: ["custom.plan"] });
+
+    await waitFor(() =>
+      expect(mockFetchFilterKeys).toHaveBeenLastCalledWith("app-1", "builds", [
+        "custom.plan",
+      ]),
+    );
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.data?.keys).toEqual([{ name: "k1" }]);
+  });
+});
+
+describe("useRootSpanNamesQuery", () => {
+  const app = { id: "a1", name: "App 1", onboarded: true } as any;
+
+  it("is disabled without an app", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useRootSpanNamesQuery(null), {
+      wrapper,
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchRootSpanNames).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the app and returns the parsed results", async () => {
+    mockFetchRootSpanNames.mockResolvedValueOnce(["root.a", "root.b"]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useRootSpanNamesQuery(app), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
     expect(result.current.data).toEqual(["root.a", "root.b"]);
+    expect(mockFetchRootSpanNames).toHaveBeenCalledWith(app);
+  });
+
+  it("refetches when the app changes", async () => {
+    mockFetchRootSpanNames
+      .mockResolvedValueOnce(["root.a"])
+      .mockResolvedValueOnce(["root.b"]);
+
+    const { wrapper } = makeWrapper();
+    const { result, rerender } = renderHook(
+      ({ current }: { current: any }) => useRootSpanNamesQuery(current),
+      { wrapper, initialProps: { current: app } },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(["root.a"]));
+
+    rerender({ current: { ...app, id: "a2" } });
+
+    await waitFor(() => expect(result.current.data).toEqual(["root.b"]));
+    expect(mockFetchRootSpanNames).toHaveBeenCalledTimes(2);
   });
 
   it("surfaces a failed fetch as a query error", async () => {
@@ -357,10 +415,9 @@ describe("useRootSpanNamesQuery", () => {
     mockFetchRootSpanNames.mockRejectedValueOnce(failure);
 
     const { wrapper } = makeWrapper();
-    const { result } = renderHook(
-      () => useRootSpanNamesQuery(app, FilterSource.Spans),
-      { wrapper },
-    );
+    const { result } = renderHook(() => useRootSpanNamesQuery(app), {
+      wrapper,
+    });
 
     await waitFor(() => expect(result.current.status).toBe("error"));
     expect(result.current.error).toBe(failure);
@@ -523,12 +580,9 @@ describe("useErrorsOverviewQuery", () => {
 
 describe("useBuildsQuery", () => {
   const filteredBy = (filterExpr: string | null) => ({
-    app: { id: "app-1" } as any,
-    date: {
-      dateRange: "Last 6 Hours",
-      startDate: "2026-01-01T00:00:00Z",
-      endDate: "2026-01-02T00:00:00Z",
-    },
+    appId: "app-1",
+    startDate: "2026-01-01T00:00:00Z",
+    endDate: "2026-01-02T00:00:00Z",
     filterExpr,
   });
 
@@ -635,6 +689,216 @@ describe("useBuildsQuery", () => {
       {
         wrapper,
       },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
+  });
+});
+
+describe("useSpansQuery", () => {
+  const filteredBy = (filterExpr: string | null) => ({
+    appId: "app-1",
+    startDate: "2026-01-01T00:00:00Z",
+    endDate: "2026-01-02T00:00:00Z",
+    filterExpr,
+  });
+
+  it("does not fetch without an app and a date range", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSpansQuery(null, "root.a", 0), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchSpans).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a span name", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpansQuery(filteredBy(null), null, 0),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchSpans).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the span, range, filter and page, and returns the data", async () => {
+    mockFetchSpans.mockResolvedValueOnce({
+      results: [{ span_id: "s1" }],
+      meta: { next: false, previous: false },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpansQuery(filteredBy("span_status:in:error"), "root.a", 10),
+      { wrapper },
+    );
+
+    expect(result.current.status).toBe("pending");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchSpans).toHaveBeenCalledWith(
+      "app-1",
+      "root.a",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      "span_status:in:error",
+      5,
+      10,
+    );
+    expect((result.current.data as any).results[0].span_id).toBe("s1");
+  });
+
+  it("fetches without a filter when none is given", async () => {
+    mockFetchSpans.mockResolvedValueOnce({
+      results: [],
+      meta: { next: false, previous: false },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpansQuery(filteredBy(null), "root.a", 0),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(mockFetchSpans).toHaveBeenCalledWith(
+      "app-1",
+      "root.a",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      null,
+      5,
+      0,
+    );
+  });
+
+  it("fetches again for another page, and shows the last one meanwhile", async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({
+        results: [{ span_id: "s1" }],
+        meta: { next: true, previous: false },
+      })
+      // The second page never arrives, so the hook stays mid-fetch.
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    const { wrapper } = makeWrapper();
+    const { result, rerender } = renderHook(
+      ({ offset }) => useSpansQuery(filteredBy(null), "root.a", offset),
+      { wrapper, initialProps: { offset: 0 } },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    rerender({ offset: 5 });
+
+    await waitFor(() =>
+      expect(mockFetchSpans).toHaveBeenLastCalledWith(
+        "app-1",
+        "root.a",
+        "2026-01-01T00:00:00Z",
+        "2026-01-02T00:00:00Z",
+        null,
+        5,
+        5,
+      ),
+    );
+    expect(result.current.isFetching).toBe(true);
+    expect((result.current.data as any).results[0].span_id).toBe("s1");
+  });
+
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchSpans.mockRejectedValueOnce(failure);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpansQuery(filteredBy(null), "root.a", 0),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
+  });
+});
+
+describe("useSpanMetricsPlotQuery", () => {
+  const filteredBy = (filterExpr: string | null) => ({
+    appId: "app-1",
+    startDate: "2026-01-01T00:00:00Z",
+    endDate: "2026-01-02T00:00:00Z",
+    filterExpr,
+  });
+
+  it("does not fetch without an app and a date range", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpanMetricsPlotQuery(null, "root.a"),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchSpanMetricsPlot).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a span name", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpanMetricsPlotQuery(filteredBy(null), null),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchSpanMetricsPlot).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the span, range and filter, and returns the raw plot", async () => {
+    const rawPlot = [{ id: "v1", data: [{ datetime: "2026-01-01", p50: 1 }] }];
+    mockFetchSpanMetricsPlot.mockResolvedValueOnce(rawPlot);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpanMetricsPlotQuery(filteredBy("span_status:in:ok"), "root.a"),
+      { wrapper },
+    );
+
+    expect(result.current.status).toBe("pending");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchSpanMetricsPlot).toHaveBeenCalledWith(
+      "app-1",
+      "root.a",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      "span_status:in:ok",
+    );
+    expect(result.current.data).toEqual(rawPlot);
+  });
+
+  it("passes a null plot through", async () => {
+    mockFetchSpanMetricsPlot.mockResolvedValueOnce(null);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpanMetricsPlotQuery(filteredBy(null), "root.a"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchSpanMetricsPlot.mockRejectedValueOnce(failure);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useSpanMetricsPlotQuery(filteredBy(null), "root.a"),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.status).toBe("error"));

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -8,7 +8,6 @@ import {
   HttpMethod,
   OsVersion,
   SessionType,
-  SpanStatus,
 } from "@/app/api/api_calls";
 
 const mockFetchQuery = jest.fn((..._args: any[]) => Promise.resolve(null));
@@ -25,7 +24,6 @@ import {
   type FilterOptionsData,
   type InitConfig,
   pickApp,
-  resolveRootSpanName,
 } from "@/app/stores/filters_store";
 
 function makeApp(id: string, overrides: Partial<App> = {}): App {
@@ -183,36 +181,6 @@ describe("appsEqual", () => {
   });
 });
 
-describe("resolveRootSpanName", () => {
-  const app = makeApp("a");
-
-  it("returns the URL rootSpanName when the URL appId matches", () => {
-    expect(
-      resolveRootSpanName(
-        ["root.a", "root.b"],
-        initConfig({ appId: "a", rootSpanName: "root.b" }),
-        app,
-      ),
-    ).toBe("root.b");
-  });
-
-  it("falls back to first when URL rootSpanName is invalid for current data", () => {
-    expect(
-      resolveRootSpanName(
-        ["root.a", "root.b"],
-        initConfig({ appId: "a", rootSpanName: "missing" }),
-        app,
-      ),
-    ).toBe("root.a");
-  });
-
-  it("returns first when no URL rootSpanName", () => {
-    expect(resolveRootSpanName(["root.a", "root.b"], initConfig({}), app)).toBe(
-      "root.a",
-    );
-  });
-});
-
 describe("applyFilterOptions", () => {
   const app = makeApp("a");
 
@@ -346,26 +314,6 @@ describe("applyFilterOptions", () => {
     expect(patch.selectedUdAttrMatchers).toEqual([
       { key: "plan", type: "string", op: "eq", value: "pro" },
     ]);
-  });
-
-  it("defaults span statuses to all when filterSource is Spans", () => {
-    const cfg = { ...initConfig({}), filterSource: FilterSource.Spans };
-    const patch = applyFilterOptions(emptyOptions(), app, cfg, state());
-    expect(patch.selectedSpanStatuses).toEqual([
-      SpanStatus.Unset,
-      SpanStatus.Ok,
-      SpanStatus.Error,
-    ]);
-  });
-
-  it("defaults span statuses to [] for non-Spans filterSource", () => {
-    const patch = applyFilterOptions(
-      emptyOptions(),
-      app,
-      initConfig({}),
-      state(),
-    );
-    expect(patch.selectedSpanStatuses).toEqual([]);
   });
 
   it("defaults bug report statuses to [Open]", () => {
@@ -548,20 +496,6 @@ describe("filtersStore actions", () => {
     store.getState().setFilterOptions(null, "not-onboarded");
     expect(store.getState().filterOptionsState).toBe("not-onboarded");
     expect(store.getState().versions).toEqual([]);
-  });
-
-  it("setRootSpanNames stores list and status", () => {
-    const store = createFiltersStore();
-    store.getState().setRootSpanNames(["a", "b"], "loaded");
-    expect(store.getState().rootSpanNames).toEqual(["a", "b"]);
-    expect(store.getState().rootSpanNamesState).toBe("loaded");
-  });
-
-  it("setRootSpanNames with null data only updates status", () => {
-    const store = createFiltersStore();
-    store.getState().setRootSpanNames(null, "no-data");
-    expect(store.getState().rootSpanNamesState).toBe("no-data");
-    expect(store.getState().rootSpanNames).toEqual([]);
   });
 
   it("setConfig wipes per-page selections when filterSource changes", () => {

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -2,6 +2,7 @@
 
 import FilterBar, {
   type FilterState,
+  type ReadyFilterState,
   filterExprUrlKey,
 } from "@/app/components/filter_bar/filter_bar";
 import { filterExprIssuesIn } from "@/app/api/api_error";
@@ -24,8 +25,6 @@ const {
   endDate: endDateUrlKey,
 } = urlFiltersKeyMap;
 
-type ReadyFilter = Extract<FilterState, { status: "ready" }>;
-
 function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
   return {
     app: searchParams.get(appIdUrlKey),
@@ -38,7 +37,7 @@ function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
   };
 }
 
-function buildFilterUrl(filter: ReadyFilter, paginationOffset: number) {
+function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
   const urlParams = new URLSearchParams();
   urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
   urlParams.set(appIdUrlKey, filter.app.id);
@@ -63,22 +62,37 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
   const [filterState, setFilterState] = useState<FilterState>({
     status: "pending",
   });
-  const readyFilter = filterState.status === "ready" ? filterState : null;
 
-  const buildsQuery = useBuildsQuery(readyFilter, paginationOffset);
+  // The query reads the filter and the pagination offset from the URL, so
+  // each fetch uses one searchParams snapshot. The filter is null until the
+  // URL matches the bar's report. A value the bar discarded is never fetched.
+  const filterParams =
+    filterState.status === "ready" &&
+    requestedFilters.app === filterState.app.id &&
+    requestedFilters.dateRange.startDate === filterState.date.startDate &&
+    requestedFilters.dateRange.endDate === filterState.date.endDate &&
+    requestedFilters.filterExpr === filterState.filterExpr
+      ? {
+          appId: requestedFilters.app,
+          startDate: requestedFilters.dateRange.startDate,
+          endDate: requestedFilters.dateRange.endDate,
+          filterExpr: requestedFilters.filterExpr,
+        }
+      : null;
+
+  const buildsQuery = useBuildsQuery(filterParams, paginationOffset);
 
   const filterExprIssues = filterExprIssuesIn(buildsQuery.error);
 
   const onFilterChange = (newFilterState: FilterState) => {
-    const hasInitializedFilters = readyFilter !== null;
     setFilterState(newFilterState);
 
     if (newFilterState.status !== "ready") {
       return;
     }
-    // The first ready state is the one the page opened on, so it keeps the
-    // page the link asked for. Every change after that starts at page one.
-    const offset = hasInitializedFilters ? 0 : paginationOffset;
+    // The URL's pagination offset is kept only when the bar applied the URL's
+    // request unchanged. Any edit or substitution starts back at page one.
+    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
     router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
   };
 

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { useFiltersStore } from "@/app/stores/provider";
 
-import { FilterSource, emptySpansResponse } from "@/app/api/api_calls";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import { emptySpansResponse } from "@/app/api/api_calls";
+import { filterExprIssuesIn } from "@/app/api/api_error";
+import FilterBar, {
+  type FilterState,
+  type ReadyFilterState,
+  filterExprUrlKey,
+} from "@/app/components/filter_bar/filter_bar";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import Pill, { PillType } from "@/app/components/pill";
@@ -18,17 +20,63 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/components/table";
-import { paginationOffsetUrlKey, useSpansQuery } from "@/app/query/hooks";
+import {
+  paginationOffsetUrlKey,
+  useSpanMetricsPlotQuery,
+  useSpansQuery,
+} from "@/app/query/hooks";
+import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import {
   formatDateToHumanReadableDate,
   formatDateToHumanReadableTime,
   formatMillisToHumanReadable,
 } from "@/app/utils/time_utils";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { use, useEffect, useRef, useState } from "react";
+import {
+  type ReadonlyURLSearchParams,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { use, useState } from "react";
 
 const PAGINATION_LIMIT = 5;
+
+const {
+  appId: appIdUrlKey,
+  dateRange: dateRangeUrlKey,
+  startDate: startDateUrlKey,
+  endDate: endDateUrlKey,
+  rootSpanName: rootSpanNameUrlKey,
+} = urlFiltersKeyMap;
+
+function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
+  return {
+    app: searchParams.get(appIdUrlKey),
+    dateRange: {
+      dateRange: searchParams.get(dateRangeUrlKey),
+      startDate: searchParams.get(startDateUrlKey),
+      endDate: searchParams.get(endDateUrlKey),
+    },
+    filterExpr: searchParams.get(filterExprUrlKey),
+    rootSpanName: searchParams.get(rootSpanNameUrlKey),
+  };
+}
+
+function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
+  const urlParams = new URLSearchParams();
+  urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
+  urlParams.set(appIdUrlKey, filter.app.id);
+  urlParams.set(dateRangeUrlKey, filter.date.dateRange);
+  urlParams.set(startDateUrlKey, filter.date.startDate);
+  urlParams.set(endDateUrlKey, filter.date.endDate);
+  if (filter.rootSpanName !== null) {
+    urlParams.set(rootSpanNameUrlKey, filter.rootSpanName);
+  }
+  if (filter.filterExpr) {
+    urlParams.set(filterExprUrlKey, filter.filterExpr);
+  }
+  return `?${urlParams.toString()}`;
+}
 
 export default function TracesOverview(props: {
   params: Promise<{ teamId: string }>;
@@ -37,218 +85,253 @@ export default function TracesOverview(props: {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const filters = useFiltersStore((state) => state.filters);
+  const paginationOffset =
+    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
+  const requestedFilters = readRequestedFilters(searchParams);
 
-  // Pagination is component-local state, initialized from URL
-  const [paginationOffset, setPaginationOffset] = useState(() => {
-    const po = searchParams.get(paginationOffsetUrlKey);
-    return po ? parseInt(po) : 0;
+  const [filterState, setFilterState] = useState<FilterState>({
+    status: "pending",
   });
+  const readyFilter = filterState.status === "ready" ? filterState : null;
 
-  // Reset pagination when filters change (skip pre-ready transitions)
-  const prevFiltersRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!filters.ready) return;
-    if (
-      prevFiltersRef.current !== null &&
-      prevFiltersRef.current !== filters.serialisedFilters
-    ) {
-      setPaginationOffset(0);
-    }
-    prevFiltersRef.current = filters.serialisedFilters;
-  }, [filters.ready, filters.serialisedFilters]);
+  // The queries read the filter, the span name and the pagination offset
+  // from the URL, so each fetch uses one searchParams snapshot. The filter
+  // is null until the URL matches the bar's report. A span name or filter the
+  // bar discarded is never fetched.
+  const filterParams =
+    filterState.status === "ready" &&
+    requestedFilters.app === filterState.app.id &&
+    requestedFilters.dateRange.startDate === filterState.date.startDate &&
+    requestedFilters.dateRange.endDate === filterState.date.endDate &&
+    requestedFilters.filterExpr === filterState.filterExpr &&
+    requestedFilters.rootSpanName === filterState.rootSpanName
+      ? {
+          appId: requestedFilters.app,
+          startDate: requestedFilters.dateRange.startDate,
+          endDate: requestedFilters.dateRange.endDate,
+          filterExpr: requestedFilters.filterExpr,
+        }
+      : null;
+  const rootSpanName = requestedFilters.rootSpanName;
 
-  // URL sync
-  useEffect(() => {
-    if (!filters.ready) {
+  const spansQuery = useSpansQuery(
+    filterParams,
+    rootSpanName,
+    paginationOffset,
+  );
+  const spanMetricsPlotQuery = useSpanMetricsPlotQuery(
+    filterParams,
+    rootSpanName,
+  );
+
+  const filterExprIssues =
+    filterExprIssuesIn(spansQuery.error) ??
+    filterExprIssuesIn(spanMetricsPlotQuery.error);
+
+  const onFilterChange = (newFilterState: FilterState) => {
+    setFilterState(newFilterState);
+
+    if (newFilterState.status !== "ready") {
       return;
     }
-    router.replace(
-      `?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`,
-      { scroll: false },
-    );
-  }, [paginationOffset, filters.ready, filters.serialisedFilters]);
+    // The URL's pagination offset is kept only when the bar applied the URL's
+    // request unchanged. Any edit or substitution starts back at page one.
+    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
+    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
+  };
 
-  const {
-    data: spans = emptySpansResponse,
-    status,
-    isFetching,
-  } = useSpansQuery(paginationOffset);
+  const navigateToOffset = (offset: number) => {
+    const urlParams = new URLSearchParams(searchParams);
+    urlParams.set(paginationOffsetUrlKey, String(offset));
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  };
 
-  const nextPage = () => setPaginationOffset((o) => o + PAGINATION_LIMIT);
+  const nextPage = () => navigateToOffset(paginationOffset + PAGINATION_LIMIT);
   const prevPage = () =>
-    setPaginationOffset((o) => Math.max(0, o - PAGINATION_LIMIT));
+    navigateToOffset(Math.max(0, paginationOffset - PAGINATION_LIMIT));
+
+  const { data: spans = emptySpansResponse, status, isFetching } = spansQuery;
 
   return (
     <div className="flex flex-col items-start">
       <div className="py-4" />
 
-      <Filters
+      <FilterBar
         teamId={params.teamId}
-        filterSource={FilterSource.Spans}
-        appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showOsVersions={true}
-        showCountries={true}
-        showNetworkTypes={true}
-        showNetworkProviders={true}
-        showNetworkGenerations={true}
-        showLocales={true}
-        showDeviceManufacturers={true}
-        showDeviceNames={true}
-        showUdAttrs={true}
+        entity="spans"
+        placeholder="Filter traces…"
+        requestedAppId={requestedFilters.app}
+        requestedDateRange={requestedFilters.dateRange}
+        requestedFilterExpr={requestedFilters.filterExpr}
+        filterExprIssues={filterExprIssues}
+        showRootSpanSelector
+        requestedRootSpanName={requestedFilters.rootSpanName}
+        onFilterChange={onFilterChange}
       />
       <div className="py-4" />
 
-      {filters.loading && <SkeletonListPage />}
-
-      {/* Error state for sessions fetch */}
-      {filters.ready && status === "error" && (
-        <p className="text-lg font-display">
-          Error fetching list of traces, please change filters, refresh page or
-          select a different app to try again
-        </p>
+      {filterState.status === "error" && (
+        <p className="text-lg font-display">{filterState.message}</p>
       )}
 
-      {/* Main root spans list UI */}
-      {filters.ready && (status === "success" || status === "pending") && (
-        <div className="flex flex-col items-center w-full">
-          <SpanMetricsPlot />
-          <div className="self-end">
-            <Paginator
-              prevEnabled={isFetching ? false : spans.meta.previous}
-              nextEnabled={isFetching ? false : spans.meta.next}
-              displayText=""
-              onNext={nextPage}
-              onPrev={prevPage}
-            />
-          </div>
+      {filterState.status === "pending" && <SkeletonListPage />}
 
-          <div
-            className={`py-1 w-full ${isFetching ? "visible" : "invisible"}`}
-          >
-            <LoadingBar />
-          </div>
-          <div className="py-4" />
-          <Table className="font-display select-none">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[60%]">Trace</TableHead>
-                <TableHead className="w-[20%] text-center">
-                  Start Time
-                </TableHead>
-                <TableHead className="w-[10%] text-center">Duration</TableHead>
-                <TableHead className="w-[10%] text-center">Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody className="font-body">
-              {spans.results?.map(
-                (
-                  {
-                    app_id,
-                    span_name,
-                    span_id,
-                    trace_id,
-                    status,
-                    start_time,
-                    duration,
-                    app_version,
-                    app_build,
-                    os_name,
-                    os_version,
-                    device_manufacturer,
-                    device_model,
-                  }: any,
-                  idx: number,
-                ) => {
-                  const traceHref = `/${params.teamId}/traces/${app_id}/${trace_id}`;
-                  return (
-                    <TableRow
-                      key={`${idx}-${span_id}`}
-                      className="font-body select-none"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          router.push(traceHref);
-                        }
-                      }}
-                    >
-                      <TableCell className="w-[60%] relative p-0">
-                        <Link
-                          href={traceHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-label={`ID: ${trace_id}`}
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4">
-                          <p className="text-xs truncate text-muted-foreground select-none">
-                            ID: {trace_id}
-                          </p>
-                          <div className="py-1" />
-                          <p className="truncate select-none">{span_name}</p>
-                          <div className="py-1" />
-                          <p className="text-xs truncate text-muted-foreground select-none">{`${app_version}(${app_build}), ${os_name === "android" ? "Android API Level" : os_name === "ios" ? "iOS" : os_name === "ipados" ? "iPadOS" : os_name} ${os_version}, ${device_manufacturer} ${device_model}`}</p>
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-[20%] text-center relative p-0">
-                        <Link
-                          href={traceHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4">
-                          <p className="truncate select-none">
-                            {formatDateToHumanReadableDate(start_time)}
-                          </p>
-                          <div className="py-1" />
-                          <p className="text-xs truncate select-none">
-                            {formatDateToHumanReadableTime(start_time)}
-                          </p>
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-[10%] text-center truncate select-none relative p-0">
-                        <Link
-                          href={traceHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4">
-                          {formatMillisToHumanReadable(duration)}
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-[10%] text-center truncate select-none relative p-0">
-                        <Link
-                          href={traceHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4 flex justify-center">
-                          <Pill
-                            type={
-                              status === 1
-                                ? PillType.StatusOkay
-                                : status === 2
-                                  ? PillType.StatusError
-                                  : PillType.StatusUnset
-                            }
+      {readyFilter !== null &&
+        status === "error" &&
+        filterExprIssues === null && (
+          <p className="text-lg font-display">
+            Error fetching list of traces, please change filters, refresh page
+            or select a different app to try again
+          </p>
+        )}
+
+      {readyFilter !== null &&
+        (status === "success" || status === "pending") && (
+          <div className="flex flex-col items-center w-full">
+            {filterParams !== null && (
+              <SpanMetricsPlot
+                filterParams={filterParams}
+                query={spanMetricsPlotQuery}
+              />
+            )}
+            <div className="self-end">
+              <Paginator
+                prevEnabled={isFetching ? false : spans.meta.previous}
+                nextEnabled={isFetching ? false : spans.meta.next}
+                displayText=""
+                onNext={nextPage}
+                onPrev={prevPage}
+              />
+            </div>
+
+            <div
+              className={`py-1 w-full ${isFetching ? "visible" : "invisible"}`}
+            >
+              <LoadingBar />
+            </div>
+            <div className="py-4" />
+            <Table className="font-display select-none">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[60%]">Trace</TableHead>
+                  <TableHead className="w-[20%] text-center">
+                    Start Time
+                  </TableHead>
+                  <TableHead className="w-[10%] text-center">
+                    Duration
+                  </TableHead>
+                  <TableHead className="w-[10%] text-center">Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="font-body">
+                {spans.results?.map(
+                  (
+                    {
+                      app_id,
+                      span_name,
+                      span_id,
+                      trace_id,
+                      status,
+                      start_time,
+                      duration,
+                      app_version,
+                      app_build,
+                      os_name,
+                      os_version,
+                      device_manufacturer,
+                      device_model,
+                    }: any,
+                    idx: number,
+                  ) => {
+                    const traceHref = `/${params.teamId}/traces/${app_id}/${trace_id}`;
+                    return (
+                      <TableRow
+                        key={`${idx}-${span_id}`}
+                        className="font-body select-none"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            router.push(traceHref);
+                          }
+                        }}
+                      >
+                        <TableCell className="w-[60%] relative p-0">
+                          <Link
+                            href={traceHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-label={`ID: ${trace_id}`}
+                            style={{ display: "block" }}
                           />
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                },
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+                          <div className="pointer-events-none p-4">
+                            <p className="text-xs truncate text-muted-foreground select-none">
+                              ID: {trace_id}
+                            </p>
+                            <div className="py-1" />
+                            <p className="truncate select-none">{span_name}</p>
+                            <div className="py-1" />
+                            <p className="text-xs truncate text-muted-foreground select-none">{`${app_version}(${app_build}), ${os_name === "android" ? "Android API Level" : os_name === "ios" ? "iOS" : os_name === "ipados" ? "iPadOS" : os_name} ${os_version}, ${device_manufacturer} ${device_model}`}</p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-[20%] text-center relative p-0">
+                          <Link
+                            href={traceHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            style={{ display: "block" }}
+                          />
+                          <div className="pointer-events-none p-4">
+                            <p className="truncate select-none">
+                              {formatDateToHumanReadableDate(start_time)}
+                            </p>
+                            <div className="py-1" />
+                            <p className="text-xs truncate select-none">
+                              {formatDateToHumanReadableTime(start_time)}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-[10%] text-center truncate select-none relative p-0">
+                          <Link
+                            href={traceHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            style={{ display: "block" }}
+                          />
+                          <div className="pointer-events-none p-4">
+                            {formatMillisToHumanReadable(duration)}
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-[10%] text-center truncate select-none relative p-0">
+                          <Link
+                            href={traceHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            style={{ display: "block" }}
+                          />
+                          <div className="pointer-events-none p-4 flex justify-center">
+                            <Pill
+                              type={
+                                status === 1
+                                  ? PillType.StatusOkay
+                                  : status === 2
+                                    ? PillType.StatusError
+                                    : PillType.StatusUnset
+                              }
+                            />
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  },
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
     </div>
   );
 }

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -37,7 +37,6 @@ export enum JourneyType {
 
 export enum FilterSource {
   Events,
-  Spans,
   Errors,
   Builds,
 }
@@ -51,12 +50,6 @@ export enum SessionType {
   UserInteraction = "User Interaction Sessions",
   Foreground = "Foreground Sessions",
   Background = "Background Sessions",
-}
-
-export enum SpanStatus {
-  Unset = "Unset",
-  Ok = "Ok",
-  Error = "Error",
 }
 
 export enum BugReportStatus {
@@ -646,12 +639,10 @@ export type Filters = {
   ready: boolean;
   loading: boolean;
   app: App | null;
-  rootSpanName: string;
   startDate: string;
   endDate: string;
   versions: { selected: AppVersion[]; all: boolean };
   sessionTypes: { selected: SessionType[]; all: boolean };
-  spanStatuses: { selected: SpanStatus[]; all: boolean };
   bugReportStatuses: { selected: BugReportStatus[]; all: boolean };
   httpMethods: { selected: HttpMethod[]; all: boolean };
   osVersions: { selected: OsVersion[]; all: boolean };
@@ -679,12 +670,10 @@ export const defaultFilters: Filters = {
   ready: false,
   loading: true,
   app: null,
-  rootSpanName: "",
   startDate: "",
   endDate: "",
   versions: { selected: [], all: false },
   sessionTypes: { selected: [], all: false },
-  spanStatuses: { selected: [], all: false },
   bugReportStatuses: { selected: [], all: false },
   httpMethods: { selected: [], all: false },
   osVersions: { selected: [], all: false },
@@ -843,24 +832,6 @@ async function applyGenericFiltersToUrl(
   // leaking onto endpoints that don't filter by session content (e.g.
   // /errorGroups, which uses its own `type` param for selectedErrorTypes).
 
-  // Append span name if needed
-  if (filters.rootSpanName !== "") {
-    searchParams.append("span_name", encodeURIComponent(filters.rootSpanName));
-  }
-
-  // Append span statuses if needed
-  if (!filters.spanStatuses.all && filters.spanStatuses.selected.length > 0) {
-    filters.spanStatuses.selected.forEach((v) => {
-      if (v === SpanStatus.Unset) {
-        searchParams.append("span_statuses", "0");
-      } else if (v === SpanStatus.Ok) {
-        searchParams.append("span_statuses", "1");
-      } else if (v === SpanStatus.Error) {
-        searchParams.append("span_statuses", "2");
-      }
-    });
-  }
-
   // Append bug report statuses if needed
   if (
     !filters.bugReportStatuses.all &&
@@ -949,28 +920,6 @@ function appendSessionTypesToUrl(url: string, filters: Filters): string {
     if (severities.size > 0) {
       u.searchParams.append("severity", Array.from(severities).join(","));
     }
-  }
-  return u.toString();
-}
-
-function appendSpanFiltersToUrl(url: string, filters: Filters): string {
-  const u = new URL(url, window.location.origin);
-  if (filters.rootSpanName !== "") {
-    u.searchParams.append(
-      "span_name",
-      encodeURIComponent(filters.rootSpanName),
-    );
-  }
-  if (!filters.spanStatuses.all && filters.spanStatuses.selected.length > 0) {
-    filters.spanStatuses.selected.forEach((v) => {
-      if (v === SpanStatus.Unset) {
-        u.searchParams.append("span_statuses", "0");
-      } else if (v === SpanStatus.Ok) {
-        u.searchParams.append("span_statuses", "1");
-      } else if (v === SpanStatus.Error) {
-        u.searchParams.append("span_statuses", "2");
-      }
-    });
   }
   return u.toString();
 }
@@ -1114,35 +1063,6 @@ export const fetchRootSpanNamesFromServer = async (
   return (data.results as string[] | null) ?? null;
 };
 
-export const fetchSpansFromServer = async (
-  filters: Filters,
-  limit: number,
-  offset: number,
-) => {
-  var url = `/api/apps/${filters.app!.id}/spans?`;
-
-  url = await applyGenericFiltersToUrl(url, filters, limit, offset);
-  url = appendSpanFiltersToUrl(url, filters);
-
-  const data = await request(url, { failsWith: "Failed to fetch spans" });
-
-  return data;
-};
-
-export const fetchSpanMetricsPlotFromServer = async (filters: Filters) => {
-  var url = `/api/apps/${filters.app!.id}/spans/plots/metrics?`;
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null);
-  url = appendSpanFiltersToUrl(url, filters);
-  url = appendPlotTimeGroupToUrl(url, filters);
-
-  const data = await request(url, {
-    failsWith: "Failed to fetch span metrics plot",
-  });
-
-  return data;
-};
-
 export const fetchTraceFromServer = async (appId: string, traceId: string) => {
   const data = await request(`/api/apps/${appId}/traces/${traceId}`, {
     failsWith: "Failed to fetch trace",
@@ -1171,11 +1091,9 @@ export const fetchFiltersFromServer = async (
   // fetch the user defined attributes
   url += "?ud_attr_keys=1";
 
-  // if filter is for Spans, Errors or Builds we append a query param
+  // if filter is for Errors or Builds we append a query param
   // indicating it
-  if (filterSource === FilterSource.Spans) {
-    url += "&span=1";
-  } else if (filterSource === FilterSource.Errors) {
+  if (filterSource === FilterSource.Errors) {
     url += "&type=error,anr";
   } else if (filterSource === FilterSource.Builds) {
     url += "&builds=1";
@@ -1861,28 +1779,20 @@ export const downloadBuildFile = async (downloadUrl: string) => {
   navigateTo(downloadUrl);
 };
 
-export const fetchBuildsFromServer = async (
-  filters: Filters,
-  limit: number,
-  offset: number,
-) => {
-  var url = `/api/apps/${filters.app!.id}/builds?`;
-
-  url = await applyGenericFiltersToUrl(url, filters, limit, offset);
-
-  const data = await request(url, { failsWith: "Failed to fetch builds" });
-
-  return data;
-};
-
 // ─── Dynamic filters ─────────────────────────────────────────────────────
 
 export const fetchFilterKeys = async (
   appId: string,
   entity: string,
+  keyNames: string[],
 ): Promise<FilterKeysResponse> => {
+  // Keys the caller specifies are resolved even when the app has more custom
+  // keys than the listing returns.
+  const keyParams = keyNames
+    .map((name) => `&key=${encodeURIComponent(name)}`)
+    .join("");
   const data = await request(
-    `/api/apps/${appId}/filters/keys?entity=${encodeURIComponent(entity)}`,
+    `/api/apps/${appId}/filters/keys?entity=${encodeURIComponent(entity)}${keyParams}`,
     { failsWith: "Failed to fetch filter keys" },
   );
 
@@ -1911,7 +1821,7 @@ export const fetchFilterValues = async (
   return { values: data.values ?? [], truncated: data.truncated ?? false };
 };
 
-export const fetchBuildsWithFilter = async (
+export const fetchBuildsFromServer = async (
   appId: string,
   startDate: string,
   endDate: string,
@@ -1933,6 +1843,56 @@ export const fetchBuildsWithFilter = async (
   return await request(`/api/apps/${appId}/builds?${params.toString()}`, {
     failsWith: "Failed to fetch builds",
   });
+};
+
+export const fetchSpansFromServer = async (
+  appId: string,
+  spanName: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
+  limit: number,
+  offset: number,
+) => {
+  const params = new URLSearchParams({
+    span_name: spanName,
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+    limit: String(limit),
+    offset: String(offset),
+  });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
+
+  return await request(`/api/apps/${appId}/spans?${params.toString()}`, {
+    failsWith: "Failed to fetch spans",
+  });
+};
+
+export const fetchSpanMetricsPlotFromServer = async (
+  appId: string,
+  spanName: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
+) => {
+  const params = new URLSearchParams({
+    span_name: spanName,
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+    plot_time_group: getPlotTimeGroupForRange(startDate, endDate),
+  });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
+
+  return await request(
+    `/api/apps/${appId}/spans/plots/metrics?${params.toString()}`,
+    { failsWith: "Failed to fetch span metrics plot" },
+  );
 };
 
 export const fetchAlertsOverviewFromServer = async (

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -16,10 +16,15 @@ import {
   type FilterOperator,
   type FilterValue,
 } from "../../api/filter_types";
-import { useAppsQuery, useFilterKeysQuery } from "../../query/hooks";
+import {
+  useAppsQuery,
+  useFilterKeysQuery,
+  useRootSpanNamesQuery,
+} from "../../query/hooks";
 import { toastNegative } from "../toast";
 import { useFiltersStore } from "../../stores/provider";
 import { Skeleton } from "../skeleton";
+import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
 import AppSelect from "./app_select";
 import DateRangeSelect, {
   type DateSelection,
@@ -81,6 +86,8 @@ function normalizeFilterExpr(
   return writeFilterExpr(buildConditionGroup(parsed.tree, keys));
 }
 
+export type ReadyFilterState = Extract<FilterState, { status: "ready" }>;
+
 export type FilterState =
   | { status: "pending" }
   | { status: "error"; message: string }
@@ -89,6 +96,11 @@ export type FilterState =
       app: App;
       date: DateSelection;
       filterExpr: string | null;
+      rootSpanName: string | null;
+      // True when the caller's request was applied unchanged: the user made no
+      // edits and nothing requested was discarded. Unrequested fields count as
+      // honored.
+      appliedAsRequested: boolean;
     };
 
 interface FilterBarProps {
@@ -99,6 +111,8 @@ interface FilterBarProps {
   requestedDateRange: UncheckedDateRange;
   requestedFilterExpr: string | null;
   filterExprIssues?: FilterExprIssue[] | null;
+  showRootSpanSelector?: boolean;
+  requestedRootSpanName?: string | null;
   onFilterChange: (state: FilterState) => void;
 }
 
@@ -110,11 +124,12 @@ export default function FilterBar({
   requestedDateRange,
   requestedFilterExpr,
   filterExprIssues,
+  showRootSpanSelector = false,
+  requestedRootSpanName = null,
   onFilterChange,
 }: FilterBarProps) {
   const store = useFiltersStore();
-  const selectedApp = useFiltersStore((s) => s.selectedApp);
-  const apps = useFiltersStore((s) => s.apps);
+  const rememberedAppId = useFiltersStore((s) => s.selectedApp?.id);
 
   const [keyListOpen, setKeyListOpen] = useState(false);
   const [editingAsText, setEditingAsText] = useState(false);
@@ -138,7 +153,104 @@ export default function FilterBar({
   const addConditionButtonRef = useRef<HTMLButtonElement>(null);
 
   const appsQuery = useAppsQuery(teamId);
-  const keysQuery = useFilterKeysQuery(selectedApp?.id, entity);
+  const apps = useMemo(() => appsQuery.data ?? [], [appsQuery.data]);
+
+  const [editedApp, setEditedApp] = useState<App | null>(null);
+  // The user's pick wins, then the app requested, then the app
+  // from store, then the first app as fallback
+  const selectedApp =
+    apps.find((app) => app.id === editedApp?.id) ??
+    apps.find((app) => app.id === requestedAppId) ??
+    apps.find((app) => app.id === rememberedAppId) ??
+    apps[0] ??
+    null;
+
+  useEffect(() => {
+    if (selectedApp && selectedApp.id !== rememberedAppId) {
+      store.setSelectedApp(selectedApp);
+    }
+  }, [selectedApp?.id]);
+
+  const parsedRequestedFilter = useMemo(
+    () => (requestedFilterExpr ? parseFilterExpr(requestedFilterExpr) : null),
+    [requestedFilterExpr],
+  );
+
+  // The keys listing caps how many custom keys it returns, so a custom key
+  // the requested expression specifies can be missing from it. Asking the query
+  // for those names resolves them, and the discard check below then keeps
+  // the expression.
+  const requestedCustomKeyNames = useMemo(() => {
+    const names = (parsedRequestedFilter?.tokens ?? [])
+      .filter(
+        (token) => token.kind === "key" && token.text.startsWith("custom."),
+      )
+      .map((token) => token.text);
+    return [...new Set(names)].sort();
+  }, [parsedRequestedFilter]);
+
+  // A custom key typed into the text editor can be beyond the listing cap
+  // as well, so names in the draft join the request. A draft name is only
+  // sent once its condition has an operator, which keeps the query key
+  // stable while the user is still typing the key name itself.
+  const queriedCustomKeyNames = useMemo(() => {
+    const parsedDraft = editedFilter
+      ? parseFilterExpr(editedFilter.draftExpr, { draft: true })
+      : null;
+    const draftNames = (parsedDraft?.tokens ?? [])
+      .filter(
+        (token, index, tokens) =>
+          token.kind === "key" &&
+          token.text.startsWith("custom.") &&
+          tokens[index + 2]?.kind === "operator",
+      )
+      .map((token) => token.text);
+    return [...new Set([...requestedCustomKeyNames, ...draftNames])].sort();
+  }, [editedFilter, requestedCustomKeyNames]);
+
+  const keysQuery = useFilterKeysQuery(
+    selectedApp?.id,
+    entity,
+    queriedCustomKeyNames,
+  );
+
+  const rootSpanNamesQuery = useRootSpanNamesQuery(
+    showRootSpanSelector ? selectedApp : null,
+  );
+  // The server answers null when the app has never
+  // reported a trace; both mean there is nothing to select.
+  const rootSpanNames = useMemo(
+    () => rootSpanNamesQuery.data ?? [],
+    [rootSpanNamesQuery.data],
+  );
+
+  const [selectedRootSpanName, setSelectedRootSpanName] = useState<
+    string | null
+  >(null);
+  const resolvedRootSpanName = useMemo(() => {
+    if (!showRootSpanSelector || rootSpanNames.length === 0) {
+      return null;
+    }
+    // An app switch replaces the list
+    if (selectedRootSpanName && rootSpanNames.includes(selectedRootSpanName)) {
+      return selectedRootSpanName;
+    }
+    if (
+      requestedAppId === selectedApp?.id &&
+      requestedRootSpanName &&
+      rootSpanNames.includes(requestedRootSpanName)
+    ) {
+      return requestedRootSpanName;
+    }
+    return rootSpanNames[0];
+  }, [
+    showRootSpanSelector,
+    rootSpanNames,
+    selectedRootSpanName,
+    requestedAppId,
+    requestedRootSpanName,
+    selectedApp?.id,
+  ]);
 
   // The requested date range takes precedence over the persisted store range.
   const initialDate = useMemo(
@@ -171,28 +283,10 @@ export default function FilterBar({
 
     const loaded = appsQuery.data;
     store.setApps(loaded, loaded.length === 0 ? "no-apps" : "loaded");
-    if (loaded.length === 0) {
-      return;
-    }
-
-    // Falling back to the stored app stops moving between pages from jumping to
-    // another app.
-    const chosenApp =
-      loaded.find((app: App) => app.id === requestedAppId) ??
-      loaded.find((app: App) => app.id === selectedApp?.id) ??
-      loaded[0];
-    if (chosenApp.id !== selectedApp?.id) {
-      store.setSelectedApp(chosenApp);
-    }
   }, [appsQuery.status, appsQuery.data]);
 
   const keys = keysQuery.data?.keys ?? [];
   const keyGroups = keysQuery.data?.key_groups ?? [];
-
-  const parsedRequestedFilter = useMemo(
-    () => (requestedFilterExpr ? parseFilterExpr(requestedFilterExpr) : null),
-    [requestedFilterExpr],
-  );
 
   const checkingRequestedFilter =
     editedFilter === null &&
@@ -251,7 +345,7 @@ export default function FilterBar({
   // builds request fails otherwise |  nothing              | fetch error
   // apps or keys cannot be fetched |  skeleton or disabled | fetch error
   // the team has no apps           |  skeleton             | a prompt to add one
-  // url names one it cannot use    |  falls back to default| rows as normal, toast
+  // request names one it can't use |  falls back to default| rows as normal, toast
   //
   // The filter is cleared only in the last case.
   const ownFilterIssues = useMemo(
@@ -300,7 +394,60 @@ export default function FilterBar({
       : `${first.message} (+${rest.length} more)`;
   }, [draftFilterIssues]);
 
-  const filterState: FilterState = useMemo(() => {
+  // The requested app, date, filter expression and root span name can each
+  // be invalid for this app. We discard those, use defaults instead and we
+  // inform the user via a toast.
+  const appDiscarded =
+    requestedAppId !== null &&
+    appsQuery.status === "success" &&
+    !appsQuery.data.some((app: App) => app.id === requestedAppId);
+
+  const dateDiscarded =
+    requestedDateRange.dateRange !== null &&
+    !isValidDateRange(requestedDateRange);
+
+  const rootSpanNameDiscarded =
+    showRootSpanSelector &&
+    requestedRootSpanName !== null &&
+    requestedAppId === selectedApp?.id &&
+    rootSpanNamesQuery.isSuccess &&
+    !rootSpanNames.includes(requestedRootSpanName);
+
+  const anythingDiscarded =
+    appDiscarded ||
+    dateDiscarded ||
+    rootSpanNameDiscarded ||
+    requestedFilterDiscarded;
+
+  // The ready state is the caller's unchanged request, as long as the
+  // user has made no edits and nothing was discarded. The app is checked
+  // by ID because a requested app may no longer be available, in which
+  // case it is replaced with a fallback.
+  const appliedAsRequested =
+    editedApp === null &&
+    editedDate === null &&
+    editedFilter === null &&
+    selectedRootSpanName === null &&
+    !dateDiscarded &&
+    !requestedFilterDiscarded &&
+    !rootSpanNameDiscarded &&
+    (requestedAppId === null || selectedApp?.id === requestedAppId);
+
+  // The readiness of the app, date and filter expression, before the root
+  // span selector is considered. The bar's own controls render once this is
+  // ready, so a slow or failed root span names fetch leaves the app select
+  // usable.
+  const baseFilterState = useMemo<
+    | { status: "pending" }
+    | { status: "error"; message: string }
+    | {
+        status: "ready";
+        app: App;
+        date: DateSelection;
+        filterExpr: string | null;
+        appliedAsRequested: boolean;
+      }
+  >(() => {
     if (appsQuery.status === "error") {
       return {
         status: "error",
@@ -332,6 +479,7 @@ export default function FilterBar({
       app: selectedApp,
       date,
       filterExpr: currentFilterExpr,
+      appliedAsRequested,
     };
   }, [
     appsQuery.status,
@@ -341,26 +489,47 @@ export default function FilterBar({
     date,
     checkingRequestedFilter,
     currentFilterExpr,
+    appliedAsRequested,
+  ]);
+
+  // With the selector shown, the ready state is held back until a name has
+  // resolved, because the page's span queries cannot run without one.
+  const filterState: FilterState = useMemo(() => {
+    if (baseFilterState.status !== "ready") {
+      return baseFilterState;
+    }
+    if (!showRootSpanSelector) {
+      return { ...baseFilterState, rootSpanName: null };
+    }
+    if (rootSpanNamesQuery.isError) {
+      return {
+        status: "error",
+        message:
+          "Error fetching traces list, please refresh page or select a different app to try again",
+      };
+    }
+    if (rootSpanNamesQuery.isSuccess && rootSpanNames.length === 0) {
+      return {
+        status: "error",
+        message: "No traces received for this app yet",
+      };
+    }
+    if (resolvedRootSpanName === null) {
+      return { status: "pending" };
+    }
+    return { ...baseFilterState, rootSpanName: resolvedRootSpanName };
+  }, [
+    baseFilterState,
+    showRootSpanSelector,
+    rootSpanNamesQuery.isError,
+    rootSpanNamesQuery.isSuccess,
+    rootSpanNames,
+    resolvedRootSpanName,
   ]);
 
   useEffect(() => {
     onFilterChange(filterState);
   }, [filterState]);
-
-  // The requested app, date and filter expression can each be one this app
-  // cannot use. We discard those, use defaults instead and we inform the
-  // user via a toast.
-  const appDiscarded =
-    requestedAppId !== null &&
-    appsQuery.status === "success" &&
-    !appsQuery.data.some((app: App) => app.id === requestedAppId);
-
-  const dateDiscarded =
-    requestedDateRange.dateRange !== null &&
-    !isValidDateRange(requestedDateRange);
-
-  const anythingDiscarded =
-    appDiscarded || dateDiscarded || requestedFilterDiscarded;
 
   useEffect(() => {
     if (anythingDiscarded) {
@@ -373,9 +542,10 @@ export default function FilterBar({
   }, [focusedId]);
 
   function setApp(app: App) {
-    store.setSelectedApp(app);
+    setEditedApp(app);
     // Clear filters on app change
     setEditedFilter({ draftExpr: "", appliedExpr: null });
+    setSelectedRootSpanName(null);
   }
 
   // Turns an edit to the conditions back into the text the bar holds.
@@ -494,7 +664,7 @@ export default function FilterBar({
   if (
     !selectedApp ||
     (!keysUnavailable &&
-      (filterState.status !== "ready" || keysQuery.isPending))
+      (baseFilterState.status !== "ready" || keysQuery.isPending))
   ) {
     return (
       <div className="flex flex-wrap gap-4 items-center w-full">
@@ -523,6 +693,23 @@ export default function FilterBar({
     <div className="flex flex-wrap gap-4 items-start w-full">
       <AppSelect apps={apps} selected={selectedApp} onChange={setApp} />
       <DateRangeSelect selection={date} onChange={setEditedDate} />
+      {showRootSpanSelector &&
+        (rootSpanNamesQuery.isPending ? (
+          <Skeleton className="h-9 w-37.5" />
+        ) : resolvedRootSpanName !== null ? (
+          <DropdownSelect
+            title="Trace Name"
+            type={DropdownSelectType.SingleString}
+            items={rootSpanNames}
+            initialSelected={resolvedRootSpanName}
+            onChangeSelected={(item) => {
+              const name = item as string;
+              if (name !== resolvedRootSpanName) {
+                setSelectedRootSpanName(name);
+              }
+            }}
+          />
+        ) : null)}
 
       <div className="flex-1 min-w-64">
         <div

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -24,13 +24,8 @@ import {
   FilterSource,
   HttpMethod,
   SessionType,
-  SpanStatus,
 } from "../api/api_calls";
-import {
-  useAppsQuery,
-  useFilterOptionsQuery,
-  useRootSpanNamesQuery,
-} from "../query/hooks";
+import { useAppsQuery, useFilterOptionsQuery } from "../query/hooks";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   applyFilterOptions,
@@ -41,7 +36,6 @@ import {
   type Filters,
   type InitConfig,
   pickApp,
-  resolveRootSpanName,
   type URLFilters,
   urlFiltersKeyMap,
 } from "../stores/filters_store";
@@ -152,10 +146,8 @@ enum DateRange {
 
 function isStringKey(
   key: string,
-): key is "appId" | "rootSpanName" | "startDate" | "endDate" | "freeText" {
-  return ["appId", "rootSpanName", "startDate", "endDate", "freeText"].includes(
-    key,
-  );
+): key is "appId" | "startDate" | "endDate" | "freeText" {
+  return ["appId", "startDate", "endDate", "freeText"].includes(key);
 }
 
 // A filter's selection as chip text. `label` is the compact form shown on the
@@ -226,14 +218,6 @@ export function deserializeUrlFilters(queryString: string): URLFilters {
               return { key, type, op, value: val } as UdAttrMatcher;
             })
             .filter((m) => m.key && m.type && m.op && m.value);
-          break;
-
-        case "spanStatuses":
-          result[originalKey] = value
-            .split(",")
-            .filter((s): s is SpanStatus =>
-              Object.values(SpanStatus).includes(s as SpanStatus),
-            );
           break;
 
         case "bugReportStatuses":
@@ -722,41 +706,6 @@ const FiltersComponent = forwardRef<
       selectedApp?.onboarded,
     ]);
 
-    const rootSpanNamesQuery = useRootSpanNamesQuery(selectedApp, filterSource);
-
-    useEffect(() => {
-      if (filterSource !== FilterSource.Spans) {
-        return;
-      }
-      if (!selectedApp) {
-        return;
-      }
-      if (rootSpanNamesQuery.status === "pending") {
-        store.setRootSpanNames(null, "pending");
-        return;
-      }
-      if (rootSpanNamesQuery.status === "error") {
-        store.setRootSpanNames(null, "error");
-        return;
-      }
-      // An app that has never reported a trace answers with a null list.
-      // This is not the same as a server that answers with an empty list.
-      const names = rootSpanNamesQuery.data;
-      if (names === null) {
-        store.setRootSpanNames(null, "no-data");
-        return;
-      }
-      store.setRootSpanNames(names, "loaded");
-      store.setSelectedRootSpanName(
-        resolveRootSpanName(names, initConfig, selectedApp),
-      );
-    }, [
-      rootSpanNamesQuery.status,
-      rootSpanNamesQuery.data,
-      selectedApp?.id,
-      filterSource,
-    ]);
-
     // Refetch apps + filter-option queries, then optionally focus a
     // specific app once the fresh apps list lands.
     const refresh = useCallback(
@@ -775,13 +724,8 @@ const FiltersComponent = forwardRef<
         await queryClient.refetchQueries({
           queryKey: ["filterOptions", selectedApp?.id],
         });
-        if (filterSource === FilterSource.Spans) {
-          await queryClient.refetchQueries({
-            queryKey: ["rootSpanNames", selectedApp?.id],
-          });
-        }
       },
-      [teamId, selectedApp?.id, filterSource, store],
+      [teamId, selectedApp?.id, store],
     );
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
@@ -803,7 +747,6 @@ const FiltersComponent = forwardRef<
     // confirms.
     type PendingModalFilters = {
       selectedSessionTypes: SessionType[];
-      selectedSpanStatuses: SpanStatus[];
       selectedBugReportStatuses: BugReportStatus[];
       selectedHttpMethods: HttpMethod[];
       selectedOsVersions: typeof store.selectedOsVersions;
@@ -819,7 +762,6 @@ const FiltersComponent = forwardRef<
     const [pendingModalFilters, setPendingModalFilters] =
       useState<PendingModalFilters>(() => ({
         selectedSessionTypes: store.selectedSessionTypes,
-        selectedSpanStatuses: store.selectedSpanStatuses,
         selectedBugReportStatuses: store.selectedBugReportStatuses,
         selectedHttpMethods: store.selectedHttpMethods,
         selectedOsVersions: store.selectedOsVersions,
@@ -843,7 +785,6 @@ const FiltersComponent = forwardRef<
       if (moreFiltersOpen) {
         setPendingModalFilters({
           selectedSessionTypes: store.selectedSessionTypes,
-          selectedSpanStatuses: store.selectedSpanStatuses,
           selectedBugReportStatuses: store.selectedBugReportStatuses,
           selectedHttpMethods: store.selectedHttpMethods,
           selectedOsVersions: store.selectedOsVersions,
@@ -862,7 +803,6 @@ const FiltersComponent = forwardRef<
     // Commit the pending snapshot to the store and close the modal.
     const saveMoreFilters = () => {
       store.setSelectedSessionTypes(pendingModalFilters.selectedSessionTypes);
-      store.setSelectedSpanStatuses(pendingModalFilters.selectedSpanStatuses);
       store.setSelectedBugReportStatuses(
         pendingModalFilters.selectedBugReportStatuses,
       );
@@ -910,7 +850,6 @@ const FiltersComponent = forwardRef<
     // (no loaded data) so the skeleton can reserve the trigger's slot.
     const hasMoreFiltersConfig =
       showSessionTypes ||
-      filterSource === FilterSource.Spans ||
       showBugReportStatus ||
       showHttpMethods ||
       showOsVersions ||
@@ -934,12 +873,11 @@ const FiltersComponent = forwardRef<
     const showSeverityControl =
       isErrorsSource && showSeverity && !onlyAnrSelected;
 
-    // Dropdowns that stay inline: app, trace name, date range, app versions,
+    // Dropdowns that stay inline: app, date range, app versions,
     // the Errors-only controls, plus the "More filters" trigger.
     const skeletonMainRowCount =
       [
         showAppSelector,
-        filterSource === FilterSource.Spans,
         showDates,
         showAppVersions,
         showErrorTypeControl,
@@ -950,7 +888,6 @@ const FiltersComponent = forwardRef<
     // trigger so it never opens an empty modal.
     const hasMoreFilters =
       showSessionTypes ||
-      filterSource === FilterSource.Spans ||
       showBugReportStatus ||
       showHttpMethods ||
       (showOsVersions && store.osVersions.length > 0) ||
@@ -982,23 +919,6 @@ const FiltersComponent = forwardRef<
           : resetAction(() =>
               store.setSelectedSessionTypes(defaultSessionTypes),
             ),
-      });
-    }
-    if (
-      filterSource === FilterSource.Spans &&
-      store.selectedSpanStatuses.length > 0
-    ) {
-      filterChips.push({
-        key: "spanStatuses",
-        ...chipLabels("Span Status", store.selectedSpanStatuses),
-        action:
-          store.selectedSpanStatuses.length === Object.values(SpanStatus).length
-            ? undefined
-            : resetAction(() =>
-                store.setSelectedSpanStatuses(
-                  Object.values(SpanStatus) as SpanStatus[],
-                ),
-              ),
       });
     }
     if (showBugReportStatus && store.selectedBugReportStatuses.length > 0) {
@@ -1201,20 +1121,6 @@ const FiltersComponent = forwardRef<
               setPendingModalFilters((p) => ({
                 ...p,
                 selectedSessionTypes: items as SessionType[],
-              }))
-            }
-          />
-        )}
-        {filterSource === FilterSource.Spans && (
-          <StringMultiRow
-            rowKey="spanStatuses"
-            title="Span Status"
-            items={Object.values(SpanStatus)}
-            selected={pendingModalFilters.selectedSpanStatuses}
-            onChange={(items) =>
-              setPendingModalFilters((p) => ({
-                ...p,
-                selectedSpanStatuses: items as SpanStatus[],
               }))
             }
           />
@@ -1439,37 +1345,6 @@ const FiltersComponent = forwardRef<
           )}
 
         {store.appsState === "loaded" &&
-          store.filterOptionsState === "loaded" &&
-          filterSource === FilterSource.Spans &&
-          store.rootSpanNamesState !== "loaded" && (
-            <div className="flex flex-col">
-              {showAppSelector &&
-                store.rootSpanNamesState === "pending" &&
-                filtersSkeleton(skeletonMainRowCount - 1, appSelectorDropdown)}
-              {showAppSelector && store.rootSpanNamesState !== "pending" && (
-                <div className="flex flex-wrap gap-8 items-center">
-                  {appSelectorDropdown}
-                </div>
-              )}
-              <div className="py-4" />
-              {store.rootSpanNamesState === "error" && (
-                <p className="font-body text-sm">
-                  Error fetching traces list, please refresh page or select a
-                  different app to try again
-                </p>
-              )}
-              {store.rootSpanNamesState === "no-data" && (
-                <p className="font-body text-sm">
-                  No traces received for this app yet
-                </p>
-              )}
-            </div>
-          )}
-
-        {store.appsState === "loaded" &&
-          ((filterSource === FilterSource.Spans &&
-            store.rootSpanNamesState === "loaded") ||
-            filterSource !== FilterSource.Spans) &&
           store.filterOptionsState === "loaded" && (
             <div>
               <div className="flex flex-wrap gap-8 items-center">
@@ -1483,18 +1358,6 @@ const FiltersComponent = forwardRef<
                       const app = store.apps.find((e) => e.name === item);
                       if (app) store.setSelectedApp(app);
                     }}
-                  />
-                )}
-
-                {filterSource === FilterSource.Spans && (
-                  <DropdownSelect
-                    title="Trace Name"
-                    type={DropdownSelectType.SingleString}
-                    items={store.rootSpanNames}
-                    initialSelected={store.selectedRootSpanName}
-                    onChangeSelected={(item) =>
-                      store.setSelectedRootSpanName(item as string)
-                    }
                   />
                 )}
 

--- a/frontend/dashboard/app/components/span_metrics_plot.tsx
+++ b/frontend/dashboard/app/components/span_metrics_plot.tsx
@@ -2,9 +2,10 @@
 
 import {
   RootSpanMetricsQuantile,
-  useSpanMetricsPlotQuery,
+  transformSpanMetricsPlotData,
+  type FilterParams,
+  type useSpanMetricsPlotQuery,
 } from "@/app/query/hooks";
-import { useFiltersStore } from "@/app/stores/provider";
 import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo, useState } from "react";
@@ -24,30 +25,32 @@ import {
 import { SkeletonPlot } from "./skeleton";
 import TabSelect from "./tab_select";
 
-const SpanMetricsPlot: React.FC = () => {
-  const filters = useFiltersStore((state) => state.filters);
+const SpanMetricsPlot: React.FC<{
+  filterParams: FilterParams;
+  query: ReturnType<typeof useSpanMetricsPlotQuery>;
+}> = ({ filterParams, query }) => {
   const [quantile, setQuantile] = useState<RootSpanMetricsQuantile>(
     RootSpanMetricsQuantile.p50,
   );
-  const { data: rawPlot, status } = useSpanMetricsPlotQuery(quantile);
+  const { data: rawData, status } = query;
   const { theme } = useTheme();
   const chartColors = useChartColors();
   const canvasTheme = useChartCanvasTheme();
   const plotTimeGroup = getPlotTimeGroupForRange(
-    filters.startDate,
-    filters.endDate,
+    filterParams.startDate,
+    filterParams.endDate,
   );
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
   const plot = useMemo(() => {
-    if (!rawPlot) {
-      return rawPlot;
+    if (!rawData) {
+      return rawData;
     }
     return embedSiblingPoints(
-      rawPlot,
+      transformSpanMetricsPlotData(rawData, quantile),
       (_: string, index: number) => chartColors[index % chartColors.length],
     );
-  }, [rawPlot, chartColors]);
+  }, [rawData, quantile, chartColors]);
 
   function mapQuantileStringToQuantile(quantile: string) {
     switch (quantile) {

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -22,7 +22,7 @@ import {
   fetchBugReportFromServer,
   fetchBugReportsOverviewFromServer,
   fetchBugReportsOverviewPlotFromServer,
-  fetchBuildsWithFilter,
+  fetchBuildsFromServer,
   fetchCheckoutSessionFromServer,
   fetchCustomerPortalUrlFromServer,
   fetchErrorGroupCommonPathFromServer,
@@ -85,7 +85,6 @@ import type { FilterKeysResponse } from "@/app/api/filter_types";
 import { ApiError } from "@/app/api/api_error";
 import { apiClient } from "@/app/api/api_client";
 import { queryClient } from "@/app/query/query_client";
-import type { DateSelection } from "@/app/components/filter_bar/date_range_select";
 import type { FilterOptionsData } from "@/app/stores/filters_store";
 import { useFiltersStore } from "@/app/stores/provider";
 import {
@@ -190,11 +189,19 @@ export function useFilterOptionsQuery(
 
 // ─── Dynamic filters ─────────────────────────────────────────────────────
 
-export function useFilterKeysQuery(appId: string | undefined, entity: string) {
+export function useFilterKeysQuery(
+  appId: string | undefined,
+  entity: string,
+  keyNames: string[],
+) {
   return useQuery<FilterKeysResponse>({
-    queryKey: ["filterKeys", appId, entity] as const,
-    queryFn: () => fetchFilterKeys(appId!, entity),
+    queryKey: ["filterKeys", appId, entity, keyNames] as const,
+    queryFn: () => fetchFilterKeys(appId!, entity, keyNames),
     enabled: !!appId,
+    // The key names grow while the user types a custom key into the filter
+    // text editor; keeping the last response stops every loaded key from
+    // being flagged unknown during the refetch.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -216,14 +223,11 @@ export function useFilterValuesQuery(
   });
 }
 
-export function useRootSpanNamesQuery(
-  app: App | null | undefined,
-  filterSource: FilterSource,
-) {
+export function useRootSpanNamesQuery(app: App | null | undefined) {
   return useQuery<string[] | null>({
     queryKey: ["rootSpanNames", app?.id] as const,
     queryFn: () => fetchRootSpanNamesFromServer(app!),
-    enabled: !!app && filterSource === FilterSource.Spans,
+    enabled: !!app,
   });
 }
 
@@ -308,6 +312,18 @@ export type ExceptionGroupCommonPath = {
 // ─── Constants re-exported for components ────────────────────────────────
 
 export const paginationOffsetUrlKey = "po";
+
+/**
+ * Query inputs for the pages whose filter lives in the URL. The page derives
+ * these from searchParams, so a query's filter and pagination offset always
+ * come from the same URL snapshot.
+ */
+export type FilterParams = {
+  appId: string;
+  startDate: string;
+  endDate: string;
+  filterExpr: string | null;
+};
 
 export enum TrendsTab {
   Latency = "Latency",
@@ -617,14 +633,29 @@ export function useAppHealthPlotQuery() {
 
 // ─── Plot: Span Metrics ──────────────────────────────────────────────────
 
-export function useSpanMetricsPlotQuery(quantile: RootSpanMetricsQuantile) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useSpanMetricsPlotQuery(
+  params: FilterParams | null,
+  spanName: string | null,
+) {
   return useQuery({
-    queryKey: ["spanMetricsPlot", filters.serialisedFilters] as const,
-    queryFn: () => fetchSpanMetricsPlotFromServer(filters),
-    select: (rawData) =>
-      rawData ? transformSpanMetricsPlotData(rawData, quantile) : null,
-    enabled: filters.ready,
+    queryKey: [
+      "spanMetricsPlot",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+      spanName,
+    ] as const,
+    queryFn: () =>
+      fetchSpanMetricsPlotFromServer(
+        params!.appId,
+        spanName!,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+      ),
+    enabled: params !== null && spanName !== null,
+    retry: false,
   });
 }
 
@@ -674,36 +705,30 @@ export function useBugReportsOverviewQuery(paginationOffset: number) {
 
 const BUILDS_LIMIT = 10;
 
-export type BuildsFilter = {
-  app: App;
-  date: DateSelection;
-  filterExpr: string | null;
-};
-
 export function useBuildsQuery(
-  filter: BuildsFilter | null,
+  params: FilterParams | null,
   paginationOffset: number,
 ) {
   return useQuery({
     queryKey: [
       "builds",
-      filter?.app.id,
-      filter?.date.startDate,
-      filter?.date.endDate,
-      filter?.filterExpr,
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
     queryFn: () =>
-      fetchBuildsWithFilter(
-        filter!.app.id,
-        filter!.date.startDate,
-        filter!.date.endDate,
-        filter!.filterExpr,
+      fetchBuildsFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
         BUILDS_LIMIT,
         paginationOffset,
       ),
-    enabled: filter !== null,
+    enabled: params !== null,
     retry: false,
   });
 }
@@ -712,14 +737,34 @@ export function useBuildsQuery(
 
 const TRACES_LIMIT = 5;
 
-export function useSpansQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useSpansQuery(
+  params: FilterParams | null,
+  spanName: string | null,
+  paginationOffset: number,
+) {
   return useQuery({
-    queryKey: ["spans", filters.serialisedFilters, paginationOffset] as const,
+    queryKey: [
+      "spans",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+      spanName,
+      paginationOffset,
+    ] as const,
     placeholderData: keepPreviousData,
     queryFn: () =>
-      fetchSpansFromServer(filters, TRACES_LIMIT, paginationOffset),
-    enabled: filters.ready,
+      fetchSpansFromServer(
+        params!.appId,
+        spanName!,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        TRACES_LIMIT,
+        paginationOffset,
+      ),
+    enabled: params !== null && spanName !== null,
+    retry: false,
   });
 }
 

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -12,7 +12,6 @@ import {
   OsVersion,
   saveListFiltersToServer,
   SessionType,
-  SpanStatus,
   UdAttrMatcher,
   UserDefAttr,
 } from "../api/api_calls";
@@ -50,13 +49,11 @@ export type FilterConfig = {
 
 export type URLFilters = {
   appId?: string;
-  rootSpanName?: string;
   startDate?: string;
   endDate?: string;
   dateRange?: string;
   versions?: number[];
   sessionTypes?: SessionType[];
-  spanStatuses?: SpanStatus[];
   bugReportStatuses?: BugReportStatus[];
   httpMethods?: HttpMethod[];
   osVersions?: number[];
@@ -119,7 +116,6 @@ export const defaultSessionTypes = [
   SessionType.Foreground,
   SessionType.UserInteraction,
 ];
-const allSpanStatuses = [SpanStatus.Unset, SpanStatus.Ok, SpanStatus.Error];
 const allBugReportStatuses = [BugReportStatus.Open, BugReportStatus.Closed];
 
 const urlFiltersKeyMap = {
@@ -130,7 +126,6 @@ const urlFiltersKeyMap = {
   endDate: "ed",
   versions: "v",
   sessionTypes: "st",
-  spanStatuses: "ss",
   bugReportStatuses: "bs",
   httpMethods: "hm",
   osVersions: "os",
@@ -250,10 +245,6 @@ function serializeUrlFilters(
       case "appId":
         if (!config.showAppSelector) return;
         break;
-      case "rootSpanName":
-      case "spanStatuses":
-        if (config.filterSource !== FilterSource.Spans) return;
-        break;
       case "errorTypes":
       case "severities":
       case "customErrorsOnly":
@@ -289,7 +280,6 @@ function serializeUrlFilters(
           )
           .join("|");
         break;
-      case "spanStatuses":
       case "bugReportStatuses":
       case "httpMethods":
         if ((value as string[]).length === 0) return;
@@ -344,9 +334,6 @@ export type FilterOptionsState =
   | "not-onboarded"
   | "no-builds";
 
-/** How far the root span names query has got. Only the Spans source runs it. */
-export type RootSpanNamesState = "pending" | "error" | "loaded" | "no-data";
-
 interface FiltersStoreState {
   filters: Filters;
 
@@ -354,11 +341,9 @@ interface FiltersStoreState {
 
   appsState: AppsState;
   filterOptionsState: FilterOptionsState;
-  rootSpanNamesState: RootSpanNamesState;
 
   apps: App[];
   versions: AppVersion[];
-  rootSpanNames: string[];
   osVersions: OsVersion[];
   countries: string[];
   networkProviders: string[];
@@ -379,9 +364,7 @@ interface FiltersStoreState {
   // Per-page selections — reset to URL filter (if present) or default on
   // every Filters mount via applyFilterOptions.
   selectedVersions: AppVersion[];
-  selectedRootSpanName: string;
   selectedSessionTypes: SessionType[];
-  selectedSpanStatuses: SpanStatus[];
   selectedBugReportStatuses: BugReportStatus[];
   selectedHttpMethods: HttpMethod[];
   selectedOsVersions: OsVersion[];
@@ -409,20 +392,14 @@ interface FiltersStoreActions {
     data: FilterOptionsData | null,
     state: FilterOptionsState,
   ) => void;
-  setRootSpanNames: (
-    rootSpanNames: string[] | null,
-    state: RootSpanNamesState,
-  ) => void;
   setCurrentTeamId: (teamId: string) => void;
 
   setSelectedApp: (app: App | null) => void;
-  setSelectedRootSpanName: (name: string) => void;
   setSelectedDateRange: (range: string) => void;
   setSelectedStartDate: (date: string) => void;
   setSelectedEndDate: (date: string) => void;
   setSelectedVersions: (versions: AppVersion[]) => void;
   setSelectedSessionTypes: (types: SessionType[]) => void;
-  setSelectedSpanStatuses: (statuses: SpanStatus[]) => void;
   setSelectedBugReportStatuses: (statuses: BugReportStatus[]) => void;
   setSelectedHttpMethods: (methods: HttpMethod[]) => void;
   setSelectedOsVersions: (versions: OsVersion[]) => void;
@@ -457,11 +434,9 @@ const initialState: FiltersStoreState = {
 
   appsState: "pending",
   filterOptionsState: "pending",
-  rootSpanNamesState: "pending",
 
   apps: [],
   versions: [],
-  rootSpanNames: [],
   osVersions: [],
   countries: [],
   networkProviders: [],
@@ -474,13 +449,11 @@ const initialState: FiltersStoreState = {
   userDefAttrOps: new Map(),
 
   selectedApp: null,
-  selectedRootSpanName: "",
   selectedDateRange: "",
   selectedStartDate: "",
   selectedEndDate: "",
   selectedVersions: [],
   selectedSessionTypes: defaultSessionTypes,
-  selectedSpanStatuses: [],
   selectedBugReportStatuses: [BugReportStatus.Open],
   selectedHttpMethods: allHttpMethods,
   selectedOsVersions: [],
@@ -520,16 +493,10 @@ function computeFilters(state: FiltersStoreState): Filters {
       state.filterOptionsState === "not-onboarded") ||
     (!config.showNoBuilds && state.filterOptionsState === "no-builds");
 
-  const ready =
-    state.appsState === "loaded" &&
-    ((config.filterSource === FilterSource.Spans &&
-      state.rootSpanNamesState === "loaded") ||
-      config.filterSource !== FilterSource.Spans) &&
-    filtersReady;
+  const ready = state.appsState === "loaded" && filtersReady;
 
   const updatedUrlFilters: URLFilters = {
     appId: state.selectedApp.id,
-    rootSpanName: state.selectedRootSpanName,
     startDate: state.selectedStartDate,
     endDate: state.selectedEndDate,
     dateRange: state.selectedDateRange || undefined,
@@ -539,7 +506,6 @@ function computeFilters(state: FiltersStoreState): Filters {
       ),
     ),
     sessionTypes: state.selectedSessionTypes,
-    spanStatuses: state.selectedSpanStatuses,
     bugReportStatuses: state.selectedBugReportStatuses,
     httpMethods: state.selectedHttpMethods,
     osVersions: state.selectedOsVersions.map((os) =>
@@ -573,17 +539,12 @@ function computeFilters(state: FiltersStoreState): Filters {
 
   const loading =
     state.appsState === "pending" ||
-    (state.appsState === "loaded" && state.filterOptionsState === "pending") ||
-    (state.appsState === "loaded" &&
-      state.filterOptionsState === "loaded" &&
-      config.filterSource === FilterSource.Spans &&
-      state.rootSpanNamesState === "pending");
+    (state.appsState === "loaded" && state.filterOptionsState === "pending");
 
   return {
     ready,
     loading,
     app: state.selectedApp,
-    rootSpanName: state.selectedRootSpanName,
     startDate: state.selectedStartDate,
     endDate: state.selectedEndDate,
     versions: {
@@ -593,10 +554,6 @@ function computeFilters(state: FiltersStoreState): Filters {
     sessionTypes: {
       selected: state.selectedSessionTypes,
       all: state.selectedSessionTypes.length === allSessionTypes.length,
-    },
-    spanStatuses: {
-      selected: state.selectedSpanStatuses,
-      all: state.selectedSpanStatuses.length === allSpanStatuses.length,
     },
     bugReportStatuses: {
       selected: state.selectedBugReportStatuses,
@@ -665,8 +622,7 @@ export function applyFilterOptions(
   initConfig: InitConfig,
   _currentState: FiltersStoreState,
 ): Partial<FiltersStoreState> {
-  const { urlFilters, appVersionsInitialSelectionType, filterSource } =
-    initConfig;
+  const { urlFilters, appVersionsInitialSelectionType } = initConfig;
   // Pages that hide the app selector (e.g. crash/trace details) don't write
   // `a=appId` into the URL, but they DO write filter selections. Treat URL
   // filters as applicable when the URL has no appId at all — the indices
@@ -756,18 +712,6 @@ export function applyFilterOptions(
     selectedUdAttrMatchers = [];
   }
 
-  let selectedSpanStatuses: SpanStatus[];
-  if (isUrlMatch && urlFilters.spanStatuses) {
-    selectedSpanStatuses = urlFilters.spanStatuses
-      .filter((s: string) =>
-        Object.values(SpanStatus).includes(s as SpanStatus),
-      )
-      .map((s: string) => s as SpanStatus);
-  } else {
-    selectedSpanStatuses =
-      filterSource === FilterSource.Spans ? allSpanStatuses : [];
-  }
-
   let selectedBugReportStatuses: BugReportStatus[];
   if (isUrlMatch && urlFilters.bugReportStatuses) {
     selectedBugReportStatuses = urlFilters.bugReportStatuses
@@ -851,7 +795,6 @@ export function applyFilterOptions(
     selectedDeviceManufacturers,
     selectedDeviceNames,
     selectedUdAttrMatchers,
-    selectedSpanStatuses,
     selectedBugReportStatuses,
     selectedHttpMethods,
     selectedSessionTypes,
@@ -903,23 +846,6 @@ export function pickApp(
 // so their key order matches and stringify comparison is reliable.
 export function appsEqual(a: App, b: App): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
-}
-
-export function resolveRootSpanName(
-  rootSpanNames: string[],
-  initConfig: InitConfig,
-  app: App,
-): string {
-  if (
-    initConfig.urlFilters.appId === app.id &&
-    initConfig.urlFilters.rootSpanName
-  ) {
-    const found = rootSpanNames.find(
-      (name) => name === initConfig.urlFilters.rootSpanName,
-    );
-    return found ?? rootSpanNames[0];
-  }
-  return rootSpanNames[0];
 }
 
 // Signature of the exact /shortFilters POST that saveListFiltersToServer
@@ -984,12 +910,10 @@ export function createFiltersStore() {
           selectedDeviceManufacturers: [],
           selectedDeviceNames: [],
           selectedSessionTypes: [],
-          selectedSpanStatuses: [],
           selectedBugReportStatuses: [],
           selectedHttpMethods: [],
           selectedUdAttrMatchers: [],
           selectedFreeText: "",
-          selectedRootSpanName: "",
           selectedErrorTypes: ["error", "anr"],
           selectedSeverities: [],
           customErrorsOnly: false,
@@ -1019,14 +943,6 @@ export function createFiltersStore() {
         });
       },
 
-      setRootSpanNames: (rootSpanNames, state) => {
-        if (rootSpanNames === null) {
-          set({ rootSpanNamesState: state });
-          return;
-        }
-        set({ rootSpanNamesState: state, rootSpanNames });
-      },
-
       setCurrentTeamId: (teamId) => set({ currentTeamId: teamId }),
 
       setSelectedApp: (app) => {
@@ -1045,14 +961,11 @@ export function createFiltersStore() {
         }
       },
 
-      setSelectedRootSpanName: (name) => set({ selectedRootSpanName: name }),
       setSelectedDateRange: (range) => set({ selectedDateRange: range }),
       setSelectedStartDate: (date) => set({ selectedStartDate: date }),
       setSelectedEndDate: (date) => set({ selectedEndDate: date }),
       setSelectedVersions: (versions) => set({ selectedVersions: versions }),
       setSelectedSessionTypes: (types) => set({ selectedSessionTypes: types }),
-      setSelectedSpanStatuses: (statuses) =>
-        set({ selectedSpanStatuses: statuses }),
       setSelectedBugReportStatuses: (statuses) =>
         set({ selectedBugReportStatuses: statuses }),
       setSelectedHttpMethods: (methods) =>

--- a/frontend/dashboard/content/docs/mcp.mdx
+++ b/frontend/dashboard/content/docs/mcp.mdx
@@ -45,6 +45,14 @@ List all apps the authenticated user has access to.
 
 Get available filter options (versions, OS, countries, devices, etc.) for an app. 
 
+### `get_filter_keys`
+
+List the filter keys of an entity (spans or builds): the vocabulary a filter expression is written with.
+
+### `get_filter_values`
+
+List the values a filter key can be set to for an app.
+
 ### `get_metrics`
 
 Get app metrics including adoption, crash-free/ANR-free sessions and launch performance (cold/warm/hot p95).

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -725,23 +725,8 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: timezone
-          in: query
-          required: true
-          description: IANA timezone used to bucket and format datetime values in the response.
-          schema:
-            type: string
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
-            enum:
-              - minutes
-              - hours
-              - days
-              - months
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -1018,6 +1003,21 @@ paths:
             type: string
             enum:
               - builds
+              - spans
+        - name: key
+          in: query
+          required: false
+          description: |
+            Name of a key to resolve and include even when the custom key
+            listing is truncated. Repeat the parameter for each name, like
+            `key=custom.plan&key=custom.tier`. Keys not present in app data
+            are ignored.
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Successful response, no errors.
@@ -1037,12 +1037,18 @@ paths:
                       them in. Every key's `key_group` is one of these.
                     items:
                       type: string
+                  keys_truncated:
+                    type: boolean
+                    description: |
+                      True when the app has more custom keys than the listing
+                      returns.
               examples:
                 response:
                   value:
                     key_groups:
                       - Version
                       - Build
+                    keys_truncated: false
                     keys:
                       - name: version_name
                         label: App version
@@ -1118,6 +1124,7 @@ paths:
             type: string
             enum:
               - builds
+              - spans
         - name: key_name
           in: query
           required: true
@@ -1416,18 +1423,8 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: timezone
-          in: query
-          required: true
-          description: "Client timezone for time bucket alignment. Example: `Asia/Kolkata`."
-          schema:
-            type: string
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket granularity. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -1940,18 +1937,8 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: timezone
-          in: query
-          required: true
-          description: "Client timezone for time bucket alignment. Example: `Asia/Kolkata`."
-          schema:
-            type: string
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket granularity. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -2489,18 +2476,8 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: timezone
-          in: query
-          required: true
-          description: IANA timezone used to bucket and format datetime values in the response.
-          schema:
-            type: string
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -3320,11 +3297,10 @@ paths:
         - Traces
       summary: Fetch a span's list of instances
       description: |
-        Fetch a span's list of instances with optional filters.
+        Fetch a span's list of instances, optionally narrowed by a filter
+        expression.
 
-        For multiple comma separated fields, make sure no whitespace characters
-        exist before or after commas. Pass `limit` and `offset` values to
-        paginate results.
+        Pass `limit` and `offset` values to paginate results.
       parameters:
         - name: id
           in: path
@@ -3341,60 +3317,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version codes to return only matching sessions.
-          schema:
-            type: string
-        - name: countries
-          in: query
-          required: false
-          description: List of comma separated country identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_names
-          in: query
-          required: false
-          description: List of comma separated device name identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated device locale identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings to return only matching sessions.
-          schema:
-            type: string
+        - $ref: "#/components/parameters/FilterExpr"
         - name: offset
           in: query
           required: false
@@ -3407,22 +3330,6 @@ paths:
           description: Number of items to return. Used for pagination. Should be used along with `offset`.
           schema:
             type: integer
-        - name: filter_short_code
-          in: query
-          required: false
-          description: Code representing combination of filters.
-          schema:
-            type: string
-        - name: span_statuses
-          in: query
-          required: false
-          description: Should be 0 (Unset), 1 (Ok) or 2 (Error). If multiple statuses are required, they should be passed as multiple query params like `span_statuses=0&span_statuses=1&span_statuses=2`.
-          style: form
-          explode: true
-          schema:
-            type: array
-            items:
-              type: integer
       responses:
         "200":
           description: Successful response, no errors.
@@ -3524,11 +3431,8 @@ paths:
         - Traces
       summary: Fetch a span's metrics plot
       description: |
-        Fetch a span's metrics plot with optional filters.
-
-        For multiple comma separated fields, make sure no whitespace characters
-        exist before or after commas. Pass `limit` and `offset` values to
-        paginate results.
+        Fetch a span's metrics plot, optionally narrowed by a filter
+        expression.
       parameters:
         - name: id
           in: path
@@ -3545,94 +3449,9 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version codes to return only matching sessions.
-          schema:
-            type: string
-        - name: countries
-          in: query
-          required: false
-          description: List of comma separated country identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_names
-          in: query
-          required: false
-          description: List of comma separated device name identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated device locale identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: offset
-          in: query
-          required: false
-          description: Number of items to skip when paginating. Use with `limit` parameter to control amount of items fetched.
-          schema:
-            type: integer
-        - name: limit
-          in: query
-          required: false
-          description: Number of items to return. Used for pagination. Should be used along with `offset`.
-          schema:
-            type: integer
-        - name: filter_short_code
-          in: query
-          required: false
-          description: Code representing combination of filters.
-          schema:
-            type: string
-        - name: span_statuses
-          in: query
-          required: false
-          description: Should be 0 (Unset), 1 (Ok) or 2 (Error). If multiple statuses are required, they should be passed as multiple query params like `span_statuses=0&span_statuses=1&span_statuses=2`.
-          style: form
-          explode: true
-          schema:
-            type: array
-            items:
-              type: integer
+        - $ref: "#/components/parameters/FilterExpr"
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
       responses:
         "200":
           description: Successful response, no errors.
@@ -3823,12 +3642,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucket used for plot aggregation. Accepted values: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -5190,12 +5004,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucketing granularity. One of: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -5332,12 +5141,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucketing granularity. One of: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -5484,12 +5288,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: plot_time_group
-          in: query
-          required: false
-          description: "Time bucketing granularity. One of: `minutes`, `hours`, `days`, `months`. Defaults to `days`."
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PlotTimeGroup"
         - name: versions
           in: query
           required: false
@@ -7280,6 +7079,25 @@ components:
       description: "ISO 8601 UTC string in milliseconds precision. Example: `2023-11-01T18:30:00.000Z`. Omitting both `from` and `to` returns the last seven days."
       schema:
         type: string
+    Timezone:
+      name: timezone
+      in: query
+      required: true
+      description: "IANA timezone used to bucket and format datetime values in the response. Example: `Asia/Kolkata`."
+      schema:
+        type: string
+    PlotTimeGroup:
+      name: plot_time_group
+      in: query
+      required: false
+      description: "Time bucket used for plot aggregation. Defaults to `days`."
+      schema:
+        type: string
+        enum:
+          - minutes
+          - hours
+          - days
+          - months
     FilterExpr:
         name: filter_expr
         in: query

--- a/go.work.sum
+++ b/go.work.sum
@@ -222,6 +222,7 @@ github.com/mkevac/debugcharts v0.0.0-20191222103121-ae1c48aa8615/go.mod h1:Ad7oe
 github.com/moby/moby/api v1.54.2/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
 github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
 github.com/moby/sys/mount v0.3.4/go.mod h1:KcQJMbQdJHPlq5lcYT+/CjatWM4PuxKe+XLSVS4J6Os=
+github.com/moby/sys/mount v0.3.5/go.mod h1:WUQDO+/uCiCIkIztx8SrwIDVn2dtMFRBebRhpDFT71M=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/reexec v0.1.0/go.mod h1:EqjBg8F3X7iZe5pU6nRZnYCMUTXoxsjiIfHup5wYIN8=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=


### PR DESCRIPTION
# Description

- add a spans entity to exprfilter covering the old traces filters
- rewrite the span list and metrics plot endpoints on the ExprFilter pattern, dropping the legacy filter params
- add custom keys: user-defined span attributes filter as dynamic custom.* keys, resolved and bound through membership subqueries on span_user_def_attrs
- resolve filter keys by name past the custom key listing cap: the keys endpoint and MCP tool accept requested names, and the filter bar sends the names its expression uses
- add root span selector to FilterBar and use it in traces page
- drive the builds and traces queries from the URL so filters, pagination and app selection come from one snapshot
- keep a deep link's pagination offset only when the bar applied the request unchanged, and do not fetch a value the bar discarded
- remove the legacy span filter lane: FilterSource.Spans, span statuses, and the store's root span plumbing
- add get_filter_keys and get_filter_values MCP tools and switch the span tools to a filter_expr input



