### PR TITLE
docs(backend): document sampling rate range in open api spec

### DIFF
--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -4393,8 +4393,12 @@ paths:
                     type: integer
                   trace_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                   journey_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                   screenshot_mask_level:
                     type: string
                   log_autocollect_enabled:
@@ -4415,10 +4419,14 @@ paths:
                     type: boolean
                   launch_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                   gesture_click_take_snapshot:
                     type: boolean
                   http_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                   http_disable_event_for_urls:
                     type: array
                     items:
@@ -4437,6 +4445,8 @@ paths:
                       type: string
                   profile_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
               examples:
                 response:
                   value:

--- a/frontend/dashboard/content/openapi/sdk.yaml
+++ b/frontend/dashboard/content/openapi/sdk.yaml
@@ -2358,9 +2358,13 @@ paths:
                       The duration of session timeline collected with bug reports.
                   trace_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                     description: Sampling rate for all traces.
                   journey_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                     description: >
                       Sampling rate for sessions that should report journey events:
                       `lifecycle_activity`, `lifecycle_fragment`,
@@ -2405,6 +2409,8 @@ paths:
                     description: Whether to take screenshot on ANR.
                   launch_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                     description: >
                       Sampling rate for launch events: cold_launch, warm_launch and
                       hot_launch.
@@ -2413,6 +2419,8 @@ paths:
                     description: Whether to take snapshot with gesture_click event.
                   http_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                     description: Sampling rate for HTTP events.
                   http_disable_event_for_urls:
                     type: array
@@ -2438,6 +2446,8 @@ paths:
                     description: HTTP header names to never capture.
                   profile_sampling_rate:
                     type: number
+                    minimum: 0
+                    maximum: 100
                     description: Sampling rate for profile events.
               example:
                 max_events_in_batch: 1000


### PR DESCRIPTION
## Summary

This PR documents the 0-100 range of the SDK config sampling rates in both OpenAPI specs. The five rates are typed as plain numbers, so the scale has to be inferred from the examples, which invites the 0-1 fraction convention other vendors use. The range now sits in the schema & mirrors what the API already validates, so runtime behavior stays the same.
