### PR TITLE
Consolidate expression filter handling

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -1133,6 +1133,37 @@ func mcpExprFilter(entity exprfilter.Entity, appID, teamID uuid.UUID, fromStr, t
 	return ef, nil
 }
 
+// mcpPrepareExprFilter runs the request prologue shared by the tools that
+// query with an exprfilter.ExprFilter: it resolves the caller's access to the
+// app, builds the filter from the tool's time range and filter_expr inputs,
+// lets the tool set its pagination and timezone fields through apply, then
+// resolves the filter's custom keys and validates it.
+func (c *Config) mcpPrepareExprFilter(ctx context.Context, entity exprfilter.Entity, rawAppID, from, to, filterExpr string, apply func(*exprfilter.ExprFilter)) (appID, teamID uuid.UUID, ef *exprfilter.ExprFilter, err error) {
+	appID, teamID, err = c.mcpResolveAppAccess(ctx, rawAppID)
+	if err != nil {
+		return uuid.UUID{}, uuid.UUID{}, nil, err
+	}
+
+	ef, err = mcpExprFilter(entity, appID, teamID, from, to, filterExpr)
+	if err != nil {
+		return uuid.UUID{}, uuid.UUID{}, nil, err
+	}
+
+	if apply != nil {
+		apply(ef)
+	}
+
+	if err := ef.ResolveCustomKeys(ctx, c.Deps.RchPool); err != nil {
+		return uuid.UUID{}, uuid.UUID{}, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
+	}
+
+	if err := ef.Validate(); err != nil {
+		return uuid.UUID{}, uuid.UUID{}, nil, mcpFilterExprError(err)
+	}
+
+	return appID, teamID, ef, nil
+}
+
 // mcpFilterExprError renders a filter_expr parse or validation failure as one
 // error whose text names each problem and where in the expression it is, so
 // the model can correct the expression and call again. Other errors pass
@@ -1795,32 +1826,19 @@ func (c *Config) mcpGetSession(ctx context.Context, in mcpGetSessionInput) (*mcp
 
 func (c *Config) mcpGetBugReports(ctx context.Context, in mcpGetBugReportsInput) (*mcpsdk.CallToolResult, any, error) {
 	deps := c.Deps
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.BugReportsEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		limit := in.Limit
+		if limit <= 0 {
+			limit = 10
+		}
+		if limit > 30 {
+			limit = 30
+		}
+		ef.Limit = limit
+		ef.Offset = in.Offset
+	})
 	if err != nil {
 		return nil, nil, err
-	}
-
-	ef, err := mcpExprFilter(exprfilter.BugReportsEntity, appID, teamID, in.From, in.To, in.FilterExpr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	limit := in.Limit
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 30 {
-		limit = 30
-	}
-	ef.Limit = limit
-	ef.Offset = in.Offset
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
-	}
-
-	if err := ef.Validate(); err != nil {
-		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
@@ -1839,23 +1857,11 @@ func (c *Config) mcpGetBugReportsOverTime(ctx context.Context, in mcpGetBugRepor
 		return nil, nil, fmt.Errorf("timezone is required for over time tools")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.BugReportsEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		ef.Timezone = in.Timezone
+	})
 	if err != nil {
 		return nil, nil, err
-	}
-
-	ef, err := mcpExprFilter(exprfilter.BugReportsEntity, appID, teamID, in.From, in.To, in.FilterExpr)
-	if err != nil {
-		return nil, nil, err
-	}
-	ef.Timezone = in.Timezone
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
-	}
-
-	if err := ef.Validate(); err != nil {
-		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
@@ -1913,32 +1919,19 @@ func (c *Config) mcpGetSpanInstances(ctx context.Context, in mcpGetSpanInstances
 		return nil, nil, fmt.Errorf("root_span_name is required")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.SpansEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		limit := in.Limit
+		if limit <= 0 {
+			limit = 10
+		}
+		if limit > 30 {
+			limit = 30
+		}
+		ef.Limit = limit
+		ef.Offset = in.Offset
+	})
 	if err != nil {
 		return nil, nil, err
-	}
-
-	ef, err := mcpExprFilter(exprfilter.SpansEntity, appID, teamID, in.From, in.To, in.FilterExpr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	limit := in.Limit
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 30 {
-		limit = 30
-	}
-	ef.Limit = limit
-	ef.Offset = in.Offset
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
-	}
-
-	if err := ef.Validate(); err != nil {
-		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
@@ -1960,23 +1953,11 @@ func (c *Config) mcpGetSpanMetricsOverTime(ctx context.Context, in mcpGetSpanMet
 		return nil, nil, fmt.Errorf("timezone is required for over time tools")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.SpansEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		ef.Timezone = in.Timezone
+	})
 	if err != nil {
 		return nil, nil, err
-	}
-
-	ef, err := mcpExprFilter(exprfilter.SpansEntity, appID, teamID, in.From, in.To, in.FilterExpr)
-	if err != nil {
-		return nil, nil, err
-	}
-	ef.Timezone = in.Timezone
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		return nil, nil, fmt.Errorf("failed to read the filter's custom keys: %v", err)
-	}
-
-	if err := ef.Validate(); err != nil {
-		return nil, nil, mcpFilterExprError(err)
 	}
 
 	app := &measure.App{ID: &appID, TeamId: teamID}

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -2689,7 +2689,7 @@ func TestMCPGetFilterValues(t *testing.T) {
 		// The span_filters rollup serving these values keeps only spans
 		// carrying every attribute, so the seeds set them all.
 		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
-			SpanName: "checkout", Status: 1, StartTime: now.Add(-2*time.Hour),
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-2 * time.Hour),
 			AppVersion: "v1", AppBuild: "1",
 			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
 			NetworkGeneration: "5g", DeviceLocale: "en-US",
@@ -2717,7 +2717,7 @@ func TestMCPGetFilterValues(t *testing.T) {
 	t.Run("search narrows values", func(t *testing.T) {
 		appID, teamID, rawToken := setupToolTest(t, "fvals4@mcp.test")
 		th.SeedSpanRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.SpanRow{
-			SpanName: "checkout", Status: 1, StartTime: now.Add(-2*time.Hour),
+			SpanName: "checkout", Status: 1, StartTime: now.Add(-2 * time.Hour),
 			AppVersion: "1.2.0", AppBuild: "1",
 			CountryCode: "US", NetworkProvider: "T-Mobile", NetworkType: "wifi",
 			NetworkGeneration: "5g", DeviceLocale: "en-US",

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -2707,120 +2707,15 @@ func (h Handlers) GetRootSpanNames(c *gin.Context) {
 
 func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	spanName := c.Query("span_name")
-	if spanName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Missing span_name query param",
-		})
-		return
-	}
-
-	ef := exprfilter.ExprFilter{
-		AppID: id,
-		Limit: exprfilter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&ef); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	ef.Entity = exprfilter.SpansEntity
-
-	if err := ef.BuildExprTree(); err != nil {
-		respondFilterError(c, err)
-		return
-	}
-
-	ef.SetDefaultTimeRangeIfUnset()
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	app.TeamId = *team.ID
-	ef.TeamID = *team.ID
-
-	lc := logcomment.New(2)
-	settings := clickhouse.Settings{
-		"log_comment":     lc.MustPut(logcomment.Root, logcomment.Spans),
-		"use_query_cache": gin.Mode() == gin.ReleaseMode,
-	}
-
-	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "list"))
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		msg := "failed to read the filter's custom keys"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if err := ef.Validate(); err != nil {
-		respondFilterError(c, err)
+	app, ef, ctx, spanName, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:          exprfilter.SpansEntity,
+		appScope:        *measure.ScopeAppRead,
+		logRoot:         logcomment.Spans,
+		logName:         "list",
+		useQueryCache:   true,
+		requireSpanName: true,
+	})
+	if !ok {
 		return
 	}
 
@@ -2845,119 +2740,14 @@ func (h Handlers) GetSpansForSpanName(c *gin.Context) {
 
 func (h Handlers) GetMetricsPlotForSpanName(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	spanName := c.Query("span_name")
-	if spanName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Missing span_name query param",
-		})
-		return
-	}
-
-	ef := exprfilter.ExprFilter{
-		AppID: id,
-		Limit: exprfilter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&ef); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	ef.Entity = exprfilter.SpansEntity
-
-	if err := ef.BuildExprTree(); err != nil {
-		respondFilterError(c, err)
-		return
-	}
-
-	ef.SetDefaultTimeRangeIfUnset()
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	app.TeamId = *team.ID
-	ef.TeamID = *team.ID
-
-	lc := logcomment.New(2)
-	settings := clickhouse.Settings{
-		"log_comment": lc.MustPut(logcomment.Root, logcomment.Spans),
-	}
-
-	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "plots_metrics"))
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		msg := "failed to read the filter's custom keys"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if err := ef.Validate(); err != nil {
-		respondFilterError(c, err)
+	app, ef, ctx, spanName, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:          exprfilter.SpansEntity,
+		appScope:        *measure.ScopeAppRead,
+		logRoot:         logcomment.Spans,
+		logName:         "plots_metrics",
+		requireSpanName: true,
+	})
+	if !ok {
 		return
 	}
 
@@ -3092,113 +2882,13 @@ func (h Handlers) GetTrace(c *gin.Context) {
 
 func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	ef := exprfilter.ExprFilter{
-		AppID: id,
-		Limit: exprfilter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&ef); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	ef.Entity = exprfilter.BugReportsEntity
-
-	if err := ef.BuildExprTree(); err != nil {
-		respondFilterError(c, err)
-		return
-	}
-
-	ef.SetDefaultTimeRangeIfUnset()
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeBugReportRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	app.TeamId = *team.ID
-	ef.TeamID = *team.ID
-
-	lc := logcomment.New(2)
-	settings := clickhouse.Settings{
-		"log_comment": lc.
-			MustPut(logcomment.Root, logcomment.BugReports).
-			String(),
-	}
-
-	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "list"))
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		msg := "failed to read the filter's custom keys"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if err := ef.Validate(); err != nil {
-		respondFilterError(c, err)
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.BugReportsEntity,
+		appScope: *measure.ScopeBugReportRead,
+		logRoot:  logcomment.BugReports,
+		logName:  "list",
+	})
+	if !ok {
 		return
 	}
 
@@ -3223,120 +2913,14 @@ func (h Handlers) GetBugReportsOverview(c *gin.Context) {
 
 func (h Handlers) GetBugReportsInstancesPlot(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	ef := exprfilter.ExprFilter{
-		AppID: id,
-		Limit: exprfilter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&ef); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	ef.Entity = exprfilter.BugReportsEntity
-
-	if err := ef.BuildExprTree(); err != nil {
-		respondFilterError(c, err)
-		return
-	}
-
-	if ef.Timezone == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "missing required field `timezone`",
-		})
-		return
-	}
-
-	ef.SetDefaultTimeRangeIfUnset()
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeBugReportRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	app.TeamId = *team.ID
-	ef.TeamID = *team.ID
-
-	lc := logcomment.New(2)
-	settings := clickhouse.Settings{
-		"log_comment": lc.
-			MustPut(logcomment.Root, logcomment.BugReports).
-			String(),
-	}
-
-	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "plots_instances"))
-
-	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
-		msg := "failed to read the filter's custom keys"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": msg,
-		})
-		return
-	}
-
-	if err := ef.Validate(); err != nil {
-		respondFilterError(c, err)
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:          exprfilter.BugReportsEntity,
+		appScope:        *measure.ScopeBugReportRead,
+		logRoot:         logcomment.BugReports,
+		logName:         "plots_instances",
+		requireTimezone: true,
+	})
+	if !ok {
 		return
 	}
 

--- a/backend/api/handlers/exprfilter.go
+++ b/backend/api/handlers/exprfilter.go
@@ -1,13 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 
+	"backend/libs/chquery"
 	"backend/libs/exprfilter"
+	"backend/libs/logcomment"
 	"backend/libs/measure"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -32,6 +36,164 @@ func respondFilterError(c *gin.Context, err error) {
 		"error":              "invalid_filter_expr",
 		"filter_expr_issues": issues,
 	})
+}
+
+// exprFilterEndpoint carries what varies between the endpoints that query
+// with an exprfilter.ExprFilter: which entity the filter_expr grammar is
+// checked against, which scope (besides team read) the caller must hold,
+// the log_comment root and name the endpoint's ClickHouse queries are
+// tagged with, and which extra query params the endpoint requires.
+type exprFilterEndpoint struct {
+	entity   exprfilter.Entity
+	appScope measure.Scope
+	logRoot  string
+	logName  string
+	// useQueryCache adds the use_query_cache ClickHouse setting, enabled in
+	// release mode, to the endpoint's queries.
+	useQueryCache bool
+	// requireSpanName rejects requests without a span_name query param.
+	requireSpanName bool
+	// requireTimezone rejects requests without a timezone query param, which
+	// plot endpoints need to bucket rows by day.
+	requireTimezone bool
+}
+
+// prepareExprFilter runs the request prologue shared by the endpoints that
+// query with an exprfilter.ExprFilter: it parses the app id from the :id
+// route param, binds the query params into a filter, parses the filter_expr
+// into its expression tree, authorizes the caller on the app's team, tags the
+// context with the endpoint's ClickHouse settings, resolves the filter's
+// custom keys and validates the filter. On a failed check it writes the
+// error response itself and returns ok false; the handler then just returns.
+func (h Handlers) prepareExprFilter(c *gin.Context, endpoint exprFilterEndpoint) (app measure.App, ef exprfilter.ExprFilter, ctx context.Context, spanName string, ok bool) {
+	deps := h.Deps
+	ctx = c.Request.Context()
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		msg := `id invalid or missing`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	spanName = c.Query("span_name")
+	if endpoint.requireSpanName && spanName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Missing span_name query param",
+		})
+		return
+	}
+
+	ef = exprfilter.ExprFilter{
+		AppID: id,
+		Limit: exprfilter.DefaultPaginationLimit,
+	}
+
+	if err := c.ShouldBindQuery(&ef); err != nil {
+		msg := `failed to parse query parameters`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"details": err.Error(),
+		})
+		return
+	}
+
+	ef.Entity = endpoint.entity
+
+	if err := ef.BuildExprTree(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	if endpoint.requireTimezone && ef.Timezone == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "missing required field `timezone`",
+		})
+		return
+	}
+
+	ef.SetDefaultTimeRangeIfUnset()
+
+	app = measure.App{
+		ID: &id,
+	}
+	team, err := app.GetTeam(ctx, deps.PgPool)
+	if err != nil {
+		msg := "failed to get team from app id"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+	if team == nil {
+		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	userId := c.GetString("userId")
+	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), endpoint.appScope)
+	if err != nil {
+		msg := `failed to perform authorization`
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if !okTeam || !okApp {
+		msg := `you are not authorized to access this app`
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	app.TeamId = *team.ID
+	ef.TeamID = *team.ID
+
+	lc := logcomment.New(2)
+	settings := clickhouse.Settings{
+		"log_comment": lc.MustPut(logcomment.Root, endpoint.logRoot).String(),
+	}
+	if endpoint.useQueryCache {
+		settings["use_query_cache"] = gin.Mode() == gin.ReleaseMode
+	}
+
+	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, endpoint.logName))
+
+	if err := ef.ResolveCustomKeys(ctx, deps.RchPool); err != nil {
+		msg := "failed to read the filter's custom keys"
+		fmt.Println(msg, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": msg,
+		})
+		return
+	}
+
+	if err := ef.Validate(); err != nil {
+		respondFilterError(c, err)
+		return
+	}
+
+	return app, ef, ctx, spanName, true
 }
 
 // authorizeAppRead reports whether the caller may read the app, along with the

