### PR TITLE
Migrate bug reports to expression filters

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -420,7 +420,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_filter_keys
 		newTool(&mcpsdk.Tool{
 			Name:        "get_filter_keys",
-			Description: "List the filter keys of an entity (spans or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
+			Description: "List the filter keys of an entity (spans, bug_reports or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
 			InputSchema: mcpMustInferSchema[mcpGetFilterKeysInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFilterKeysInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetFilterKeys(ctx, in)
@@ -528,8 +528,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_bug_reports
 		newTool(&mcpsdk.Tool{
 			Name:        "get_bug_reports",
-			Description: "Get bug reports for an app, ordered by most recent first. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
-			InputSchema: mcpMustInferSchema[mcpGetBugReportsInput](),
+			Description: "Get bug reports for an app, ordered by most recent first. Covers every bug report unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.BugReportsEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetBugReportsInput](mcpBugReportsFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetBugReportsInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetBugReports(ctx, in)
 		}),
@@ -537,8 +537,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_bug_reports_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_bug_reports_over_time",
-			Description: "Get time-series of bug report counts. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
-			InputSchema: mcpMustInferSchema[mcpGetBugReportsOverTimeInput](),
+			Description: "Get time-series of bug report counts. Covers every bug report unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.BugReportsEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetBugReportsOverTimeInput](mcpBugReportsFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetBugReportsOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetBugReportsOverTime(ctx, in)
 		}),
@@ -573,8 +573,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_instances
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_instances",
-			Description: "Get span instances for a root span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint + ".",
-			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanInstancesInput](),
+			Description: "Get span instances for a root span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.SpansEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanInstancesInput](mcpSpansFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanInstancesInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanInstances(ctx, in)
 		}),
@@ -582,8 +582,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_span_metrics_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_span_metrics_over_time",
-			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint + ".",
-			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanMetricsOverTimeInput](),
+			Description: "Get p50/p90/p95/p99 duration metrics over time for a span name. Covers every span unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.SpansEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetSpanMetricsOverTimeInput](mcpSpansFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetSpanMetricsOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetSpanMetricsOverTime(ctx, in)
 		}),
@@ -672,19 +672,34 @@ func commonTools(cfg *Config) []Tool {
 }
 
 // mcpFilterExprToolsHint tells the client where the vocabulary of a
-// filter_expr comes from. It is shared by every tool that takes one.
-const mcpFilterExprToolsHint = "get_filter_keys with entity spans lists the keys and operators a filter_expr may use, get_filter_values lists a key's suggested values"
+// filter_expr comes from, naming the entity whose keys get_filter_keys is
+// called with. It is shared by every tool that takes a filter_expr.
+func mcpFilterExprToolsHint(entity exprfilter.Entity) string {
+	return "get_filter_keys with entity " + entity.Name + " lists the keys and operators a filter_expr may use, get_filter_values lists a key's suggested values"
+}
 
 // mcpFilterExprGrammar is the filter_expr grammar, condensed from
-// backend/libs/exprfilter/parse.go, shared as the field's schema description
-// by every tool that takes one.
-const mcpFilterExprGrammar = "Filter expression narrowing the spans. A condition is key:operator:value or key:operator:[v1,v2]; a no-value operator like is_set is written key:operator. Conditions join with AND / OR, parentheses group, and AND binds tighter than OR. A value holding a space, comma, bracket, colon or quote is written in double quotes. Example: version_name:in:[1.2.0,1.1.9] AND span_status:in:error. User-defined span attribute keys appear under the Custom key group and carry the custom. prefix, as in custom.is_premium:eq:true. " + mcpFilterExprToolsHint
+// backend/libs/exprfilter/parse.go, shared as the filter_expr property's
+// schema description by every tool that takes one. The prose names the
+// entity being narrowed and the example is written in that entity's keys.
+func mcpFilterExprGrammar(entity exprfilter.Entity, example string) string {
+	noun := strings.ReplaceAll(entity.Name, "_", " ")
+	return "Filter expression narrowing the " + noun + ". A condition is key:operator:value or key:operator:[v1,v2]; a no-value operator like is_set is written key:operator. Conditions join with AND / OR, parentheses group, and AND binds tighter than OR. A value holding a space, comma, bracket, colon or quote is written in double quotes. Example: " + example + ". User-defined attribute keys appear under the Custom key group and carry the custom. prefix, as in custom.is_premium:eq:true. " + mcpFilterExprToolsHint(entity)
+}
+
+// The grammar text each entity's tools advertise, built from the shared
+// template with an example in that entity's keys.
+var (
+	mcpSpansFilterExprGrammar      = mcpFilterExprGrammar(exprfilter.SpansEntity, "version_name:in:[1.2.0,1.1.9] AND span_status:in:error")
+	mcpBugReportsFilterExprGrammar = mcpFilterExprGrammar(exprfilter.BugReportsEntity, "version_name:in:[1.2.0] AND bug_report_status:in:open")
+)
 
 // mcpMustInferFilterExprSchema infers a JSON schema from a Go type and sets
