### PR TITLE
fix(frontend): show traces plot loading state immediately on filter change

### DIFF
--- a/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/span_metrics_plot_test.tsx
@@ -44,11 +44,9 @@ jest.mock("@/app/components/tab_select", () => ({
 
 import SpanMetricsPlot from "@/app/components/span_metrics_plot";
 
-const filterParams = {
-  appId: "app-1",
+const plotDates = {
   startDate: "2026-02-01T00:00:00Z",
   endDate: "2026-02-01T08:00:00Z",
-  filterExpr: null,
 };
 
 function queryWith(overrides: any) {
@@ -80,7 +78,7 @@ describe("SpanMetricsPlot", () => {
   it("renders no data state when the server sends a null plot", async () => {
     render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ data: null, status: "success" })}
       />,
     );
@@ -91,7 +89,7 @@ describe("SpanMetricsPlot", () => {
   it("renders error state", async () => {
     render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ status: "error", error: new Error("test") })}
       />,
     );
@@ -99,16 +97,14 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("renders loading state before the request resolves", async () => {
-    render(
-      <SpanMetricsPlot filterParams={filterParams} query={queryWith({})} />,
-    );
+    render(<SpanMetricsPlot {...plotDates} query={queryWith({})} />);
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 
   it("maps quantile and updates when tab changes", async () => {
     render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -130,7 +126,7 @@ describe("SpanMetricsPlot", () => {
   it("renders tooltip with human readable millis", async () => {
     render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -152,15 +148,14 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("uses hour axis configuration for multi-day ranges", async () => {
-    const hoursParams = {
-      ...filterParams,
+    const hoursDates = {
       startDate: "2026-02-01T00:00:00Z",
       endDate: "2026-02-06T00:00:00Z",
     };
 
     render(
       <SpanMetricsPlot
-        filterParams={hoursParams}
+        {...hoursDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -171,15 +166,14 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("uses day axis configuration for medium ranges", async () => {
-    const daysParams = {
-      ...filterParams,
+    const daysDates = {
       startDate: "2026-01-01T00:00:00Z",
       endDate: "2026-03-15T00:00:00Z",
     };
 
     render(
       <SpanMetricsPlot
-        filterParams={daysParams}
+        {...daysDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -190,15 +184,14 @@ describe("SpanMetricsPlot", () => {
   });
 
   it("uses month axis configuration for large ranges", async () => {
-    const monthsParams = {
-      ...filterParams,
+    const monthsDates = {
       startDate: "2025-01-01T00:00:00Z",
       endDate: "2026-01-01T00:00:00Z",
     };
 
     render(
       <SpanMetricsPlot
-        filterParams={monthsParams}
+        {...monthsDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -211,7 +204,7 @@ describe("SpanMetricsPlot", () => {
   it("throws for invalid quantile selection", async () => {
     render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -231,7 +224,7 @@ describe("SpanMetricsPlot", () => {
   it("hides stale chart while new range data is loading", async () => {
     const { rerender } = render(
       <SpanMetricsPlot
-        filterParams={filterParams}
+        {...plotDates}
         query={queryWith({ data: rawPlotData, status: "success" })}
       />,
     );
@@ -239,9 +232,7 @@ describe("SpanMetricsPlot", () => {
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    rerender(
-      <SpanMetricsPlot filterParams={filterParams} query={queryWith({})} />,
-    );
+    rerender(<SpanMetricsPlot {...plotDates} query={queryWith({})} />);
 
     await waitFor(() => {
       expect(screen.getByText("loading")).toBeInTheDocument();

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -184,10 +184,18 @@ jest.mock("@/app/components/skeleton", () => ({
   SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
 }));
 
+// The real plot shows a skeleton while its query is pending, so the stub
+// distinguishes that case for tests that check what fills the plot area.
 jest.mock("@/app/components/span_metrics_plot", () => ({
   __esModule: true,
-  default: () => (
-    <div data-testid="span-metrics-plot-mock">TracesOverviewPlot Rendered</div>
+  default: (props: any) => (
+    <div data-testid="span-metrics-plot-mock">
+      {props.query.status === "pending" ? (
+        <div data-testid="skeleton-plot-mock" />
+      ) : (
+        "TracesOverviewPlot Rendered"
+      )}
+    </div>
   ),
 }));
 
@@ -365,6 +373,18 @@ describe("TracesOverview page", () => {
     expect(screen.getByTestId("span-metrics-plot-mock")).toBeInTheDocument();
     expect(screen.getByTestId("next-button")).toBeDisabled();
     expect(screen.getByTestId("prev-button")).toBeDisabled();
+  });
+
+  it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
+    mockDeferReplace = true;
+    spansLoaded();
+    renderPage();
+
+    // The URL write has not landed, so the bar's report does not match the
+    // URL yet and the queries stay disabled with a null filter.
+    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 0);
+    expect(screen.getByTestId("span-metrics-plot-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton-plot-mock")).toBeInTheDocument();
   });
 
   it("renders the plot, paginator and table headers once ready", async () => {

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -188,12 +188,11 @@ export default function TracesOverview(props: {
       {readyFilter !== null &&
         (status === "success" || status === "pending") && (
           <div className="flex flex-col items-center w-full">
-            {filterParams !== null && (
-              <SpanMetricsPlot
-                filterParams={filterParams}
-                query={spanMetricsPlotQuery}
-              />
-            )}
+            <SpanMetricsPlot
+              startDate={readyFilter.date.startDate}
+              endDate={readyFilter.date.endDate}
+              query={spanMetricsPlotQuery}
+            />
             <div className="self-end">
               <Paginator
                 prevEnabled={isFetching ? false : spans.meta.previous}

--- a/frontend/dashboard/app/components/span_metrics_plot.tsx
+++ b/frontend/dashboard/app/components/span_metrics_plot.tsx
@@ -3,7 +3,6 @@
 import {
   RootSpanMetricsQuantile,
   transformSpanMetricsPlotData,
-  type FilterParams,
   type useSpanMetricsPlotQuery,
 } from "@/app/query/hooks";
 import { ResponsiveLineCanvas } from "@nivo/line";
@@ -26,9 +25,10 @@ import { SkeletonPlot } from "./skeleton";
 import TabSelect from "./tab_select";
 
 const SpanMetricsPlot: React.FC<{
-  filterParams: FilterParams;
+  startDate: string;
+  endDate: string;
   query: ReturnType<typeof useSpanMetricsPlotQuery>;
-}> = ({ filterParams, query }) => {
+}> = ({ startDate, endDate, query }) => {
   const [quantile, setQuantile] = useState<RootSpanMetricsQuantile>(
     RootSpanMetricsQuantile.p50,
   );
@@ -36,10 +36,7 @@ const SpanMetricsPlot: React.FC<{
   const { theme } = useTheme();
   const chartColors = useChartColors();
   const canvasTheme = useChartCanvasTheme();
-  const plotTimeGroup = getPlotTimeGroupForRange(
-    filterParams.startDate,
-    filterParams.endDate,
-  );
+  const plotTimeGroup = getPlotTimeGroupForRange(startDate, endDate);
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
   const plot = useMemo(() => {


### PR DESCRIPTION
# Description

- keep the span metrics plot mounted while the filter bar's report waits to reach the URL, instead of unmounting it for a frame. The disabled query reports pending during that window, so the plot's skeleton displays
- pass the plot its date range from the ready filter state; it only uses the dates for time-axis grouping, and fetches still read the URL only
- add a page test covering the state-to-URL lag window

## Related issue
Fixes #4316


