### PR TITLE
fix(backend): resolve bespoke plans over an attached free product

### DIFF
--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -119,42 +120,36 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 // Subscriptions with status != "active" (e.g. a Free that's "scheduled" to
 // take over after a Pro cancellation) are ignored — we only report on the
 // plan currently in effect.
+//
+// A customer can hold several active products at once: Autumn auto-attaches
+// the Free product on customer create, and attaching a bespoke plan from the
+// Autumn dashboard does not detach it unless the two share a product group.
+// The highest tier wins, using the same order as planRank: any non-free,
+// non-pro plan (bespoke Enterprise) over Pro over Free.
 func DeterminePlan(c *autumn.Customer) string {
-	hasActiveSub := false
-	hasActiveProduct := false
-	hasPlan := func(id string) bool {
-		for _, s := range c.Subscriptions {
-			if s.Status != "active" {
-				continue
-			}
-			hasActiveSub = true
-			if s.PlanID == id {
-				return true
-			}
+	var activePlans []string
+	for _, s := range c.Subscriptions {
+		if s.Status != "active" {
+			continue
 		}
-		for _, p := range c.Products {
-			// Webhook payloads sometimes omit status — treat empty as active
-			// for back-compat. Otherwise skip non-active (e.g. scheduled).
-			if p.Status != "" && p.Status != "active" {
-				continue
-			}
-			hasActiveProduct = true
-			if p.ID == id {
-				return true
-			}
+		activePlans = append(activePlans, s.PlanID)
+	}
+	for _, p := range c.Products {
+		// Webhook payloads sometimes omit status — treat empty as active
+		// for back-compat. Otherwise skip non-active (e.g. scheduled).
+		if p.Status != "" && p.Status != "active" {
+			continue
 		}
-		return false
+		activePlans = append(activePlans, p.ID)
 	}
 
-	if hasPlan(AutumnPlanPro) {
-		return PlanPro
-	}
-	if hasPlan(AutumnPlanFree) {
-		return PlanFree
-	}
-	// Any attached non-free, non-pro plan counts as Enterprise (bespoke plan).
-	if hasActiveSub || hasActiveProduct {
+	if slices.ContainsFunc(activePlans, func(id string) bool {
+		return id != AutumnPlanFree && id != AutumnPlanPro
+	}) {
 		return PlanEnterprise
+	}
+	if slices.Contains(activePlans, AutumnPlanPro) {
+		return PlanPro
 	}
 	return PlanFree
 }

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -140,6 +140,46 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanFree,
 		},
 		{
+			name: "active free + active bespoke product → enterprise",
+			cust: autumn.Customer{
+				Products: []autumn.CustomerProduct{
+					{ID: AutumnPlanFree, Status: "active"},
+					{ID: "turtlemint_one_year", Status: "active"},
+				},
+			},
+			want: PlanEnterprise,
+		},
+		{
+			name: "active pro + active bespoke product → enterprise",
+			cust: autumn.Customer{
+				Products: []autumn.CustomerProduct{
+					{ID: AutumnPlanPro, Status: "active"},
+					{ID: "plan_ent_acme", Status: "active"},
+				},
+			},
+			want: PlanEnterprise,
+		},
+		{
+			name: "active free sub + active bespoke sub → enterprise",
+			cust: autumn.Customer{
+				Subscriptions: []autumn.Subscription{
+					{PlanID: AutumnPlanFree, Status: "active"},
+					{PlanID: "turtlemint_one_year", Status: "active"},
+				},
+			},
+			want: PlanEnterprise,
+		},
+		{
+			name: "active free + scheduled bespoke product → free",
+			cust: autumn.Customer{
+				Products: []autumn.CustomerProduct{
+					{ID: AutumnPlanFree, Status: "active"},
+					{ID: "turtlemint_one_year", Status: "scheduled"},
+				},
+			},
+			want: PlanFree,
+		},
+		{
 			name: "empty customer → free",
 			cust: autumn.Customer{},
 			want: PlanFree,


### PR DESCRIPTION
# Description

- pick the highest tier among all active products in DeterminePlan: bespoke (non-free, non-pro) over pro over free, matching planRank's ordering
- previously an active measure_free returned free before the bespoke check ran; Autumn auto-attaches the free product on customer create and attaching a bespoke plan does not detach it unless the two share a product group, so bespoke customers saw the free plan UI
- add DeterminePlan cases for free+bespoke, pro+bespoke, bespoke subscriptions, and a scheduled bespoke staying free

## Related issue
Fixes #4315 