-// the shared grammar text as the description of its "filter_expr" property.
-// A struct tag cannot hold a constant, so the description is set here. Used
-// by tools whose input carries a filter_expr field.
-func mcpMustInferFilterExprSchema[T any]() json.RawMessage {
+// the given entity grammar text as the description of its "filter_expr"
+// property. A struct tag cannot hold the entity-specific text, so the
+// description is set here. Used by tools whose input carries a filter_expr
+// field.
+func mcpMustInferFilterExprSchema[T any](grammar string) json.RawMessage {
 	schema, err := jsonschema.For[T](nil)
 	if err != nil {
 		panic("mcp: failed to infer schema: " + err.Error())
@@ -693,7 +708,7 @@ func mcpMustInferFilterExprSchema[T any]() json.RawMessage {
 	if !ok {
 		panic("mcp: schema has no filter_expr property")
 	}
-	p.Description = mcpFilterExprGrammar
+	p.Description = grammar
 	data, err := schema.MarshalJSON()
 	if err != nil {
 		panic("mcp: failed to marshal schema: " + err.Error())
@@ -777,12 +792,12 @@ type mcpGetFiltersInput struct {
 }
 type mcpGetFilterKeysInput struct {
 	AppID  string   `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans or builds"`
+	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports or builds"`
 	Keys   []string `json:"keys,omitempty" jsonschema:"Key names you already know, for example from the user's request, to include in the result even when the listing is truncated"`
 }
 type mcpGetFilterValuesInput struct {
 	AppID   string `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans or builds"`
+	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports or builds"`
 	KeyName string `json:"key_name" jsonschema:"Name of the filter key to list values for, as get_filter_keys returns it"`
 	Search  string `json:"search,omitempty" jsonschema:"Return only values containing this text"`
 	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum number of values to return (default: 50, max: 200)"`
@@ -846,16 +861,19 @@ type mcpGetSessionInput struct {
 	SessionID string `json:"session_id" jsonschema:"UUID of the session"`
 }
 type mcpGetBugReportsInput struct {
-	mcpCommonFilters
-	BugReportStatuses []int  `json:"bug_report_statuses,omitempty" jsonschema:"Filter by status: 0=OPEN, 1=CLOSED"`
-	FreeText          string `json:"free_text,omitempty" jsonschema:"Free text search filter"`
-	Limit             int    `json:"limit,omitempty" jsonschema:"Maximum number of bug reports to return (default: 10)"`
-	Offset            int    `json:"offset,omitempty" jsonschema:"Number of bug reports to skip for pagination (default: 0)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Limit      int    `json:"limit,omitempty" jsonschema:"Maximum number of bug reports to return (default: 10)"`
+	Offset     int    `json:"offset,omitempty" jsonschema:"Number of bug reports to skip for pagination (default: 0)"`
 }
 type mcpGetBugReportsOverTimeInput struct {
-	mcpCommonFilters
-	BugReportStatuses []int  `json:"bug_report_statuses,omitempty" jsonschema:"Filter by status: 0=OPEN, 1=CLOSED"`
-	Timezone          string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Timezone   string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
 }
 type mcpGetBugReportInput struct {
 	AppID       string `json:"app_id" jsonschema:"UUID of the app"`
@@ -1088,10 +1106,11 @@ func (c *Config) mcpBuildAppFilter(ctx context.Context, appID uuid.UUID, cf mcpC
 	return af, nil
 }
 
-// mcpSpanExprFilter builds the exprfilter.ExprFilter the span query tools pass
-// to the spans queries, parsing the tool's filter_expr input into the filter
-// tree. The caller still sets Limit, Offset and Timezone, then runs Validate.
-func mcpSpanExprFilter(appID, teamID uuid.UUID, fromStr, toStr, filterExpr string) (*exprfilter.ExprFilter, error) {
+// mcpExprFilter builds the exprfilter.ExprFilter a query tool passes to the
+// given entity's queries, parsing the tool's filter_expr input into the
+// filter tree. The caller still sets Limit, Offset and Timezone, then runs
+// Validate.
+func mcpExprFilter(entity exprfilter.Entity, appID, teamID uuid.UUID, fromStr, toStr, filterExpr string) (*exprfilter.ExprFilter, error) {
 	from, to, err := mcpParseTimeRangeStrings(fromStr, toStr)
 	if err != nil {
 		return nil, err
@@ -1100,7 +1119,7 @@ func mcpSpanExprFilter(appID, teamID uuid.UUID, fromStr, toStr, filterExpr strin
 	ef := &exprfilter.ExprFilter{
 		AppID:      appID,
 		TeamID:     teamID,
-		Entity:     exprfilter.SpansEntity,
+		Entity:     entity,
 		From:       from,
 		To:         to,
 		Limit:      exprfilter.DefaultPaginationLimit,
@@ -1781,7 +1800,7 @@ func (c *Config) mcpGetBugReports(ctx context.Context, in mcpGetBugReportsInput)
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildAppFilter(ctx, appID, in.mcpCommonFilters)
+	ef, err := mcpExprFilter(exprfilter.BugReportsEntity, appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1793,24 +1812,20 @@ func (c *Config) mcpGetBugReports(ctx context.Context, in mcpGetBugReportsInput)
 	if limit > 30 {
 		limit = 30
 	}
-	af.Limit = limit
-	af.Offset = in.Offset
-	af.BugReport = true
+	ef.Limit = limit
+	ef.Offset = in.Offset
 
-	if in.FreeText != "" {
-		af.FreeText = in.FreeText
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
 	}
-	if len(in.BugReportStatuses) > 0 {
-		statuses := make([]int8, len(in.BugReportStatuses))
-		for i, s := range in.BugReportStatuses {
-			statuses[i] = int8(s)
-		}
-		af.BugReportStatuses = statuses
+
+	if err := ef.Validate(); err != nil {
+		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
 	bugCtx := ambient.WithTeamId(ctx, teamID)
-	bugReports, _, _, bugErr := app.GetBugReportsWithFilter(bugCtx, deps.RchPool, af)
+	bugReports, _, _, bugErr := app.GetBugReportsWithFilter(bugCtx, deps.RchPool, ef)
 	if bugErr != nil {
 		return nil, nil, fmt.Errorf("failed to get bug reports: %v", bugErr)
 	}
@@ -1829,25 +1844,23 @@ func (c *Config) mcpGetBugReportsOverTime(ctx context.Context, in mcpGetBugRepor
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildAppFilter(ctx, appID, in.mcpCommonFilters)
+	ef, err := mcpExprFilter(exprfilter.BugReportsEntity, appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}
-	af.Timezone = in.Timezone
-	af.Limit = filter.DefaultPaginationLimit
-	af.BugReport = true
+	ef.Timezone = in.Timezone
 
-	if len(in.BugReportStatuses) > 0 {
-		statuses := make([]int8, len(in.BugReportStatuses))
-		for i, s := range in.BugReportStatuses {
-			statuses[i] = int8(s)
-		}
-		af.BugReportStatuses = statuses
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
+	}
+
+	if err := ef.Validate(); err != nil {
+		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
 	plotCtx := ambient.WithTeamId(ctx, teamID)
-	instances, plotErr := app.GetBugReportInstancesPlot(plotCtx, deps.RchPool, af)
+	instances, plotErr := app.GetBugReportInstancesPlot(plotCtx, deps.RchPool, ef)
 	if plotErr != nil {
 		return nil, nil, fmt.Errorf("failed to get bug reports plot: %v", plotErr)
 	}
@@ -1905,7 +1918,7 @@ func (c *Config) mcpGetSpanInstances(ctx context.Context, in mcpGetSpanInstances
 		return nil, nil, err
 	}
 
-	ef, err := mcpSpanExprFilter(appID, teamID, in.From, in.To, in.FilterExpr)
+	ef, err := mcpExprFilter(exprfilter.SpansEntity, appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1952,7 +1965,7 @@ func (c *Config) mcpGetSpanMetricsOverTime(ctx context.Context, in mcpGetSpanMet
 		return nil, nil, err
 	}
 
-	ef, err := mcpSpanExprFilter(appID, teamID, in.From, in.To, in.FilterExpr)
+	ef, err := mcpExprFilter(exprfilter.SpansEntity, appID, teamID, in.From, in.To, in.FilterExpr)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -2500,6 +2500,36 @@ func TestMCPGetFilterKeys(t *testing.T) {
 			t.Error("want non-empty key_groups")
 		}
 	})
+	t.Run("bug_reports keys", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "fkeysbr@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_keys", map[string]any{"app_id": appID.String(), "entity": "bug_reports"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+
+		var result struct {
+			Keys []struct {
+				Name string `json:"name"`
+			} `json:"keys"`
+			KeyGroups []string `json:"key_groups"`
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+			t.Fatalf("parse filter keys response: %v", err)
+		}
+
+		keysByName := make(map[string]bool)
+		for _, key := range result.Keys {
+			keysByName[key.Name] = true
+		}
+		for _, want := range []string{"version_name", "version_code", "bug_report_status", "user_id", "bug_report_description", "session_id", "os_name", "country"} {
+			if !keysByName[want] {
+				t.Errorf("bug_reports keys missing %q", want)
+			}
+		}
+		if len(result.KeyGroups) == 0 {
+			t.Error("want non-empty key_groups")
+		}
+	})
 	t.Run("a user-defined attribute joins the spans keys", func(t *testing.T) {
 		cleanupAll(ctx, t)
 		userID := uuid.New()
@@ -2719,6 +2749,17 @@ func TestMCPGetFilterValues(t *testing.T) {
 		texts := valueTexts(t, resp)
 		if !reflect.DeepEqual(texts, []string{"unset", "ok", "error"}) {
 			t.Errorf("want [unset ok error], got %v", texts)
+		}
+	})
+	t.Run("bug report status enum lists its full set", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "fvalsbr@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_filter_values", map[string]any{"app_id": appID.String(), "entity": "bug_reports", "key_name": "bug_report_status"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		texts := valueTexts(t, resp)
+		if !reflect.DeepEqual(texts, []string{"open", "closed"}) {
+			t.Errorf("want [open closed], got %v", texts)
 		}
 	})
 	t.Run("limit above the maximum", func(t *testing.T) {
@@ -3252,7 +3293,7 @@ func TestMCPGetSession(t *testing.T) {
 
 func TestMCPGetBugReports(t *testing.T) {
 	ctx := context.Background()
-	setupToolTest := func(t *testing.T, email string) (uuid.UUID, string) {
+	setupToolTest := func(t *testing.T, email string) (uuid.UUID, uuid.UUID, string) {
 		cleanupAll(ctx, t)
 		userID := uuid.New()
 		seedUser(ctx, t, userID.String(), email)
@@ -3263,7 +3304,7 @@ func TestMCPGetBugReports(t *testing.T) {
 		seedApp(ctx, t, appID, teamID, 30)
 		rawToken := "msr_" + email
 		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
-		return appID, rawToken
+		return appID, teamID, rawToken
 	}
 	now := time.Now().UTC()
 	from := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
@@ -3281,17 +3322,105 @@ func TestMCPGetBugReports(t *testing.T) {
 		}
 	})
 	t.Run("valid call", func(t *testing.T) {
-		appID, rawToken := setupToolTest(t, "br2@mcp.test")
+		appID, _, rawToken := setupToolTest(t, "br2@mcp.test")
 		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "from": from, "to": to})
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
 		}
 	})
-	t.Run("with free_text filter", func(t *testing.T) {
-		appID, rawToken := setupToolTest(t, "brfree@mcp.test")
-		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "free_text": "crash on button", "from": from, "to": to})
+	t.Run("filter_expr narrows results", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "brexpr@mcp.test")
+		th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+			Status: 0, Description: "open bug", Timestamp: now.Add(-time.Hour),
+		})
+		th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+			Status: 1, Description: "closed bug", Timestamp: now.Add(-time.Hour),
+		})
+
+		args := map[string]any{"app_id": appID.String(), "from": from, "to": to}
+		resp := callMCPTool(t, rawToken, "get_bug_reports", args)
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		var reports []map[string]any
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &reports); err != nil {
+			t.Fatalf("unmarshal bug reports: %v", err)
+		}
+		if len(reports) != 2 {
+			t.Fatalf("want 2 bug reports with no filter, got %d", len(reports))
+		}
+
+		args["filter_expr"] = "bug_report_status:in:open"
+		resp = callMCPTool(t, rawToken, "get_bug_reports", args)
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &reports); err != nil {
+			t.Fatalf("unmarshal filtered bug reports: %v", err)
+		}
+		if len(reports) != 1 {
+			t.Fatalf("want 1 bug report with status filter, got %d", len(reports))
+		}
+		if reports[0]["description"] != "open bug" {
+			t.Errorf("filtered bug report description = %v, want open bug", reports[0]["description"])
+		}
+	})
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "brexprbad@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "bogus_key:in:x"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unknown filter key")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "bogus_key") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+	t.Run("unparseable filter_expr returns the parse error", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "brexprparse@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "version_name:in:v1 AND"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unparseable filter")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "filter_expr could not be parsed") || !strings.Contains(text, "at position") {
+			t.Errorf("error text %q should report the parse failure and its position", text)
+		}
+	})
+	t.Run("a custom filter_expr narrows results", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "brexprcustom@mcp.test")
+		reportOne := uuid.New().String()
+		th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+			EventID: reportOne, Status: 0, Description: "premium bug", Timestamp: now.Add(-time.Hour),
+		})
+		th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+			Status: 0, Description: "free bug", Timestamp: now.Add(-time.Hour),
+		})
+		th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{
+			EventID: reportOne, BugReport: true, Key: "plan", Value: "pro", Timestamp: now.Add(-time.Hour),
+		})
+
+		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "custom.plan:in:pro"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		var reports []map[string]any
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &reports); err != nil {
+			t.Fatalf("unmarshal bug reports: %v", err)
+		}
+		if len(reports) != 1 {
+			t.Fatalf("want 1 bug report with the custom filter, got %d", len(reports))
+		}
+		if reports[0]["description"] != "premium bug" {
+			t.Errorf("filtered bug report description = %v, want premium bug", reports[0]["description"])
+		}
+	})
+	t.Run("an unknown custom key returns the issue", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "brexprnocustom@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_bug_reports", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "custom.nope:in:x"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for an attribute the app's bug reports never reported")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "custom.nope") {
+			t.Errorf("error text %q should name the unknown key", text)
 		}
 	})
 }
@@ -3325,6 +3454,25 @@ func TestMCPGetBugReportsPlot(t *testing.T) {
 		resp := callMCPTool(t, rawToken, "get_bug_reports_over_time", map[string]any{"app_id": appID.String(), "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339)})
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+	})
+	t.Run("valid filter_expr is accepted", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "brplotexpr@mcp.test")
+		now := time.Now().UTC()
+		resp := callMCPTool(t, rawToken, "get_bug_reports_over_time", map[string]any{"app_id": appID.String(), "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339), "filter_expr": "version_name:in:v1 AND bug_report_status:in:open"})
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+	})
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		appID, rawToken := setupToolTest(t, "brplotexprbad@mcp.test")
+		now := time.Now().UTC()
+		resp := callMCPTool(t, rawToken, "get_bug_reports_over_time", map[string]any{"app_id": appID.String(), "timezone": "UTC", "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339), "filter_expr": "bug_report_status:in:bogus"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for invalid bug_report_status value")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "bug_report_status") || !strings.Contains(text, "bogus") {
+			t.Errorf("error text %q should name the bad value", text)
 		}
 	})
 }

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -3155,12 +3155,12 @@ func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 		return
 	}
 
-	af := filter.AppFilter{
+	ef := exprfilter.ExprFilter{
 		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
+		Limit: exprfilter.DefaultPaginationLimit,
 	}
 
-	if err := c.ShouldBindQuery(&af); err != nil {
+	if err := c.ShouldBindQuery(&ef); err != nil {
 		msg := `failed to parse query parameters`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -3170,44 +3170,14 @@ func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 		return
 	}
 
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
+	ef.Entity = exprfilter.BugReportsEntity
+
+	if err := ef.BuildExprTree(); err != nil {
+		respondFilterError(c, err)
 		return
 	}
 
-	msg := "bug reports overview request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
+	ef.SetDefaultTimeRangeIfUnset()
 
 	app := measure.App{
 		ID: &id,
@@ -3259,6 +3229,7 @@ func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 	}
 
 	app.TeamId = *team.ID
+	ef.TeamID = *team.ID
 
 	lc := logcomment.New(2)
 	settings := clickhouse.Settings{
@@ -3269,7 +3240,21 @@ func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 
 	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "list"))
 
-	bugReports, next, previous, err := app.GetBugReportsWithFilter(ctx, deps.RchPool, &af)
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		msg := "failed to read the filter's custom keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if err := ef.Validate(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	bugReports, next, previous, err := app.GetBugReportsWithFilter(ctx, deps.RchPool, &ef)
 	if err != nil {
 		msg := "failed to get app's bug reports"
 		fmt.Println(msg, err)
@@ -3301,12 +3286,12 @@ func (h Handlers) GetBugReportsInstancesPlot(c *gin.Context) {
 		return
 	}
 
-	af := filter.AppFilter{
+	ef := exprfilter.ExprFilter{
 		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
+		Limit: exprfilter.DefaultPaginationLimit,
 	}
 
-	if err := c.ShouldBindQuery(&af); err != nil {
+	if err := c.ShouldBindQuery(&ef); err != nil {
 		msg := `failed to parse query parameters`
 		fmt.Println(msg, err)
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -3316,52 +3301,21 @@ func (h Handlers) GetBugReportsInstancesPlot(c *gin.Context) {
 		return
 	}
 
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
+	ef.Entity = exprfilter.BugReportsEntity
+
+	if err := ef.BuildExprTree(); err != nil {
+		respondFilterError(c, err)
 		return
 	}
 
-	msg := `bug reports plot request validation failed`
-
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if !af.HasTimezone() {
+	if ef.Timezone == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "missing required field `timezone`",
 		})
 		return
 	}
 
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
+	ef.SetDefaultTimeRangeIfUnset()
 
 	app := measure.App{
 		ID: &id,
@@ -3413,6 +3367,7 @@ func (h Handlers) GetBugReportsInstancesPlot(c *gin.Context) {
 	}
 
 	app.TeamId = *team.ID
+	ef.TeamID = *team.ID
 
 	lc := logcomment.New(2)
 	settings := clickhouse.Settings{
@@ -3423,7 +3378,21 @@ func (h Handlers) GetBugReportsInstancesPlot(c *gin.Context) {
 
 	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "plots_instances"))
 
-	bugReportInstances, err := app.GetBugReportInstancesPlot(ctx, deps.RchPool, &af)
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		msg := "failed to read the filter's custom keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if err := ef.Validate(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	bugReportInstances, err := app.GetBugReportInstancesPlot(ctx, deps.RchPool, &ef)
 	if err != nil {
 		msg := `failed to query data for bug reports plot`
 		fmt.Println(msg, err)

--- a/backend/libs/exprfilter/bugreports.go
+++ b/backend/libs/exprfilter/bugreports.go
@@ -1,0 +1,328 @@
+package exprfilter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"backend/libs/chquery"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+// BugReportsEntity is an app's bug reports. Filtering and value lists both
+// read the bug_reports table in ClickHouse, which stores every attribute as a
+// flat column, and its user-defined attributes are the user_def_attrs rows
+// flagged bug_report.
+var BugReportsEntity = Entity{
+	Name:                  "bug_reports",
+	Keys:                  bugReportsKeys,
+	BindKey:               bindBugReportsKeyToColumns(bugReportsTableColumns),
+	SuggestKeyValues:      fetchBugReportsKeySuggestions,
+	FetchCustomKeys:       fetchBugReportCustomKeys,
+	FetchCustomKeysByName: fetchBugReportCustomKeysByName,
+	BindCustomKeys:        bindCustomConditionsToMembership("user_def_attrs", "event_id", "bug_report = true"),
+}
+
+var bugReportsKeys = []Key{
+	versionName,
+	versionCode,
+	bugReportStatus,
+	userID,
+	bugReportDescription,
+	sessionID,
+	osName,
+	osVersion,
+	deviceName,
+	deviceManufacturer,
+	locale,
+	networkType,
+	networkGeneration,
+	networkProvider,
+	country,
+}
+
+// The column expression each bug report key compares against. The bug_reports
+// table stores every attribute as a flat column and holds the app and os
+// versions as (name, version) tuples.
+var bugReportsTableColumns = map[string]string{
+	versionName.Name:          "tupleElement(app_version, 1)",
+	versionCode.Name:          "tupleElement(app_version, 2)",
+	bugReportStatus.Name:      "status",
+	userID.Name:               "user_id",
+	bugReportDescription.Name: "description",
+	sessionID.Name:            "session_id",
+	osName.Name:               "tupleElement(os_version, 1)",
+	osVersion.Name:            "tupleElement(os_version, 2)",
+	deviceName.Name:           "device_name",
+	deviceManufacturer.Name:   "device_manufacturer",
+	locale.Name:               "device_locale",
+	networkType.Name:          "network_type",
+	networkGeneration.Name:    "network_generation",
+	networkProvider.Name:      "network_provider",
+	country.Name:              "country_code",
+}
+
+// bugReportStatusCodes maps the status names a filter carries to the integer
+// codes the status column stores.
+var bugReportStatusCodes = map[string]uint8{
+	"open":   0,
+	"closed": 1,
+}
+
+// bindBugReportsKeyToColumns compares one key against the column expression
+// the mapping names for it.
+func bindBugReportsKeyToColumns(columns map[string]string) KeyBinding {
+	return func(condition Condition) (*sqlf.Stmt, error) {
+		column, ok := columns[condition.KeyName]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrKeyNotSupported, condition.KeyName)
+		}
+
+		if condition.KeyName == bugReportStatus.Name {
+			return bindBugReportStatusCondition(column, condition)
+		}
+
+		switch condition.Operator {
+		case OperatorIn:
+			return sqlf.New(column+" in ?", condition.TextValues()), nil
+		case OperatorNotIn:
+			return sqlf.New(column+" not in ?", condition.TextValues()), nil
+		case OperatorContains:
+			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorNotContains:
+			return sqlf.New(column+" not ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorStartsWith:
+			return sqlf.New(column+" ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorEndsWith:
+			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())), nil
+		}
+
+		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+	}
+}
+
+func bindBugReportStatusCondition(column string, condition Condition) (*sqlf.Stmt, error) {
+	codes := make([]uint8, 0, len(condition.Values))
+	for _, name := range condition.TextValues() {
+		code, ok := bugReportStatusCodes[name]
+		if !ok {
+			return nil, fmt.Errorf("Key %q has no value %q", condition.KeyName, name)
+		}
+		codes = append(codes, code)
+	}
+
+	switch condition.Operator {
+	case OperatorIn:
+		return sqlf.New(column+" in ?", codes), nil
+	case OperatorNotIn:
+		return sqlf.New(column+" not in ?", codes), nil
+	}
+
+	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+}
+
+// fetchBugReportsKeySuggestions lists what one key can be set to, narrowed by
+// what has been typed. Values are read from the bug_reports table itself,
+// most recently seen first, asking for one row past the limit so it can
+// report that more matched without counting them. The table holds one row per
+// report, so no rollup is needed.
+func fetchBugReportsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	if len(key.EnumValues) > 0 {
+		return narrowEnumValues(key, valueRequest), nil
+	}
+
+	if key.ValueSuggestionMode == ValueSuggestionModeNone {
+		return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
+	}
+
+	if strings.HasPrefix(key.Name, CustomKeyPrefix) {
+		return fetchBugReportCustomKeySuggestions(ctx, chPool, teamID, appID, key, valueRequest)
+	}
+
+	column, ok := bugReportsTableColumns[key.Name]
+	if !ok {
+		return ValueList{}, fmt.Errorf("%w: %q", ErrKeyNotSupported, key.Name)
+	}
+
+	limit := valueRequest.Limit
+	if limit <= 0 {
+		limit = DefaultValueLimit
+	}
+
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	// A report that did not carry an attribute holds an empty string in that
+	// column, so those rows are left out.
+	stmt := sqlf.
+		From("bug_reports").
+		Select(column+" as suggested_value").
+		Select("max(timestamp) as recency").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		Where(column + " <> ''").
+		GroupBy("suggested_value").
+		OrderBy("recency desc, suggested_value").
+		Limit(limit + 1)
+
+	defer stmt.Close()
+
+	if valueRequest.Search != "" {
+		stmt.Where(column+" ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+	}
+
+	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+	defer rows.Close()
+
+	values := []Value{}
+	for rows.Next() {
+		var text string
+		var recency time.Time
+		if err := rows.Scan(&text, &recency); err != nil {
+			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+		}
+		values = append(values, Value{Text: text})
+	}
+	if err := rows.Err(); err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}, nil
+	}
+
+	return ValueList{Values: values}, nil
+}
+
+// The custom keys of bug reports are the user-defined attributes an app set
+// on the session a report was filed in. The user_def_attrs table holds one
+// row per event, attribute and value for several event kinds, with bug report
+// rows flagged bug_report, and each condition on one becomes an event_id
+// membership subquery against it. The attributes are read from ClickHouse, so
+// the Postgres pool the entity fields carry is unused here.
+
+// fetchBugReportCustomKeys lists the filter keys for every user-defined
+// attribute of an app's bug reports, ordered by name. It asks for one key
+// past the limit so it can report that more exist without counting them.
+func fetchBugReportCustomKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
+	stmt := bugReportCustomKeyQuery(teamID, appID).
+		Limit(limit + 1).
+		// Most granules hold rows of this team and app anyway, so skip
+		// indexes cost analysis without pruning reads.
+		Clause("settings use_skip_indexes = 0")
+
+	defer stmt.Close()
+
+	keys, err := readCustomKeys(ctx, chPool, teamID, stmt)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(keys) > limit {
+		return keys[:limit], true, nil
+	}
+	return keys, false, nil
+}
+
+// fetchBugReportCustomKeysByName reads the filter keys for the named
+// user-defined bug report attributes of one app.
+func fetchBugReportCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
+	if len(rawNames) == 0 {
+		return nil, nil
+	}
+
+	stmt := bugReportCustomKeyQuery(teamID, appID).
+		Where("key in ?", rawNames)
+
+	defer stmt.Close()
+
+	return readCustomKeys(ctx, chPool, teamID, stmt)
+}
+
+// bugReportCustomKeyQuery reads an app's user-defined bug report attribute
+// keys with their types. An attribute rewritten under a new type keeps one
+// row per type, so the type written last is the one its key offers.
+//
+// The scan is on the full table without a time bound. If needed in future:
+// time bound it so only keys in time range show up or add a rollup of
+// distinct keys and values like the span_filters rollup that fixed keys read.
+func bugReportCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
+	return sqlf.
+		From("user_def_attrs").
+		Select("key").
+		Select("argMax(type, timestamp) as type").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		Where("bug_report = true").
+		GroupBy("key").
+		OrderBy("key")
+}
+
+// fetchBugReportCustomKeySuggestions lists what one user-defined attribute
+// has been set to on bug reports, most recently written first, asking for one
+// row past the limit so it can report that more matched without counting
+// them. Empty ones are left out.
+//
+// The scan is on the full table without a time bound. If needed in future:
+// time bound it so only suggestions in time range show up or add a rollup of
+// distinct keys and values like the span_filters rollup that fixed keys read.
+func fetchBugReportCustomKeySuggestions(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	limit := valueRequest.Limit
+	if limit <= 0 {
+		limit = DefaultValueLimit
+	}
+
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	stmt := sqlf.
+		From("user_def_attrs").
+		Select("value").
+		Select("max(timestamp) as recency").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID).
+		Where("bug_report = true").
+		Where("key = ?", strings.TrimPrefix(key.Name, CustomKeyPrefix)).
+		Where("type = ?", string(key.ValueType)).
+		Where("value <> ''").
+		GroupBy("value").
+		OrderBy("recency desc, value").
+		Limit(limit + 1)
+
+	defer stmt.Close()
+
+	if valueRequest.Search != "" {
+		stmt.Where("value ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+	}
+
+	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+	defer rows.Close()
+
+	values := []Value{}
+	for rows.Next() {
+		var text string
+		var recency time.Time
+		if err := rows.Scan(&text, &recency); err != nil {
+			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+		}
+		values = append(values, Value{Text: text})
+	}
+	if err := rows.Err(); err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}, nil
+	}
+
+	return ValueList{Values: values}, nil
+}

--- a/backend/libs/exprfilter/bugreports_values_test.go
+++ b/backend/libs/exprfilter/bugreports_values_test.go
@@ -1,0 +1,299 @@
+//go:build integration
+
+package exprfilter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+func seedBugReports(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+	otherAppID = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "bug report values team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "bug report values app", 90)
+	th.SeedApp(ctx, t, otherAppID.String(), teamID.String(), "another bug report app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+		Timestamp:          base,
+		Status:             0,
+		Description:        "checkout button does nothing",
+		UserID:             "alice",
+		DeviceName:         "pixel 4a",
+		DeviceManufacturer: "Google",
+	})
+	th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+		Timestamp:          base.Add(10 * time.Minute),
+		Status:             1,
+		Description:        "app freezes on login",
+		UserID:             "bob",
+		DeviceName:         "iPhone 15",
+		DeviceManufacturer: "Apple",
+		OSName:             "iOS",
+		OSVersion:          "17.4",
+	})
+	th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+		Timestamp:   base.Add(20 * time.Minute),
+		Description: "default attributes",
+	})
+
+	// Another app's report, which must stay out of this app's lists.
+	th.SeedBugReportRow(ctx, t, teamID.String(), otherAppID.String(), testinfra.BugReportRow{
+		Timestamp:   base,
+		Description: "other app report",
+		DeviceName:  "galaxy s24",
+		UserID:      "mallory",
+	})
+
+	return teamID, appID, otherAppID
+}
+
+func TestBugReportsValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, otherAppID := seedBugReports(ctx, t)
+
+	byName := IndexKeysByName(BugReportsEntity.Keys)
+
+	list := func(t *testing.T, keyName string, valueRequest ValueRequest) ([]Value, bool) {
+		t.Helper()
+		valueList, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName[keyName], valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		return valueList.Values, valueList.Truncated
+	}
+
+	texts := func(values []Value) []string {
+		out := make([]string, len(values))
+		for i, value := range values {
+			out[i] = value.Text
+		}
+		return out
+	}
+
+	t.Run("device names come back most recently seen first", func(t *testing.T) {
+		values, truncated := list(t, "device_name", ValueRequest{})
+		if truncated {
+			t.Error("want the whole list for three device names")
+		}
+		got := texts(values)
+		if len(got) != 3 || got[0] != "Pixel" || got[1] != "iPhone 15" || got[2] != "pixel 4a" {
+			t.Errorf("want [Pixel, iPhone 15, pixel 4a], got %v", got)
+		}
+	})
+
+	t.Run("user ids are suggested", func(t *testing.T) {
+		values, _ := list(t, "user_id", ValueRequest{})
+		got := texts(values)
+		if len(got) != 3 || got[0] != "u1" || got[1] != "bob" || got[2] != "alice" {
+			t.Errorf("want [u1 bob alice], got %v", got)
+		}
+	})
+
+	t.Run("os names are read from the version tuple", func(t *testing.T) {
+		values, _ := list(t, "os_name", ValueRequest{})
+		if got := texts(values); len(got) != 2 {
+			t.Errorf("want [Android iOS] in some order, got %v", got)
+		}
+	})
+
+	t.Run("another app's reports stay out", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{})
+		for _, value := range texts(values) {
+			if value == "galaxy s24" {
+				t.Error("want another app's device out of this app's list")
+			}
+		}
+
+		otherApp, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, otherAppID, byName["device_name"], ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		if got := texts(otherApp.Values); len(got) != 1 || got[0] != "galaxy s24" {
+			t.Errorf("want the other app to see only its own device, got %v", got)
+		}
+	})
+
+	t.Run("typing narrows the list without regard to case", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{Search: "PHONE"})
+		if got := texts(values); len(got) != 1 || got[0] != "iPhone 15" {
+			t.Errorf("want only iPhone 15, got %v", got)
+		}
+	})
+
+	t.Run("a percent sign is matched as literal text", func(t *testing.T) {
+		values, _ := list(t, "device_name", ValueRequest{Search: "%"})
+		if len(values) != 0 {
+			t.Errorf("want a literal percent sign to match nothing, got %v", texts(values))
+		}
+	})
+
+	t.Run("a limit reports that more matched", func(t *testing.T) {
+		values, truncated := list(t, "device_name", ValueRequest{Limit: 1})
+		if len(values) != 1 {
+			t.Errorf("want one value, got %v", texts(values))
+		}
+		if !truncated {
+			t.Error("want the picker told the list is partial")
+		}
+	})
+
+	t.Run("statuses are the fixed set", func(t *testing.T) {
+		values, truncated := list(t, "bug_report_status", ValueRequest{})
+		if truncated {
+			t.Error("want a fixed list reported whole")
+		}
+		if got := texts(values); len(got) != 2 || got[0] != "open" || got[1] != "closed" {
+			t.Errorf("want [open closed], got %v", got)
+		}
+
+		narrowed, _ := list(t, "bug_report_status", ValueRequest{Search: "clo"})
+		if got := texts(narrowed); len(got) != 1 || got[0] != "closed" {
+			t.Errorf("want closed, got %v", got)
+		}
+	})
+
+	t.Run("the description takes typed-in values only", func(t *testing.T) {
+		if _, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName["bug_report_description"], ValueRequest{}); err == nil {
+			t.Error("want the description's value list refused")
+		}
+	})
+
+	t.Run("the session id takes typed-in values only", func(t *testing.T) {
+		if _, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName["session_id"], ValueRequest{}); err == nil {
+			t.Error("want the session id's value list refused")
+		}
+	})
+
+	t.Run("an app with no reports has no values", func(t *testing.T) {
+		emptyApp, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, uuid.New(), byName["device_name"], ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		if len(emptyApp.Values) != 0 {
+			t.Errorf("want no values, got %v", texts(emptyApp.Values))
+		}
+	})
+}
+
+func seedBugReportUDAttrs(ctx context.Context, t *testing.T) (teamID, appID uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "bug report custom keys team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "bug report custom keys app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{BugReport: true, Key: "plan", Value: "free", Timestamp: base})
+	th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{BugReport: true, Key: "plan", Value: "pro", Timestamp: base.Add(10 * time.Minute)})
+	th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{BugReport: true, Key: "retries", Type: "int64", Value: "3", Timestamp: base})
+
+	// Attributes of other event kinds, which must stay out of the bug report
+	// key and value lists.
+	th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{BugReport: false, Key: "plan", Value: "enterprise", Timestamp: base})
+	th.SeedUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.UDAttrRow{BugReport: false, Key: "cart_size", Type: "int64", Value: "7", Timestamp: base})
+
+	return teamID, appID
+}
+
+func TestFetchBugReportCustomKeys(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID := seedBugReportUDAttrs(ctx, t)
+
+	t.Run("only bug report keys come back ordered by name", func(t *testing.T) {
+		keys, truncated, err := BugReportsEntity.FetchCustomKeys(ctx, pgPool, chConn, teamID, appID, CustomKeyLimit)
+		if err != nil {
+			t.Fatalf("fetch custom keys: %v", err)
+		}
+		if truncated {
+			t.Error("want the whole list for two keys")
+		}
+
+		want := []string{"custom.plan", "custom.retries"}
+		got := customKeyNames(keys)
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("want %v, got %v", want, got)
+		}
+	})
+
+	t.Run("a listing past the limit reports truncation", func(t *testing.T) {
+		keys, truncated, err := BugReportsEntity.FetchCustomKeys(ctx, pgPool, chConn, teamID, appID, 1)
+		if err != nil {
+			t.Fatalf("fetch custom keys: %v", err)
+		}
+		if !truncated {
+			t.Error("want the listing marked truncated")
+		}
+		if got := customKeyNames(keys); len(got) != 1 || got[0] != "custom.plan" {
+			t.Errorf("want the first key by name, got %v", got)
+		}
+	})
+
+	t.Run("only the requested names come back", func(t *testing.T) {
+		keys, err := BugReportsEntity.FetchCustomKeysByName(ctx, pgPool, chConn, teamID, appID, []string{"plan", "cart_size", "nope"})
+		if err != nil {
+			t.Fatalf("fetch custom keys by name: %v", err)
+		}
+		got := customKeyNames(keys)
+		if len(got) != 1 || got[0] != "custom.plan" {
+			t.Errorf("want [custom.plan], a non-bug-report key left out, got %v", got)
+		}
+	})
+}
+
+func TestCustomBugReportKeyValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID := seedBugReportUDAttrs(ctx, t)
+
+	plan := CustomKey("plan", ValueTypeString)
+
+	list := func(t *testing.T, valueRequest ValueRequest) []string {
+		t.Helper()
+		valueList, err := BugReportsEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, plan, valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		texts := make([]string, len(valueList.Values))
+		for i, value := range valueList.Values {
+			texts[i] = value.Text
+		}
+		return texts
+	}
+
+	t.Run("values come back most recently written first", func(t *testing.T) {
+		got := list(t, ValueRequest{})
+		if len(got) != 2 || got[0] != "pro" || got[1] != "free" {
+			t.Errorf("want [pro free], got %v", got)
+		}
+	})
+
+	t.Run("a non-bug-report row's value stays out", func(t *testing.T) {
+		got := list(t, ValueRequest{})
+		for _, text := range got {
+			if text == "enterprise" {
+				t.Error("want the session attribute's value out of the bug report list")
+			}
+		}
+	})
+
+	t.Run("search narrows the list", func(t *testing.T) {
+		got := list(t, ValueRequest{Search: "fr"})
+		if len(got) != 1 || got[0] != "free" {
+			t.Errorf("want [free], got %v", got)
+		}
+	})
+}

--- a/backend/libs/exprfilter/custom_test.go
+++ b/backend/libs/exprfilter/custom_test.go
@@ -555,6 +555,51 @@ func TestBindCustomGroupDedupesTheKeyList(t *testing.T) {
 	}
 }
 
+const bugReportCustomSubqueryScope = "select event_id from user_def_attrs where team_id = toUUID(?) and app_id = toUUID(?) and timestamp >= ? and timestamp <= ? and bug_report = true and key = ? and type = ?"
+
+const bugReportCustomGroupedScope = "select event_id from user_def_attrs where team_id = toUUID(?) and app_id = toUUID(?) and timestamp >= ? and timestamp <= ? and bug_report = true and key in ? group by event_id having "
+
+// TestBindBugReportCustomKeyScopesToBugReportRows checks that every
+// membership subquery of the bug reports entity keeps to the user_def_attrs
+// rows flagged bug_report, since the table also holds the attributes of other
+// event kinds.
+func TestBindBugReportCustomKeyScopesToBugReportRows(t *testing.T) {
+	keys := []Key{
+		CustomKey("plan", ValueTypeString),
+		CustomKey("retries", ValueTypeInt64),
+	}
+	binding := BugReportsEntity.BindCustomKeys(testCustomKeyScope(), keys)
+
+	bind := func(t *testing.T, operator LogicalOperator, conditions []Condition) string {
+		t.Helper()
+		stmt, err := binding(operator, conditions)
+		if err != nil {
+			t.Fatalf("bind %v: %v", conditions, err)
+		}
+		defer stmt.Close()
+		return stmt.String()
+	}
+
+	t.Run("a lone condition", func(t *testing.T) {
+		got := bind(t, LogicalAnd, []Condition{customCondition("custom.plan", OperatorIn, "pro")})
+		want := "event_id in (" + bugReportCustomSubqueryScope + " and value in ?)"
+		if got != want {
+			t.Errorf("\n got %s\nwant %s", got, want)
+		}
+	})
+
+	t.Run("a grouped scan", func(t *testing.T) {
+		got := bind(t, LogicalAnd, []Condition{
+			customCondition("custom.plan", OperatorIn, "pro"),
+			customCondition("custom.retries", OperatorGt, "9"),
+		})
+		want := "event_id in (" + bugReportCustomGroupedScope + "countIf(key = ? and type = ? and value in ?) > 0 and countIf(key = ? and type = ? and toInt64OrNull(value) > ?) > 0)"
+		if got != want {
+			t.Errorf("\n got %s\nwant %s", got, want)
+		}
+	})
+}
+
 func TestCollectRootVersionConditions(t *testing.T) {
 	assertLists := func(t *testing.T, label string, got, want [][]string) {
 		t.Helper()

--- a/backend/libs/exprfilter/custommembership.go
+++ b/backend/libs/exprfilter/custommembership.go
@@ -127,6 +127,7 @@ func matchCustomCondition(key Key, condition Condition) (customConditionMatch, e
 type customMembershipBinder struct {
 	table      string
 	idColumn   string
+	extraScope string
 	scope      CustomKeyScope
 	keysByName map[string]Key
 }
@@ -135,14 +136,27 @@ type customMembershipBinder struct {
 const customAttrScope = " where team_id = toUUID(?) and app_id = toUUID(?)" +
 	" and timestamp >= ? and timestamp <= ?"
 
+// scopeSQL is customAttrScope extended with the binder's extra clause, so
+// every membership subquery scans only the rows its entity owns.
+func (b *customMembershipBinder) scopeSQL() string {
+	if b.extraScope == "" {
+		return customAttrScope
+	}
+	return customAttrScope + " and " + b.extraScope
+}
+
 // bindCustomConditionsToMembership creates a GroupKeyBinding for custom-key
 // conditions. Multiple conditions are evaluated with countIf over one grouped
 // query instead of generating a separate subquery for each condition.
-func bindCustomConditionsToMembership(table, idColumn string) func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
+// extraScope is an extra boolean SQL clause for tables shared by more than one
+// entity, such as the bug_report flag of user_def_attrs; empty when the table
+// holds one entity's rows only.
+func bindCustomConditionsToMembership(table, idColumn, extraScope string) func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
 	return func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
 		binder := &customMembershipBinder{
 			table:      table,
 			idColumn:   idColumn,
+			extraScope: extraScope,
 			scope:      scope,
 			keysByName: IndexKeysByName(keys),
 		}
@@ -279,7 +293,7 @@ func (b *customMembershipBinder) single(match customConditionMatch) (string, []a
 	versionSQL, versionArgs := b.versionConditions()
 	text := b.idColumn + " " + operator + " (" +
 		"select " + b.idColumn + " from " + b.table +
-		customAttrScope +
+		b.scopeSQL() +
 		versionSQL +
 		" and " + match.sql +
 		")"
@@ -303,7 +317,7 @@ func (b *customMembershipBinder) grouped(operator string, matches []customCondit
 	versionSQL, versionArgs := b.versionConditions()
 	text := b.idColumn + " " + operator + " (" +
 		"select " + b.idColumn + " from " + b.table +
-		customAttrScope +
+		b.scopeSQL() +
 		versionSQL +
 		" and key in ?" +
 		" group by " + b.idColumn +

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -75,6 +75,8 @@ func FindByName(name string) (Entity, error) {
 		return BuildsEntity, nil
 	case SpansEntity.Name:
 		return SpansEntity, nil
+	case BugReportsEntity.Name:
+		return BugReportsEntity, nil
 	}
 
 	return Entity{}, fmt.Errorf("Unknown filter entity %q", name)
@@ -82,21 +84,24 @@ func FindByName(name string) (Entity, error) {
 
 // The groups a key can belong to.
 const (
-	KeyGroupVersion  KeyGroup = "Version"
-	KeyGroupBuild    KeyGroup = "Build"
-	KeyGroupSpan     KeyGroup = "Span"
-	KeyGroupOS       KeyGroup = "OS"
-	KeyGroupDevice   KeyGroup = "Device"
-	KeyGroupNetwork  KeyGroup = "Network"
-	KeyGroupLocation KeyGroup = "Location"
-	KeyGroupCustom   KeyGroup = "Custom"
+	KeyGroupVersion   KeyGroup = "Version"
+	KeyGroupBuild     KeyGroup = "Build"
+	KeyGroupSpan      KeyGroup = "Span"
+	KeyGroupBugReport KeyGroup = "Bug Report"
+	KeyGroupSession   KeyGroup = "Session"
+	KeyGroupUser      KeyGroup = "User"
+	KeyGroupOS        KeyGroup = "OS"
+	KeyGroupDevice    KeyGroup = "Device"
+	KeyGroupNetwork   KeyGroup = "Network"
+	KeyGroupLocation  KeyGroup = "Location"
+	KeyGroupCustom    KeyGroup = "Custom"
 )
 
 // keyGroupOrder is the order the filter bar shows groups in.
 var keyGroupOrder = []KeyGroup{
-	KeyGroupVersion, KeyGroupBuild, KeyGroupSpan,
+	KeyGroupBugReport, KeyGroupVersion, KeyGroupBuild, KeyGroupSpan,
 	KeyGroupOS, KeyGroupDevice, KeyGroupNetwork, KeyGroupLocation,
-	KeyGroupCustom,
+	KeyGroupUser, KeyGroupSession, KeyGroupCustom,
 }
 
 // ListKeyGroups lists the groups a set of keys falls into, in the order the
@@ -189,6 +194,53 @@ var (
 		Operators:           []Operator{OperatorIn, OperatorNotIn},
 		ValueSuggestionMode: ValueSuggestionModeFullList,
 		EnumValues:          []string{"unset", "ok", "error"},
+	}
+
+	bugReportStatus = Key{
+		Name:                "bug_report_status",
+		Label:               "Status",
+		Description:         "Whether the bug report is open or closed.",
+		KeyGroup:            KeyGroupBugReport,
+		ValueType:           ValueTypeEnum,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeFullList,
+		EnumValues:          []string{"open", "closed"},
+	}
+
+	userID = Key{
+		Name:        "user_id",
+		Label:       "User ID",
+		Description: "The user id of the session.",
+		KeyGroup:    KeyGroupUser,
+		ValueType:   ValueTypeString,
+		Operators: []Operator{
+			OperatorIn, OperatorNotIn,
+			OperatorContains, OperatorStartsWith,
+		},
+		ValueSuggestionMode: ValueSuggestionModeSample,
+	}
+
+	bugReportDescription = Key{
+		Name:        "bug_report_description",
+		Label:       "Description",
+		Description: "The bug report description written by the reporter.",
+		KeyGroup:    KeyGroupBugReport,
+		ValueType:   ValueTypeString,
+		Operators: []Operator{
+			OperatorContains, OperatorNotContains,
+			OperatorStartsWith, OperatorEndsWith,
+		},
+		ValueSuggestionMode: ValueSuggestionModeNone,
+	}
+
+	sessionID = Key{
+		Name:                "session_id",
+		Label:               "Session ID",
+		Description:         "The id of the session.",
+		KeyGroup:            KeyGroupSession,
+		ValueType:           ValueTypeUUID,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeNone,
 	}
 
 	osName = Key{

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var allEntities = []Entity{BuildsEntity, SpansEntity}
+var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity}
 
 func sampleValues(t *testing.T, key Key, operator Operator) []Value {
 	t.Helper()
@@ -277,6 +277,89 @@ func TestSpanStatusBindsTheColumnCodes(t *testing.T) {
 		KeyName:  "span_status",
 		Operator: OperatorIn,
 		Values:   []Value{{Text: "cancelled"}},
+	}); err == nil {
+		t.Error("want a status name the column does not store refused")
+	}
+}
+
+func TestBugReportsEntityOffersEveryBugReportKey(t *testing.T) {
+	byName := IndexKeysByName(BugReportsEntity.Keys)
+
+	wanted := []string{
+		"version_name", "version_code",
+		"bug_report_status", "user_id", "bug_report_description", "session_id",
+		"os_name", "os_version",
+		"device_name", "device_manufacturer", "locale",
+		"network_type", "network_generation", "network_provider",
+		"country",
+	}
+	for _, name := range wanted {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("want a %q key on the bug reports entity", name)
+		}
+	}
+	if len(BugReportsEntity.Keys) != len(wanted) {
+		t.Errorf("want %d bug report keys, got %d", len(wanted), len(BugReportsEntity.Keys))
+	}
+}
+
+func TestBugReportsBindKeyRefusesAKeyTheEntityDoesNotHave(t *testing.T) {
+	_, err := BugReportsEntity.BindKey(Condition{
+		KeyName:  "span_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "error"}},
+	})
+
+	if err == nil {
+		t.Fatal("want a key the bug reports entity does not have refused")
+	}
+	if !strings.Contains(err.Error(), "span_status") {
+		t.Errorf("want the key named, got %q", err)
+	}
+}
+
+func TestBugReportStatusBindsTheColumnCodes(t *testing.T) {
+	stmt, err := BugReportsEntity.BindKey(Condition{
+		KeyName:  "bug_report_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "open"}, {Text: "closed"}},
+	})
+	if err != nil {
+		t.Fatalf("bind bug_report_status: %v", err)
+	}
+	defer stmt.Close()
+
+	if got := stmt.String(); got != "status in ?" {
+		t.Errorf("want the status column compared, got %q", got)
+	}
+	args := stmt.Args()
+	if len(args) != 1 {
+		t.Fatalf("want one bound argument, got %v", args)
+	}
+	if got, ok := args[0].([]uint8); !ok || !slices.Equal(got, []uint8{0, 1}) {
+		t.Errorf("want the codes [0 1] bound, got %v", args[0])
+	}
+
+	notIn, err := BugReportsEntity.BindKey(Condition{
+		KeyName:  "bug_report_status",
+		Operator: OperatorNotIn,
+		Values:   []Value{{Text: "closed"}},
+	})
+	if err != nil {
+		t.Fatalf("bind bug_report_status not_in: %v", err)
+	}
+	defer notIn.Close()
+	if got := notIn.String(); got != "status not in ?" {
+		t.Errorf("want the status column excluded, got %q", got)
+	}
+	if got, ok := notIn.Args()[0].([]uint8); !ok || !slices.Equal(got, []uint8{1}) {
+		t.Errorf("want the code [1] bound, got %v", notIn.Args()[0])
+	}
+
+	if _, err := BugReportsEntity.BindKey(Condition{
+		KeyName:  "bug_report_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "resolved"}},
 	}); err == nil {
 		t.Error("want a status name the column does not store refused")
 	}

--- a/backend/libs/exprfilter/exprfilter.go
+++ b/backend/libs/exprfilter/exprfilter.go
@@ -130,6 +130,12 @@ func (ef *ExprFilter) Validate() error {
 		return fmt.Errorf("`plot_time_group` must be one of: %s", strings.Join(plotTimeGroups, ", "))
 	}
 
+	if ef.Timezone != "" {
+		if _, err := time.LoadLocation(ef.Timezone); err != nil {
+			return fmt.Errorf("`timezone` must be a valid IANA time zone name, got %q", ef.Timezone)
+		}
+	}
+
 	if !ef.HasFilterExpr() {
 		return nil
 	}

--- a/backend/libs/exprfilter/exprfilter_test.go
+++ b/backend/libs/exprfilter/exprfilter_test.go
@@ -57,6 +57,23 @@ func TestExprFilterValidate(t *testing.T) {
 			wantErr: "App id",
 		},
 		{
+			name: "a valid timezone",
+			build: func() *ExprFilter {
+				ef := base()
+				ef.Timezone = "Asia/Kolkata"
+				return ef
+			},
+		},
+		{
+			name: "a timezone ClickHouse would reject",
+			build: func() *ExprFilter {
+				ef := base()
+				ef.Timezone = "EST5"
+				return ef
+			},
+			wantErr: "`timezone`",
+		},
+		{
 			name: "only one end of the time range",
 			build: func() *ExprFilter {
 				ef := base()

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -25,7 +25,7 @@ var SpansEntity = Entity{
 	SuggestKeyValues:      fetchSpansKeySuggestions,
 	FetchCustomKeys:       fetchSpanCustomKeys,
 	FetchCustomKeysByName: fetchSpanCustomKeysByName,
-	BindCustomKeys:        bindCustomConditionsToMembership("span_user_def_attrs", "span_id"),
+	BindCustomKeys:        bindCustomConditionsToMembership("span_user_def_attrs", "span_id", ""),
 	// span_metrics groups spans into 15-minute buckets by start time. A query
 	// can therefore include spans whose bucket extends past the range end.
 	MaxTimeBucketWidth: 15 * time.Minute,

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -293,7 +293,7 @@ func fetchSpanCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool
 // of distinct keys and values like the span_filters rollupthat fixed keys read.
 func spanCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
 	return sqlf.
-		From("span_user_def_attrs final").
+		From("span_user_def_attrs").
 		Select("key").
 		Select("argMax(type, timestamp) as type").
 		Where("team_id = toUUID(?)", teamID).

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -327,7 +327,7 @@ func fetchSpanCustomKeySuggestions(ctx context.Context, chPool driver.Conn, team
 		Where("type = ?", string(key.ValueType)).
 		Where("value <> ''").
 		GroupBy("value").
-		OrderBy("recency desc").
+		OrderBy("recency desc, value").
 		Limit(limit + 1)
 
 	defer stmt.Close()

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -2562,9 +2562,9 @@ func (a App) GetTrace(ctx context.Context, rch driver.Conn, traceId string) (tra
 	return
 }
 
-// GetBugReportsWithFilter provides bug reports that matches various
-// filter criteria in a paginated fashion.
-func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *filter.AppFilter) (bugReports []BugReportDisplay, next, previous bool, err error) {
+// GetBugReportsWithFilter provides bug reports that match the filter
+// expression, newest first, in a paginated fashion.
+func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter) (bugReports []BugReportDisplay, next, previous bool, err error) {
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
 	stmt := sqlf.
 		From("bug_reports final").
@@ -2584,114 +2584,28 @@ func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *f
 		Select("user_id").
 		Where("team_id = toUUID(?)", a.TeamId).
 		Where("app_id = toUUID(?)", a.ID).
-		Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
+		Where("timestamp >= ? and timestamp <= ?", ef.From, ef.To)
 
 	defer stmt.Close()
 
-	if af.HasVersions() {
-		stmt.Where("app_version.1 in ?", af.Versions)
-		stmt.Where("app_version.2 in ?", af.VersionCodes)
-	}
-
-	if af.Limit > 0 {
-		stmt.Limit(uint64(af.Limit) + 1)
-	}
-
-	if af.Offset >= 0 {
-		stmt.Offset(uint64(af.Offset))
-	}
-
-	if af.HasBugReportStatuses() {
-		stmt.Where("status").In(af.BugReportStatuses)
-	}
-
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err != nil {
-			return bugReports, next, previous, err
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(nil)
+		if errPredicate != nil {
+			err = errPredicate
+			return
 		}
-
-		stmt.Where("os_version in (?)", selectedOSVersions.Parameterize())
-	}
-
-	if af.HasCountries() {
-		stmt.Where("country_code in ?", af.Countries)
-	}
-
-	if af.HasNetworkProviders() {
-		stmt.Where("network_provider in ?", af.NetworkProviders)
-	}
-
-	if af.HasNetworkTypes() {
-		stmt.Where("network_type in ?", af.NetworkTypes)
-	}
-
-	if af.HasNetworkGenerations() {
-		stmt.Where("network_generation in ?", af.NetworkGenerations)
-	}
-
-	if af.HasDeviceLocales() {
-		stmt.Where("device_locale in ?", af.Locales)
-	}
-
-	if af.HasDeviceManufacturers() {
-		stmt.Where("device_manufacturer in ?", af.DeviceManufacturers)
-	}
-
-	if af.HasDeviceNames() {
-		stmt.Where("device_name in ?", af.DeviceNames)
-	}
-
-	if af.HasUDExpression() && !af.UDExpression.Empty() {
-		subQuery := sqlf.
-			From("user_def_attrs").
-			Select("event_id").
-			Where("team_id = toUUID(?)", a.TeamId).
-			Where("app_id = toUUID(?)", a.ID).
-			Where("bug_report = true").
-			Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
-
-		if af.HasVersions() {
-			subQuery.
-				Where("app_version.1 in ?", af.Versions).
-				Where("app_version.2 in ?", af.VersionCodes)
-		}
-
-		if af.HasOSVersions() {
-			selectedOSVersions, errVersions := af.OSVersionPairs()
-			if err != nil {
-				err = errVersions
-				return
-			}
-
-			subQuery.
-				Where("os_version in (?)", selectedOSVersions.Parameterize())
-		}
-
-		af.UDExpression.Augment(subQuery)
-		subQuery.GroupBy("event_id")
-		stmt.SubQuery("event_id in (", ")", subQuery)
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
 	}
 
 	stmt.OrderBy("timestamp desc")
 
-	if af.HasFreeText() {
-		partial := fmt.Sprintf("%%%s%%", af.FreeText)
+	if ef.Limit > 0 {
+		stmt.Limit(uint64(ef.Limit) + 1)
+	}
 
-		stmtMatch := sqlf.
-			New("").
-			SubQuery("(", ")", sqlf.
-				New("").
-				Clause("user_id ilike ?", af.FreeText).
-				Clause("or").
-				Clause("toString(event_id) ilike ?", af.FreeText).
-				Clause("or").
-				Clause("toString(session_id) ilike ?", af.FreeText).
-				Clause("or").
-				Clause("description ilike ?", partial),
-			)
-
-		stmt.Where(stmtMatch.String(), stmtMatch.Args()...)
+	if ef.Offset >= 0 {
+		stmt.Offset(uint64(ef.Offset))
 	}
 
 	rows, err := rch.Query(ctx, stmt.String(), stmt.Args()...)
@@ -2699,11 +2613,13 @@ func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *f
 		return
 	}
 
+	defer rows.Close()
+
 	for rows.Next() {
 		var bugReport BugReportDisplay
 		bugReport.BugReport = new(BugReport)
 		bugReport.Attribute = new(event.Attribute)
-		bugReport.AppID = af.AppID
+		bugReport.AppID = ef.AppID
 
 		dest := []any{
 			&bugReport.EventID,
@@ -2727,9 +2643,6 @@ func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *f
 			return
 		}
 
-		// set matched free text results
-		bugReport.MatchedFreeText = extractMatches(af.FreeText, bugReport.Attribute.UserID, bugReport.EventID.String(), bugReport.SessionID.String(), bugReport.Description)
-
 		bugReports = append(bugReports, bugReport)
 	}
 
@@ -2738,11 +2651,11 @@ func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *f
 	resultLen := len(bugReports)
 
 	// Set pagination next & previous flags
-	if resultLen > af.Limit {
+	if resultLen > ef.Limit {
 		bugReports = bugReports[:resultLen-1]
 		next = true
 	}
-	if af.Offset > 0 {
+	if ef.Offset > 0 {
 		previous = true
 	}
 
@@ -2750,18 +2663,20 @@ func (a App) GetBugReportsWithFilter(ctx context.Context, rch driver.Conn, af *f
 }
 
 // GetBugReportInstancesPlot provides aggregated bug report instances
-// matching various filters.
-func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, af *filter.AppFilter) (bugReportInstances []BugReportInstance, err error) {
+// matching the filter expression.
+func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter) (bugReportInstances []BugReportInstance, err error) {
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
-	if af.Timezone == "" {
-		return nil, errors.New("missing timezone filter")
+	if ef.Timezone == "" {
+		err = fmt.Errorf("timezone is required")
+		return
 	}
 
-	if !af.HasPlotTimeGroup() {
-		af.SetDefaultPlotTimeGroup()
+	plotTimeGroup := ef.PlotTimeGroup
+	if plotTimeGroup == "" {
+		plotTimeGroup = exprfilter.PlotTimeGroupDays
 	}
 
-	groupExpr, err := GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	groupExpr, err := GetPlotTimeGroupExpr("timestamp", plotTimeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -2772,102 +2687,15 @@ func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, af 
 		Select("timestamp").
 		Where("team_id = toUUID(?)", a.TeamId).
 		Where("app_id = toUUID(?)", a.ID).
-		Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
+		Where("timestamp >= ? and timestamp <= ?", ef.From, ef.To)
 
-	if af.HasVersions() {
-		base.Where("app_version.1 in ?", af.Versions)
-		base.Where("app_version.2 in ?", af.VersionCodes)
-	}
-
-	if af.HasBugReportStatuses() {
-		base.Where("status").In(af.BugReportStatuses)
-	}
-
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err != nil {
-			return nil, err
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(nil)
+		if errPredicate != nil {
+			return nil, errPredicate
 		}
-
-		base.Where("os_version in (?)", selectedOSVersions.Parameterize())
-	}
-
-	if af.HasCountries() {
-		base.Where("country_code in ?", af.Countries)
-	}
-
-	if af.HasNetworkProviders() {
-		base.Where("network_provider in ?", af.NetworkProviders)
-	}
-
-	if af.HasNetworkTypes() {
-		base.Where("network_type in ?", af.NetworkTypes)
-	}
-
-	if af.HasNetworkGenerations() {
-		base.Where("network_generation in ?", af.NetworkGenerations)
-	}
-
-	if af.HasDeviceLocales() {
-		base.Where("device_locale in ?", af.Locales)
-	}
-
-	if af.HasDeviceManufacturers() {
-		base.Where("device_manufacturer in ?", af.DeviceManufacturers)
-	}
-
-	if af.HasDeviceNames() {
-		base.Where("device_name in ?", af.DeviceNames)
-	}
-
-	if af.HasFreeText() {
-		partial := fmt.Sprintf("%%%s%%", af.FreeText)
-
-		stmtMatch := sqlf.
-			New("").
-			SubQuery("(", ")", sqlf.
-				New("").
-				Clause("user_id ilike ?", af.FreeText).
-				Clause("or").
-				Clause("toString(event_id) ilike ?", af.FreeText).
-				Clause("or").
-				Clause("toString(session_id) ilike ?", af.FreeText).
-				Clause("or").
-				Clause("description ilike ?", partial),
-			)
-
-		base.Where(stmtMatch.String(), stmtMatch.Args()...)
-	}
-
-	if af.HasUDExpression() && !af.UDExpression.Empty() {
-		subQuery := sqlf.
-			From("user_def_attrs").
-			Select("event_id").
-			Where("team_id = toUUID(?)", a.TeamId).
-			Where("app_id = toUUID(?)", a.ID).
-			Where("bug_report = true").
-			Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
-
-		if af.HasVersions() {
-			subQuery.
-				Where("app_version.1 in ?", af.Versions).
-				Where("app_version.2 in ?", af.VersionCodes)
-		}
-
-		if af.HasOSVersions() {
-			selectedOSVersions, errVersions := af.OSVersionPairs()
-			if err != nil {
-				err = errVersions
-				return
-			}
-
-			subQuery.
-				Where("os_version in (?)", selectedOSVersions.Parameterize())
-		}
-
-		af.UDExpression.Augment(subQuery)
-		subQuery.GroupBy("event_id")
-		base.SubQuery("event_id in (", ")", subQuery)
+		defer predicate.Close()
+		base.Where(predicate.String(), predicate.Args()...)
 	}
 
 	base.OrderBy("timestamp desc")
@@ -2879,7 +2707,7 @@ func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, af 
 		With("base", base).
 		From("base").
 		Select("uniq(event_id) instances").
-		Select(groupExpr.BucketExpr+" as datetime_bucket", af.Timezone).
+		Select(groupExpr.BucketExpr+" as datetime_bucket", ef.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", groupExpr.DatetimeFormat).
 		Select("concat(tupleElement(app_version, 1), ' ', '(', tupleElement(app_version, 2), ')') app_version_fmt").
 		GroupBy("app_version, datetime_bucket").
@@ -2891,6 +2719,7 @@ func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, af 
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var bugReportInstance BugReportInstance

--- a/backend/libs/measure/bugreport.go
+++ b/backend/libs/measure/bugreport.go
@@ -1,8 +1,6 @@
 package measure
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"backend/libs/event"
@@ -29,7 +27,6 @@ type BugReport struct {
 // wrapper over BugReport for display purposes.
 type BugReportDisplay struct {
 	*BugReport
-	MatchedFreeText string `json:"matched_free_text"`
 }
 
 // BugReportInstance represents an entity
@@ -49,38 +46,4 @@ type BugReportStatusUpdatePayload struct {
 	// pointer differentiates between 0 and nil, to validate
 	// non-existant status.
 	Status *uint8 `json:"status" binding:"required"`
-}
-
-// ExtractMatches extracts matching text from
-// bug report's various fields.
-func extractMatches(needle, userId, eventId, sessionId, description string) (matched string) {
-	if needle == "" {
-		return
-	}
-
-	buff := []string{}
-
-	// user id
-	if strings.Contains(strings.ToLower(userId), strings.ToLower(needle)) {
-		buff = append(buff, fmt.Sprintf("User Id: %s", userId))
-	}
-
-	// event id
-	if strings.Contains(strings.ToLower(eventId), strings.ToLower(needle)) {
-		buff = append(buff, fmt.Sprintf("Bug Report Id: %s", eventId))
-	}
-
-	// session id
-	if strings.Contains(strings.ToLower(sessionId), strings.ToLower(needle)) {
-		buff = append(buff, fmt.Sprintf("Session Id: %s", sessionId))
-	}
-
-	// description
-	if strings.Contains(strings.ToLower(description), strings.ToLower(needle)) {
-		buff = append(buff, fmt.Sprintf("Description: %s", description))
-	}
-
-	matched = strings.Join(buff, " ")
-
-	return
 }

--- a/backend/libs/measure/bugreport_test.go
+++ b/backend/libs/measure/bugreport_test.go
@@ -1,0 +1,382 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/libs/exprfilter"
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+type bugReportFixture struct {
+	spanFixture
+	openEventID     uuid.UUID
+	openSessionID   uuid.UUID
+	closedEventID   uuid.UUID
+	closedSessionID uuid.UUID
+}
+
+// newBugReportFixture seeds two bug reports for one app: an open report from
+// alice on version v1 on an Android Google Pixel, and ten minutes later a
+// closed report from bob on version v2 on an iOS Apple iPhone. A report of
+// another app is seeded too, which every query must leave out.
+func newBugReportFixture(t *testing.T) (bugReportFixture, time.Time) {
+	t.Helper()
+
+	f := bugReportFixture{
+		openEventID:     uuid.New(),
+		openSessionID:   uuid.New(),
+		closedEventID:   uuid.New(),
+		closedSessionID: uuid.New(),
+	}
+
+	ctx := context.Background()
+	cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	otherAppID := uuid.New()
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+		EventID:            f.openEventID.String(),
+		SessionID:          f.openSessionID.String(),
+		Status:             0,
+		Description:        "checkout button does nothing",
+		Timestamp:          base,
+		AppVersion:         "v1",
+		AppBuild:           "1",
+		UserID:             "alice",
+		DeviceManufacturer: "Google",
+		DeviceName:         "pixel 4a",
+	})
+	th.SeedBugReportRow(ctx, t, teamID.String(), appID.String(), testinfra.BugReportRow{
+		EventID:            f.closedEventID.String(),
+		SessionID:          f.closedSessionID.String(),
+		Status:             1,
+		Description:        "app freezes on login",
+		Timestamp:          base.Add(10 * time.Minute),
+		AppVersion:         "v2",
+		AppBuild:           "2",
+		OSName:             "iOS",
+		OSVersion:          "17.4",
+		UserID:             "bob",
+		DeviceManufacturer: "Apple",
+		DeviceName:         "iPhone 15",
+	})
+	th.SeedBugReportRow(ctx, t, teamID.String(), otherAppID.String(), testinfra.BugReportRow{
+		Timestamp:   base,
+		Description: "another app report",
+	})
+
+	f.spanFixture = spanFixture{
+		ctx:    ctx,
+		teamID: teamID,
+		appID:  appID,
+		app:    App{ID: &appID, TeamId: teamID},
+	}
+	return f, base
+}
+
+func (f bugReportFixture) exprFilter(from, to time.Time, exprTree *exprfilter.ExprTree) *exprfilter.ExprFilter {
+	ef := f.spanFixture.exprFilter(from, to, exprTree)
+	ef.Entity = exprfilter.BugReportsEntity
+	return ef
+}
+
+func bugReportVersions(t *testing.T, ef *exprfilter.ExprFilter, f bugReportFixture) []string {
+	t.Helper()
+	bugReports, _, _, err := f.app.GetBugReportsWithFilter(f.ctx, deps.RchPool, ef)
+	if err != nil {
+		t.Fatalf("GetBugReportsWithFilter: %v", err)
+	}
+	versions := make([]string, len(bugReports))
+	for i, bugReport := range bugReports {
+		versions[i] = bugReport.Attribute.AppVersion
+	}
+	return versions
+}
+
+func TestGetBugReportsWithFilter(t *testing.T) {
+	f, base := newBugReportFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	t.Run("no filter returns the app's reports newest first", func(t *testing.T) {
+		got := bugReportVersions(t, f.exprFilter(from, to, nil), f)
+		if len(got) != 2 || got[0] != "v2" || got[1] != "v1" {
+			t.Fatalf("want [v2 v1], got %v", got)
+		}
+	})
+
+	t.Run("status filter translates names to codes", func(t *testing.T) {
+		exprTree := leaf("bug_report_status", exprfilter.OperatorIn, "open")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want the open report [v1], got %v", got)
+		}
+
+		exprTree = leaf("bug_report_status", exprfilter.OperatorIn, "closed")
+		got = bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want the closed report [v2], got %v", got)
+		}
+
+		exprTree = leaf("bug_report_status", exprfilter.OperatorIn, "open", "closed")
+		got = bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 2 {
+			t.Fatalf("want both reports, got %v", got)
+		}
+	})
+
+	t.Run("version filter", func(t *testing.T) {
+		exprTree := leaf("version_name", exprfilter.OperatorIn, "v1")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("os name filter reads the version tuple", func(t *testing.T) {
+		exprTree := leaf("os_name", exprfilter.OperatorIn, "iOS")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("description substring match", func(t *testing.T) {
+		exprTree := leaf("bug_report_description", exprfilter.OperatorContains, "freezes")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+
+		exprTree = leaf("bug_report_description", exprfilter.OperatorNotContains, "freezes")
+		got = bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("user id filter", func(t *testing.T) {
+		exprTree := leaf("user_id", exprfilter.OperatorIn, "alice")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("session id filter binds the uuid column", func(t *testing.T) {
+		exprTree := leaf("session_id", exprfilter.OperatorIn, f.openSessionID.String())
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+
+		exprTree = leaf("session_id", exprfilter.OperatorNotIn, f.openSessionID.String())
+		got = bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("or group matches either side", func(t *testing.T) {
+		exprTree := exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalOr, Children: []exprfilter.ExprTree{
+			leaf("user_id", exprfilter.OperatorIn, "alice"),
+			leaf("bug_report_status", exprfilter.OperatorIn, "closed"),
+		}}
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 2 {
+			t.Fatalf("want both reports, got %v", got)
+		}
+	})
+
+	t.Run("a filter matching nothing", func(t *testing.T) {
+		exprTree := leaf("network_type", exprfilter.OperatorIn, "vpn")
+		got := bugReportVersions(t, f.exprFilter(from, to, &exprTree), f)
+		if len(got) != 0 {
+			t.Fatalf("want no reports, got %v", got)
+		}
+	})
+
+	t.Run("pagination flags", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.Limit = 1
+
+		bugReports, next, previous, err := f.app.GetBugReportsWithFilter(f.ctx, deps.RchPool, ef)
+		if err != nil {
+			t.Fatalf("GetBugReportsWithFilter: %v", err)
+		}
+		if len(bugReports) != 1 || !next || previous {
+			t.Fatalf("want the first page with more to come, got %d reports next=%v previous=%v", len(bugReports), next, previous)
+		}
+
+		ef.Offset = 1
+		bugReports, next, previous, err = f.app.GetBugReportsWithFilter(f.ctx, deps.RchPool, ef)
+		if err != nil {
+			t.Fatalf("GetBugReportsWithFilter: %v", err)
+		}
+		if len(bugReports) != 1 || next || !previous {
+			t.Fatalf("want the last page with one before it, got %d reports next=%v previous=%v", len(bugReports), next, previous)
+		}
+	})
+}
+
+func bugReportPlotVersions(t *testing.T, ef *exprfilter.ExprFilter, f bugReportFixture) map[string]bool {
+	t.Helper()
+	items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef)
+	if err != nil {
+		t.Fatalf("GetBugReportInstancesPlot: %v", err)
+	}
+	versions := map[string]bool{}
+	for _, item := range items {
+		versions[item.Version] = true
+	}
+	return versions
+}
+
+func TestGetBugReportInstancesPlotWithExprFilter(t *testing.T) {
+	f, base := newBugReportFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	plot := func(t *testing.T, exprTree *exprfilter.ExprTree, plotTimeGroup string) map[string]bool {
+		t.Helper()
+		ef := f.exprFilter(from, to, exprTree)
+		ef.PlotTimeGroup = plotTimeGroup
+		return bugReportPlotVersions(t, ef, f)
+	}
+
+	t.Run("no filter returns one series per version", func(t *testing.T) {
+		got := plot(t, nil, exprfilter.PlotTimeGroupDays)
+		if len(got) != 2 || !got["v1 (1)"] || !got["v2 (2)"] {
+			t.Fatalf("want v1 (1) and v2 (2), got %v", got)
+		}
+	})
+
+	t.Run("status filter translates names to codes", func(t *testing.T) {
+		exprTree := leaf("bug_report_status", exprfilter.OperatorIn, "open")
+		got := plot(t, &exprTree, exprfilter.PlotTimeGroupDays)
+		if len(got) != 1 || !got["v1 (1)"] {
+			t.Fatalf("want only v1 (1), got %v", got)
+		}
+	})
+
+	t.Run("an empty plot time group defaults to days", func(t *testing.T) {
+		got := plot(t, nil, "")
+		if len(got) != 2 {
+			t.Fatalf("want both versions, got %v", got)
+		}
+	})
+
+	t.Run("missing timezone returns an error", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.Timezone = ""
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef); err == nil {
+			t.Fatal("want an error for a missing timezone")
+		}
+	})
+
+	t.Run("unsupported plot time group returns an error", func(t *testing.T) {
+		ef := f.exprFilter(from, to, nil)
+		ef.PlotTimeGroup = "weeks"
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef); err == nil {
+			t.Fatal("want an error for an unsupported plot time group")
+		}
+	})
+}
+
+func TestGetBugReportsWithCustomKeys(t *testing.T) {
+	f, base := newBugReportFixture(t)
+	from, to := base.Add(-time.Hour), base.Add(time.Hour)
+
+	th.SeedUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.UDAttrRow{
+		EventID: f.openEventID.String(), BugReport: true,
+		Key: "plan", Value: "pro", Timestamp: base,
+	})
+	th.SeedUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.UDAttrRow{
+		EventID: f.closedEventID.String(), BugReport: true,
+		Key: "plan", Value: "free", AppVersion: "v2", AppBuild: "2", Timestamp: base.Add(10 * time.Minute),
+	})
+	th.SeedUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.UDAttrRow{
+		EventID: f.openEventID.String(), BugReport: true,
+		Key: "retries", Type: "int64", Value: "9", Timestamp: base,
+	})
+	// A session attribute on the closed report's event with the same key and
+	// value as the open report's. Its row is not flagged bug_report, so it
+	// must never pull the closed report into a result.
+	th.SeedUDAttrRow(f.ctx, t, f.teamID.String(), f.appID.String(), testinfra.UDAttrRow{
+		EventID: f.closedEventID.String(), BugReport: false,
+		Key: "plan", Value: "pro", AppVersion: "v2", AppBuild: "2", Timestamp: base.Add(10 * time.Minute),
+	})
+
+	listVersions := func(t *testing.T, exprTree exprfilter.ExprTree) []string {
+		t.Helper()
+		ef := f.exprFilter(from, to, &exprTree)
+		resolveCustomKeys(t, ef)
+		return bugReportVersions(t, ef, f)
+	}
+
+	t.Run("string value narrows to its report", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.plan", exprfilter.OperatorIn, "free"))
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("a non-bug-report attribute row does not leak in", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.plan", exprfilter.OperatorIn, "pro"))
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want only the open report [v1], got %v", got)
+		}
+	})
+
+	t.Run("numbers compare as numbers", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.retries", exprfilter.OperatorGt, "5"))
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("is_not_set matches reports without the attribute", func(t *testing.T) {
+		got := listVersions(t, leaf("custom.retries", exprfilter.OperatorIsNotSet))
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("a custom key beside a built-in key", func(t *testing.T) {
+		got := listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "pro", "free"),
+			leaf("bug_report_status", exprfilter.OperatorIn, "closed"),
+		}})
+		if len(got) != 1 || got[0] != "v2" {
+			t.Fatalf("want [v2], got %v", got)
+		}
+	})
+
+	t.Run("two custom conditions under and share one scan", func(t *testing.T) {
+		got := listVersions(t, exprfilter.ExprTree{LogicalOperator: exprfilter.LogicalAnd, Children: []exprfilter.ExprTree{
+			leaf("custom.plan", exprfilter.OperatorIn, "pro"),
+			leaf("custom.retries", exprfilter.OperatorGt, "5"),
+		}})
+		if len(got) != 1 || got[0] != "v1" {
+			t.Fatalf("want [v1], got %v", got)
+		}
+	})
+
+	t.Run("the plot narrows by the same membership", func(t *testing.T) {
+		exprTree := leaf("custom.plan", exprfilter.OperatorIn, "pro")
+		ef := f.exprFilter(from, to, &exprTree)
+		ef.PlotTimeGroup = exprfilter.PlotTimeGroupDays
+		resolveCustomKeys(t, ef)
+		got := bugReportPlotVersions(t, ef, f)
+		if len(got) != 1 || !got["v1 (1)"] {
+			t.Fatalf("want only v1 (1), got %v", got)
+		}
+	})
+}

--- a/backend/libs/measure/plot_test.go
+++ b/backend/libs/measure/plot_test.go
@@ -73,6 +73,19 @@ func (f plotFixture) spanExprFilter(from, to time.Time, timezone, plotTimeGroup 
 	}
 }
 
+func (f plotFixture) bugReportExprFilter(from, to time.Time, timezone, plotTimeGroup string) *exprfilter.ExprFilter {
+	return &exprfilter.ExprFilter{
+		AppID:         f.appID,
+		TeamID:        f.teamID,
+		Entity:        exprfilter.BugReportsEntity,
+		From:          from,
+		To:            to,
+		Timezone:      timezone,
+		Limit:         exprfilter.DefaultPaginationLimit,
+		PlotTimeGroup: plotTimeGroup,
+	}
+}
+
 func (f plotFixture) teamIDStr() string { return f.teamID.String() }
 func (f plotFixture) appIDStr() string  { return f.appID.String() }
 
@@ -181,7 +194,7 @@ func TestPlotMethodsGroupByPlotTimeGroup(t *testing.T) {
 					seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", ts)
 				}
 
-				items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+				items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, f.bugReportExprFilter(from, to, "UTC", tc.group))
 				if err != nil {
 					t.Fatalf("GetBugReportInstancesPlot: %v", err)
 				}
@@ -206,7 +219,7 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 		if _, err := f.app.GetSessionsInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
 			t.Fatalf("expected error for missing timezone in sessions plot")
 		}
-		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, f.bugReportExprFilter(now.Add(-time.Hour), now.Add(time.Hour), "", exprfilter.PlotTimeGroupDays)); err == nil {
 			t.Fatalf("expected error for missing timezone in bug report plot")
 		}
 	})
@@ -216,7 +229,7 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 		if _, err := f.app.GetSessionsInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
 			t.Fatalf("expected error for unsupported plot_time_group in sessions plot")
 		}
-		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af); err == nil {
+		if _, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, f.bugReportExprFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", "weeks")); err == nil {
 			t.Fatalf("expected error for unsupported plot_time_group in bug report plot")
 		}
 	})
@@ -240,7 +253,7 @@ func TestPlotMethodsValidationAndEmptyResults(t *testing.T) {
 			t.Fatalf("expected empty spans plot, got %d rows", len(spans))
 		}
 
-		bugReports, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+		bugReports, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, f.bugReportExprFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupDays))
 		if err != nil {
 			t.Fatalf("GetBugReportInstancesPlot: %v", err)
 		}
@@ -285,8 +298,8 @@ func TestNonExceptionPlotsRespectTimezoneBucketing(t *testing.T) {
 	t.Run("bug reports", func(t *testing.T) {
 		cleanupAll(f.ctx, t)
 		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "tz bug report", ts)
-		af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", filter.PlotTimeGroupDays)
-		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+		ef := f.bugReportExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "Asia/Kolkata", exprfilter.PlotTimeGroupDays)
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef)
 		if err != nil {
 			t.Fatalf("GetBugReportInstancesPlot: %v", err)
 		}
@@ -327,8 +340,8 @@ func TestPlotMethodsDefaultToDaysWhenPlotTimeGroupMissing(t *testing.T) {
 		cleanupAll(f.ctx, t)
 		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", t1)
 		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", t2)
-		af := f.appFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
-		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+		ef := f.bugReportExprFilter(t1.Add(-time.Hour), t2.Add(time.Hour), "UTC", "")
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef)
 		if err != nil {
 			t.Fatalf("GetBugReportInstancesPlot: %v", err)
 		}
@@ -346,11 +359,13 @@ func TestPlotMethodsRespectOptionalFilters(t *testing.T) {
 
 	t.Run("bug report status filter", func(t *testing.T) {
 		cleanupAll(f.ctx, t)
+		// seedBugReport writes the report closed.
 		seedBugReport(f.ctx, t, f.teamIDStr(), f.appIDStr(), uuid.New().String(), "test report", now)
 
-		af := f.appFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", filter.PlotTimeGroupDays)
-		af.BugReportStatuses = []int8{1}
-		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+		ef := f.bugReportExprFilter(now.Add(-time.Hour), now.Add(time.Hour), "UTC", exprfilter.PlotTimeGroupDays)
+		closedTree := leaf("bug_report_status", exprfilter.OperatorIn, "closed")
+		ef.ExprTree = &closedTree
+		items, err := f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef)
 		if err != nil {
 			t.Fatalf("GetBugReportInstancesPlot: %v", err)
 		}
@@ -358,8 +373,9 @@ func TestPlotMethodsRespectOptionalFilters(t *testing.T) {
 			t.Fatalf("expected non-empty bug report plot for matching status")
 		}
 
-		af.BugReportStatuses = []int8{0}
-		items, err = f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, af)
+		openTree := leaf("bug_report_status", exprfilter.OperatorIn, "open")
+		ef.ExprTree = &openTree
+		items, err = f.app.GetBugReportInstancesPlot(f.ctx, deps.RchPool, ef)
 		if err != nil {
 			t.Fatalf("GetBugReportInstancesPlot mismatch status: %v", err)
 		}

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -929,16 +929,188 @@ func (h *TestHelper) SeedLaunchEvent(ctx context.Context, t *testing.T, teamID, 
 	}
 }
 
-// SeedBugReport inserts a single bug report into the bug_reports table.
-func (h *TestHelper) SeedBugReport(ctx context.Context, t *testing.T, teamID, appID, eventID, description string, ts time.Time) {
+// BugReportRow describes one row to insert into the bug_reports table.
+// A zero Status is an open report.
+//
+// Zero-value fields fall back to defaults applied by (BugReportRow).filled:
+//   - Timestamp:  time.Now().UTC()
+//   - AppVersion: "v1", AppBuild: "b1"
+//   - OSName: "Android", OSVersion: "14"
+//   - EventID, SessionID: fresh per row
+//
+// The country, network, device and user attributes default to a Google Pixel
+// on Verizon wifi 4g in the US, locale en-US, user id "u1".
+type BugReportRow struct {
+	EventID            string
+	SessionID          string
+	Status             uint8
+	Description        string
+	Timestamp          time.Time
+	AppVersion         string
+	AppBuild           string
+	OSName             string
+	OSVersion          string
+	CountryCode        string
+	NetworkProvider    string
+	NetworkType        string
+	NetworkGeneration  string
+	DeviceLocale       string
+	DeviceManufacturer string
+	DeviceName         string
+	DeviceModel        string
+	UserID             string
+}
+
+func (r BugReportRow) filled() BugReportRow {
+	if r.EventID == "" {
+		r.EventID = uuid.New().String()
+	}
+	if r.SessionID == "" {
+		r.SessionID = uuid.New().String()
+	}
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now().UTC()
+	}
+	if r.AppVersion == "" {
+		r.AppVersion = "v1"
+	}
+	if r.AppBuild == "" {
+		r.AppBuild = "b1"
+	}
+	if r.OSName == "" {
+		r.OSName = "Android"
+	}
+	if r.OSVersion == "" {
+		r.OSVersion = "14"
+	}
+	if r.CountryCode == "" {
+		r.CountryCode = "US"
+	}
+	if r.NetworkProvider == "" {
+		r.NetworkProvider = "Verizon"
+	}
+	if r.NetworkType == "" {
+		r.NetworkType = "wifi"
+	}
+	if r.NetworkGeneration == "" {
+		r.NetworkGeneration = "4g"
+	}
+	if r.DeviceLocale == "" {
+		r.DeviceLocale = "en-US"
+	}
+	if r.DeviceManufacturer == "" {
+		r.DeviceManufacturer = "Google"
+	}
+	if r.DeviceName == "" {
+		r.DeviceName = "Pixel"
+	}
+	if r.DeviceModel == "" {
+		r.DeviceModel = "Pixel 6"
+	}
+	if r.UserID == "" {
+		r.UserID = "u1"
+	}
+	return r
+}
+
+// SeedBugReportRow inserts one row described by row into the bug_reports
+// table.
+func (h *TestHelper) SeedBugReportRow(ctx context.Context, t *testing.T, teamID, appID string, row BugReportRow) {
 	t.Helper()
-	query := fmt.Sprintf(`
+	row = row.filled()
+	ts := row.Timestamp.UTC()
+	query := `
 		INSERT INTO measure.bug_reports
 		(team_id, event_id, app_id, session_id, timestamp, updated_at, status, description, app_version, os_version, country_code, network_provider, network_type, network_generation, device_locale, device_manufacturer, device_name, device_model, user_id, device_low_power_mode, device_thermal_throttling_enabled, user_defined_attribute, attachments)
-		VALUES (toUUID('%s'), '%s', '%s', '%s', '%s', '%s', 1, '%s', ('v1', 'b1'), ('Android', '14'), 'US', 'Verizon', 'wifi', '4g', 'en-US', 'Google', 'Pixel', 'Pixel 6', 'u1', false, false, map('test', (1, 'val')), '[]')`,
-		teamID, eventID, appID, uuid.New().String(), ts.UTC().Format("2006-01-02 15:04:05"), ts.UTC().Format("2006-01-02 15:04:05"), description)
-	if err := h.ChConn.Exec(ctx, query); err != nil {
+		VALUES (toUUID(?), ?, ?, ?, ?, ?, ?, ?, (?, ?), (?, ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, false, false, map('test', (1, 'val')), '[]')`
+	if err := h.ChConn.Exec(ctx, query,
+		teamID, row.EventID, appID, row.SessionID, ts, ts, row.Status, row.Description,
+		row.AppVersion, row.AppBuild, row.OSName, row.OSVersion,
+		row.CountryCode, row.NetworkProvider, row.NetworkType, row.NetworkGeneration,
+		row.DeviceLocale, row.DeviceManufacturer, row.DeviceName, row.DeviceModel, row.UserID); err != nil {
 		t.Fatalf("seed bug report: %v", err)
+	}
+}
+
+// SeedBugReport inserts a single closed bug report into the bug_reports table
+// with default attributes.
+func (h *TestHelper) SeedBugReport(ctx context.Context, t *testing.T, teamID, appID, eventID, description string, ts time.Time) {
+	t.Helper()
+	h.SeedBugReportRow(ctx, t, teamID, appID, BugReportRow{
+		EventID:     eventID,
+		Status:      1,
+		Description: description,
+		Timestamp:   ts,
+	})
+}
+
+// UDAttrRow describes one row to insert into the user_def_attrs table: one
+// user-defined attribute of one event. Values of every type are stored as
+// text in the one value column, with Type naming which of "string", "int64",
+// "float64" or "bool" the text holds. BugReport marks the row as coming from
+// a bug report event.
+//
+// Zero-value fields fall back to defaults:
+//   - Type:       "string"
+//   - Timestamp:  time.Now().UTC()
+//   - AppVersion: "v1", AppBuild: "b1"
+//   - OSName: "Android", OSVersion: "14"
+//   - EventID, SessionID: fresh per row
+//
+// Pin EventID to attach the attribute to an event seeded with the same id.
+type UDAttrRow struct {
+	EventID    string
+	SessionID  string
+	BugReport  bool
+	Key        string
+	Type       string
+	Value      string
+	Timestamp  time.Time
+	AppVersion string
+	AppBuild   string
+	OSName     string
+	OSVersion  string
+}
+
+// SeedUDAttrRow inserts one row described by row into the user_def_attrs
+// table.
+func (h *TestHelper) SeedUDAttrRow(ctx context.Context, t *testing.T, teamID, appID string, row UDAttrRow) {
+	t.Helper()
+
+	if row.EventID == "" {
+		row.EventID = uuid.New().String()
+	}
+	if row.SessionID == "" {
+		row.SessionID = uuid.New().String()
+	}
+	if row.Type == "" {
+		row.Type = "string"
+	}
+	if row.Timestamp.IsZero() {
+		row.Timestamp = time.Now().UTC()
+	}
+	if row.AppVersion == "" {
+		row.AppVersion = "v1"
+	}
+	if row.AppBuild == "" {
+		row.AppBuild = "b1"
+	}
+	if row.OSName == "" {
+		row.OSName = "Android"
+	}
+	if row.OSVersion == "" {
+		row.OSVersion = "14"
+	}
+
+	query := `INSERT INTO measure.user_def_attrs
+		(team_id, app_id, event_id, session_id, app_version, os_version, bug_report, key, type, value, timestamp)
+		VALUES (?, ?, ?, ?, (?,?), (?,?), ?, ?, ?, ?, ?)`
+	if err := h.ChConn.Exec(ctx, query,
+		teamID, appID, row.EventID, row.SessionID,
+		row.AppVersion, row.AppBuild, row.OSName, row.OSVersion,
+		row.BugReport, row.Key, row.Type, row.Value,
+		row.Timestamp.UTC()); err != nil {
+		t.Fatalf("seed user-defined attribute (%s): %v", row.Key, err)
 	}
 }
 

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -25,7 +25,6 @@ jest.mock("@/app/utils/navigation", () => ({
 }));
 
 import {
-  BugReportStatus,
   buildShortFiltersPostBody,
   changeAppApiKeyFromServer,
   changeAppNameFromServer,
@@ -851,18 +850,6 @@ describe("sessions, bug reports, alerts", () => {
     expect(lastFetchUrl()).toBe("/api/apps/app-1/sessions/sess-1");
   });
 
-  it("fetchBugReportsOverviewFromServer includes path and filters", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
-    await fetchBugReportsOverviewFromServer(makeFilters(), 5, 0);
-    expect(lastFetchUrl()).toContain("/api/apps/app-a/bugReports");
-  });
-
-  it("fetchBugReportsOverviewPlotFromServer returns null on a null body", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    const r = await fetchBugReportsOverviewPlotFromServer(makeFilters());
-    expect(r).toBeNull();
-  });
-
   it("fetchBugReportFromServer returns the body on 200", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ bug: {} }));
     const r = await fetchBugReportFromServer("app-1", "bug-1");
@@ -1283,28 +1270,6 @@ describe("applyGenericFiltersToUrl filter branches", () => {
     expect(url).not.toContain("background=");
   });
 
-  it("appends bug_report_statuses for Open/Closed", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchBugReportsOverviewFromServer(
-      makeFilters({
-        bugReportStatuses: {
-          all: false,
-          selected: [BugReportStatus.Open, BugReportStatus.Closed],
-        },
-      }),
-      5,
-      0,
-    );
-    const url = lastFetchUrl();
-    // NOTE: fetchBugReportsOverviewFromServer calls both
-    // applyGenericFiltersToUrl (which appends bug_report_statuses) AND
-    // appendBugReportStatusesToUrl (which appends them again) — so each
-    // status shows up twice in the final URL. This is a duplication in
-    // api_calls.ts; pin the current behaviour here rather than the ideal.
-    expect(url).toContain("bug_report_statuses=0");
-    expect(url).toContain("bug_report_statuses=1");
-  });
-
   it("appends free_text when non-empty", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
     await fetchMetricsFromServer(makeFilters({ freeText: "search me" }));
@@ -1437,6 +1402,102 @@ describe("fetchSpanMetricsPlotFromServer", () => {
   });
 });
 
+describe("fetchBugReportsOverviewFromServer", () => {
+  const call = (filterExpr: string | null = null) =>
+    fetchBugReportsOverviewFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      filterExpr,
+      5,
+      10,
+    );
+
+  it("sends the range, timezone and page in the URL", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await call();
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/bugReports");
+    expect(url.searchParams.get("from")).toBe("2026-04-01T00:00:00.000Z");
+    expect(url.searchParams.get("to")).toBe("2026-04-10T00:00:00.000Z");
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    expect(url.searchParams.get("limit")).toBe("5");
+    expect(url.searchParams.get("offset")).toBe("10");
+    expect(url.searchParams.has("filter_expr")).toBe(false);
+    expect(url.searchParams.has("filter_short_code")).toBe(false);
+    expect(url.searchParams.has("bug_report_statuses")).toBe(false);
+    expect(url.searchParams.has("free_text")).toBe(false);
+  });
+
+  it("sends the filter expression when one is given", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
+    await call("bug_report_status:in:open");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe(
+      "bug_report_status:in:open",
+    );
+  });
+
+  it("returns data, throws on failure", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({ a: 1 }));
+    expect(await call()).toEqual({ a: 1 });
+
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(call()).rejects.toThrow(ApiError);
+
+    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+    await expect(call()).rejects.toThrow(RequestError);
+  });
+});
+
+describe("fetchBugReportsOverviewPlotFromServer", () => {
+  const call = (filterExpr: string | null = null) =>
+    fetchBugReportsOverviewPlotFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      filterExpr,
+    );
+
+  it("sends the range, timezone and time group in the URL", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
+    await call();
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/bugReports/plots/instances");
+    expect(url.searchParams.get("from")).toBe("2026-04-01T00:00:00.000Z");
+    expect(url.searchParams.get("to")).toBe("2026-04-10T00:00:00.000Z");
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    // A nine day range buckets by day.
+    expect(url.searchParams.get("plot_time_group")).toBe("days");
+    expect(url.searchParams.has("filter_expr")).toBe(false);
+  });
+
+  it("sends the filter expression when one is given", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
+    await call("bug_report_status:in:open");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe(
+      "bug_report_status:in:open",
+    );
+  });
+
+  it("returns null when response data is null", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
+    expect(await call()).toBeNull();
+  });
+
+  it("returns data, throws on failure", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse([{ id: "v1" }]));
+    expect(await call()).toEqual([{ id: "v1" }]);
+
+    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
+    await expect(call()).rejects.toThrow(ApiError);
+
+    mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
+    await expect(call()).rejects.toThrow(RequestError);
+  });
+});
+
 // ========================================================================
 // Failure paths for the fetch functions that didn't get them in the
 // happy-path tests above. Parameterized to keep it compact.
@@ -1462,11 +1523,25 @@ describe("fetch functions: failure paths", () => {
     ],
     [
       "fetchBugReportsOverviewFromServer",
-      () => fetchBugReportsOverviewFromServer(makeFilters(), 5, 0),
+      () =>
+        fetchBugReportsOverviewFromServer(
+          "app-a",
+          "2026-04-01T00:00:00.000Z",
+          "2026-04-10T00:00:00.000Z",
+          null,
+          5,
+          0,
+        ),
     ],
     [
       "fetchBugReportsOverviewPlotFromServer",
-      () => fetchBugReportsOverviewPlotFromServer(makeFilters()),
+      () =>
+        fetchBugReportsOverviewPlotFromServer(
+          "app-a",
+          "2026-04-01T00:00:00.000Z",
+          "2026-04-10T00:00:00.000Z",
+          null,
+        ),
     ],
     ["fetchBugReportFromServer", () => fetchBugReportFromServer("a", "b")],
     [
@@ -1665,13 +1740,6 @@ describe("additional branch coverage", () => {
     expect(url).not.toContain("background=");
   });
 
-  it("fetchBugReportsOverviewPlotFromServer throws on non-ok", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    await expect(
-      fetchBugReportsOverviewPlotFromServer(makeFilters()),
-    ).rejects.toThrow(ApiError);
-  });
-
   it("fetchUsageFromServer returns null on 404", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse(404));
     const r = await fetchUsageFromServer("t1");
@@ -1718,12 +1786,6 @@ describe("additional branch coverage", () => {
   it("OsVersion class passes through unknown OS name", async () => {
     const { OsVersion } = jest.requireActual("@/app/api/api_calls");
     expect(new OsVersion("windows", "11").displayName).toBe("windows 11");
-  });
-
-  it("fetchBugReportsOverviewPlotFromServer passes an empty body through", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    const r = await fetchBugReportsOverviewPlotFromServer(makeFilters());
-    expect(r).toEqual({});
   });
 
   it("createTeamFromServer throws the server message on non-ok", async () => {

--- a/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
+++ b/frontend/dashboard/__tests__/components/bug_reports_overview_plot_test.tsx
@@ -16,114 +16,81 @@ jest.mock("@/app/components/skeleton", () => ({
   SkeletonPlot: () => <div data-testid="skeleton-mock">loading</div>,
 }));
 
-const mockUseBugReportsOverviewPlotQuery = jest.fn(
-  (): { data: any; status: string; error: Error | null } => ({
+const plotDates = {
+  startDate: "2025-01-01T00:00:00Z",
+  endDate: "2025-12-31T00:00:00Z",
+};
+
+function queryWith(overrides: any) {
+  return {
     data: undefined,
     status: "pending",
     error: null,
-  }),
-);
-
-jest.mock("@/app/query/hooks", () => ({
-  __esModule: true,
-  useBugReportsOverviewPlotQuery: () => mockUseBugReportsOverviewPlotQuery(),
-}));
-
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
-});
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
-
-const filters = {
-  ready: true,
-  startDate: "2025-01-01T00:00:00Z",
-  endDate: "2025-12-31T00:00:00Z",
-} as any;
+    ...overrides,
+  } as any;
+}
 
 describe("BugReportsOverviewPlot", () => {
   beforeEach(() => {
     lastLineProps = null;
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "pending",
-      error: null,
-    });
   });
 
   it("renders error state", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "error",
-      error: new Error("test"),
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({ status: "error", error: new Error("test") })}
+      />,
+    );
     expect(await screen.findByText(/Error fetching plot/)).toBeInTheDocument();
   });
 
   it("renders no data state", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: null,
-      status: "success",
-      error: null,
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({ data: null, status: "success" })}
+      />,
+    );
     expect(await screen.findByText("No Data")).toBeInTheDocument();
-  });
-
-  it("does not fetch when filters are not ready", async () => {
-    useFiltersStore.setState({ filters: { ...filters, ready: false } });
-    render(<BugReportsOverviewPlot />);
-    // Query hook is called but TanStack Query handles the enabled flag internally
-    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenCalled();
+    expect(screen.getByTestId("bug-reports-plot-no-data")).toBeInTheDocument();
   });
 
   it("renders loading state before data is available", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "pending",
-      error: null,
-    });
-
-    render(<BugReportsOverviewPlot />);
+    render(<BugReportsOverviewPlot {...plotDates} query={queryWith({})} />);
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 
   it("maps API result shape to nivo data", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
-      status: "success",
-      error: null,
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({
+          data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
+          status: "success",
+        })}
+      />,
+    );
 
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
+    expect(screen.getByTestId("bug-reports-plot-data")).toBeInTheDocument();
     expect(lastLineProps.data[0].id).toBe("v1");
     expect(lastLineProps.data[0].data[0].y).toBe(2);
     expect(lastLineProps.axisLeft.legend).toBe("Bug Reports");
   });
 
   it("uses month-style axis formatting for long range", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [{ id: "v", data: [{ id: "v.0", x: "2025-02-01", y: 1 }] }],
-      status: "success",
-      error: null,
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({
+          data: [{ id: "v", data: [{ id: "v.0", x: "2025-02-01", y: 1 }] }],
+          status: "success",
+        })}
+      />,
+    );
 
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
@@ -132,20 +99,21 @@ describe("BugReportsOverviewPlot", () => {
   });
 
   it("uses minute/day configs for shorter ranges", async () => {
-    const minuteFilters = {
-      ...filters,
+    const minuteDates = {
       startDate: "2026-02-01T00:00:00Z",
       endDate: "2026-02-01T06:00:00Z",
     };
-    useFiltersStore.setState({ filters: minuteFilters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [
-        { id: "v", data: [{ id: "v.0", x: "2026-02-01T01:00:00", y: 1 }] },
-      ],
-      status: "success",
-      error: null,
-    });
-    const { unmount } = render(<BugReportsOverviewPlot />);
+    const { unmount } = render(
+      <BugReportsOverviewPlot
+        {...minuteDates}
+        query={queryWith({
+          data: [
+            { id: "v", data: [{ id: "v.0", x: "2026-02-01T01:00:00", y: 1 }] },
+          ],
+          status: "success",
+        })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -154,18 +122,19 @@ describe("BugReportsOverviewPlot", () => {
     unmount();
     lastLineProps = null;
 
-    const dayFilters = {
-      ...filters,
+    const dayDates = {
       startDate: "2026-01-01T00:00:00Z",
       endDate: "2026-03-30T00:00:00Z",
     };
-    useFiltersStore.setState({ filters: dayFilters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [{ id: "v", data: [{ id: "v.0", x: "2026-02-01", y: 1 }] }],
-      status: "success",
-      error: null,
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...dayDates}
+        query={queryWith({
+          data: [{ id: "v", data: [{ id: "v.0", x: "2026-02-01", y: 1 }] }],
+          status: "success",
+        })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -173,13 +142,15 @@ describe("BugReportsOverviewPlot", () => {
   });
 
   it("pluralizes tooltip labels for singular and plural", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
-      status: "success",
-      error: null,
-    });
-    render(<BugReportsOverviewPlot />);
+    render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({
+          data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
+          status: "success",
+        })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
@@ -207,33 +178,26 @@ describe("BugReportsOverviewPlot", () => {
   });
 
   it("hides stale chart while new range data is loading", async () => {
-    useFiltersStore.setState({ filters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
-      status: "success",
-      error: null,
-    });
-    const { unmount } = render(<BugReportsOverviewPlot />);
+    const { rerender } = render(
+      <BugReportsOverviewPlot
+        {...plotDates}
+        query={queryWith({
+          data: [{ id: "v1", data: [{ id: "v1.0", x: "2025-02-01", y: 2 }] }],
+          status: "success",
+        })}
+      />,
+    );
     await waitFor(() =>
       expect(screen.getByTestId("line-mock")).toBeInTheDocument(),
     );
 
-    unmount();
-
-    // Simulate new range: filters changed, query is loading
-    const newFilters = {
-      ...filters,
-      startDate: "2026-02-01T00:00:00Z",
-      endDate: "2026-02-01T06:00:00Z",
-    };
-    useFiltersStore.setState({ filters: newFilters });
-    mockUseBugReportsOverviewPlotQuery.mockReturnValue({
-      data: undefined,
-      status: "pending",
-      error: null,
-    });
-
-    render(<BugReportsOverviewPlot />);
+    rerender(
+      <BugReportsOverviewPlot
+        startDate="2026-02-01T00:00:00Z"
+        endDate="2026-02-01T06:00:00Z"
+        query={queryWith({})}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("loading")).toBeInTheDocument();

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -539,6 +539,27 @@ describe("FilterBar", () => {
       );
     });
 
+    it("reports again when the request changes, even to the same resolution", async () => {
+      const { onFilterChange, askAgain } = await renderBar({
+        requestedAppId: "app-1",
+      });
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        app: { id: "app-1" },
+      });
+      const settledCalls = onFilterChange.mock.calls.length;
+
+      // Dropping the app from the request resolves to the same app, date
+      // and filter as before.
+      await askAgain({ requestedAppId: null });
+
+      expect(onFilterChange.mock.calls.length).toBeGreaterThan(settledCalls);
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        app: { id: "app-1" },
+      });
+    });
+
     it("holds the page back until the keys can vouch for it", async () => {
       mockUseFilterKeysQuery.mockReturnValue({
         data: undefined,

--- a/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
@@ -307,6 +307,13 @@ describe("ValuePicker", () => {
       expect(screen.getByTestId("filter-value-input")).toBeInTheDocument();
     });
 
+    it("asks the server for nothing when the key offers no values", () => {
+      mockUseFilterValuesQuery.mockClear();
+      renderPicker({ valueSuggestionMode: "none", valueType: "string" });
+
+      expect(mockUseFilterValuesQuery).not.toHaveBeenCalled();
+    });
+
     it("opens on the value the condition already has", () => {
       renderPicker({ valueSuggestionMode: "none", selected: [{ text: "42" }] });
 

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -147,7 +147,6 @@ function defaultProps(overrides: Record<string, any> = {}) {
     showLocales: true,
     showDeviceManufacturers: true,
     showDeviceNames: true,
-    showBugReportStatus: false,
     showHttpMethods: false,
     showUdAttrs: false,
     showFreeText: false,

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -1,15 +1,14 @@
 /**
  * Integration tests for the wiring between the Bug Reports pages and the
- * server: request paths and parameters, filter serialisation into the
- * shortFilters POST and the bug reports GET, pagination round-trips, the
- * status toggle PATCH, and error responses. Rendering details of the
- * overview rows and the detail surface are covered by the unit tests in
+ * server: request paths and parameters, the filter expression carried by
+ * the URL, pagination round-trips, the status toggle PATCH, and error
+ * responses. Rendering details of the overview rows and the detail surface
+ * are covered by the unit tests in
  * __tests__/pages/bug_reports_overview_test.tsx and
  * __tests__/components/bug_report_test.tsx.
  *
  * Unique to bug reports:
- *   - bugReportStatus filter (Open/Closed)
- *   - freeText search
+ *   - the bug_reports filter entity (bug_report_status, user_id, ...)
  *   - PATCH endpoint for status toggle
  */
 import { promiseParams } from "@/__tests__/helpers/promise_params";
@@ -28,6 +27,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 
@@ -38,13 +38,33 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
 const mockRouterPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
+
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's queries read the URL, so without this
+// they would never see what the bar settled on.
+let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const mockRouterReplace = jest.fn(
+  (url: string, _options?: { scroll: boolean }) => {
+    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+    searchParamsSubscribers.forEach((notify) => notify());
+  },
+);
 jest.mock("next/navigation", () => ({
   __esModule: true,
   useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
   usePathname: () => "/test-team/bug_reports",
 }));
 
@@ -84,10 +104,23 @@ jest.mock("@nivo/line", () => {
   };
 });
 
+// The filter pickers are Radix popovers, which need a resize observer and
+// pointer capture that jsdom does not have.
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn(() => false);
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
+
 // --- MSW ---
 import {
   makeAppFixture,
   makeBugReportDetailFixture,
+  makeBugReportsFilterKeysFixture,
   makeBugReportsOverviewFixture,
   makeBugReportsPlotFixture,
 } from "../msw/fixtures";
@@ -127,12 +160,13 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
+const appId = makeAppFixture().id;
+
 beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  filtersStore.getState().reset();
-  for (const key of [...mockSearchParams.keys()]) mockSearchParams.delete(key);
+  mockSearchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -147,68 +181,219 @@ function renderWithProviders(ui: React.ReactElement) {
 // BUG REPORTS OVERVIEW
 // ====================================================================
 describe("Bug Reports Overview (MSW integration)", () => {
-  const {
-    AppVersion,
-    OsVersion,
-    BugReportStatus,
-  } = require("@/app/api/api_calls");
-
-  async function renderAndWaitForData() {
-    renderWithProviders(
+  function renderPage() {
+    return renderWithProviders(
       <BugReportsOverview params={promiseParams({ teamId: "test-team" })} />,
     );
+  }
+
+  function recordBugReportsRequests() {
+    const sent: URL[] = [];
+    server.use(
+      http.get("*/api/apps/:appId/bugReports", ({ request }) => {
+        const url = new URL(request.url);
+        // Only match the list endpoint, not /bugReports/:id or
+        // /bugReports/plots/*.
+        const pathParts = url.pathname.split("/").filter(Boolean);
+        if (pathParts.length > 4) {
+          return;
+        }
+        sent.push(url);
+        return HttpResponse.json(makeBugReportsOverviewFixture());
+      }),
+    );
+    return sent;
+  }
+
+  async function waitForBugReports() {
     await waitFor(
-      () => {
+      () =>
         expect(
           screen.getByText("App crashes when tapping checkout button"),
-        ).toBeTruthy();
-      },
+        ).toBeTruthy(),
       { timeout: 5000 },
     );
   }
 
-  // ================================================================
-  // PAGE LOAD
-  // ================================================================
-  describe("page load", () => {
-    it("shows error when overview API returns 500", async () => {
+  describe("opening the page", () => {
+    it("lists the bug reports the server sent under the plot", async () => {
+      renderPage();
+      await waitForBugReports();
+
+      expect(screen.getByText("ID: evt-br-001")).toBeTruthy();
+      expect(screen.getByTestId("nivo-line-chart")).toBeTruthy();
+    });
+
+    it("asks for the app's bug reports over the range it settled on", async () => {
+      const sent = recordBugReportsRequests();
+      renderPage();
+      await waitForBugReports();
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].pathname).toBe(`/api/apps/${appId}/bugReports`);
+      const from = sent[0].searchParams.get("from")!;
+      const to = sent[0].searchParams.get("to")!;
+      expect(from).toMatch(/Z$/);
+      expect(to).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("timezone")).toBeTruthy();
+      expect(sent[0].searchParams.get("limit")).toBe("5");
+      expect(sent[0].searchParams.get("offset")).toBe("0");
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+      expect(sent[0].searchParams.has("filter_short_code")).toBe(false);
+      expect(sent[0].searchParams.has("bug_report_statuses")).toBe(false);
+      expect(sent[0].searchParams.has("free_text")).toBe(false);
+    });
+
+    it("sends the time group in the plot request", async () => {
+      const plotUrls: URL[] = [];
       server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          return new HttpResponse(null, { status: 500 });
+        http.get(
+          "*/api/apps/:appId/bugReports/plots/instances",
+          ({ request }) => {
+            plotUrls.push(new URL(request.url));
+            return HttpResponse.json(makeBugReportsPlotFixture());
+          },
+        ),
+      );
+      renderPage();
+      await waitForBugReports();
+
+      await waitFor(() => expect(plotUrls.length).toBeGreaterThan(0));
+      expect(plotUrls[0].pathname).toBe(
+        `/api/apps/${appId}/bugReports/plots/instances`,
+      );
+      expect(plotUrls[0].searchParams.get("plot_time_group")).toBeTruthy();
+      expect(plotUrls[0].searchParams.has("filter_expr")).toBe(false);
+    });
+
+    it("records the app and range it settled on in the URL", async () => {
+      renderPage();
+      await waitForBugReports();
+
+      const written = new URLSearchParams(
+        mockRouterReplace.mock.calls[0][0].slice(1),
+      );
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(written.get("sd")).toBeTruthy();
+      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("po")).toBe("0");
+    });
+
+    it("offers the keys the entity has, in the groups the server named", async () => {
+      const keysUrls: URL[] = [];
+      server.use(
+        http.get("*/api/apps/:appId/filters/keys", ({ request }) => {
+          keysUrls.push(new URL(request.url));
+          return HttpResponse.json(makeBugReportsFilterKeysFixture());
         }),
       );
+      renderPage();
+      await waitForBugReports();
 
-      renderWithProviders(
-        <BugReportsOverview params={promiseParams({ teamId: "test-team" })} />,
+      fireEvent.click(screen.getByTestId("filter-input"));
+
+      // The list opens on the first group's keys, with the other groups as
+      // tabs; a search reaches keys in every group.
+      const list = within(await screen.findByRole("dialog"));
+      expect(list.getByText("Bug report status")).toBeTruthy();
+      expect(list.getByText("Bug Report")).toBeTruthy();
+      expect(list.getByText("Version")).toBeTruthy();
+      fireEvent.change(list.getByTestId("filter-key-search"), {
+        target: { value: "App version" },
+      });
+      expect(await screen.findByTestId("filter-key-version_name")).toBeTruthy();
+      expect(keysUrls[0].searchParams.get("entity")).toBe("bug_reports");
+    });
+  });
+
+  // ================================================================
+  // FILTER EXPRESSION
+  // ================================================================
+  describe("a link carrying a filter", () => {
+    it("filters the bug reports and the plot by it", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
       );
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(/Error fetching list of bug reports/),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
+      const sent = recordBugReportsRequests();
+      const plotUrls: URL[] = [];
+      server.use(
+        http.get(
+          "*/api/apps/:appId/bugReports/plots/instances",
+          ({ request }) => {
+            plotUrls.push(new URL(request.url));
+            return HttpResponse.json(makeBugReportsPlotFixture());
+          },
+        ),
+      );
+      renderPage();
+      await waitForBugReports();
+
+      expect(sent[0].searchParams.get("filter_expr")).toBe(
+        "bug_report_status:in:open",
+      );
+      await waitFor(() => expect(plotUrls.length).toBeGreaterThan(0));
+      expect(plotUrls[0].searchParams.get("filter_expr")).toBe(
+        "bug_report_status:in:open",
       );
     });
 
-    it("shows plot error when plot API returns 500", async () => {
+    it("draws it as a condition a person can edit", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
+      );
+      renderPage();
+      await waitForBugReports();
+
+      const bar = within(screen.getByTestId("filter-bar"));
+      expect(await screen.findByText("Bug report status")).toBeTruthy();
+      expect(bar.getByText("is")).toBeTruthy();
+      expect(bar.getByText("open")).toBeTruthy();
+    });
+
+    it("filters by nothing when it cannot be read", async () => {
+      mockSearchParams = new URLSearchParams(
+        `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:")}`,
+      );
+      const sent = recordBugReportsRequests();
+      renderPage();
+      await waitForBugReports();
+
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+    });
+  });
+
+  describe("filtering by a value", () => {
+    it("asks the server for the key's values, then filters by the one picked", async () => {
+      const values: URL[] = [];
       server.use(
-        http.get("*/api/apps/:appId/bugReports/plots/instances", () => {
-          return new HttpResponse(null, { status: 500 });
+        http.get("*/api/apps/:appId/filters/values", ({ request }) => {
+          values.push(new URL(request.url));
+          return HttpResponse.json({
+            values: [{ text: "open", label: "Open" }, { text: "closed" }],
+            truncated: false,
+          });
         }),
       );
+      const sent = recordBugReportsRequests();
+      renderPage();
+      await waitForBugReports();
 
-      renderWithProviders(
-        <BugReportsOverview params={promiseParams({ teamId: "test-team" })} />,
+      fireEvent.click(screen.getByTestId("filter-input"));
+      fireEvent.change(await screen.findByTestId("filter-key-search"), {
+        target: { value: "Bug report status" },
+      });
+      fireEvent.click(
+        await screen.findByTestId("filter-key-bug_report_status"),
       );
-      await waitFor(
-        () => {
-          expect(screen.getByText(/Error fetching plot/)).toBeTruthy();
-        },
-        { timeout: 5000 },
+      fireEvent.click(await screen.findByText("<values>"));
+      fireEvent.click(await screen.findByTestId("filter-value-open"));
+
+      await waitFor(() => expect(sent).toHaveLength(2));
+      expect(values[0].searchParams.get("entity")).toBe("bug_reports");
+      expect(values[0].searchParams.get("key_name")).toBe("bug_report_status");
+      expect(sent[1].searchParams.get("filter_expr")).toBe(
+        "bug_report_status:in:open",
       );
     });
   });
@@ -241,10 +426,8 @@ describe("Bug Reports Overview (MSW integration)", () => {
         }),
       );
 
-      await renderAndWaitForData();
-      expect(
-        screen.getByText("App crashes when tapping checkout button"),
-      ).toBeTruthy();
+      renderPage();
+      await waitForBugReports();
 
       // Navigate to page 2
       await act(async () => {
@@ -264,14 +447,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
       await act(async () => {
         fireEvent.click(screen.getByText("Previous").closest("button")!);
       });
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText("App crashes when tapping checkout button"),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
+      await waitForBugReports();
       expect(screen.queryByText("Page 2 bug report")).toBeNull();
 
       // URL reflects page 1
@@ -305,10 +481,8 @@ describe("Bug Reports Overview (MSW integration)", () => {
         }),
       );
 
-      mockSearchParams.set("po", "5");
-      renderWithProviders(
-        <BugReportsOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
+      mockSearchParams = new URLSearchParams("po=5");
+      renderPage();
       await waitFor(
         () => {
           expect(
@@ -325,427 +499,59 @@ describe("Bug Reports Overview (MSW integration)", () => {
   });
 
   // ================================================================
-  // FILTERS — all relevant filter types
+  // ERROR STATES
   // ================================================================
-  describe("filters", () => {
-    let shortFilterBodies: any[];
-    let requestUrls: string[];
-
-    beforeEach(() => {
-      shortFilterBodies = [];
-      requestUrls = [];
-      server.use(
-        http.post("*/api/apps/:appId/shortFilters", async ({ request }) => {
-          shortFilterBodies.push(await request.json());
-          return HttpResponse.json({
-            filter_short_code: `code-${shortFilterBodies.length}`,
-          });
-        }),
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-    });
-
-    // Each row applies one filter through the store and states what the page
-    // must send to the server: most filters travel as a field in the
-    // shortFilters POST body (bodyField/bodyValue), while free text and bug
-    // report status go directly as query parameters on the bug reports GET
-    // request (urlContains).
-    const filterCases: {
-      name: string;
-      apply: () => void;
-      bodyField?: string;
-      bodyValue?: unknown;
-      urlContains?: string;
-    }[] = [
-      {
-        name: "version change sends versions in shortFilters POST",
-        apply: () =>
-          filtersStore
-            .getState()
-            .setSelectedVersions([new AppVersion("3.0.1", "301")]),
-        bodyField: "versions",
-        bodyValue: ["3.0.1"],
-      },
-      {
-        name: "OS version change sends os_names in shortFilters POST",
-        apply: () =>
-          filtersStore
-            .getState()
-            .setSelectedOsVersions([new OsVersion("android", "14")]),
-        bodyField: "os_names",
-        bodyValue: ["android"],
-      },
-      {
-        name: "country change sends countries in POST",
-        apply: () => filtersStore.getState().setSelectedCountries(["DE"]),
-        bodyField: "countries",
-        bodyValue: ["DE"],
-      },
-      {
-        name: "network provider change sends network_providers in POST",
-        apply: () =>
-          filtersStore.getState().setSelectedNetworkProviders(["Jio"]),
-        bodyField: "network_providers",
-        bodyValue: ["Jio"],
-      },
-      {
-        name: "network type change sends network_types in POST",
-        apply: () =>
-          filtersStore.getState().setSelectedNetworkTypes(["cellular"]),
-        bodyField: "network_types",
-        bodyValue: ["cellular"],
-      },
-      {
-        name: "network generation change sends network_generations in POST",
-        apply: () =>
-          filtersStore.getState().setSelectedNetworkGenerations(["5g"]),
-        bodyField: "network_generations",
-        bodyValue: ["5g"],
-      },
-      {
-        name: "locale change sends locales in POST",
-        apply: () => filtersStore.getState().setSelectedLocales(["hi-IN"]),
-        bodyField: "locales",
-        bodyValue: ["hi-IN"],
-      },
-      {
-        name: "device manufacturer change sends device_manufacturers in POST",
-        apply: () =>
-          filtersStore.getState().setSelectedDeviceManufacturers(["Samsung"]),
-        bodyField: "device_manufacturers",
-        bodyValue: ["Samsung"],
-      },
-      {
-        name: "device name change sends device_names in POST",
-        apply: () =>
-          filtersStore.getState().setSelectedDeviceNames(["Galaxy S24"]),
-        bodyField: "device_names",
-        bodyValue: ["Galaxy S24"],
-      },
-      {
-        name: "free text change triggers re-fetch with free_text in URL",
-        apply: () => filtersStore.getState().setSelectedFreeText("user-123"),
-        urlContains: "free_text=",
-      },
-      {
-        name: "bug report status filter sends bug_report_statuses in URL",
-        apply: () =>
-          filtersStore
-            .getState()
-            .setSelectedBugReportStatuses([BugReportStatus.Closed]),
-        urlContains: "bug_report_statuses=1",
-      },
-    ];
-
-    it.each(filterCases)(
-      "$name",
-      async ({ apply, bodyField, bodyValue, urlContains }) => {
-        await renderAndWaitForData();
-        shortFilterBodies.length = 0;
-        requestUrls.length = 0;
-
-        await act(async () => {
-          apply();
-        });
-
-        if (bodyField !== undefined) {
-          await waitFor(
-            () => expect(shortFilterBodies.length).toBeGreaterThan(0),
-            { timeout: 5000 },
-          );
-          expect(
-            shortFilterBodies[shortFilterBodies.length - 1].filters[bodyField],
-          ).toEqual(bodyValue);
-        } else {
-          await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-            timeout: 5000,
-          });
-          expect(requestUrls[requestUrls.length - 1]).toContain(urlContains!);
-        }
-      },
-    );
-  });
-
-  // ================================================================
-  // URL SYNC
-  // ================================================================
-  describe("URL sync", () => {
-    it("serialises filters into URL", async () => {
-      await renderAndWaitForData();
-      expect(mockRouterReplace).toHaveBeenCalled();
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      // The URL should contain serialised filter params (app, dates, etc.)
-      expect(url).toContain("a=");
-      expect(url).toContain("sd=");
-      expect(url).toContain("ed=");
-    });
-  });
-
-  // ================================================================
-  // API PATH VERIFICATION
-  // ================================================================
-  describe("API paths", () => {
-    it("fetches from /bugReports path (not /crashGroups or /anrGroups)", async () => {
-      const requestPaths: string[] = [];
+  describe("when the server fails", () => {
+    it("shows error when overview API returns 500", async () => {
       server.use(
         http.get("*/api/apps/:appId/bugReports", ({ request }) => {
           const url = new URL(request.url);
           const pathParts = url.pathname.split("/").filter(Boolean);
           if (pathParts.length > 4) return;
-          requestPaths.push(url.pathname);
-          return HttpResponse.json(makeBugReportsOverviewFixture());
+          return new HttpResponse(null, { status: 500 });
         }),
       );
 
-      await renderAndWaitForData();
-      expect(requestPaths.some((p) => p.includes("/bugReports"))).toBe(true);
-      expect(requestPaths.some((p) => p.includes("/crashGroups"))).toBe(false);
-    });
-
-    it("plot endpoint uses /bugReports/plots/instances", async () => {
-      const plotPaths: string[] = [];
-      server.use(
-        http.get(
-          "*/api/apps/:appId/bugReports/plots/instances",
-          ({ request }) => {
-            plotPaths.push(new URL(request.url).pathname);
-            return HttpResponse.json(makeBugReportsPlotFixture());
-          },
-        ),
-      );
-
-      await renderAndWaitForData();
+      renderPage();
       expect(
-        plotPaths.some((p) => p.includes("/bugReports/plots/instances")),
-      ).toBe(true);
-    });
-  });
-
-  // ================================================================
-  // REQUEST URL PARAMS
-  // ================================================================
-  describe("request URL params", () => {
-    it("sends limit=5 and offset in request URL", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("limit=5");
-      expect(lastUrl).toContain("offset=0");
+        await screen.findByText(/Error fetching list of bug reports/),
+      ).toBeTruthy();
     });
 
-    it("default selection (Open only) sends bug_report_statuses=0 in initial request", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      // Default bug report status selection is [Open], so initial request should include status 0
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("bug_report_statuses=0");
-      expect(lastUrl).not.toContain("bug_report_statuses=1");
-    });
-
-    it("selecting all statuses omits bug_report_statuses from URL", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedBugReportStatuses([
-            BugReportStatus.Open,
-            BugReportStatus.Closed,
-          ]);
-      });
-
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      // When all statuses selected, the filter is omitted (all=true → no param)
-      expect(lastUrl).not.toContain("bug_report_statuses=");
-    });
-
-    it("ud_expression sent in shortFilters POST for user-defined attribute filter", async () => {
-      let shortFilterBodies: any[] = [];
-      server.use(
-        http.post("*/api/apps/:appId/shortFilters", async ({ request }) => {
-          shortFilterBodies.push(await request.json());
-          return HttpResponse.json({
-            filter_short_code: `code-ud-${shortFilterBodies.length}`,
-          });
-        }),
-      );
-
-      await renderAndWaitForData();
-      shortFilterBodies.length = 0;
-
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedUdAttrMatchers([
-            { key: "premium", type: "bool", op: "eq", value: true },
-          ]);
-      });
-
-      await waitFor(() => expect(shortFilterBodies.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      const body = shortFilterBodies[shortFilterBodies.length - 1];
-      expect(body.filters.ud_expression).toBeDefined();
-      const expr = JSON.parse(body.filters.ud_expression);
-      expect(expr.and[0].cmp.key).toBe("premium");
-      expect(expr.and[0].cmp.op).toBe("eq");
-      // Value may be serialized as string "true" or boolean true depending on JSON encoding
-      expect(String(expr.and[0].cmp.value)).toBe("true");
-    });
-
-    it("request URL contains correct app ID from filters", async () => {
-      const requestPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestPaths.push(url.pathname);
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      expect(requestPaths[requestPaths.length - 1]).toContain(
-        `/apps/${makeAppFixture().id}/bugReports`,
-      );
-    });
-  });
-
-  // ================================================================
-  // PAGINATION EDGE CASES
-  // ================================================================
-  describe("pagination edge cases", () => {
-    it("offset updates in request URL after nextPage", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          requestUrls.push(url.toString());
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      await act(async () => {
-        fireEvent.click(screen.getByText("Next").closest("button")!);
-      });
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      expect(requestUrls[requestUrls.length - 1]).toContain("offset=5");
-    });
-  });
-
-  // ================================================================
-  // PLOT STORE
-  // ================================================================
-  describe("plot store", () => {
-    it("plot re-fetches when filters change", async () => {
-      let plotFetchCount = 0;
+    it("shows plot error when plot API returns 500", async () => {
       server.use(
         http.get("*/api/apps/:appId/bugReports/plots/instances", () => {
-          plotFetchCount++;
-          return HttpResponse.json(makeBugReportsPlotFixture());
+          return new HttpResponse(null, { status: 500 });
         }),
       );
 
-      await renderAndWaitForData();
-      const initialPlotCount = plotFetchCount;
+      renderPage();
+      expect(await screen.findByText(/Error fetching plot/)).toBeTruthy();
+    });
 
-      await act(async () => {
-        filtersStore
-          .getState()
-          .setSelectedVersions([new AppVersion("3.0.1", "301")]);
-      });
-
-      await waitFor(
-        () => {
-          expect(plotFetchCount).toBeGreaterThan(initialPlotCount);
-        },
-        { timeout: 5000 },
+    it("says so when the team's apps cannot be fetched", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
       );
+      renderPage();
+
+      expect(await screen.findByText(/Error fetching apps/)).toBeTruthy();
     });
   });
 
   // ================================================================
-  // CONCURRENT / RE-RENDER
+  // RE-RENDER
   // ================================================================
-  describe("concurrent and re-render", () => {
-    it("rapid pagination does not produce duplicate fetches for same offset", async () => {
-      let fetchCount = 0;
-      server.use(
-        http.get("*/api/apps/:appId/bugReports", ({ request }) => {
-          const url = new URL(request.url);
-          const pathParts = url.pathname.split("/").filter(Boolean);
-          if (pathParts.length > 4) return;
-          fetchCount++;
-          return HttpResponse.json(makeBugReportsOverviewFixture());
-        }),
-      );
+  describe("re-render", () => {
+    it("re-render still shows data", async () => {
+      const { unmount } = renderPage();
+      await waitForBugReports();
 
-      await renderAndWaitForData();
-      fetchCount = 0;
-
-      // Rapidly click next then previous — should settle at offset 0
-      await act(async () => {
-        fireEvent.click(screen.getByText("Next").closest("button")!);
-        fireEvent.click(screen.getByText("Previous").closest("button")!);
-      });
-
-      // Wait for any fetches to settle
-      await new Promise((r) => setTimeout(r, 200));
-      // The final offset is 0 (same as initial), so no new fetch should be needed
-      // (or at most 1 if the intermediate state triggered one)
-      expect(fetchCount).toBeLessThanOrEqual(1);
+      unmount();
+      renderPage();
+      await waitForBugReports();
     });
   });
 });

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -617,7 +617,6 @@ export function makeBugReportsOverviewFixture(
         },
         user_defined_attribute: null,
         attachments: null,
-        matched_free_text: "",
       },
       {
         session_id: "sess-br-002",
@@ -654,7 +653,6 @@ export function makeBugReportsOverviewFixture(
         },
         user_defined_attribute: null,
         attachments: null,
-        matched_free_text: "",
       },
     ],
     ...overrides,
@@ -1395,6 +1393,83 @@ export function makeFilterKeysFixture(overrides: Record<string, any> = {}) {
       },
     ],
     key_groups: ["Version", "Build"],
+    ...overrides,
+  };
+}
+
+// --- Filter keys for the bug_reports entity ---
+
+export function makeBugReportsFilterKeysFixture(
+  overrides: Record<string, any> = {},
+) {
+  return {
+    keys: [
+      {
+        name: "version_name",
+        label: "App version",
+        description: "The app version the bug report was filed on",
+        key_group: "Version",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "bug_report_status",
+        label: "Bug report status",
+        description: "Whether the bug report is open or closed",
+        key_group: "Bug Report",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "user_id",
+        label: "User ID",
+        description: "The user the bug report was filed by",
+        key_group: "User",
+        value_type: "string",
+        value_suggestion_mode: "sample",
+        operators: ["in", "not_in", "contains"],
+      },
+      {
+        name: "bug_report_description",
+        label: "Description",
+        description: "The bug report's description text",
+        key_group: "Bug Report",
+        value_type: "string",
+        value_suggestion_mode: "none",
+        operators: ["contains", "not_contains"],
+      },
+      {
+        name: "session_id",
+        label: "Session ID",
+        description: "The session the bug report was filed in",
+        key_group: "Session",
+        value_type: "uuid",
+        value_suggestion_mode: "none",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "os_name",
+        label: "OS name",
+        description: "The operating system's name",
+        key_group: "OS",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+    ],
+    key_groups: [
+      "Bug Report",
+      "Version",
+      "OS",
+      "Device",
+      "Network",
+      "Location",
+      "User",
+      "Session",
+      "Custom",
+    ],
     ...overrides,
   };
 }

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -18,6 +18,7 @@ import {
   makeAuthzAndMembersFixture,
   makeBillingInfoFixture,
   makeBugReportDetailFixture,
+  makeBugReportsFilterKeysFixture,
   makeBugReportsOverviewFixture,
   makeBugReportsPlotFixture,
   makeBuildsFixture,
@@ -409,8 +410,12 @@ export const handlers = [
     return HttpResponse.json({ url: "https://billing.stripe.com/portal/test" });
   }),
 
-  // 68. GET /api/apps/:appId/filters/keys
-  http.get("*/api/apps/:appId/filters/keys", () => {
+  // 68. GET /api/apps/:appId/filters/keys (keys differ per entity)
+  http.get("*/api/apps/:appId/filters/keys", ({ request }) => {
+    const entity = new URL(request.url).searchParams.get("entity");
+    if (entity === "bug_reports") {
+      return HttpResponse.json(makeBugReportsFilterKeysFixture());
+    }
     return HttpResponse.json(makeFilterKeysFixture());
   }),
 

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -4,66 +4,184 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-// Global replace mock for router.replace
-const replaceMock = jest.fn();
 const pushMock = jest.fn();
 
-// Mock next/navigation hooks
+// The mocked router applies each replace back into the mocked searchParams
+// and notifies subscribers, the way the real router re-renders the page with
+// the URL it just wrote. The page's queries read the URL, so without this
+// they would never see what the bar settled on.
 let mockSearchParams = new URLSearchParams();
+const searchParamsSubscribers = new Set<() => void>();
+const applyReplaceUrl = (url: string) => {
+  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+  searchParamsSubscribers.forEach((notify) => notify());
+};
+// Holds a replace's URL for the test to apply later, modeling the real
+// router landing a write one render after the call.
+let mockDeferReplace = false;
+let deferredReplaceUrl: string | null = null;
+const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
+  if (mockDeferReplace) {
+    deferredReplaceUrl = url;
+    return;
+  }
+  applyReplaceUrl(url);
+});
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-    push: pushMock,
-  }),
-  // By default, return empty search params.
-  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  useSearchParams: () => {
+    const { useSyncExternalStore } = require("react");
+    return useSyncExternalStore(
+      (notify: () => void) => {
+        searchParamsSubscribers.add(notify);
+        return () => searchParamsSubscribers.delete(notify);
+      },
+      () => mockSearchParams,
+    );
+  },
 }));
 
-// Mock API calls and constants
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
   emptyBugReportsOverviewResponse: {
     meta: { next: false, previous: false },
     results: [],
   },
-  FilterSource: { Events: "events" },
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
-});
+jest.mock("@/app/stores/filters_store", () => ({
+  __esModule: true,
+  urlFiltersKeyMap: {
+    appId: "a",
+    dateRange: "d",
+    startDate: "sd",
+    endDate: "ed",
+  },
+}));
 
