### PR TITLE
chore: replace pro upgrade CTAs with contact us for enterprise plans

### DIFF
--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -105,24 +105,36 @@ func TeamDailySummaryEmail(teamName string, date time.Time, apps []AppDailySumma
 // UsageLimitEmail builds the usage limit threshold notification email.
 // Percentages are safe to include (they're plan-agnostic); absolute byte
 // counts are not, since the dashboard is the source of truth for plan limits.
-func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int) (subject, body string) {
-	dashboardURL := fmt.Sprintf("%s/%s/usage", siteOrigin, teamId)
+// isEnterprise swaps the Pro upgrade CTA for a contact-us mailto link.
+func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int, isEnterprise bool) (subject, body string) {
+	ctaText := "Upgrade to Measure Pro"
+	ctaURL := fmt.Sprintf("%s/%s/usage", siteOrigin, teamId)
+	if isEnterprise {
+		ctaText = "Contact Us"
+		ctaURL = "mailto:hello@measure.sh"
+	}
 
-	var title, message, ctaText string
+	var title, message string
 	switch threshold {
 	case 100:
 		subject = fmt.Sprintf("%s - Usage Limit Reached", teamName)
 		title = "Usage Limit Reached"
-		message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Upgrade to Measure Pro to resume.`, escape(teamName))
-		ctaText = "Upgrade to Measure Pro"
+		if isEnterprise {
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Contact us to increase your limit.`, escape(teamName))
+		} else {
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Upgrade to Measure Pro to resume.`, escape(teamName))
+		}
 	default:
 		subject = fmt.Sprintf("%s - %d%% of Usage Limit Reached", teamName, threshold)
 		title = fmt.Sprintf("%d%% Usage Limit Reached", threshold)
-		message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Consider upgrading to Measure Pro for unlimited usage!`, escape(teamName), threshold)
-		ctaText = "Upgrade to Measure Pro"
+		if isEnterprise {
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Contact us if you need a higher limit.`, escape(teamName), threshold)
+		} else {
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Consider upgrading to Measure Pro for unlimited usage!`, escape(teamName), threshold)
+		}
 	}
 
-	body = RenderEmailBody(title, UsageLimitContent(message, threshold), ctaText, dashboardURL)
+	body = RenderEmailBody(title, UsageLimitContent(message, threshold), ctaText, ctaURL)
 	return
 }
 

--- a/backend/libs/email/cmd/preview/main.go
+++ b/backend/libs/email/cmd/preview/main.go
@@ -110,13 +110,13 @@ func main() {
 
 	// --- Billing: Usage limits ---
 
-	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 75)
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 75, false)
 	add("08-usage-75-percent.html", body)
 
-	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 90)
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 90, false)
 	add("09-usage-90-percent.html", body)
 
-	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 100)
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 100, false)
 	add("10-usage-100-percent.html", body)
 
 	// --- Billing: Subscription ---
@@ -218,6 +218,17 @@ func main() {
 	}
 	_, body = email.TeamDailySummaryEmail("Acme Corp", summaryDate, singleAppSummary, "https://measure.sh", "team-abc")
 	add("17-team-daily-summary-single-app.html", body)
