### PR TITLE
Improve span custom attribute filter scanning

### DIFF
--- a/backend/libs/exprfilter/custom.go
+++ b/backend/libs/exprfilter/custom.go
@@ -155,6 +155,39 @@ func collectCustomKeyNames(exprTree *ExprTree) []string {
 	return rawNames
 }
 
+// Only a condition at the root or a direct child of a root and-group bounds
+// every matching row; or-groups, negation, and text matching do not.
+func collectRootVersionConditions(exprTree *ExprTree) (versionNames, versionCodes [][]string) {
+	if exprTree == nil {
+		return nil, nil
+	}
+
+	rootConditions := []*Condition{}
+	if exprTree.Condition != nil {
+		rootConditions = append(rootConditions, exprTree.Condition)
+	} else if exprTree.LogicalOperator == LogicalAnd {
+		for i := range exprTree.Children {
+			if child := &exprTree.Children[i]; child.Condition != nil {
+				rootConditions = append(rootConditions, child.Condition)
+			}
+		}
+	}
+
+	for _, condition := range rootConditions {
+		if condition.Operator != OperatorIn {
+			continue
+		}
+		switch condition.KeyName {
+		case versionName.Name:
+			versionNames = append(versionNames, condition.TextValues())
+		case versionCode.Name:
+			versionCodes = append(versionCodes, condition.TextValues())
+		}
+	}
+
+	return versionNames, versionCodes
+}
+
 // ResolveCustomKeys reads the custom keys in the filter expression,
 // extends this request's copy of the entity with them for validation, and
 // installs the group binder Predicate routes their conditions to. Keys not
@@ -179,7 +212,14 @@ func (ef *ExprFilter) ResolveCustomKeys(ctx context.Context, chPool driver.Conn)
 	// array untouched.
 	ef.Entity.Keys = append(slices.Clip(ef.Entity.Keys), keys...)
 
-	to := ef.To.Add(ef.Entity.MaxTimeBucketWidth)
-	ef.customBinder = ef.Entity.BindCustomKeys(ef.TeamID, ef.AppID, ef.From, to, keys)
+	versionNames, versionCodes := collectRootVersionConditions(ef.ExprTree)
+	ef.customBinder = ef.Entity.BindCustomKeys(CustomKeyScope{
+		TeamID:       ef.TeamID,
+		AppID:        ef.AppID,
+		From:         ef.From,
+		To:           ef.To.Add(ef.Entity.MaxTimeBucketWidth),
+		VersionNames: versionNames,
+		VersionCodes: versionCodes,
+	}, keys)
 	return nil
 }

--- a/backend/libs/exprfilter/custom_test.go
+++ b/backend/libs/exprfilter/custom_test.go
@@ -136,7 +136,7 @@ func TestResolveCustomKeysBindsEveryMentionedKey(t *testing.T) {
 			}
 			return keys, nil
 		},
