### PR TITLE
perf(ios): improve bug report screen transition

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportManager.swift
@@ -62,12 +62,30 @@ final class BaseBugReportManager: BugReportManager {
 
             if takeScreenshot,
                let window = UIWindow.keyWindow() {
-                screenshotGenerator.generate(window: window, name: screenshotName, storageType: .data, sync: false) { attachment in
-                    if let attachment = attachment {
-                        self.localAttachments.append(attachment)
+                var hasOpened = false
+                var redactedImage: UIImage?
+                screenshotGenerator.generate(
+                    window: window,
+                    name: screenshotName,
+                    storageType: .data,
+                    sync: false,
+                    onRedactedImage: { image in
+                        redactedImage = image
+                        guard !hasOpened else { return }
+                        hasOpened = true
+                        finishOpening()
+                    },
+                    completion: { attachment in
+                        if let attachment = attachment {
+                            self.localAttachments.append(attachment)
+                            self.bugReportingViewController?.addAttachment(attachment, previewImage: redactedImage)
+                        }
+                        if !hasOpened {
+                            hasOpened = true
+                            finishOpening()
+                        }
                     }
-                    finishOpening()
-                }
+                )
             } else {
                 finishOpening()
             }
@@ -75,6 +93,11 @@ final class BaseBugReportManager: BugReportManager {
     }
 
     private func openBugReportViewController() {
+        guard let root = UIWindow.keyWindow()?.rootViewController else {
+            clearState()
+            return
+        }
+
         let bugVC = BugReportingViewController(description: description,
                                                attachments: self.localAttachments,
                                                configProvider: configProvider,
@@ -84,14 +107,13 @@ final class BaseBugReportManager: BugReportManager {
         bugVC.modalPresentationStyle = .fullScreen
         bugVC.delegate = self
         self.bugReportingViewController = bugVC
-        if let root = UIWindow.keyWindow()?.rootViewController {
-            var top = root
-            while let presented = top.presentedViewController {
-                top = presented
-            }
-            top.present(bugVC, animated: true) {
-                self.isBugReporterOpen = true
-            }
+
+        var top = root
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        top.present(bugVC, animated: true) {
+            self.isBugReporterOpen = true
         }
     }
 

--- a/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/BugReportingViewController.swift
@@ -37,6 +37,11 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
     private let maxAttachmentsLabel = UILabel()
     private var attachments: [MsrAttachment]
 
+    private var previewImages: [String: UIImage] = [:]
+
+    private static let cellSize = CGSize(width: 100, height: 140)
+    private static let thumbnailScale: CGFloat = 0.8
+
     private let screenshotButton = UIButton(type: .system)
     private let galleryButton = UIButton(type: .system)
 
@@ -293,11 +298,32 @@ class BugReportingViewController: UIViewController, UINavigationControllerDelega
         }
     }
 
-    func addAttachment(_ attachment: MsrAttachment) {
+    func addAttachment(_ attachment: MsrAttachment, previewImage: UIImage? = nil) {
         guard attachments.count < configProvider.maxAttachmentsInBugReport else { return }
         attachments.append(attachment)
+        if let previewImage = previewImage {
+            previewImages[attachment.id] = Self.thumbnail(from: previewImage)
+        }
         imagesCollectionView.reloadData()
         updateActionButtonsState()
+    }
+
+    private static func thumbnail(from image: UIImage) -> UIImage {
+        let box = CGSize(width: cellSize.width * thumbnailScale,
+                         height: cellSize.height * thumbnailScale)
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return image }
+
+        let ratio = min(box.width / size.width, box.height / size.height)
+        guard ratio < 1 else { return image }
+
+        let target = CGSize(width: (size.width * ratio).rounded(),
+                            height: (size.height * ratio).rounded())
+        let format = UIGraphicsImageRendererFormat.default()
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: target, format: format).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: target))
+        }
     }
 
     private func updateActionButtonsState() {
@@ -371,17 +397,26 @@ extension BugReportingViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ImageCell", for: indexPath) as? BugReportImageCell else {
             return UICollectionViewCell()
         }