--- a/backend/libs/exprfilter/bugreports.go
+++ b/backend/libs/exprfilter/bugreports.go
@@ -1,19 +1,5 @@
 package exprfilter
 
-import (
-	"context"
-	"fmt"
-	"strings"
-	"time"
-
-	"backend/libs/chquery"
-
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/leporo/sqlf"
-)
-
 // BugReportsEntity is an app's bug reports. Filtering and value lists both
 // read the bug_reports table in ClickHouse, which stores every attribute as a
 // flat column, and its user-defined attributes are the user_def_attrs rows
@@ -21,11 +7,9 @@ import (
 var BugReportsEntity = Entity{
 	Name:                  "bug_reports",
 	Keys:                  bugReportsKeys,
-	BindKey:               bindBugReportsKeyToColumns(bugReportsTableColumns),
-	SuggestKeyValues:      fetchBugReportsKeySuggestions,
-	FetchCustomKeys:       fetchBugReportCustomKeys,
-	FetchCustomKeysByName: fetchBugReportCustomKeysByName,
-	BindCustomKeys:        bindCustomConditionsToMembership("user_def_attrs", "event_id", "bug_report = true"),
+	BindKey:               bindKeysToColumns(bugReportsTableColumns, bugReportsKeyBindingOverrides),
+	SuggestFixedKeyValues: suggestFixedKeyValuesFromClickHouse(bugReportFixedKeyValues),
+	CustomKeys:            &bugReportCustomKeys,
 }
 
 var bugReportsKeys = []Key{
@@ -74,255 +58,23 @@ var bugReportStatusCodes = map[string]uint8{
 	"closed": 1,
 }
 
-// bindBugReportsKeyToColumns compares one key against the column expression
-// the mapping names for it.
-func bindBugReportsKeyToColumns(columns map[string]string) KeyBinding {
-	return func(condition Condition) (*sqlf.Stmt, error) {
-		column, ok := columns[condition.KeyName]
-		if !ok {
-			return nil, fmt.Errorf("%w: %q", ErrKeyNotSupported, condition.KeyName)
-		}
-
-		if condition.KeyName == bugReportStatus.Name {
-			return bindBugReportStatusCondition(column, condition)
-		}
-
-		switch condition.Operator {
-		case OperatorIn:
-			return sqlf.New(column+" in ?", condition.TextValues()), nil
-		case OperatorNotIn:
-			return sqlf.New(column+" not in ?", condition.TextValues()), nil
-		case OperatorContains:
-			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
-		case OperatorNotContains:
-			return sqlf.New(column+" not ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
-		case OperatorStartsWith:
-			return sqlf.New(column+" ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
-		case OperatorEndsWith:
-			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())), nil
-		}
-
-		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
-	}
+var bugReportsKeyBindingOverrides = map[string]columnKeyBinding{
+	bugReportStatus.Name: bindEnumKeyToCodes(bugReportStatusCodes),
 }
 
-func bindBugReportStatusCondition(column string, condition Condition) (*sqlf.Stmt, error) {
-	codes := make([]uint8, 0, len(condition.Values))
-	for _, name := range condition.TextValues() {
-		code, ok := bugReportStatusCodes[name]
-		if !ok {
-			return nil, fmt.Errorf("Key %q has no value %q", condition.KeyName, name)
-		}
-		codes = append(codes, code)
-	}
-
-	switch condition.Operator {
-	case OperatorIn:
-		return sqlf.New(column+" in ?", codes), nil
-	case OperatorNotIn:
-		return sqlf.New(column+" not in ?", codes), nil
-	}
-
-	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
-}
-
-// fetchBugReportsKeySuggestions lists what one key can be set to, narrowed by
-// what has been typed. Values are read from the bug_reports table itself,
-// most recently seen first, asking for one row past the limit so it can
-// report that more matched without counting them. The table holds one row per
-// report, so no rollup is needed.
-func fetchBugReportsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
-	if len(key.EnumValues) > 0 {
-		return narrowEnumValues(key, valueRequest), nil
-	}
-
-	if key.ValueSuggestionMode == ValueSuggestionModeNone {
-		return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
-	}
-
-	if strings.HasPrefix(key.Name, CustomKeyPrefix) {
-		return fetchBugReportCustomKeySuggestions(ctx, chPool, teamID, appID, key, valueRequest)
-	}
-
-	column, ok := bugReportsTableColumns[key.Name]
-	if !ok {
-		return ValueList{}, fmt.Errorf("%w: %q", ErrKeyNotSupported, key.Name)
-	}
-
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
-
-	ctx = chquery.WithTeamScope(ctx, teamID)
-
-	// A report that did not carry an attribute holds an empty string in that
-	// column, so those rows are left out.
-	stmt := sqlf.
-		From("bug_reports").
-		Select(column+" as suggested_value").
-		Select("max(timestamp) as recency").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		Where(column + " <> ''").
-		GroupBy("suggested_value").
-		OrderBy("recency desc, suggested_value").
-		Limit(limit + 1)
-
-	defer stmt.Close()
-
-	if valueRequest.Search != "" {
-		stmt.Where(column+" ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
-	}
-
-	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-	defer rows.Close()
-
-	values := []Value{}
-	for rows.Next() {
-		var text string
-		var recency time.Time
-		if err := rows.Scan(&text, &recency); err != nil {
-			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-		}
-		values = append(values, Value{Text: text})
-	}
-	if err := rows.Err(); err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-
-	if len(values) > limit {
-		return ValueList{Values: values[:limit], Truncated: true}, nil
-	}
-
-	return ValueList{Values: values}, nil
+// Fixed-key value suggestions read the bug_reports table itself
+var bugReportFixedKeyValues = fixedKeyValueSource{
+	table:       "bug_reports",
+	columns:     bugReportsTableColumns,
+	recencyExpr: "max(timestamp)",
 }
 
 // The custom keys of bug reports are the user-defined attributes an app set
-// on the session a report was filed in. The user_def_attrs table holds one
-// row per event, attribute and value for several event kinds, with bug report
-// rows flagged bug_report, and each condition on one becomes an event_id
-// membership subquery against it. The attributes are read from ClickHouse, so
-// the Postgres pool the entity fields carry is unused here.
-
-// fetchBugReportCustomKeys lists the filter keys for every user-defined
-// attribute of an app's bug reports, ordered by name. It asks for one key
-// past the limit so it can report that more exist without counting them.
-func fetchBugReportCustomKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
-	stmt := bugReportCustomKeyQuery(teamID, appID).
-		Limit(limit + 1).
-		// Most granules hold rows of this team and app anyway, so skip
-		// indexes cost analysis without pruning reads.
-		Clause("settings use_skip_indexes = 0")
-
-	defer stmt.Close()
-
-	keys, err := readCustomKeys(ctx, chPool, teamID, stmt)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if len(keys) > limit {
-		return keys[:limit], true, nil
-	}
-	return keys, false, nil
-}
-
-// fetchBugReportCustomKeysByName reads the filter keys for the named
-// user-defined bug report attributes of one app.
-func fetchBugReportCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
-	if len(rawNames) == 0 {
-		return nil, nil
-	}
-
-	stmt := bugReportCustomKeyQuery(teamID, appID).
-		Where("key in ?", rawNames)
-
-	defer stmt.Close()
-
-	return readCustomKeys(ctx, chPool, teamID, stmt)
-}
-
-// bugReportCustomKeyQuery reads an app's user-defined bug report attribute
-// keys with their types. An attribute rewritten under a new type keeps one
-// row per type, so the type written last is the one its key offers.
-//
-// The scan is on the full table without a time bound. If needed in future:
-// time bound it so only keys in time range show up or add a rollup of
-// distinct keys and values like the span_filters rollup that fixed keys read.
-func bugReportCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
-	return sqlf.
-		From("user_def_attrs").
-		Select("key").
-		Select("argMax(type, timestamp) as type").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		Where("bug_report = true").
-		GroupBy("key").
-		OrderBy("key")
-}
-
-// fetchBugReportCustomKeySuggestions lists what one user-defined attribute
-// has been set to on bug reports, most recently written first, asking for one
-// row past the limit so it can report that more matched without counting
-// them. Empty ones are left out.
-//
-// The scan is on the full table without a time bound. If needed in future:
-// time bound it so only suggestions in time range show up or add a rollup of
-// distinct keys and values like the span_filters rollup that fixed keys read.
-func fetchBugReportCustomKeySuggestions(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
-
-	ctx = chquery.WithTeamScope(ctx, teamID)
-
-	stmt := sqlf.
-		From("user_def_attrs").
-		Select("value").
-		Select("max(timestamp) as recency").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		Where("bug_report = true").
-		Where("key = ?", strings.TrimPrefix(key.Name, CustomKeyPrefix)).
-		Where("type = ?", string(key.ValueType)).
-		Where("value <> ''").
-		GroupBy("value").
-		OrderBy("recency desc, value").
-		Limit(limit + 1)
-
-	defer stmt.Close()
-
-	if valueRequest.Search != "" {
-		stmt.Where("value ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
-	}
-
-	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-	defer rows.Close()
-
-	values := []Value{}
-	for rows.Next() {
-		var text string
-		var recency time.Time
-		if err := rows.Scan(&text, &recency); err != nil {
-			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-		}
-		values = append(values, Value{Text: text})
-	}
-	if err := rows.Err(); err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-
-	if len(values) > limit {
-		return ValueList{Values: values[:limit], Truncated: true}, nil
-	}
-
-	return ValueList{Values: values}, nil
+// on the session a report was filed in. The user_def_attrs table holds
+// attribute rows for several event kinds, with bug report rows flagged
+// bug_report.
+var bugReportCustomKeys = customKeyStore{
+	table:      "user_def_attrs",
+	idColumn:   "event_id",
+	extraScope: "bug_report = true",
 }

--- a/backend/libs/exprfilter/builds.go
+++ b/backend/libs/exprfilter/builds.go
@@ -13,10 +13,10 @@ import (
 // BuildsEntity is an app's uploaded builds. Both its filtering and its
 // value lists read the build_mappings rows in Postgres.
 var BuildsEntity = Entity{
-	Name:             "builds",
-	Keys:             buildsKeys,
-	BindKey:          bindBuildsKey,
-	SuggestKeyValues: fetchBuildsKeySuggestions,
+	Name:                  "builds",
+	Keys:                  buildsKeys,
+	BindKey:               bindBuildsKey,
+	SuggestFixedKeyValues: fetchBuildsKeySuggestions,
 }
 
 var buildsKeys = []Key{
@@ -105,10 +105,7 @@ func fetchBuildsKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool
 		return ValueList{}, fmt.Errorf("Key %q is typed in rather than picked from a list", key.Name)
 	}
 
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
+	limit := valueRequest.effectiveLimit()
 
 	// A row the key does not apply to holds the unset value in that column, so
 	// those rows are left out: a regular build has no patch columns and a patch

--- a/backend/libs/exprfilter/columnbinding.go
+++ b/backend/libs/exprfilter/columnbinding.go
@@ -1,0 +1,75 @@
+package exprfilter
+
+import (
+	"fmt"
+
+	"github.com/leporo/sqlf"
+)
+
+// columnKeyBinding turns one condition into a boolean SQL expression against
+// the given column expression. Overrides take this form instead of KeyBinding
+// so the column always comes from the table's own column map, and one
+// overrides map can be rebound against any table that has the key.
+type columnKeyBinding func(column string, condition Condition) (*sqlf.Stmt, error)
+
+// bindKeysToColumns builds a KeyBinding that compares each key against the
+// column expression the mapping names for it, answering the full set of text
+// operators. Which of them a key actually accepts is decided by the key's
+// Operators list during validation, so a condition reaching the binding is
+// already known to be allowed. overrides replaces the comparison for keys
+// whose values cannot be compared against their column as they are, such as
+// enum names a column stores as integer codes.
+func bindKeysToColumns(columns map[string]string, overrides map[string]columnKeyBinding) KeyBinding {
+	return func(condition Condition) (*sqlf.Stmt, error) {
+		column, ok := columns[condition.KeyName]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrKeyNotSupported, condition.KeyName)
+		}
+
+		if override, overridden := overrides[condition.KeyName]; overridden {
+			return override(column, condition)
+		}
+
+		switch condition.Operator {
+		case OperatorIn:
+			return sqlf.New(column+" in ?", condition.TextValues()), nil
+		case OperatorNotIn:
+			return sqlf.New(column+" not in ?", condition.TextValues()), nil
+		case OperatorContains:
+			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorNotContains:
+			return sqlf.New(column+" not ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorStartsWith:
+			return sqlf.New(column+" ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
+		case OperatorEndsWith:
+			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())), nil
+		}
+
+		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+	}
+}
+
+// bindEnumKeyToCodes builds the columnKeyBinding for an enum key whose column
+// stores integer codes: each value name a condition carries is translated
+// through the mapping before comparison, and a name outside it is refused.
+func bindEnumKeyToCodes[Code int8 | uint8](codes map[string]Code) columnKeyBinding {
+	return func(column string, condition Condition) (*sqlf.Stmt, error) {
+		bound := make([]Code, 0, len(condition.Values))
+		for _, name := range condition.TextValues() {
+			code, ok := codes[name]
+			if !ok {
+				return nil, fmt.Errorf("Key %q has no value %q", condition.KeyName, name)
+			}
+			bound = append(bound, code)
+		}
+
+		switch condition.Operator {
+		case OperatorIn:
+			return sqlf.New(column+" in ?", bound), nil
+		case OperatorNotIn:
+			return sqlf.New(column+" not in ?", bound), nil
+		}
+
+		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+	}
+}

--- a/backend/libs/exprfilter/columnbinding_test.go
+++ b/backend/libs/exprfilter/columnbinding_test.go
@@ -1,0 +1,56 @@
+package exprfilter
+
+import (
+	"testing"
+)
+
+// TestColumnBindingSQL asserts the exact SQL each text operator produces for
+// a column-mapped key.
+func TestColumnBindingSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		entity   Entity
+		keyName  string
+		operator Operator
+		text     string
+		wantSQL  string
+		wantArg  any
+	}{
+		{
+			name:   "spans contains reads the attribute-prefixed column",
+			entity: SpansEntity, keyName: "device_name", operator: OperatorContains, text: "pix",
+			wantSQL: "attribute.device_name ilike ?", wantArg: "%pix%",
+		},
+		{
+			name:   "bug report not_contains negates the match",
+			entity: BugReportsEntity, keyName: "bug_report_description", operator: OperatorNotContains, text: "crash",
+			wantSQL: "description not ilike ?", wantArg: "%crash%",
+		},
+		{
+			name:   "bug report ends_with anchors the end",
+			entity: BugReportsEntity, keyName: "bug_report_description", operator: OperatorEndsWith, text: "crash",
+			wantSQL: "description ilike ?", wantArg: "%crash",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := test.entity.BindKey(Condition{
+				KeyName:  test.keyName,
+				Operator: test.operator,
+				Values:   []Value{{Text: test.text}},
+			})
+			if err != nil {
+				t.Fatalf("bind %s %s: %v", test.keyName, test.operator, err)
+			}
+			defer stmt.Close()
+
+			if got := stmt.String(); got != test.wantSQL {
+				t.Errorf("\n got %s\nwant %s", got, test.wantSQL)
+			}
+			if args := stmt.Args(); len(args) != 1 || args[0] != test.wantArg {
+				t.Errorf("want the one argument %#v, got %#v", test.wantArg, args)
+			}
+		})
+	}
+}

