### PR TITLE
perf(android): show bug report screen before encoding screenshot

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/BugReportCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/BugReportCollector.kt
@@ -2,11 +2,13 @@ package sh.measure.android.bugreport
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import sh.measure.android.SessionManager
 import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.bugreport.BugReportCollector.Companion.MAX_OUTPUT_IMAGE_WIDTH
+import sh.measure.android.bugreport.BugReportCollector.Companion.MAX_PREVIEW_IMAGE_SIZE
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
@@ -14,6 +16,7 @@ import sh.measure.android.events.SignalProcessor
 import sh.measure.android.executors.MeasureExecutorService
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
+import sh.measure.android.mainHandler
 import sh.measure.android.screenshot.ScreenshotMask
 import sh.measure.android.storage.FileStorage
 import sh.measure.android.tracing.InternalTrace
@@ -24,6 +27,7 @@ import sh.measure.android.utils.ScreenshotMaskConfig
 import sh.measure.android.utils.TimeProvider
 import java.io.File
 import java.lang.ref.WeakReference
+import java.util.concurrent.Callable
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.roundToInt
@@ -31,10 +35,10 @@ import sh.measure.android.events.Attachment as EventAttachment
 
 internal interface BugReportCollector {
     companion object {
-        const val INITIAL_SCREENSHOT_EXTRA = "msr_br_screenshot"
         const val MAX_ATTACHMENTS_EXTRA = "msr_br_max_attachments"
         const val MAX_DESCRIPTION_LENGTH = "msr_br_description_length"
         const val MAX_OUTPUT_IMAGE_WIDTH = 1080
+        const val MAX_PREVIEW_IMAGE_SIZE = 1024
     }
 
     fun startBugReportFlow(
@@ -52,6 +56,8 @@ internal interface BugReportCollector {
     fun validateBugReport(attachments: Int, descriptionLength: Int): Boolean
     fun setBugReportFlowActive()
     fun setBugReportFlowInactive()
+    fun getPendingScreenshot(): PendingScreenshot?
+    fun discardPendingScreenshot(screenshot: PendingScreenshot)
 }
 
 internal class BugReportCollectorImpl internal constructor(
@@ -66,6 +72,7 @@ internal class BugReportCollectorImpl internal constructor(
     private val resumedActivityProvider: ResumedActivityProvider,
 ) : BugReportCollector {
     private var attributes: MutableMap<String, AttributeValue>? = null
+    private var pendingScreenshot: PendingScreenshot? = null
     private val isBugReportFlowActive = AtomicBoolean(false)
 
     override fun startBugReportFlow(
@@ -78,23 +85,22 @@ internal class BugReportCollectorImpl internal constructor(
         }
         this.attributes = attributes
         val activity = resumedActivityProvider.getResumedActivity() ?: return
-        fun launchActivity(initialAttachment: ParcelableAttachment?) {
-            MsrBugReportActivity.launch(
-                activity,
-                initialAttachment,
-                configProvider.maxAttachmentsInBugReport,
-                configProvider.maxDescriptionLengthInBugReport,
-            )
+        pendingScreenshot?.discard()
+        pendingScreenshot = if (takeScreenshot) captureScreenshot(activity) else null
+        MsrBugReportActivity.launch(
+            activity,
+            configProvider.maxAttachmentsInBugReport,
+            configProvider.maxDescriptionLengthInBugReport,
+        )
+    }
+
+    override fun getPendingScreenshot(): PendingScreenshot? = pendingScreenshot
+
+    override fun discardPendingScreenshot(screenshot: PendingScreenshot) {
+        if (pendingScreenshot === screenshot) {
+            pendingScreenshot = null
         }
-        if (takeScreenshot) {
-            captureScreenshot(activity = activity, onSuccess = { screenshot ->
-                launchActivity(screenshot)
-            }, onError = {
-                launchActivity(null)
-            })
-        } else {
-            launchActivity(null)
-        }
+        screenshot.discard()
     }
 
     override fun setBugReportFlowActive() {
@@ -114,6 +120,8 @@ internal class BugReportCollectorImpl internal constructor(
         val timestamp = timeProvider.now()
         val threadName = Thread.currentThread().name
         val appContextRef = WeakReference(context.applicationContext)
+        val screenshot = pendingScreenshot?.takeIf { it.isEncoding() }
+        pendingScreenshot = null
         ioExecutor.submit {
             try {
                 InternalTrace.trace(
@@ -122,10 +130,10 @@ internal class BugReportCollectorImpl internal constructor(
                     },
                     block = {
                         val appContext = appContextRef.get() ?: return@trace
+                        val pending = listOfNotNull(screenshot?.awaitEncoded())
                         val eventAttachments =
-                            parcelableAttachments.toEventAttachments() + uris.toEventAttachments(
-                                appContext,
-                            )
+                            (parcelableAttachments + pending).toEventAttachments() +
+                                uris.toEventAttachments(appContext)
                         signalProcessor.track(
                             data = BugReportData(description = description),
                             timestamp = timestamp,
@@ -145,61 +153,73 @@ internal class BugReportCollectorImpl internal constructor(
 
     override fun validateBugReport(attachments: Int, descriptionLength: Int): Boolean = attachments > 0 || descriptionLength > 0
 
-    private fun captureScreenshot(
-        activity: Activity,
-        onSuccess: (ParcelableAttachment) -> Unit,
-        onError: () -> Unit,
-    ) {
-        InternalTrace.trace(
-            label = {
-                "msr-captureScreenshot"
-            },
-            block = {
-                val screenshotMaskConfig = ScreenshotMaskConfig(
-                    maskHexColor = configProvider.screenshotMaskHexColor,
-                    getMaskRects = { view ->
-                        ScreenshotMask(configProvider).findRectsToMask(view)
-                    },
-                )
-                val bitmap = BitmapHelper.captureBitmap(activity, logger, screenshotMaskConfig)
-                if (bitmap == null) {
-                    onError()
-                    return@trace
-                }
+    /**
+     * Captures the screen being reported, which has to happen before the bug report window covers
+     * it, and leaves encoding to the IO executor so that the screen can be shown straight away.
+     */
+    private fun captureScreenshot(activity: Activity): PendingScreenshot? {
+        val bitmap = InternalTrace.trace("msr-captureScreenshot") {
+            val screenshotMaskConfig = ScreenshotMaskConfig(
+                maskHexColor = configProvider.screenshotMaskHexColor,
+                getMaskRects = { view ->
+                    ScreenshotMask(configProvider).findRectsToMask(view)
+                },
+            )
+            BitmapHelper.captureBitmap(activity, logger, screenshotMaskConfig)
+        } ?: return null
+        val preview = scalePreview(bitmap) ?: return null
+        val screenshot = PendingScreenshot(preview)
+        return try {
+            screenshot.encoding = ioExecutor.submit(
+                Callable {
+                    val encoded = encodeScreenshot(bitmap)
+                    screenshot.recordEncoded(encoded)
+                    mainHandler.post { screenshot.finishEncoding(encoded) }
+                    encoded
+                },
+            )
+            screenshot
+        } catch (_: RejectedExecutionException) {
+            null
+        }
+    }
 
-                try {
-                    ioExecutor.submit {
-                        val compressedBitmap = BitmapHelper.compressBitmap(
-                            bitmap,
-                            configProvider.screenshotCompressionQuality,
-                            logger,
-                        )
-                        if (compressedBitmap == null) {
-                            activity.runOnUiThread { onError() }
-                            return@submit
-                        }
-                        val id = idProvider.uuid()
-                        val path = fileStorage.writeTempBugReportScreenshot(
-                            id,
-                            compressedBitmap.first,
-                            compressedBitmap.second,
-                            sessionManager.getSessionId(),
-                        )
-                        if (path == null) {
-                            activity.runOnUiThread { onError() }
-                            return@submit
-                        }
-                        val parcelableAttachment = ParcelableAttachment(
-                            name = "screenshot.${compressedBitmap.first}",
-                            path = path,
-                        )
-                        activity.runOnUiThread { onSuccess(parcelableAttachment) }
-                    }
-                } catch (_: RejectedExecutionException) {
-                    onError()
-                }
-            },
-        )
+    private fun encodeScreenshot(bitmap: Bitmap): ParcelableAttachment? = InternalTrace.trace("msr-encodeScreenshot") {
+        val (extension, bytes) = BitmapHelper.compressBitmap(
+            bitmap,
+            configProvider.screenshotCompressionQuality,
+            logger,
+        ) ?: return@trace null
+        val path = fileStorage.writeTempBugReportScreenshot(
+            idProvider.uuid(),
+            extension,
+            bytes,
+            sessionManager.getSessionId(),
+        ) ?: return@trace null
+        ParcelableAttachment(name = "screenshot.$extension", path = path)
+    }
+
+    /**
+     * The bug report screen shows a thumbnail, so the full size bitmap is never handed to it.
+     */
+    private fun scalePreview(bitmap: Bitmap): Bitmap? = InternalTrace.trace("msr-scalePreview") {
+        val longestSide = maxOf(bitmap.width, bitmap.height)
+        val scale = if (longestSide <= MAX_PREVIEW_IMAGE_SIZE) {
+            1f
+        } else {
+            MAX_PREVIEW_IMAGE_SIZE.toFloat() / longestSide
+        }
+        try {
+            Bitmap.createScaledBitmap(
+                bitmap,
+                (bitmap.width * scale).roundToInt().coerceAtLeast(1),
+                (bitmap.height * scale).roundToInt().coerceAtLeast(1),
+                true,
+            )
+        } catch (e: Exception) {
+            logger.log(LogLevel.Error, "Failed to scale bug report screenshot", e)
+            null
+        }
     }
 
     private fun List<ParcelableAttachment>.toEventAttachments(): List<EventAttachment> = mapNotNull { attachment: ParcelableAttachment ->

--- a/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/MsrBugReportActivity.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/MsrBugReportActivity.kt
@@ -19,13 +19,11 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.annotation.RequiresApi
-import androidx.core.content.IntentCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import sh.measure.android.Measure
 import sh.measure.android.R
-import sh.measure.android.bugreport.BugReportCollector.Companion.INITIAL_SCREENSHOT_EXTRA
 import sh.measure.android.bugreport.BugReportCollector.Companion.MAX_ATTACHMENTS_EXTRA
 import sh.measure.android.bugreport.BugReportCollector.Companion.MAX_DESCRIPTION_LENGTH
 
@@ -40,7 +38,10 @@ internal class MsrBugReportActivity : ComponentActivity() {
     private var maxAttachments: Int = 1
     private var uris: MutableSet<Uri> = mutableSetOf()
     private var attachments: MutableSet<ParcelableAttachment> = mutableSetOf()
-    private val totalAttachments: Int get() = attachments.size + uris.size
+    private var pendingScreenshot: PendingScreenshot? = null
+    private var pendingScreenshotView: ScreenshotView? = null
+    private val totalAttachments: Int
+        get() = attachments.size + uris.size + if (pendingScreenshot != null) 1 else 0
 
     private val pickMultipleMedia =
         registerForActivityResult(PickMultipleVisualMedia()) { selectedUris ->
@@ -57,14 +58,10 @@ internal class MsrBugReportActivity : ComponentActivity() {
 
         fun launch(
             context: Context,
-            initialScreenshot: ParcelableAttachment? = null,
             maxAttachmentsInBugReport: Int,
             maxDescriptionLengthInBugReport: Int,
         ) {
             val intent = Intent(context, MsrBugReportActivity::class.java)
-            initialScreenshot?.let {
-                intent.putExtra(INITIAL_SCREENSHOT_EXTRA, it)
-            }
             intent.putExtra(MAX_ATTACHMENTS_EXTRA, maxAttachmentsInBugReport)
             intent.putExtra(MAX_DESCRIPTION_LENGTH, maxDescriptionLengthInBugReport)
             context.startActivity(intent)
@@ -89,6 +86,16 @@ internal class MsrBugReportActivity : ComponentActivity() {
         bugReportCollector.setBugReportFlowInactive()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        pendingScreenshot?.setListener(null)
+        if (isFinishing) {
+            pendingScreenshot?.let { bugReportCollector.discardPendingScreenshot(it) }
+        }
+        pendingScreenshot = null
+        pendingScreenshotView = null
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putParcelableArray(PARCEL_SCREENSHOTS, attachments.toTypedArray())
@@ -99,12 +106,11 @@ internal class MsrBugReportActivity : ComponentActivity() {
         bugReportCollector = Measure.getBugReportCollector()
         maxAttachments = intent.getIntExtra(MAX_ATTACHMENTS_EXTRA, 1)
         tvChooseImage.visibility = View.VISIBLE
-        if (savedInstanceState == null) {
-            showInitialScreenshot()
-        } else {
+        if (savedInstanceState != null) {
             restoreState(savedInstanceState)
             restoreViews()
         }
+        showPendingScreenshot()
     }
 
     private fun initViews() {
@@ -177,17 +183,51 @@ internal class MsrBugReportActivity : ComponentActivity() {
         }
     }
 
-    private fun showInitialScreenshot() {
-        val screenshot = getInitialScreenshot() ?: return
-        attachments.add(screenshot)
-        addAttachmentView(screenshot)
+    /**
+     * Shows the screenshot captured for this flow while it is still being encoded. Its file does
+     * not exist yet, so the thumbnail comes from the in memory preview.
+     */
+    private fun showPendingScreenshot() {
+        val screenshot = bugReportCollector.getPendingScreenshot()
+            ?.takeIf { it.isEncoding() } ?: return
+        val preview = screenshot.preview ?: return
+        val view = ScreenshotView(this)
+        view.setImageFromBitmap(preview)
+        view.setRemoveClickListener { removePendingScreenshot(view) }
+        slScreenshotsContainer.addView(view)
+        pendingScreenshot = screenshot
+        pendingScreenshotView = view
+        screenshot.setListener(::onScreenshotEncoded)
+        updateAddImageClickListener()
     }
 
-    private fun getInitialScreenshot(): ParcelableAttachment? = IntentCompat.getParcelableExtra(
-        intent,
-        INITIAL_SCREENSHOT_EXTRA,
-        ParcelableAttachment::class.java,
-    )
+    private fun onScreenshotEncoded(attachment: ParcelableAttachment?) {
+        val view = pendingScreenshotView
+        pendingScreenshot = null
+        pendingScreenshotView = null
+        if (attachment == null) {
+            view?.let { slScreenshotsContainer.removeView(it) }
+            updateAddImageClickListener()
+            return
+        }
+        attachments.add(attachment)
+        view?.setRemoveClickListener {
+            attachments.remove(attachment)
+            slScreenshotsContainer.removeView(view)
+            updateAddImageClickListener()
+        }
+    }
+
+    private fun removePendingScreenshot(view: ScreenshotView) {
+        pendingScreenshot?.let {
+            it.setListener(null)
+            bugReportCollector.discardPendingScreenshot(it)
+        }
+        pendingScreenshot = null
+        pendingScreenshotView = null
+        slScreenshotsContainer.removeView(view)
+        updateAddImageClickListener()
+    }
 
     private fun restoreState(savedInstanceState: Bundle) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/PendingScreenshot.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/PendingScreenshot.kt
@@ -1,0 +1,73 @@
+package sh.measure.android.bugreport
+
+import android.graphics.Bitmap
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+/**
+ * A screenshot shown in the bug report screen while its full size bitmap is still being encoded.
+ */
+internal class PendingScreenshot(preview: Bitmap) {
+    private enum class State { ENCODING, ENCODED, DISCARDED }
+
+    var preview: Bitmap? = preview
+        private set
+
+    @Volatile
+    var encoding: Future<ParcelableAttachment?>? = null
+
+    @Volatile
+    private var encoded: ParcelableAttachment? = null
+
+    private var state = State.ENCODING
+    private var listener: ((ParcelableAttachment?) -> Unit)? = null
+
+    fun isEncoding(): Boolean = state == State.ENCODING
+
+    fun setListener(listener: ((ParcelableAttachment?) -> Unit)?) {
+        this.listener = listener
+    }
+
+    fun finishEncoding(attachment: ParcelableAttachment?) {
+        if (state != State.ENCODING) {
+            return
+        }
+        state = State.ENCODED
+        val listener = this.listener
+        this.listener = null
+        listener?.invoke(attachment)
+    }
+
+    fun discard() {
+        if (state == State.DISCARDED) {
+            return
+        }
+        val wasEncoding = state == State.ENCODING
+        state = State.DISCARDED
+        preview = null
+        val listener = this.listener
+        this.listener = null
+        if (wasEncoding) {
+            listener?.invoke(null)
+        }
+    }
+
+    fun recordEncoded(attachment: ParcelableAttachment?) {
+        encoded = attachment
+    }
+
+    /**
+     * Blocks until the encode finishes. The encode is always queued before the task that tracks
+     * the report, so on the single threaded IO executor it has already run by the time this is
+     * called.
+     */
+    fun awaitEncoded(): ParcelableAttachment? = try {
+        encoding?.get(AWAIT_ENCODE_TIMEOUT_MS, TimeUnit.MILLISECONDS) ?: encoded
+    } catch (_: Exception) {
+        encoded
+    }
+
+    private companion object {
+        const val AWAIT_ENCODE_TIMEOUT_MS = 2_000L
+    }
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/ScreenshotView.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/bugreport/ScreenshotView.kt
@@ -1,6 +1,7 @@
 package sh.measure.android.bugreport
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import android.util.AttributeSet
 import android.view.View
@@ -30,6 +31,12 @@ internal class ScreenshotView @JvmOverloads constructor(
         closeButton.setOnClickListener {
             removeListener?.invoke()
         }
+    }
+
+    fun setImageFromBitmap(bitmap: Bitmap) {
+        setInitialStateBeforeAnimation()
+        imageView.setImageBitmap(bitmap)
+        animateAppearance()
     }
 
     fun setImageFromPath(path: String) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/bugreport/BugReportCollectorImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/bugreport/BugReportCollectorImplTest.kt
@@ -5,11 +5,14 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.net.Uri
+import android.os.Looper
 import androidx.concurrent.futures.ResolvableFuture
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,9 +22,14 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verify
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import sh.measure.android.TestLifecycleActivity
 import sh.measure.android.events.Attachment
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
+import sh.measure.android.executors.MeasureExecutorService
+import sh.measure.android.fakes.DeferredExecutorService
 import sh.measure.android.fakes.FakeConfigProvider
 import sh.measure.android.fakes.FakeIdProvider
 import sh.measure.android.fakes.FakeSessionManager
@@ -46,7 +54,9 @@ class BugReportCollectorImplTest {
     private val fileStorage = FileStorageImpl(application.filesDir.path, logger)
     private val idProvider = FakeIdProvider()
     private val configProvider = FakeConfigProvider()
-    private val resumedActivityProvider = ResumedActivityProviderImpl(application)
+    private val resumedActivityProvider = ResumedActivityProviderImpl(application).apply {
+        register()
+    }
     private val bugReportCollector = BugReportCollectorImpl(
         logger = logger,
         signalProcessor = signalProcessor,
@@ -58,6 +68,136 @@ class BugReportCollectorImplTest {
         idProvider = idProvider,
         resumedActivityProvider = resumedActivityProvider,
     )
+
+    private fun collector(executor: MeasureExecutorService) = BugReportCollectorImpl(
+        logger = logger,
+        signalProcessor = signalProcessor,
+        timeProvider = timeProvider,
+        ioExecutor = executor,
+        configProvider = configProvider,
+        sessionManager = sessionManager,
+        fileStorage = fileStorage,
+        idProvider = idProvider,
+        resumedActivityProvider = resumedActivityProvider,
+    )
+
+    private fun resumeHostActivity() {
+        Robolectric.buildActivity(TestLifecycleActivity::class.java).setup()
+    }
+
+    @Test
+    fun `launches the bug report screen before the screenshot is encoded`() {
+        resumeHostActivity()
+        val executor = DeferredExecutorService()
+        val collector = collector(executor)
+
+        collector.startBugReportFlow()
+
+        val started = shadowOf(application).nextStartedActivity
+        assertEquals(MsrBugReportActivity::class.java.name, started.component?.className)
+        assertEquals(1, executor.pendingTaskCount)
+        assertTrue(collector.getPendingScreenshot()?.isEncoding() == true)
+    }
+
+    @Test
+    fun `does not put the screenshot in the launch intent`() {
+        resumeHostActivity()
+        val collector = collector(DeferredExecutorService())
+
+        collector.startBugReportFlow()
+
+        val extras = shadowOf(application).nextStartedActivity.extras
+        assertEquals(
+            setOf(
+                BugReportCollector.MAX_ATTACHMENTS_EXTRA,
+                BugReportCollector.MAX_DESCRIPTION_LENGTH,
+            ),
+            extras?.keySet(),
+        )
+    }
+
+    @Test
+    fun `notifies the screen once the screenshot is encoded`() {
+        resumeHostActivity()
+        val executor = DeferredExecutorService()
+        val collector = collector(executor)
+        collector.startBugReportFlow()
+        val screenshot = collector.getPendingScreenshot()
+        var encoded: ParcelableAttachment? = null
+        screenshot?.setListener { encoded = it }
+
+        executor.runAll()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertNotNull(encoded)
+        assertTrue(File(encoded!!.path).exists())
+        assertFalse(screenshot?.isEncoding() == true)
+    }
+
+    @Test
+    fun `tracks the screenshot when sent before encoding completes`() {
+        resumeHostActivity()
+        val executor = DeferredExecutorService()
+        val collector = collector(executor)
+        collector.startBugReportFlow()
+
+        collector.track(application, "description", emptyList(), emptyList())
+        executor.runAll()
+
+        val attachmentsCaptor = argumentCaptor<MutableList<Attachment>>()
+        verify(signalProcessor).track(
+            data = eq(BugReportData("description")),
+            timestamp = eq(timeProvider.now()),
+            type = eq(EventType.BUG_REPORT),
+            attributes = eq(emptyMap<String, Any?>().toMutableMap()),
+            userDefinedAttributes = eq(emptyMap()),
+            attachments = attachmentsCaptor.capture(),
+            threadName = any(),
+            sessionId = isNull(),
+            userTriggered = eq(false),
+            isSampled = eq(true),
+        )
+        assertEquals(1, attachmentsCaptor.firstValue.size)
+    }
+
+    @Test
+    fun `does not track a discarded screenshot`() {
+        resumeHostActivity()
+        val executor = DeferredExecutorService()
+        val collector = collector(executor)
+        collector.startBugReportFlow()
+        collector.getPendingScreenshot()?.let { collector.discardPendingScreenshot(it) }
+
+        collector.track(application, "description", emptyList(), emptyList())
+        executor.runAll()
+
+        val attachmentsCaptor = argumentCaptor<MutableList<Attachment>>()
+        verify(signalProcessor).track(
+            data = eq(BugReportData("description")),
+            timestamp = eq(timeProvider.now()),
+            type = eq(EventType.BUG_REPORT),
+            attributes = eq(emptyMap<String, Any?>().toMutableMap()),
+            userDefinedAttributes = eq(emptyMap()),
+            attachments = attachmentsCaptor.capture(),
+            threadName = any(),
+            sessionId = isNull(),
+            userTriggered = eq(false),
+            isSampled = eq(true),
+        )
+        assertEquals(0, attachmentsCaptor.firstValue.size)
+    }
+
+    @Test
+    fun `does not capture a screenshot when takeScreenshot is false`() {
+        resumeHostActivity()
+        val executor = DeferredExecutorService()
+        val collector = collector(executor)
+
+        collector.startBugReportFlow(takeScreenshot = false)
+
+        assertNull(collector.getPendingScreenshot())
+        assertEquals(0, executor.pendingTaskCount)
+    }
 
     @Test
     fun `tracks bug report event`() {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/DeferredExecutorService.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/DeferredExecutorService.kt
@@ -1,0 +1,47 @@
+package sh.measure.android.fakes
+
+import sh.measure.android.executors.MeasureExecutorService
+import java.util.concurrent.Callable
+import java.util.concurrent.Future
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+
+/**
+ * Queues tasks until a test runs them, so a test can assert on what happens while a task is
+ * still pending.
+ */
+internal class DeferredExecutorService : MeasureExecutorService {
+    private val tasks = ArrayDeque<FutureTask<*>>()
+
+    val pendingTaskCount: Int get() = tasks.size
+
+    override fun execute(command: Runnable) {
+        tasks.addLast(FutureTask(command, null))
+    }
+
+    override fun <T> submit(callable: Callable<T>): Future<T> = FutureTask(callable).also {
+        tasks.addLast(it)
+    }
+
+    override fun <T> schedule(callable: Callable<T>, delayMillis: Long): Future<T> = submit(callable)
+
+    override fun scheduleAtFixedRate(
+        runnable: Runnable,
+        initialDelay: Long,
+        delayMillis: Long,
+        delayUnit: TimeUnit,
+    ): Future<*> = FutureTask(runnable, null).also {
+        tasks.addLast(it)
+    }
+
+    override fun shutdown() {
+        tasks.clear()
+    }
+
+    fun runAll() {
+        while (true) {
+            val task = tasks.removeFirstOrNull() ?: return
+            task.run()
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Open the bug report screen as soon as the screenshot is captured, instead of after it is encoded and saved
- Encode on the IO thread
- Show a scaled preview instead of the full size bitmap

## Benchmarks

Ran on Pixel 4a (API 36), measured from the tap's `deliverInputEvent` to the first `draw-VRI[MsrBugReportActivity]`.

| Run | `main` | `now` |
|---|---|---|
| 1 | 492.5ms | 91.8ms |
| 2 | 436.7ms | 108.7ms |
| 3 | 423.8ms | 99.8ms |

<img width="1649" height="421" alt="image" src="https://github.com/user-attachments/assets/eb852c96-6ce3-43d9-be86-6603a304d5cc" />

The transition now only waits on the `PixelCopy` capture, which has to finish before the bug report window covers the screen being reported. Everything else has moved off that path. Around 273ms went into encoding the screenshot to WebP and writing it to disk before `startActivity` was called and another ~18ms into decoding it back in `onCreate` to draw the thumbnail.

References: #4281
Fixes: #4299 