-        var imageData = attachments[indexPath.item].bytes
-        if imageData == nil, let path = attachments[indexPath.item].path {
-            imageData = systemFileManager.retrieveFile(atPath: path)
+        let attachment = attachments[indexPath.item]
+
+        var image = previewImages[attachment.id]
+        if image == nil {
+            var imageData = attachment.bytes
+            if imageData == nil, let path = attachment.path {
+                imageData = systemFileManager.retrieveFile(atPath: path)
+            }
+            image = imageData.flatMap { UIImage(data: $0) }
         }
-        if let data = imageData, let image = UIImage(data: data) {
+
+        if let image = image {
             cell.configure(with: image, colors: bugReportConfig.colors)
             cell.onDelete = { [weak self] in
                 guard let self = self else { return }
-                if let path = self.attachments[indexPath.item].path {
+                let removed = self.attachments[indexPath.item]
+                if let path = removed.path {
                     self.systemFileManager.deleteFile(atPath: path)
                 }
+                self.previewImages.removeValue(forKey: removed.id)
                 self.attachments.remove(at: indexPath.item)
                 collectionView.reloadData()
                 self.updateActionButtonsState()
@@ -394,7 +429,7 @@ extension BugReportingViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegateFlowLayout
 extension BugReportingViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 100, height: 140)
+        return Self.cellSize
     }
 }
 
@@ -403,7 +438,8 @@ extension BugReportingViewController: UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         if let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage,
            let imageData = WebPEncoder.encode(image, quality: CGFloat(configProvider.screenshotCompressionQuality) / 100.0) {
-            addAttachment(MsrAttachment(name: galleryImageName, type: .screenshot, size: Int64(imageData.count), id: idProvider.uuid(), bytes: imageData, path: nil))
+            addAttachment(MsrAttachment(name: galleryImageName, type: .screenshot, size: Int64(imageData.count), id: idProvider.uuid(), bytes: imageData, path: nil),
+                          previewImage: image)
         }
         picker.dismiss(animated: true)
     }

--- a/ios/Sources/MeasureSDK/Swift/BugReport/FloatingButtonViewController.swift
+++ b/ios/Sources/MeasureSDK/Swift/BugReport/FloatingButtonViewController.swift
@@ -140,7 +140,7 @@ final class FloatingButtonViewController: UIViewController {
     }
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
-        screenshotGenerator.generate(window: view.window!, name: screenshotName, storageType: .data, sync: false) { [weak self] attachment in
+        screenshotGenerator.generate(window: view.window!, name: screenshotName, storageType: .data, sync: false, onRedactedImage: nil) { [weak self] attachment in
             guard let self = self, let attachment = attachment else { return }
             self.animateScreenshotToButton(attachment)
         }

--- a/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
@@ -170,11 +170,13 @@ final class BaseInternalSignalCollector: InternalSignalCollector { // swiftlint:
                             self.screenshotGenerator.generate(window: window,
                                                               name: screenshotName,
                                                               storageType: .data,
-                                                              sync: true) { attachment in
+                                                              sync: true,
+                                                              onRedactedImage: nil,
+                                                              completion: { attachment in
                                 if let attachment = attachment {
                                     exceptionAttachments = [attachment]
                                 }
-                            }
+                            })
                         }
                     }
                     if Thread.isMainThread {

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/ScreenshotGenerator.swift
@@ -10,10 +10,11 @@ import WebKit
 import AVKit
 
 protocol ScreenshotGenerator {
-    func generate(window: UIWindow,
+    func generate(window: UIWindow, // swiftlint:disable:this function_parameter_count
                   name: String,
                   storageType: AttachmentStorageType,
                   sync: Bool,
+                  onRedactedImage: ((UIImage) -> Void)?,
                   completion: @escaping (MsrAttachment?) -> Void)
 
     func generate(viewController: UIViewController,
@@ -60,64 +61,44 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
                   name: String,
                   storageType: AttachmentStorageType,
                   sync: Bool = false,
+                  onRedactedImage: ((UIImage) -> Void)? = nil,
                   completion: @escaping (MsrAttachment?) -> Void) {
-        let work = { [weak self] in
-            guard let self = self else {
+        if sync {
+            let runInline = { [weak self] in
+                guard let self = self, let captured = self.captureScreenshot(window: window) else {
+                    completion(nil)
+                    return
+                }
+                completion(self.processScreenshot(captured.screenshot,
+                                                  sensitiveFrames: captured.sensitiveFrames,
+                                                  storageType: storageType,
+                                                  publishRedacted: { onRedactedImage?($0) }))
+            }
+            if Thread.isMainThread {
+                runInline()
+            } else {
+                DispatchQueue.main.sync(execute: runInline)
+            }
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let captured = self.captureScreenshot(window: window) else {
                 completion(nil)
                 return
             }
 
-            SignPost.trace(subcategory: "Attachment", label: "generateScreenshot") {
-                let level = self.configProvider.screenshotMaskLevel
-                let typesToMask = self.typesToMask(for: level)
-                let fragmentsToMask = self.classNameFragmentsToMask(for: level)
-                let result = self.findSensitiveFrames(in: window, rootView: window, types: typesToMask, fragments: fragmentsToMask)
-
-                // Subtract exempt frames from sensitive frames
-                var sensitiveFrames = result.sensitive
-                if !result.exempt.isEmpty {
-                    sensitiveFrames = sensitiveFrames.filter { frame in
-                        !result.exempt.contains { $0.intersects(frame) }
-                    }
+            MeasureQueue.screenshotProcessor.async {
+                let attachment = self.processScreenshot(
+                    captured.screenshot,
+                    sensitiveFrames: captured.sensitiveFrames,
+                    storageType: storageType
+                ) { image in
+                    guard let onRedactedImage = onRedactedImage else { return }
+                    DispatchQueue.main.async { onRedactedImage(image) }
                 }
-
-                let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
-                let screenshot = renderer.image { _ in
-                    window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-                }
-
-                guard let redactedImage = self.redactScreenshot(
-                    screenshot,
-                    sensitiveFrames: sensitiveFrames,
-                    maskColor: self.maskColor
-                ) else {
-                    completion(nil)
-                    return
-                }
-
-                guard let compressedData = WebPEncoder.encode(redactedImage, quality: CGFloat(self.configProvider.screenshotCompressionQuality) / 100.0) else {
-                    self.logger.log(level: .debug, message: "ScreenshotGenerator: Failed to compress image.", error: nil, data: nil)
-                    completion(nil)
-                    return
-                }
-
-                let attachment = self.attachmentProcessor.getAttachmentObject(
-                    for: compressedData,
-                    storageType: storageType,
-                    attachmentType: .screenshot
-                )
-                completion(attachment)
+                DispatchQueue.main.async { completion(attachment) }
             }
-        }
-
-        if sync {
-            if Thread.isMainThread {
-                work()
-            } else {
-                DispatchQueue.main.sync(execute: work)
-            }
-        } else {
-            DispatchQueue.main.async(execute: work)
         }
     }
 
@@ -139,11 +120,61 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
         }
     }
 
+    private func captureScreenshot(window: UIWindow) -> (screenshot: UIImage, sensitiveFrames: [CGRect])? {
+        SignPost.trace(subcategory: "Attachment", label: "captureScreenshot") {
+            let level = configProvider.screenshotMaskLevel
+            let result = findSensitiveFrames(in: window,
+                                             rootView: window,
+                                             types: typesToMask(for: level),
+                                             fragments: classNameFragmentsToMask(for: level))
+
+            // Subtract exempt frames from sensitive frames
+            var sensitiveFrames = result.sensitive
+            if !result.exempt.isEmpty {
+                sensitiveFrames = sensitiveFrames.filter { frame in
+                    !result.exempt.contains { $0.intersects(frame) }
+                }
+            }
+
+            let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+            let screenshot = renderer.image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            return (screenshot, sensitiveFrames)
+        }
+    }
+
+    private func processScreenshot(_ screenshot: UIImage,
+                                   sensitiveFrames: [CGRect],
+                                   storageType: AttachmentStorageType,
+                                   publishRedacted: (UIImage) -> Void) -> MsrAttachment? {
+        SignPost.trace(subcategory: "Attachment", label: "processScreenshot") {
+            guard let redactedImage = redactScreenshot(screenshot,
+                                                      sensitiveFrames: sensitiveFrames,
+                                                      maskColor: maskColor) else {
+                return nil
+            }
+
+            publishRedacted(redactedImage)
+
+            let quality = CGFloat(configProvider.screenshotCompressionQuality) / 100.0
+            guard let compressedData = WebPEncoder.encode(redactedImage, quality: quality) else {
+                logger.log(level: .debug, message: "ScreenshotGenerator: Failed to compress image.", error: nil, data: nil)
+                return nil
+            }
+
+            return attachmentProcessor.getAttachmentObject(for: compressedData,
+                                                           storageType: storageType,
+                                                           attachmentType: .screenshot)
+        }
+    }
+
     private func findSensitiveFrames(in view: UIView, rootView: UIView, types: [UIView.Type], fragments: [String]) -> (sensitive: [CGRect], exempt: [CGRect]) {
         var sensitive: [CGRect] = []
         var exempt: [CGRect] = []
 
-        // Per-instance override from .msrMask() takes highest priority
+        let className = String(describing: type(of: view))
+
         if MsrRedactViewHelper.shouldMask(view) {
             sensitive.append(view.convert(view.bounds, to: rootView))
         } else if MsrRedactViewHelper.shouldUnmask(view) {
@@ -151,7 +182,6 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
             exempt.append(view.convert(view.bounds, to: rootView))
         } else {
             // Fall through to class-based and fragment-based checks
-            let className = String(describing: type(of: view))
             let matchesType = types.contains { view.isKind(of: $0) }
             let matchesFragment = fragments.contains { className.contains($0) }
 
@@ -163,7 +193,6 @@ final class BaseScreenshotGenerator: ScreenshotGenerator {
         // Skip subtree traversal for known crash-prone view types.
         // The view itself is still masked above if it matched — only
         // traversal into its children is skipped.
-        let className = String(describing: type(of: view))
         let isBlocked = traversalBlocklist.contains { className.contains($0) }
         guard !isBlocked else {
             return (sensitive, exempt)

--- a/ios/Sources/MeasureSDK/Swift/Utils/MeasureQueue.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/MeasureQueue.swift
@@ -17,4 +17,9 @@ struct MeasureQueue {
         let queue = DispatchQueue(label: "sh.measure.attachment.exporter", qos: .utility)
         return queue
     }()
+
+    static let screenshotProcessor: DispatchQueue = {
+        let queue = DispatchQueue(label: "sh.measure.screenshot.processor", qos: .userInitiated)
+        return queue
+    }()
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockScreenshotGenerator.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockScreenshotGenerator.swift
@@ -10,8 +10,17 @@ import UIKit
 
 final class MockScreenshotGenerator: ScreenshotGenerator {
     var attachment: MsrAttachment?
+    var redactedImage: UIImage?
 
-    func generate(window: UIWindow, name: String, storageType: AttachmentStorageType, sync: Bool, completion: @escaping (MsrAttachment?) -> Void) {
+    func generate(window: UIWindow, // swiftlint:disable:this function_parameter_count
+                  name: String,
+                  storageType: AttachmentStorageType,
+                  sync: Bool,
+                  onRedactedImage: ((UIImage) -> Void)?,
+                  completion: @escaping (MsrAttachment?) -> Void) {
+        if let redactedImage = redactedImage {
+            onRedactedImage?(redactedImage)
+        }
         completion(attachment)
     }
 


### PR DESCRIPTION
# Description

This PR contains below changes

  - Encode screenshots off main thread
  - Present bug report after redaction
  - Derive view class name only once for view traversal
  - Opens **~136ms faster**, down from **~175 ms** to **~55 ms**

## Related issue
Closes #4305 