### PR TITLE
chore(ios): prepare sdk release 0.13.0

### DIFF
--- a/frontend/dashboard/content/docs/getting-started/ios.mdx
+++ b/frontend/dashboard/content/docs/getting-started/ios.mdx
@@ -35,7 +35,7 @@ Create a new app in the _Apps_ section on the dashboard and copy its `API URL` a
 
 ```swift
 // In Package.swift
-.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.12.1")
+.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.13.0")
 ```
 
 </Tab>

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -5,11 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ios-v0.13.0] - 2026-08-28
+
+### :bug: Bug fixes
+
+
+- (**ios**): Apply correct theming to bug report attachment thumbnail (#4296) by @adwinross in #4296
+- (**ios**): Ignore non http urls in url session interceptor (#4157) by @adwinross in #4157
+- (**ios**): Correct misspelled lifecycle api names (#4153) by @adwinross in #4153
+
+### :hammer: Misc
+
+
+- (**ios**): Stop dropping crash reports before export (#4298) by @adwinross in #4298
+- (**ios**): Raise minimum deployment target to ios 13 (#4295) by @adwinross in #4295
+- (**ios**): Update json serialisation logic (#4270) by @adwinross in #4270
+- (**ios**): Allow modifying sdk credentials in frank app (#4225) by @adwinross in #4225
+- (**ios**): Add swift lint check on ci (#4216) by @adwinross in #4216
+- (**ios**): Update docs (#4210) by @adwinross in #4210
+- (**ios**): Remove attribute.platform from event payload (#4152) by @adwinross in #4152
+- (**ios**): Update prepare release to update version in package.json (#4125) by @adwinross in #4125
+
+### :zap: Performance
+
+
+- (**ios**): Improve bug report screen transition (#4306) by @adwinross in #4306
+
 ## [ios-v0.12.1] - 2026-07-23
 
 ### :hammer: Misc
 
 
+- (**ios**): Prepare sdk release 0.12.1 (#4123) by @adwinross in #4123
 - (**ios**): Update podspec to add proper import for measure webp (#4117) by @adwinross in #4117
 
 ## [ios-v0.12.0] - 2026-07-22
@@ -445,6 +472,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**ios**): Expose API to get current session ID (#1677) by @adwinross in #1677
 - (**ios**): Initial project setup  (#1034) by @adwinross in #1034
 
+[ios-v0.13.0]: https://github.com/measure-sh/measure/compare/ios-v0.12.1..ios-v0.13.0
 [ios-v0.12.1]: https://github.com/measure-sh/measure/compare/ios-v0.12.0..ios-v0.12.1
 [ios-v0.12.0]: https://github.com/measure-sh/measure/compare/ios-v0.11.0..ios-v0.12.0
 [ios-v0.11.0]: https://github.com/measure-sh/measure/compare/ios-v0.10.0..ios-v0.11.0

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
-// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
+// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -40,30 +40,30 @@ extension Measure.AttributeValue : Swift.Codable {
   public init(from decoder: any Swift.Decoder) throws
 }
 public typealias SessionObCoreDataClassSet = Foundation.NSSet
-@_inheritsConvenienceInitializers @objc(SessionOb) nonisolated public class SessionOb : CoreData.NSManagedObject {
-  @objc override nonisolated dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
+@_inheritsConvenienceInitializers @objc(SessionOb) public class SessionOb : CoreData.NSManagedObject {
+  @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
   @objc deinit
 }
 public typealias SessionObCoreDataPropertiesSet = Foundation.NSSet
 extension Measure.SessionOb {
   @nonobjc public class func fetchRequest() -> CoreData.NSFetchRequest<Measure.SessionOb>
-  @objc @NSManaged nonisolated dynamic public var crashed: Swift.Bool {
+  @objc @NSManaged dynamic public var crashed: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var createdAt: Swift.Int64 {
+  @objc @NSManaged dynamic public var createdAt: Swift.Int64 {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var needsReporting: Swift.Bool {
+  @objc @NSManaged dynamic public var needsReporting: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var pid: Swift.Int32 {
+  @objc @NSManaged dynamic public var pid: Swift.Int32 {
     @objc get
     @objc set
   }
-  @objc @NSManaged nonisolated dynamic public var sessionId: Swift.String? {
+  @objc @NSManaged dynamic public var sessionId: Swift.String? {
     @objc get
     @objc set
   }

--- a/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
+++ b/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct FrameworkInfo {
-    static let version = "0.12.1"
+    static let version = "0.13.0"
 }

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "measure-sh"
   spec.module_name  = "Measure"
-  spec.version      = "0.12.1"
+  spec.version      = "0.13.0"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
   spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }


### PR DESCRIPTION
This PR prepares the iOS SDK for release version 0.13.0.

Changes:
- Updated version to 0.13.0 in FrameworkInfo.swift
- Updated version to 0.13.0 in measure-sh.podspec
- Updated version in frontend/dashboard/content/docs/getting-started/ios.mdx
- Generated changelog for version 0.13.0