### PR TITLE
fix(backend): write the sdk config cache after row is updated

### DIFF
--- a/backend/api/handlers/sdkconfig.go
+++ b/backend/api/handlers/sdkconfig.go
@@ -29,7 +29,7 @@ const configColumns = `max_events_in_batch, crash_timeline_duration, anr_timelin
 	http_track_request_for_urls, http_track_response_for_urls, http_blocked_headers,
 	profile_sampling_rate, updated_at, updated_by`
 
-// PatchConfigForApp applies a patch to an app's SDK config, updating Postgres & the cache together.
+// PatchConfigForApp applies a patch to an app's SDK config in Postgres, then refreshes the cache.
 func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userID string) error {
 	var patch sdkconfig.ConfigPatch
 	if err := c.ShouldBindJSON(&patch); err != nil {
@@ -127,7 +127,8 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 		}
 		stmt.Set("profile_sampling_rate", *patch.ProfileSamplingRate)
 	}
-	stmt.Set("updated_at", time.Now())
+	// the database clock, evaluated after the row lock, orders concurrent patches
+	stmt.SetExpr("updated_at", "clock_timestamp()")
 	stmt.Set("updated_by", &userIdUUID)
 	stmt.Where("app_id = ?", appID)
 
@@ -137,15 +138,8 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 
 	ctx := c.Request.Context()
 
-	tx, err := deps.PgPool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-
-	defer tx.Rollback(ctx)
-
 	var config sdkconfig.SdkConfig
