### PR TITLE
refactor: consolidate plan-tier naming on "enterprise"

### DIFF
--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -353,8 +353,8 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 
 	t.Run("enterprise plan exposes retention_days and bytes_unlimited", func(t *testing.T) {
-		// A bespoke Enterprise plan typically has unlimited bytes and a
-		// custom retention entitlement (e.g. 365 days). Note that Autumn
+		// An enterprise plan typically has unlimited bytes and its own
+		// retention entitlement (e.g. 365 days). Note that Autumn
 		// hardcodes balance.usage=0 for any feature marked unlimited, so
 		// even though the customer may be ingesting data, BytesUsed comes
 		// through as 0.
@@ -437,8 +437,8 @@ func TestGetTeamBilling(t *testing.T) {
 		}
 	})
 
-	t.Run("bespoke Enterprise plan with bounded quota + overage_allowed flows through correctly", func(t *testing.T) {
-		// Some Enterprise plans aren't unlimited — they have a
+	t.Run("enterprise plan with bounded quota + overage_allowed flows through correctly", func(t *testing.T) {
+		// Some enterprise plans aren't unlimited — they have a
 		// quota with overage permitted (Autumn returns Granted > 0,
 		// Unlimited=false, OverageAllowed=true).
 		defer cleanupAll(ctx, t)
@@ -492,7 +492,7 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 
 	t.Run("bytes_overage_allowed=false flows through (e.g. Free, hard-capped Enterprise)", func(t *testing.T) {
-		// The Free plan and any bespoke Enterprise plan with a hard byte
+		// The Free plan and any enterprise plan with a hard byte
 		// cap configure bytes with overage_allowed=false.
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -52,7 +52,7 @@ type BillingInfo struct {
 	BytesGranted     float64   `json:"bytes_granted"`
 	BytesUsed        float64   `json:"bytes_used"`
 	// BytesUnlimited is true when the customer's bytes feature is configured
-	// as unlimited in Autumn — typically only on bespoke Enterprise plans.
+	// as unlimited in Autumn, typically only on enterprise plans.
 	BytesUnlimited bool `json:"bytes_unlimited"`
 	// BytesOverageAllowed is true when the customer's plan permits going
 	// over BytesGranted (Pro: yes, Free: no, Enterprise: depends).
@@ -122,10 +122,10 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 // plan currently in effect.
 //
 // A customer can hold several active products at once: Autumn auto-attaches
-// the Free product on customer create, and attaching a bespoke plan from the
-// Autumn dashboard does not detach it unless the two share a product group.
+// the Free product on customer create, and attaching an enterprise plan from
+// the Autumn dashboard does not detach it unless the two share a product group.
 // The highest tier wins, using the same order as planRank: any non-free,
-// non-pro plan (bespoke Enterprise) over Pro over Free.
+// non-pro plan counts as enterprise and wins over Pro, which wins over Free.
 func DeterminePlan(c *autumn.Customer) string {
 	var activePlans []string
 	for _, s := range c.Subscriptions {
@@ -354,8 +354,8 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 }
 
 // planRank orders plans by tier so a transition's direction can be read from the
-// plans that activated and expired: Free < Pro < everything else (custom
-// Enterprise plans).
+// plans that activated and expired: Free < Pro < everything else (enterprise
+// plans).
 func planRank(planID string) int {
 	switch planID {
 	case AutumnPlanFree:

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -140,7 +140,7 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanFree,
 		},
 		{
-			name: "active free + active bespoke product → enterprise",
+			name: "active free + active enterprise product → enterprise",
 			cust: autumn.Customer{
 				Products: []autumn.CustomerProduct{
 					{ID: AutumnPlanFree, Status: "active"},
@@ -150,7 +150,7 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanEnterprise,
 		},
 		{
-			name: "active pro + active bespoke product → enterprise",
+			name: "active pro + active enterprise product → enterprise",
 			cust: autumn.Customer{
 				Products: []autumn.CustomerProduct{
 					{ID: AutumnPlanPro, Status: "active"},
@@ -160,7 +160,7 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanEnterprise,
 		},
 		{
-			name: "active free sub + active bespoke sub → enterprise",
+			name: "active free sub + active enterprise sub → enterprise",
 			cust: autumn.Customer{
 				Subscriptions: []autumn.Subscription{
 					{PlanID: AutumnPlanFree, Status: "active"},
@@ -170,7 +170,7 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanEnterprise,
 		},
 		{
-			name: "active free + scheduled bespoke product → free",
+			name: "active free + scheduled enterprise product → free",
 			cust: autumn.Customer{
 				Products: []autumn.CustomerProduct{
 					{ID: AutumnPlanFree, Status: "active"},
@@ -199,13 +199,13 @@ func TestDeterminePlan(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestPlanRank(t *testing.T) {
-	// Free < Pro < Enterprise (any custom plan), so a transition's direction can
-	// be read from the plans that activated and expired.
+	// Free < Pro < Enterprise (any plan id that is neither free nor pro), so a
+	// transition's direction can be read from the plans that activated and expired.
 	if planRank(AutumnPlanFree) >= planRank(AutumnPlanPro) {
 		t.Error("Free should rank below Pro")
 	}
 	if planRank(AutumnPlanPro) >= planRank("plan_ent_acme") {
-		t.Error("Pro should rank below a custom Enterprise plan")
+		t.Error("Pro should rank below an enterprise plan")
 	}
 }
 

--- a/frontend/dashboard/__tests__/pages/usage_test.tsx
+++ b/frontend/dashboard/__tests__/pages/usage_test.tsx
@@ -316,8 +316,8 @@ const proBillingInfo = {
   current_period_end: 1702678400,
 };
 
-// Helper: default enterprise plan billing info — bespoke plan with unlimited
-// bytes and a custom retention entitlement, the typical Enterprise shape.
+// Default enterprise plan billing info, the typical shape: unlimited bytes
+// and the plan's own retention entitlement.
 const enterpriseBillingInfo = {
   team_id: "team1",
   plan: "enterprise",

--- a/frontend/dashboard/app/[teamId]/usage/page.tsx
+++ b/frontend/dashboard/app/[teamId]/usage/page.tsx
@@ -724,7 +724,7 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
 
                 {/* Enterprise Plan Card — full-width, no price. Bytes can be
                     unlimited; retention and plan length come from the
-                    bespoke Autumn plan. */}
+                    enterprise plan configured in Autumn. */}
                 {billingInfo?.plan === "enterprise" && (
                   <Card className="w-full bg-green-50 dark:bg-card border border-green-300 dark:border-border relative">
                     {showCurrentPlanBadge()}


### PR DESCRIPTION
# Description

- rewrite comments and test names that said "bespoke" or "custom plan" to say enterprise plan
- no identifier or wire value changes; PlanEnterprise and the "enterprise" plan string were already the established terms


