### PR TITLE
fix(backend): keep sdk config cache in sync with database

### DIFF
--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -24,6 +24,7 @@ import (
 	"backend/libs/metrics"
 	"backend/libs/network"
 	"backend/libs/opsys"
+	"backend/libs/sdkconfig"
 	"backend/libs/timeline"
 	"backend/libs/udattr"
 
@@ -1526,7 +1527,7 @@ func (h Handlers) CreateApp(c *gin.Context) {
 	userUUID, _ := uuid.Parse(userId)
 	appUUID, _ := uuid.Parse(app.ID.String())
 
-	err = measure.CreateConfig(c.Request.Context(), tx, teamId, appUUID, &userUUID)
+	err = sdkconfig.CreateConfig(c.Request.Context(), tx, teamId, appUUID, &userUUID)
 	if err != nil {
 		msg := "failed to create default config for app"
 		fmt.Println(msg, err)

--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -19,8 +19,7 @@ import (
 	"github.com/leporo/sqlf"
 )
 
-// configColumns is the RETURNING list for a config update.
-// Order matches the scan in PatchConfigForApp.
+// configColumns must stay ordered to match the scan in PatchConfigForApp.
 const configColumns = `max_events_in_batch, crash_timeline_duration, anr_timeline_duration,
 	bug_report_timeline_duration, trace_sampling_rate, journey_sampling_rate,
 	screenshot_mask_level, log_autocollect_enabled, log_min_severity,
@@ -30,6 +29,7 @@ const configColumns = `max_events_in_batch, crash_timeline_duration, anr_timelin
 	http_track_request_for_urls, http_track_response_for_urls, http_blocked_headers,
 	profile_sampling_rate, updated_at, updated_by`
 
+// PatchConfigForApp applies a patch to an app's SDK config, updating Postgres & the cache together.
 func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userID string) error {
 	var patch sdkconfig.ConfigPatch
 	if err := c.ShouldBindJSON(&patch); err != nil {
@@ -182,16 +182,13 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// write-through inside the transaction: a cache write failure
-	// rolls the Postgres update back too
+	// inside the txn, a cache failure must roll the row back
 	if err := sdkconfig.SetCache(ctx, deps.VK, appID, jsonConfig); err != nil {
 		return fmt.Errorf("failed to write config cache: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		// cache write already landed, drop it or the cache keeps an
-		// uncommitted config forever. ctx may be why the commit failed,
-		// so cleanup must not inherit its cancellation
+		// ctx may be why the commit failed, so don't inherit its cancellation
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := sdkconfig.InvalidateCache(cleanupCtx, deps.VK, appID); err != nil {
@@ -203,13 +200,10 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 	return nil
 }
 
-// GetConfigForSdk proxies to the ingest service on non-Cloud so SDKs
-// hitting the API endpoint keep working. On Cloud it returns 410, since
-// the cache/DB lookup lives only in the ingest service now.
+// GetConfigForSdk proxies to the ingest service, or returns 410 on Cloud.
 func (h Handlers) GetConfigForSdk(c *gin.Context) {
 	deps := h.Deps
-	// temporary compatibility shim, remove once SDKs migrate to the
-	// ingest endpoint directly
+	// temporary, remove once SDKs move to the ingest endpoint
 	if !deps.Config.IsCloud() {
 		ingestOrigin := "http://ingest:8085"
 		target, err := url.Parse(ingestOrigin)
@@ -227,8 +221,7 @@ func (h Handlers) GetConfigForSdk(c *gin.Context) {
 	c.Status(http.StatusGone)
 }
 
-// GetConfigForDashboard retrieves the SDK config for dashboard use.
-// Always reads from Postgres, never the cache.
+// GetConfigForDashboard returns the SDK config for the dashboard, always from Postgres.
 func GetConfigForDashboard(c *gin.Context, deps *server.Deps, appID uuid.UUID) {
 	sdkConfig, err := sdkconfig.GetConfigFromDb(c.Request.Context(), deps.PgPool, appID)
 	if err != nil {

--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -13,8 +15,20 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/leporo/sqlf"
 )
+
+// configColumns is the RETURNING list for a config update.
+// Order matches the scan in PatchConfigForApp.
+const configColumns = `max_events_in_batch, crash_timeline_duration, anr_timeline_duration,
+	bug_report_timeline_duration, trace_sampling_rate, journey_sampling_rate,
+	screenshot_mask_level, log_autocollect_enabled, log_min_severity,
+	log_ignore_patterns, cpu_usage_interval, memory_usage_interval,
+	crash_take_screenshot, anr_take_screenshot, launch_sampling_rate,
+	gesture_click_take_snapshot, http_sampling_rate, http_disable_event_for_urls,
+	http_track_request_for_urls, http_track_response_for_urls, http_blocked_headers,
+	profile_sampling_rate, updated_at, updated_by`
 
 func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userID string) error {
 	var patch sdkconfig.ConfigPatch
@@ -117,37 +131,85 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 	stmt.Set("updated_by", &userIdUUID)
 	stmt.Where("app_id = ?", appID)
 
+	stmt.Returning(configColumns)
+
 	defer stmt.Close()
 
-	result, err := deps.PgPool.Exec(c.Request.Context(), stmt.String(), stmt.Args()...)
+	ctx := c.Request.Context()
+
+	tx, err := deps.PgPool.Begin(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	defer tx.Rollback(ctx)
+
+	var config sdkconfig.SdkConfig
+	if err := tx.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(
+		&config.MaxEventsInBatch,
+		&config.CrashTimelineDuration,
+		&config.ANRTimelineDuration,
+		&config.BugReportTimelineDuration,
+		&config.TraceSamplingRate,
+		&config.JourneySamplingRate,
+		&config.ScreenshotMaskLevel,
+		&config.LogAutocollectEnabled,
+		&config.LogMinSeverity,
+		&config.LogIgnorePatterns,
+		&config.CPUUsageInterval,
+		&config.MemoryUsageInterval,
+		&config.CrashTakeScreenshot,
+		&config.ANRTakeScreenshot,
+		&config.LaunchSamplingRate,
+		&config.GestureClickTakeSnapshot,
+		&config.HTTPSamplingRate,
+		&config.HTTPDisableEventForURLs,
+		&config.HTTPTrackRequestForURLs,
+		&config.HTTPTrackResponseForURLs,
+		&config.HTTPBlockedHeaders,
+		&config.ProfileSamplingRate,
+		&config.UpdatedAt,
+		&config.UpdatedBy,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("config not found for app_id: %s", appID)
+		}
 		return fmt.Errorf("failed to exec update: %w", err)
 	}
 
-	if result.RowsAffected() == 0 {
-		return fmt.Errorf("config not found for app_id: %s", appID)
+	jsonConfig, err := json.Marshal(&config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	sdkconfig.InvalidateCache(c.Request.Context(), deps.VK, appID)
+	// write-through inside the transaction: a cache write failure
+	// rolls the Postgres update back too
+	if err := sdkconfig.SetCache(ctx, deps.VK, appID, jsonConfig); err != nil {
+		return fmt.Errorf("failed to write config cache: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		// cache write already landed, drop it or the cache keeps an
+		// uncommitted config forever. ctx may be why the commit failed,
+		// so cleanup must not inherit its cancellation
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := sdkconfig.InvalidateCache(cleanupCtx, deps.VK, appID); err != nil {
+			fmt.Println("failed to invalidate config cache after commit failure, app_id:", appID, err)
+		}
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
 
 	return nil
 }
 
-// GetConfigForSdk retrieves the SDK
-// config for the app.
-// It uses the redis cache and falls back
-// to the database if needed.
+// GetConfigForSdk proxies to the ingest service on non-Cloud so SDKs
+// hitting the API endpoint keep working. On Cloud it returns 410, since
+// the cache/DB lookup lives only in the ingest service now.
 func (h Handlers) GetConfigForSdk(c *gin.Context) {
 	deps := h.Deps
-	// Proxy to ingest service
-	//
-	// Proxy to ingest service for non-Cloud
-	// environments so that SDKS using API endpoint
-	// continue to work. This is temporary & will be
-	// eventually removed.
-	//
-	// SDK consumers are encouraged to migrate to the
-	// ingest endpoint.
+	// temporary compatibility shim, remove once SDKs migrate to the
+	// ingest endpoint directly
 	if !deps.Config.IsCloud() {
 		ingestOrigin := "http://ingest:8085"
 		target, err := url.Parse(ingestOrigin)
@@ -165,9 +227,8 @@ func (h Handlers) GetConfigForSdk(c *gin.Context) {
 	c.Status(http.StatusGone)
 }
 
-// GetConfigForDashboard retrieves the SDK
-// config for dashboard use. It always
-// fetches the config from database.
+// GetConfigForDashboard retrieves the SDK config for dashboard use.
+// Always reads from Postgres, never the cache.
 func GetConfigForDashboard(c *gin.Context, deps *server.Deps, appID uuid.UUID) {
 	sdkConfig, err := sdkconfig.GetConfigFromDb(c.Request.Context(), deps.PgPool, appID)
 	if err != nil {

--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"backend/api/server"
-	"backend/libs/measure"
+	"backend/libs/sdkconfig"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -17,7 +17,7 @@ import (
 )
 
 func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userID string) error {
-	var patch measure.ConfigPatch
+	var patch sdkconfig.ConfigPatch
 	if err := c.ShouldBindJSON(&patch); err != nil {
 		return fmt.Errorf("failed to bind JSON: %w", err)
 	}
@@ -128,7 +128,7 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 		return fmt.Errorf("config not found for app_id: %s", appID)
 	}
 
-	measure.InvalidateCache(c.Request.Context(), deps.VK, appID)
+	sdkconfig.InvalidateCache(c.Request.Context(), deps.VK, appID)
 
 	return nil
 }
@@ -169,7 +169,7 @@ func (h Handlers) GetConfigForSdk(c *gin.Context) {
 // config for dashboard use. It always
 // fetches the config from database.
 func GetConfigForDashboard(c *gin.Context, deps *server.Deps, appID uuid.UUID) {
-	sdkConfig, err := measure.GetConfigFromDb(c.Request.Context(), deps.PgPool, appID)
+	sdkConfig, err := sdkconfig.GetConfigFromDb(c.Request.Context(), deps.PgPool, appID)
 	if err != nil {
 		msg := `error fetching SDK config`
 		fmt.Println(msg, err)

--- a/backend/api/handlers/sdkconfig_test.go
+++ b/backend/api/handlers/sdkconfig_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package handlers
+
+import (
+	"backend/api/server"
+	"backend/libs/sdkconfig"
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// seedSdkConfig creates a team, app & its default SDK config row,
+// returning the app id & the user id to patch as.
+func seedSdkConfig(ctx context.Context, t *testing.T) (appID uuid.UUID, userID string) {
+	t.Helper()
+
+	userID = uuid.NewString()
+	teamID := uuid.New()
+	seedUser(ctx, t, userID, "sdkconfig@test.com")
+	seedTeam(ctx, t, teamID, testTeamName)
+
+	appID = uuid.New()
+	seedApp(ctx, t, appID, teamID, 30)
+
+	tx, err := th.PgPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	uid := uuid.MustParse(userID)
+	if err := sdkconfig.CreateConfig(ctx, tx, teamID, appID, &uid); err != nil {
+		t.Fatalf("create sdk config: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit sdk config: %v", err)
+	}
+
+	return appID, userID
+}
+
+func patchMaxEvents(t *testing.T, deps *server.Deps, appID uuid.UUID, userID string, value int) error {
+	t.Helper()
+
+	body := strings.NewReader(`{"max_events_in_batch":` + strconv.Itoa(value) + `}`)
+	c, _ := newTestGinContext("PATCH", "/apps/"+appID.String()+"/config", body)
+	return PatchConfigForApp(c, deps, appID, userID)
+}
+
+func maxEventsInDb(ctx context.Context, t *testing.T, appID uuid.UUID) int {
+	t.Helper()
+
+	var n int
+	if err := th.PgPool.QueryRow(ctx,
+		`SELECT max_events_in_batch FROM sdk_config WHERE app_id = $1`, appID).Scan(&n); err != nil {
+		t.Fatalf("read max_events_in_batch: %v", err)
+	}
+	return n
+}
+
+func cachedMaxEvents(ctx context.Context, t *testing.T, appID uuid.UUID) int {
+	t.Helper()
+
+	data, err := sdkconfig.GetCache(ctx, th.VK, appID)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if data == "" {
+		t.Fatal("cache empty, want a value")
+	}
+
+	var config sdkconfig.SdkConfig
+	if err := json.Unmarshal([]byte(data), &config); err != nil {
+		t.Fatalf("unmarshal cached config: %v", err)
+	}
+	return config.MaxEventsInBatch
+}
+
+// TestPatchConfigForApp_SlowReaderCannotOverwrite pins both branches of
+// the reader repopulate: it must write when the key is absent, & it must
+// refuse once a patch has written a fresh config, so a reader that read
+// Postgres before the patch cannot pin the cache to the stale config.
+func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	appID, userID := seedSdkConfig(ctx, t)
+	staleJSON := []byte(`{"max_events_in_batch":1111}`)
+
+	// reader repopulating after a genuine miss
+	if err := sdkconfig.SetCacheIfAbsent(ctx, th.VK, appID, staleJSON); err != nil {
+		t.Fatalf("repopulate cache: %v", err)
+	}
+
+	if got := cachedMaxEvents(ctx, t, appID); got != 1111 {
+		t.Fatalf("cached max_events_in_batch = %d, want 1111, absent key was not populated", got)
+	}
+
+	if err := patchMaxEvents(t, deps, appID, userID, 4242); err != nil {
+		t.Fatalf("patch config: %v", err)
+	}
+
+	// slow reader arriving late with the pre-update config
+	if err := sdkconfig.SetCacheIfAbsent(ctx, th.VK, appID, staleJSON); err != nil {
+		t.Fatalf("repopulate cache: %v", err)
+	}
+
+	if got := cachedMaxEvents(ctx, t, appID); got != 4242 {
+		t.Errorf("cached max_events_in_batch = %d, want 4242", got)
+	}
+}
+
+// TestPatchConfigForApp_CacheFailureRollsBack proves the cache write is
+// part of the transaction, a cache failure must leave Postgres untouched.
+func TestPatchConfigForApp_CacheFailureRollsBack(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	appID, userID := seedSdkConfig(ctx, t)
+	before := maxEventsInDb(ctx, t, appID)
+
+	noCache := *deps
+	noCache.VK = nil
+
+	if err := patchMaxEvents(t, &noCache, appID, userID, 4242); err == nil {
+		t.Fatal("patch config succeeded, want cache write error")
+	}
+
+	if got := maxEventsInDb(ctx, t, appID); got != before {
+		t.Errorf("max_events_in_batch = %d, want %d, update was not rolled back", got, before)
+	}
+}
+
+// TestGetCache_ErrorIsNotMiss proves a broken cache surfaces an error
+// while a genuinely absent key does not.
+func TestGetCache_ErrorIsNotMiss(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	appID := uuid.New()
+
+	data, err := sdkconfig.GetCache(ctx, th.VK, appID)
+	if err != nil || data != "" {
+		t.Errorf("missing key: got (%q, %v), want (\"\", nil)", data, err)
+	}
+
+	deadCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	if _, err := sdkconfig.GetCache(deadCtx, th.VK, appID); err == nil {
+		t.Error("unusable client returned nil error, want an error")
+	}
+}

--- a/backend/api/handlers/sdkconfig_test.go
+++ b/backend/api/handlers/sdkconfig_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// seedSdkConfig creates a team, app & its default SDK config row,
-// returning the app id & the user id to patch as.
 func seedSdkConfig(ctx context.Context, t *testing.T) (appID uuid.UUID, userID string) {
 	t.Helper()
 
@@ -81,10 +79,6 @@ func cachedMaxEvents(ctx context.Context, t *testing.T, appID uuid.UUID) int {
 	return config.MaxEventsInBatch
 }
 
-// TestPatchConfigForApp_SlowReaderCannotOverwrite pins both branches of
-// the reader repopulate: it must write when the key is absent, & it must
-// refuse once a patch has written a fresh config, so a reader that read
-// Postgres before the patch cannot pin the cache to the stale config.
 func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
@@ -92,7 +86,6 @@ func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
 	appID, userID := seedSdkConfig(ctx, t)
 	staleJSON := []byte(`{"max_events_in_batch":1111}`)
 
-	// reader repopulating after a genuine miss
 	if err := sdkconfig.SetCacheIfAbsent(ctx, th.VK, appID, staleJSON); err != nil {
 		t.Fatalf("repopulate cache: %v", err)
 	}
@@ -105,7 +98,6 @@ func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
 		t.Fatalf("patch config: %v", err)
 	}
 
-	// slow reader arriving late with the pre-update config
 	if err := sdkconfig.SetCacheIfAbsent(ctx, th.VK, appID, staleJSON); err != nil {
 		t.Fatalf("repopulate cache: %v", err)
 	}
@@ -115,8 +107,6 @@ func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
 	}
 }
 
-// TestPatchConfigForApp_CacheFailureRollsBack proves the cache write is
-// part of the transaction, a cache failure must leave Postgres untouched.
 func TestPatchConfigForApp_CacheFailureRollsBack(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
@@ -136,8 +126,6 @@ func TestPatchConfigForApp_CacheFailureRollsBack(t *testing.T) {
 	}
 }
 
-// TestGetCache_ErrorIsNotMiss proves a broken cache surfaces an error
-// while a genuinely absent key does not.
 func TestGetCache_ErrorIsNotMiss(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)

--- a/backend/ingest/measure/sdkconfig.go
+++ b/backend/ingest/measure/sdkconfig.go
@@ -16,12 +16,13 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// Cache-Control header sent with every config response.
 const (
 	cacheControlHeader = "Cache-Control"
 	cacheControlValue  = "max-age=600"
 )
 
-// OTel metric constants
+// OTel metric name & attribute values.
 const (
 	otelMeterName               = "measure/sdk_config"
 	otelCacheRequestsMetricName = "sdkconfig.cache.requests"
@@ -32,13 +33,15 @@ const (
 	otelCacheErrorAttrValue     = "error"
 )
 
-// cacheMetrics encapsulates SDK config cache metrics
+// cacheMetrics holds the SDK config cache counters.
 type cacheMetrics struct {
 	requests metric.Int64Counter
 }
 
+// sdkConfigCache is the process wide cache metrics recorder.
 var sdkConfigCache *cacheMetrics
 
+// init builds the SDK config cache metrics counter.
 func init() {
 	meter := otel.Meter(otelMeterName)
 	counter, err := meter.Int64Counter(
@@ -51,40 +54,35 @@ func init() {
 	sdkConfigCache = &cacheMetrics{requests: counter}
 }
 
-// RecordHitETag records a cache hit
-// where client's ETag matched
+// RecordHitETag records a cache hit where the client's ETag matched.
 func (m *cacheMetrics) RecordHitETag(ctx context.Context) {
 	m.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String(otelCacheResultAttrKey, otelCacheHitETagAttrValue),
 	))
 }
 
-// RecordHitData records a cache hit
-// where data was served from cache
+// RecordHitData records a cache hit served from cached data.
 func (m *cacheMetrics) RecordHitData(ctx context.Context) {
 	m.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String(otelCacheResultAttrKey, otelCacheHitDataAttrValue),
 	))
 }
 
-// RecordMiss records a cache miss
+// RecordMiss records a cache miss.
 func (m *cacheMetrics) RecordMiss(ctx context.Context) {
 	m.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String(otelCacheResultAttrKey, otelCacheMissAttrValue),
 	))
 }
 
-// RecordError records a cache request that
-// could not consult the cache at all
+// RecordError records a request that could not consult the cache.
 func (m *cacheMetrics) RecordError(ctx context.Context) {
 	m.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String(otelCacheResultAttrKey, otelCacheErrorAttrValue),
 	))
 }
 
-// serveConfigFromDb fetches the SDK config from PostgreSQL, populates
-// the Valkey cache if vk is available (only if the key is absent, so a
-// slow reader can't overwrite a fresher config), & writes the JSON response.
+// serveConfigFromDb serves an app's config from Postgres & repopulates the cache.
 func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk valkey.Client) {
 	sdkConfig, err := sdkconfig.GetConfigFromDb(ctx, server.Server.PgPool, appId)
 	if err != nil {
@@ -113,10 +111,7 @@ func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk 
 	c.Data(http.StatusOK, "application/json", jsonConfig)
 }
 
-// GetConfigForSdk retrieves the SDK config for the app.
-// It serves from the Valkey cache when available, falling
-// back to PostgreSQL on cache miss or when Valkey is
-// unavailable.
+// GetConfigForSdk serves the SDK config, from the Valkey cache when warm, else Postgres.
 func GetConfigForSdk(c *gin.Context) {
 	appId, err := uuid.Parse(c.GetString("appId"))
 	if err != nil {

--- a/backend/ingest/measure/sdkconfig.go
+++ b/backend/ingest/measure/sdkconfig.go
@@ -2,17 +2,14 @@ package measure
 
 import (
 	"backend/ingest/server"
+	"backend/libs/sdkconfig"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/leporo/sqlf"
 	"github.com/valkey-io/valkey-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,9 +17,8 @@ import (
 )
 
 const (
-	configCacheKeyPrefix = "sdk_config:"
-	cacheControlHeader   = "Cache-Control"
-	cacheControlValue    = "max-age=600"
+	cacheControlHeader = "Cache-Control"
+	cacheControlValue  = "max-age=600"
 )
 
 // OTel metric constants
@@ -34,41 +30,6 @@ const (
 	otelCacheHitDataAttrValue   = "hit_data"
 	otelCacheMissAttrValue      = "miss"
 )
-
-const (
-	ScreenshotMaskLevelAllTextAndMedia        ScreenshotMaskLevel = "all_text_and_media"
-	ScreenshotMaskLevelAllText                ScreenshotMaskLevel = "all_text"
-	ScreenshotMaskLevelAllTextExceptClickable ScreenshotMaskLevel = "all_text_except_clickable"
-	ScreenshotMaskLevelSensitiveFieldsOnly    ScreenshotMaskLevel = "sensitive_fields_only"
-)
-
-type ScreenshotMaskLevel string
-
-type SdkConfig struct {
-	MaxEventsInBatch          int                 `json:"max_events_in_batch"`
-	CrashTimelineDuration     int                 `json:"crash_timeline_duration"`
-	ANRTimelineDuration       int                 `json:"anr_timeline_duration"`
-	BugReportTimelineDuration int                 `json:"bug_report_timeline_duration"`
-	TraceSamplingRate         float64             `json:"trace_sampling_rate"`
-	JourneySamplingRate       float64             `json:"journey_sampling_rate"`
-	ScreenshotMaskLevel       ScreenshotMaskLevel `json:"screenshot_mask_level"`
-	LogAutocollectEnabled     bool                `json:"log_autocollect_enabled"`
-	LogMinSeverity            int                 `json:"log_min_severity"`
-	LogIgnorePatterns         []string            `json:"log_ignore_patterns"`
-	CPUUsageInterval          int                 `json:"cpu_usage_interval"`
-	MemoryUsageInterval       int                 `json:"memory_usage_interval"`
-	CrashTakeScreenshot       bool                `json:"crash_take_screenshot"`
-	ANRTakeScreenshot         bool                `json:"anr_take_screenshot"`
-	LaunchSamplingRate        float64             `json:"launch_sampling_rate"`
-	GestureClickTakeSnapshot  bool                `json:"gesture_click_take_snapshot"`
-	HTTPDisableEventForURLs   []string            `json:"http_disable_event_for_urls"`
-	HTTPTrackRequestForURLs   []string            `json:"http_track_request_for_urls"`
-	HTTPTrackResponseForURLs  []string            `json:"http_track_response_for_urls"`
-	HTTPBlockedHeaders        []string            `json:"http_blocked_headers"`
-	ProfileSamplingRate       float64             `json:"profile_sampling_rate"`
-	UpdatedAt                 *time.Time          `json:"-"`
-	UpdatedBy                 *uuid.UUID          `json:"-"`
-}
 
 // cacheMetrics encapsulates SDK config cache metrics
 type cacheMetrics struct {
@@ -112,176 +73,11 @@ func (m *cacheMetrics) RecordMiss(ctx context.Context) {
 	))
 }
 
-// createDefaultConfig returns an SdkConfig populated
-// with sensible defaults for new apps.
-func createDefaultConfig() SdkConfig {
-	return SdkConfig{
-		MaxEventsInBatch:          10000,
-		CrashTimelineDuration:     300,
-		ANRTimelineDuration:       300,
-		BugReportTimelineDuration: 300,
-		TraceSamplingRate:         100,
-		JourneySamplingRate:       100,
-		ScreenshotMaskLevel:       ScreenshotMaskLevelAllTextAndMedia,
-		LogAutocollectEnabled:     false,
-		LogMinSeverity:            16,
-		LogIgnorePatterns:         []string{},
-		CPUUsageInterval:          5,
-		MemoryUsageInterval:       5,
-		CrashTakeScreenshot:       true,
-		ANRTakeScreenshot:         true,
-		LaunchSamplingRate:        100,
-		GestureClickTakeSnapshot:  true,
-		HTTPDisableEventForURLs:   []string{},
-		HTTPTrackRequestForURLs:   []string{},
-		HTTPTrackResponseForURLs:  []string{},
-		HTTPBlockedHeaders:        []string{},
-		ProfileSamplingRate:       100,
-	}
-}
-
-func configCacheKey(appID uuid.UUID) string {
-	return fmt.Sprintf("%s{%s}", configCacheKeyPrefix, appID.String())
-}
-
-func computeETag(data []byte) string {
-	h := fnv.New64a()
-	_, _ = h.Write(data)
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// getConfigETag fetches the cached ETag for an app's
-// SDK config from Valkey.
-func getConfigETag(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
-	key := configCacheKey(appID)
-	cmd := vk.B().Hget().Key(key).Field("etag").Build()
-	result := vk.Do(ctx, cmd)
-
-	str, err := result.ToString()
-	if err != nil {
-		return "", nil
-	}
-	return str, nil
-}
-
-// getConfigData fetches the cached JSON SDK config
-// for an app from Valkey.
-func getConfigData(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
-	key := configCacheKey(appID)
-	cmd := vk.B().Hget().Key(key).Field("data").Build()
-	result := vk.Do(ctx, cmd)
-
-	str, err := result.ToString()
-	if err != nil {
-		return "", nil
-	}
-	return str, nil
-}
-
-// setCacheWithETag stores the JSON SDK config and its
-// computed ETag in Valkey as a hash.
-func setCacheWithETag(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) (string, error) {
-	key := configCacheKey(appID)
-	etag := computeETag(jsonConfig)
-
-	cmd := vk.B().Hset().Key(key).FieldValue().
-		FieldValue("etag", etag).
-		FieldValue("data", string(jsonConfig)).
-		Build()
-
-	if err := vk.Do(ctx, cmd).Error(); err != nil {
-		return "", fmt.Errorf("failed to store config hash: %w", err)
-	}
-
-	return etag, nil
-}
-
-// getConfigFromDb fetches the SDK config for an app
-// directly from PostgreSQL.
-func getConfigFromDb(ctx context.Context, appID uuid.UUID) (*SdkConfig, error) {
-	q := sqlf.PostgreSQL.
-		Select("max_events_in_batch").
-		Select("crash_timeline_duration").
-		Select("anr_timeline_duration").
-		Select("bug_report_timeline_duration").
-		Select("trace_sampling_rate").
-		Select("journey_sampling_rate").
-		Select("screenshot_mask_level").
-		Select("log_autocollect_enabled").
-		Select("log_min_severity").
-		Select("log_ignore_patterns").
-		Select("cpu_usage_interval").
-		Select("memory_usage_interval").
-		Select("crash_take_screenshot").
-		Select("anr_take_screenshot").
-		Select("launch_sampling_rate").
-		Select("gesture_click_take_snapshot").
-		Select("http_disable_event_for_urls").
-		Select("http_track_request_for_urls").
-		Select("http_track_response_for_urls").
-		Select("http_blocked_headers").
-		Select("profile_sampling_rate").
-		Select("updated_at").
-		Select("updated_by").
-		From("measure.sdk_config").
-		Where("app_id = ?", appID)
-
-	defer q.Close()
-
-	var sdkConfig SdkConfig
-
-	err := server.Server.PgPool.QueryRow(ctx, q.String(), q.Args()...).Scan(
-		&sdkConfig.MaxEventsInBatch,
-		&sdkConfig.CrashTimelineDuration,
-		&sdkConfig.ANRTimelineDuration,
-		&sdkConfig.BugReportTimelineDuration,
-		&sdkConfig.TraceSamplingRate,
-		&sdkConfig.JourneySamplingRate,
-		&sdkConfig.ScreenshotMaskLevel,
-		&sdkConfig.LogAutocollectEnabled,
-		&sdkConfig.LogMinSeverity,
-		&sdkConfig.LogIgnorePatterns,
-		&sdkConfig.CPUUsageInterval,
-		&sdkConfig.MemoryUsageInterval,
-		&sdkConfig.CrashTakeScreenshot,
-		&sdkConfig.ANRTakeScreenshot,
-		&sdkConfig.LaunchSamplingRate,
-		&sdkConfig.GestureClickTakeSnapshot,
-		&sdkConfig.HTTPDisableEventForURLs,
-		&sdkConfig.HTTPTrackRequestForURLs,
-		&sdkConfig.HTTPTrackResponseForURLs,
-		&sdkConfig.HTTPBlockedHeaders,
-		&sdkConfig.ProfileSamplingRate,
-		&sdkConfig.UpdatedAt,
-		&sdkConfig.UpdatedBy,
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get config: %w", err)
-	}
-
-	return &sdkConfig, nil
-}
-
-// invalidateCache deletes the cached SDK config for
-// an app from Valkey. No-ops if vk is nil.
-func invalidateCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) error {
-	if vk == nil {
-		return nil
-	}
-
-	cacheKey := configCacheKey(appID)
-	cmd := vk.B().Del().Key(cacheKey).Build()
-	result := vk.Do(ctx, cmd)
-
-	return result.Error()
-}
-
 // serveConfigFromDb fetches the SDK config from PostgreSQL,
-// populates the Valkey cache if vk is available, and writes
+// populates the Valkey cache if vk is available, & writes
 // the JSON response.
 func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk valkey.Client) {
-	sdkConfig, err := getConfigFromDb(ctx, appId)
+	sdkConfig, err := sdkconfig.GetConfigFromDb(ctx, server.Server.PgPool, appId)
 	if err != nil {
 		msg := `error fetching SDK config`
 		fmt.Println(msg, err)
@@ -297,7 +93,7 @@ func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk 
 
 	var etag string
 	if vk != nil {
-		etag, err = setCacheWithETag(ctx, vk, appId, jsonConfig)
+		etag, err = sdkconfig.SetCacheWithETag(ctx, vk, appId, jsonConfig)
 		if err != nil {
 			fmt.Println("error setting cache with ETag:", err)
 		}
@@ -340,7 +136,7 @@ func GetConfigForSdk(c *gin.Context) {
 		return
 	}
 
-	cachedETag, err := getConfigETag(ctx, vk, appId)
+	cachedETag, err := sdkconfig.GetConfigETag(ctx, vk, appId)
 	if err == nil && cachedETag != "" {
 		if cachedETag == clientETag {
 			fmt.Println("sdk config cache hit (etag match)")
@@ -351,7 +147,7 @@ func GetConfigForSdk(c *gin.Context) {
 			return
 		}
 
-		data, err := getConfigData(ctx, vk, appId)
+		data, err := sdkconfig.GetConfigData(ctx, vk, appId)
 		if err == nil && data != "" {
 			fmt.Println("sdk config cache hit")
 			sdkConfigCache.RecordHitData(ctx)

--- a/backend/ingest/measure/sdkconfig.go
+++ b/backend/ingest/measure/sdkconfig.go
@@ -29,6 +29,7 @@ const (
 	otelCacheHitETagAttrValue   = "hit_etag"
 	otelCacheHitDataAttrValue   = "hit_data"
 	otelCacheMissAttrValue      = "miss"
+	otelCacheErrorAttrValue     = "error"
 )
 
 // cacheMetrics encapsulates SDK config cache metrics
@@ -73,9 +74,17 @@ func (m *cacheMetrics) RecordMiss(ctx context.Context) {
 	))
 }
 
-// serveConfigFromDb fetches the SDK config from PostgreSQL,
-// populates the Valkey cache if vk is available, & writes
-// the JSON response.
+// RecordError records a cache request that
+// could not consult the cache at all
+func (m *cacheMetrics) RecordError(ctx context.Context) {
+	m.requests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(otelCacheResultAttrKey, otelCacheErrorAttrValue),
+	))
+}
+
+// serveConfigFromDb fetches the SDK config from PostgreSQL, populates
+// the Valkey cache if vk is available (only if the key is absent, so a
+// slow reader can't overwrite a fresher config), & writes the JSON response.
 func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk valkey.Client) {
 	sdkConfig, err := sdkconfig.GetConfigFromDb(ctx, server.Server.PgPool, appId)
 	if err != nil {
@@ -91,11 +100,11 @@ func serveConfigFromDb(c *gin.Context, ctx context.Context, appId uuid.UUID, vk 
 		return
 	}
 
-	var etag string
+	etag := sdkconfig.ComputeETag(jsonConfig)
+
 	if vk != nil {
-		etag, err = sdkconfig.SetCacheWithETag(ctx, vk, appId, jsonConfig)
-		if err != nil {
-			fmt.Println("error setting cache with ETag:", err)
+		if err := sdkconfig.SetCacheIfAbsent(ctx, vk, appId, jsonConfig); err != nil {
+			fmt.Println("error populating config cache:", err)
 		}
 	}
 
@@ -132,33 +141,38 @@ func GetConfigForSdk(c *gin.Context) {
 
 	if vk == nil {
 		fmt.Println("valkey client not available, skipping cache")
+		sdkConfigCache.RecordError(ctx)
 		serveConfigFromDb(c, ctx, appId, nil)
 		return
 	}
 
-	cachedETag, err := sdkconfig.GetConfigETag(ctx, vk, appId)
-	if err == nil && cachedETag != "" {
-		if cachedETag == clientETag {
-			fmt.Println("sdk config cache hit (etag match)")
-			sdkConfigCache.RecordHitETag(ctx)
-			c.Header(cacheControlHeader, cacheControlValue)
-			c.Header("ETag", cachedETag)
-			c.Status(http.StatusNotModified)
-			return
-		}
-
-		data, err := sdkconfig.GetConfigData(ctx, vk, appId)
-		if err == nil && data != "" {
-			fmt.Println("sdk config cache hit")
-			sdkConfigCache.RecordHitData(ctx)
-			c.Header(cacheControlHeader, cacheControlValue)
-			c.Header("ETag", cachedETag)
-			c.Data(http.StatusOK, "application/json", []byte(data))
-			return
-		}
+	data, err := sdkconfig.GetCache(ctx, vk, appId)
+	if err != nil {
+		fmt.Println("sdk config cache error:", err)
+		sdkConfigCache.RecordError(ctx)
+		serveConfigFromDb(c, ctx, appId, vk)
+		return
 	}
 
-	fmt.Println("sdk config cache miss")
-	sdkConfigCache.RecordMiss(ctx)
-	serveConfigFromDb(c, ctx, appId, vk)
+	if data == "" {
+		fmt.Println("sdk config cache miss")
+		sdkConfigCache.RecordMiss(ctx)
+		serveConfigFromDb(c, ctx, appId, vk)
+		return
+	}
+
+	etag := sdkconfig.ComputeETag([]byte(data))
+	c.Header(cacheControlHeader, cacheControlValue)
+	c.Header("ETag", etag)
+
+	if etag == clientETag {
+		fmt.Println("sdk config cache hit (etag match)")
+		sdkConfigCache.RecordHitETag(ctx)
+		c.Status(http.StatusNotModified)
+		return
+	}
+
+	fmt.Println("sdk config cache hit")
+	sdkConfigCache.RecordHitData(ctx)
+	c.Data(http.StatusOK, "application/json", []byte(data))
 }

--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -1,8 +1,10 @@
-package measure
+package sdkconfig
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"time"
 
 	"github.com/google/uuid"
@@ -117,6 +119,58 @@ func createDefaultConfig() SdkConfig {
 
 func configCacheKey(appID uuid.UUID) string {
 	return fmt.Sprintf("%s{%s}", configCacheKeyPrefix, appID.String())
+}
+
+func ComputeETag(data []byte) string {
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// GetConfigETag fetches the cached ETag for an app's
+// SDK config from Valkey.
+func GetConfigETag(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
+	key := configCacheKey(appID)
+	cmd := vk.B().Hget().Key(key).Field("etag").Build()
+	result := vk.Do(ctx, cmd)
+
+	str, err := result.ToString()
+	if err != nil {
+		return "", nil
+	}
+	return str, nil
+}
+
+// GetConfigData fetches the cached JSON SDK config
+// for an app from Valkey.
+func GetConfigData(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
+	key := configCacheKey(appID)
+	cmd := vk.B().Hget().Key(key).Field("data").Build()
+	result := vk.Do(ctx, cmd)
+
+	str, err := result.ToString()
+	if err != nil {
+		return "", nil
+	}
+	return str, nil
+}
+
+// SetCacheWithETag stores the JSON SDK config & its
+// computed ETag in Valkey as a hash.
+func SetCacheWithETag(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) (string, error) {
+	key := configCacheKey(appID)
+	etag := ComputeETag(jsonConfig)
+
+	cmd := vk.B().Hset().Key(key).FieldValue().
+		FieldValue("etag", etag).
+		FieldValue("data", string(jsonConfig)).
+		Build()
+
+	if err := vk.Do(ctx, cmd).Error(); err != nil {
+		return "", fmt.Errorf("failed to store config hash: %w", err)
+	}
+
+	return etag, nil
 }
 
 func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*SdkConfig, error) {
@@ -241,6 +295,3 @@ func CreateConfig(ctx context.Context, tx pgx.Tx, teamID, appID uuid.UUID, creat
 
 	return nil
 }
-
-// PatchConfigForApp applies the
-// given patch to the SDK config.

--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -3,6 +3,7 @@ package sdkconfig
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"time"
@@ -16,7 +17,14 @@ import (
 
 const (
 	configCacheKeyPrefix = "sdk_config:"
+	// HASH not STRING so this never collides with the older
+	// etag+data two-field layout during a deploy
+	cacheFieldData = "data"
 )
+
+// ErrNoCacheClient is returned when a cache operation
+// is attempted without a Valkey client.
+var ErrNoCacheClient = errors.New("valkey client not available")
 
 const (
 	ScreenshotMaskLevelAllTextAndMedia        ScreenshotMaskLevel = "all_text_and_media"
@@ -121,56 +129,69 @@ func configCacheKey(appID uuid.UUID) string {
 	return fmt.Sprintf("%s{%s}", configCacheKeyPrefix, appID.String())
 }
 
+// ComputeETag returns an FNV-1a hash of data, hex encoded.
+// The ETag isn't stored, it's recomputed from the cached bytes on read.
 func ComputeETag(data []byte) string {
 	h := fnv.New64a()
 	_, _ = h.Write(data)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// GetConfigETag fetches the cached ETag for an app's
-// SDK config from Valkey.
-func GetConfigETag(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
+// GetCache fetches the cached JSON SDK config for an app.
+// A missing key yields empty data & a nil error, every other
+// failure yields the error so callers don't mistake a broken
+// cache for a miss.
+func GetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) (data string, err error) {
 	key := configCacheKey(appID)
-	cmd := vk.B().Hget().Key(key).Field("etag").Build()
-	result := vk.Do(ctx, cmd)
+	cmd := vk.B().Hget().Key(key).Field(cacheFieldData).Build()
 
-	str, err := result.ToString()
-	if err != nil {
+	data, err = vk.Do(ctx, cmd).ToString()
+	if valkey.IsValkeyNil(err) {
 		return "", nil
 	}
-	return str, nil
-}
-
-// GetConfigData fetches the cached JSON SDK config
-// for an app from Valkey.
-func GetConfigData(ctx context.Context, vk valkey.Client, appID uuid.UUID) (string, error) {
-	key := configCacheKey(appID)
-	cmd := vk.B().Hget().Key(key).Field("data").Build()
-	result := vk.Do(ctx, cmd)
-
-	str, err := result.ToString()
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("failed to read config cache: %w", err)
 	}
-	return str, nil
+
+	return data, nil
 }
 
-// SetCacheWithETag stores the JSON SDK config & its
-// computed ETag in Valkey as a hash.
-func SetCacheWithETag(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) (string, error) {
-	key := configCacheKey(appID)
-	etag := ComputeETag(jsonConfig)
+// SetCache stores the JSON SDK config in Valkey,
+// overwriting any existing value.
+func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
+	if vk == nil {
+		return ErrNoCacheClient
+	}
 
+	key := configCacheKey(appID)
 	cmd := vk.B().Hset().Key(key).FieldValue().
-		FieldValue("etag", etag).
-		FieldValue("data", string(jsonConfig)).
+		FieldValue(cacheFieldData, string(jsonConfig)).
 		Build()
 
 	if err := vk.Do(ctx, cmd).Error(); err != nil {
-		return "", fmt.Errorf("failed to store config hash: %w", err)
+		return fmt.Errorf("failed to store config hash: %w", err)
 	}
 
-	return etag, nil
+	return nil
+}
+
+// SetCacheIfAbsent stores the JSON SDK config only when the key
+// is absent. Readers repopulating after a miss must not overwrite,
+// else a slow reader can write a pre-update config back over a
+// fresh one written by a concurrent PATCH.
+func SetCacheIfAbsent(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
+	if vk == nil {
+		return ErrNoCacheClient
+	}
+
+	key := configCacheKey(appID)
+	cmd := vk.B().Hsetnx().Key(key).Field(cacheFieldData).Value(string(jsonConfig)).Build()
+
+	if err := vk.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("failed to store config hash: %w", err)
+	}
+
+	return nil
 }
 
 func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*SdkConfig, error) {
@@ -242,7 +263,7 @@ func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*S
 
 func InvalidateCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) error {
 	if vk == nil {
-		return nil
+		return ErrNoCacheClient
 	}
 
 	cacheKey := configCacheKey(appID)
@@ -252,8 +273,7 @@ func InvalidateCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) err
 	return result.Error()
 }
 
-// CreateConfig creates a default
-// SDK config for the given app.
+// CreateConfig creates a default SDK config for the given app.
 func CreateConfig(ctx context.Context, tx pgx.Tx, teamID, appID uuid.UUID, createdBy *uuid.UUID) error {
 	config := createDefaultConfig()
 

--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -15,17 +15,17 @@ import (
 	"github.com/valkey-io/valkey-go"
 )
 
+// Valkey cache key & field names.
 const (
 	configCacheKeyPrefix = "sdk_config:"
-	// HASH not STRING so this never collides with the older
-	// etag+data two-field layout during a deploy
+	// cacheFieldData keeps the entry a hash, changing the value type breaks readers mid deploy.
 	cacheFieldData = "data"
 )
 
-// ErrNoCacheClient is returned when a cache operation
-// is attempted without a Valkey client.
+// ErrNoCacheClient is returned by cache writes when no Valkey client is configured.
 var ErrNoCacheClient = errors.New("valkey client not available")
 
+// Screenshot mask levels an SDK accepts.
 const (
 	ScreenshotMaskLevelAllTextAndMedia        ScreenshotMaskLevel = "all_text_and_media"
 	ScreenshotMaskLevelAllText                ScreenshotMaskLevel = "all_text"
@@ -33,8 +33,10 @@ const (
 	ScreenshotMaskLevelSensitiveFieldsOnly    ScreenshotMaskLevel = "sensitive_fields_only"
 )
 
+// ScreenshotMaskLevel is how much of a screenshot an SDK masks.
 type ScreenshotMaskLevel string
 
+// SdkConfig is an app's SDK configuration as served to SDKs.
 type SdkConfig struct {
 	MaxEventsInBatch          int                 `json:"max_events_in_batch"`
 	CrashTimelineDuration     int                 `json:"crash_timeline_duration"`
@@ -62,6 +64,7 @@ type SdkConfig struct {
 	UpdatedBy                 *uuid.UUID          `json:"-"`
 }
 
+// ConfigPatch is a partial SdkConfig update, nil fields are left unchanged.
 type ConfigPatch struct {
 	MaxEventsInBatch          *int                 `json:"max_events_in_batch,omitempty"`
 	CrashTimelineDuration     *int                 `json:"crash_timeline_duration,omitempty"`
@@ -87,6 +90,7 @@ type ConfigPatch struct {
 	ProfileSamplingRate       *float64             `json:"profile_sampling_rate,omitempty"`
 }
 
+// IsValid reports whether s is a known screenshot mask level.
 func (s ScreenshotMaskLevel) IsValid() bool {
 	switch s {
 	case ScreenshotMaskLevelAllText,
@@ -98,6 +102,7 @@ func (s ScreenshotMaskLevel) IsValid() bool {
 	return false
 }
 
+// createDefaultConfig returns the SDK config new apps start with.
 func createDefaultConfig() SdkConfig {
 	return SdkConfig{
 		MaxEventsInBatch:          10000,
@@ -125,22 +130,19 @@ func createDefaultConfig() SdkConfig {
 	}
 }
 
+// configCacheKey returns the Valkey key for an app's cached config.
 func configCacheKey(appID uuid.UUID) string {
 	return fmt.Sprintf("%s{%s}", configCacheKeyPrefix, appID.String())
 }
 
-// ComputeETag returns an FNV-1a hash of data, hex encoded.
-// The ETag isn't stored, it's recomputed from the cached bytes on read.
+// ComputeETag returns the hex FNV-1a hash of data, recomputed on read.
 func ComputeETag(data []byte) string {
 	h := fnv.New64a()
 	_, _ = h.Write(data)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// GetCache fetches the cached JSON SDK config for an app.
-// A missing key yields empty data & a nil error, every other
-// failure yields the error so callers don't mistake a broken
-// cache for a miss.
+// GetCache returns the cached config JSON, empty & nil for a missing key, an error for any other failure.
 func GetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) (data string, err error) {
 	key := configCacheKey(appID)
 	cmd := vk.B().Hget().Key(key).Field(cacheFieldData).Build()
@@ -156,8 +158,7 @@ func GetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) (data stri
 	return data, nil
 }
 
-// SetCache stores the JSON SDK config in Valkey,
-// overwriting any existing value.
+// SetCache writes the config JSON unconditionally, for the patch path only.
 func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
 	if vk == nil {
 		return ErrNoCacheClient
@@ -175,10 +176,7 @@ func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig
 	return nil
 }
 
-// SetCacheIfAbsent stores the JSON SDK config only when the key
-// is absent. Readers repopulating after a miss must not overwrite,
-// else a slow reader can write a pre-update config back over a
-// fresh one written by a concurrent PATCH.
+// SetCacheIfAbsent writes the config JSON only when absent, else a slow reader can overwrite a fresh config.
 func SetCacheIfAbsent(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
 	if vk == nil {
 		return ErrNoCacheClient
@@ -194,6 +192,7 @@ func SetCacheIfAbsent(ctx context.Context, vk valkey.Client, appID uuid.UUID, js
 	return nil
 }
 
+// GetConfigFromDb returns an app's SDK config from Postgres.
 func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*SdkConfig, error) {
 	q := sqlf.PostgreSQL.
 		Select("max_events_in_batch").
@@ -261,6 +260,7 @@ func GetConfigFromDb(ctx context.Context, pg *pgxpool.Pool, appID uuid.UUID) (*S
 	return &sdkConfig, nil
 }
 
+// InvalidateCache deletes an app's cached config.
 func InvalidateCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) error {
 	if vk == nil {
 		return ErrNoCacheClient

--- a/backend/testinfra/testinfra.go
+++ b/backend/testinfra/testinfra.go
@@ -25,7 +25,7 @@ const (
 	// Test database credentials.
 	postgresImage   = "postgres:16.3-alpine"
 	clickhouseImage = "clickhouse/clickhouse-server:26.2-alpine"
-	valkeyImage     = "valkey/valkey:8-alpine"
+	valkeyImage     = "valkey/valkey:9.0.0-alpine"
 	testDBUser      = "test"
 	testDBPassword  = "test"
 	testDBName      = "measure"

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -4417,6 +4417,8 @@ paths:
                     type: number
                   gesture_click_take_snapshot:
                     type: boolean
+                  http_sampling_rate:
+                    type: number
                   http_disable_event_for_urls:
                     type: array
                     items:
@@ -4433,6 +4435,8 @@ paths:
                     type: array
                     items:
                       type: string
+                  profile_sampling_rate:
+                    type: number
               examples:
                 response:
                   value:
@@ -4452,10 +4456,12 @@ paths:
                     anr_take_screenshot: true
                     launch_sampling_rate: 1
                     gesture_click_take_snapshot: true
+                    http_sampling_rate: 100
                     http_disable_event_for_urls: []
                     http_track_request_for_urls: []
                     http_track_response_for_urls: []
                     http_blocked_headers: []
+                    profile_sampling_rate: 100
         "400":
           description: Request URI is malformed or does not meet one or more acceptance criteria. Check the `error` field for more details.
         "401":

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -2411,6 +2411,9 @@ paths:
                   gesture_click_take_snapshot:
                     type: boolean
                     description: Whether to take snapshot with gesture_click event.
+                  http_sampling_rate:
+                    type: number
+                    description: Sampling rate for HTTP events.
                   http_disable_event_for_urls:
                     type: array
                     items:
@@ -2453,10 +2456,12 @@ paths:
                 anr_take_screenshot: true
                 launch_sampling_rate: 1
                 gesture_click_take_snapshot: true
+                http_sampling_rate: 100
                 http_disable_event_for_urls: []
                 http_track_request_for_urls: []
                 http_track_response_for_urls: []
                 http_blocked_headers: []
+                profile_sampling_rate: 100
         "304":
           description: The config has not changed, the body will be empty.
         "400":


### PR DESCRIPTION
## Summary

This PR makes the SDK config cache authoritative on write. A dashboard config update now writes Postgres & the cache inside one transaction, keeping both in sync & returning an error the user can retry. Repopulating the cache on read is conditional, so a slow reader leaves a fresh config intact. Shared SDK config code moves into its own leaf package, which also delivers `http_sampling_rate` to SDKs.

## Tasks

- [x] Write through Postgres & the cache in one transaction on config update
- [x] Make cache repopulation conditional to close the stale reader race
- [x] Consolidate SDK config into a leaf package, `libs/sdkconfig`
- [x] Deliver `http_sampling_rate` to SDKs
- [x] Separate cache errors from cache misses in metrics
- [x] Surface cache & commit failures as errors with logging
- [x] Document `http_sampling_rate` & `profile_sampling_rate` in the OpenAPI specs
- [x] Cover the write through path & the reader race with integration tests

## See also

- fixes #4330