-		BindCustomKeys: func(teamID, appID uuid.UUID, from, to time.Time, boundKeys []Key) GroupKeyBinding {
+		BindCustomKeys: func(scope CustomKeyScope, boundKeys []Key) GroupKeyBinding {
 			names := make([]string, len(boundKeys))
 			for i, key := range boundKeys {
 				names[i] = key.Name
@@ -227,12 +227,26 @@ func customCondition(keyName string, operator Operator, texts ...string) Conditi
 	return Condition{KeyName: keyName, Operator: operator, Values: values}
 }
 
+func testCustomKeyScope() CustomKeyScope {
+	return CustomKeyScope{
+		TeamID: uuid.New(),
+		AppID:  uuid.New(),
+		From:   time.Now().UTC().Add(-time.Hour),
+		To:     time.Now().UTC(),
+	}
+}
+
 // bindCustomGroup writes the SQL for one batch of custom-key conditions,
 // failing the test on a binding error.
 func bindCustomGroup(t *testing.T, keys []Key, operator LogicalOperator, conditions []Condition) (string, []any) {
 	t.Helper()
+	return bindCustomGroupInScope(t, testCustomKeyScope(), keys, operator, conditions)
+}
 
-	binding := SpansEntity.BindCustomKeys(uuid.New(), uuid.New(), time.Now().UTC().Add(-time.Hour), time.Now().UTC(), keys)
+func bindCustomGroupInScope(t *testing.T, scope CustomKeyScope, keys []Key, operator LogicalOperator, conditions []Condition) (string, []any) {
+	t.Helper()
+
+	binding := SpansEntity.BindCustomKeys(scope, keys)
 
 	stmt, err := binding(operator, conditions)
 	if err != nil {
@@ -378,7 +392,7 @@ func TestBindSpanCustomKeyEscapesLikeWildcards(t *testing.T) {
 
 func TestBindSpanCustomKeyRefusesAnOperatorTheTypeDoesNotOffer(t *testing.T) {
 	key := CustomKey("retries", ValueTypeInt64)
-	binding := SpansEntity.BindCustomKeys(uuid.New(), uuid.New(), time.Now().UTC().Add(-time.Hour), time.Now().UTC(), []Key{key})
+	binding := SpansEntity.BindCustomKeys(testCustomKeyScope(), []Key{key})
 
 	_, err := binding(LogicalAnd, []Condition{customCondition(key.Name, OperatorContains, "9")})
 	if err == nil {
@@ -538,5 +552,172 @@ func TestBindCustomGroupDedupesTheKeyList(t *testing.T) {
 	rawNames, ok := args[4].([]string)
 	if !ok || !slices.Equal(rawNames, []string{"retries"}) {
 		t.Errorf("want the key bound once, got %v", args[4])
+	}
+}
+
+func TestCollectRootVersionConditions(t *testing.T) {
+	assertLists := func(t *testing.T, label string, got, want [][]string) {
+		t.Helper()
+		if !slices.EqualFunc(got, want, slices.Equal) {
+			t.Errorf("want %s %v, got %v", label, want, got)
+		}
+	}
+
+	t.Run("a root leaf's in-list", func(t *testing.T) {
+		names, codes := collectRootVersionConditions(leafExprTree("version_name", OperatorIn, "v1", "v2"))
+		assertLists(t, "names", names, [][]string{{"v1", "v2"}})
+		assertLists(t, "codes", codes, nil)
+	})
+
+	t.Run("direct children of a root and-group", func(t *testing.T) {
+		names, codes := collectRootVersionConditions(&ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
+			*leafExprTree("version_name", OperatorIn, "v1"),
+			*leafExprTree("custom.plan", OperatorIn, "pro"),
+			*leafExprTree("version_code", OperatorIn, "7"),
+		}})
+		assertLists(t, "names", names, [][]string{{"v1"}})
+		assertLists(t, "codes", codes, [][]string{{"7"}})
+	})
+
+	t.Run("each condition keeps its own list", func(t *testing.T) {
+		names, _ := collectRootVersionConditions(&ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
+			*leafExprTree("version_name", OperatorIn, "v1"),
+			*leafExprTree("version_name", OperatorIn, "v2", "v3"),
+		}})
+		assertLists(t, "names", names, [][]string{{"v1"}, {"v2", "v3"}})
+	})
+
+	t.Run("an or root bounds nothing", func(t *testing.T) {
+		names, codes := collectRootVersionConditions(&ExprTree{LogicalOperator: LogicalOr, Children: []ExprTree{
+			*leafExprTree("version_name", OperatorIn, "v1"),
+			*leafExprTree("custom.plan", OperatorIn, "pro"),
+		}})
+		assertLists(t, "names", names, nil)
+		assertLists(t, "codes", codes, nil)
+	})
+
+	t.Run("not_in bounds nothing", func(t *testing.T) {
+		names, _ := collectRootVersionConditions(leafExprTree("version_name", OperatorNotIn, "v1"))
+		assertLists(t, "names", names, nil)
+	})
+
+	t.Run("contains bounds nothing", func(t *testing.T) {
+		names, _ := collectRootVersionConditions(leafExprTree("version_name", OperatorContains, "v"))
+		assertLists(t, "names", names, nil)
+	})
+
+	t.Run("a nested group's condition is not collected", func(t *testing.T) {
+		names, _ := collectRootVersionConditions(&ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
+			*leafExprTree("custom.plan", OperatorIn, "pro"),
+			{LogicalOperator: LogicalOr, Children: []ExprTree{
+				*leafExprTree("version_name", OperatorIn, "v1"),
+				*leafExprTree("custom.retries", OperatorGt, "9"),
+			}},
+		}})
+		assertLists(t, "names", names, nil)
+	})
+
+	t.Run("an empty tree", func(t *testing.T) {
+		names, codes := collectRootVersionConditions(nil)
+		assertLists(t, "names", names, nil)
+		assertLists(t, "codes", codes, nil)
+	})
+}
+
+func TestBindCustomGroupAppendsRootVersionConditionsToTheScan(t *testing.T) {
+	keys := []Key{CustomKey("plan", ValueTypeString), CustomKey("retries", ValueTypeInt64)}
+	twoConditions := []Condition{
+		customCondition("custom.plan", OperatorIn, "pro"),
+		customCondition("custom.retries", OperatorGt, "9"),
+	}
+
+	const scan = "select span_id from span_user_def_attrs where team_id = toUUID(?) and app_id = toUUID(?) and timestamp >= ? and timestamp <= ?"
+	const havingTwo = " group by span_id having countIf(key = ? and type = ? and value in ?) > 0 and countIf(key = ? and type = ? and toInt64OrNull(value) > ?) > 0"
+
+	tests := []struct {
+		name         string
+		versionNames [][]string
+		versionCodes [][]string
+		conditions   []Condition
+		want         string
+		wantArgs     int
+	}{
+		{
+			name:         "version names narrow a grouped scan",
+			versionNames: [][]string{{"v1"}},
+			conditions:   twoConditions,
+			want:         "span_id in (" + scan + " and tupleElement(app_version, 1) in ? and key in ?" + havingTwo + ")",
+			wantArgs:     12,
+		},
+		{
+			name:         "version names narrow a lone condition's scan",
+			versionNames: [][]string{{"v1"}},
+			conditions:   []Condition{customCondition("custom.plan", OperatorIn, "pro")},
+			want:         "span_id in (" + scan + " and tupleElement(app_version, 1) in ? and key = ? and type = ? and value in ?)",
+			wantArgs:     8,
+		},
+		{
+			name:         "version codes push independently",
+			versionCodes: [][]string{{"7"}},
+			conditions:   twoConditions,
+			want:         "span_id in (" + scan + " and tupleElement(app_version, 2) in ? and key in ?" + havingTwo + ")",
+			wantArgs:     12,
+		},
+		{
+			name:         "names and codes push together",
+			versionNames: [][]string{{"v1"}},
+			versionCodes: [][]string{{"7"}},
+			conditions:   twoConditions,
+			want:         "span_id in (" + scan + " and tupleElement(app_version, 1) in ? and tupleElement(app_version, 2) in ? and key in ?" + havingTwo + ")",
+			wantArgs:     13,
+		},
+		{
+			name:         "each condition keeps its own clause",
+			versionNames: [][]string{{"v1"}, {"v2", "v3"}},
+			conditions:   twoConditions,
+			want:         "span_id in (" + scan + " and tupleElement(app_version, 1) in ? and tupleElement(app_version, 1) in ? and key in ?" + havingTwo + ")",
+			wantArgs:     13,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scope := testCustomKeyScope()
+			scope.VersionNames = test.versionNames
+			scope.VersionCodes = test.versionCodes
+
+			got, args := bindCustomGroupInScope(t, scope, keys, LogicalAnd, test.conditions)
+			if got != test.want {
+				t.Errorf("\n got %s\nwant %s", got, test.want)
+			}
+			if len(args) != test.wantArgs {
+				t.Errorf("want %d bound arguments, got %d: %v", test.wantArgs, len(args), args)
+			}
+		})
+	}
+}
+
+func TestBindCustomGroupBindsVersionArgsAfterTheTimeRange(t *testing.T) {
+	scope := testCustomKeyScope()
+	scope.VersionNames = [][]string{{"v1"}}
+	scope.VersionCodes = [][]string{{"7"}}
+	keys := []Key{CustomKey("plan", ValueTypeString), CustomKey("retries", ValueTypeInt64)}
+
+	_, args := bindCustomGroupInScope(t, scope, keys, LogicalAnd, []Condition{
+		customCondition("custom.plan", OperatorIn, "pro"),
+		customCondition("custom.retries", OperatorGt, "9"),
+	})
+
+	if names, ok := args[4].([]string); !ok || !slices.Equal(names, []string{"v1"}) {
+		t.Errorf("want the version names after the time range, got %v", args[4])
+	}
+	if codes, ok := args[5].([]string); !ok || !slices.Equal(codes, []string{"7"}) {
+		t.Errorf("want the version codes next, got %v", args[5])
+	}
+	if rawNames, ok := args[6].([]string); !ok || !slices.Equal(rawNames, []string{"plan", "retries"}) {
+		t.Errorf("want the key list after the version clauses, got %v", args[6])
+	}
+	if len(args) != 13 || args[7] != "plan" {
+		t.Errorf("want the having terms last in %d arguments, got %v", 13, args)
 	}
 }

