### PR TITLE
fix(backend): expire sdk config cache entries after ttl

### DIFF
--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -182,9 +182,12 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// inside the txn, a cache failure must roll the row back
+	// inside the txn, a cache failure rolls the row back, except a TTL-only failure
 	if err := sdkconfig.SetCache(ctx, deps.VK, appID, jsonConfig); err != nil {
-		return fmt.Errorf("failed to write config cache: %w", err)
+		if !errors.Is(err, sdkconfig.ErrCacheTTLNotSet) {
+			return fmt.Errorf("failed to write config cache: %w", err)
+		}
+		fmt.Println("failed to set config cache ttl, app_id:", appID, err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math/rand"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,8 +24,28 @@ const (
 	cacheFieldData = "config"
 )
 
+// Config cache TTL & jitter.
+const (
+	// configCacheTTL is how long a cached config entry lives, jittered so
+	// entries written together don't expire together.
+	configCacheTTL = 24 * time.Hour
+	// configCacheTTLJitter is the fraction configCacheTTL varies by, either way.
+	configCacheTTLJitter = 0.10
+)
+
 // ErrNoCacheClient is returned by cache writes when no Valkey client is configured.
 var ErrNoCacheClient = errors.New("valkey client not available")
+
+// ErrCacheTTLNotSet is returned when the value was cached but its expiry was not
+// set, so the entry risks living forever.
+var ErrCacheTTLNotSet = errors.New("failed to set config cache ttl")
+
+// jitteredCacheTTL returns configCacheTTL varied by up to configCacheTTLJitter
+// either way, in whole seconds.
+func jitteredCacheTTL() int64 {
+	factor := 1 + configCacheTTLJitter*(2*rand.Float64()-1)
+	return int64(configCacheTTL.Seconds() * factor)
+}
 
 // Screenshot mask levels an SDK accepts.
 const (
@@ -159,35 +180,51 @@ func GetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) (data stri
 	return data, nil
 }
 
-// SetCache writes the config JSON unconditionally, for the patch path only.
+// SetCache writes the config JSON unconditionally & refreshes its TTL, for the
+// patch path only. Returns ErrCacheTTLNotSet if the write succeeds but the TTL
+// could not be set.
 func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
 	if vk == nil {
 		return ErrNoCacheClient
 	}
 
 	key := configCacheKey(appID)
-	cmd := vk.B().Hset().Key(key).FieldValue().
+	set := vk.B().Hset().Key(key).FieldValue().
 		FieldValue(cacheFieldData, string(jsonConfig)).
 		Build()
+	// unconditional, refreshes the ttl on every write
+	expire := vk.B().Expire().Key(key).Seconds(jitteredCacheTTL()).Build()
 
-	if err := vk.Do(ctx, cmd).Error(); err != nil {
+	results := vk.DoMulti(ctx, set, expire)
+	if err := results[0].Error(); err != nil {
 		return fmt.Errorf("failed to store config hash: %w", err)
+	}
+	if err := results[1].Error(); err != nil {
+		return fmt.Errorf("%w: %w", ErrCacheTTLNotSet, err)
 	}
 
 	return nil
 }
 
-// SetCacheIfAbsent writes the config JSON only when absent, else a slow reader can overwrite a fresh config.
+// SetCacheIfAbsent writes the config JSON & sets a TTL only when absent, else
+// a slow reader can overwrite a fresh config or extend its TTL. Returns
+// ErrCacheTTLNotSet if the write succeeds but the TTL could not be set.
 func SetCacheIfAbsent(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
 	if vk == nil {
 		return ErrNoCacheClient
 	}
 
 	key := configCacheKey(appID)
-	cmd := vk.B().Hsetnx().Key(key).Field(cacheFieldData).Value(string(jsonConfig)).Build()
+	set := vk.B().Hsetnx().Key(key).Field(cacheFieldData).Value(string(jsonConfig)).Build()
+	// NX only, readers hit this path on a live key & must not extend its ttl
+	expire := vk.B().Expire().Key(key).Seconds(jitteredCacheTTL()).Nx().Build()
 
-	if err := vk.Do(ctx, cmd).Error(); err != nil {
+	results := vk.DoMulti(ctx, set, expire)
+	if err := results[0].Error(); err != nil {
 		return fmt.Errorf("failed to store config hash: %w", err)
+	}
+	if err := results[1].Error(); err != nil {
+		return fmt.Errorf("%w: %w", ErrCacheTTLNotSet, err)
 	}
 
 	return nil

--- a/backend/libs/sdkconfig/sdkconfig_test.go
+++ b/backend/libs/sdkconfig/sdkconfig_test.go
@@ -27,6 +27,94 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func ttlOf(t *testing.T, ctx context.Context, key string) int64 {
+	t.Helper()
+	ttl, err := vk.Do(ctx, vk.B().Ttl().Key(key).Build()).AsInt64()
+	if err != nil {
+		t.Fatalf("read ttl: %v", err)
+	}
+	return ttl
+}
+
+func assertTTLInJitterWindow(t *testing.T, ttl int64) {
+	t.Helper()
+	const lo, hi = int64(21.6 * 3600), int64(26.4 * 3600)
+	if ttl <= lo || ttl > hi {
+		t.Fatalf("expected ttl in (%d, %d], got %d", lo, hi, ttl)
+	}
+}
+
+func TestSetCacheSetsTTL(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`)); err != nil {
+		t.Fatalf("SetCache: %v", err)
+	}
+
+	assertTTLInJitterWindow(t, ttlOf(t, ctx, configCacheKey(appID)))
+}
+
+func TestSetCacheIfAbsentSetsTTL(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	if err := SetCacheIfAbsent(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`)); err != nil {
+		t.Fatalf("SetCacheIfAbsent: %v", err)
+	}
+
+	assertTTLInJitterWindow(t, ttlOf(t, ctx, configCacheKey(appID)))
+}
+
+func TestSetCacheIfAbsentCannotExtendLiveTTL(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	key := configCacheKey(appID)
+
+	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`)); err != nil {
+		t.Fatalf("SetCache: %v", err)
+	}
+	if err := vk.Do(ctx, vk.B().Expire().Key(key).Seconds(60).Build()).Error(); err != nil {
+		t.Fatalf("shorten ttl: %v", err)
+	}
+
+	if err := SetCacheIfAbsent(ctx, vk, appID, []byte(`{"max_events_in_batch":42}`)); err != nil {
+		t.Fatalf("SetCacheIfAbsent: %v", err)
+	}
+
+	ttl := ttlOf(t, ctx, key)
+	if ttl <= 0 || ttl > 60 {
+		t.Fatalf("expected ttl to stay near 60s, got %d", ttl)
+	}
+}
+
+func TestSetCacheIfAbsentGivesLegacyKeyTTL(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	key := configCacheKey(appID)
+
+	legacyJSON := `{"max_events_in_batch":10000}`
+	legacy := vk.B().Hset().Key(key).FieldValue().
+		FieldValue("etag", ComputeETag([]byte(legacyJSON))).
+		FieldValue("data", legacyJSON).
+		Build()
+
+	if err := vk.Do(ctx, legacy).Error(); err != nil {
+		t.Fatalf("seed legacy entry: %v", err)
+	}
+	if ttl := ttlOf(t, ctx, key); ttl != -1 {
+		t.Fatalf("expected legacy key to have no ttl, got %d", ttl)
+	}
+
+	if err := SetCacheIfAbsent(ctx, vk, appID, []byte(legacyJSON)); err != nil {
+		t.Fatalf("SetCacheIfAbsent: %v", err)
+	}
+
+	if ttl := ttlOf(t, ctx, key); ttl <= 0 {
+		t.Fatalf("expected legacy key to gain a ttl, got %d", ttl)
+	}
+}
+
 func TestGetCacheLegacyFieldMisses(t *testing.T) {
 	ctx := context.Background()
 	appID := uuid.New()


### PR DESCRIPTION
## Summary

This PR expires SDK config cache entries after roughly a day. An entry lives until a config update replaces it, so a value that survives both a failed commit & its cleanup can be served indefinitely. A jittered TTL bounds that exposure, with the jitter spreading expiry so entries written together lapse apart.

## Tasks

- [x] Expire cache entries after a jittered ~24h
- [x] Keep a live entry's original expiry when a reader repopulates it
- [x] Treat a TTL-only write failure as non-fatal on a config update
- [x] Cover both TTL paths & the reader guard with tests

## See also

- follows up #4330
