### PR TITLE
chore(backend): add configurable concurrent Iggy processing

### DIFF
--- a/backend/ingest-worker/server/server.go
+++ b/backend/ingest-worker/server/server.go
@@ -459,7 +459,31 @@ func Init(config *ServerConfig) {
 			}
 		}
 		log.Printf("iggy poll interval: %v\n", pollInterval)
+		processingConcurrency := 1
 
+		ingestProcessingConcurrency := os.Getenv(
+			"INGEST_PROCESSING_CONCURRENCY",
+		)
+
+		if ingestProcessingConcurrency != "" {
+			parsedConcurrency, parseErr := strconv.Atoi(
+				ingestProcessingConcurrency,
+			)
+
+			if parseErr != nil || parsedConcurrency < 1 {
+				log.Printf(
+					"invalid INGEST_PROCESSING_CONCURRENCY %q; using default 1",
+					ingestProcessingConcurrency,
+				)
+			} else {
+				processingConcurrency = parsedConcurrency
+			}
+		}
+
+		log.Printf(
+			"iggy processing concurrency: %d\n",
+			processingConcurrency,
+		)
 		consumer, err := bus.NewIggyGroupConsumer(
 			config.IG.Addr,
 			config.IG.Username,
@@ -469,6 +493,7 @@ func Init(config *ServerConfig) {
 			ingest.IngestBatchTopic,
 			bus.WithIggyBatchSize(batchSize),
 			bus.WithIggyPollInterval(pollInterval),
+			bus.WithIggyProcessingConcurrency(processingConcurrency),
 		)
 		if err != nil {
 			log.Printf("failed to create Iggy consumer: %v\n", err)

--- a/backend/libs/bus/bus.go
+++ b/backend/libs/bus/bus.go
@@ -108,6 +108,10 @@ type iggyConfig struct {
 	pollInterval time.Duration
 	// pollingStrategy selects how the server determines the next batch of messages (consumer-only).
 	pollingStrategy *iggcon.PollingStrategy
+	// processingConcurrency is the maximum number of messages whose handlers
+	// may run concurrently within one poll result.
+	// A value less than 1 falls back to 1.
+	processingConcurrency int
 }
 
 // WithIggyPartitionID routes all produced messages to the given partition ID.
@@ -140,6 +144,18 @@ func WithIggyBatchSize(n int) IggyOption {
 func WithIggyPollInterval(d time.Duration) IggyOption {
 	return func(c *iggyConfig) {
 		c.pollInterval = d
+	}
+}
+
+// WithIggyProcessingConcurrency sets the maximum number of Iggy messages
+// processed concurrently inside a single consumer.
+//
+// The default is 1, which preserves the original serial processing behavior.
+func WithIggyProcessingConcurrency(concurrency int) IggyOption {
+	return func(c *iggyConfig) {
+		if concurrency > 0 {
+			c.processingConcurrency = concurrency
+		}
 	}
 }
 

--- a/backend/libs/bus/bus_test.go
+++ b/backend/libs/bus/bus_test.go
@@ -31,10 +31,20 @@ type sentMessage struct {
 type mockIggyClient struct {
 	mu sync.Mutex
 
-	pollFn           func(iggcon.Identifier, iggcon.Identifier, iggcon.Consumer, iggcon.PollingStrategy, uint32, bool, *uint32) (*iggcon.PolledMessage, error)
+	pollFn func(
+		iggcon.Identifier,
+		iggcon.Identifier,
+		iggcon.Consumer,
+		iggcon.PollingStrategy,
+		uint32,
+		bool,
+		*uint32,
+	) (*iggcon.PolledMessage, error)
+
 	offsets          []storedOffset
 	sentMessages     []sentMessage
 	sendErr          error
+	storeOffsetErrAt *uint64
 	leaveGroupCalled bool
 	closeCalled      bool
 }
@@ -46,17 +56,35 @@ func (m *mockIggyClient) PollMessages(streamId, topicId iggcon.Identifier, consu
 	return nil, nil
 }
 
-func (m *mockIggyClient) StoreConsumerOffset(_ iggcon.Consumer, _ iggcon.Identifier, _ iggcon.Identifier, offset uint64, partitionId *uint32) error {
+func (m *mockIggyClient) StoreConsumerOffset(
+	_ iggcon.Consumer,
+	_ iggcon.Identifier,
+	_ iggcon.Identifier,
+	offset uint64,
+	partitionId *uint32,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.storeOffsetErrAt != nil && offset == *m.storeOffsetErrAt {
+		return errors.New("offset store failed")
+	}
+
 	var pid uint32
 	if partitionId != nil {
 		pid = *partitionId
 	}
-	m.offsets = append(m.offsets, storedOffset{Offset: offset, PartitionID: pid})
+
+	m.offsets = append(
+		m.offsets,
+		storedOffset{
+			Offset:      offset,
+			PartitionID: pid,
+		},
+	)
+
 	return nil
 }
-
 func (m *mockIggyClient) SendMessages(streamId, topicId iggcon.Identifier, partitioning iggcon.Partitioning, messages []iggcon.IggyMessage) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -191,14 +219,100 @@ func newTestConsumer(client iggcon.Client, kind iggcon.ConsumerKind) *iggyConsum
 	}
 
 	return &iggyConsumer{
-		client:          client,
-		streamID:        streamID,
-		topicID:         topicID,
-		consumer:        consumer,
-		partID:          nil,
-		batchSize:       10,
-		pollInterval:    1 * time.Millisecond,
-		pollingStrategy: iggcon.NextPollingStrategy(),
+		client:                client,
+		streamID:              streamID,
+		topicID:               topicID,
+		consumer:              consumer,
+		partID:                nil,
+		batchSize:             10,
+		pollInterval:          1 * time.Millisecond,
+		pollingStrategy:       iggcon.NextPollingStrategy(),
+		processingConcurrency: 1,
+	}
+}
+
+func TestIggyConsumerProcessesWindowConcurrently(t *testing.T) {
+	var pollCalls atomic.Int32
+	cancelListen := context.CancelFunc(nil)
+
+	mock := &mockIggyClient{}
+	mock.pollFn = func(
+		_ iggcon.Identifier,
+		_ iggcon.Identifier,
+		_ iggcon.Consumer,
+		_ iggcon.PollingStrategy,
+		_ uint32,
+		_ bool,
+		_ *uint32,
+	) (*iggcon.PolledMessage, error) {
+		if pollCalls.Add(1) == 1 {
+			return &iggcon.PolledMessage{
+				PartitionId: 7,
+				Messages: []iggcon.IggyMessage{
+					{
+						Header:  iggcon.MessageHeader{Offset: 10},
+						Payload: []byte("msg-a"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 11},
+						Payload: []byte("msg-b"),
+					},
+				},
+			}, nil
+		}
+
+		cancelListen()
+		return nil, nil
+	}
+
+	c := newTestConsumer(mock, iggcon.ConsumerKindSingle)
+	c.processingConcurrency = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelListen = cancel
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	listenResult := make(chan error, 1)
+
+	go func() {
+		listenResult <- c.Listen(
+			ctx,
+			func(_ context.Context, _ []byte) error {
+				started <- struct{}{}
+				<-release
+				return nil
+			},
+		)
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("handlers did not start concurrently")
+		}
+	}
+
+	close(release)
+
+	select {
+	case err := <-listenResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Listen did not exit")
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.offsets) != 2 {
+		t.Fatalf(
+			"offsets committed = %d, want 2",
+			len(mock.offsets),
+		)
 	}
 }
 
@@ -233,7 +347,18 @@ func TestWithIggyPartitionID(t *testing.T) {
 		t.Errorf("partitioningKind = %d, want PartitionIdKind (%d)", cfg.partitioningKind, iggcon.PartitionIdKind)
 	}
 }
+func TestWithIggyProcessingConcurrency(t *testing.T) {
+	cfg := &iggyConfig{}
 
+	WithIggyProcessingConcurrency(3)(cfg)
+
+	if cfg.processingConcurrency != 3 {
+		t.Errorf(
+			"processingConcurrency = %d, want 3",
+			cfg.processingConcurrency,
+		)
+	}
+}
 func TestWithIggyMessageKey(t *testing.T) {
 	cfg := &iggyConfig{}
 	key := []byte("routing-key")
@@ -516,6 +641,247 @@ func TestIggyConsumerListen(t *testing.T) {
 			t.Errorf("offset[0] = %d, want 10", mock.offsets[0].Offset)
 		}
 	})