--- a/backend/libs/exprfilter/custommembership.go
+++ b/backend/libs/exprfilter/custommembership.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/leporo/sqlf"
 )
 
@@ -129,10 +127,7 @@ func matchCustomCondition(key Key, condition Condition) (customConditionMatch, e
 type customMembershipBinder struct {
 	table      string
 	idColumn   string
-	teamID     uuid.UUID
-	appID      uuid.UUID
-	from       time.Time
-	to         time.Time
+	scope      CustomKeyScope
 	keysByName map[string]Key
 }
 
@@ -143,15 +138,12 @@ const customAttrScope = " where team_id = toUUID(?) and app_id = toUUID(?)" +
 // bindCustomConditionsToMembership creates a GroupKeyBinding for custom-key
 // conditions. Multiple conditions are evaluated with countIf over one grouped
 // query instead of generating a separate subquery for each condition.
-func bindCustomConditionsToMembership(table, idColumn string) func(teamID, appID uuid.UUID, from, to time.Time, keys []Key) GroupKeyBinding {
-	return func(teamID, appID uuid.UUID, from, to time.Time, keys []Key) GroupKeyBinding {
+func bindCustomConditionsToMembership(table, idColumn string) func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
+	return func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
 		binder := &customMembershipBinder{
 			table:      table,
 			idColumn:   idColumn,
-			teamID:     teamID,
-			appID:      appID,
-			from:       from,
-			to:         to,
+			scope:      scope,
 			keysByName: IndexKeysByName(keys),
 		}
 		return binder.bind
@@ -261,6 +253,22 @@ func (b *customMembershipBinder) anyOf(matches []customConditionMatch) *sqlf.Stm
 	return sqlf.New(text.String(), args...)
 }
 
+// versionConditions writes the scope's version lists as subquery conditions to
+// reduce the rows scanned.
+func (b *customMembershipBinder) versionConditions() (string, []any) {
+	var text strings.Builder
+	args := []any{}
+	for _, names := range b.scope.VersionNames {
+		text.WriteString(" and tupleElement(app_version, 1) in ?")
+		args = append(args, names)
+	}
+	for _, codes := range b.scope.VersionCodes {
+		text.WriteString(" and tupleElement(app_version, 2) in ?")
+		args = append(args, codes)
+	}
+	return text.String(), args
+}
+
 // single builds the membership query for one condition.
 // Negated conditions use NOT IN so IDs without the attribute also match.
 func (b *customMembershipBinder) single(match customConditionMatch) (string, []any) {
@@ -268,13 +276,16 @@ func (b *customMembershipBinder) single(match customConditionMatch) (string, []a
 	if match.negated {
 		operator = "not in"
 	}
+	versionSQL, versionArgs := b.versionConditions()
 	text := b.idColumn + " " + operator + " (" +
 		"select " + b.idColumn + " from " + b.table +
 		customAttrScope +
+		versionSQL +
 		" and " + match.sql +
 		")"
-	args := make([]any, 0, 4+len(match.args))
-	args = append(args, b.teamID, b.appID, b.from, b.to)
+	args := make([]any, 0, 4+len(versionArgs)+len(match.args))
+	args = append(args, b.scope.TeamID, b.scope.AppID, b.scope.From, b.scope.To)
+	args = append(args, versionArgs...)
 	args = append(args, match.args...)
 	return text, args
 }
@@ -289,15 +300,19 @@ func (b *customMembershipBinder) grouped(operator string, matches []customCondit
 		}
 	}
 
+	versionSQL, versionArgs := b.versionConditions()
 	text := b.idColumn + " " + operator + " (" +
 		"select " + b.idColumn + " from " + b.table +
 		customAttrScope +
+		versionSQL +
 		" and key in ?" +
 		" group by " + b.idColumn +
 		" having " + having +
 		")"
-	args := make([]any, 0, 5+len(havingArgs))
-	args = append(args, b.teamID, b.appID, b.from, b.to, rawNames)
+	args := make([]any, 0, 5+len(versionArgs)+len(havingArgs))
+	args = append(args, b.scope.TeamID, b.scope.AppID, b.scope.From, b.scope.To)
+	args = append(args, versionArgs...)
+	args = append(args, rawNames)
 	args = append(args, havingArgs...)
 	return text, args
 }

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -48,13 +48,25 @@ type Entity struct {
 
 	// BindCustomKeys builds the GroupKeyBinding for the given custom keys.
 	// Nil for an entity whose keys are all fixed.
-	BindCustomKeys func(teamID, appID uuid.UUID, from, to time.Time, keys []Key) GroupKeyBinding
+	BindCustomKeys func(scope CustomKeyScope, keys []Key) GroupKeyBinding
 
 	// MaxTimeBucketWidth is the widest time bucket used by any of the entity's
 	// tables. Bucketed queries may include rows from this bucket past the range
 	// end, so custom key bindings must be resolved that far past it. Zero means
 	// all tables store raw timestamps.
 	MaxTimeBucketWidth time.Duration
+}
+
+// CustomKeyScope is the request context a custom-key binding queries with.
+// The version lists mirror app version conditions already present in the filter.
+// A custom key binding may use it to reduce scans.
+type CustomKeyScope struct {
+	TeamID       uuid.UUID
+	AppID        uuid.UUID
+	From         time.Time
+	To           time.Time
+	VersionNames [][]string
+	VersionCodes [][]string
 }
 
 func FindByName(name string) (Entity, error) {

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -287,6 +287,10 @@ func fetchSpanCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool
 // spanCustomKeyQuery reads an app's user-defined span attribute keys with
 // their types. An attribute rewritten under a new type keeps one row per
 // type, so the type written last is the one its key offers.
+//
+// The scan is on the full table without a time bound. If needed in future:
+// time bound it so only keys in time range show up or add a rollup
+// of distinct keys and values like the span_filters rollupthat fixed keys read.
 func spanCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
 	return sqlf.
 		From("span_user_def_attrs final").
@@ -301,6 +305,10 @@ func spanCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
 // fetchSpanCustomKeySuggestions lists what one user-defined attribute has
 // been set to, most recently written first, asking for one row past the limit
 // so it can report that more matched without counting them. Empty ones are left out.
+//
+// The scan is on the full table without a time bound. If needed in future: time bound
+// it so only suggestions in time range show up or add a rollup of distinct keys and
+// values like the span_filters rollup that fixed keys read.
 func fetchSpanCustomKeySuggestions(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
 	limit := valueRequest.Limit
 	if limit <= 0 {

--- a/backend/libs/measure/span_test.go
+++ b/backend/libs/measure/span_test.go
@@ -4,6 +4,7 @@ package measure
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -292,12 +293,12 @@ func newCustomKeySpanFixture(t *testing.T) (spanFixture, time.Time) {
 	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "retries", Type: "int64", Value: "9", Timestamp: base})
 	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "is_premium", Type: "bool", Value: "true", Timestamp: base})
 	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "coupon", Value: "WELCOME", Timestamp: base})
