### PR TITLE
fix(ios): parse cache control header for config refresh window

### DIFF
--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		CF7CABB32F261DA800A9DC30 /* MockSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABB22F261DA800A9DC30 /* MockSessionStore.swift */; };
 		CF7CABB52F27429800A9DC30 /* ConfigLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABB42F27429800A9DC30 /* ConfigLoaderTests.swift */; };
 		CF7CABB72F2789B100A9DC30 /* ExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABB62F2789B100A9DC30 /* ExporterTests.swift */; };
+		259AE825871705F7F35EA997 /* NetworkClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED4DDB5C02156A7ECFC1616 /* NetworkClientTests.swift */; };
 		CF7CABB92F278BF900A9DC30 /* MockHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABB82F278BF900A9DC30 /* MockHttpClient.swift */; };
 		CF7CABBB2F27BE4000A9DC30 /* SignalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CABBA2F27BE4000A9DC30 /* SignalStoreTests.swift */; };
 		CF7CAE552D952FA600E15CDB /* HttpEventValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */; };
@@ -653,6 +654,7 @@
 		CF7CABB22F261DA800A9DC30 /* MockSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionStore.swift; sourceTree = "<group>"; };
 		CF7CABB42F27429800A9DC30 /* ConfigLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLoaderTests.swift; sourceTree = "<group>"; };
 		CF7CABB62F2789B100A9DC30 /* ExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExporterTests.swift; sourceTree = "<group>"; };
+		1ED4DDB5C02156A7ECFC1616 /* NetworkClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClientTests.swift; sourceTree = "<group>"; };
 		CF7CABB82F278BF900A9DC30 /* MockHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHttpClient.swift; sourceTree = "<group>"; };
 		CF7CABBA2F27BE4000A9DC30 /* SignalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalStoreTests.swift; sourceTree = "<group>"; };
 		CF7CAE542D952FA600E15CDB /* HttpEventValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpEventValidator.swift; sourceTree = "<group>"; };
@@ -1225,6 +1227,7 @@
 				CFAA00030000000000000001 /* JSONWriterEscapingTests.swift */,
 				52B7F0F92D757F81001498BC /* HttpClientTests.swift */,
 				CF7CABB62F2789B100A9DC30 /* ExporterTests.swift */,
+				1ED4DDB5C02156A7ECFC1616 /* NetworkClientTests.swift */,
 			);
 			path = Exporter;
 			sourceTree = "<group>";
@@ -2118,6 +2121,7 @@
 				CF4EA2D52EA243EB0020FC71 /* UserTriggeredEventCollectorTests.swift in Sources */,
 				52B7F16B2D757F81001498BC /* MockTimeProvider.swift in Sources */,
 				CF7CABB72F2789B100A9DC30 /* ExporterTests.swift in Sources */,
+				259AE825871705F7F35EA997 /* NetworkClientTests.swift in Sources */,
 				52B7F1652D757F81001498BC /* MockScreenshotGenerator.swift in Sources */,
 				52B7F1582D757F81001498BC /* MockConfigProvider.swift in Sources */,
 				CF1BB4FF2DDF35E600588506 /* MockMotionManager.swift in Sources */,