+}
+
+func TestIggyConsumerConcurrentHandlerErrorCommitsSuccessfulPrefix(
+	t *testing.T,
+) {
+	var pollCalls atomic.Int32
+	cancelListen := context.CancelFunc(nil)
+
+	mock := &mockIggyClient{}
+	mock.pollFn = func(
+		_ iggcon.Identifier,
+		_ iggcon.Identifier,
+		_ iggcon.Consumer,
+		_ iggcon.PollingStrategy,
+		_ uint32,
+		_ bool,
+		_ *uint32,
+	) (*iggcon.PolledMessage, error) {
+		if pollCalls.Add(1) == 1 {
+			return &iggcon.PolledMessage{
+				PartitionId: 3,
+				Messages: []iggcon.IggyMessage{
+					{
+						Header:  iggcon.MessageHeader{Offset: 10},
+						Payload: []byte("msg-a"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 11},
+						Payload: []byte("msg-b"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 12},
+						Payload: []byte("msg-c"),
+					},
+				},
+			}, nil
+		}
+
+		cancelListen()
+		return nil, nil
+	}
+
+	c := newTestConsumer(mock, iggcon.ConsumerKindSingle)
+	c.processingConcurrency = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelListen = cancel
+
+	var handlerCalls atomic.Int32
+
+	err := c.Listen(ctx, func(
+		_ context.Context,
+		data []byte,
+	) error {
+		handlerCalls.Add(1)
+
+		if string(data) == "msg-b" {
+			return errors.New("processing failed")
+		}
+
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+
+	if calls := handlerCalls.Load(); calls != 2 {
+		t.Errorf("handler called %d times, want 2", calls)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.offsets) != 1 {
+		t.Fatalf(
+			"offsets committed = %d, want 1",
+			len(mock.offsets),
+		)
+	}
+
+	if mock.offsets[0].Offset != 10 {
+		t.Errorf(
+			"committed offset = %d, want 10",
+			mock.offsets[0].Offset,
+		)
+	}
+}
+
+func TestIggyConsumerConcurrentFirstFailureCommitsNothing(
+	t *testing.T,
+) {
+	var pollCalls atomic.Int32
+	cancelListen := context.CancelFunc(nil)
+
+	mock := &mockIggyClient{}
+	mock.pollFn = func(
+		_ iggcon.Identifier,
+		_ iggcon.Identifier,
+		_ iggcon.Consumer,
+		_ iggcon.PollingStrategy,
+		_ uint32,
+		_ bool,
+		_ *uint32,
+	) (*iggcon.PolledMessage, error) {
+		if pollCalls.Add(1) == 1 {
+			return &iggcon.PolledMessage{
+				PartitionId: 5,
+				Messages: []iggcon.IggyMessage{
+					{
+						Header:  iggcon.MessageHeader{Offset: 20},
+						Payload: []byte("msg-a"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 21},
+						Payload: []byte("msg-b"),
+					},
+				},
+			}, nil
+		}
+
+		cancelListen()
+		return nil, nil
+	}
+
+	c := newTestConsumer(mock, iggcon.ConsumerKindSingle)
+	c.processingConcurrency = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelListen = cancel
+
+	err := c.Listen(ctx, func(
+		_ context.Context,
+		data []byte,
+	) error {
+		if string(data) == "msg-a" {
+			return errors.New("processing failed")
+		}
+
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.offsets) != 0 {
+		t.Fatalf(
+			"offsets committed = %d, want 0",
+			len(mock.offsets),
+		)
+	}
+}
+
+func TestIggyConsumerConcurrentOffsetCommitErrorCommitsSuccessfulPrefix(
+	t *testing.T,
+) {
+	var pollCalls atomic.Int32
+	cancelListen := context.CancelFunc(nil)
+
+	failOffset := uint64(11)
+	mock := &mockIggyClient{
+		storeOffsetErrAt: &failOffset,
+	}
+
+	mock.pollFn = func(
+		_ iggcon.Identifier,
+		_ iggcon.Identifier,
+		_ iggcon.Consumer,
+		_ iggcon.PollingStrategy,
+		_ uint32,
+		_ bool,
+		_ *uint32,
+	) (*iggcon.PolledMessage, error) {
+		if pollCalls.Add(1) == 1 {
+			return &iggcon.PolledMessage{
+				PartitionId: 3,
+				Messages: []iggcon.IggyMessage{
+					{
+						Header:  iggcon.MessageHeader{Offset: 10},
+						Payload: []byte("msg-a"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 11},
+						Payload: []byte("msg-b"),
+					},
+					{
+						Header:  iggcon.MessageHeader{Offset: 12},
+						Payload: []byte("msg-c"),
+					},
+				},
+			}, nil
+		}
+
+		cancelListen()
+		return nil, nil
+	}
+
+	c := newTestConsumer(mock, iggcon.ConsumerKindSingle)
+	c.processingConcurrency = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelListen = cancel
+
+	var handlerCalls atomic.Int32
+
+	err := c.Listen(ctx, func(
+		_ context.Context,
+		_ []byte,
+	) error {
+		handlerCalls.Add(1)
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+
+	if calls := handlerCalls.Load(); calls != 2 {
+		t.Errorf("handler called %d times, want 2", calls)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.offsets) != 1 {
+		t.Fatalf(
+			"offsets committed = %d, want 1",
+			len(mock.offsets),
+		)
+	}
+
+	if mock.offsets[0].Offset != 10 {
+		t.Errorf(
+			"committed offset = %d, want 10",
+			mock.offsets[0].Offset,
+		)
+	}
 }
 
 // --- Iggy consumer Close tests ---

--- a/backend/libs/bus/iggy_consumer.go
+++ b/backend/libs/bus/iggy_consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	iggclient "github.com/apache/iggy/foreign/go/client"
@@ -29,6 +30,9 @@ type iggyConsumer struct {
 	pollInterval time.Duration
 	// pollingStrategy selects how the server determines the next batch of messages.
 	pollingStrategy iggcon.PollingStrategy
+	// processingConcurrency limits the number of message handlers running
+	// concurrently inside this consumer.
+	processingConcurrency int
 }
 
 // newIggyConsumer is the shared builder for both NewIggyConsumer and
@@ -106,7 +110,10 @@ func newIggyConsumer(address, username, password, consumerName, streamName, topi
 	if cfg.pollInterval > 0 {
 		pollInterval = cfg.pollInterval
 	}
-
+	processingConcurrency := 1
+	if cfg.processingConcurrency > 0 {
+		processingConcurrency = cfg.processingConcurrency
+	}
 	pollingStrategy := iggcon.NextPollingStrategy()
 	if cfg.pollingStrategy != nil {
 		pollingStrategy = *cfg.pollingStrategy
@@ -114,14 +121,15 @@ func newIggyConsumer(address, username, password, consumerName, streamName, topi
 
 	ok = true
 	return &iggyConsumer{
-		client:          client,
-		consumer:        consumer,
-		streamID:        streamID,
-		topicID:         topicID,
-		partID:          partID,
-		batchSize:       batchSize,
-		pollInterval:    pollInterval,
-		pollingStrategy: pollingStrategy,
+		client:                client,
+		consumer:              consumer,
+		streamID:              streamID,
+		topicID:               topicID,
+		partID:                partID,
+		batchSize:             batchSize,
+		pollInterval:          pollInterval,
+		pollingStrategy:       pollingStrategy,
+		processingConcurrency: processingConcurrency,
 	}, nil
 }
 
@@ -138,6 +146,79 @@ func NewIggyConsumer(address, username, password, consumerName, streamName, topi
 // group name; streamName and topicName identify the source stream/topic.
 func NewIggyGroupConsumer(address, username, password, consumerName, streamName, topicName string, opts ...IggyOption) (Consumer, error) {
 	return newIggyConsumer(address, username, password, consumerName, streamName, topicName, iggcon.ConsumerKindGroup, opts...)
+}
+
+// processMessages handles messages in bounded concurrent windows.
+//
+// Handlers run concurrently inside each window, but offsets are committed
+// sequentially in the original message order. Only the successful prefix is
+// committed. Processing stops at the first handler or offset-commit failure.
+func (c *iggyConsumer) processMessages(
+	ctx context.Context,
+	partitionID uint32,
+	messages []iggcon.IggyMessage,
+	handler func(context.Context, []byte) error,
+) bool {
+	concurrency := c.processingConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	for start := 0; start < len(messages); start += concurrency {
+		end := start + concurrency
+		if end > len(messages) {
+			end = len(messages)
+		}
+
+		results := make([]error, end-start)
+
+		var wg sync.WaitGroup
+		wg.Add(end - start)
+
+		for messageIndex := start; messageIndex < end; messageIndex++ {
+			resultIndex := messageIndex - start
+			payload := messages[messageIndex].Payload
+
+			go func(resultIndex int, payload []byte) {
+				defer wg.Done()
+				results[resultIndex] = handler(ctx, payload)
+			}(resultIndex, payload)
+		}
+		wg.Wait()
+
+		// Commit only the successful prefix and preserve the original
+		// offset order.
+		for resultIndex, handlerErr := range results {
+			msg := messages[start+resultIndex]
+
+			if handlerErr != nil {
+				log.Printf(
+					"bus: iggy handler error (offset %d will be retried): %v",
+					msg.Header.Offset,
+					handlerErr,
+				)
+				return false
+			}
+
+			err := c.client.StoreConsumerOffset(
+				c.consumer,
+				c.streamID,
+				c.topicID,
+				msg.Header.Offset,
+				&partitionID,
+			)
+			if err != nil {
+				log.Printf(
+					"bus: iggy offset commit failed (offset %d will be retried): %v",
+					msg.Header.Offset,
+					err,
+				)
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func (c *iggyConsumer) Listen(ctx context.Context, handler func(ctx context.Context, data []byte) error) error {
@@ -190,15 +271,16 @@ func (c *iggyConsumer) Listen(ctx context.Context, handler func(ctx context.Cont
 		}
 
 		partitionID := polled.PartitionId
-		for _, msg := range polled.Messages {
-			if err := handler(ctx, msg.Payload); err != nil {
-				log.Printf("bus: iggy handler error (offset %d will be retried): %v", msg.Header.Offset, err)
-				break
-			}
 
-			if err := c.client.StoreConsumerOffset(c.consumer, c.streamID, c.topicID, msg.Header.Offset, &partitionID); err != nil {
-				log.Printf("bus: iggy offset commit failed (offset %d): %v", msg.Header.Offset, err)
-			}
+		if !c.processMessages(
+			ctx,
+			partitionID,
+			polled.Messages,
+			handler,
+		) {
+			// A failed handler or offset commit leaves the failed message and
+			// any later message uncommitted. The next poll retries them.
+			continue
 		}
 	}
 }


### PR DESCRIPTION
## Problem

In self-hosted deployments with high ingestion volume, scaling
`ingest-worker` replicas eventually becomes limited by the number of
Iggy partitions.

In our deployment, the Iggy topic has 9 partitions and we initially ran
9 `ingest-worker` replicas. Even with one worker effectively available
per partition, the consumers were unable to keep up with the incoming
data and the backlog grew to approximately 2 days.

At that point, adding more worker replicas provided little benefit,
because the available partition-level parallelism was already exhausted.

Each consumer was still processing messages serially within a polled
batch, which became the next throughput limitation.

## Changes

This PR adds configurable per-consumer message processing concurrency
for ingest workers via:

`INGEST_PROCESSING_CONCURRENCY`

The default value remains `1`, preserving the existing serial processing
behavior.

When configured to a value greater than 1, messages from a polled batch
are processed concurrently in bounded windows.

Offsets are still committed sequentially in the original message order.
Only the contiguous successful prefix is committed.

If message processing or offset commit fails, the failed message and
subsequent messages remain uncommitted and will be processed again on a
later poll.

## Results from our self-hosted deployment

In our workload, we tested:

- 9 Iggy partitions
- initially 9 `ingest-worker` replicas
- approximately 2 days of accumulated backlog
- `INGEST_PROCESSING_CONCURRENCY=80`

After enabling concurrent processing, we were able to process the
workload with only 3 `ingest-worker` replicas.

In this test, we did not observe a meaningful increase in database load.
The main resource change we observed was increased memory usage in the
ingest workers.

These numbers are workload-specific and are not intended to suggest that
a concurrency value of `80` is appropriate for every deployment.

## Memory considerations

Higher processing concurrency increases the number of messages being
processed simultaneously and therefore increases memory usage inside
each ingest worker.

With a high concurrency value and a low container memory limit, the
worker may be OOM-killed.

For this reason, concurrency is intentionally configurable rather than
enabled with a high default value. Operators should tune it together
with the pod CPU/memory requests and limits based on their workload.

## Failure and retry behavior

Concurrent processing does not change the existing at-least-once style
processing behavior.

If processing fails, the failed offset is not committed. The failed
message and subsequent uncommitted messages are therefore retried.

This means an OOM or worker restart may cause some already-processed
messages to be delivered again, but messages are not silently skipped.

In our deployment this is also safe for the downstream write path because
the database persistence logic already performs deduplication, so
reprocessing an uncommitted message does not create duplicate records.

## ClickHouse considerations

As mentioned in the discussion, increasing Iggy processing concurrency
can potentially move the bottleneck downstream to ClickHouse by
increasing the number of concurrent inserts/writes.

In our workload, we did not observe a meaningful increase in database
load when enabling this feature, but this may vary depending on ingestion
rate, event size, ClickHouse configuration, hardware, and the configured
concurrency.

For this reason:

- the default concurrency remains `1`;
- concurrency is explicitly configurable;
- operators can tune it based on both ingest-worker resources and
  downstream ClickHouse capacity;
- this PR does not attempt to automatically determine or maximize
  concurrency.

## Summary

This adds a second scaling dimension for self-hosted ingestion:

1. partition-level parallelism through Iggy partitions and worker replicas;
2. message-level parallelism within each ingest worker.

This is especially useful when the number of workers already matches the
number of Iggy partitions but consumer lag continues to grow.