-const mockUseBugReportsOverviewQuery = jest.fn(() => ({
+const pendingQueryState = () => ({
   data: undefined as any,
   status: "pending" as string,
   isFetching: true,
   error: null as Error | null,
-}));
+});
+
+const mockUseBugReportsOverviewQuery = jest.fn(
+  (_filter: any, _offset: number) => pendingQueryState(),
+);
+const mockUseBugReportsOverviewPlotQuery = jest.fn((_filter: any) =>
+  pendingQueryState(),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useBugReportsOverviewQuery: () => mockUseBugReportsOverviewQuery(),
+  useBugReportsOverviewQuery: (filter: any, offset: number) =>
+    mockUseBugReportsOverviewQuery(filter, offset),
+  useBugReportsOverviewPlotQuery: (filter: any) =>
+    mockUseBugReportsOverviewPlotQuery(filter),
   paginationOffsetUrlKey: "po",
 }));
 
-jest.mock("@/app/components/filters", () => ({
+const mockReportedApp = { id: "app-1", name: "Sample" };
+const mockReportedDate = {
+  dateRange: "Last 6 Hours",
+  startDate: "2026-01-01T00:00:00.000Z",
+  endDate: "2026-01-01T06:00:00.000Z",
+};
+
+// Makes the stub drop the URL's filter on mount, like the bar discarding
+// a filter it cannot read.
+let mockMountDiscardsFilter = false;
+
+// Like the real bar, this stub reports an app, a range and a filter as it
+// mounts, and offers buttons that report a changed filter, a cleared filter,
+// or a failure. Only the mount report carries appliedAsRequested true, and
+// only when the URL's filter was not discarded; a report from a button
+// models a user edit.
+jest.mock("@/app/components/filter_bar/filter_bar", () => {
+  const { useEffect } = require("react");
+
+  function FilterBarMock(props: any) {
+    const ready = (
+      filterExpr: string | null,
+      appliedAsRequested: boolean = false,
+    ) => ({
+      status: "ready",
+      app: mockReportedApp,
+      date: mockReportedDate,
+      filterExpr,
+      appliedAsRequested,
+    });
+
+    useEffect(() => {
+      if (mockMountDiscardsFilter) {
+        props.onFilterChange(ready(null, false));
+      } else {
+        props.onFilterChange(ready(props.requestedFilterExpr, true));
+      }
+    }, []);
+
+    return (
+      <div data-testid="filter-bar-mock">
+        <span data-testid="filter-bar-expr">
+          {props.requestedFilterExpr ?? "none"}
+        </span>
+        <button
+          data-testid="filter-bar-apply"
+          onClick={() =>
+            props.onFilterChange(ready("bug_report_status:in:open"))
+          }
+        >
+          apply
+        </button>
+        <button
+          data-testid="filter-bar-clear"
+          onClick={() => props.onFilterChange(ready(null))}
+        >
+          clear
+        </button>
+        <button
+          data-testid="filter-bar-fail"
+          onClick={() =>
+            props.onFilterChange({
+              status: "error",
+              message: "Error fetching apps, please refresh page to try again",
+            })
+          }
+        >
+          fail
+        </button>
+      </div>
+    );
+  }
+
+  return {
+    __esModule: true,
+    default: FilterBarMock,
+    filterExprUrlKey: "filter_expr",
+  };
+});
+
+jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { All: "all" },
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
 }));
 