-	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "plan", Value: "free", Timestamp: base.Add(10 * time.Minute)})
-	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "retries", Type: "int64", Value: "10", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "plan", Value: "free", AppVersion: "v2", AppBuild: "2", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "retries", Type: "int64", Value: "10", AppVersion: "v2", AppBuild: "2", Timestamp: base.Add(10 * time.Minute)})
 	// The badge attribute changes type over time: the older row is a string,
 	// the newer a bool, so the key resolves as bool.
 	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanOne, Key: "badge", Value: "gold", Timestamp: base})
-	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "badge", Type: "bool", Value: "true", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedSpanUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.SpanUDAttrRow{SpanID: spanTwo, Key: "badge", Type: "bool", Value: "true", AppVersion: "v2", AppBuild: "2", Timestamp: base.Add(10 * time.Minute)})
 
 	return f, base
 }
@@ -507,6 +508,37 @@ func TestGetSpansForSpanNameWithCustomKeys(t *testing.T) {
 		}
 	})
 
+	t.Run("a root version condition narrows the attribute scan without changing results", func(t *testing.T) {
+		customOnly := exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("custom.retries", exprfilter.OperatorGt, "5"),
+		}}
+		withVersion := exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("version_name", exprfilter.OperatorIn, "v1"),
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("custom.retries", exprfilter.OperatorGt, "5"),
+		}}
+
+		got, want := listVersions(t, withVersion), listVersions(t, customOnly)
+		if !slices.Equal(got, want) {
+			t.Fatalf("want the version condition to leave the result unchanged, got %v want %v", got, want)
+		}
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("a root version condition matching no attributed span returns nothing", func(t *testing.T) {
+		got := listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("version_name", exprfilter.OperatorIn, "v2"),
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("custom.retries", exprfilter.OperatorGt, "5"),
+		}})
+		if len(got) != 0 {
+			t.Fatalf("want no spans, got %v", got)
+		}
+	})
+
 	t.Run("an unknown custom key fails validation", func(t *testing.T) {
 		exprTree := leaf("custom.nope", exprfilter.OperatorIn, "x")
 		ef := f.exprFilter(from, to, &exprTree)
@@ -607,6 +639,17 @@ func TestGetMetricsPlotForSpanNameWithCustomKeys(t *testing.T) {
 		}})
 		if len(got) != 1 || !got["v2 (2)"] {
 			t.Fatalf("want only v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("a root version condition narrows the rollup's attribute scan", func(t *testing.T) {
+		got := plotVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("version_name", exprfilter.OperatorIn, "v1"),
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("custom.retries", exprfilter.OperatorGt, "5"),
+		}})
+		if len(got) != 1 || !got["v1 (1)"] {
+			t.Fatalf("want only v1 (1), got %v", got)
 		}
 	})
 }


### PR DESCRIPTION
# Description

- Adds app versions in top level filter to custom attribute subqueries for  smaller scans
- Adds comments at key and value discovery code for potential future optimisations: show only keys and values in time range or add a rollup of distinct keys and values like `span_filters` for custom attributes also.

## Related issue
References #4293



