### PR TITLE
fix(backend): serve http_sampling_rate to sdks

### DIFF
--- a/backend/ingest/measure/sdkconfig.go
+++ b/backend/ingest/measure/sdkconfig.go
@@ -61,6 +61,7 @@ type SdkConfig struct {
 	ANRTakeScreenshot         bool                `json:"anr_take_screenshot"`
 	LaunchSamplingRate        float64             `json:"launch_sampling_rate"`
 	GestureClickTakeSnapshot  bool                `json:"gesture_click_take_snapshot"`
+	HTTPSamplingRate          float64             `json:"http_sampling_rate"`
 	HTTPDisableEventForURLs   []string            `json:"http_disable_event_for_urls"`
 	HTTPTrackRequestForURLs   []string            `json:"http_track_request_for_urls"`
 	HTTPTrackResponseForURLs  []string            `json:"http_track_response_for_urls"`
@@ -132,6 +133,7 @@ func createDefaultConfig() SdkConfig {
 		ANRTakeScreenshot:         true,
 		LaunchSamplingRate:        100,
 		GestureClickTakeSnapshot:  true,
+		HTTPSamplingRate:          100,
 		HTTPDisableEventForURLs:   []string{},
 		HTTPTrackRequestForURLs:   []string{},
 		HTTPTrackResponseForURLs:  []string{},
@@ -216,6 +218,7 @@ func getConfigFromDb(ctx context.Context, appID uuid.UUID) (*SdkConfig, error) {
 		Select("anr_take_screenshot").
 		Select("launch_sampling_rate").
 		Select("gesture_click_take_snapshot").
+		Select("http_sampling_rate").
 		Select("http_disable_event_for_urls").
 		Select("http_track_request_for_urls").
 		Select("http_track_response_for_urls").
@@ -247,6 +250,7 @@ func getConfigFromDb(ctx context.Context, appID uuid.UUID) (*SdkConfig, error) {
 		&sdkConfig.ANRTakeScreenshot,
 		&sdkConfig.LaunchSamplingRate,
 		&sdkConfig.GestureClickTakeSnapshot,
+		&sdkConfig.HTTPSamplingRate,
 		&sdkConfig.HTTPDisableEventForURLs,
 		&sdkConfig.HTTPTrackRequestForURLs,
 		&sdkConfig.HTTPTrackResponseForURLs,

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -2411,6 +2411,9 @@ paths:
                   gesture_click_take_snapshot:
                     type: boolean
                     description: Whether to take snapshot with gesture_click event.
+                  http_sampling_rate:
+                    type: number
+                    description: Sampling rate for HTTP events.
                   http_disable_event_for_urls:
                     type: array
                     items:
@@ -2453,6 +2456,7 @@ paths:
                 anr_take_screenshot: true
                 launch_sampling_rate: 1
                 gesture_click_take_snapshot: true
+                http_sampling_rate: 100
                 http_disable_event_for_urls: []
                 http_track_request_for_urls: []
                 http_track_response_for_urls: []


### PR DESCRIPTION
# Description

The `http_sampling_rate` config was added in #3227 but it was never served to the SDK which continued using the defaults. This PR fixes the bug and now correctly serves the config to the SDKs.

## Related issue
Fixes #4338