-// Mock BugReportsOverviewPlot component.
-jest.mock("@/app/components/bug_reports_overview_plot", () => () => (
-  <div data-testid="bug-reports-overview-plot-mock">
-    BugReportsOverviewPlot Rendered
-  </div>
-));
+// The real plot shows a skeleton while its query is pending, so the stub
+// distinguishes that case for tests that check what fills the plot area.
+jest.mock("@/app/components/bug_reports_overview_plot", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="bug-reports-overview-plot-mock">
+      {props.query.status === "pending" ? (
+        <div data-testid="skeleton-plot-mock" />
+      ) : (
+        "BugReportsOverviewPlot Rendered"
+      )}
+    </div>
+  ),
+}));
 
-// Updated Paginator mock renders Next and Prev buttons.
 jest.mock("@/app/components/paginator", () => ({
   __esModule: true,
   default: (props: any) => (
@@ -87,18 +205,14 @@ jest.mock("@/app/components/paginator", () => ({
   ),
 }));
 
-// Mock LoadingBar component.
 jest.mock("@/app/components/loading_bar", () => () => (
   <div data-testid="loading-bar-mock">LoadingBar Rendered</div>
 ));
 
-// Mock time utils
 jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableDate: jest.fn(() => "Jan 1, 2020"),
   formatDateToHumanReadableTime: jest.fn(() => "12:00 AM"),
 }));
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
 
 const mockBugReportResult = {
   session_id: "session1",
@@ -107,7 +221,6 @@ const mockBugReportResult = {
   description: "Test Bug Report",
   status: 0,
   timestamp: "2020-01-01T00:00:00Z",
-  matched_free_text: "error",
   attribute: {
     app_version: "1.0",
     app_build: "1",
@@ -125,217 +238,190 @@ const mockBugReportsData = {
   meta: { previous: true, next: true },
 };
 
-describe("BugReportsOverview Component", () => {
+function bugReportsLoaded(data: any = mockBugReportsData) {
+  mockUseBugReportsOverviewQuery.mockReturnValue({
+    data,
+    status: "success",
+    isFetching: false,
+    error: null,
+  });
+}
+
+// What the stub bar reports, as the page writes it into the URL.
+const selectionParams =
+  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+
+const selectionUrl = (offset: number, filterParam?: string) =>
+  `?po=${offset}&${selectionParams}${filterParam ? `&${filterParam}` : ""}`;
+
+function renderPage() {
+  return render(
+    <BugReportsOverview params={promiseParams({ teamId: "123" })} />,
+  );
+}
+
+describe("BugReportsOverview page", () => {
   beforeEach(() => {
     replaceMock.mockClear();
     pushMock.mockClear();
+    mockMountDiscardsFilter = false;
+    mockDeferReplace = false;
+    deferredReplaceUrl = null;
     mockSearchParams = new URLSearchParams();
     mockUseBugReportsOverviewQuery.mockReset();
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: undefined,
-      status: "pending" as string,
-      isFetching: true,
-      error: null,
-    });
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
+    mockUseBugReportsOverviewQuery.mockReturnValue(pendingQueryState());
+    mockUseBugReportsOverviewPlotQuery.mockReset();
+    mockUseBugReportsOverviewPlotQuery.mockReturnValue(pendingQueryState());
+  });
+
+  it("renders the filter bar", () => {
+    renderPage();
+    expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
+  });
+
+  it("hands the bar the filter the URL opened on", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=0&filter_expr=bug_report_status%3Ain%3Aopen",
+    );
+    bugReportsLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
+      "bug_report_status:in:open",
+    );
+  });
+
+  it("fetches nothing until the bar settles on an app and a range", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
+    );
+    bugReportsLoaded();
+    renderPage();
+
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenNthCalledWith(1, null, 20);
+    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenNthCalledWith(1, null);
+  });
+
+  it("fetches the page the URL names, filtered by what the bar reported", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
+    );
+    bugReportsLoaded();
+    renderPage();
+
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
+      {
+        appId: mockReportedApp.id,
+        startDate: mockReportedDate.startDate,
+        endDate: mockReportedDate.endDate,
+        filterExpr: "bug_report_status:in:open",
+      },
+      20,
+    );
+    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenLastCalledWith({
+      appId: mockReportedApp.id,
+      startDate: mockReportedDate.startDate,
+      endDate: mockReportedDate.endDate,
+      filterExpr: "bug_report_status:in:open",
     });
   });
 
