### PR TITLE
chore(frontend): open the key picker on the selected key's group

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
@@ -150,6 +150,17 @@ describe("KeyPicker", () => {
     expect(screen.queryByText("Patch id")).not.toBeInTheDocument();
   });
 
+  it("opens on the group of the key already selected", () => {
+    openPicker({ selected: keys[1] });
+
+    expect(screen.getByTestId("tabs")).toHaveAttribute(
+      "data-selected",
+      "Build",
+    );
+    expect(screen.getByText("Patch id")).toBeInTheDocument();
+    expect(screen.queryByText("App version")).not.toBeInTheDocument();
+  });
+
   it("shows the keys of the group that is picked", () => {
     openPicker();
 

--- a/frontend/dashboard/app/components/filter_bar/key_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/key_picker.tsx
@@ -107,7 +107,12 @@ function KeyList({
   const [search, setSearch] = useState("");
   const searching = search !== "";
 
-  const [openGroup, setOpenGroup] = useState<string | null>(null);
+  // When opened from a condition key, start with that key's group.
+  // Without a selected key, start with the first group.
+  const [openGroup, setOpenGroup] = useState<string | null>(
+    selected?.key_group ?? null,
+  );
+
   // The chosen group can disappear from the server's list, so the first group
   // stands in.
   const group =


### PR DESCRIPTION
# Description

Clicking a condition chip's key now opens the picker on that key's group tab instead of the first group; adding a new condition still starts on the first group



