### PR TITLE
fix(android): update config cache state on 304 responses

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
@@ -40,8 +40,8 @@ internal class ConfigLoaderImpl(
             }
 
             val lastFetchTimestamp = prefsStorage.getConfigFetchTimestamp()
-            val cacheControlDuration = prefsStorage.getConfigCacheControl()
-            val shouldRefreshConfig = timeProvider.now() - lastFetchTimestamp > cacheControlDuration
+            val cacheControlMs = prefsStorage.getConfigCacheControlMs()
+            val shouldRefreshConfig = timeProvider.now() - lastFetchTimestamp > cacheControlMs
             val eTag = prefsStorage.getConfigEtag()
 
             if (shouldRefreshConfig) {
@@ -51,7 +51,7 @@ internal class ConfigLoaderImpl(
                         configFile.writeText(response.body)
                         prefsStorage.setConfigFetchTimestamp(timeProvider.now())
                         response.eTag?.let { prefsStorage.setConfigEtag(it) }
-                        prefsStorage.setConfigCacheControl(response.cacheControl)
+                        prefsStorage.setConfigCacheControlMs(response.cacheControlMs)
                         logger.log(
                             LogLevel.Debug,
                             "ConfigLoader: New config loaded from server successfully",

--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigLoader.kt
@@ -66,7 +66,12 @@ internal class ConfigLoaderImpl(
                         )
                     }
 
-                    ConfigResponse.NotModified -> {
+                    is ConfigResponse.NotModified -> {
+                        prefsStorage.setConfigFetchTimestamp(timeProvider.now())
+                        // A response without the header parses to 0, keep the known window.
+                        if (response.cacheControlMs > 0) {
+                            prefsStorage.setConfigCacheControlMs(response.cacheControlMs)
+                        }
                         logger.log(LogLevel.Debug, "ConfigLoader: 304 Not Modified")
                     }
                 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigResponse.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigResponse.kt
@@ -7,7 +7,7 @@ internal sealed class ConfigResponse {
         val cacheControlMs: Long,
     ) : ConfigResponse()
 
-    object NotModified : ConfigResponse()
+    data class NotModified(val cacheControlMs: Long) : ConfigResponse()
 
     data class Error(val exception: Exception? = null) : ConfigResponse()
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigResponse.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/config/ConfigResponse.kt
@@ -4,7 +4,7 @@ internal sealed class ConfigResponse {
     data class Success(
         val body: String,
         val eTag: String?,
-        val cacheControl: Long,
+        val cacheControlMs: Long,
     ) : ConfigResponse()
 
     object NotModified : ConfigResponse()

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
@@ -138,12 +138,13 @@ internal class HttpUrlConnectionClient(private val logger: Logger) : HttpClient 
                 HttpURLConnection.HTTP_OK -> {
                     val body = connection.inputStream.source().buffer().readString(Charsets.UTF_8)
                     val newETag = connection.getHeaderField("ETag")
-                    val cacheControl = parseCacheControlMaxAge(connection.getHeaderField("Cache-Control"))
+                    val cacheControlMs =
+                        parseCacheControlMaxAgeMs(connection.getHeaderField("Cache-Control"))
 
                     ConfigResponse.Success(
                         body = body,
                         eTag = newETag,
-                        cacheControl = cacheControl,
+                        cacheControlMs = cacheControlMs,
                     )
                 }
 
@@ -164,13 +165,14 @@ internal class HttpUrlConnectionClient(private val logger: Logger) : HttpClient 
         }
     }
 
-    private fun parseCacheControlMaxAge(cacheControlHeader: String?): Long {
+    private fun parseCacheControlMaxAgeMs(cacheControlHeader: String?): Long {
         if (cacheControlHeader == null) return 0
 
         return try {
             val maxAgeRegex = "max-age=(\\d+)".toRegex()
             val matchResult = maxAgeRegex.find(cacheControlHeader)
-            matchResult?.groupValues?.get(1)?.toLong() ?: 0
+            val maxAgeSeconds = matchResult?.groupValues?.get(1)?.toLong() ?: 0
+            maxAgeSeconds * 1000
         } catch (e: NumberFormatException) {
             logger.log(LogLevel.Error, "Failed to parse Cache-Control max-age", e)
             0

--- a/android/measure-android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/exporter/HttpUrlConnectionClient.kt
@@ -149,7 +149,11 @@ internal class HttpUrlConnectionClient(private val logger: Logger) : HttpClient 
                 }
 
                 HttpURLConnection.HTTP_NOT_MODIFIED -> {
-                    ConfigResponse.NotModified
+                    ConfigResponse.NotModified(
+                        cacheControlMs = parseCacheControlMaxAgeMs(
+                            connection.getHeaderField("Cache-Control"),
+                        ),
+                    )
                 }
 
                 else -> {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/storage/PrefsStorage.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/storage/PrefsStorage.kt
@@ -11,10 +11,10 @@ internal interface PrefsStorage {
     fun getUserId(): String?
     fun setUserId(userId: String?)
     fun getConfigFetchTimestamp(): Long
-    fun getConfigCacheControl(): Long
+    fun getConfigCacheControlMs(): Long
     fun getConfigEtag(): String?
     fun setConfigFetchTimestamp(timestamp: Long)
-    fun setConfigCacheControl(cacheControl: Long)
+    fun setConfigCacheControlMs(cacheControlMs: Long)
     fun setConfigEtag(etag: String)
 }
 
@@ -50,7 +50,7 @@ internal class PrefsStorageImpl(private val context: Context) : PrefsStorage {
 
     override fun getConfigFetchTimestamp(): Long = sharedPreferences.getLong(CONFIG_FETCH_TIMESTAMP, 0)
 
-    override fun getConfigCacheControl(): Long = sharedPreferences.getLong(CONFIG_CACHE_CONTROL, 0)
+    override fun getConfigCacheControlMs(): Long = sharedPreferences.getLong(CONFIG_CACHE_CONTROL, 0)
 
     override fun getConfigEtag(): String? = sharedPreferences.getString(CONFIG_ETAG, null)
 
@@ -58,8 +58,8 @@ internal class PrefsStorageImpl(private val context: Context) : PrefsStorage {
         sharedPreferences.edit { putLong(CONFIG_FETCH_TIMESTAMP, timestamp) }
     }
 
-    override fun setConfigCacheControl(cacheControl: Long) {
-        sharedPreferences.edit { putLong(CONFIG_CACHE_CONTROL, cacheControl) }
+    override fun setConfigCacheControlMs(cacheControlMs: Long) {
+        sharedPreferences.edit { putLong(CONFIG_CACHE_CONTROL, cacheControlMs) }
     }
 
     override fun setConfigEtag(etag: String) {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/config/ConfigLoaderImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/config/ConfigLoaderImplTest.kt
@@ -154,7 +154,7 @@ internal class ConfigLoaderImplTest {
         setupCacheExpired()
         val etag = "etag-123"
         `when`(prefsStorage.getConfigEtag()).thenReturn(etag)
-        `when`(networkClient.getConfig(etag)).thenReturn(ConfigResponse.NotModified)
+        `when`(networkClient.getConfig(etag)).thenReturn(ConfigResponse.NotModified(cacheControlMs = 600_000L))
 
         // When
         configLoader.loadDynamicConfig { }
@@ -222,14 +222,69 @@ internal class ConfigLoaderImplTest {
         val configFile = createTempConfigFile(originalContent)
         `when`(fileStorage.getConfigFile()).thenReturn(configFile)
         setupCacheExpired()
-        `when`(networkClient.getConfig(any())).thenReturn(ConfigResponse.NotModified)
+        `when`(networkClient.getConfig(any())).thenReturn(ConfigResponse.NotModified(cacheControlMs = 600_000L))
 
         // When
         configLoader.loadDynamicConfig { }
 
         // Then
         assertEquals(originalContent, configFile.readText())
-        verify(prefsStorage, never()).setConfigFetchTimestamp(any())
+        verify(prefsStorage, never()).setConfigEtag(any())
+        configFile.delete()
+    }
+
+    @Test
+    fun `loadDynamicConfig updates fetch timestamp on NotModified response`() {
+        // Given
+        val configFile = createTempConfigFile("{}")
+        `when`(fileStorage.getConfigFile()).thenReturn(configFile)
+        setupCacheExpired()
+        val expectedTimestamp = timeProvider.now()
+        `when`(networkClient.getConfig(any())).thenReturn(
+            ConfigResponse.NotModified(cacheControlMs = 600_000L),
+        )
+
+        // When
+        configLoader.loadDynamicConfig { }
+
+        // Then
+        verify(prefsStorage).setConfigFetchTimestamp(expectedTimestamp)
+        configFile.delete()
+    }
+
+    @Test
+    fun `loadDynamicConfig updates cache control on NotModified response`() {
+        // Given
+        val configFile = createTempConfigFile("{}")
+        `when`(fileStorage.getConfigFile()).thenReturn(configFile)
+        setupCacheExpired()
+        `when`(networkClient.getConfig(any())).thenReturn(
+            ConfigResponse.NotModified(cacheControlMs = 900_000L),
+        )
+
+        // When
+        configLoader.loadDynamicConfig { }
+
+        // Then
+        verify(prefsStorage).setConfigCacheControlMs(900_000L)
+        configFile.delete()
+    }
+
+    @Test
+    fun `loadDynamicConfig keeps cache control when NotModified response has no header`() {
+        // Given
+        val configFile = createTempConfigFile("{}")
+        `when`(fileStorage.getConfigFile()).thenReturn(configFile)
+        setupCacheExpired()
+        `when`(networkClient.getConfig(any())).thenReturn(
+            ConfigResponse.NotModified(cacheControlMs = 0L),
+        )
+
+        // When
+        configLoader.loadDynamicConfig { }
+
+        // Then
+        verify(prefsStorage, never()).setConfigCacheControlMs(any())
         configFile.delete()
     }
 
@@ -249,7 +304,7 @@ internal class ConfigLoaderImplTest {
 
         // Then
         assertEquals(originalContent, configFile.readText())
-        verify(prefsStorage, never()).setConfigFetchTimestamp(any())
+        verify(prefsStorage, never()).setConfigEtag(any())
         configFile.delete()
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/config/ConfigLoaderImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/config/ConfigLoaderImplTest.kt
@@ -128,7 +128,7 @@ internal class ConfigLoaderImplTest {
         val configFile = createTempConfigFile(validConfig)
         `when`(fileStorage.getConfigFile()).thenReturn(configFile)
         `when`(prefsStorage.getConfigFetchTimestamp()).thenReturn(timeProvider.now())
-        `when`(prefsStorage.getConfigCacheControl()).thenReturn(3600L)
+        `when`(prefsStorage.getConfigCacheControlMs()).thenReturn(600_000L)
         // Advance by less than cache duration so cache is NOT expired
         testClock.advance(Duration.ofMillis(2000))
 
@@ -173,12 +173,12 @@ internal class ConfigLoaderImplTest {
         val expectedTimestamp = timeProvider.now()
         val newConfig = """{"http_body_capture_enabled": true}"""
         val newEtag = "new-etag"
-        val newCacheControl = 3600L
+        val newCacheControlMs = 600_000L
         `when`(networkClient.getConfig(any())).thenReturn(
             ConfigResponse.Success(
                 body = newConfig,
                 eTag = newEtag,
-                cacheControl = newCacheControl,
+                cacheControlMs = newCacheControlMs,
             ),
         )
 
@@ -189,7 +189,7 @@ internal class ConfigLoaderImplTest {
         assertEquals(newConfig, configFile.readText())
         verify(prefsStorage).setConfigFetchTimestamp(expectedTimestamp)
         verify(prefsStorage).setConfigEtag(newEtag)
-        verify(prefsStorage).setConfigCacheControl(newCacheControl)
+        verify(prefsStorage).setConfigCacheControlMs(newCacheControlMs)
         configFile.delete()
     }
 
@@ -203,7 +203,7 @@ internal class ConfigLoaderImplTest {
             ConfigResponse.Success(
                 body = "{}",
                 eTag = null,
-                cacheControl = 3600L,
+                cacheControlMs = 600_000L,
             ),
         )
 
@@ -254,12 +254,12 @@ internal class ConfigLoaderImplTest {
     }
 
     private fun setupCacheExpired() {
-        val cacheControlDuration = 3600L
+        val cacheControlMs = 600_000L
         // Set last fetch time to current time
         `when`(prefsStorage.getConfigFetchTimestamp()).thenReturn(timeProvider.now())
-        `when`(prefsStorage.getConfigCacheControl()).thenReturn(cacheControlDuration)
+        `when`(prefsStorage.getConfigCacheControlMs()).thenReturn(cacheControlMs)
         // Advance clock beyond cache duration to make it expired
-        testClock.advance(Duration.ofMillis(cacheControlDuration + 1000))
+        testClock.advance(Duration.ofMillis(cacheControlMs + 1000))
         `when`(prefsStorage.getConfigEtag()).thenReturn("")
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import sh.measure.android.config.ConfigResponse
 import sh.measure.android.fakes.NoopLogger
 
 class HttpUrlConnectionClientTest {
@@ -369,5 +370,31 @@ class HttpUrlConnectionClientTest {
 
         assertTrue(result is HttpResponse.Error.ClientError)
         assertEquals(400, (result as HttpResponse.Error.ClientError).code)
+    }
+
+    @Test
+    fun `test config response converts cache control max age to milliseconds`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200)
+                .setHeader("Cache-Control", "max-age=600")
+                .setHeader("ETag", "etag-123")
+                .setBody("{}"),
+        )
+
+        val result = client.getConfig(mockWebServer.url("/").toString(), null, emptyMap())
+
+        assertEquals(
+            ConfigResponse.Success(body = "{}", eTag = "etag-123", cacheControlMs = 600_000L),
+            result,
+        )
+    }
+
+    @Test
+    fun `test config response defaults cache control to zero when header is missing`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        val result = client.getConfig(mockWebServer.url("/").toString(), null, emptyMap())
+
+        assertEquals(0L, (result as ConfigResponse.Success).cacheControlMs)
     }
 }

--- a/android/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/exporter/HttpUrlConnectionClientTest.kt
@@ -397,4 +397,15 @@ class HttpUrlConnectionClientTest {
 
         assertEquals(0L, (result as ConfigResponse.Success).cacheControlMs)
     }
+
+    @Test
+    fun `test not modified config response carries cache control max age`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(304).setHeader("Cache-Control", "max-age=600"),
+        )
+
+        val result = client.getConfig(mockWebServer.url("/").toString(), "etag-123", emptyMap())
+
+        assertEquals(ConfigResponse.NotModified(cacheControlMs = 600_000L), result)
+    }
 }


### PR DESCRIPTION
# Description

Fixes two issues related to handling of 304 response for config:

- Update the last fetch timestamp on a 304 response.
- Update the cache control on a 304 response. It was being updated only in case of a 200 response earlier.

## Related issue
Fixes #4328 