-  it("renders the Filters component", () => {
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
-  });
+  it("never fetches a filter the bar discarded on mount", async () => {
+    mockMountDiscardsFilter = true;
+    mockDeferReplace = true;
+    mockSearchParams = new URLSearchParams(
+      `po=30&filter_expr=bug_report_status%3Ain%3Aopen&${selectionParams}`,
+    );
+    bugReportsLoaded();
+    renderPage();
 
-  it("does not render main bug reports UI when filters are not ready", () => {
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    expect(
-      screen.queryByTestId("bug-reports-overview-plot-mock"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId("paginator-mock")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("loading-bar-mock")).not.toBeInTheDocument();
-    expect(screen.queryByText("Bug Report Id")).not.toBeInTheDocument();
-  });
+    // The write has not landed, so the URL still holds the discarded
+    // filter and the queries stay disabled.
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 30);
 
-  it("renders main bug reports UI, updates URL when filters become ready, and renders table headers", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: mockBugReportsData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
+      applyReplaceUrl(deferredReplaceUrl!);
     });
 
-    // Check URL update.
-    expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
+    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
       scroll: false,
     });
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
+      {
+        appId: mockReportedApp.id,
+        startDate: mockReportedDate.startDate,
+        endDate: mockReportedDate.endDate,
+        filterExpr: null,
+      },
+      0,
+    );
+    for (const [params] of mockUseBugReportsOverviewQuery.mock.calls) {
+      expect(params?.filterExpr ?? null).not.toBe("bug_report_status:in:open");
+    }
+  });
 