--- a/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
+++ b/ios/Sources/MeasureSDK/Swift/Config/ConfigLoader.swift
@@ -101,9 +101,10 @@ struct BaseConfigLoader: ConfigLoader {
         }
 
         if !shouldRefresh {
+            let remaining = cacheControl - (now - lastFetch)
             logger.internalLog(
                 level: .debug,
-                message: "ConfigLoader: CacheControl not expired, skipping refresh",
+                message: "ConfigLoader: CacheControl not expired, skipping refresh. now=\(now)ms, lastFetch=\(lastFetch)ms, cacheControl=\(cacheControl)ms, remaining=\(remaining)ms",
                 error: nil,
                 data: nil
             )
@@ -133,9 +134,12 @@ struct BaseConfigLoader: ConfigLoader {
                     data: nil
                 )
 
-            case .notModified:
-
+            case .notModified(let cacheControl):
                 userDefaultStorage.setConfigFetchTimestamp(now)
+
+                if cacheControl > 0 {
+                    userDefaultStorage.setConfigCacheControl(cacheControl)
+                }
 
                 logger.internalLog(
                     level: .debug,

--- a/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/Exporter.swift
@@ -166,7 +166,7 @@ final class BaseExporter: Exporter {
 
     private func handleBatchResponse(response: HttpResponse, batch: BatchEntity, events: [EventEntity], spans: [SpanEntity]) {
         switch response {
-        case .success(let body, _):
+        case .success(let body, _, _):
             logger.internalLog(level: .debug, message: "Exporter: batch \(batch.batchId) sent successfully", error: nil, data: nil)
             parseAndSaveAttachmentMetadata(responseBody: body)
             deleteEventsAndSpans(batch, events: events, spans: spans)

--- a/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/HttpClient.swift
@@ -177,13 +177,16 @@ final class BaseHttpClient: HttpClient {
         }
 
         let etag = httpResponse.allHeaderFields["Etag"] as? String
+        let cacheControl = httpResponse.allHeaderFields["Cache-Control"] as? String
         switch httpResponse.statusCode {
         case 200..<300:
-            return .success(body: responseBody, eTag: etag)
+            return .success(body: responseBody, eTag: etag, cacheControl: cacheControl)
+        case 304:
+            return .error(.clientError(responseCode: httpResponse.statusCode, body: responseBody, cacheControl: cacheControl))
         case 429:
             return .error(.rateLimitError(body: responseBody))
         case 400..<500:
-            return .error(.clientError(responseCode: httpResponse.statusCode, body: responseBody))
+            return .error(.clientError(responseCode: httpResponse.statusCode, body: responseBody, cacheControl: nil))
         case 500..<600:
             return .error(.serverError(responseCode: httpResponse.statusCode, body: responseBody))
         default:

--- a/ios/Sources/MeasureSDK/Swift/Exporter/HttpModels.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/HttpModels.swift
@@ -13,14 +13,14 @@ enum MultipartData {
 }
 
 enum HttpResponse {
-    case success(body: String?, eTag: String?)
+    case success(body: String?, eTag: String?, cacheControl: String?)
     case error(HttpError)
 }
 
 enum HttpError {
     case unknownError(String)
     case rateLimitError(body: String?)
-    case clientError(responseCode: Int, body: String?)
+    case clientError(responseCode: Int, body: String?, cacheControl: String?)
     case serverError(responseCode: Int, body: String?)
 }
 

--- a/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exporter/NetworkClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum ConfigResponse {
     case success(config: BaseDynamicConfig, eTag: String?, cacheControl: Number)
-    case notModified
+    case notModified(cacheControl: Number)
     case error
 }
 
@@ -24,13 +24,15 @@ final class BaseNetworkClient: NetworkClient {
     private let httpClient: HttpClient
     private let eventSerializer: EventSerializer
     private let systemFileManager: SystemFileManager
+    private let logger: Logger
 
-    init(client: Client, httpClient: HttpClient, eventSerializer: EventSerializer, systemFileManager: SystemFileManager) {
+    init(client: Client, httpClient: HttpClient, eventSerializer: EventSerializer, systemFileManager: SystemFileManager, logger: Logger) {
         self.baseUrl = client.apiUrl
         self.apiKey = client.apiKey
         self.httpClient = httpClient
         self.eventSerializer = eventSerializer
         self.systemFileManager = systemFileManager
+        self.logger = logger
     }
 
     func execute(batchId: String, events: [EventEntity], spans: [SpanEntity]) -> HttpResponse {
@@ -38,7 +40,7 @@ final class BaseNetworkClient: NetworkClient {
         let serializedSpans = spans.compactMap { eventSerializer.serializeSpan($0) }
 
         if serializedEvents.isEmpty && serializedSpans.isEmpty {
-            return .success(body: "{}", eTag: nil)
+            return .success(body: "{}", eTag: nil, cacheControl: nil)
         }
 
         let jsonBody = buildBatchPayload(events: serializedEvents, spans: serializedSpans)
@@ -71,7 +73,7 @@ final class BaseNetworkClient: NetworkClient {
         )
 
         switch response {
-        case .success(let body, let newETag):
+        case .success(let body, let newETag, let cacheControlHeader):
 
             guard let body,
                   let data = body.data(using: .utf8) else {
@@ -82,26 +84,40 @@ final class BaseNetworkClient: NetworkClient {
                 let decoder = JSONDecoder()
                 let config = try decoder.decode(BaseDynamicConfig.self, from: data)
 
-                // default 5 minutes if backend forgets
-                let cacheControl = 300
+                let cacheControlMs = parseCacheControlMaxAgeMs(cacheControlHeader)
 
                 return .success(
                     config: config,
                     eTag: newETag,
-                    cacheControl: Number(cacheControl)
+                    cacheControl: cacheControlMs
                 )
             } catch {
                 return .error
             }
 
         case .error(let error):
-
-            if case .clientError(let code, _) = error, code == 304 {
-                return .notModified
+            if case .clientError(let code, _, let cacheControlHeader) = error, code == 304 {
+                let cacheControlMs = parseCacheControlMaxAgeMs(cacheControlHeader)
+                return .notModified(cacheControl: cacheControlMs)
             }
 
             return .error
         }
+    }
+
+    private func parseCacheControlMaxAgeMs(_ header: String?) -> Number {
+        guard let header,
+              let range = header.range(of: "max-age=(\\d+)", options: .regularExpression) else {
+            return 0
+        }
+
+        let match = header[range]
+        guard let equalsIndex = match.firstIndex(of: "="),
+              let maxAgeSeconds = Number(match[match.index(after: equalsIndex)...]) else {
+            return 0
+        }
+
+        return maxAgeSeconds * 1000
     }
 
     private func buildBatchPayload(events: [Data], spans: [Data]) -> Data {

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -233,7 +233,8 @@ final class BaseMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
         self.networkClient = BaseNetworkClient(client: client,
                                                httpClient: httpClient,
                                                eventSerializer: EventSerializer(),
-                                               systemFileManager: systemFileManager)
+                                               systemFileManager: systemFileManager,
+                                               logger: logger)
         self.timeProvider = BaseTimeProvider()
         self.measureDispatchQueue = BaseMeasureDispatchQueue()
         self.configLoader = BaseConfigLoader(userDefaultStorage: userDefaultStorage,

--- a/ios/Tests/MeasureSDKTests/Config/ConfigLoaderTests.swift
+++ b/ios/Tests/MeasureSDKTests/Config/ConfigLoaderTests.swift
@@ -100,7 +100,7 @@ final class ConfigLoaderTests: XCTestCase {
     func testLoadConfig_fetchesConfig_whenCacheExpired() {
         setupCacheExpired()
 
-        mockNetworkClient.configResponse = .notModified
+        mockNetworkClient.configResponse = .notModified(cacheControl: 0)
 
         configLoader.loadDynamicConfig { _ in }
 
@@ -140,15 +140,30 @@ final class ConfigLoaderTests: XCTestCase {
         XCTAssert(mockUserDefaults.eTag!.isEmpty)
     }
 
-    func testLoadConfig_notModified_onlyUpdatesTimestamp() {
+    func testLoadConfig_notModified_withoutCacheControl_onlyUpdatesTimestamp() {
         setupCacheExpired()
 
         mockUserDefaults.configFetchTimestamp = 10
-        mockNetworkClient.configResponse = .notModified
+        let existingCacheControl = mockUserDefaults.configCacheControl
+        mockNetworkClient.configResponse = .notModified(cacheControl: 0)
 
         configLoader.loadDynamicConfig { _ in }
 
         XCTAssertEqual(mockUserDefaults.configFetchTimestamp, mockTimeProvider.current)
+        XCTAssertEqual(mockUserDefaults.configCacheControl, existingCacheControl)
+        XCTAssertTrue(mockFileManager.savedFiles.isEmpty)
+    }
+
+    func testLoadConfig_notModified_withCacheControl_updatesWindow() {
+        setupCacheExpired()
+
+        mockUserDefaults.configFetchTimestamp = 10
+        mockNetworkClient.configResponse = .notModified(cacheControl: 3600)
+
+        configLoader.loadDynamicConfig { _ in }
+
+        XCTAssertEqual(mockUserDefaults.configFetchTimestamp, mockTimeProvider.current)
+        XCTAssertEqual(mockUserDefaults.configCacheControl, 3600)
         XCTAssertTrue(mockFileManager.savedFiles.isEmpty)
     }
 
@@ -167,7 +182,7 @@ final class ConfigLoaderTests: XCTestCase {
     func testLoadConfig_passesStoredEtag() {
         setupCacheExpired()
         mockUserDefaults.eTag = "old-etag"
-        mockNetworkClient.configResponse = .notModified
+        mockNetworkClient.configResponse = .notModified(cacheControl: 0)
 
         configLoader.loadDynamicConfig { _ in }
 

--- a/ios/Tests/MeasureSDKTests/Exporter/ExporterTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/ExporterTests.swift
@@ -131,7 +131,7 @@ final class BaseExporterTests: XCTestCase {
     }
 
     func testExportsExistingBatch() {
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         let event = makeEvent(id: "e1", sessionId: "s1")
         eventStore.insertEvent(event: event)
@@ -152,7 +152,7 @@ final class BaseExporterTests: XCTestCase {
     }
 
     func testDeletesBatchOnSuccess() {
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         let event = makeEvent(id: "e1", sessionId: "s1")
         eventStore.insertEvent(event: event)
@@ -202,8 +202,8 @@ final class BaseExporterTests: XCTestCase {
         {"attachments":[{"id":"a1","type":"screenshot","filename":"layout_snapshot.png","upload_url":"https://example.com/a1","expires_at":"x","headers":{}}]}
         """
 
-        network.executeResponse = .success(body: json, eTag: nil)
-        http.uploadResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: json, eTag: nil, cacheControl: nil)
+        http.uploadResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         let event = makeEvent(id: "e1", sessionId: "s1")
         eventStore.insertEvent(event: event)
@@ -240,7 +240,7 @@ final class BaseExporterTests: XCTestCase {
     }
 
     func testExportsExistingBatchesInOrder() {
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
         
         eventStore.insertEvent(event: makeEvent(id: "e1", sessionId: "s1"))
         _ = batchStore.insertBatch(.init(batchId: "b1", eventIds: ["e1"], spanIds: [], createdAt: 0))
@@ -261,7 +261,7 @@ final class BaseExporterTests: XCTestCase {
     }
     
     func testExportsBatchWithEventsAndSpans() {
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
         
         eventStore.insertEvent(event: makeEvent(id: "e1", sessionId: "s1"))
         spanStore.insertSpan(span: makeSpan(id: "sp1", sessionId: "s1"))
@@ -312,7 +312,7 @@ final class BaseExporterTests: XCTestCase {
     }
     
     func testHandlesNilResponseBodyGracefully() {
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
         
         eventStore.insertEvent(event: makeEvent(id: "e1", sessionId: "s1"))
         _ = batchStore.insertBatch(.init(batchId: "b1", eventIds: ["e1"], spanIds: [], createdAt: 0))
@@ -330,7 +330,7 @@ final class BaseExporterTests: XCTestCase {
     }
     
     func testHandlesMalformedResponseBody() {
-        network.executeResponse = .success(body: "nope", eTag: nil)
+        network.executeResponse = .success(body: "nope", eTag: nil, cacheControl: nil)
         
         eventStore.insertEvent(event: makeEvent(id: "e1", sessionId: "s1"))
         _ = batchStore.insertBatch(.init(batchId: "b1", eventIds: ["e1"], spanIds: [], createdAt: 0))
@@ -348,7 +348,7 @@ final class BaseExporterTests: XCTestCase {
     }
     
     func testDeletesBatchOnClientError() {
-        network.executeResponse = .error(.clientError(responseCode: 400, body: nil))
+        network.executeResponse = .error(.clientError(responseCode: 400, body: nil, cacheControl: nil))
         
         eventStore.insertEvent(event: makeEvent(id: "e1", sessionId: "s1"))
         _ = batchStore.insertBatch(.init(batchId: "b1", eventIds: ["e1"], spanIds: [], createdAt: 0))
@@ -385,7 +385,7 @@ final class BaseExporterTests: XCTestCase {
 
     func testCreatesMultipleBatchesWhenEventsExceedConfigLimit() {
         config.maxEventsInBatch = 5
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         for i in 0..<11 {
             eventStore.insertEvent(event: makeEvent(id: "e\(i)", sessionId: "s1"))
@@ -407,7 +407,7 @@ final class BaseExporterTests: XCTestCase {
 
     func testSpansAreSplitIntoMultipleBatches() {
         config.maxEventsInBatch = 3
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         for i in 0..<7 {
             spanStore.insertSpan(span: makeSpan(id: "sp\(i)", sessionId: "s1"))
@@ -430,7 +430,7 @@ final class BaseExporterTests: XCTestCase {
     func testPayloadLimitSplitsBatchWhenConfigLimitIsLarger() {
         // payload limit: 9 MB / 1 KB = 8_789 events per batch
         config.maxEventsInBatch = 20_000
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         for i in 0..<8_790 {
             eventStore.insertEvent(event: makeEvent(id: "e\(i)", sessionId: "s1"))
@@ -453,7 +453,7 @@ final class BaseExporterTests: XCTestCase {
     func testUsesConfigLimitWhenSmallerThanPayloadLimit() {
         // config limit (5) < payload limit (8_789), so config wins
         config.maxEventsInBatch = 5
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         for i in 0..<6 {
             eventStore.insertEvent(event: makeEvent(id: "e\(i)", sessionId: "s1"))
@@ -475,7 +475,7 @@ final class BaseExporterTests: XCTestCase {
 
     func testMixedEventsAndSpansRespectPayloadLimit() {
         config.maxEventsInBatch = 5
-        network.executeResponse = .success(body: nil, eTag: nil)
+        network.executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
         for i in 0..<4 {
             eventStore.insertEvent(event: makeEvent(id: "e\(i)", sessionId: "s1"))

--- a/ios/Tests/MeasureSDKTests/Exporter/NetworkClientTests.swift
+++ b/ios/Tests/MeasureSDKTests/Exporter/NetworkClientTests.swift
@@ -1,0 +1,101 @@
+//
+//  NetworkClientTests.swift
+//  MeasureSDKTests
+//
+
+import XCTest
+@testable import Measure
+
+final class NetworkClientTests: XCTestCase {
+    private var mockHttpClient: MockHttpClient!
+    private var networkClient: BaseNetworkClient!
+    private var configBody: String!
+
+    override func setUp() {
+        super.setUp()
+
+        mockHttpClient = MockHttpClient()
+        networkClient = BaseNetworkClient(
+            client: ClientInfo(apiKey: "test", apiUrl: "https://test.com"),
+            httpClient: mockHttpClient,
+            eventSerializer: EventSerializer(),
+            systemFileManager: MockSystemFileManager(),
+            logger: MockLogger()
+        )
+
+        let data = try? JSONEncoder().encode(BaseDynamicConfig())
+        configBody = String(data: data ?? Data(), encoding: .utf8)
+    }
+
+    override func tearDown() {
+        mockHttpClient = nil
+        networkClient = nil
+        configBody = nil
+        super.tearDown()
+    }
+
+    func testGetConfig_success_parsesMaxAgeFromHeader() throws {
+        mockHttpClient.sendResponse = .success(body: configBody, eTag: "etag", cacheControl: "max-age=600")
+
+        let response = networkClient.getConfig(eTag: nil)
+
+        guard case .success(_, _, let cacheControl) = response else {
+            return XCTFail("Expected .success")
+        }
+        XCTAssertEqual(cacheControl, 600_000)
+    }
+
+    func testGetConfig_success_fallsBackToZero_whenHeaderMissing() throws {
+        mockHttpClient.sendResponse = .success(body: configBody, eTag: "etag", cacheControl: nil)
+
+        let response = networkClient.getConfig(eTag: nil)
+
+        guard case .success(_, _, let cacheControl) = response else {
+            return XCTFail("Expected .success")
+        }
+        XCTAssertEqual(cacheControl, 0)
+    }
+
+    func testGetConfig_success_fallsBackToZero_whenHeaderUnparseable() throws {
+        mockHttpClient.sendResponse = .success(body: configBody, eTag: "etag", cacheControl: "no-cache")
+
+        let response = networkClient.getConfig(eTag: nil)
+
+        guard case .success(_, _, let cacheControl) = response else {
+            return XCTFail("Expected .success")
+        }
+        XCTAssertEqual(cacheControl, 0)
+    }
+
+    func testGetConfig_notModified_parsesMaxAgeFromHeader() {
+        mockHttpClient.sendResponse = .error(.clientError(responseCode: 304, body: nil, cacheControl: "max-age=600"))
+
+        let response = networkClient.getConfig(eTag: "etag")
+
+        guard case .notModified(let cacheControl) = response else {
+            return XCTFail("Expected .notModified")
+        }
+        XCTAssertEqual(cacheControl, 600_000)
+    }
+
+    func testGetConfig_notModified_fallsBackToZero_whenHeaderMissing() {
+        mockHttpClient.sendResponse = .error(.clientError(responseCode: 304, body: nil, cacheControl: nil))
+
+        let response = networkClient.getConfig(eTag: "etag")
+
+        guard case .notModified(let cacheControl) = response else {
+            return XCTFail("Expected .notModified")
+        }
+        XCTAssertEqual(cacheControl, 0)
+    }
+
+    func testGetConfig_error_whenClientErrorIsNot304() {
+        mockHttpClient.sendResponse = .error(.clientError(responseCode: 400, body: nil, cacheControl: nil))
+
+        let response = networkClient.getConfig(eTag: nil)
+
+        guard case .error = response else {
+            return XCTFail("Expected .error")
+        }
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockHttpClient.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockHttpClient.swift
@@ -12,8 +12,8 @@ final class MockHttpClient: HttpClient {
     private(set) var sentUrls: [URL] = []
     private(set) var uploadedUrls: [URL] = []
 
-    var sendResponse: HttpResponse = .success(body: nil, eTag: nil)
-    var uploadResponse: HttpResponse = .success(body: nil, eTag: nil)
+    var sendResponse: HttpResponse = .success(body: nil, eTag: nil, cacheControl: nil)
+    var uploadResponse: HttpResponse = .success(body: nil, eTag: nil, cacheControl: nil)
 
     func sendJsonRequest(
         url: URL,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -152,7 +152,8 @@ final class MockMeasureInitializer: MeasureInitializer {
         self.networkClient = networkClient ?? BaseNetworkClient(client: self.client,
                                                httpClient: self.httpClient,
                                                eventSerializer: EventSerializer(),
-                                               systemFileManager: self.systemFileManager)
+                                               systemFileManager: self.systemFileManager,
+                                               logger: self.logger)
         self.timeProvider = timeProvider ?? BaseTimeProvider()
         self.measureDispatchQueue = measureDispatchQueue ?? BaseMeasureDispatchQueue()
         self.configLoader = configLoader ?? BaseConfigLoader(userDefaultStorage: self.userDefaultStorage,

--- a/ios/Tests/MeasureSDKTests/Mocks/MockNetworkClient.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockNetworkClient.swift
@@ -17,8 +17,8 @@ final class MockNetworkClient: NetworkClient {
     private(set) var executedEventCounts: [Int] = []
     private(set) var executedSpanCounts: [Int] = []
 
-    var executeResponse: HttpResponse = .success(body: nil, eTag: nil)
-    var configResponse: ConfigResponse = .notModified
+    var executeResponse: HttpResponse = .success(body: nil, eTag: nil, cacheControl: nil)
+    var configResponse: ConfigResponse = .notModified(cacheControl: 0)
 
     func execute(batchId: String, events: [EventEntity], spans: [SpanEntity]) -> HttpResponse {
         executedBatchIds.append(batchId)
@@ -40,15 +40,15 @@ final class MockNetworkClient: NetworkClient {
         lastEvents = []
         lastSpans = []
         lastETag = nil
-        executeResponse = .success(body: nil, eTag: nil)
-        configResponse = .notModified
+        executeResponse = .success(body: nil, eTag: nil, cacheControl: nil)
+        configResponse = .notModified(cacheControl: 0)
         executedBatchIds = []
         executedEventCounts = []
         executedSpanCounts = []
     }
 
     func stubExecuteSuccess(body: String? = nil, eTag: String? = nil) {
-        executeResponse = .success(body: body, eTag: eTag)
+        executeResponse = .success(body: body, eTag: eTag, cacheControl: nil)
     }
 
     func stubExecuteError(_ error: HttpError) {


### PR DESCRIPTION
# Description

This PR contains below changes:

- Parse max-age from the Cache-Control header instead of hardcoding 300s
- Store the cache-control window in milliseconds to match timestamp units
- Classify 304 responses correctly and preserve the cache window when the header is absent

## Related issue
Fixes #4329
Fixes #4327 