### PR TITLE
fix(backend): set sender display name & drop repeated alert copy

### DIFF
--- a/backend/libs/alertmsg/alertmsg.go
+++ b/backend/libs/alertmsg/alertmsg.go
@@ -10,22 +10,20 @@ import "fmt"
 
 // CrashSpikeMessage builds the plain text message for a crash spike alert.
 func CrashSpikeMessage(file, method, message string) string {
-	return fmt.Sprintf("Crashes are spiking at:\n\n%s: %s() - %s", file, method, message)
+	return fmt.Sprintf("%s: %s() - %s", file, method, message)
 }
 
 // AnrSpikeMessage builds the plain text message for an ANR spike alert.
 func AnrSpikeMessage(file, method, message string) string {
-	return fmt.Sprintf("ANRs are spiking at:\n\n%s: %s() - %s", file, method, message)
+	return fmt.Sprintf("%s: %s() - %s", file, method, message)
 }
 
 // BugReportMessage builds the plain text message for a bug report alert.
-// An empty description is replaced with a placeholder so the alert never
-// reads as truncated.
 func BugReportMessage(description string) string {
 	if description == "" {
-		description = "No description provided."
+		return "No description provided."
 	}
-	return fmt.Sprintf("A new bug report has been submitted:\n\n%s", description)
+	return description
 }
 
 // CrashSpikeURL builds the dashboard URL for a crash spike alert. A