-    // Verify main UI components are rendered.
+  it("records what the bar settled on, keeping the page the link asked for", () => {
+    mockSearchParams = new URLSearchParams(
+      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
+    );
+    bugReportsLoaded();
+    renderPage();
+
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).toHaveBeenCalledWith(
+      selectionUrl(20, "filter_expr=bug_report_status%3Ain%3Aopen"),
+      { scroll: false },
+    );
+  });
+
+  it("keeps the plot area up with paging disabled while the reports load", () => {
+    renderPage();
+    expect(
+      screen.getByTestId("bug-reports-overview-plot-mock"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("next-button")).toBeDisabled();
+    expect(screen.getByTestId("prev-button")).toBeDisabled();
+  });
+
+  it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
+    mockDeferReplace = true;
+    bugReportsLoaded();
+    renderPage();
+
+    // The URL write has not landed, so the bar's report does not match the
+    // URL yet and the queries stay disabled with a null filter.
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 0);
+    expect(
+      screen.getByTestId("bug-reports-overview-plot-mock"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton-plot-mock")).toBeInTheDocument();
+  });
+
+  it("renders the plot, paginator and table headers once ready", async () => {
+    bugReportsLoaded();
+    renderPage();
+
     expect(
       await screen.findByTestId("bug-reports-overview-plot-mock"),
     ).toBeInTheDocument();
     expect(await screen.findByTestId("paginator-mock")).toBeInTheDocument();
-    // Check that the table header cells are rendered.
     expect(screen.getByText("Bug Report")).toBeInTheDocument();
     expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
-  it("displays bug report data correctly when API returns results", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: mockBugReportsData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
+  it("displays bug report data correctly", () => {
+    bugReportsLoaded();
+    renderPage();
 
-    // Verify the bug report data is displayed
     expect(screen.getByText("Test Bug Report")).toBeInTheDocument();
     expect(screen.getByText("Jan 1, 2020")).toBeInTheDocument();
     expect(screen.getByText("12:00 AM")).toBeInTheDocument();
     expect(screen.getByText("Open")).toBeInTheDocument();
     expect(screen.getByText("ID: bug1")).toBeInTheDocument();
-    expect(screen.getByText("Matched error")).toBeInTheDocument();
     expect(
       screen.getByText("1.0(1), iOS 15.0, Apple iPhone 12"),
     ).toBeInTheDocument();
-  });
-
-  it("shows error message when API returns error status", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: undefined,
-      status: "error",
-      isFetching: false,
-      error: new Error("fail"),
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    // Check that error message is displayed
-    expect(
-      screen.getByText(/Error fetching list of bug reports/),
-    ).toBeInTheDocument();
-  });
-
-  it("renders appropriate link for each bug report that includes teamId, app_id and event_id", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: mockBugReportsData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    // Check that the bug report link is rendered with the correct href and accessible name
-    const link = screen.getByRole("link", { name: /ID: bug1/i });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "/123/bug_reports/app1/bug1");
-
-    // Find the table row that contains this link
-    const row = link.closest("tr");
-    expect(row).toBeInTheDocument();
-
-    // Simulate keyboard navigation (Enter) on the row
-    await act(async () => {
-      fireEvent.keyDown(row!, { key: "Enter" });
-    });
-    expect(pushMock).toHaveBeenCalledWith("/123/bug_reports/app1/bug1");
-
-    // Simulate keyboard navigation (Space) on the row
-    await act(async () => {
-      fireEvent.keyDown(row!, { key: " " });
-    });
-    expect(pushMock).toHaveBeenCalledWith("/123/bug_reports/app1/bug1");
-  });
-
-  it("handles bug reports with no description properly", async () => {
-    const noDescData = {
-      results: [
-        { ...mockBugReportResult, description: null, matched_free_text: "" },
-      ],
-      meta: { previous: false, next: false },
-    };
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: noDescData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    // Verify "No Description" text is displayed
-    expect(screen.getByText("No Description")).toBeInTheDocument();
-  });
-
-  it("does not render matched badge when matched_free_text is empty", async () => {
-    const noMatchData = {
-      results: [{ ...mockBugReportResult, matched_free_text: "" }],
-      meta: { previous: false, next: false },
-    };
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: noMatchData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    expect(screen.queryByText(/Matched /)).not.toBeInTheDocument();
   });
 
   // The device info line maps os_name to a display label: android becomes
@@ -359,8 +445,8 @@ describe("BugReportsOverview Component", () => {
     },
   ])(
     "formats device info line for os_name $osName",
-    async ({ osName, osVersion, expected }) => {
-      const osData = {
+    ({ osName, osVersion, expected }) => {
+      bugReportsLoaded({
         results: [
           {
             ...mockBugReportResult,
@@ -372,308 +458,257 @@ describe("BugReportsOverview Component", () => {
           },
         ],
         meta: { previous: false, next: false },
-      };
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: osData,
-        status: "success",
-        isFetching: false,
-        error: null,
       });
-      render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app1" },
-          },
-        });
-      });
+      renderPage();
 
       expect(screen.getByText(expected)).toBeInTheDocument();
     },
   );
 
-  it("renders table headers but no rows when results are empty", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: { results: [], meta: { previous: false, next: false } },
-      status: "success",
-      isFetching: false,
-      error: null,
+  it("handles bug reports with no description properly", () => {
+    bugReportsLoaded({
+      results: [{ ...mockBugReportResult, description: null }],
+      meta: { previous: false, next: false },
     });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
+    renderPage();
+
+    expect(screen.getByText("No Description")).toBeInTheDocument();
+  });
+
+  it("renders table headers but no rows when results are empty", () => {
+    bugReportsLoaded({
+      results: [],
+      meta: { previous: false, next: false },
     });
+    renderPage();
 
     expect(screen.getByText("Bug Report")).toBeInTheDocument();
     expect(screen.queryByText("ID: bug1")).not.toBeInTheDocument();
   });
 
-  describe("Pagination offset handling", () => {
-    it("initializes pagination offset to 0 when no offset is provided", async () => {
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: mockBugReportsData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app1" },
-          },
-        });
-      });
-      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-        scroll: false,
-      });
+  it("shows an error message when the bug reports request fails", () => {
+    mockUseBugReportsOverviewQuery.mockReturnValue({
+      data: undefined,
+      status: "error",
+      isFetching: false,
+      error: new Error("fail"),
+    });
+    renderPage();
+
+    expect(
+      screen.getByText(/Error fetching list of bug reports/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders appropriate link for each bug report", async () => {
+    bugReportsLoaded();
+    renderPage();
+
+    const link = screen.getByRole("link", { name: /ID: bug1/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/123/bug_reports/app1/bug1");
+
+    const row = link.closest("tr");
+    expect(row).toHaveAttribute("data-testid", "bug-report-row");
+    await act(async () => {
+      fireEvent.keyDown(row!, { key: "Enter" });
+    });
+    expect(pushMock).toHaveBeenCalledWith("/123/bug_reports/app1/bug1");
+
+    await act(async () => {
+      fireEvent.keyDown(row!, { key: " " });
+    });
+    expect(pushMock).toHaveBeenCalledWith("/123/bug_reports/app1/bug1");
+  });
+
+  it('renders "Open" and "Closed" status correctly based on status value', () => {
+    bugReportsLoaded();
+    const { unmount } = renderPage();
+
+    const openStatusBadge = screen
+      .getByText("Open")
+      .closest('[data-slot="badge"]');
+    expect(openStatusBadge).toHaveClass("border-green-400");
+    expect(openStatusBadge).toHaveClass("text-green-700");
+    expect(openStatusBadge).toHaveClass("bg-green-100");
+
+    unmount();
+
+    bugReportsLoaded({
+      results: [{ ...mockBugReportResult, status: 1 }],
+      meta: { previous: true, next: true },
+    });
+    renderPage();
+
+    const closedStatusBadge = screen
+      .getByText("Closed")
+      .closest('[data-slot="badge"]');
+    expect(closedStatusBadge).toHaveClass("border-indigo-400");
+    expect(closedStatusBadge).toHaveClass("text-indigo-700");
+    expect(closedStatusBadge).toHaveClass("bg-indigo-100");
+  });
+
+  describe("a filter the bar could not settle", () => {
+    beforeEach(() => {
+      mockSearchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      bugReportsLoaded();
     });
 
-    it("increments pagination offset when Next is clicked", async () => {
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: mockBugReportsData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
+    it("is said by the page, in place of the list", async () => {
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      // The pagination limit is 5 so offset should be 5.
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
+
+      expect(
+        screen.getByText(
+          "Error fetching apps, please refresh page to try again",
+        ),
+      ).toBeInTheDocument();
     });
 
-    it("decrements pagination offset when Prev is clicked, but not below 0", async () => {
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: mockBugReportsData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
+    it("stops the page fetching anything", async () => {
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
-      const prevButton = await screen.findByTestId("prev-button");
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
+
+      expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 10);
     });
 
-    it("resets pagination offset to 0 when filters change (if previous filters were non-default)", async () => {
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: mockBugReportsData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-
-      render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app1" },
-          },
-        });
-      });
-      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-
-      // Click Next twice to get to offset 10.
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
+    it("leaves the URL where the link had it", async () => {
+      renderPage();
+      replaceMock.mockClear();
 
       await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=10&updated", {
-        scroll: false,
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
 
-      // Now simulate a filter change with a different value.
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated2",
-            app: { id: "app1" },
-          },
-        });
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated2", {
-        scroll: false,
-      });
+      expect(replaceMock).not.toHaveBeenCalled();
     });
   });
 
-  it("correctly toggles loading bar visibility based on API status", async () => {
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: undefined,
-      status: "pending" as string,
-      isFetching: true,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
+  describe("pagination", () => {
+    it("moves the offset on by the page size when Next is clicked", async () => {
+      mockSearchParams = new URLSearchParams(`po=0&${selectionParams}`);
+      bugReportsLoaded();
+      renderPage();
 
-    // Set loading state
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("next-button"));
+      });
+
+      // Paging keeps everything else the URL was carrying.
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(5), {
+        scroll: false,
       });
     });
 