--- a/backend/libs/exprfilter/custom.go
+++ b/backend/libs/exprfilter/custom.go
@@ -62,17 +62,50 @@ func CustomKey(rawName string, valueType ValueType) Key {
 	return key
 }
 
+// FetchCustomKeys lists the keys an app's user-defined attributes add to the
+// entity's fixed set, reporting whether the listing was cut off at limit.
+func (e Entity) FetchCustomKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
+	if e.CustomKeys == nil {
+		return nil, false, nil
+	}
+	return e.CustomKeys.fetchKeys(ctx, pgPool, chPool, teamID, appID, limit)
+}
+
+// FetchCustomKeysByName reads the entity's custom keys with the given names,
+// each name without the custom prefix. A name not present in user-defined
+// attributes yields no key.
+func (e Entity) FetchCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
+	if e.CustomKeys == nil {
+		return nil, nil
+	}
+	return e.CustomKeys.fetchKeysByName(ctx, pgPool, chPool, teamID, appID, rawNames)
+}
+
+// BindCustomKeys builds the GroupKeyBinding for the given custom keys.
+func (e Entity) BindCustomKeys(scope CustomKeyScope, keys []Key) GroupKeyBinding {
+	if e.CustomKeys == nil {
+		return nil
+	}
+	return e.CustomKeys.bindConditions(scope, keys)
+}
+
 // ListKeys returns the entity's fixed keys followed by the app's custom
 // keys, reporting whether the custom set was cut off at CustomKeyLimit. Any
 // names the caller passes that carry the custom prefix and did not make the
-// listing are resolved by name and appended. The fixed Keys slice is
-// package-level state, so the merge reallocates to leave it untouched.
+// listing are resolved by name and appended.
 func (e Entity) ListKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, names []string) ([]Key, bool, error) {
-	if e.FetchCustomKeys == nil {
+	return e.listKeys(ctx, pgPool, chPool, teamID, appID, names, CustomKeyLimit)
+}
+
+// listKeys is ListKeys with the custom-key listing cap as a parameter. The
+// fixed Keys slice is package-level state, so the merge reallocates to leave
+// it untouched.
+func (e Entity) listKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, names []string, limit int) ([]Key, bool, error) {
+	if e.CustomKeys == nil {
 		return e.Keys, false, nil
 	}
 
-	customKeys, truncated, err := e.FetchCustomKeys(ctx, pgPool, chPool, teamID, appID, CustomKeyLimit)
+	customKeys, truncated, err := e.CustomKeys.fetchKeys(ctx, pgPool, chPool, teamID, appID, limit)
 	if err != nil {
 		return nil, false, err
 	}
@@ -93,8 +126,8 @@ func (e Entity) ListKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool drive
 			missingRawNames = append(missingRawNames, rawName)
 		}
 	}