--- a/backend/libs/alertmsg/alertmsg_test.go
+++ b/backend/libs/alertmsg/alertmsg_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestCrashSpikeMessage(t *testing.T) {
 	got := CrashSpikeMessage("Foo.kt", "<init>", "x < 1")
-	want := "Crashes are spiking at:\n\nFoo.kt: <init>() - x < 1"
+	want := "Foo.kt: <init>() - x < 1"
 	if got != want {
 		t.Errorf("CrashSpikeMessage = %q, want %q", got, want)
 	}
@@ -12,7 +12,7 @@ func TestCrashSpikeMessage(t *testing.T) {
 
 func TestAnrSpikeMessage(t *testing.T) {
 	got := AnrSpikeMessage("Bar.kt", "run", "Input dispatching timed out")
-	want := "ANRs are spiking at:\n\nBar.kt: run() - Input dispatching timed out"
+	want := "Bar.kt: run() - Input dispatching timed out"
 	if got != want {
 		t.Errorf("AnrSpikeMessage = %q, want %q", got, want)
 	}
@@ -21,7 +21,7 @@ func TestAnrSpikeMessage(t *testing.T) {
 func TestBugReportMessage(t *testing.T) {
 	t.Run("carries the description through unchanged", func(t *testing.T) {
 		got := BugReportMessage("Login button <b>does nothing</b>")
-		want := "A new bug report has been submitted:\n\nLogin button <b>does nothing</b>"
+		want := "Login button <b>does nothing</b>"
 		if got != want {
 			t.Errorf("BugReportMessage = %q, want %q", got, want)
 		}
@@ -29,7 +29,7 @@ func TestBugReportMessage(t *testing.T) {
 
 	t.Run("replaces an empty description with a placeholder", func(t *testing.T) {
 		got := BugReportMessage("")
-		want := "A new bug report has been submitted:\n\nNo description provided."
+		want := "No description provided."
 		if got != want {
 			t.Errorf("BugReportMessage = %q, want %q", got, want)
 		}

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -73,7 +73,7 @@ func RoleChangedEmail(newRole, changedByEmail, teamName, siteOrigin, teamId stri
 // text alert message.
 func CrashSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - Crash Spike Alert"
-	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(appName), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
@@ -81,7 +81,7 @@ func CrashSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body str
 // text alert message.
 func AnrSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - ANR Spike Alert"
-	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(appName), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 
@@ -89,7 +89,7 @@ func AnrSpikeAlertEmail(appName, alertMsg, alertURL string) (subject, body strin
 // text alert message.
 func BugReportAlertEmail(appName, alertMsg, alertURL string) (subject, body string) {
 	subject = appName + " - New Bug Report"
-	body = RenderEmailBody(escape(subject), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
+	body = RenderEmailBody(escape(appName), PlainTextContent(alertMsg), "View in Dashboard", alertURL)
 	return
 }
 

--- a/backend/libs/email/email.go
+++ b/backend/libs/email/email.go
@@ -15,6 +15,9 @@ import (
 	"github.com/wneessen/go-mail"
 )
 
+// fromName is the sender display name shown in mail clients.
+const fromName = "Measure Notification"
+
 // EmailInfo describes an email to be sent or queued.
 type EmailInfo struct {
 	From        string `json:"from"`
@@ -41,6 +44,24 @@ type AppDailySummary struct {
 	Metrics []MetricData
 }
 
+// buildMessage constructs the mail.Msg for an EmailInfo, setting a display
+// name on the From address.
+func buildMessage(info EmailInfo) (message *mail.Msg, err error) {
+	message = mail.NewMsg()
+	if err = message.FromFormat(fromName, info.From); err != nil {
+		fmt.Printf("failed to set From address: %s\n", err)
+		return nil, err
+	}
+	if err = message.To(info.To); err != nil {
+		fmt.Printf("failed to set To address: %s\n", err)
+		return nil, err
+	}
+	message.Subject(info.Subject)
+	message.SetBodyString(mail.ContentType(info.ContentType), info.Body)
+
+	return message, nil
+}
+
 // SendEmail sends an email immediately using the provided mail client.
 // Use QueueEmail instead to queue an email for later delivery.
 func SendEmail(client *mail.Client, info EmailInfo) error {
@@ -48,17 +69,10 @@ func SendEmail(client *mail.Client, info EmailInfo) error {
 		return fmt.Errorf("email client is not initialized")
 	}
 
-	message := mail.NewMsg()
-	if err := message.From(info.From); err != nil {
-		fmt.Printf("failed to set From address: %s\n", err)
+	message, err := buildMessage(info)
+	if err != nil {
 		return err
 	}
-	if err := message.To(info.To); err != nil {
-		fmt.Printf("failed to set To address: %s\n", err)
-		return err
-	}
-	message.Subject(info.Subject)
-	message.SetBodyString(mail.ContentType(info.ContentType), info.Body)
 
 	if err := client.DialAndSend(message); err != nil {
 		fmt.Printf("failed to send mail: %s\n", err)

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -539,6 +539,25 @@ func TestQueueEmailOmitsEmptyAlertType(t *testing.T) {
 	}
 }
 
+func TestBuildMessageSetsFromName(t *testing.T) {
+	message, err := buildMessage(EmailInfo{
+		From:        testFromEmail,
+		To:          testToEmail,
+		Subject:     "Test",
+		ContentType: "text/html",
+		Body:        "<p>Hello</p>",
+	})
+	if err != nil {
+		t.Fatalf("buildMessage: %v", err)
+	}
+
+	from := message.GetFromString()
+	want := `"Measure Notification" <test@example.com>`
+	if len(from) != 1 || from[0] != want {
+		t.Errorf("From header = %v, want [%q]", from, want)
+	}
+}
+
 func TestSendEmailNilClient(t *testing.T) {
 	err := SendEmail(nil, EmailInfo{
 		From:        testFromEmail,

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -4258,7 +4258,7 @@ paths:
                         app_id: 19e26d60-2ad8-4ef7-8aab-333e1f5377fc
                         entity_id: 09ef78940bd258030ebe3937bf1e32a2
                         type: anr_spike
-                        message: "ANRs are spiking at:\n\nCpuUsageCollector: run() - Application Not Responding for at least 5s"
+                        message: "CpuUsageCollector: run() - Application Not Responding for at least 5s"
                         url: http://localhost:3000/29f0f5b2-f03f-4dbe-bd18-acf163b91965/anrs/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/09ef78940bd258030ebe3937bf1e32a2/sh.measure.android.anr.AnrError@CpuUsageCollector
                         created_at: "2025-07-10T11:35:48.069383Z"
                         updated_at: "2025-07-10T11:35:48.069383Z"
@@ -4267,7 +4267,7 @@ paths:
                         app_id: 19e26d60-2ad8-4ef7-8aab-333e1f5377fc
                         entity_id: f94859bc4b47fbf05b4eec2a300de0a4
                         type: crash_spike
-                        message: "Crashes are spiking at:\n\nExceptionDemoActivity: onClick() - This is a nested custom exception"
+                        message: "ExceptionDemoActivity: onClick() - This is a nested custom exception"
                         url: http://localhost:3000/29f0f5b2-f03f-4dbe-bd18-acf163b91965/crashes/19e26d60-2ad8-4ef7-8aab-333e1f5377fc/f94859bc4b47fbf05b4eec2a300de0a4/sh.measure.sample.CustomException@ExceptionDemoActivity
                         created_at: "2025-07-10T11:35:48.057192Z"
                         updated_at: "2025-07-10T11:35:48.057192Z"


### PR DESCRIPTION
## Summary

This PR gives outbound emails a proper sender display name & removes text that repeated across the alert emails. Mail clients showed `noreply` in place of a sender name because the `From` header carried a bare address. Alert emails stated their alert type three times, so the body header now shows the app name & the message carries only its payload, which shortens the Slack alerts too.

## Tasks

- [x] Set the `From` display name to `Measure Notification`
- [x] Drop the lead-in sentences from crash spike, ANR spike & bug report messages
- [x] Show the app name in the alert email header
- [x] Update the alerts examples in the dashboard API spec

## Details

The three alert emails (changed)

  | Subject | Header bar | Body
-- | -- | -- | --
Crash spike | MyApp - Crash Spike Alert | MyApp | MainActivity.java: onCreate() -  NullPointerException: Attempt to invoke virtual method on a null object reference
ANR spike | MyApp - ANR Spike Alert | MyApp | NetworkService.java: fetchData() - Application Not Responding: Input dispatching timed out
Bug report | MyApp - New Bug Report | MyApp | the description verbatim, or No description provided.

## See also

- fixes #2787