-    // Test the loading state - loading bar should be visible
+    it("moves the offset back when Prev is clicked, and never below zero", async () => {
+      mockSearchParams = new URLSearchParams("po=5&a=app-1");
+      bugReportsLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("prev-button"));
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+        scroll: false,
+      });
+
+      mockSearchParams = new URLSearchParams("po=0&a=app-1");
+      renderPage();
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("prev-button")[1]);
+      });
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+        scroll: false,
+      });
+    });
+
+    it("goes back to the first page when the filter changes", async () => {
+      mockSearchParams = new URLSearchParams("po=30&a=app-1");
+      bugReportsLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-apply"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl(0, "filter_expr=bug_report_status%3Ain%3Aopen"),
+        { scroll: false },
+      );
+      // The changed filter and the reset offset reach the query together,
+      // through the URL, so the new filter is never fetched at the page the
+      // old filter was on.
+      expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ filterExpr: "bug_report_status:in:open" }),
+        0,
+      );
+      for (const [params, offset] of mockUseBugReportsOverviewQuery.mock
+        .calls) {
+        if (params?.filterExpr === "bug_report_status:in:open") {
+          expect(offset).toBe(0);
+        }
+      }
+    });
+
+    it("goes back to the first page when the filter is cleared", async () => {
+      mockSearchParams = new URLSearchParams(
+        "po=30&filter_expr=bug_report_status%3Ain%3Aopen",
+      );
+      bugReportsLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-clear"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
+        scroll: false,
+      });
+    });
+
+    it("cannot be used while a refetch is in flight", () => {
+      mockUseBugReportsOverviewQuery.mockReturnValue({
+        data: mockBugReportsData,
+        status: "success",
+        isFetching: true,
+        error: null,
+      });
+      renderPage();
+
+      expect(screen.getByTestId("next-button")).toBeDisabled();
+      expect(screen.getByTestId("prev-button")).toBeDisabled();
+    });
+  });
+
+  it("shows the loading bar only while a refetch is in flight", async () => {
+    mockUseBugReportsOverviewQuery.mockReturnValue({
+      data: mockBugReportsData,
+      status: "success",
+      isFetching: true,
+      error: null,
+    });
+    const { rerender } = renderPage();
+
     const loadingBarContainer =
       screen.getByTestId("loading-bar-mock").parentElement;
     expect(loadingBarContainer).toHaveClass("visible");
     expect(loadingBarContainer).not.toHaveClass("invisible");
 
-    // Set success state
     await act(async () => {
-      mockUseBugReportsOverviewQuery.mockReturnValue({
-        data: mockBugReportsData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
+      bugReportsLoaded();
+      rerender(
+        <BugReportsOverview params={promiseParams({ teamId: "123" })} />,
+      );
     });
 
-    // After loading, the loading bar should be invisible
     await screen.findByText("Test Bug Report");
     expect(loadingBarContainer).not.toHaveClass("visible");
     expect(loadingBarContainer).toHaveClass("invisible");
-  });
-
-  it('renders "Open" and "Closed" status correctly based on status value', async () => {
-    // First render with status 0 (Open)
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: mockBugReportsData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    const { unmount } = render(
-      <BugReportsOverview params={promiseParams({ teamId: "123" })} />,
-    );
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    // Find the Open status element
-    const openStatusText = screen.getByText("Open");
-    const statusBadge = openStatusText.closest('[data-slot="badge"]');
-
-    // Check for correct styling on the status badge
-    expect(statusBadge).toHaveClass("border-green-400");
-    expect(statusBadge).toHaveClass("text-green-700");
-    expect(statusBadge).toHaveClass("bg-green-100");
-
-    // Clean up the first render
-    unmount();
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
-
-    // Re-render with status 1 (Closed)
-    const closedData = {
-      results: [{ ...mockBugReportResult, status: 1, matched_free_text: "" }],
-      meta: { previous: true, next: true },
-    };
-    mockUseBugReportsOverviewQuery.mockReturnValue({
-      data: closedData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<BugReportsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app1" },
-        },
-      });
-    });
-
-    // Find the Closed status element
-    const closedStatusText = screen.getByText("Closed");
-    const closedStatusBadge = closedStatusText.closest('[data-slot="badge"]');
-
-    // Check for correct styling on the closed status badge
-    expect(closedStatusBadge).toHaveClass("border-indigo-400");
-    expect(closedStatusBadge).toHaveClass("text-indigo-700");
-    expect(closedStatusBadge).toHaveClass("bg-indigo-100");
   });
 });