+
+	// --- Billing: Usage limits (enterprise) ---
+
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 75, true)
+	add("18-usage-75-percent-enterprise.html", body)
+
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 90, true)
+	add("19-usage-90-percent-enterprise.html", body)
+
+	_, body = email.UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 100, true)
+	add("20-usage-100-percent-enterprise.html", body)
 
 	for _, e := range emails {
 		path := filepath.Join(dir, e.name)

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -650,7 +650,7 @@ func TestUsageLimitEmail_Thresholds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%d%%", tt.threshold), func(t *testing.T) {
-			subject, body := UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", tt.threshold)
+			subject, body := UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", tt.threshold, false)
 
 			if !strings.Contains(subject, tt.wantSubject) {
 				t.Errorf("subject = %q, want substring %q", subject, tt.wantSubject)
@@ -682,7 +682,7 @@ func TestUsageLimitEmail_Thresholds(t *testing.T) {
 func TestUsageLimitEmail_NonStandardThreshold(t *testing.T) {
 	// Autumn dashboard can send any numeric threshold — handler should not
 	// panic and should fall into the non-100 branch with an upgrade CTA.
-	subject, body := UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 50)
+	subject, body := UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", 50, false)
 
 	if !strings.Contains(subject, "50% of Usage Limit Reached") {
 		t.Errorf("subject = %q, want '50%%' mention", subject)
@@ -691,6 +691,49 @@ func TestUsageLimitEmail_NonStandardThreshold(t *testing.T) {
 		t.Errorf("body missing 50%% usage copy")
 	}
 	mustNotContainByteNumbers(t, "UsageLimitEmail(50)", body)
+}
+
+func TestUsageLimitEmail_Enterprise(t *testing.T) {
+	tests := []struct {
+		threshold      int
+		wantSubject    string
+		wantBodySubstr string
+		wantExtraCopy  string
+	}{
+		{75, "75% of Usage Limit Reached", "has used <strong>75%</strong>", "Contact us if you need a higher limit."},
+		{90, "90% of Usage Limit Reached", "has used <strong>90%</strong>", "Contact us if you need a higher limit."},
+		{100, "Usage Limit Reached", "has reached its plan's data limit", "Data ingestion has been paused. Contact us to increase your limit."},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d%%", tt.threshold), func(t *testing.T) {
+			subject, body := UsageLimitEmail("Acme Corp", "team-abc", "https://measure.sh", tt.threshold, true)
+
+			if !strings.Contains(subject, tt.wantSubject) {
+				t.Errorf("subject = %q, want substring %q", subject, tt.wantSubject)
+			}
+			if !strings.Contains(body, tt.wantBodySubstr) {
+				t.Errorf("body missing %q", tt.wantBodySubstr)
+			}
+			if !strings.Contains(body, tt.wantExtraCopy) {
+				t.Errorf("body missing enterprise copy %q", tt.wantExtraCopy)
+			}
+			if !strings.Contains(body, "Contact Us") {
+				t.Errorf("body missing 'Contact Us' CTA")
+			}
+			if !strings.Contains(body, "mailto:hello@measure.sh") {
+				t.Errorf("body missing mailto CTA link")
+			}
+			if strings.Contains(body, "Upgrade to Measure Pro") {
+				t.Errorf("enterprise body should not mention upgrading to Measure Pro")
+			}
+			if strings.Contains(body, "team-abc/usage") {
+				t.Errorf("enterprise CTA should not link to the usage page")
+			}
+
+			mustNotContainByteNumbers(t, fmt.Sprintf("UsageLimitEmail(%d, enterprise)", tt.threshold), body)
+		})
+	}
 }
 
 func TestRemovedFromTeamEmail(t *testing.T) {
@@ -734,8 +777,9 @@ func TestTeamNameMarkupIsEscaped(t *testing.T) {
 	_, bodies["InviteExistingUserEmail"] = InviteExistingUserEmail("attacker@example.com", "admin", payload, "https://measure.sh")
 	_, bodies["RemovedFromTeamEmail"] = RemovedFromTeamEmail(payload, "attacker@example.com", "https://measure.sh", "team-abc")
 	_, bodies["RoleChangedEmail"] = RoleChangedEmail("admin", "attacker@example.com", payload, "https://measure.sh", "team-abc")
-	_, bodies["UsageLimitEmail"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 90)
-	_, bodies["UsageLimitEmail(100)"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 100)
+	_, bodies["UsageLimitEmail"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 90, false)
+	_, bodies["UsageLimitEmail(100)"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 100, false)
+	_, bodies["UsageLimitEmail(enterprise)"] = UsageLimitEmail(payload, "team-abc", "https://measure.sh", 90, true)
 	_, bodies["UpgradeEmail"] = UpgradeEmail(payload, "team-abc", "https://measure.sh")
 	_, bodies["ManualDowngradeEmail"] = ManualDowngradeEmail(payload, "team-abc", "https://measure.sh")
 

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -411,7 +411,7 @@ func HandleLimitReached(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEma
 		log.Printf("webhook: team not found for autumn customer %s: %v", data.CustomerID, err)
 		return
 	}
-	notifyLimitReached(ctx, pg, siteOrigin, txEmail, teamID)
+	notifyLimitReached(ctx, pg, siteOrigin, txEmail, teamID, isEnterpriseCustomer(ctx, data.CustomerID))
 }
 
 func HandleUsageAlert(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail string, data autumn.BalancesUsageAlertData) {
@@ -420,7 +420,19 @@ func HandleUsageAlert(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail
 		log.Printf("webhook: team not found for autumn customer %s: %v", data.CustomerID, err)
 		return
 	}
-	notifyUsageAlert(ctx, pg, siteOrigin, txEmail, teamID, int(data.UsageAlert.Threshold))
+	notifyUsageAlert(ctx, pg, siteOrigin, txEmail, teamID, int(data.UsageAlert.Threshold), isEnterpriseCustomer(ctx, data.CustomerID))
+}
+
+// isEnterpriseCustomer reports whether the Autumn customer is on an enterprise
+// plan. A failed lookup reports false so the email still goes out with the
+// standard upgrade copy.
+func isEnterpriseCustomer(ctx context.Context, customerID string) bool {
+	cust, err := autumn.GetCustomer(ctx, customerID)
+	if err != nil {
+		log.Printf("webhook: autumn get customer %s failed: %v", customerID, err)
+		return false
+	}
+	return DeterminePlan(cust) == PlanEnterprise
 }
 
 // ----------------------------------------------------------------------------
@@ -447,17 +459,17 @@ func notifyDowngrade(ctx context.Context, pg *pgxpool.Pool, tx pgx.Tx, siteOrigi
 	return queueTeamEmail(ctx, pg, tx, txEmail, teamID, subject, body)
 }
 
-func notifyLimitReached(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail string, teamID uuid.UUID) {
+func notifyLimitReached(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail string, teamID uuid.UUID, isEnterprise bool) {
 	name := teamName(ctx, pg, teamID)
-	subject, body := email.UsageLimitEmail(name, teamID.String(), siteOrigin, 100)
+	subject, body := email.UsageLimitEmail(name, teamID.String(), siteOrigin, 100, isEnterprise)
 	if err := queueTeamEmail(ctx, pg, nil, txEmail, teamID, subject, body); err != nil {
 		log.Printf("failed to queue email for team %s: %v", teamID, err)
 	}
 }
 
-func notifyUsageAlert(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail string, teamID uuid.UUID, threshold int) {
+func notifyUsageAlert(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail string, teamID uuid.UUID, threshold int, isEnterprise bool) {
 	name := teamName(ctx, pg, teamID)
-	subject, body := email.UsageLimitEmail(name, teamID.String(), siteOrigin, threshold)
+	subject, body := email.UsageLimitEmail(name, teamID.String(), siteOrigin, threshold, isEnterprise)
 	if err := queueTeamEmail(ctx, pg, nil, txEmail, teamID, subject, body); err != nil {
 		log.Printf("failed to queue email for team %s: %v", teamID, err)
 	}

--- a/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
+++ b/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
@@ -49,6 +49,18 @@ function freeAt(percent: number) {
   };
 }
 
+// Helper: build a billingInfo payload that produces a given usage percentage
+// on an Enterprise plan with a finite data limit.
+function enterpriseAt(percent: number) {
+  const granted = 100_000_000_000;
+  return {
+    plan: "enterprise",
+    bytes_granted: granted,
+    bytes_used: granted * (percent / 100),
+    bytes_unlimited: false,
+  };
+}
+
 describe("UsageThresholdBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,8 +100,8 @@ describe("UsageThresholdBanner", () => {
     });
   });
 
-  describe("When the team is not on the Free plan", () => {
-    it("renders nothing even at 100% usage (Pro/Enterprise have their own overage rules)", () => {
+  describe("When the team is on the Pro plan", () => {
+    it("renders nothing even at 100% usage (Pro self-manages overages)", () => {
       isBillingEnabled.mockReturnValue(true);
       mockBillingInfo = {
         plan: "pro",
@@ -100,6 +112,83 @@ describe("UsageThresholdBanner", () => {
       const { container } = render(<UsageThresholdBanner teamId="team-1" />);
 
       expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("When the team is on Enterprise with unlimited bytes", () => {
+    it("renders nothing even at 100% of the granted bytes", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = {
+        plan: "enterprise",
+        bytes_granted: 100_000_000_000,
+        bytes_used: 100_000_000_000,
+        bytes_unlimited: true,
+      };
+
+      const { container } = render(<UsageThresholdBanner teamId="team-1" />);
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("When an Enterprise team with a finite limit crosses thresholds", () => {
+    it("shows yellow banner with Contact Us mailto at 75%", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = enterpriseAt(80);
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      expect(
+        screen.getByText("75% of plan data limit used."),
+      ).toBeInTheDocument();
+
+      const banner = screen.getByText(
+        "75% of plan data limit used.",
+      ).parentElement!;
+      expect(banner).toHaveClass("bg-yellow-300");
+
+      const link = screen.getByRole("link", { name: /Contact Us/i });
+      expect(link).toHaveAttribute("href", "mailto:hello@measure.sh");
+    });
+
+    it("shows orange banner with Contact Us mailto at 90%", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = enterpriseAt(95);
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      expect(
+        screen.getByText("90% of plan data limit used."),
+      ).toBeInTheDocument();
+
+      const banner = screen.getByText(
+        "90% of plan data limit used.",
+      ).parentElement!;
+      expect(banner).toHaveClass("bg-orange-300");
+
+      const link = screen.getByRole("link", { name: /Contact Us/i });
+      expect(link).toHaveAttribute("href", "mailto:hello@measure.sh");
+    });
+
+    it("shows red banner with Contact Us mailto at 100%", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = enterpriseAt(100);
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      expect(
+        screen.getByText(
+          "100% of plan data limit used — event ingestion blocked.",
+        ),
+      ).toBeInTheDocument();
+
+      const banner = screen.getByText(
+        "100% of plan data limit used — event ingestion blocked.",
+      ).parentElement!;
+      expect(banner).toHaveClass("bg-red-300");
+
+      const link = screen.getByRole("link", { name: /Contact Us/i });
+      expect(link).toHaveAttribute("href", "mailto:hello@measure.sh");
     });
   });
 

--- a/frontend/dashboard/app/components/usage_threshold_banner.tsx
+++ b/frontend/dashboard/app/components/usage_threshold_banner.tsx
@@ -8,13 +8,25 @@ type UsageThresholdBannerProps = {
   teamId: string;
 };
 
-// Banner only fires for Free plan above 75% — Pro/Enterprise self-manage overages.
+// Banner fires above 75% for the free plan and for enterprise plans with a
+// finite limit — Pro self-manages overages.
 function thresholdFor(
   billingInfo:
-    | { plan?: string; bytes_granted?: number; bytes_used?: number }
+    | {
+        plan?: string;
+        bytes_granted?: number;
+        bytes_used?: number;
+        bytes_unlimited?: boolean;
+      }
     | undefined,
 ): number {
-  if (!billingInfo || billingInfo.plan !== "free") {
+  if (!billingInfo) {
+    return 0;
+  }
+  if (billingInfo.plan !== "free" && billingInfo.plan !== "enterprise") {
+    return 0;
+  }
+  if (billingInfo.bytes_unlimited) {
     return 0;
   }
   const granted = billingInfo.bytes_granted ?? 0;
@@ -41,19 +53,24 @@ export default function UsageThresholdBanner({
     return null;
   }
 
-  const usagePageUrl = `/${teamId}/usage`;
+  const isEnterprise = billingInfo?.plan === "enterprise";
+  const planLabel = isEnterprise ? "plan data limit" : "free plan";
+  const linkHref = isEnterprise
+    ? "mailto:hello@measure.sh"
+    : `/${teamId}/usage`;
+  const linkText = isEnterprise ? "Contact Us →" : "Upgrade to Pro →";
 
   let message: string;
   let bannerClass: string;
 
   if (threshold >= 100) {
-    message = "100% of free plan used — event ingestion blocked.";
+    message = `100% of ${planLabel} used — event ingestion blocked.`;
     bannerClass = "bg-red-300 text-primary-foreground";
   } else if (threshold >= 90) {
-    message = "90% of free plan used.";
+    message = `90% of ${planLabel} used.`;
     bannerClass = "bg-orange-300 text-primary-foreground";
   } else {
-    message = "75% of free plan used.";
+    message = `75% of ${planLabel} used.`;
     bannerClass = "bg-yellow-300 text-primary-foreground";
   }
 
@@ -63,10 +80,10 @@ export default function UsageThresholdBanner({
     >
       <span>{message}</span>
       <Link
-        href={usagePageUrl}
+        href={linkHref}
         className="font-semibold underline ml-4 whitespace-nowrap"
       >
-        Upgrade to Pro →
+        {linkText}
       </Link>
     </div>
   );


### PR DESCRIPTION
# Description

- usage limit emails and the usage threshold banner show a Contact Us mailto link for enterprise plans
- autumn webhook handlers resolve the plan to pick the email variant