-	if err := tx.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(
+	if err := deps.PgPool.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(
 		&config.MaxEventsInBatch,
 		&config.CrashTimelineDuration,
 		&config.ANRTimelineDuration,
@@ -182,22 +176,23 @@ func PatchConfigForApp(c *gin.Context, deps *server.Deps, appID uuid.UUID, userI
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// inside the txn, a cache failure rolls the row back, except a TTL-only failure
-	if err := sdkconfig.SetCache(ctx, deps.VK, appID, jsonConfig); err != nil {
-		if !errors.Is(err, sdkconfig.ErrCacheTTLNotSet) {
-			return fmt.Errorf("failed to write config cache: %w", err)
-		}
-		fmt.Println("failed to set config cache ttl, app_id:", appID, err)
+	// the cache guard fences on this, a nil means RETURNING dropped a column we set
+	if config.UpdatedAt == nil {
+		return fmt.Errorf("update returned no updated_at for app_id: %s", appID)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		// ctx may be why the commit failed, so don't inherit its cancellation
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer cancel()
-		if err := sdkconfig.InvalidateCache(cleanupCtx, deps.VK, appID); err != nil {
-			fmt.Println("failed to invalidate config cache after commit failure, app_id:", appID, err)
+	// postgres is already updated & is the source of truth, the cache is best effort
+	cacheCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
+	if err := sdkconfig.SetCache(cacheCtx, deps.VK, appID, jsonConfig, *config.UpdatedAt); err != nil {
+		fmt.Println("failed to write config cache, app_id:", appID, err)
+		// a fresh deadline, cacheCtx may be exhausted by the write that just failed
+		dropCtx, dropCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer dropCancel()
+		if err := sdkconfig.InvalidateCache(dropCtx, deps.VK, appID); err != nil {
+			fmt.Println("failed to drop config cache, app_id:", appID, err)
 		}
-		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return nil

--- a/backend/api/handlers/sdkconfig_test.go
+++ b/backend/api/handlers/sdkconfig_test.go
@@ -107,22 +107,21 @@ func TestPatchConfigForApp_SlowReaderCannotOverwrite(t *testing.T) {
 	}
 }
 
-func TestPatchConfigForApp_CacheFailureRollsBack(t *testing.T) {
+func TestPatchConfigForApp_CacheFailureStillUpdates(t *testing.T) {
 	ctx := context.Background()
 	defer cleanupAll(ctx, t)
 
 	appID, userID := seedSdkConfig(ctx, t)
-	before := maxEventsInDb(ctx, t, appID)
 
 	noCache := *deps
 	noCache.VK = nil
 
-	if err := patchMaxEvents(t, &noCache, appID, userID, 4242); err == nil {
-		t.Fatal("patch config succeeded, want cache write error")
+	if err := patchMaxEvents(t, &noCache, appID, userID, 4242); err != nil {
+		t.Fatalf("patch config: %v", err)
 	}
 
-	if got := maxEventsInDb(ctx, t, appID); got != before {
-		t.Errorf("max_events_in_batch = %d, want %d, update was not rolled back", got, before)
+	if got := maxEventsInDb(ctx, t, appID); got != 4242 {
+		t.Errorf("max_events_in_batch = %d, want 4242", got)
 	}
 }
 

--- a/backend/libs/sdkconfig/sdkconfig.go
+++ b/backend/libs/sdkconfig/sdkconfig.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,23 +23,21 @@ const (
 	// cacheFieldData keeps the entry a hash & marks the payload shape.
 	// Rename it when the shape changes so legacy entries read as a miss.
 	cacheFieldData = "config"
+	// cacheFieldUpdatedAt holds the source row's updated_at in unix micros.
+	cacheFieldUpdatedAt = "updated_at"
 )
 
 // Config cache TTL & jitter.
 const (
 	// configCacheTTL is how long a cached config entry lives, jittered so
 	// entries written together don't expire together.
-	configCacheTTL = 24 * time.Hour
+	configCacheTTL = 4 * time.Hour
 	// configCacheTTLJitter is the fraction configCacheTTL varies by, either way.
 	configCacheTTLJitter = 0.10
 )
 
 // ErrNoCacheClient is returned by cache writes when no Valkey client is configured.
 var ErrNoCacheClient = errors.New("valkey client not available")
-
-// ErrCacheTTLNotSet is returned when the value was cached but its expiry was not
-// set, so the entry risks living forever.
-var ErrCacheTTLNotSet = errors.New("failed to set config cache ttl")
 
 // jitteredCacheTTL returns configCacheTTL varied by up to configCacheTTLJitter
 // either way, in whole seconds.
@@ -180,51 +179,72 @@ func GetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID) (data stri
 	return data, nil
 }
 
-// SetCache writes the config JSON unconditionally & refreshes its TTL, for the
-// patch path only. Returns ErrCacheTTLNotSet if the write succeeds but the TTL
-// could not be set.
-func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
+// setCacheScript stores the config & refreshes the TTL only when the incoming
+// updated_at is strictly newer than the cached one, so two concurrent patches
+// can't land out of order. ARGV: 1 config JSON, 2 updated_at in unix micros,
+// 3 TTL seconds. Returns 1 on write, 0 when a newer entry already won.
+//
+// The fence depends on updated_at, so changing how the patch path stamps it
+// stops this guard working.
+//
+// Micros, not nanos, embedded Lua is 5.1 so numbers are float64 & unix nanos
+// exceed the 53-bit mantissa.
+var setCacheScript = valkey.NewLuaScript(fmt.Sprintf(`
+local cur = redis.call('HGET', KEYS[1], '%[2]s')
+if cur and tonumber(cur) >= tonumber(ARGV[2]) then
+  return 0
+end
+redis.call('HSET', KEYS[1], '%[1]s', ARGV[1], '%[2]s', ARGV[2])
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+return 1
+`, cacheFieldData, cacheFieldUpdatedAt))
+
+// setCacheIfAbsentScript stores the config only when absent, but always tries
+// the TTL so a legacy key with no expiry gains one. ARGV: 1 config JSON,
+// 2 TTL seconds.
+var setCacheIfAbsentScript = valkey.NewLuaScript(fmt.Sprintf(`
+redis.call('HSETNX', KEYS[1], '%s', ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[2], 'NX')
+return 1
+`, cacheFieldData))
+
+// SetCache writes the config JSON & refreshes its TTL, for the patch path only.
+// A write older than what is cached is dropped, which is the guard working, not
+// an error.
+func SetCache(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte, updatedAt time.Time) error {
 	if vk == nil {
 		return ErrNoCacheClient
 	}
 
-	key := configCacheKey(appID)
-	set := vk.B().Hset().Key(key).FieldValue().
-		FieldValue(cacheFieldData, string(jsonConfig)).
-		Build()
-	// unconditional, refreshes the ttl on every write
-	expire := vk.B().Expire().Key(key).Seconds(jitteredCacheTTL()).Build()
-
-	results := vk.DoMulti(ctx, set, expire)
-	if err := results[0].Error(); err != nil {
-		return fmt.Errorf("failed to store config hash: %w", err)
+	keys := []string{configCacheKey(appID)}
+	args := []string{
+		string(jsonConfig),
+		strconv.FormatInt(updatedAt.UnixMicro(), 10),
+		strconv.FormatInt(jitteredCacheTTL(), 10),
 	}
-	if err := results[1].Error(); err != nil {
-		return fmt.Errorf("%w: %w", ErrCacheTTLNotSet, err)
+
+	if err := setCacheScript.Exec(ctx, vk, keys, args).Error(); err != nil {
+		return fmt.Errorf("failed to store config hash: %w", err)
 	}
 
 	return nil
 }
 
 // SetCacheIfAbsent writes the config JSON & sets a TTL only when absent, else
-// a slow reader can overwrite a fresh config or extend its TTL. Returns
-// ErrCacheTTLNotSet if the write succeeds but the TTL could not be set.
+// a slow reader can overwrite a fresh config or extend its TTL.
 func SetCacheIfAbsent(ctx context.Context, vk valkey.Client, appID uuid.UUID, jsonConfig []byte) error {
 	if vk == nil {
 		return ErrNoCacheClient
 	}
 
-	key := configCacheKey(appID)
-	set := vk.B().Hsetnx().Key(key).Field(cacheFieldData).Value(string(jsonConfig)).Build()
-	// NX only, readers hit this path on a live key & must not extend its ttl
-	expire := vk.B().Expire().Key(key).Seconds(jitteredCacheTTL()).Nx().Build()
-
-	results := vk.DoMulti(ctx, set, expire)
-	if err := results[0].Error(); err != nil {
-		return fmt.Errorf("failed to store config hash: %w", err)
+	keys := []string{configCacheKey(appID)}
+	args := []string{
+		string(jsonConfig),
+		strconv.FormatInt(jitteredCacheTTL(), 10),
 	}
-	if err := results[1].Error(); err != nil {
-		return fmt.Errorf("%w: %w", ErrCacheTTLNotSet, err)
+
+	if err := setCacheIfAbsentScript.Exec(ctx, vk, keys, args).Error(); err != nil {
+		return fmt.Errorf("failed to store config hash: %w", err)
 	}
 
 	return nil

--- a/backend/libs/sdkconfig/sdkconfig_test.go
+++ b/backend/libs/sdkconfig/sdkconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"backend/testinfra"
 
@@ -38,9 +39,10 @@ func ttlOf(t *testing.T, ctx context.Context, key string) int64 {
 
 func assertTTLInJitterWindow(t *testing.T, ttl int64) {
 	t.Helper()
-	const lo, hi = int64(21.6 * 3600), int64(26.4 * 3600)
-	if ttl <= lo || ttl > hi {
-		t.Fatalf("expected ttl in (%d, %d], got %d", lo, hi, ttl)
+	lo := int64(configCacheTTL.Seconds() * (1 - configCacheTTLJitter))
+	hi := int64(configCacheTTL.Seconds() * (1 + configCacheTTLJitter))
+	if ttl < lo || ttl > hi {
+		t.Fatalf("expected ttl in [%d, %d], got %d", lo, hi, ttl)
 	}
 }
 
@@ -48,7 +50,7 @@ func TestSetCacheSetsTTL(t *testing.T) {
 	ctx := context.Background()
 	appID := uuid.New()
 
-	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`)); err != nil {
+	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`), time.Now()); err != nil {
 		t.Fatalf("SetCache: %v", err)
 	}
 
@@ -71,7 +73,7 @@ func TestSetCacheIfAbsentCannotExtendLiveTTL(t *testing.T) {
 	appID := uuid.New()
 	key := configCacheKey(appID)
 
-	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`)); err != nil {
+	if err := SetCache(ctx, vk, appID, []byte(`{"max_events_in_batch":10000}`), time.Now()); err != nil {
 		t.Fatalf("SetCache: %v", err)
 	}
 	if err := vk.Do(ctx, vk.B().Expire().Key(key).Seconds(60).Build()).Error(); err != nil {
@@ -112,6 +114,76 @@ func TestSetCacheIfAbsentGivesLegacyKeyTTL(t *testing.T) {
 
 	if ttl := ttlOf(t, ctx, key); ttl <= 0 {
 		t.Fatalf("expected legacy key to gain a ttl, got %d", ttl)
+	}
+}
+
+func TestSetCacheRejectsOlderWrite(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	t2 := time.Now()
+	t1 := t2.Add(-time.Minute)
+
+	newer := []byte(`{"max_events_in_batch":2222}`)
+	older := []byte(`{"max_events_in_batch":1111}`)
+
+	if err := SetCache(ctx, vk, appID, newer, t2); err != nil {
+		t.Fatalf("SetCache newer: %v", err)
+	}
+	if err := SetCache(ctx, vk, appID, older, t1); err != nil {
+		t.Fatalf("SetCache older: %v", err)
+	}
+
+	data, err := GetCache(ctx, vk, appID)
+	if err != nil {
+		t.Fatalf("GetCache: %v", err)
+	}
+	if data != string(newer) {
+		t.Fatalf("expected %q, got %q", newer, data)
+	}
+}
+
+func TestSetCacheAcceptsNewerWrite(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Minute)
+
+	older := []byte(`{"max_events_in_batch":1111}`)
+	newer := []byte(`{"max_events_in_batch":2222}`)
+
+	if err := SetCache(ctx, vk, appID, older, t1); err != nil {
+		t.Fatalf("SetCache older: %v", err)
+	}
+	if err := SetCache(ctx, vk, appID, newer, t2); err != nil {
+		t.Fatalf("SetCache newer: %v", err)
+	}
+
+	data, err := GetCache(ctx, vk, appID)
+	if err != nil {
+		t.Fatalf("GetCache: %v", err)
+	}
+	if data != string(newer) {
+		t.Fatalf("expected %q, got %q", newer, data)
+	}
+}
+
+func TestSetCacheWritesEmptyKey(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	jsonConfig := []byte(`{"max_events_in_batch":3333}`)
+	if err := SetCache(ctx, vk, appID, jsonConfig, time.Now()); err != nil {
+		t.Fatalf("SetCache: %v", err)
+	}
+
+	data, err := GetCache(ctx, vk, appID)
+	if err != nil {
+		t.Fatalf("GetCache: %v", err)
+	}
+	if data != string(jsonConfig) {
+		t.Fatalf("expected %q, got %q", jsonConfig, data)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR reorders the SDK config cache write to happen after the row is updated, so the cache only ever holds a config Postgres has committed. Concurrent saves are ordered by the row's version. The value & its expiry are written as one atomic step, with a shorter entry lifetime so any remaining lag repairs itself within hours.

## Tasks

- [x] Write the cache after the row is updated
- [x] Order concurrent saves by the row's version
- [x] Write the config & its expiry as one atomic step
- [x] Shorten a cache entry's lifetime to ~4h

## See also

- follows up #4330