--- a/frontend/dashboard/__tests__/query/hooks_test.tsx
+++ b/frontend/dashboard/__tests__/query/hooks_test.tsx
@@ -11,6 +11,8 @@ jest.mock("@/app/api/api_calls", () => {
   return {
     ...actual,
     fetchAppsFromServer: jest.fn(),
+    fetchBugReportsOverviewFromServer: jest.fn(),
+    fetchBugReportsOverviewPlotFromServer: jest.fn(),
     fetchBuildsFromServer: jest.fn(),
     fetchFilterKeys: jest.fn(),
     fetchFiltersFromServer: jest.fn(),
@@ -53,6 +55,8 @@ jest.mock("@/app/api/api_client", () => ({
 
 import {
   fetchAppsFromServer,
+  fetchBugReportsOverviewFromServer,
+  fetchBugReportsOverviewPlotFromServer,
   fetchBuildsFromServer,
   fetchErrorGroupCommonPathFromServer,
   fetchErrorsDetailsFromServer,
@@ -71,6 +75,8 @@ import {
   fetchCurrentSession,
   signOut,
   useAppsQuery,
+  useBugReportsOverviewPlotQuery,
+  useBugReportsOverviewQuery,
   useBuildsQuery,
   useErrorGroupCommonPathQuery,
   useErrorsDetailsPlotQuery,
@@ -87,6 +93,10 @@ import {
 } from "@/app/query/hooks";
 
 const mockFetchApps = fetchAppsFromServer as jest.Mock;
+const mockFetchBugReportsOverview =
+  fetchBugReportsOverviewFromServer as jest.Mock;
+const mockFetchBugReportsOverviewPlot =
+  fetchBugReportsOverviewPlotFromServer as jest.Mock;
 const mockFetchBuilds = fetchBuildsFromServer as jest.Mock;
 const mockFetchFilterKeys = fetchFilterKeys as jest.Mock;
 const mockFetchFilters = fetchFiltersFromServer as jest.Mock;
@@ -898,6 +908,194 @@ describe("useSpanMetricsPlotQuery", () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(
       () => useSpanMetricsPlotQuery(filteredBy(null), "root.a"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
+  });
+});
+
+describe("useBugReportsOverviewQuery", () => {
+  const filteredBy = (filterExpr: string | null) => ({
+    appId: "app-1",
+    startDate: "2026-01-01T00:00:00Z",
+    endDate: "2026-01-02T00:00:00Z",
+    filterExpr,
+  });
+
+  it("does not fetch without an app and a date range", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useBugReportsOverviewQuery(null, 0), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchBugReportsOverview).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the app, range, filter and page, and returns the data", async () => {
+    mockFetchBugReportsOverview.mockResolvedValueOnce({
+      results: [{ event_id: "br1" }],
+      meta: { next: false, previous: false },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useBugReportsOverviewQuery(filteredBy("bug_report_status:in:open"), 10),
+      { wrapper },
+    );
+
+    expect(result.current.status).toBe("pending");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchBugReportsOverview).toHaveBeenCalledWith(
+      "app-1",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      "bug_report_status:in:open",
+      5,
+      10,
+    );
+    expect((result.current.data as any).results[0].event_id).toBe("br1");
+  });
+
+  it("fetches without a filter when none is given", async () => {
+    mockFetchBugReportsOverview.mockResolvedValueOnce({
+      results: [],
+      meta: { next: false, previous: false },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useBugReportsOverviewQuery(filteredBy(null), 0),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(mockFetchBugReportsOverview).toHaveBeenCalledWith(
+      "app-1",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      null,
+      5,
+      0,
+    );
+  });
+
+  it("fetches again for another page, and shows the last one meanwhile", async () => {
+    mockFetchBugReportsOverview
+      .mockResolvedValueOnce({
+        results: [{ event_id: "br1" }],
+        meta: { next: true, previous: false },
+      })
+      // The second page never arrives, so the hook stays mid-fetch.
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    const { wrapper } = makeWrapper();
+    const { result, rerender } = renderHook(
+      ({ offset }) => useBugReportsOverviewQuery(filteredBy(null), offset),
+      { wrapper, initialProps: { offset: 0 } },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    rerender({ offset: 5 });
+
+    await waitFor(() =>
+      expect(mockFetchBugReportsOverview).toHaveBeenLastCalledWith(
+        "app-1",
+        "2026-01-01T00:00:00Z",
+        "2026-01-02T00:00:00Z",
+        null,
+        5,
+        5,
+      ),
+    );
+    expect(result.current.isFetching).toBe(true);
+    expect((result.current.data as any).results[0].event_id).toBe("br1");
+  });
+
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchBugReportsOverview.mockRejectedValueOnce(failure);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useBugReportsOverviewQuery(filteredBy(null), 0),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
+  });
+});
+
+describe("useBugReportsOverviewPlotQuery", () => {
+  const filteredBy = (filterExpr: string | null) => ({
+    appId: "app-1",
+    startDate: "2026-01-01T00:00:00Z",
+    endDate: "2026-01-02T00:00:00Z",
+    filterExpr,
+  });
+
+  it("does not fetch without an app and a date range", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useBugReportsOverviewPlotQuery(null), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockFetchBugReportsOverviewPlot).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the app, range and filter, and returns the mapped plot", async () => {
+    mockFetchBugReportsOverviewPlot.mockResolvedValueOnce([
+      { id: "v1", data: [{ datetime: "2026-01-01", instances: 3 }] },
+    ]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useBugReportsOverviewPlotQuery(filteredBy("bug_report_status:in:open")),
+      { wrapper },
+    );
+
+    expect(result.current.status).toBe("pending");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    expect(mockFetchBugReportsOverviewPlot).toHaveBeenCalledWith(
+      "app-1",
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      "bug_report_status:in:open",
+    );
+    expect(result.current.data).toEqual([
+      { id: "v1", data: [{ x: "2026-01-01", y: 3 }] },
+    ]);
+  });
+
+  it("passes a null plot through", async () => {
+    mockFetchBugReportsOverviewPlot.mockResolvedValueOnce(null);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useBugReportsOverviewPlotQuery(filteredBy(null)),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("surfaces a failed fetch as a query error", async () => {
+    const failure = new ApiError(500, "request failed");
+    mockFetchBugReportsOverviewPlot.mockRejectedValueOnce(failure);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useBugReportsOverviewPlotQuery(filteredBy(null)),
       { wrapper },
     );
 

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import {
   App,
   AppVersion,
-  BugReportStatus,
   FilterSource,
   HttpMethod,
   OsVersion,
@@ -64,7 +63,6 @@ const baseConfig = {
   showLocales: true,
   showDeviceManufacturers: true,
   showDeviceNames: true,
-  showBugReportStatus: true,
   showHttpMethods: true,
   showUdAttrs: true,
   showFreeText: true,
@@ -314,26 +312,6 @@ describe("applyFilterOptions", () => {
     expect(patch.selectedUdAttrMatchers).toEqual([
       { key: "plan", type: "string", op: "eq", value: "pro" },
     ]);
-  });
-
-  it("defaults bug report statuses to [Open]", () => {
-    const patch = applyFilterOptions(
-      emptyOptions(),
-      app,
-      initConfig({}),
-      state(),
-    );
-    expect(patch.selectedBugReportStatuses).toEqual([BugReportStatus.Open]);
-  });
-
-  it("honors URL bug report statuses when valid", () => {
-    const patch = applyFilterOptions(
-      emptyOptions(),
-      app,
-      initConfig({ bugReportStatuses: [BugReportStatus.Closed] }),
-      state(),
-    );
-    expect(patch.selectedBugReportStatuses).toEqual([BugReportStatus.Closed]);
   });
 
   it("honors URL session types when valid", () => {

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -1,14 +1,13 @@
 "use client";
-import { useFiltersStore } from "@/app/stores/provider";
 
-import {
-  FilterSource,
-  emptyBugReportsOverviewResponse,
-} from "@/app/api/api_calls";
+import { emptyBugReportsOverviewResponse } from "@/app/api/api_calls";
+import { filterExprIssuesIn } from "@/app/api/api_error";
 import BugReportsOverviewPlot from "@/app/components/bug_reports_overview_plot";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import FilterBar, {
+  type FilterState,
+  type ReadyFilterState,
+  filterExprUrlKey,
+} from "@/app/components/filter_bar/filter_bar";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import Pill, { PillType } from "@/app/components/pill";
@@ -23,17 +22,55 @@ import {
 } from "@/app/components/table";
 import {
   paginationOffsetUrlKey,
+  useBugReportsOverviewPlotQuery,
   useBugReportsOverviewQuery,
 } from "@/app/query/hooks";
+import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import {
   formatDateToHumanReadableDate,
   formatDateToHumanReadableTime,
 } from "@/app/utils/time_utils";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { use, useEffect, useRef, useState } from "react";
+import {
+  type ReadonlyURLSearchParams,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { use, useState } from "react";
 
 const PAGINATION_LIMIT = 5;
+
+const {
+  appId: appIdUrlKey,
+  dateRange: dateRangeUrlKey,
+  startDate: startDateUrlKey,
+  endDate: endDateUrlKey,
+} = urlFiltersKeyMap;
+
+function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
+  return {
+    app: searchParams.get(appIdUrlKey),
+    dateRange: {
+      dateRange: searchParams.get(dateRangeUrlKey),
+      startDate: searchParams.get(startDateUrlKey),
+      endDate: searchParams.get(endDateUrlKey),
+    },
+    filterExpr: searchParams.get(filterExprUrlKey),
+  };
+}
+
+function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
+  const urlParams = new URLSearchParams();
+  urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
+  urlParams.set(appIdUrlKey, filter.app.id);
+  urlParams.set(dateRangeUrlKey, filter.date.dateRange);
+  urlParams.set(startDateUrlKey, filter.date.startDate);
+  urlParams.set(endDateUrlKey, filter.date.endDate);
+  if (filter.filterExpr) {
+    urlParams.set(filterExprUrlKey, filter.filterExpr);
+  }
+  return `?${urlParams.toString()}`;
+}
 
 export default function BugReportsOverview(props: {
   params: Promise<{ teamId: string }>;
@@ -42,228 +79,246 @@ export default function BugReportsOverview(props: {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const filters = useFiltersStore((state) => state.filters);
+  const paginationOffset =
+    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
+  const requestedFilters = readRequestedFilters(searchParams);
 
-  // Pagination is component-local state, initialized from URL
-  const [paginationOffset, setPaginationOffset] = useState(() => {
-    const po = searchParams.get(paginationOffsetUrlKey);
-    return po ? parseInt(po) : 0;
+  const [filterState, setFilterState] = useState<FilterState>({
+    status: "pending",
   });
+  const readyFilter = filterState.status === "ready" ? filterState : null;
 
-  // Reset pagination when filters change (skip pre-ready transitions)
-  const prevFiltersRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!filters.ready) return;
-    if (
-      prevFiltersRef.current !== null &&
-      prevFiltersRef.current !== filters.serialisedFilters
-    ) {
-      setPaginationOffset(0);
-    }
-    prevFiltersRef.current = filters.serialisedFilters;
-  }, [filters.ready, filters.serialisedFilters]);
+  // The queries read the filter and the pagination offset from the URL, so
+  // each fetch uses one searchParams snapshot. The filter is null until the
+  // URL matches the bar's report. A filter the bar discarded is never fetched.
+  const filterParams =
+    filterState.status === "ready" &&
+    requestedFilters.app === filterState.app.id &&
+    requestedFilters.dateRange.startDate === filterState.date.startDate &&
+    requestedFilters.dateRange.endDate === filterState.date.endDate &&
+    requestedFilters.filterExpr === filterState.filterExpr
+      ? {
+          appId: requestedFilters.app,
+          startDate: requestedFilters.dateRange.startDate,
+          endDate: requestedFilters.dateRange.endDate,
+          filterExpr: requestedFilters.filterExpr,
+        }
+      : null;
 
-  // URL sync
-  useEffect(() => {
-    if (!filters.ready) {
+  const bugReportsQuery = useBugReportsOverviewQuery(
+    filterParams,
+    paginationOffset,
+  );
+  const bugReportsPlotQuery = useBugReportsOverviewPlotQuery(filterParams);
+
+  const filterExprIssues =
+    filterExprIssuesIn(bugReportsQuery.error) ??
+    filterExprIssuesIn(bugReportsPlotQuery.error);
+
+  const onFilterChange = (newFilterState: FilterState) => {
+    setFilterState(newFilterState);
+
+    if (newFilterState.status !== "ready") {
       return;
     }
-    router.replace(
-      `?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`,
-      { scroll: false },
-    );
-  }, [paginationOffset, filters.ready, filters.serialisedFilters]);
+    // The URL's pagination offset is kept only when the bar applied the URL's
+    // request unchanged. Any edit or substitution starts back at page one.
+    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
+    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
+  };
+
+  const navigateToOffset = (offset: number) => {
+    const urlParams = new URLSearchParams(searchParams);
+    urlParams.set(paginationOffsetUrlKey, String(offset));
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  };
+
+  const nextPage = () => navigateToOffset(paginationOffset + PAGINATION_LIMIT);
+  const prevPage = () =>
+    navigateToOffset(Math.max(0, paginationOffset - PAGINATION_LIMIT));
 
   const {
     data: bugReportsOverview = emptyBugReportsOverviewResponse,
     status,
     isFetching,
-  } = useBugReportsOverviewQuery(paginationOffset);
-
-  const nextPage = () => setPaginationOffset((o) => o + PAGINATION_LIMIT);
-  const prevPage = () =>
-    setPaginationOffset((o) => Math.max(0, o - PAGINATION_LIMIT));
+  } = bugReportsQuery;
 
   return (
     <div className="flex flex-col items-start">
       <div className="py-4" />
 
-      <Filters
+      <FilterBar
         teamId={params.teamId}
-        filterSource={FilterSource.Events}
-        appVersionsInitialSelectionType={AppVersionsInitialSelectionType.Latest}
-        showOsVersions={true}
-        showCountries={true}
-        showNetworkTypes={true}
-        showNetworkProviders={true}
-        showNetworkGenerations={true}
-        showLocales={true}
-        showDeviceManufacturers={true}
-        showDeviceNames={true}
-        showBugReportStatus={true}
-        showUdAttrs={true}
-        showFreeText={true}
-        freeTextPlaceholder="Search User ID, Session Id, Bug Report ID or description.."
+        entity="bug_reports"
+        placeholder="Filter bug reports…"
+        requestedAppId={requestedFilters.app}
+        requestedDateRange={requestedFilters.dateRange}
+        requestedFilterExpr={requestedFilters.filterExpr}
+        filterExprIssues={filterExprIssues}
+        onFilterChange={onFilterChange}
       />
       <div className="py-4" />
 
-      {filters.loading && <SkeletonListPage />}
-
-      {/* Error state for bug reports fetch */}
-      {filters.ready && status === "error" && (
-        <p className="text-lg font-display">
-          Error fetching list of bug reports, please change filters, refresh
-          page or select a different app to try again
-        </p>
+      {filterState.status === "error" && (
+        <p className="text-lg font-display">{filterState.message}</p>
       )}
 
-      {/* Main bug reports list UI */}
-      {filters.ready && (status === "success" || status === "pending") && (
-        <div className="flex flex-col items-center w-full">
-          <BugReportsOverviewPlot />
-          <div className="self-end">
-            <Paginator
-              prevEnabled={
-                isFetching ? false : bugReportsOverview.meta.previous
-              }
-              nextEnabled={isFetching ? false : bugReportsOverview.meta.next}
-              displayText=""
-              onNext={nextPage}
-              onPrev={prevPage}
+      {filterState.status === "pending" && <SkeletonListPage />}
+
+      {readyFilter !== null &&
+        status === "error" &&
+        filterExprIssues === null && (
+          <p className="text-lg font-display">
+            Error fetching list of bug reports, please change filters, refresh
+            page or select a different app to try again
+          </p>
+        )}
+
+      {readyFilter !== null &&
+        (status === "success" || status === "pending") && (
+          <div className="flex flex-col items-center w-full">
+            <BugReportsOverviewPlot
+              startDate={readyFilter.date.startDate}
+              endDate={readyFilter.date.endDate}
+              query={bugReportsPlotQuery}
             />
-          </div>
-          <div
-            className={`py-1 w-full ${isFetching ? "visible" : "invisible"}`}
-          >
-            <LoadingBar />
-          </div>
-          <div className="py-4" />
-          <Table className="font-display select-none">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[60%]">Bug Report</TableHead>
-                <TableHead className="w-[20%] text-center">Time</TableHead>
-                <TableHead className="w-[20%] text-center">Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {bugReportsOverview.results?.map(
-                (
-                  {
-                    event_id,
-                    description,
-                    status,
-                    app_id,
-                    timestamp,
-                    matched_free_text,
-                    attribute,
-                  }: any,
-                  idx: number,
-                ) => {
-                  const bugReportHref = `/${params.teamId}/bug_reports/${app_id}/${event_id}`;
-                  return (
-                    <TableRow
-                      key={`${idx}-${event_id}`}
-                      data-testid="bug-report-row"
-                      className="font-body"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          router.push(bugReportHref);
-                        }
-                      }}
-                    >
-                      <TableCell className="w-[60%] relative p-0">
-                        <Link
-                          href={bugReportHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-label={`ID: ${event_id}`}
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4">
-                          <p className="truncate text-xs text-muted-foreground select-none">
-                            ID: {event_id}
-                          </p>
-                          <div className="py-1" />
-                          <p
-                            data-testid="bug-report-row-description"
-                            className="truncate select-none"
-                          >
-                            {description ? description : "No Description"}
-                          </p>
-                          <div className="py-1" />
-                          <p className="text-xs truncate text-muted-foreground select-none">
-                            {attribute.app_version +
-                              "(" +
-                              attribute.app_build +
-                              "), " +
-                              (attribute.os_name === "android"
-                                ? "Android API Level"
-                                : attribute.os_name === "ios"
-                                  ? "iOS"
-                                  : attribute.os_name === "ipados"
-                                    ? "iPadOS"
-                                    : attribute.os_name) +
-                              " " +
-                              attribute.os_version +
-                              ", " +
-                              attribute.device_manufacturer +
-                              " " +
-                              attribute.device_model}
-                          </p>
-                          {matched_free_text !== "" && (
-                            <p className="p-1 mt-2 text-xs truncate border border-border rounded-md ">
-                              {"Matched " + matched_free_text}
-                            </p>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-[20%] text-center relative p-0">
-                        <Link
-                          href={bugReportHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4">
-                          <p className="truncate select-none">
-                            {formatDateToHumanReadableDate(timestamp)}
-                          </p>
-                          <div className="py-1" />
-                          <p className="text-xs truncate select-none">
-                            {formatDateToHumanReadableTime(timestamp)}
-                          </p>
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-[20%] text-center relative p-0">
-                        <Link
-                          href={bugReportHref}
-                          className="absolute inset-0 z-10 cursor-pointer"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          style={{ display: "block" }}
-                        />
-                        <div className="pointer-events-none p-4 items-center flex justify-center">
-                          <Pill
-                            type={
-                              status === 0
-                                ? PillType.OpenStatus
-                                : PillType.ClosedStatus
-                            }
+            <div className="self-end">
+              <Paginator
+                prevEnabled={
+                  isFetching ? false : bugReportsOverview.meta.previous
+                }
+                nextEnabled={isFetching ? false : bugReportsOverview.meta.next}
+                displayText=""
+                onNext={nextPage}
+                onPrev={prevPage}
+              />
+            </div>
+
+            <div
+              className={`py-4 w-full ${isFetching ? "visible" : "invisible"}`}
+            >
+              <LoadingBar />
+            </div>
+            <Table className="font-display select-none">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[60%]">Bug Report</TableHead>
+                  <TableHead className="w-[20%] text-center">Time</TableHead>
+                  <TableHead className="w-[20%] text-center">Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bugReportsOverview.results?.map(
+                  (
+                    {
+                      event_id,
+                      description,
+                      status,
+                      app_id,
+                      timestamp,
+                      attribute,
+                    }: any,
+                    idx: number,
+                  ) => {
+                    const bugReportHref = `/${params.teamId}/bug_reports/${app_id}/${event_id}`;
+                    return (
+                      <TableRow
+                        key={`${idx}-${event_id}`}
+                        data-testid="bug-report-row"
+                        className="font-body"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            router.push(bugReportHref);
+                          }
+                        }}
+                      >
+                        <TableCell className="w-[60%] relative p-0">
+                          <Link
+                            href={bugReportHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-label={`ID: ${event_id}`}
+                            style={{ display: "block" }}
                           />
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                },
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+                          <div className="pointer-events-none p-4">
+                            <p className="truncate text-xs text-muted-foreground select-none">
+                              ID: {event_id}
+                            </p>
+                            <div className="py-1" />
+                            <p
+                              data-testid="bug-report-row-description"
+                              className="truncate select-none"
+                            >
+                              {description ? description : "No Description"}
+                            </p>
+                            <div className="py-1" />
+                            <p className="text-xs truncate text-muted-foreground select-none">
+                              {attribute.app_version +
+                                "(" +
+                                attribute.app_build +
+                                "), " +
+                                (attribute.os_name === "android"
+                                  ? "Android API Level"
+                                  : attribute.os_name === "ios"
+                                    ? "iOS"
+                                    : attribute.os_name === "ipados"
+                                      ? "iPadOS"
+                                      : attribute.os_name) +
+                                " " +
+                                attribute.os_version +
+                                ", " +
+                                attribute.device_manufacturer +
+                                " " +
+                                attribute.device_model}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-[20%] text-center relative p-0">
+                          <Link
+                            href={bugReportHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            style={{ display: "block" }}
+                          />
+                          <div className="pointer-events-none p-4">
+                            <p className="truncate select-none">
+                              {formatDateToHumanReadableDate(timestamp)}
+                            </p>
+                            <div className="py-1" />
+                            <p className="text-xs truncate select-none">
+                              {formatDateToHumanReadableTime(timestamp)}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-[20%] text-center relative p-0">
+                          <Link
+                            href={bugReportHref}
+                            className="absolute inset-0 z-10 cursor-pointer"
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            style={{ display: "block" }}
+                          />
+                          <div className="pointer-events-none p-4 items-center flex justify-center">
+                            <Pill
+                              type={
+                                status === 0
+                                  ? PillType.OpenStatus
+                                  : PillType.ClosedStatus
+                              }
+                            />
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  },
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
     </div>
   );
 }

--- a/frontend/dashboard/app/[teamId]/layout.tsx
+++ b/frontend/dashboard/app/[teamId]/layout.tsx
@@ -31,7 +31,22 @@ import UserAvatar from "../components/user_avatar";
 import { useMeasureStoreRegistry } from "../stores/provider";
 import { isCloud } from "../utils/env_utils";
 
-function buildInitNavData() {
+type NavItem = {
+  title: string;
+  url: string;
+  // Query string appended when navigating, so a page opens with a default
+  // view. Not part of the pathname-based active match.
+  queryString?: string;
+  isActive: boolean;
+  external: boolean;
+};
+
+type NavSection = {
+  title: string;
+  items: NavItem[];
+};
+
+function buildInitNavData(): { navMain: NavSection[] } {
   return {
     navMain: [
       {
@@ -69,6 +84,7 @@ function buildInitNavData() {
           {
             title: "Bug Reports",
             url: "bug_reports",
+            queryString: "?filter_expr=bug_report_status:in:open",
             isActive: false,
             external: false,
           },
@@ -289,7 +305,7 @@ export default function DashboardLayout({
                                 href={
                                   item.external
                                     ? `${item.url}`
-                                    : `/${selectedTeam?.id}/${item.url}`
+                                    : `/${selectedTeam?.id}/${item.url}${item.queryString ?? ""}`
                                 }
                                 className="font-body"
                                 onClick={(e) => {
@@ -297,7 +313,7 @@ export default function DashboardLayout({
                                     e.preventDefault();
                                     handleNavClick(item.url);
                                     router.push(
-                                      `/${selectedTeam?.id}/${item.url}`,
+                                      `/${selectedTeam?.id}/${item.url}${item.queryString ?? ""}`,
                                     );
                                   }
                                 }}

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -52,11 +52,6 @@ export enum SessionType {
   Background = "Background Sessions",
 }
 
-export enum BugReportStatus {
-  Open = "Open",
-  Closed = "Closed",
-}
-
 export enum HttpMethod {
   GET = "get",
   POST = "post",
@@ -475,7 +470,6 @@ export const emptyBugReportsOverviewResponse = {
     };
     user_defined_attribute: null;
     attachments: null;
-    matched_free_text: string;
   }[],
 };
 
@@ -643,7 +637,6 @@ export type Filters = {
   endDate: string;
   versions: { selected: AppVersion[]; all: boolean };
   sessionTypes: { selected: SessionType[]; all: boolean };
-  bugReportStatuses: { selected: BugReportStatus[]; all: boolean };
   httpMethods: { selected: HttpMethod[]; all: boolean };
   osVersions: { selected: OsVersion[]; all: boolean };
   countries: { selected: string[]; all: boolean };
@@ -674,7 +667,6 @@ export const defaultFilters: Filters = {
   endDate: "",
   versions: { selected: [], all: false },
   sessionTypes: { selected: [], all: false },
-  bugReportStatuses: { selected: [], all: false },
   httpMethods: { selected: [], all: false },
   osVersions: { selected: [], all: false },
   countries: { selected: [], all: false },
@@ -832,20 +824,6 @@ async function applyGenericFiltersToUrl(
   // leaking onto endpoints that don't filter by session content (e.g.
   // /errorGroups, which uses its own `type` param for selectedErrorTypes).
 
-  // Append bug report statuses if needed
-  if (
-    !filters.bugReportStatuses.all &&
-    filters.bugReportStatuses.selected.length > 0
-  ) {
-    filters.bugReportStatuses.selected.forEach((v) => {
-      if (v === BugReportStatus.Open) {
-        searchParams.append("bug_report_statuses", "0");
-      } else if (v === BugReportStatus.Closed) {
-        searchParams.append("bug_report_statuses", "1");
-      }
-    });
-  }
-
   // Append free text if present
   if (filters.freeText !== "") {
     searchParams.append("free_text", filters.freeText);
@@ -920,23 +898,6 @@ function appendSessionTypesToUrl(url: string, filters: Filters): string {
     if (severities.size > 0) {
       u.searchParams.append("severity", Array.from(severities).join(","));
     }
-  }
-  return u.toString();
-}
-
-function appendBugReportStatusesToUrl(url: string, filters: Filters): string {
-  const u = new URL(url, window.location.origin);
-  if (
-    !filters.bugReportStatuses.all &&
-    filters.bugReportStatuses.selected.length > 0
-  ) {
-    filters.bugReportStatuses.selected.forEach((v) => {
-      if (v === BugReportStatus.Open) {
-        u.searchParams.append("bug_report_statuses", "0");
-      } else if (v === BugReportStatus.Closed) {
-        u.searchParams.append("bug_report_statuses", "1");
-      }
-    });
   }
   return u.toString();
 }
@@ -1712,36 +1673,49 @@ export const fetchCustomerPortalUrlFromServer = async (
 };
 
 export const fetchBugReportsOverviewFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   limit: number,
   offset: number,
 ) => {
-  var url = `/api/apps/${filters.app!.id}/bugReports?`;
+  const params = new URLSearchParams({
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+    limit: String(limit),
+    offset: String(offset),
+  });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
 
-  url = await applyGenericFiltersToUrl(url, filters, limit, offset);
-  url = appendBugReportStatusesToUrl(url, filters);
-
-  const data = await request(url, {
+  return await request(`/api/apps/${appId}/bugReports?${params.toString()}`, {
     failsWith: "Failed to fetch bug reports overview",
   });
-
-  return data;
 };
 
 export const fetchBugReportsOverviewPlotFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
 ) => {
-  var url = `/api/apps/${filters.app!.id}/bugReports/plots/instances?`;
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null);
-  url = appendBugReportStatusesToUrl(url, filters);
-  url = appendPlotTimeGroupToUrl(url, filters);
-
-  const data = await request(url, {
-    failsWith: "Failed to fetch bug reports overview plot",
+  const params = new URLSearchParams({
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+    plot_time_group: getPlotTimeGroupForRange(startDate, endDate),
   });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
 
-  return data;
+  return await request(
+    `/api/apps/${appId}/bugReports/plots/instances?${params.toString()}`,
+    { failsWith: "Failed to fetch bug reports overview plot" },
+  );
 };
 
 export const fetchBugReportFromServer = async (

--- a/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
+++ b/frontend/dashboard/app/components/bug_reports_overview_plot.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useBugReportsOverviewPlotQuery } from "@/app/query/hooks";
-import { useFiltersStore } from "@/app/stores/provider";
+import { type useBugReportsOverviewPlotQuery } from "@/app/query/hooks";
 import { ResponsiveLineCanvas } from "@nivo/line";
 import { useTheme } from "next-themes";
 import React, { useMemo } from "react";
@@ -19,16 +18,16 @@ import {
 } from "./plot_tooltip";
 import { SkeletonPlot } from "./skeleton";
 
-const BugReportsOverviewPlot: React.FC = () => {
-  const filters = useFiltersStore((state) => state.filters);
-  const { data: rawPlot, status } = useBugReportsOverviewPlotQuery();
+const BugReportsOverviewPlot: React.FC<{
+  startDate: string;
+  endDate: string;
+  query: ReturnType<typeof useBugReportsOverviewPlotQuery>;
+}> = ({ startDate, endDate, query }) => {
+  const { data: rawPlot, status } = query;
   const { theme } = useTheme();
   const chartColors = useChartColors();
   const canvasTheme = useChartCanvasTheme();
-  const plotTimeGroup = getPlotTimeGroupForRange(
-    filters.startDate,
-    filters.endDate,
-  );
+  const plotTimeGroup = getPlotTimeGroupForRange(startDate, endDate);
   const timeConfig = getPlotTimeGroupNivoConfig(plotTimeGroup);
 
   const plot = useMemo(() => {

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -527,9 +527,21 @@ export default function FilterBar({
     resolvedRootSpanName,
   ]);
 
+  // Every request gets a report, even when it resolves to the same
+  // values as the previous request. For example, after a request for
+  // app 1, a request with no app also resolves to app 1. Reporting
+  // only changed resolutions would leave that second request with no report.
   useEffect(() => {
     onFilterChange(filterState);
-  }, [filterState]);
+  }, [
+    filterState,
+    requestedAppId,
+    requestedDateRange.dateRange,
+    requestedDateRange.startDate,
+    requestedDateRange.endDate,
+    requestedFilterExpr,
+    requestedRootSpanName,
+  ]);
 
   useEffect(() => {
     if (anythingDiscarded) {

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -20,7 +20,6 @@ import React, {
 import {
   App,
   AppVersion,
-  BugReportStatus,
   FilterSource,
   HttpMethod,
   SessionType,
@@ -94,7 +93,6 @@ interface FiltersProps {
   showLocales?: boolean;
   showDeviceManufacturers?: boolean;
   showDeviceNames?: boolean;
-  showBugReportStatus?: boolean;
   showHttpMethods?: boolean;
   showUdAttrs?: boolean;
   showFreeText?: boolean;
@@ -218,14 +216,6 @@ export function deserializeUrlFilters(queryString: string): URLFilters {
               return { key, type, op, value: val } as UdAttrMatcher;
             })
             .filter((m) => m.key && m.type && m.op && m.value);
-          break;
-
-        case "bugReportStatuses":
-          result[originalKey] = value
-            .split(",")
-            .filter((s): s is BugReportStatus =>
-              Object.values(BugReportStatus).includes(s as BugReportStatus),
-            );
           break;
 
         case "httpMethods":
@@ -503,7 +493,6 @@ const FiltersComponent = forwardRef<
       showLocales = false,
       showDeviceManufacturers = false,
       showDeviceNames = false,
-      showBugReportStatus = false,
       showHttpMethods = false,
       showUdAttrs = false,
       showFreeText = false,
@@ -558,7 +547,6 @@ const FiltersComponent = forwardRef<
         showLocales,
         showDeviceManufacturers,
         showDeviceNames,
-        showBugReportStatus,
         showHttpMethods,
         showUdAttrs,
         showFreeText,
@@ -580,7 +568,6 @@ const FiltersComponent = forwardRef<
       showLocales,
       showDeviceManufacturers,
       showDeviceNames,
-      showBugReportStatus,
       showHttpMethods,
       showUdAttrs,
       showFreeText,
@@ -747,7 +734,6 @@ const FiltersComponent = forwardRef<
     // confirms.
     type PendingModalFilters = {
       selectedSessionTypes: SessionType[];
-      selectedBugReportStatuses: BugReportStatus[];
       selectedHttpMethods: HttpMethod[];
       selectedOsVersions: typeof store.selectedOsVersions;
       selectedCountries: string[];
@@ -762,7 +748,6 @@ const FiltersComponent = forwardRef<
     const [pendingModalFilters, setPendingModalFilters] =
       useState<PendingModalFilters>(() => ({
         selectedSessionTypes: store.selectedSessionTypes,
-        selectedBugReportStatuses: store.selectedBugReportStatuses,
         selectedHttpMethods: store.selectedHttpMethods,
         selectedOsVersions: store.selectedOsVersions,
         selectedCountries: store.selectedCountries,
@@ -785,7 +770,6 @@ const FiltersComponent = forwardRef<
       if (moreFiltersOpen) {
         setPendingModalFilters({
           selectedSessionTypes: store.selectedSessionTypes,
-          selectedBugReportStatuses: store.selectedBugReportStatuses,
           selectedHttpMethods: store.selectedHttpMethods,
           selectedOsVersions: store.selectedOsVersions,
           selectedCountries: store.selectedCountries,
@@ -803,9 +787,6 @@ const FiltersComponent = forwardRef<
     // Commit the pending snapshot to the store and close the modal.
     const saveMoreFilters = () => {
       store.setSelectedSessionTypes(pendingModalFilters.selectedSessionTypes);
-      store.setSelectedBugReportStatuses(
-        pendingModalFilters.selectedBugReportStatuses,
-      );
       store.setSelectedHttpMethods(pendingModalFilters.selectedHttpMethods);
       store.setSelectedOsVersions(pendingModalFilters.selectedOsVersions);
       store.setSelectedCountries(pendingModalFilters.selectedCountries);
@@ -850,7 +831,6 @@ const FiltersComponent = forwardRef<
     // (no loaded data) so the skeleton can reserve the trigger's slot.
     const hasMoreFiltersConfig =
       showSessionTypes ||
-      showBugReportStatus ||
       showHttpMethods ||
       showOsVersions ||
       showCountries ||
@@ -888,7 +868,6 @@ const FiltersComponent = forwardRef<
     // trigger so it never opens an empty modal.
     const hasMoreFilters =
       showSessionTypes ||
-      showBugReportStatus ||
       showHttpMethods ||
       (showOsVersions && store.osVersions.length > 0) ||
       (showCountries && store.countries.length > 0) ||
@@ -919,19 +898,6 @@ const FiltersComponent = forwardRef<
           : resetAction(() =>
               store.setSelectedSessionTypes(defaultSessionTypes),
             ),
-      });
-    }
-    if (showBugReportStatus && store.selectedBugReportStatuses.length > 0) {
-      filterChips.push({
-        key: "bugReportStatuses",
-        ...chipLabels("Bug Report Status", store.selectedBugReportStatuses),
-        action:
-          store.selectedBugReportStatuses.length === 1 &&
-          store.selectedBugReportStatuses[0] === BugReportStatus.Open
-            ? undefined
-            : resetAction(() =>
-                store.setSelectedBugReportStatuses([BugReportStatus.Open]),
-              ),
       });
     }
     if (showHttpMethods && store.selectedHttpMethods.length > 0) {
@@ -1121,20 +1087,6 @@ const FiltersComponent = forwardRef<
               setPendingModalFilters((p) => ({
                 ...p,
                 selectedSessionTypes: items as SessionType[],
-              }))
-            }
-          />
-        )}
-        {showBugReportStatus && (
-          <StringMultiRow
-            rowKey="bugReportStatuses"
-            title="Bug Report Status"
-            items={Object.values(BugReportStatus)}
-            selected={pendingModalFilters.selectedBugReportStatuses}
-            onChange={(items) =>
-              setPendingModalFilters((p) => ({
-                ...p,
-                selectedBugReportStatuses: items as BugReportStatus[],
               }))
             }
           />

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -570,15 +570,26 @@ export function useNetworkTrendsQuery(active: boolean) {
 
 // ─── Plot: Overview ──────────────────────────────────────────────────────
 
-export function useBugReportsOverviewPlotQuery() {
-  const filters = useFiltersStore((s) => s.filters);
+export function useBugReportsOverviewPlotQuery(params: FilterParams | null) {
   return useQuery({
-    queryKey: ["bugReportsOverviewPlot", filters.serialisedFilters] as const,
+    queryKey: [
+      "bugReportsOverviewPlot",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+    ] as const,
     queryFn: async () => {
-      const result = await fetchBugReportsOverviewPlotFromServer(filters);
+      const result = await fetchBugReportsOverviewPlotFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+      );
       return mapPlotData(result);
     },
-    enabled: filters.ready,
+    enabled: params !== null,
+    retry: false,
   });
 }
 
@@ -654,22 +665,31 @@ export function useAlertsOverviewQuery(paginationOffset: number) {
 
 const BUG_REPORTS_LIMIT = 5;
 
-export function useBugReportsOverviewQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useBugReportsOverviewQuery(
+  params: FilterParams | null,
+  paginationOffset: number,
+) {
   return useQuery({
     queryKey: [
       "bugReportsOverview",
-      filters.serialisedFilters,
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
     queryFn: () =>
       fetchBugReportsOverviewFromServer(
-        filters,
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
         BUG_REPORTS_LIMIT,
         paginationOffset,
       ),
-    enabled: filters.ready,
+    enabled: params !== null,
+    retry: false,
   });
 }
 

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -3,7 +3,6 @@ import { createStore } from "zustand/vanilla";
 import {
   App,
   AppVersion,
-  BugReportStatus,
   buildShortFiltersPostBody,
   defaultFilters,
   Filters,
@@ -41,7 +40,6 @@ export type FilterConfig = {
   showLocales: boolean;
   showDeviceManufacturers: boolean;
   showDeviceNames: boolean;
-  showBugReportStatus: boolean;
   showHttpMethods: boolean;
   showUdAttrs: boolean;
   showFreeText: boolean;
@@ -54,7 +52,6 @@ export type URLFilters = {
   dateRange?: string;
   versions?: number[];
   sessionTypes?: SessionType[];
-  bugReportStatuses?: BugReportStatus[];
   httpMethods?: HttpMethod[];
   osVersions?: number[];
   countries?: number[];
@@ -116,8 +113,6 @@ export const defaultSessionTypes = [
   SessionType.Foreground,
   SessionType.UserInteraction,
 ];
-const allBugReportStatuses = [BugReportStatus.Open, BugReportStatus.Closed];
-
 const urlFiltersKeyMap = {
   appId: "a",
   rootSpanName: "r",
@@ -126,7 +121,6 @@ const urlFiltersKeyMap = {
   endDate: "ed",
   versions: "v",
   sessionTypes: "st",
-  bugReportStatuses: "bs",
   httpMethods: "hm",
   osVersions: "os",
   countries: "c",
@@ -225,9 +219,6 @@ function serializeUrlFilters(
       case "deviceNames":
         if (!config.showDeviceNames) return;
         break;
-      case "bugReportStatuses":
-        if (!config.showBugReportStatus) return;
-        break;
       case "httpMethods":
         if (!config.showHttpMethods) return;
         break;
@@ -280,7 +271,6 @@ function serializeUrlFilters(
           )
           .join("|");
         break;
-      case "bugReportStatuses":
       case "httpMethods":
         if ((value as string[]).length === 0) return;
         serializedValue = (value as string[]).join(",");
@@ -365,7 +355,6 @@ interface FiltersStoreState {
   // every Filters mount via applyFilterOptions.
   selectedVersions: AppVersion[];
   selectedSessionTypes: SessionType[];
-  selectedBugReportStatuses: BugReportStatus[];
   selectedHttpMethods: HttpMethod[];
   selectedOsVersions: OsVersion[];
   selectedCountries: string[];
@@ -400,7 +389,6 @@ interface FiltersStoreActions {
   setSelectedEndDate: (date: string) => void;
   setSelectedVersions: (versions: AppVersion[]) => void;
   setSelectedSessionTypes: (types: SessionType[]) => void;
-  setSelectedBugReportStatuses: (statuses: BugReportStatus[]) => void;
   setSelectedHttpMethods: (methods: HttpMethod[]) => void;
   setSelectedOsVersions: (versions: OsVersion[]) => void;
   setSelectedCountries: (countries: string[]) => void;
@@ -454,7 +442,6 @@ const initialState: FiltersStoreState = {
   selectedEndDate: "",
   selectedVersions: [],
   selectedSessionTypes: defaultSessionTypes,
-  selectedBugReportStatuses: [BugReportStatus.Open],
   selectedHttpMethods: allHttpMethods,
   selectedOsVersions: [],
   selectedCountries: [],
@@ -506,7 +493,6 @@ function computeFilters(state: FiltersStoreState): Filters {
       ),
     ),
     sessionTypes: state.selectedSessionTypes,
-    bugReportStatuses: state.selectedBugReportStatuses,
     httpMethods: state.selectedHttpMethods,
     osVersions: state.selectedOsVersions.map((os) =>
       state.osVersions.findIndex(
@@ -554,11 +540,6 @@ function computeFilters(state: FiltersStoreState): Filters {
     sessionTypes: {
       selected: state.selectedSessionTypes,
       all: state.selectedSessionTypes.length === allSessionTypes.length,
-    },
-    bugReportStatuses: {
-      selected: state.selectedBugReportStatuses,
-      all:
-        state.selectedBugReportStatuses.length === allBugReportStatuses.length,
     },
     httpMethods: {
       selected: state.selectedHttpMethods,
@@ -712,17 +693,6 @@ export function applyFilterOptions(
     selectedUdAttrMatchers = [];
   }
 
-  let selectedBugReportStatuses: BugReportStatus[];
-  if (isUrlMatch && urlFilters.bugReportStatuses) {
-    selectedBugReportStatuses = urlFilters.bugReportStatuses
-      .filter((s: string) =>
-        Object.values(BugReportStatus).includes(s as BugReportStatus),
-      )
-      .map((s: string) => s as BugReportStatus);
-  } else {
-    selectedBugReportStatuses = [BugReportStatus.Open];
-  }
-
   let selectedHttpMethods: HttpMethod[];
   if (isUrlMatch && urlFilters.httpMethods) {
     selectedHttpMethods = urlFilters.httpMethods
@@ -795,7 +765,6 @@ export function applyFilterOptions(
     selectedDeviceManufacturers,
     selectedDeviceNames,
     selectedUdAttrMatchers,
-    selectedBugReportStatuses,
     selectedHttpMethods,
     selectedSessionTypes,
     selectedFreeText,
@@ -910,7 +879,6 @@ export function createFiltersStore() {
           selectedDeviceManufacturers: [],
           selectedDeviceNames: [],
           selectedSessionTypes: [],
-          selectedBugReportStatuses: [],
           selectedHttpMethods: [],
           selectedUdAttrMatchers: [],
           selectedFreeText: "",
@@ -966,8 +934,6 @@ export function createFiltersStore() {
       setSelectedEndDate: (date) => set({ selectedEndDate: date }),
       setSelectedVersions: (versions) => set({ selectedVersions: versions }),
       setSelectedSessionTypes: (types) => set({ selectedSessionTypes: types }),
-      setSelectedBugReportStatuses: (statuses) =>
-        set({ selectedBugReportStatuses: statuses }),
       setSelectedHttpMethods: (methods) =>
         set({ selectedHttpMethods: methods }),
       setSelectedOsVersions: (versions) =>

--- a/frontend/dashboard/content/docs/mcp.mdx
+++ b/frontend/dashboard/content/docs/mcp.mdx
@@ -47,7 +47,7 @@ Get available filter options (versions, OS, countries, devices, etc.) for an app
 
 ### `get_filter_keys`
 
-List the filter keys of an entity (spans or builds): the vocabulary a filter expression is written with.
+List the filter keys of an entity (spans, bug_reports or builds): the vocabulary a filter expression is written with.
 
 ### `get_filter_values`
 

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -1004,6 +1004,7 @@ paths:
             enum:
               - builds
               - spans
+              - bug_reports
         - name: key
           in: query
           required: false
@@ -1125,6 +1126,7 @@ paths:
             enum:
               - builds
               - spans
+              - bug_reports
         - name: key_name
           in: query
           required: true
@@ -3627,11 +3629,10 @@ paths:
         - Bug Reports
       summary: Fetch an app's bug reports
       description: |
-        Fetch an app's bug reports by applying various optional filters.
+        Fetch an app's bug reports, optionally narrowed by a filter
+        expression.
 
-        For multiple comma separated fields, make sure no whitespace characters
-        exist before or after commas. Pass `limit` and `offset` values to
-        paginate results.
+        Pass `limit` and `offset` values to paginate results.
       parameters:
         - name: id
           in: path
@@ -3642,77 +3643,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - $ref: "#/components/parameters/PlotTimeGroup"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version codes to return only matching sessions.
-          schema:
-            type: string
-        - name: countries
-          in: query
-          required: false
-          description: List of comma separated country identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_names
-          in: query
-          required: false
-          description: List of comma separated device name identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated device locale identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: free_text
-          in: query
-          required: false
-          description: A sequence of characters used to filter sessions matching various criteria like user_id, description and so on.
-          schema:
-            type: string
-        - name: bug_report_statuses
-          in: query
-          required: false
-          description: Should be 0 (Open) or 1 (Closed). If multiple statuses are required, they should be passed as multiple query params like `bug_report_statuses=0&bug_report_statuses=1`.
-          style: form
-          explode: true
-          schema:
-            type: array
-            items:
-              type: integer
+        - $ref: "#/components/parameters/FilterExpr"
         - name: offset
           in: query
           required: false
@@ -3725,18 +3656,6 @@ paths:
           description: Number of items to return. Used for pagination. Should be used along with `offset`.
           schema:
             type: integer
-        - name: filter_short_code
-          in: query
-          required: false
-          description: Code representing combination of filters.
-          schema:
-            type: string
-        - name: ud_expression
-          in: query
-          required: false
-          description: Expression in JSON to filter using user defined attributes.
-          schema:
-            type: string
       responses:
         "200":
           description: Successful response, no errors.
@@ -3784,8 +3703,6 @@ paths:
                           type:
                             - array
                             - "null"
-                        matched_free_text:
-                          type: string
               examples:
                 response:
                   value:
@@ -3811,7 +3728,6 @@ paths:
                           os_version: "34"
                         user_defined_attribute: null
                         attachments: null
-                        matched_free_text: ""
                       - session_id: e19be4bf-0896-42bf-a4a0-ba4529c57f1e
                         app_id: 47cf0390-b11c-4e1f-8f8a-770bf9c159bb
                         event_id: ea5f4312-af64-47f5-9d36-e7ad5b00362c
@@ -3830,7 +3746,6 @@ paths:
                           os_version: "33"
                         user_defined_attribute: null
                         attachments: null
-                        matched_free_text: ""
         "400":
           description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":
@@ -3848,12 +3763,8 @@ paths:
         - Bug Reports
       summary: Fetch an app's bug report instances plot
       description: |
-        Fetch an app's bug report instances plot by applying various optional
-        filters.
-
-        For multiple comma separated fields, make sure no whitespace characters
-        exist before or after commas. Pass `limit` and `offset` values to
-        paginate results.
+        Fetch an app's bug report instances plot, optionally narrowed by a
+        filter expression.
       parameters:
         - name: id
           in: path
@@ -3864,100 +3775,9 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version codes to return only matching sessions.
-          schema:
-            type: string
-        - name: countries
-          in: query
-          required: false
-          description: List of comma separated country identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_names
-          in: query
-          required: false
-          description: List of comma separated device name identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated device locale identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings to return only matching sessions.
-          schema:
-            type: string
-        - name: free_text
-          in: query
-          required: false
-          description: A sequence of characters used to filter sessions matching various criteria like user_id, description and so on.
-          schema:
-            type: string
-        - name: bug_report_statuses
-          in: query
-          required: false
-          description: Should be 0 (Open) or 1 (Closed). If multiple statuses are required, they should be passed as multiple query params like `bug_report_statuses=0&bug_report_statuses=1`.
-          style: form
-          explode: true
-          schema:
-            type: array
-            items:
-              type: integer
-        - name: offset
-          in: query
-          required: false
-          description: Number of items to skip when paginating. Use with `limit` parameter to control amount of items fetched.
-          schema:
-            type: integer
-        - name: limit
-          in: query
-          required: false
-          description: Number of items to return. Used for pagination. Should be used along with `offset`.
-          schema:
-            type: integer
-        - name: filter_short_code
-          in: query
-          required: false
-          description: Code representing combination of filters.
-          schema:
-            type: string
-        - name: ud_expression
-          in: query
-          required: false
-          description: Expression in JSON to filter using user defined attributes.
-          schema:
-            type: string
+        - $ref: "#/components/parameters/FilterExpr"
+        - $ref: "#/components/parameters/Timezone"
+        - $ref: "#/components/parameters/PlotTimeGroup"
       responses:
         "200":
           description: Successful response, no errors.


### PR DESCRIPTION
# Description

- Add a bug_reports filter entity with attribute, status, user, session and custom keys; free text is replaced by keys
- Rewrite the handlers, queries and MCP tools on the ExprFilter pattern
- Rebuild the bug reports page on the builds/traces FilterBar mechanics
- Default the sidebar entry to open reports via its link's query string
- Fix a FilterBar bug where an unchanged resolution produced no report
- Validate timezones in ExprFilter
- Make value suggestion ordering deterministic
- Drop FINAL and skip-index analysis from suggestion queries
- Bind args in test seeders instead of splicing SQL strings
- Close a leaked rows handle in the plot query
- Document the new entity in the OpenAPI spec



