### PR TITLE
fix(ios): clamp unsafe numeric narrowing conversions

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/Gestures/GestureCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Gestures/GestureCollector.swift
@@ -79,8 +79,8 @@ final class BaseGestureCollector: GestureCollector {
                 return
             }
 
-            let width = UInt16((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0)
-            let height = UInt16((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0)
+            let width = UInt16(clamping: Int((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0))
+            let height = UInt16(clamping: Int((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0))
 
             let data = ClickData(target: gestureTargetFinderData.target ?? target,
                                  targetId: gestureTargetFinderData.targetId ?? targetId,
@@ -111,8 +111,8 @@ final class BaseGestureCollector: GestureCollector {
                 return
             }
 
-            let width = UInt16((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0)
-            let height = UInt16((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0)
+            let width = UInt16(clamping: Int((gestureTargetFinderData.targetFrame?.width ?? targetFrame?.width) ?? 0))
+            let height = UInt16(clamping: Int((gestureTargetFinderData.targetFrame?.height ?? targetFrame?.height) ?? 0))
 
             let data = LongClickData(target: gestureTargetFinderData.target ?? target,
                                      targetId: gestureTargetFinderData.targetId ?? targetId,

--- a/ios/Sources/MeasureSDK/Swift/Screenshots/WebPEncoder.swift
+++ b/ios/Sources/MeasureSDK/Swift/Screenshots/WebPEncoder.swift
@@ -37,9 +37,9 @@ struct WebPEncoder {
         var output: UnsafeMutablePointer<UInt8>?
         let size = WebPEncodeRGBA(
             pixelData.assumingMemoryBound(to: UInt8.self),
-            Int32(width),
-            Int32(height),
-            Int32(bytesPerRow),
+            Int32(clamping: width),
+            Int32(clamping: height),
+            Int32(clamping: bytesPerRow),
             Float(quality * 100.0),
             &output
         )
@@ -61,7 +61,7 @@ struct WebPEncoder {
         return pixels.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Data? in
             guard let base = buf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return nil }
             var output: UnsafeMutablePointer<UInt8>?
-            let size = WebPEncodeRGBA(base, Int32(width), Int32(height), Int32(stride), clamped, &output)
+            let size = WebPEncodeRGBA(base, Int32(clamping: width), Int32(clamping: height), Int32(clamping: stride), clamped, &output)
             guard size > 0, let outputPtr = output else { return nil }
             defer { WebPFree(outputPtr) }
             return Data(bytes: outputPtr, count: size)

--- a/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SysCtl.swift
@@ -29,7 +29,7 @@ final class BaseSysCtl: SysCtl {
         var numCores = 0
         var size = MemoryLayout<Int>.size
         sysctlbyname("hw.ncpu", &numCores, &size, nil, 0)
-        cpuCores = UInt8(numCores)
+        cpuCores = UInt8(clamping: numCores)
         return cpuCores
     }
 


### PR DESCRIPTION
# Description

Casting Double/Int values to smaller integer types (UInt16, UInt8, Int32) without bounds checking leads to runtime issues. This PR clamps unsafe numeric conversions.

## Related issue
Fixes #4335 