### PR TITLE
fix(backend): bust stale sdk config cache entries on deploy

### DIFF
--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -18,8 +18,9 @@ import (
 // Valkey cache key & field names.
 const (
 	configCacheKeyPrefix = "sdk_config:"
-	// cacheFieldData keeps the entry a hash, changing the value type breaks readers mid deploy.
-	cacheFieldData = "data"
+	// cacheFieldData keeps the entry a hash & marks the payload shape.
+	// Rename it when the shape changes so legacy entries read as a miss.
+	cacheFieldData = "config"
 )
 
 // ErrNoCacheClient is returned by cache writes when no Valkey client is configured.

--- a/backend/libs/sdkconfig/sdkconfig_test.go
+++ b/backend/libs/sdkconfig/sdkconfig_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package sdkconfig
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+	valkey "github.com/valkey-io/valkey-go"
+)
+
+var vk valkey.Client
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	client, vkCleanup := testinfra.SetupValkey(ctx)
+	vk = client
+
+	code := m.Run()
+
+	vkCleanup()
+	os.Exit(code)
+}
+
+func TestGetCacheLegacyFieldMisses(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	key := configCacheKey(appID)
+
+	legacyJSON := `{"max_events_in_batch":10000,"trace_sampling_rate":100}`
+	legacy := vk.B().Hset().Key(key).FieldValue().
+		FieldValue("etag", ComputeETag([]byte(legacyJSON))).
+		FieldValue("data", legacyJSON).
+		Build()
+
+	if err := vk.Do(ctx, legacy).Error(); err != nil {
+		t.Fatalf("seed legacy entry: %v", err)
+	}
+
+	data, err := GetCache(ctx, vk, appID)
+	if err != nil {
+		t.Fatalf("GetCache: %v", err)
+	}
+	if data != "" {
+		t.Fatalf("expected legacy entry to miss, got %q", data)
+	}
+
+	freshJSON := []byte(`{"max_events_in_batch":10000,"http_sampling_rate":42}`)
+	if err := SetCacheIfAbsent(ctx, vk, appID, freshJSON); err != nil {
+		t.Fatalf("SetCacheIfAbsent: %v", err)
+	}
+
+	data, err = GetCache(ctx, vk, appID)
+	if err != nil {
+		t.Fatalf("GetCache after repopulate: %v", err)
+	}
+	if data != string(freshJSON) {
+		t.Fatalf("expected %q, got %q", freshJSON, data)
+	}
+}


### PR DESCRIPTION
## Summary

This PR busts SDK config cache entries left behind by the older payload format. #4340 added `http_sampling_rate` to the config SDKs receive but reused the same cache field, so warm entries kept serving the previous payload & the recomputed ETag kept matching what SDKs already held. Renaming the field makes those entries read as a miss, so they repopulate from Postgres on the first request after deploy.

## Tasks

- [x] Rename the cache field so entries in the older format read as a miss
- [x] Repopulate warm entries from Postgres on the first request after deploy
- [x] Cover legacy entry invalidation with a test

## See also

- follows up #4340