-	if len(missingRawNames) > 0 && e.FetchCustomKeysByName != nil {
-		namedKeys, err := e.FetchCustomKeysByName(ctx, pgPool, chPool, teamID, appID, missingRawNames)
+	if len(missingRawNames) > 0 {
+		namedKeys, err := e.CustomKeys.fetchKeysByName(ctx, pgPool, chPool, teamID, appID, missingRawNames)
 		if err != nil {
 			return nil, false, err
 		}
@@ -112,11 +145,11 @@ func (e Entity) FindKey(ctx context.Context, ch driver.Conn, teamID, appID uuid.
 	}
 
 	rawName, isCustom := strings.CutPrefix(name, CustomKeyPrefix)
-	if !isCustom || e.FetchCustomKeysByName == nil {
+	if !isCustom || e.CustomKeys == nil {
 		return Key{}, false, nil
 	}
 
-	customKeys, err := e.FetchCustomKeysByName(ctx, nil, ch, teamID, appID, []string{rawName})
+	customKeys, err := e.CustomKeys.fetchKeysByName(ctx, nil, ch, teamID, appID, []string{rawName})
 	if err != nil {
 		return Key{}, false, err
 	}
@@ -198,11 +231,11 @@ func (ef *ExprFilter) ResolveCustomKeys(ctx context.Context, chPool driver.Conn)
 		return nil
 	}
 
-	if ef.Entity.FetchCustomKeysByName == nil || ef.Entity.BindCustomKeys == nil {
+	if ef.Entity.CustomKeys == nil {
 		return nil
 	}
 
-	keys, err := ef.Entity.FetchCustomKeysByName(ctx, nil, chPool, ef.TeamID, ef.AppID, rawNames)
+	keys, err := ef.Entity.CustomKeys.fetchKeysByName(ctx, nil, chPool, ef.TeamID, ef.AppID, rawNames)
 	if err != nil {
 		return err
 	}
@@ -213,7 +246,7 @@ func (ef *ExprFilter) ResolveCustomKeys(ctx context.Context, chPool driver.Conn)
 	ef.Entity.Keys = append(slices.Clip(ef.Entity.Keys), keys...)
 
 	versionNames, versionCodes := collectRootVersionConditions(ef.ExprTree)
-	ef.customBinder = ef.Entity.BindCustomKeys(CustomKeyScope{
+	ef.customBinder = ef.Entity.CustomKeys.bindConditions(CustomKeyScope{
 		TeamID:       ef.TeamID,
 		AppID:        ef.AppID,
 		From:         ef.From,

--- a/backend/libs/exprfilter/custom_test.go
+++ b/backend/libs/exprfilter/custom_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/leporo/sqlf"
 )
 
 func TestCustomKeyMapping(t *testing.T) {
@@ -123,58 +121,69 @@ func TestCollectCustomKeyNames(t *testing.T) {
 	})
 }
 
-func TestResolveCustomKeysBindsEveryMentionedKey(t *testing.T) {
-	keys := []Key{CustomKey("plan", ValueTypeString), CustomKey("retries", ValueTypeInt64)}
+// customKeyRowsStub feeds readCustomKeys the (name, stored type) rows a key
+// query would return; the embedded driver.Rows covers methods never called.
+type customKeyRowsStub struct {
+	driver.Rows
+	rows [][2]string
+	read int
+}
 
-	binderCalls := 0
-	entity := Entity{
-		Name: "stub",
-		Keys: []Key{versionName},
-		FetchCustomKeysByName: func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
-			if !slices.Equal(rawNames, []string{"plan", "retries"}) {
-				t.Errorf("want the mentioned names fetched, got %v", rawNames)
-			}
-			return keys, nil
-		},
-		BindCustomKeys: func(scope CustomKeyScope, boundKeys []Key) GroupKeyBinding {
-			names := make([]string, len(boundKeys))
-			for i, key := range boundKeys {
-				names[i] = key.Name
-			}
-			if !slices.Equal(names, []string{"custom.plan", "custom.retries"}) {
-				t.Errorf("want every fetched key handed to the binder, got %v", names)
-			}
-			return func(operator LogicalOperator, conditions []Condition) (*sqlf.Stmt, error) {
-				binderCalls++
-				conditionNames := make([]string, len(conditions))
-				for i, condition := range conditions {
-					conditionNames[i] = condition.KeyName
-				}
-				return sqlf.New("bound ?", strings.Join(conditionNames, ",")), nil
-			}
-		},
-	}
+func (r *customKeyRowsStub) Next() bool {
+	r.read++
+	return r.read <= len(r.rows)
+}
+
+func (r *customKeyRowsStub) Scan(dest ...any) error {
+	row := r.rows[r.read-1]
+	*(dest[0].(*string)) = row[0]
+	*(dest[1].(*string)) = row[1]
+	return nil
+}
+
+func (r *customKeyRowsStub) Err() error   { return nil }
+func (r *customKeyRowsStub) Close() error { return nil }
+
+// customKeyConnStub answers every query with the configured key rows,
+// recording the arguments so a test can assert which names were fetched.
+type customKeyConnStub struct {
+	driver.Conn
+	rows [][2]string
+	args []any
+}
+
+func (c *customKeyConnStub) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	c.args = slices.Clone(args)
+	return &customKeyRowsStub{rows: c.rows}, nil
+}
+
+func TestResolveCustomKeysBindsEveryMentionedKey(t *testing.T) {
+	conn := &customKeyConnStub{rows: [][2]string{{"plan", "string"}, {"retries", "int64"}}}
 
 	ef := &ExprFilter{
 		AppID:  uuid.New(),
 		TeamID: uuid.New(),
-		Entity: entity,
+		Entity: SpansEntity,
 		ExprTree: &ExprTree{LogicalOperator: LogicalAnd, Children: []ExprTree{
 			*leafExprTree("custom.plan", OperatorIn, "pro"),
 			*leafExprTree("custom.retries", OperatorGt, "9"),
 		}},
 	}
 
-	if err := ef.ResolveCustomKeys(context.Background(), nil); err != nil {
+	if err := ef.ResolveCustomKeys(context.Background(), conn); err != nil {
 		t.Fatalf("ResolveCustomKeys: %v", err)
+	}
+
+	if rawNames, ok := conn.args[len(conn.args)-1].([]string); !ok || !slices.Equal(rawNames, []string{"plan", "retries"}) {
+		t.Errorf("want the mentioned names fetched, got %v", conn.args)
 	}
 	if ef.customBinder == nil {
 		t.Fatal("want the group binder installed on the filter")
 	}
 	byName := IndexKeysByName(ef.Entity.Keys)
-	for _, key := range keys {
-		if _, found := byName[key.Name]; !found {
-			t.Errorf("want %q added to the request's key set", key.Name)
+	for _, name := range []string{"custom.plan", "custom.retries"} {
+		if _, found := byName[name]; !found {
+			t.Errorf("want %q added to the request's key set", name)
 		}
 	}
 
@@ -183,14 +192,11 @@ func TestResolveCustomKeysBindsEveryMentionedKey(t *testing.T) {
 		t.Fatalf("Predicate: %v", err)
 	}
 	defer predicate.Close()
-	if binderCalls != 1 {
-		t.Errorf("want both conditions bound in one binder call, got %d calls", binderCalls)
-	}
-	if got := predicate.String(); got != "((bound ?))" {
-		t.Errorf("want the binder's fragment as the group's one child, got %q", got)
-	}
-	if got := predicate.Args()[0]; got != "custom.plan,custom.retries" {
-		t.Errorf("want both conditions in the one call, got %v", got)
+	// Both conditions inside one membership scan proves a single binder call.
+	want := "((span_id in (" + customGroupedScope +
+		"countIf(key = ? and type = ? and value in ?) > 0 and countIf(key = ? and type = ? and toInt64OrNull(value) > ?) > 0)))"
+	if got := predicate.String(); got != want {
+		t.Errorf("\n got %s\nwant %s", got, want)
 	}
 }
 

--- a/backend/libs/exprfilter/custom_values_test.go
+++ b/backend/libs/exprfilter/custom_values_test.go
@@ -9,9 +9,7 @@ import (
 
 	"backend/testinfra"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func seedSpanUDAttrs(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID) {
@@ -115,15 +113,14 @@ func TestListKeysResolvesRequestedNames(t *testing.T) {
 	ctx := context.Background()
 	teamID, appID, _ := seedSpanUDAttrs(ctx, t)
 
-	// The listing is held to the first two custom keys by name, flag and
+	// The listing is capped at the first two custom keys by name, flag and
 	// is_premium, so the other seeded keys stand in for keys past
 	// CustomKeyLimit.
-	entity := SpansEntity
-	entity.FetchCustomKeys = func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
-		return SpansEntity.FetchCustomKeys(ctx, pgPool, chPool, teamID, appID, 2)
+	listKeys := func(names []string) ([]Key, bool, error) {
+		return SpansEntity.listKeys(ctx, pgPool, chConn, teamID, appID, names, 2)
 	}
 
-	baseKeys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, nil)
+	baseKeys, _, err := listKeys(nil)
 	if err != nil {
 		t.Fatalf("list keys: %v", err)
 	}
@@ -132,7 +129,7 @@ func TestListKeysResolvesRequestedNames(t *testing.T) {
 	}
 
 	t.Run("a requested name beyond the listing is appended with its type", func(t *testing.T) {
-		keys, truncated, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.retries"})
+		keys, truncated, err := listKeys([]string{"custom.retries"})
 		if err != nil {
 			t.Fatalf("list keys: %v", err)
 		}
@@ -149,7 +146,7 @@ func TestListKeysResolvesRequestedNames(t *testing.T) {
 	})
 
 	t.Run("a requested name the app never reported is ignored", func(t *testing.T) {
-		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.nope"})
+		keys, _, err := listKeys([]string{"custom.nope"})
 		if err != nil {
 			t.Fatalf("list keys: %v", err)
 		}
@@ -159,7 +156,7 @@ func TestListKeysResolvesRequestedNames(t *testing.T) {
 	})
 
 	t.Run("a requested name already listed is not duplicated", func(t *testing.T) {
-		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"custom.flag"})
+		keys, _, err := listKeys([]string{"custom.flag"})
 		if err != nil {
 			t.Fatalf("list keys: %v", err)
 		}
@@ -178,7 +175,7 @@ func TestListKeysResolvesRequestedNames(t *testing.T) {
 	})
 
 	t.Run("a name without the custom prefix is ignored", func(t *testing.T) {
-		keys, _, err := entity.ListKeys(ctx, pgPool, chConn, teamID, appID, []string{"retries"})
+		keys, _, err := listKeys([]string{"retries"})
 		if err != nil {
 			t.Fatalf("list keys: %v", err)
 		}

--- a/backend/libs/exprfilter/custommembership.go
+++ b/backend/libs/exprfilter/custommembership.go
@@ -125,9 +125,7 @@ func matchCustomCondition(key Key, condition Condition) (customConditionMatch, e
 // customMembershipBinder holds the request-scoped context needed to build
 // custom-key membership queries.
 type customMembershipBinder struct {
-	table      string
-	idColumn   string
-	extraScope string
+	store      customKeyStore
 	scope      CustomKeyScope
 	keysByName map[string]Key
 }
@@ -136,32 +134,26 @@ type customMembershipBinder struct {
 const customAttrScope = " where team_id = toUUID(?) and app_id = toUUID(?)" +
 	" and timestamp >= ? and timestamp <= ?"
 
-// scopeSQL is customAttrScope extended with the binder's extra clause, so
+// scopeSQL is customAttrScope extended with the store's extra clause, so
 // every membership subquery scans only the rows its entity owns.
 func (b *customMembershipBinder) scopeSQL() string {
-	if b.extraScope == "" {
+	if b.store.extraScope == "" {
 		return customAttrScope
 	}
-	return customAttrScope + " and " + b.extraScope
+	return customAttrScope + " and " + b.store.extraScope
 }
 
-// bindCustomConditionsToMembership creates a GroupKeyBinding for custom-key
-// conditions. Multiple conditions are evaluated with countIf over one grouped
-// query instead of generating a separate subquery for each condition.
-// extraScope is an extra boolean SQL clause for tables shared by more than one
-// entity, such as the bug_report flag of user_def_attrs; empty when the table
-// holds one entity's rows only.
-func bindCustomConditionsToMembership(table, idColumn, extraScope string) func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
-	return func(scope CustomKeyScope, keys []Key) GroupKeyBinding {
-		binder := &customMembershipBinder{
-			table:      table,
-			idColumn:   idColumn,
-			extraScope: extraScope,
-			scope:      scope,
-			keysByName: IndexKeysByName(keys),
-		}
-		return binder.bind
+// bindConditions creates a GroupKeyBinding for one request's conditions on
+// the store's custom keys. Multiple conditions are evaluated with countIf
+// over one grouped query instead of generating a separate subquery for each
+// condition.
+func (s customKeyStore) bindConditions(scope CustomKeyScope, keys []Key) GroupKeyBinding {
+	binder := &customMembershipBinder{
+		store:      s,
+		scope:      scope,
+		keysByName: IndexKeysByName(keys),
 	}
+	return binder.bind
 }
 
 // bind is the GroupKeyBinding for one request's custom keys.
@@ -291,8 +283,8 @@ func (b *customMembershipBinder) single(match customConditionMatch) (string, []a
 		operator = "not in"
 	}
 	versionSQL, versionArgs := b.versionConditions()
-	text := b.idColumn + " " + operator + " (" +
-		"select " + b.idColumn + " from " + b.table +
+	text := b.store.idColumn + " " + operator + " (" +
+		"select " + b.store.idColumn + " from " + b.store.table +
 		b.scopeSQL() +
 		versionSQL +
 		" and " + match.sql +
@@ -315,12 +307,12 @@ func (b *customMembershipBinder) grouped(operator string, matches []customCondit
 	}
 
 	versionSQL, versionArgs := b.versionConditions()
-	text := b.idColumn + " " + operator + " (" +
-		"select " + b.idColumn + " from " + b.table +
+	text := b.store.idColumn + " " + operator + " (" +
+		"select " + b.store.idColumn + " from " + b.store.table +
 		b.scopeSQL() +
 		versionSQL +
 		" and key in ?" +
-		" group by " + b.idColumn +
+		" group by " + b.store.idColumn +
 		" having " + having +
 		")"
 	args := make([]any, 0, 5+len(versionArgs)+len(havingArgs))

--- a/backend/libs/exprfilter/customstore.go
+++ b/backend/libs/exprfilter/customstore.go
@@ -1,0 +1,164 @@
+package exprfilter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"backend/libs/chquery"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+// customKeyStore says where an entity's user-defined attributes are stored: a
+// ClickHouse table holding one row per entity row, attribute and value, with
+// the value of every type stored in one String column. The store answers the
+// entity's custom-key listing, by-name resolution and value suggestions, and
+// bindConditions turns conditions on its keys into membership subqueries. The
+// attributes are read from ClickHouse, so the Postgres pool the entity fields
+// carry is unused here.
+type customKeyStore struct {
+	table string
+
+	// idColumn identifies the entity row an attribute row belongs to, and is
+	// what membership subqueries select.
+	idColumn string
+
+	// extraScope is an extra boolean SQL clause for tables shared by more than
+	// one entity, such as the bug_report flag of user_def_attrs; empty when
+	// the table holds one entity's rows only.
+	extraScope string
+}
+
+// keyQuery reads an app's user-defined attribute keys with their types. An
+// attribute rewritten under a new type keeps one row per type, so the type
+// written last is the one its key offers.
+//
+// The scan is on the full table without a time bound. If needed in future:
+// time bound it so only keys in time range show up or add a rollup of
+// distinct keys and values like the span_filters rollup that fixed keys read.
+func (s customKeyStore) keyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
+	stmt := sqlf.
+		From(s.table).
+		Select("key").
+		Select("argMax(type, timestamp) as type").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID)
+
+	if s.extraScope != "" {
+		stmt.Where(s.extraScope)
+	}
+
+	return stmt.
+		GroupBy("key").
+		OrderBy("key")
+}
+
+// fetchKeys lists the filter keys for every user-defined attribute of an
+// app's entity rows, ordered by name. It asks for one key past the limit so
+// it can report that more exist without counting them.
+func (s customKeyStore) fetchKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
+	stmt := s.keyQuery(teamID, appID).
+		Limit(limit + 1).
+		// Most granules hold rows of this team and app anyway, so skip
+		// indexes cost analysis without pruning reads.
+		Clause("settings use_skip_indexes = 0")
+
+	defer stmt.Close()
+
+	keys, err := readCustomKeys(ctx, chPool, teamID, stmt)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(keys) > limit {
+		return keys[:limit], true, nil
+	}
+	return keys, false, nil
+}
+
+// fetchKeysByName reads the filter keys for the named user-defined attributes
+// of one app.
+func (s customKeyStore) fetchKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
+	if len(rawNames) == 0 {
+		return nil, nil
+	}
+
+	stmt := s.keyQuery(teamID, appID).
+		Where("key in ?", rawNames)
+
+	defer stmt.Close()
+
+	return readCustomKeys(ctx, chPool, teamID, stmt)
+}
+
+// suggestValues lists what one user-defined attribute has been set to, most
+// recently written first, asking for one row past the limit so it can report
+// that more matched without counting them. Empty ones are left out.
+//
+// The scan is on the full table without a time bound. If needed in future:
+// time bound it so only suggestions in time range show up or add a rollup of
+// distinct keys and values like the span_filters rollup that fixed keys read.
+func (s customKeyStore) suggestValues(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	limit := valueRequest.effectiveLimit()
+
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	stmt := sqlf.
+		From(s.table).
+		Select("value").
+		Select("max(timestamp) as recency").
+		Where("team_id = toUUID(?)", teamID).
+		Where("app_id = toUUID(?)", appID)
+
+	if s.extraScope != "" {
+		stmt.Where(s.extraScope)
+	}
+
+	stmt.
+		Where("key = ?", strings.TrimPrefix(key.Name, CustomKeyPrefix)).
+		Where("type = ?", string(key.ValueType)).
+		Where("value <> ''").
+		GroupBy("value").
+		OrderBy("recency desc, value").
+		Limit(limit + 1)
+
+	defer stmt.Close()
+
+	if valueRequest.Search != "" {
+		stmt.Where("value ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+	}
+
+	return readSuggestedValues(ctx, chPool, key, stmt, limit)
+}
+
+func readCustomKeys(ctx context.Context, ch driver.Conn, teamID uuid.UUID, stmt *sqlf.Stmt) ([]Key, error) {
+	ctx = chquery.WithTeamScope(ctx, teamID)
+
+	rows, err := ch.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+	}
+	defer rows.Close()
+
+	keys := []Key{}
+	for rows.Next() {
+		var rawName, storedType string
+		if err := rows.Scan(&rawName, &storedType); err != nil {
+			return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+		}
+		valueType, ok := customValueTypes[storedType]
+		if !ok {
+			return nil, fmt.Errorf("Attribute %q stores values of unknown type %q", rawName, storedType)
+		}
+		keys = append(keys, CustomKey(rawName, valueType))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
+	}
+
+	return keys, nil
+}

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -6,13 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"backend/libs/chquery"
 	"backend/libs/symbol"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/leporo/sqlf"
 )
 
 // Entity is one subject a filter can be written against, such as builds,
@@ -32,23 +30,16 @@ type Entity struct {
 	// ErrKeyNotSupported.
 	BindKey KeyBinding
 
-	// SuggestKeyValues lists what one key can be set to, narrowed by what has been
-	// typed. Both pools are passed because which one an entity reads is its own
-	// choice.
-	SuggestKeyValues func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error)
+	// SuggestFixedKeyValues lists what one fixed key can be set to, narrowed
+	// by what has been typed. Both pools are passed because which one an
+	// entity reads is its own choice.
+	SuggestFixedKeyValues func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error)
 
-	// FetchCustomKeys lists the keys an app's user-defined attributes add to
-	// the entity's fixed set. Nil for an entity whose keys are all fixed.
-	FetchCustomKeys func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error)
-
-	// FetchCustomKeysByName reads the entity's custom keys with the given
-	// names, each name without the custom prefix. A name not present in
-	// user defined attributes yields no key. Nil for an entity whose keys are all fixed.
-	FetchCustomKeysByName func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error)
-
-	// BindCustomKeys builds the GroupKeyBinding for the given custom keys.
-	// Nil for an entity whose keys are all fixed.
-	BindCustomKeys func(scope CustomKeyScope, keys []Key) GroupKeyBinding
+	// CustomKeys is the one store every custom-key listing, lookup, value
+	// read and condition binding goes through, so an entity cannot list keys
+	// from one table and bind conditions against another. Nil for an entity
+	// whose keys are all fixed.
+	CustomKeys *customKeyStore
 
 	// MaxTimeBucketWidth is the widest time bucket used by any of the entity's
 	// tables. Bucketed queries may include rows from this bucket past the range
@@ -360,40 +351,9 @@ func narrowEnumValues(key Key, valueRequest ValueRequest) ValueList {
 		values = append(values, Value{Text: text})
 	}
 
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
+	limit := valueRequest.effectiveLimit()
 	if len(values) > limit {
 		return ValueList{Values: values[:limit], Truncated: true}
 	}
 	return ValueList{Values: values}
-}
-
-func readCustomKeys(ctx context.Context, ch driver.Conn, teamID uuid.UUID, stmt *sqlf.Stmt) ([]Key, error) {
-	ctx = chquery.WithTeamScope(ctx, teamID)
-
-	rows, err := ch.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
-	}
-	defer rows.Close()
-
-	keys := []Key{}
-	for rows.Next() {
-		var rawName, storedType string
-		if err := rows.Scan(&rawName, &storedType); err != nil {
-			return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
-		}
-		valueType, ok := customValueTypes[storedType]
-		if !ok {
-			return nil, fmt.Errorf("Attribute %q stores values of unknown type %q", rawName, storedType)
-		}
-		keys = append(keys, CustomKey(rawName, valueType))
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("Failed to read the user-defined attribute keys: %w", err)
-	}
-
-	return keys, nil
 }

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -56,8 +56,8 @@ func TestEntitiesFillEveryField(t *testing.T) {
 			if entity.BindKey == nil {
 				t.Error("an entity with no BindKey cannot write a filter")
 			}
-			if entity.SuggestKeyValues == nil {
-				t.Error("an entity with no SuggestKeyValues cannot list what a key can be set to")
+			if entity.SuggestFixedKeyValues == nil {
+				t.Error("an entity with no SuggestFixedKeyValues cannot list what a fixed key can be set to")
 			}
 		})
 	}

--- a/backend/libs/exprfilter/key.go
+++ b/backend/libs/exprfilter/key.go
@@ -42,6 +42,15 @@ type ValueRequest struct {
 	Limit  int
 }
 
+// effectiveLimit is the requested limit, or DefaultValueLimit when the
+// request does not name one.
+func (r ValueRequest) effectiveLimit() int {
+	if r.Limit <= 0 {
+		return DefaultValueLimit
+	}
+	return r.Limit
+}
+
 // ValueList is the answer to a ValueRequest. Truncated says more values matched
 // than the list holds.
 type ValueList struct {

--- a/backend/libs/exprfilter/predicate_test.go
+++ b/backend/libs/exprfilter/predicate_test.go
@@ -19,8 +19,8 @@ var testEntity = Entity{
 		{Name: "patch_id", ValueType: ValueTypeUUID, Operators: AllowedOperatorsFor(ValueTypeUUID), ValueSuggestionMode: ValueSuggestionModeSample},
 		{Name: "file_size", ValueType: ValueTypeInt32, Operators: AllowedOperatorsFor(ValueTypeInt32), ValueSuggestionMode: ValueSuggestionModeNone},
 	},
-	BindKey:          bindTestKey,
-	SuggestKeyValues: fetchTestKeySuggestions,
+	BindKey:               bindTestKey,
+	SuggestFixedKeyValues: fetchTestKeySuggestions,
 }
 
 func bindTestKey(condition Condition) (*sqlf.Stmt, error) {

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -1,17 +1,7 @@
 package exprfilter
 
 import (
-	"context"
-	"fmt"
-	"strings"
 	"time"
-
-	"backend/libs/chquery"
-
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/leporo/sqlf"
 )
 
 // SpansEntity is an app's performance trace spans. Both its filtering and its
@@ -21,11 +11,9 @@ import (
 var SpansEntity = Entity{
 	Name:                  "spans",
 	Keys:                  spansKeys,
-	BindKey:               bindSpansKeyToColumns(spansTableColumns),
-	SuggestKeyValues:      fetchSpansKeySuggestions,
-	FetchCustomKeys:       fetchSpanCustomKeys,
-	FetchCustomKeysByName: fetchSpanCustomKeysByName,
-	BindCustomKeys:        bindCustomConditionsToMembership("span_user_def_attrs", "span_id", ""),
+	BindKey:               bindKeysToColumns(spansTableColumns, spansKeyBindingOverrides),
+	SuggestFixedKeyValues: suggestFixedKeyValuesFromClickHouse(spanFixedKeyValues),
+	CustomKeys:            &spanCustomKeys,
 	// span_metrics groups spans into 15-minute buckets by start time. A query
 	// can therefore include spans whose bucket extends past the range end.
 	MaxTimeBucketWidth: 15 * time.Minute,
@@ -96,18 +84,6 @@ var (
 	}
 )
 
-// SpanMetricsKeyBindings maps every fixed spans key onto the flat columns of
-// the span_metrics rollup, as Predicate overrides for queries that read that
-// table.
-func SpanMetricsKeyBindings() map[string]KeyBinding {
-	binding := bindSpansKeyToColumns(spanMetricsTableColumns)
-	overrides := make(map[string]KeyBinding, len(spansKeys))
-	for _, key := range spansKeys {
-		overrides[key.Name] = binding
-	}
-	return overrides
-}
-
 // spanStatusCodes maps the status names a filter carries to the integer codes
 // the status column stores.
 var spanStatusCodes = map[string]int8{
@@ -116,248 +92,32 @@ var spanStatusCodes = map[string]int8{
 	"error": 2,
 }
 
-// bindSpansKeyToColumns compares one key against the column expression the
-// mapping names for it.
-func bindSpansKeyToColumns(columns map[string]string) KeyBinding {
-	return func(condition Condition) (*sqlf.Stmt, error) {
-		column, ok := columns[condition.KeyName]
-		if !ok {
-			return nil, fmt.Errorf("%w: %q", ErrKeyNotSupported, condition.KeyName)
-		}
-
-		if condition.KeyName == spanStatus.Name {
-			return bindSpanStatusCondition(column, condition)
-		}
-
-		switch condition.Operator {
-		case OperatorIn:
-			return sqlf.New(column+" in ?", condition.TextValues()), nil
-		case OperatorNotIn:
-			return sqlf.New(column+" not in ?", condition.TextValues()), nil
-		case OperatorContains:
-			return sqlf.New(column+" ilike ?", "%"+EscapeLikeWildcards(condition.TextValue())+"%"), nil
-		case OperatorStartsWith:
-			return sqlf.New(column+" ilike ?", EscapeLikeWildcards(condition.TextValue())+"%"), nil
-		}
-
-		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
-	}
+var spansKeyBindingOverrides = map[string]columnKeyBinding{
+	spanStatus.Name: bindEnumKeyToCodes(spanStatusCodes),
 }
 
-func bindSpanStatusCondition(column string, condition Condition) (*sqlf.Stmt, error) {
-	codes := make([]int8, 0, len(condition.Values))
-	for _, name := range condition.TextValues() {
-		code, ok := spanStatusCodes[name]
-		if !ok {
-			return nil, fmt.Errorf("Key %q has no value %q", condition.KeyName, name)
-		}
-		codes = append(codes, code)
-	}
-
-	switch condition.Operator {
-	case OperatorIn:
-		return sqlf.New(column+" in ?", codes), nil
-	case OperatorNotIn:
-		return sqlf.New(column+" not in ?", codes), nil
-	}
-
-	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+// Fixed-key value suggestions read the span_filters rollup, which stores the
+// distinct attribute combinations seen per month. Recency therefore carries
+// month granularity, so values seen in the same month order alphabetically.
+var spanFixedKeyValues = fixedKeyValueSource{
+	table:       "span_filters",
+	columns:     spanFilterColumns,
+	recencyExpr: "max(end_of_month)",
 }
 
-// fetchSpansKeySuggestions lists what one key can be set to, narrowed by what
-// has been typed. Values are read from the spans table in ClickHouse, most
-// recently seen first, asking for one row past the limit so it can report that
-// more matched without counting them.
-func fetchSpansKeySuggestions(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
-	if len(key.EnumValues) > 0 {
-		return narrowEnumValues(key, valueRequest), nil
-	}
-
-	if key.ValueSuggestionMode == ValueSuggestionModeNone {
-		return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
-	}
-
-	if strings.HasPrefix(key.Name, CustomKeyPrefix) {
-		return fetchSpanCustomKeySuggestions(ctx, chPool, teamID, appID, key, valueRequest)
-	}
-
-	column, ok := spanFilterColumns[key.Name]
-	if !ok {
-		return ValueList{}, fmt.Errorf("%w: %q", ErrKeyNotSupported, key.Name)
-	}
-
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
-
-	ctx = chquery.WithTeamScope(ctx, teamID)
-
-	// A span that did not carry an attribute holds an empty string in that
-	// column, so those rows are left out. Recency carries month granularity,
-	// so values seen in the same month order alphabetically.
-	stmt := sqlf.
-		From("span_filters").
-		Select(column+" as suggested_value").
-		Select("max(end_of_month) as recency").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		Where(column + " <> ''").
-		GroupBy("suggested_value").
-		OrderBy("recency desc, suggested_value").
-		Limit(limit + 1)
-
-	defer stmt.Close()
-
-	if valueRequest.Search != "" {
-		stmt.Where(column+" ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
-	}
-
-	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-	defer rows.Close()
-
-	values := []Value{}
-	for rows.Next() {
-		var text string
-		var recency time.Time
-		if err := rows.Scan(&text, &recency); err != nil {
-			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-		}
-		values = append(values, Value{Text: text})
-	}
-	if err := rows.Err(); err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-
-	if len(values) > limit {
-		return ValueList{Values: values[:limit], Truncated: true}, nil
-	}
-
-	return ValueList{Values: values}, nil
+var spanCustomKeys = customKeyStore{
+	table:    "span_user_def_attrs",
+	idColumn: "span_id",
 }
 
-// The custom keys of spans are the user-defined attributes an app set on
-// its spans. The span_user_def_attrs table holds one row per span, attribute
-// and value, with the value of every type stored in one String column, and
-// each condition on one becomes a span_id membership subquery against it.
-// The attributes are read from ClickHouse, so the Postgres pool the entity
-// fields carry is unused here.
-
-// fetchSpanCustomKeys lists the filter keys for every user-defined attribute
-// of an app's spans, ordered by name. It asks for one key past the limit so
-// it can report that more exist without counting them.
-func fetchSpanCustomKeys(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, limit int) ([]Key, bool, error) {
-	stmt := spanCustomKeyQuery(teamID, appID).
-		Limit(limit + 1).
-		// Most granules hold rows of this team and app anyway, so skip
-		// indexes cost analysis without pruning reads.
-		Clause("settings use_skip_indexes = 0")
-
-	defer stmt.Close()
-
-	keys, err := readCustomKeys(ctx, chPool, teamID, stmt)
-	if err != nil {
-		return nil, false, err
+// SpanMetricsKeyBindings maps every fixed spans key onto the flat columns of
+// the span_metrics rollup, as Predicate overrides for queries that read that
+// table.
+func SpanMetricsKeyBindings() map[string]KeyBinding {
+	binding := bindKeysToColumns(spanMetricsTableColumns, spansKeyBindingOverrides)
+	overrides := make(map[string]KeyBinding, len(spansKeys))
+	for _, key := range spansKeys {
+		overrides[key.Name] = binding
 	}
-
-	if len(keys) > limit {
-		return keys[:limit], true, nil
-	}
-	return keys, false, nil
-}
-
-// fetchSpanCustomKeysByName reads the filter keys for the named user-defined
-// span attributes of one app.
-func fetchSpanCustomKeysByName(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, rawNames []string) ([]Key, error) {
-	if len(rawNames) == 0 {
-		return nil, nil
-	}
-
-	stmt := spanCustomKeyQuery(teamID, appID).
-		Where("key in ?", rawNames)
-
-	defer stmt.Close()
-
-	return readCustomKeys(ctx, chPool, teamID, stmt)
-}
-
-// spanCustomKeyQuery reads an app's user-defined span attribute keys with
-// their types. An attribute rewritten under a new type keeps one row per
-// type, so the type written last is the one its key offers.
-//
-// The scan is on the full table without a time bound. If needed in future:
-// time bound it so only keys in time range show up or add a rollup
-// of distinct keys and values like the span_filters rollupthat fixed keys read.
-func spanCustomKeyQuery(teamID, appID uuid.UUID) *sqlf.Stmt {
-	return sqlf.
-		From("span_user_def_attrs").
-		Select("key").
-		Select("argMax(type, timestamp) as type").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		GroupBy("key").
-		OrderBy("key")
-}
-
-// fetchSpanCustomKeySuggestions lists what one user-defined attribute has
-// been set to, most recently written first, asking for one row past the limit
-// so it can report that more matched without counting them. Empty ones are left out.
-//
-// The scan is on the full table without a time bound. If needed in future: time bound
-// it so only suggestions in time range show up or add a rollup of distinct keys and
-// values like the span_filters rollup that fixed keys read.
-func fetchSpanCustomKeySuggestions(ctx context.Context, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
-	limit := valueRequest.Limit
-	if limit <= 0 {
-		limit = DefaultValueLimit
-	}
-
-	ctx = chquery.WithTeamScope(ctx, teamID)
-
-	stmt := sqlf.
-		From("span_user_def_attrs").
-		Select("value").
-		Select("max(timestamp) as recency").
-		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID).
-		Where("key = ?", strings.TrimPrefix(key.Name, CustomKeyPrefix)).
-		Where("type = ?", string(key.ValueType)).
-		Where("value <> ''").
-		GroupBy("value").
-		OrderBy("recency desc, value").
-		Limit(limit + 1)
-
-	defer stmt.Close()
-
-	if valueRequest.Search != "" {
-		stmt.Where("value ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
-	}
-
-	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
-	if err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-	defer rows.Close()
-
-	values := []Value{}
-	for rows.Next() {
-		var text string
-		var recency time.Time
-		if err := rows.Scan(&text, &recency); err != nil {
-			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-		}
-		values = append(values, Value{Text: text})
-	}
-	if err := rows.Err(); err != nil {
-		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
-	}
-
-	if len(values) > limit {
-		return ValueList{Values: values[:limit], Truncated: true}, nil
-	}
-
-	return ValueList{Values: values}, nil
+	return overrides
 }

--- a/backend/libs/exprfilter/valuesuggestions.go
+++ b/backend/libs/exprfilter/valuesuggestions.go
@@ -1,0 +1,116 @@
+package exprfilter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"backend/libs/chquery"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/leporo/sqlf"
+)
+
+// fixedKeyValueSource says where an entity's fixed-key value suggestions are
+// read from: a ClickHouse table, the column expression each key's values are
+// read from, and the aggregate expression that dates a value for
+// most-recently-seen-first ordering.
+type fixedKeyValueSource struct {
+	table       string
+	columns     map[string]string
+	recencyExpr string
+}
+
+// SuggestKeyValues lists what one key can be set to, narrowed by what has
+// been typed. An enum key answers from its own value list without a read, a
+// custom key reads the entity's custom key store, and every other key is
+// answered by the entity's fixed-key suggester.
+func (e Entity) SuggestKeyValues(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	if len(key.EnumValues) > 0 {
+		return narrowEnumValues(key, valueRequest), nil
+	}
+
+	if e.CustomKeys != nil && strings.HasPrefix(key.Name, CustomKeyPrefix) {
+		if key.ValueSuggestionMode == ValueSuggestionModeNone {
+			return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
+		}
+		return e.CustomKeys.suggestValues(ctx, chPool, teamID, appID, key, valueRequest)
+	}
+
+	return e.SuggestFixedKeyValues(ctx, pgPool, chPool, teamID, appID, key, valueRequest)
+}
+
+// suggestFixedKeyValuesFromClickHouse builds an entity's fixed-key value
+// suggester over a ClickHouse value source: each key reads its column, most
+// recently seen first, and a key that takes typed-in values only is refused.
+func suggestFixedKeyValuesFromClickHouse(fixedValues fixedKeyValueSource) func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+	return func(ctx context.Context, pgPool *pgxpool.Pool, chPool driver.Conn, teamID, appID uuid.UUID, key Key, valueRequest ValueRequest) (ValueList, error) {
+		if key.ValueSuggestionMode == ValueSuggestionModeNone {
+			return ValueList{}, fmt.Errorf("Key %q takes typed-in values only", key.Name)
+		}
+
+		column, ok := fixedValues.columns[key.Name]
+		if !ok {
+			return ValueList{}, fmt.Errorf("%w: %q", ErrKeyNotSupported, key.Name)
+		}
+
+		limit := valueRequest.effectiveLimit()
+
+		ctx = chquery.WithTeamScope(ctx, teamID)
+
+		// A row that did not carry an attribute holds an empty string in that
+		// column, so those rows are left out. Values tied on recency order
+		// alphabetically.
+		stmt := sqlf.
+			From(fixedValues.table).
+			Select(column+" as suggested_value").
+			Select(fixedValues.recencyExpr+" as recency").
+			Where("team_id = toUUID(?)", teamID).
+			Where("app_id = toUUID(?)", appID).
+			Where(column + " <> ''").
+			GroupBy("suggested_value").
+			OrderBy("recency desc, suggested_value").
+			Limit(limit + 1)
+
+		defer stmt.Close()
+
+		if valueRequest.Search != "" {
+			stmt.Where(column+" ilike ?", "%"+EscapeLikeWildcards(valueRequest.Search)+"%")
+		}
+
+		return readSuggestedValues(ctx, chPool, key, stmt, limit)
+	}
+}
+
+// readSuggestedValues runs a suggestion statement that selects a value and
+// its recency per row, and reports the list truncated when more than limit
+// rows come back, which the statement arranged by asking for one extra row.
+func readSuggestedValues(ctx context.Context, chPool driver.Conn, key Key, stmt *sqlf.Stmt, limit int) (ValueList, error) {
+	rows, err := chPool.Query(ctx, stmt.String(), stmt.Args()...)
+	if err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+	defer rows.Close()
+
+	values := []Value{}
+	for rows.Next() {
+		var text string
+		var recency time.Time
+		if err := rows.Scan(&text, &recency); err != nil {
+			return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+		}
+		values = append(values, Value{Text: text})
+	}
+	if err := rows.Err(); err != nil {
+		return ValueList{}, fmt.Errorf("Failed to read the values of key %q: %w", key.Name, err)
+	}
+
+	if len(values) > limit {
+		return ValueList{Values: values[:limit], Truncated: true}, nil
+	}
+
+	return ValueList{Values: values}, nil
+}

--- a/backend/libs/exprfilter/valuesuggestions_test.go
+++ b/backend/libs/exprfilter/valuesuggestions_test.go
@@ -1,0 +1,154 @@
+package exprfilter
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+)
+
+var errQueryRecorded = errors.New("query recorded")
+
+// sqlRecorder satisfies driver.Conn through the embedded interface and
+// records the one query a fetch function issues before failing it, so a test
+// can assert the SQL an entity sends to ClickHouse without a database.
+type sqlRecorder struct {
+	driver.Conn
+	query string
+	args  []any
+}
+
+func (r *sqlRecorder) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	r.query = query
+	// The fetch functions close their statement on return, which recycles the
+	// argument slice, so the recorder copies it while the values are intact.
+	r.args = slices.Clone(args)
+	return nil, errQueryRecorded
+}
+
+// The suggestion and key-listing statements below are pinned verbatim: the
+// key listing carries `settings use_skip_indexes = 0` and no final, value
+// reads carry neither, values order by recency desc then value, and listings
+// order by key. The bug reports statements keep the bug_report flag between
+// the app scope and the key conditions.
+func TestSuggestionSQL(t *testing.T) {
+	teamID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	appID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		run      func(recorder *sqlRecorder)
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name: "spans fixed key values read the span_filters rollup by month",
+			run: func(recorder *sqlRecorder) {
+				byName := IndexKeysByName(SpansEntity.Keys)
+				_, _ = SpansEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, byName["device_name"], ValueRequest{Search: "Ph%one_x"})
+			},
+			wantSQL: "SELECT device_name as suggested_value, max(end_of_month) as recency" +
+				" FROM span_filters" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND device_name <> '' AND device_name ilike ?" +
+				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
+			wantArgs: []any{teamID, appID, `%Ph\%one\_x%`, DefaultValueLimit + 1},
+		},
+		{
+			name: "bug report fixed key values read the bug_reports table by timestamp",
+			run: func(recorder *sqlRecorder) {
+				byName := IndexKeysByName(BugReportsEntity.Keys)
+				_, _ = BugReportsEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, byName["device_name"], ValueRequest{})
+			},
+			wantSQL: "SELECT device_name as suggested_value, max(timestamp) as recency" +
+				" FROM bug_reports" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND device_name <> ''" +
+				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
+			wantArgs: []any{teamID, appID, DefaultValueLimit + 1},
+		},
+		{
+			name: "span custom key values read span_user_def_attrs by key and type",
+			run: func(recorder *sqlRecorder) {
+				_, _ = SpansEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, CustomKey("plan", ValueTypeString), ValueRequest{})
+			},
+			wantSQL: "SELECT value, max(timestamp) as recency" +
+				" FROM span_user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND key = ? AND type = ? AND value <> ''" +
+				" GROUP BY value ORDER BY recency desc, value LIMIT ?",
+			wantArgs: []any{teamID, appID, "plan", "string", DefaultValueLimit + 1},
+		},
+		{
+			name: "bug report custom key values keep to the rows flagged bug_report",
+			run: func(recorder *sqlRecorder) {
+				_, _ = BugReportsEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, CustomKey("plan", ValueTypeString), ValueRequest{Search: "fr", Limit: 3})
+			},
+			wantSQL: "SELECT value, max(timestamp) as recency" +
+				" FROM user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND bug_report = true AND key = ? AND type = ? AND value <> '' AND value ilike ?" +
+				" GROUP BY value ORDER BY recency desc, value LIMIT ?",
+			wantArgs: []any{teamID, appID, "plan", "string", "%fr%", 4},
+		},
+		{
+			name: "the span custom key listing skips the skip indexes",
+			run: func(recorder *sqlRecorder) {
+				_, _, _ = SpansEntity.FetchCustomKeys(ctx, nil, recorder, teamID, appID, CustomKeyLimit)
+			},
+			wantSQL: "SELECT key, argMax(type, timestamp) as type" +
+				" FROM span_user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?)" +
+				" GROUP BY key ORDER BY key LIMIT ? settings use_skip_indexes = 0",
+			wantArgs: []any{teamID, appID, CustomKeyLimit + 1},
+		},
+		{
+			name: "the bug report custom key listing keeps to the rows flagged bug_report",
+			run: func(recorder *sqlRecorder) {
+				_, _, _ = BugReportsEntity.FetchCustomKeys(ctx, nil, recorder, teamID, appID, CustomKeyLimit)
+			},
+			wantSQL: "SELECT key, argMax(type, timestamp) as type" +
+				" FROM user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND bug_report = true" +
+				" GROUP BY key ORDER BY key LIMIT ? settings use_skip_indexes = 0",
+			wantArgs: []any{teamID, appID, CustomKeyLimit + 1},
+		},
+		{
+			name: "span custom keys resolve by name without a limit or settings",
+			run: func(recorder *sqlRecorder) {
+				_, _ = SpansEntity.FetchCustomKeysByName(ctx, nil, recorder, teamID, appID, []string{"plan", "retries"})
+			},
+			wantSQL: "SELECT key, argMax(type, timestamp) as type" +
+				" FROM span_user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND key in ?" +
+				" GROUP BY key ORDER BY key",
+			wantArgs: []any{teamID, appID, []string{"plan", "retries"}},
+		},
+		{
+			name: "bug report custom keys resolve by name behind the bug_report flag",
+			run: func(recorder *sqlRecorder) {
+				_, _ = BugReportsEntity.FetchCustomKeysByName(ctx, nil, recorder, teamID, appID, []string{"plan"})
+			},
+			wantSQL: "SELECT key, argMax(type, timestamp) as type" +
+				" FROM user_def_attrs" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND bug_report = true AND key in ?" +
+				" GROUP BY key ORDER BY key",
+			wantArgs: []any{teamID, appID, []string{"plan"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &sqlRecorder{}
+			test.run(recorder)
+
+			if recorder.query != test.wantSQL {
+				t.Errorf("\n got %s\nwant %s", recorder.query, test.wantSQL)
+			}
+			if !reflect.DeepEqual(recorder.args, test.wantArgs) {
+				t.Errorf("\n got args %#v\nwant args %#v", recorder.args, test.wantArgs)
+			}
+		})
+	}
+}

--- a/backend/libs/measure/authz.go
+++ b/backend/libs/measure/authz.go
@@ -104,12 +104,15 @@ var (
 	ScopeBugReportRead             = newScope("bugReport", "read")
 )
 
-type scope struct {
+// Scope is one permission an authorization check tests, such as reading a
+// team's apps. Its fields and constructor are unexported, so new scopes can
+// only be declared in this package.
+type Scope struct {
 	resource string
 	perm     string
 }
 
-func (s scope) GetRolesSameOrLower(r Rank) []Rank {
+func (s Scope) GetRolesSameOrLower(r Rank) []Rank {
 	lowerRoles := r.getLower()
 	var roles []Rank
 
@@ -128,7 +131,7 @@ func (s scope) GetRolesSameOrLower(r Rank) []Rank {
 	return roles
 }
 
-var ScopeMap = map[Rank][]scope{
+var ScopeMap = map[Rank][]Scope{
 	owner:     {*ScopeBillingAll, *ScopeTeamAll, *ScopeAlertAll, *ScopeAppAll, *ScopeBugReportAll},
 	admin:     {*ScopeBillingAll, *ScopeAlertAll, *ScopeAppAll, *ScopeBugReportAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
 	developer: {*ScopeBillingRead, *ScopeAlertAll, *ScopeAppRead, *ScopeBugReportAll, *ScopeTeamInviteSameOrLower, *ScopeTeamChangeRoleSameOrLower},
@@ -142,18 +145,18 @@ var RoleMap = map[string]Rank{
 	"viewer":    viewer,
 }
 
-func (s *scope) String() string {
+func (s *Scope) String() string {
 	return fmt.Sprintf("%s:%s", s.resource, s.perm)
 }
 
-func newScope(resource, perm string) *scope {
-	return &scope{
+func newScope(resource, perm string) *Scope {
+	return &Scope{
 		resource: resource,
 		perm:     perm,
 	}
 }
 
-func PerformAuthz(pg *pgxpool.Pool, uid string, rid string, scope scope) (bool, error) {
+func PerformAuthz(pg *pgxpool.Pool, uid string, rid string, scope Scope) (bool, error) {
 	u := &User{
 		ID: &uid,
 	}

--- a/backend/libs/measure/authz_test.go
+++ b/backend/libs/measure/authz_test.go
@@ -283,7 +283,7 @@ func TestScopeMap_TeamInviteAndAlertScopes(t *testing.T) {
 func TestGetRolesSameOrLower_NonTeamScopesReturnEmpty(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
-		scope scope
+		scope Scope
 	}{
 		{name: "app read", scope: *ScopeAppRead},
 		{name: "app all", scope: *ScopeAppAll},
@@ -309,7 +309,7 @@ func TestPerformAuthzMatrix(t *testing.T) {
 	tests := []struct {
 		name      string
 		role      string
-		scope     scope
+		scope     Scope
 		wantAllow bool
 	}{
 		{name: "owner app all", role: "owner", scope: *ScopeAppAll, wantAllow: true},

--- a/frontend/dashboard/__tests__/helpers/mock_router.ts
+++ b/frontend/dashboard/__tests__/helpers/mock_router.ts
@@ -1,0 +1,71 @@
+/**
+ * A stateful stand-in for next/navigation, shared by the suites of the pages
+ * that carry their filter state in the URL's query params.
+ *
+ * The mocked router applies each replace back into the mocked searchParams
+ * and notifies subscribers, the way the real router re-renders the page with
+ * the URL it just wrote. The page's queries read the URL, so without this
+ * they would never see what the bar settled on.
+ *
+ * jest.mock calls are hoisted per file, so each suite still declares its own
+ * jest.mock("next/navigation", ...) whose factory requires this module and
+ * returns nextNavigationMock(); the module registry hands the factory and
+ * the suite's imports the same instance.
+ */
+import { useSyncExternalStore } from "react";
+
+const subscribers = new Set<() => void>();
+
+const applyReplaceUrl = (url: string) => {
+  mockRouter.searchParams = new URLSearchParams(url.split("?")[1] ?? "");
+  subscribers.forEach((notify) => notify());
+};
+
+// With deferReplace set, a replace's URL is held for the test to apply
+// later, the way the real router updates searchParams only on a later render.
+const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
+  if (mockRouter.deferReplace) {
+    mockRouter.deferredReplaceUrl = url;
+    return;
+  }
+  applyReplaceUrl(url);
+});
+
+export const mockRouter = {
+  searchParams: new URLSearchParams(),
+  deferReplace: false,
+  deferredReplaceUrl: null as string | null,
+  replaceMock,
+  pushMock: jest.fn(),
+  applyReplaceUrl,
+  reset() {
+    mockRouter.searchParams = new URLSearchParams();
+    mockRouter.deferReplace = false;
+    mockRouter.deferredReplaceUrl = null;
+    mockRouter.replaceMock.mockClear();
+    mockRouter.pushMock.mockClear();
+  },
+};
+
+/**
+ * The next/navigation module shape for a suite's jest.mock factory. A suite
+ * that stubs more of the module, such as usePathname, spreads this and adds
+ * its own entries.
+ */
+export function nextNavigationMock() {
+  return {
+    __esModule: true,
+    useRouter: () => ({
+      replace: mockRouter.replaceMock,
+      push: mockRouter.pushMock,
+    }),
+    useSearchParams: () =>
+      useSyncExternalStore(
+        (notify: () => void) => {
+          subscribers.add(notify);
+          return () => subscribers.delete(notify);
+        },
+        () => mockRouter.searchParams,
+      ),
+  };
+}

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -11,6 +11,7 @@
  *   - the bug_reports filter entity (bug_report_status, user_id, ...)
  *   - PATCH endpoint for status toggle
  */
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import {
   afterAll,
@@ -38,33 +39,11 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterPush = jest.fn();
+const mockRouterReplace = mockRouter.replaceMock;
+const mockRouterPush = mockRouter.pushMock;
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's queries read the URL, so without this
-// they would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const mockRouterReplace = jest.fn(
-  (url: string, _options?: { scroll: boolean }) => {
-    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-    searchParamsSubscribers.forEach((notify) => notify());
-  },
-);
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/bug_reports",
 }));
 
@@ -166,7 +145,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockSearchParams = new URLSearchParams();
+  mockRouter.searchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -312,7 +291,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
   // ================================================================
   describe("a link carrying a filter", () => {
     it("filters the bug reports and the plot by it", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
       );
       const sent = recordBugReportsRequests();
@@ -339,7 +318,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
     });
 
     it("draws it as a condition a person can edit", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
       );
       renderPage();
@@ -352,7 +331,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
     });
 
     it("filters by nothing when it cannot be read", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:")}`,
       );
       const sent = recordBugReportsRequests();
@@ -481,7 +460,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
         }),
       );
 
-      mockSearchParams = new URLSearchParams("po=5");
+      mockRouter.searchParams = new URLSearchParams("po=5");
       renderPage();
       await waitFor(
         () => {

--- a/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
@@ -1,3 +1,4 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import {
   afterAll,
@@ -24,31 +25,10 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's query reads the URL, so without this it
-// would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const mockRouterReplace = jest.fn(
-  (url: string, _options?: { scroll: boolean }) => {
-    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-    searchParamsSubscribers.forEach((notify) => notify());
-  },
-);
+const mockRouterReplace = mockRouter.replaceMock;
+
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: jest.fn() }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/builds",
 }));
 
@@ -115,7 +95,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockSearchParams = new URLSearchParams();
+  mockRouter.searchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -208,7 +188,7 @@ describe("Builds page (MSW integration)", () => {
 
   describe("a link carrying a filter", () => {
     beforeEach(() => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("mapping_type:in:proguard")}`,
       );
     });
@@ -236,7 +216,7 @@ describe("Builds page (MSW integration)", () => {
     });
 
     it("filters by nothing when it cannot be read", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("mapping_type:in:")}`,
       );
       const sent = recordBuildsRequests();

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -10,6 +10,7 @@
  * Device, App version, Network type), TraceWaterfall timeline visualization,
  * and "View Session Replay" link.
  */
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import {
   afterAll,
@@ -37,33 +38,11 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterPush = jest.fn();
+const mockRouterReplace = mockRouter.replaceMock;
+const mockRouterPush = mockRouter.pushMock;
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's queries read the URL, so without this
-// they would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const mockRouterReplace = jest.fn(
-  (url: string, _options?: { scroll: boolean }) => {
-    mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-    searchParamsSubscribers.forEach((notify) => notify());
-  },
-);
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/traces",
 }));
 
@@ -162,7 +141,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockSearchParams = new URLSearchParams();
+  mockRouter.searchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -272,7 +251,7 @@ describe("Traces Overview (MSW integration)", () => {
 
   describe("root span selection", () => {
     it("restores the name a link asked for when its app matches", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&a=${appId}&r=api_fetch_payments`,
       );
       const sent = recordSpansRequests();
@@ -308,7 +287,7 @@ describe("Traces Overview (MSW integration)", () => {
     });
 
     it("falls back to the first name when the link's app is not the selected one", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&a=some-other-app&r=api_fetch_payments`,
       );
       const sent = recordSpansRequests();
@@ -319,7 +298,9 @@ describe("Traces Overview (MSW integration)", () => {
     });
 
     it("falls back to the first name when the link names an unknown span", async () => {
-      mockSearchParams = new URLSearchParams(`po=0&a=${appId}&r=span.gone`);
+      mockRouter.searchParams = new URLSearchParams(
+        `po=0&a=${appId}&r=span.gone`,
+      );
       const sent = recordSpansRequests();
       renderPage();
       await waitForSpans();
@@ -344,7 +325,7 @@ describe("Traces Overview (MSW integration)", () => {
 
   describe("a link carrying a filter", () => {
     it("filters the spans and the plot by it", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
       );
       const sent = recordSpansRequests();
@@ -397,7 +378,7 @@ describe("Traces Overview (MSW integration)", () => {
         }),
       );
 
-      mockSearchParams = new URLSearchParams("po=5");
+      mockRouter.searchParams = new URLSearchParams("po=5");
       renderPage();
       await waitFor(
         () => {

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -1,45 +1,17 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import BugReportsOverview from "@/app/[teamId]/bug_reports/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const pushMock = jest.fn();
+const replaceMock = mockRouter.replaceMock;
+const pushMock = mockRouter.pushMock;
+const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's queries read the URL, so without this
-// they would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const applyReplaceUrl = (url: string) => {
-  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-  searchParamsSubscribers.forEach((notify) => notify());
-};
-// Holds a replace's URL for the test to apply later, modeling the real
-// router landing a write one render after the call.
-let mockDeferReplace = false;
-let deferredReplaceUrl: string | null = null;
-const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
-  if (mockDeferReplace) {
-    deferredReplaceUrl = url;
-    return;
-  }
-  applyReplaceUrl(url);
-});
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: replaceMock, push: pushMock }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
-}));
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
@@ -262,12 +234,8 @@ function renderPage() {
 
 describe("BugReportsOverview page", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
-    pushMock.mockClear();
+    mockRouter.reset();
     mockMountDiscardsFilter = false;
-    mockDeferReplace = false;
-    deferredReplaceUrl = null;
-    mockSearchParams = new URLSearchParams();
     mockUseBugReportsOverviewQuery.mockReset();
     mockUseBugReportsOverviewQuery.mockReturnValue(pendingQueryState());
     mockUseBugReportsOverviewPlotQuery.mockReset();
@@ -280,7 +248,7 @@ describe("BugReportsOverview page", () => {
   });
 
   it("hands the bar the filter the URL opened on", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=0&filter_expr=bug_report_status%3Ain%3Aopen",
     );
     bugReportsLoaded();
@@ -292,7 +260,7 @@ describe("BugReportsOverview page", () => {
   });
 
   it("fetches nothing until the bar settles on an app and a range", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
     );
     bugReportsLoaded();
@@ -303,7 +271,7 @@ describe("BugReportsOverview page", () => {
   });
 
   it("fetches the page the URL names, filtered by what the bar reported", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
     );
     bugReportsLoaded();
@@ -328,8 +296,8 @@ describe("BugReportsOverview page", () => {
 
   it("never fetches a filter the bar discarded on mount", async () => {
     mockMountDiscardsFilter = true;
-    mockDeferReplace = true;
-    mockSearchParams = new URLSearchParams(
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
       `po=30&filter_expr=bug_report_status%3Ain%3Aopen&${selectionParams}`,
     );
     bugReportsLoaded();
@@ -340,7 +308,7 @@ describe("BugReportsOverview page", () => {
     expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 30);
 
     await act(async () => {
-      applyReplaceUrl(deferredReplaceUrl!);
+      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
     });
 
     expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
@@ -361,7 +329,7 @@ describe("BugReportsOverview page", () => {
   });
 
   it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
     );
     bugReportsLoaded();
@@ -384,7 +352,7 @@ describe("BugReportsOverview page", () => {
   });
 
   it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
-    mockDeferReplace = true;
+    mockRouter.deferReplace = true;
     bugReportsLoaded();
     renderPage();
 
@@ -550,7 +518,7 @@ describe("BugReportsOverview page", () => {
 
   describe("a filter the bar could not settle", () => {
     beforeEach(() => {
-      mockSearchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
       bugReportsLoaded();
     });
 
@@ -592,7 +560,7 @@ describe("BugReportsOverview page", () => {
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockSearchParams = new URLSearchParams(`po=0&${selectionParams}`);
+      mockRouter.searchParams = new URLSearchParams(`po=0&${selectionParams}`);
       bugReportsLoaded();
       renderPage();
 
@@ -607,7 +575,7 @@ describe("BugReportsOverview page", () => {
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockSearchParams = new URLSearchParams("po=5&a=app-1");
+      mockRouter.searchParams = new URLSearchParams("po=5&a=app-1");
       bugReportsLoaded();
       renderPage();
 
@@ -618,7 +586,7 @@ describe("BugReportsOverview page", () => {
         scroll: false,
       });
 
-      mockSearchParams = new URLSearchParams("po=0&a=app-1");
+      mockRouter.searchParams = new URLSearchParams("po=0&a=app-1");
       renderPage();
       await act(async () => {
         fireEvent.click(screen.getAllByTestId("prev-button")[1]);
@@ -629,7 +597,7 @@ describe("BugReportsOverview page", () => {
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockSearchParams = new URLSearchParams("po=30&a=app-1");
+      mockRouter.searchParams = new URLSearchParams("po=30&a=app-1");
       bugReportsLoaded();
       renderPage();
 
@@ -657,7 +625,7 @@ describe("BugReportsOverview page", () => {
     });
 
     it("goes back to the first page when the filter is cleared", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         "po=30&filter_expr=bug_report_status%3Ain%3Aopen",
       );
       bugReportsLoaded();

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -1,43 +1,16 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import Builds from "@/app/[teamId]/builds/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's query reads the URL, so without this it
-// would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const applyReplaceUrl = (url: string) => {
-  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-  searchParamsSubscribers.forEach((notify) => notify());
-};
-// Holds a replace's URL for the test to apply later, modeling the real
-// router landing a write one render after the call.
-let mockDeferReplace = false;
-let deferredReplaceUrl: string | null = null;
-const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
-  if (mockDeferReplace) {
-    deferredReplaceUrl = url;
-    return;
-  }
-  applyReplaceUrl(url);
-});
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: replaceMock }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
-}));
+const replaceMock = mockRouter.replaceMock;
+const applyReplaceUrl = mockRouter.applyReplaceUrl;
+
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
 const downloadBuildFileMock = jest.fn();
 jest.mock("@/app/api/api_calls", () => ({
@@ -221,12 +194,9 @@ function renderPage() {
 
 describe("Builds page", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
+    mockRouter.reset();
     downloadBuildFileMock.mockClear();
     mockMountDiscardsFilter = false;
-    mockDeferReplace = false;
-    deferredReplaceUrl = null;
-    mockSearchParams = new URLSearchParams();
     mockUseBuildsQuery.mockReset();
     mockUseBuildsQuery.mockReturnValue({
       data: undefined,
@@ -242,7 +212,7 @@ describe("Builds page", () => {
   });
 
   it("hands the bar the filter the URL opened on", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=0&filter_expr=patch_id%3Ais_set",
     );
     loaded();
@@ -254,7 +224,7 @@ describe("Builds page", () => {
   });
 
   it("fetches nothing until the bar settles on an app and a range", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=patch_id%3Ais_set",
     );
     loaded();
@@ -264,7 +234,7 @@ describe("Builds page", () => {
   });
 
   it("fetches the page the URL names, filtered by what the bar reported", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=patch_id%3Ais_set",
     );
     loaded();
@@ -283,8 +253,8 @@ describe("Builds page", () => {
 
   it("never fetches a filter the bar discarded on mount", async () => {
     mockMountDiscardsFilter = true;
-    mockDeferReplace = true;
-    mockSearchParams = new URLSearchParams(
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
       `po=30&filter_expr=patch_id%3Ais_set&${selectionParams}`,
     );
     loaded();
@@ -295,7 +265,7 @@ describe("Builds page", () => {
     expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 30);
 
     await act(async () => {
-      applyReplaceUrl(deferredReplaceUrl!);
+      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
     });
 
     expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
@@ -316,7 +286,7 @@ describe("Builds page", () => {
   });
 
   it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=patch_id%3Ais_set",
     );
     loaded();
@@ -501,7 +471,7 @@ describe("Builds page", () => {
 
   describe("a filter the bar could not settle", () => {
     beforeEach(() => {
-      mockSearchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
       loaded();
     });
 
@@ -543,7 +513,7 @@ describe("Builds page", () => {
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&filter_expr=patch_id%3Ais_set&${selectionParams}`,
       );
       loaded();
@@ -561,7 +531,7 @@ describe("Builds page", () => {
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         "po=10&filter_expr=patch_id%3Ais_set",
       );
       loaded();
@@ -575,7 +545,7 @@ describe("Builds page", () => {
         { scroll: false },
       );
 
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         "po=0&filter_expr=patch_id%3Ais_set",
       );
       renderPage();
@@ -589,7 +559,7 @@ describe("Builds page", () => {
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         "po=30&filter_expr=patch_id%3Ais_set",
       );
       loaded();
@@ -631,7 +601,7 @@ describe("Builds page", () => {
     });
 
     it("goes back to the first page when the filter is cleared", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         "po=30&filter_expr=patch_id%3Ais_set",
       );
       loaded();

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -1,45 +1,17 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import TracesOverview from "@/app/[teamId]/traces/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const pushMock = jest.fn();
+const replaceMock = mockRouter.replaceMock;
+const pushMock = mockRouter.pushMock;
+const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
-// The mocked router applies each replace back into the mocked searchParams
-// and notifies subscribers, the way the real router re-renders the page with
-// the URL it just wrote. The page's queries read the URL, so without this
-// they would never see what the bar settled on.
-let mockSearchParams = new URLSearchParams();
-const searchParamsSubscribers = new Set<() => void>();
-const applyReplaceUrl = (url: string) => {
-  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
-  searchParamsSubscribers.forEach((notify) => notify());
-};
-// Holds a replace's URL for the test to apply later, modeling the real
-// router landing a write one render after the call.
-let mockDeferReplace = false;
-let deferredReplaceUrl: string | null = null;
-const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
-  if (mockDeferReplace) {
-    deferredReplaceUrl = url;
-    return;
-  }
-  applyReplaceUrl(url);
-});
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: replaceMock, push: pushMock }),
-  useSearchParams: () => {
-    const { useSyncExternalStore } = require("react");
-    return useSyncExternalStore(
-      (notify: () => void) => {
-        searchParamsSubscribers.add(notify);
-        return () => searchParamsSubscribers.delete(notify);
-      },
-      () => mockSearchParams,
-    );
-  },
-}));
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
 jest.mock("@/app/api/api_calls", () => ({
   __esModule: true,
@@ -281,12 +253,8 @@ function renderPage() {
 
 describe("TracesOverview page", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
-    pushMock.mockClear();
+    mockRouter.reset();
     mockMountSubstitutesName = false;
-    mockDeferReplace = false;
-    deferredReplaceUrl = null;
-    mockSearchParams = new URLSearchParams();
     mockUseSpansQuery.mockReset();
     mockUseSpansQuery.mockReturnValue(pendingQueryState());
     mockUseSpanMetricsPlotQuery.mockReset();
@@ -306,7 +274,7 @@ describe("TracesOverview page", () => {
   });
 
   it("hands the bar the filter the URL opened on", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=0&filter_expr=span_status%3Ain%3Aerror",
     );
     spansLoaded();
@@ -318,7 +286,7 @@ describe("TracesOverview page", () => {
   });
 
   it("hands the bar the trace name the URL opened on", () => {
-    mockSearchParams = new URLSearchParams("po=0&a=app-1&r=span.second");
+    mockRouter.searchParams = new URLSearchParams("po=0&a=app-1&r=span.second");
     spansLoaded();
     renderPage();
 
@@ -355,7 +323,7 @@ describe("TracesOverview page", () => {
   });
 
   it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockSearchParams = new URLSearchParams(
+    mockRouter.searchParams = new URLSearchParams(
       "po=20&filter_expr=span_status%3Ain%3Aerror",
     );
     spansLoaded();
@@ -376,7 +344,7 @@ describe("TracesOverview page", () => {
   });
 
   it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
-    mockDeferReplace = true;
+    mockRouter.deferReplace = true;
     spansLoaded();
     renderPage();
 
@@ -502,7 +470,7 @@ describe("TracesOverview page", () => {
 
   describe("a filter the bar could not settle", () => {
     beforeEach(() => {
-      mockSearchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
       spansLoaded();
     });
 
@@ -550,7 +518,7 @@ describe("TracesOverview page", () => {
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockSearchParams = new URLSearchParams(
+      mockRouter.searchParams = new URLSearchParams(
         `po=0&r=span.first&${selectionParams}`,
       );
       spansLoaded();
@@ -567,7 +535,9 @@ describe("TracesOverview page", () => {
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockSearchParams = new URLSearchParams("po=5&r=span.first&a=app-1");
+      mockRouter.searchParams = new URLSearchParams(
+        "po=5&r=span.first&a=app-1",
+      );
       spansLoaded();
       renderPage();
 
@@ -578,7 +548,9 @@ describe("TracesOverview page", () => {
         scroll: false,
       });
 
-      mockSearchParams = new URLSearchParams("po=0&r=span.first&a=app-1");
+      mockRouter.searchParams = new URLSearchParams(
+        "po=0&r=span.first&a=app-1",
+      );
       renderPage();
       await act(async () => {
         fireEvent.click(screen.getAllByTestId("prev-button")[1]);
@@ -589,7 +561,9 @@ describe("TracesOverview page", () => {
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockSearchParams = new URLSearchParams("po=30&a=app-1&r=span.first");
+      mockRouter.searchParams = new URLSearchParams(
+        "po=30&a=app-1&r=span.first",
+      );
       spansLoaded();
       renderPage();
 
@@ -604,7 +578,7 @@ describe("TracesOverview page", () => {
     });
 
     it("goes back to the first page when the bar reports another name", async () => {
-      mockSearchParams = new URLSearchParams(`po=30&${selectionParams}`);
+      mockRouter.searchParams = new URLSearchParams(`po=30&${selectionParams}`);
       spansLoaded();
       renderPage();
 
@@ -633,8 +607,8 @@ describe("TracesOverview page", () => {
 
     it("goes back to the first page when the bar opens on a substituted name", async () => {
       mockMountSubstitutesName = true;
-      mockDeferReplace = true;
-      mockSearchParams = new URLSearchParams(
+      mockRouter.deferReplace = true;
+      mockRouter.searchParams = new URLSearchParams(
         `po=30&r=span.gone&${selectionParams}`,
       );
       spansLoaded();
@@ -645,7 +619,7 @@ describe("TracesOverview page", () => {
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, "span.gone", 30);
 
       await act(async () => {
-        applyReplaceUrl(deferredReplaceUrl!);
+        applyReplaceUrl(mockRouter.deferredReplaceUrl!);
       });
 
       expect(replaceMock).toHaveBeenLastCalledWith(

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -3,11 +3,8 @@
 import { emptyBugReportsOverviewResponse } from "@/app/api/api_calls";
 import { filterExprIssuesIn } from "@/app/api/api_error";
 import BugReportsOverviewPlot from "@/app/components/bug_reports_overview_plot";
-import FilterBar, {
-  type FilterState,
-  type ReadyFilterState,
-  filterExprUrlKey,
-} from "@/app/components/filter_bar/filter_bar";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import Pill, { PillType } from "@/app/components/pill";
@@ -21,89 +18,35 @@ import {
   TableRow,
 } from "@/app/components/table";
 import {
-  paginationOffsetUrlKey,
   useBugReportsOverviewPlotQuery,
   useBugReportsOverviewQuery,
 } from "@/app/query/hooks";
-import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import {
   formatDateToHumanReadableDate,
   formatDateToHumanReadableTime,
 } from "@/app/utils/time_utils";
 import Link from "next/link";
-import {
-  type ReadonlyURLSearchParams,
-  useRouter,
-  useSearchParams,
-} from "next/navigation";
-import { use, useState } from "react";
+import { useRouter } from "next/navigation";
+import { use } from "react";
 
 const PAGINATION_LIMIT = 5;
-
-const {
-  appId: appIdUrlKey,
-  dateRange: dateRangeUrlKey,
-  startDate: startDateUrlKey,
-  endDate: endDateUrlKey,
-} = urlFiltersKeyMap;
-
-function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
-  return {
-    app: searchParams.get(appIdUrlKey),
-    dateRange: {
-      dateRange: searchParams.get(dateRangeUrlKey),
-      startDate: searchParams.get(startDateUrlKey),
-      endDate: searchParams.get(endDateUrlKey),
-    },
-    filterExpr: searchParams.get(filterExprUrlKey),
-  };
-}
-
-function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
-  const urlParams = new URLSearchParams();
-  urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
-  urlParams.set(appIdUrlKey, filter.app.id);
-  urlParams.set(dateRangeUrlKey, filter.date.dateRange);
-  urlParams.set(startDateUrlKey, filter.date.startDate);
-  urlParams.set(endDateUrlKey, filter.date.endDate);
-  if (filter.filterExpr) {
-    urlParams.set(filterExprUrlKey, filter.filterExpr);
-  }
-  return `?${urlParams.toString()}`;
-}
 
 export default function BugReportsOverview(props: {
   params: Promise<{ teamId: string }>;
 }) {
   const params = use(props.params);
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const paginationOffset =
-    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
-  const requestedFilters = readRequestedFilters(searchParams);
-
-  const [filterState, setFilterState] = useState<FilterState>({
-    status: "pending",
-  });
+  const {
+    requestedFilters,
+    paginationOffset,
+    filterState,
+    filterParams,
+    onFilterChange,
+    nextPage,
+    prevPage,
+  } = useExprFilterPage({ paginationLimit: PAGINATION_LIMIT });
   const readyFilter = filterState.status === "ready" ? filterState : null;
-
-  // The queries read the filter and the pagination offset from the URL, so
-  // each fetch uses one searchParams snapshot. The filter is null until the
-  // URL matches the bar's report. A filter the bar discarded is never fetched.
-  const filterParams =
-    filterState.status === "ready" &&
-    requestedFilters.app === filterState.app.id &&
-    requestedFilters.dateRange.startDate === filterState.date.startDate &&
-    requestedFilters.dateRange.endDate === filterState.date.endDate &&
-    requestedFilters.filterExpr === filterState.filterExpr
-      ? {
-          appId: requestedFilters.app,
-          startDate: requestedFilters.dateRange.startDate,
-          endDate: requestedFilters.dateRange.endDate,
-          filterExpr: requestedFilters.filterExpr,
-        }
-      : null;
 
   const bugReportsQuery = useBugReportsOverviewQuery(
     filterParams,
@@ -114,28 +57,6 @@ export default function BugReportsOverview(props: {
   const filterExprIssues =
     filterExprIssuesIn(bugReportsQuery.error) ??
     filterExprIssuesIn(bugReportsPlotQuery.error);
-
-  const onFilterChange = (newFilterState: FilterState) => {
-    setFilterState(newFilterState);
-
-    if (newFilterState.status !== "ready") {
-      return;
-    }
-    // The URL's pagination offset is kept only when the bar applied the URL's
-    // request unchanged. Any edit or substitution starts back at page one.
-    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
-    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
-  };
-
-  const navigateToOffset = (offset: number) => {
-    const urlParams = new URLSearchParams(searchParams);
-    urlParams.set(paginationOffsetUrlKey, String(offset));
-    router.replace(`?${urlParams.toString()}`, { scroll: false });
-  };
-
-  const nextPage = () => navigateToOffset(paginationOffset + PAGINATION_LIMIT);
-  const prevPage = () =>
-    navigateToOffset(Math.max(0, paginationOffset - PAGINATION_LIMIT));
 
   const {
     data: bugReportsOverview = emptyBugReportsOverviewResponse,

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -1,106 +1,30 @@
 "use client";
 
-import FilterBar, {
-  type FilterState,
-  type ReadyFilterState,
-  filterExprUrlKey,
-} from "@/app/components/filter_bar/filter_bar";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import { filterExprIssuesIn } from "@/app/api/api_error";
-import { paginationOffsetUrlKey, useBuildsQuery } from "@/app/query/hooks";
-import { urlFiltersKeyMap } from "@/app/stores/filters_store";
-import {
-  type ReadonlyURLSearchParams,
-  useRouter,
-  useSearchParams,
-} from "next/navigation";
-import { use, useState } from "react";
+import { useBuildsQuery } from "@/app/query/hooks";
+import { use } from "react";
 import BuildsResults from "./builds_results";
 
 const PAGINATION_LIMIT = 10;
 
-const {
-  appId: appIdUrlKey,
-  dateRange: dateRangeUrlKey,
-  startDate: startDateUrlKey,
-  endDate: endDateUrlKey,
-} = urlFiltersKeyMap;
-
-function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
-  return {
-    app: searchParams.get(appIdUrlKey),
-    dateRange: {
-      dateRange: searchParams.get(dateRangeUrlKey),
-      startDate: searchParams.get(startDateUrlKey),
-      endDate: searchParams.get(endDateUrlKey),
-    },
-    filterExpr: searchParams.get(filterExprUrlKey),
-  };
-}
-
-function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
-  const urlParams = new URLSearchParams();
-  urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
-  urlParams.set(appIdUrlKey, filter.app.id);
-  urlParams.set(dateRangeUrlKey, filter.date.dateRange);
-  urlParams.set(startDateUrlKey, filter.date.startDate);
-  urlParams.set(endDateUrlKey, filter.date.endDate);
-  if (filter.filterExpr) {
-    urlParams.set(filterExprUrlKey, filter.filterExpr);
-  }
-  return `?${urlParams.toString()}`;
-}
-
 export default function Builds(props: { params: Promise<{ teamId: string }> }) {
   const params = use(props.params);
-  const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const paginationOffset =
-    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
-  const requestedFilters = readRequestedFilters(searchParams);
-
-  const [filterState, setFilterState] = useState<FilterState>({
-    status: "pending",
-  });
-
-  // The query reads the filter and the pagination offset from the URL, so
-  // each fetch uses one searchParams snapshot. The filter is null until the
-  // URL matches the bar's report. A value the bar discarded is never fetched.
-  const filterParams =
-    filterState.status === "ready" &&
-    requestedFilters.app === filterState.app.id &&
-    requestedFilters.dateRange.startDate === filterState.date.startDate &&
-    requestedFilters.dateRange.endDate === filterState.date.endDate &&
-    requestedFilters.filterExpr === filterState.filterExpr
-      ? {
-          appId: requestedFilters.app,
-          startDate: requestedFilters.dateRange.startDate,
-          endDate: requestedFilters.dateRange.endDate,
-          filterExpr: requestedFilters.filterExpr,
-        }
-      : null;
+  const {
+    requestedFilters,
+    paginationOffset,
+    filterState,
+    filterParams,
+    onFilterChange,
+    nextPage,
+    prevPage,
+  } = useExprFilterPage({ paginationLimit: PAGINATION_LIMIT });
 
   const buildsQuery = useBuildsQuery(filterParams, paginationOffset);
 
   const filterExprIssues = filterExprIssuesIn(buildsQuery.error);
-
-  const onFilterChange = (newFilterState: FilterState) => {
-    setFilterState(newFilterState);
-
-    if (newFilterState.status !== "ready") {
-      return;
-    }
-    // The URL's pagination offset is kept only when the bar applied the URL's
-    // request unchanged. Any edit or substitution starts back at page one.
-    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
-    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
-  };
-
-  const navigateToOffset = (offset: number) => {
-    const urlParams = new URLSearchParams(searchParams);
-    urlParams.set(paginationOffsetUrlKey, String(offset));
-    router.replace(`?${urlParams.toString()}`, { scroll: false });
-  };
 
   return (
     <div className="flex flex-col items-start">
@@ -122,10 +46,8 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
         filterState={filterState}
         query={buildsQuery}
         filterExprHasIssues={filterExprIssues !== null}
-        onNextPage={() => navigateToOffset(paginationOffset + PAGINATION_LIMIT)}
-        onPrevPage={() =>
-          navigateToOffset(Math.max(0, paginationOffset - PAGINATION_LIMIT))
-        }
+        onNextPage={nextPage}
+        onPrevPage={prevPage}
       />
     </div>
   );

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -2,11 +2,8 @@
 
 import { emptySpansResponse } from "@/app/api/api_calls";
 import { filterExprIssuesIn } from "@/app/api/api_error";
-import FilterBar, {
-  type FilterState,
-  type ReadyFilterState,
-  filterExprUrlKey,
-} from "@/app/components/filter_bar/filter_bar";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import Pill, { PillType } from "@/app/components/pill";
@@ -20,11 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/components/table";
-import {
-  paginationOffsetUrlKey,
-  useSpanMetricsPlotQuery,
-  useSpansQuery,
-} from "@/app/query/hooks";
+import { useSpanMetricsPlotQuery, useSpansQuery } from "@/app/query/hooks";
 import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import {
   formatDateToHumanReadableDate,
@@ -32,87 +25,32 @@ import {
   formatMillisToHumanReadable,
 } from "@/app/utils/time_utils";
 import Link from "next/link";
-import {
-  type ReadonlyURLSearchParams,
-  useRouter,
-  useSearchParams,
-} from "next/navigation";
-import { use, useState } from "react";
+import { useRouter } from "next/navigation";
+import { use } from "react";
 
 const PAGINATION_LIMIT = 5;
-
-const {
-  appId: appIdUrlKey,
-  dateRange: dateRangeUrlKey,
-  startDate: startDateUrlKey,
-  endDate: endDateUrlKey,
-  rootSpanName: rootSpanNameUrlKey,
-} = urlFiltersKeyMap;
-
-function readRequestedFilters(searchParams: ReadonlyURLSearchParams) {
-  return {
-    app: searchParams.get(appIdUrlKey),
-    dateRange: {
-      dateRange: searchParams.get(dateRangeUrlKey),
-      startDate: searchParams.get(startDateUrlKey),
-      endDate: searchParams.get(endDateUrlKey),
-    },
-    filterExpr: searchParams.get(filterExprUrlKey),
-    rootSpanName: searchParams.get(rootSpanNameUrlKey),
-  };
-}
-
-function buildFilterUrl(filter: ReadyFilterState, paginationOffset: number) {
-  const urlParams = new URLSearchParams();
-  urlParams.set(paginationOffsetUrlKey, String(paginationOffset));
-  urlParams.set(appIdUrlKey, filter.app.id);
-  urlParams.set(dateRangeUrlKey, filter.date.dateRange);
-  urlParams.set(startDateUrlKey, filter.date.startDate);
-  urlParams.set(endDateUrlKey, filter.date.endDate);
-  if (filter.rootSpanName !== null) {
-    urlParams.set(rootSpanNameUrlKey, filter.rootSpanName);
-  }
-  if (filter.filterExpr) {
-    urlParams.set(filterExprUrlKey, filter.filterExpr);
-  }
-  return `?${urlParams.toString()}`;
-}
 
 export default function TracesOverview(props: {
   params: Promise<{ teamId: string }>;
 }) {
   const params = use(props.params);
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const paginationOffset =
-    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
-  const requestedFilters = readRequestedFilters(searchParams);
-
-  const [filterState, setFilterState] = useState<FilterState>({
-    status: "pending",
+  const {
+    requestedFilters,
+    requestedExtras,
+    paginationOffset,
+    filterState,
+    filterParams,
+    onFilterChange,
+    nextPage,
+    prevPage,
+  } = useExprFilterPage({
+    paginationLimit: PAGINATION_LIMIT,
+    extraUrlKeys: { rootSpanName: urlFiltersKeyMap.rootSpanName },
   });
   const readyFilter = filterState.status === "ready" ? filterState : null;
-
-  // The queries read the filter, the span name and the pagination offset
-  // from the URL, so each fetch uses one searchParams snapshot. The filter
-  // is null until the URL matches the bar's report. A span name or filter the
-  // bar discarded is never fetched.
-  const filterParams =
-    filterState.status === "ready" &&
-    requestedFilters.app === filterState.app.id &&
-    requestedFilters.dateRange.startDate === filterState.date.startDate &&
-    requestedFilters.dateRange.endDate === filterState.date.endDate &&
-    requestedFilters.filterExpr === filterState.filterExpr &&
-    requestedFilters.rootSpanName === filterState.rootSpanName
-      ? {
-          appId: requestedFilters.app,
-          startDate: requestedFilters.dateRange.startDate,
-          endDate: requestedFilters.dateRange.endDate,
-          filterExpr: requestedFilters.filterExpr,
-        }
-      : null;
-  const rootSpanName = requestedFilters.rootSpanName;
+  const rootSpanName = requestedExtras.rootSpanName;
 
   const spansQuery = useSpansQuery(
     filterParams,
@@ -127,28 +65,6 @@ export default function TracesOverview(props: {
   const filterExprIssues =
     filterExprIssuesIn(spansQuery.error) ??
     filterExprIssuesIn(spanMetricsPlotQuery.error);
-
-  const onFilterChange = (newFilterState: FilterState) => {
-    setFilterState(newFilterState);
-
-    if (newFilterState.status !== "ready") {
-      return;
-    }
-    // The URL's pagination offset is kept only when the bar applied the URL's
-    // request unchanged. Any edit or substitution starts back at page one.
-    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
-    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
-  };
-
-  const navigateToOffset = (offset: number) => {
-    const urlParams = new URLSearchParams(searchParams);
-    urlParams.set(paginationOffsetUrlKey, String(offset));
-    router.replace(`?${urlParams.toString()}`, { scroll: false });
-  };
-
-  const nextPage = () => navigateToOffset(paginationOffset + PAGINATION_LIMIT);
-  const prevPage = () =>
-    navigateToOffset(Math.max(0, paginationOffset - PAGINATION_LIMIT));
 
   const { data: spans = emptySpansResponse, status, isFetching } = spansQuery;
 
@@ -165,7 +81,7 @@ export default function TracesOverview(props: {
         requestedFilterExpr={requestedFilters.filterExpr}
         filterExprIssues={filterExprIssues}
         showRootSpanSelector
-        requestedRootSpanName={requestedFilters.rootSpanName}
+        requestedRootSpanName={requestedExtras.rootSpanName}
         onFilterChange={onFilterChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import {
+  type FilterState,
+  type ReadyFilterState,
+  filterExprUrlKey,
+} from "@/app/components/filter_bar/filter_bar";
+import { type FilterParams, paginationOffsetUrlKey } from "@/app/query/hooks";
+import { urlFiltersKeyMap } from "@/app/stores/filters_store";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+const {
+  appId: appIdUrlKey,
+  dateRange: dateRangeUrlKey,
+  startDate: startDateUrlKey,
+  endDate: endDateUrlKey,
+} = urlFiltersKeyMap;
+
+/**
+ * Fields of the bar's ready report that a page may carry in the URL beyond
+ * the app, date range and filter expression: the nullable string fields,
+ * minus the filter expression the hook already owns.
+ */
+type ExtraFilterField = Exclude<
+  {
+    [P in keyof ReadyFilterState]: ReadyFilterState[P] extends string | null
+      ? null extends ReadyFilterState[P]
+        ? P
+        : never
+      : never;
+  }[keyof ReadyFilterState],
+  "filterExpr"
+>;
+
+/**
+ * The URL-driven filter mechanics shared by the pages that pair a FilterBar
+ * with paginated queries. The URL is the single source of truth: the bar's
+ * report is written into the URL, and the queries read the filter and the
+ * pagination offset back from it, so each fetch uses one searchParams
+ * snapshot.
+ *
+ * A page with a selection of its own carried in the URL, such as a root span
+ * name, declares it in `extraUrlKeys` as a map from the field of the bar's
+ * ready report to the URL key that carries it. The hook then reads the
+ * requested value, includes the field in the URL-vs-report equality gate, and
+ * writes it into the URL with the rest of the filter.
+ */
+export function useExprFilterPage<Extra extends ExtraFilterField = never>({
+  paginationLimit,
+  extraUrlKeys,
+}: {
+  paginationLimit: number;
+  extraUrlKeys?: Record<Extra, string>;
+}) {
+  const extras = Object.entries(extraUrlKeys ?? {}) as [Extra, string][];
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const paginationOffset =
+    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
+
+  const requestedFilters = {
+    app: searchParams.get(appIdUrlKey),
+    dateRange: {
+      dateRange: searchParams.get(dateRangeUrlKey),
+      startDate: searchParams.get(startDateUrlKey),
+      endDate: searchParams.get(endDateUrlKey),
+    },
+    filterExpr: searchParams.get(filterExprUrlKey),
+  };
+  const requestedExtras = Object.fromEntries(
+    extras.map(([field, urlKey]) => [field, searchParams.get(urlKey)]),
+  ) as Record<Extra, string | null>;
+
+  const [filterState, setFilterState] = useState<FilterState>({
+    status: "pending",
+  });
+
+  // The filter is null until the URL matches the bar's report, extras
+  // included, so a value the bar discarded is never fetched.
+  const filterParams: FilterParams | null =
+    filterState.status === "ready" &&
+    requestedFilters.app === filterState.app.id &&
+    requestedFilters.dateRange.startDate === filterState.date.startDate &&
+    requestedFilters.dateRange.endDate === filterState.date.endDate &&
+    requestedFilters.filterExpr === filterState.filterExpr &&
+    extras.every(([field]) => requestedExtras[field] === filterState[field])
+      ? {
+          appId: requestedFilters.app,
+          startDate: requestedFilters.dateRange.startDate,
+          endDate: requestedFilters.dateRange.endDate,
+          filterExpr: requestedFilters.filterExpr,
+        }
+      : null;
+
+  const buildFilterUrl = (filter: ReadyFilterState, offset: number) => {
+    const urlParams = new URLSearchParams();
+    urlParams.set(paginationOffsetUrlKey, String(offset));
+    urlParams.set(appIdUrlKey, filter.app.id);
+    urlParams.set(dateRangeUrlKey, filter.date.dateRange);
+    urlParams.set(startDateUrlKey, filter.date.startDate);
+    urlParams.set(endDateUrlKey, filter.date.endDate);
+    for (const [field, urlKey] of extras) {
+      const value: string | null = filter[field];
+      if (value !== null) {
+        urlParams.set(urlKey, value);
+      }
+    }
+    if (filter.filterExpr) {
+      urlParams.set(filterExprUrlKey, filter.filterExpr);
+    }
+    return `?${urlParams.toString()}`;
+  };
+
+  const onFilterChange = (newFilterState: FilterState) => {
+    setFilterState(newFilterState);
+
+    if (newFilterState.status !== "ready") {
+      return;
+    }
+    // The URL's pagination offset is kept only when the bar applied the URL's
+    // request unchanged. Any edit or substitution starts back at page one.
+    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
+    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
+  };
+
+  const navigateToOffset = (offset: number) => {
+    const urlParams = new URLSearchParams(searchParams);
+    urlParams.set(paginationOffsetUrlKey, String(offset));
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  };
+
+  const nextPage = () => navigateToOffset(paginationOffset + paginationLimit);
+  const prevPage = () =>
+    navigateToOffset(Math.max(0, paginationOffset - paginationLimit));
+
+  return {
+    requestedFilters,
+    requestedExtras,
+    paginationOffset,
+    filterState,
+    filterParams,
+    onFilterChange,
+    nextPage,
+    prevPage,
+  };
+}


### PR DESCRIPTION
# Description

- Extract the URL-driven filter page mechanics shared by the traces, builds and bug reports pages into one hook
- Reduce filter entities to declarations composing shared constructs: one custom key store, one value suggestion source, one column binder per entity
- Share the request prologue across the expression filter HTTP handlers and MCP tools
- Move the duplicated test router mock into one helper



