### PR TITLE
fix(backend): quote ilike patterns in user defined attr filters

### DIFF
--- a/backend/libs/udattr/userdefattr.go
+++ b/backend/libs/udattr/userdefattr.go
@@ -400,9 +400,9 @@ func (c *UDComparison) Augment(stmt *sqlf.Stmt) {
 	case OpEq, OpNeq, OpGt, OpGte, OpLt, OpLte:
 		exprFunc(fmt.Sprintf("(key = ? AND type = ? AND value %s ?)", opSymbol), c.Key, c.Type.String(), c.Value)
 	case OpContains:
-		exprFunc(fmt.Sprintf("(key = ? AND type = ? AND value %s %%?%%)", opSymbol), c.Key, c.Type.String(), c.EscapedValue())
+		exprFunc(fmt.Sprintf("(key = ? AND type = ? AND value %s ?)", opSymbol), c.Key, c.Type.String(), "%"+c.EscapedValue()+"%")
 	case OpStartsWith:
-		exprFunc(fmt.Sprintf("(key = ? AND type = ? AND value %s ?%%)", opSymbol), c.Key, c.Type.String(), c.EscapedValue())
+		exprFunc(fmt.Sprintf("(key = ? AND type = ? AND value %s ?)", opSymbol), c.Key, c.Type.String(), c.EscapedValue()+"%")
 	}
 }
 

--- a/backend/libs/udattr/userdefattr_test.go
+++ b/backend/libs/udattr/userdefattr_test.go
@@ -446,8 +446,8 @@ func TestAugmentComparison(t *testing.T) {
 		defer stmt.Close()
 
 		cmpStringContains.Augment(stmt)
-		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike %?%)"
-		expectedArgs := []any{true, "preference", "string", "spicy"}
+		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike ?)"
+		expectedArgs := []any{true, "preference", "string", "%spicy%"}
 		gotStmt := stmt.String()
 		gotArgs := stmt.Args()
 
@@ -468,8 +468,8 @@ func TestAugmentComparison(t *testing.T) {
 		defer stmt.Close()
 
 		cmpStringStartsWith.Augment(stmt)
-		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike ?%)"
-		expectedArgs := []any{true, "name", "string", "Dr"}
+		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike ?)"
+		expectedArgs := []any{true, "name", "string", "Dr%"}
 		gotStmt := stmt.String()
 		gotArgs := stmt.Args()
 
@@ -597,9 +597,9 @@ func TestAugmentExpression(t *testing.T) {
 		defer stmt.Close()
 		exprEscaped.Augment(stmt)
 
-		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike %?%)"
+		expectedStmt := "SELECT id, name FROM users WHERE is_active = ? AND (key = ? AND type = ? AND value ilike ?)"
 		gotStmt := stmt.String()
-		expectedArgs := []any{true, "username", "string", "ali\\%ce"}
+		expectedArgs := []any{true, "username", "string", "%ali\\%ce%"}
 		gotArgs := stmt.Args()
 
 		if expectedStmt != gotStmt {


### PR DESCRIPTION
## Summary

This PR fixes a ClickHouse syntax error raised when a filter uses the `contains` or `startsWith` operator on a user defined attribute. The ILIKE pattern is now quoted correctly.

## Tasks

- [x] Fold `%` wildcards into the bound value in `UDComparison.Augment`
- [x] Update `udattr` test expectations to the corrected SQL & args

## See also

- fixes #4300
