### PR TITLE
Improve enterprise plan handling

### DIFF
--- a/backend/api/handlers/app_retention_test.go
+++ b/backend/api/handlers/app_retention_test.go
@@ -188,8 +188,8 @@ func TestCreateAppRetention(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
 				},
@@ -213,8 +213,8 @@ func TestCreateAppRetention(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
@@ -238,8 +238,8 @@ func TestCreateAppRetention(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "plan_ent_foo"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "plan_ent_foo", Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 240},
 				},

--- a/backend/api/handlers/billing.go
+++ b/backend/api/handlers/billing.go
@@ -85,9 +85,10 @@ func (h Handlers) GetTeamBilling(c *gin.Context) {
 			if b, ok := cust.Balances[autumn.FeatureRetentionDays]; ok && b.Granted > 0 {
 				result.RetentionDays = measure.RetentionDaysFromBalance(b)
 			}
-			// Pick the active subscription. During a scheduled cancel, the
-			// customer also has a Free sub with status="scheduled" — we want
-			// the still-running Pro one, not whichever is index 0.
+			// Pick the active subscription, not whichever is index 0: during
+			// a scheduled cancel the customer also holds a scheduled Free sub.
+			// An enterpise plan is a one-off purchase and not a subscription, so for
+			// those teams this reports their Free plan, which no card shows.
 			for i := range cust.Subscriptions {
 				if cust.Subscriptions[i].Status == "active" {
 					s := &cust.Subscriptions[i]

--- a/backend/api/handlers/billing.go
+++ b/backend/api/handlers/billing.go
@@ -166,6 +166,12 @@ func (h Handlers) CreateCheckoutSession(c *gin.Context) {
 		return
 	}
 
+	if measure.DeterminePlan(cust) == measure.PlanEnterprise {
+		msg := `cannot create checkout session with enterprise plan`
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+		return
+	}
+
 	resp, err := autumn.Attach(ctx, autumn.AttachRequest{
 		CustomerID:   customerID,
 		PlanID:       measure.AutumnPlanPro,
@@ -217,6 +223,26 @@ func (h Handlers) CancelAndDowngradeToFreePlan(c *gin.Context) {
 	}
 	if customerID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "team billing not provisioned"})
+		return
+	}
+
+	// Only a Pro subscription can be cancelled from here. A free customer has
+	// nothing to cancel, and an enterprise plan is arranged directly with the
+	// Measure team, which is why the dashboard shows no downgrade button for
+	// either.
+	cust, err := autumn.GetCustomer(ctx, customerID)
+	if err != nil {
+		log.Println("autumn get customer failed (cancel pre-check):", err)
+		if autumn.IsServerOrNetworkError(err) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "billing service temporarily unavailable"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": "billing customer record is unavailable"})
+		return
+	}
+	if measure.DeterminePlan(cust) != measure.PlanPro {
+		msg := `only a pro plan can be cancelled`
+		c.JSON(http.StatusForbidden, gin.H{"error": msg})
 		return
 	}
 

--- a/backend/api/handlers/billing.go
+++ b/backend/api/handlers/billing.go
@@ -81,7 +81,7 @@ func (h Handlers) GetTeamBilling(c *gin.Context) {
 				result.TokenCreditsOverageAllowed = b.OverageAllowed
 			}
 			if b, ok := cust.Balances[autumn.FeatureRetentionDays]; ok && b.Granted > 0 {
-				result.RetentionDays = int(b.Granted)
+				result.RetentionDays = measure.RetentionDaysFromBalance(b)
 			}
 			// Pick the active subscription. During a scheduled cancel, the
 			// customer also has a Free sub with status="scheduled" — we want

--- a/backend/api/handlers/billing.go
+++ b/backend/api/handlers/billing.go
@@ -73,6 +73,8 @@ func (h Handlers) GetTeamBilling(c *gin.Context) {
 				result.BytesUsed = b.Usage
 				result.BytesUnlimited = b.Unlimited
 				result.BytesOverageAllowed = b.OverageAllowed
+				result.IngestionBlocked = !b.Unlimited && b.Remaining <= 0 && !b.OverageAllowed
+				result.DataPurchaseSpent = measure.DataPurchaseSpent(cust)
 			}
 			if b, ok := cust.Balances[autumn.FeatureAgentTokens]; ok {
 				result.TokenCreditsGranted = b.Granted

--- a/backend/api/handlers/billing.go
+++ b/backend/api/handlers/billing.go
@@ -16,10 +16,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// ----------------------------------------------------------------------------
-// HTTP handlers
-// ----------------------------------------------------------------------------
-
 func billingDisabled(c *gin.Context, deps *server.Deps) bool {
 	if !deps.Config.IsBillingEnabled() {
 		c.JSON(http.StatusNotFound, gin.H{"error": "billing is not enabled"})
@@ -85,10 +81,11 @@ func (h Handlers) GetTeamBilling(c *gin.Context) {
 			if b, ok := cust.Balances[autumn.FeatureRetentionDays]; ok && b.Granted > 0 {
 				result.RetentionDays = measure.RetentionDaysFromBalance(b)
 			}
-			// Pick the active subscription, not whichever is index 0: during
-			// a scheduled cancel the customer also holds a scheduled Free sub.
-			// An enterpise plan is a one-off purchase and not a subscription, so for
-			// those teams this reports their Free plan, which no card shows.
+			// During a scheduled cancel the customer also holds a scheduled free
+			// subscription, so the active one has to be picked rather than index
+			// 0. An enterprise plan is a one-off purchase rather than a
+			// subscription, so for those teams this reports their free plan,
+			// which no card shows.
 			for i := range cust.Subscriptions {
 				if cust.Subscriptions[i].Status == "active" {
 					s := &cust.Subscriptions[i]
@@ -151,9 +148,9 @@ func (h Handlers) CreateCheckoutSession(c *gin.Context) {
 		return
 	}
 
-	// Refuse if already Pro. Distinguish Autumn outage (503) from a 4xx
-	// (likely a missing customer record or config bug) so we don't proceed
-	// to Attach blindly and create a duplicate Stripe Checkout session.
+	// Refuse if the team is already on pro. An Autumn outage answers 503 and a
+	// 4xx, a missing customer record or a config bug, answers 400, so neither
+	// falls through to Attach and opens a duplicate Stripe Checkout session.
 	cust, err := autumn.GetCustomer(ctx, customerID)
 	if err != nil {
 		log.Println("autumn get customer failed (checkout pre-check):", err)
@@ -229,10 +226,9 @@ func (h Handlers) CancelAndDowngradeToFreePlan(c *gin.Context) {
 		return
 	}
 
-	// Only a Pro subscription can be cancelled from here. A free customer has
-	// nothing to cancel, and an enterprise plan is arranged directly with the
-	// Measure team, which is why the dashboard shows no downgrade button for
-	// either.
+	// Only a pro subscription can be cancelled from here. A free customer has
+	// nothing to cancel and an enterprise plan is arranged directly with the
+	// Measure team, so the dashboard shows no downgrade button for either.
 	cust, err := autumn.GetCustomer(ctx, customerID)
 	if err != nil {
 		log.Println("autumn get customer failed (cancel pre-check):", err)
@@ -249,10 +245,9 @@ func (h Handlers) CancelAndDowngradeToFreePlan(c *gin.Context) {
 		return
 	}
 
-	// Schedule cancellation at end of cycle. Pro stays usable until
-	// CurrentPeriodEnd. After expiry, Autumn auto-activates the plan marked
-	// is_default in the dashboard (Free), which fires billing.updated with the
-	// Pro plan expired — the webhook handler resets retention then.
+	// Pro stays usable until the end of the cycle. After it expires Autumn
+	// activates the plan marked is_default in the dashboard, the free plan,
+	// which fires a billing.updated the webhook handler acts on.
 	if _, err := autumn.Update(ctx, autumn.UpdateRequest{
 		CustomerID:   customerID,
 		PlanID:       measure.AutumnPlanPro,
@@ -298,9 +293,8 @@ func (h Handlers) UndoDowngradeToFreePlan(c *gin.Context) {
 		return
 	}
 
-	// Verify there's actually a pending cancellation to undo. Calling
-	// update(uncancel) on a customer with no scheduled cancel returns an
-	// opaque 4xx from Autumn; we'd rather give a clear 400 here.
+	// Uncancelling a customer with no scheduled cancel returns an opaque 4xx
+	// from Autumn, so check for a pending cancellation and answer clearly.
 	cust, err := autumn.GetCustomer(ctx, customerID)
 	if err != nil {
 		log.Println("autumn get customer failed (uncancel pre-check):", err)
@@ -395,10 +389,6 @@ func (h Handlers) CreateCustomerPortalSession(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"url": url})
 }
 
-// ----------------------------------------------------------------------------
-// Webhook
-// ----------------------------------------------------------------------------
-
 func (h Handlers) HandleAutumnWebhook(c *gin.Context) {
 	deps := h.Deps
 	if billingDisabled(c, deps) {
@@ -455,5 +445,3 @@ func (h Handlers) HandleAutumnWebhook(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"received": true})
 }
-
-// lookupTeamIDByAutumnCustomer finds the team with the given autumn_customer_id.

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -51,6 +51,22 @@ func signSvixWebhook(t *testing.T, secret, msgID string, payload []byte) http.He
 	return hdr
 }
 
+// countQueuedTeamEmails returns how many emails the webhook queued for a team.
+// Plan transition emails go into pending_alert_messages, one row per team
+// member, and a background worker picks them up from there.
+func countQueuedTeamEmails(ctx context.Context, t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+
+	var count int
+	err := th.PgPool.QueryRow(ctx,
+		`SELECT count(*) FROM pending_alert_messages WHERE team_id = $1 AND channel = 'email'`,
+		teamID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count queued team emails: %v", err)
+	}
+	return count
+}
+
 // --------------------------------------------------------------------------
 // DeterminePlan
 // --------------------------------------------------------------------------
@@ -1544,23 +1560,31 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		}
 	})
 
-	t.Run("billing.updated:new with measure_free is a no-op (auto-attach during team creation)", func(t *testing.T) {
-		// Free is auto-attached for every new cloud team, firing scenario=new.
-		// We must NOT send "Upgraded to Pro" emails on signup, and there are
-		// no apps yet to reset retention on.
+	t.Run("billing.updated:new with measure_free resets retention and sends no email (auto-attach during team creation)", func(t *testing.T) {
+		// Free is auto-attached for every new cloud team, firing scenario=new
+		// with a lone activation. Retention follows the plan the team now
+		// holds, and with no plan expiring alongside it there is no upgrade to
+		// announce, so no "Upgraded to Pro" email goes out on signup.
 		defer cleanupAll(ctx, t)
 		withAutumnWebhookSecret(t, secret)
 
 		teamID := uuid.New()
 		appID := uuid.New()
+		userID := uuid.New().String()
 		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, userID, "new-free@test.com")
+		seedTeamMembership(ctx, t, teamID, userID, "owner")
 		seedApp(ctx, t, appID, teamID, 90)
 		custID := uuid.New().String()
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
-			t.Errorf("autumn.GetCustomer must not be called for scenario=new+measure_free")
-			return nil, errors.New("unexpected")
+			return &autumn.Customer{
+				ID: custID,
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
+				},
+			}, nil
 		})
 
 		payload := []byte(fmt.Sprintf(
@@ -1574,8 +1598,144 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
 		}
+		if got := getAppRetention(ctx, t, appID); got != measure.MIN_RETENTION_DAYS {
+			t.Errorf("retention after new+free = %d, want %d", got, measure.MIN_RETENTION_DAYS)
+		}
+		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
+			t.Errorf("queued emails after new+free = %d, want 0", got)
+		}
+	})
+
+	t.Run("billing.updated:one-off attach resets retention and sends no email", func(t *testing.T) {
+		// A one-off plan is attached on top of the free plan the team already
+		// holds. Autumn expires nothing in that case, so the payload carries a
+		// lone activation whose plan arrives as a purchase rather than a
+		// subscription, and retention still has to follow the bespoke plan.
+		defer cleanupAll(ctx, t)
+		withAutumnWebhookSecret(t, secret)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		userID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, userID, "one-off@test.com")
+		seedTeamMembership(ctx, t, teamID, userID, "owner")
+		seedApp(ctx, t, appID, teamID, measure.MIN_RETENTION_DAYS)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		// The team holds the free plan and the bespoke one at once, so the
+		// balance breaks the grant down per plan and the longer of the two wins.
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:        custID,
+				Purchases: []autumn.Purchase{{PlanID: "acme_one_year"}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   210,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: measure.AutumnPlanFree, IncludedGrant: 30},
+							{PlanID: "acme_one_year", IncludedGrant: 180},
+						},
+					},
+				},
+			}, nil
+		})
+
+		payload := []byte(fmt.Sprintf(
+			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","purchase":{"plan_id":"acme_one_year","status":"active","expires_at":1790000000000}}]}}`,
+			custID,
+		))
+		headers := signSvixWebhook(t, secret, "msg_one_off", payload)
+		c, w := webhookReq(payload, headers)
+		h.HandleAutumnWebhook(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		if got := getAppRetention(ctx, t, appID); got != 180 {
+			t.Errorf("retention after one-off attach = %d, want 180", got)
+		}
+		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
+			t.Errorf("queued emails after one-off attach = %d, want 0", got)
+		}
+	})
+
+	t.Run("billing.updated:paired upgrade resets retention and queues the upgrade email", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		withAutumnWebhookSecret(t, secret)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		userID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, userID, "paired-upgrade@test.com")
+		seedTeamMembership(ctx, t, teamID, userID, "owner")
+		seedApp(ctx, t, appID, teamID, measure.MIN_RETENTION_DAYS)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
+				},
+			}, nil
+		})
+
+		payload := []byte(fmt.Sprintf(
+			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":%q}},{"action":"expired","subscription":{"plan_id":%q}}]}}`,
+			custID, measure.AutumnPlanPro, measure.AutumnPlanFree,
+		))
+		headers := signSvixWebhook(t, secret, "msg_paired_upgrade", payload)
+		c, w := webhookReq(payload, headers)
+		h.HandleAutumnWebhook(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
 		if got := getAppRetention(ctx, t, appID); got != 90 {
-			t.Errorf("retention after new+free = %d, want 90 (unchanged)", got)
+			t.Errorf("retention after paired upgrade = %d, want 90", got)
+		}
+		if got := countQueuedTeamEmails(ctx, t, teamID); got != 1 {
+			t.Errorf("queued emails after paired upgrade = %d, want 1", got)
+		}
+	})
+
+	t.Run("billing.updated:scheduled alone is a no-op", func(t *testing.T) {
+		// A plan queued to start later has not taken effect, so neither
+		// retention nor an email should follow it.
+		defer cleanupAll(ctx, t)
+		withAutumnWebhookSecret(t, secret)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedApp(ctx, t, appID, teamID, 90)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			t.Errorf("autumn.GetCustomer must not be called for a scheduled-only change")
+			return nil, errors.New("unexpected")
+		})
+
+		payload := []byte(fmt.Sprintf(
+			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"scheduled","subscription":{"plan_id":%q}}]}}`,
+			custID, measure.AutumnPlanFree,
+		))
+		headers := signSvixWebhook(t, secret, "msg_scheduled_only", payload)
+		c, w := webhookReq(payload, headers)
+		h.HandleAutumnWebhook(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		if got := getAppRetention(ctx, t, appID); got != 90 {
+			t.Errorf("retention after scheduled-only = %d, want 90 (unchanged)", got)
 		}
 	})
 

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -399,6 +399,48 @@ func TestGetTeamBilling(t *testing.T) {
 		}
 	})
 
+	t.Run("retention_days reports the longest single plan grant, not the pooled sum", func(t *testing.T) {
+		// A team can hold the free plan and a bespoke plan at once, and
+		// Autumn pools the two 30 day grants into Granted: 60. The usage
+		// page must show the 30 days the team was sold.
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
+				Purchases:     []autumn.Purchase{{PlanID: "acme_one_year"}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   60,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: "acme_one_year", IncludedGrant: 30},
+							{PlanID: measure.AutumnPlanFree, IncludedGrant: 30},
+						},
+					},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["retention_days"] != float64(30) {
+			t.Errorf("retention_days = %v, want 30 (max across plans, not the sum)", got["retention_days"])
+		}
+	})
+
 	t.Run("non-unlimited bytes balance leaves bytes_unlimited=false and populates retention_days + bytes_overage_allowed", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -114,7 +114,7 @@ func TestGetTeamBilling(t *testing.T) {
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
-			return &autumn.Customer{ID: custID, Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}}}, nil
+			return &autumn.Customer{ID: custID, Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}}}, nil
 		})
 
 		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
@@ -146,8 +146,7 @@ func TestGetTeamBilling(t *testing.T) {
 		endsAtSec := int64(1702592000)
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID: custID,
 				Subscriptions: []autumn.Subscription{{
 					PlanID:             measure.AutumnPlanPro,
 					Status:             "active",
@@ -291,8 +290,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes: {
 						FeatureID:      autumn.FeatureBytes,
@@ -331,8 +330,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes: {
 						FeatureID:      autumn.FeatureBytes,
@@ -368,8 +367,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes:       {FeatureID: autumn.FeatureBytes, Granted: 25_000_000_000, Usage: 1_000_000_000},
 					autumn.FeatureAgentTokens: {FeatureID: autumn.FeatureAgentTokens, Granted: 10_000_000, Usage: 1_500_000, OverageAllowed: true},
@@ -406,8 +405,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes: {FeatureID: autumn.FeatureBytes, Granted: 25_000_000_000, Usage: 1_000_000_000},
 				},
@@ -464,7 +463,6 @@ func TestGetTeamBilling(t *testing.T) {
 						CanceledAt:         canceledAtSec * 1000,
 					},
 				},
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
 			}, nil
 		})
 
@@ -550,8 +548,7 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "measure_enterprise_acme"}},
+				ID: custID,
 				Subscriptions: []autumn.Subscription{{
 					PlanID: "measure_enterprise_acme",
 					Status: "active",
@@ -634,8 +631,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes:         {FeatureID: autumn.FeatureBytes, Granted: 25_000_000_000, Usage: 100, Unlimited: false, OverageAllowed: true},
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
@@ -675,8 +672,7 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "measure_enterprise_acme"}},
+				ID: custID,
 				Subscriptions: []autumn.Subscription{{
 					PlanID: "measure_enterprise_acme",
 					Status: "active",
@@ -728,8 +724,8 @@ func TestGetTeamBilling(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureBytes: {FeatureID: autumn.FeatureBytes, Granted: 5_000_000_000, Usage: 0, Unlimited: false, OverageAllowed: false},
 				},
@@ -760,8 +756,7 @@ func TestGetTeamBilling(t *testing.T) {
 		canceledAtSec := int64(1700100000)
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID: custID,
 				Subscriptions: []autumn.Subscription{{
 					PlanID:             measure.AutumnPlanPro,
 					Status:             "active",
@@ -862,7 +857,7 @@ func TestCreateCheckoutSession(t *testing.T) {
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
-			return &autumn.Customer{ID: custID, Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}}}, nil
+			return &autumn.Customer{ID: custID, Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}}}, nil
 		})
 
 		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/checkout", body("https://s"))
@@ -911,7 +906,7 @@ func TestCreateCheckoutSession(t *testing.T) {
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
-			return &autumn.Customer{ID: custID, Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}}}, nil
+			return &autumn.Customer{ID: custID, Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}}}, nil
 		})
 		autumntest.MockAttach(t, func(_ context.Context, req autumn.AttachRequest) (*autumn.AttachResponse, error) {
 			if req.PlanID != measure.AutumnPlanPro {
@@ -1000,7 +995,7 @@ func TestCreateCheckoutSession(t *testing.T) {
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
-			return &autumn.Customer{ID: custID, Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}}}, nil
+			return &autumn.Customer{ID: custID, Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}}}, nil
 		})
 		autumntest.MockAttach(t, func(_ context.Context, req autumn.AttachRequest) (*autumn.AttachResponse, error) {
 			return &autumn.AttachResponse{CustomerID: req.CustomerID, PaymentURL: ""}, nil
@@ -1707,8 +1702,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
@@ -1745,8 +1740,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "plan_ent_acme"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "plan_ent_acme", Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 240},
 				},
@@ -1815,8 +1810,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
 				},
@@ -1854,8 +1849,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
@@ -1997,8 +1992,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
@@ -2044,8 +2039,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "acme_two_year"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "acme_two_year", Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 365},
 				},
@@ -2091,8 +2086,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "acme_one_year"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "acme_one_year", Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 180},
 				},
@@ -2166,8 +2161,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			// After Pro expires, Autumn auto-activates the is_default Free plan.
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
 				},
@@ -2216,7 +2211,8 @@ func TestHandleAutumnWebhook(t *testing.T) {
 			}, nil
 		})
 
-		// products[] still includes Pro with status=active → cancel is a no-op.
+		// Pro is only updated while Free is scheduled for the cycle boundary, so
+		// the plan in effect has not changed and the cancel is a no-op.
 		payload := []byte(fmt.Sprintf(
 			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"updated","subscription":{"plan_id":%q}},{"action":"scheduled","subscription":{"plan_id":%q}}]}}`,
 			custID, measure.AutumnPlanPro, measure.AutumnPlanFree,
@@ -2250,15 +2246,15 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			// Customer is now on Free post-cancel.
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree, Status: "active"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
 				},
 			}, nil
 		})
 
-		// products[] does NOT include Pro as active anymore.
+		// Pro expires as Free activates, so the plan in effect has changed.
 		payload := []byte(fmt.Sprintf(
 			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":%q}},{"action":"expired","subscription":{"plan_id":%q}}]}}`,
 			custID, measure.AutumnPlanFree, measure.AutumnPlanPro,

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -582,7 +582,7 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 
 	t.Run("retention_days reports the longest single plan grant, not the pooled sum", func(t *testing.T) {
-		// A team can hold the free plan and a bespoke plan at once, and
+		// A team can hold the free plan and an enterprise plan at once, and
 		// Autumn pools the two 30 day grants into Granted: 60. The usage
 		// page must show the 30 days the team was sold.
 		defer cleanupAll(ctx, t)
@@ -786,9 +786,9 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 }
 
-// enterpriseCustomer models the way the Autumn API reports a team on a bespoke
+// enterpriseCustomer models the way the Autumn API reports a team on an enterprise
 // plan. Autumn auto-attaches the free plan as a recurring subscription when the
-// customer is created and leaves it in place, and the bespoke plan arrives
+// customer is created and leaves it in place, and the enterprise plan arrives
 // beside it as a one-off purchase under its own identifier.
 func enterpriseCustomer(custID string) *autumn.Customer {
 	return &autumn.Customer{
@@ -1924,7 +1924,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		// A one-off plan is attached on top of the free plan the team already
 		// holds. Autumn expires nothing in that case, so the payload carries a
 		// lone activation whose plan arrives as a purchase rather than a
-		// subscription, and retention still has to follow the bespoke plan.
+		// subscription, and retention still has to follow the enterprise plan.
 		defer cleanupAll(ctx, t)
 		withAutumnWebhookSecret(t, secret)
 
@@ -1938,7 +1938,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		custID := uuid.New().String()
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
-		// The team holds the free plan and the bespoke one at once, so the
+		// The team holds the free plan and the enterprise one at once, so the
 		// balance breaks the grant down per plan and the longer of the two wins.
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
@@ -2019,9 +2019,9 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		}
 	})
 
-	t.Run("billing.updated:one bespoke plan replaced by another resets retention and sends no email", func(t *testing.T) {
-		// A customer's bespoke contract is re-issued at different terms, so one
-		// bespoke plan expires as another activates. Both rank the same, which
+	t.Run("billing.updated:one enterprise plan replaced by another resets retention and sends no email", func(t *testing.T) {
+		// A customer's enterprise contract is re-issued at different terms, so one
+		// enterprise plan expires as another activates. Both rank the same, which
 		// leaves no upgrade or downgrade to announce, but retention still has to
 		// follow the plan that just took effect.
 		defer cleanupAll(ctx, t)
@@ -2031,7 +2031,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		appID := uuid.New()
 		userID := uuid.New().String()
 		seedTeam(ctx, t, teamID, testTeamName)
-		seedUser(ctx, t, userID, "bespoke-swap@test.com")
+		seedUser(ctx, t, userID, "enterprise-swap@test.com")
 		seedTeamMembership(ctx, t, teamID, userID, "owner")
 		seedApp(ctx, t, appID, teamID, 180)
 		custID := uuid.New().String()
@@ -2051,7 +2051,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":"acme_two_year"}},{"action":"expired","subscription":{"plan_id":"acme_one_year"}}]}}`,
 			custID,
 		))
-		headers := signSvixWebhook(t, secret, "msg_bespoke_swap", payload)
+		headers := signSvixWebhook(t, secret, "msg_enterprise_swap", payload)
 		c, w := webhookReq(payload, headers)
 		h.HandleAutumnWebhook(c)
 
@@ -2059,14 +2059,14 @@ func TestHandleAutumnWebhook(t *testing.T) {
 			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
 		}
 		if got := getAppRetention(ctx, t, appID); got != 365 {
-			t.Errorf("retention after bespoke swap = %d, want 365", got)
+			t.Errorf("retention after enterprise swap = %d, want 365", got)
 		}
 		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
-			t.Errorf("queued emails after bespoke swap = %d, want 0", got)
+			t.Errorf("queued emails after enterprise swap = %d, want 0", got)
 		}
 	})
 
-	t.Run("billing.updated:the same bespoke plan re-attached resets retention and sends no email", func(t *testing.T) {
+	t.Run("billing.updated:the same enterprise plan re-attached resets retention and sends no email", func(t *testing.T) {
 		// Autumn re-attaches a plan to itself when a priced feature is added,
 		// putting the same plan id on both sides of the change. Writing the
 		// retention that plan grants is idempotent, and there is no transition
@@ -2078,7 +2078,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		appID := uuid.New()
 		userID := uuid.New().String()
 		seedTeam(ctx, t, teamID, testTeamName)
-		seedUser(ctx, t, userID, "bespoke-reattach@test.com")
+		seedUser(ctx, t, userID, "enterprise-reattach@test.com")
 		seedTeamMembership(ctx, t, teamID, userID, "owner")
 		seedApp(ctx, t, appID, teamID, measure.MIN_RETENTION_DAYS)
 		custID := uuid.New().String()
@@ -2098,7 +2098,7 @@ func TestHandleAutumnWebhook(t *testing.T) {
 			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":"acme_one_year"}},{"action":"expired","subscription":{"plan_id":"acme_one_year"}}]}}`,
 			custID,
 		))
-		headers := signSvixWebhook(t, secret, "msg_bespoke_reattach", payload)
+		headers := signSvixWebhook(t, secret, "msg_enterprise_reattach", payload)
 		c, w := webhookReq(payload, headers)
 		h.HandleAutumnWebhook(c)
 
@@ -2106,10 +2106,10 @@ func TestHandleAutumnWebhook(t *testing.T) {
 			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
 		}
 		if got := getAppRetention(ctx, t, appID); got != 180 {
-			t.Errorf("retention after bespoke re-attach = %d, want 180", got)
+			t.Errorf("retention after enterprise re-attach = %d, want 180", got)
 		}
 		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
-			t.Errorf("queued emails after bespoke re-attach = %d, want 0", got)
+			t.Errorf("queued emails after enterprise re-attach = %d, want 0", got)
 		}
 	})
 

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -1705,6 +1705,100 @@ func TestHandleAutumnWebhook(t *testing.T) {
 		}
 	})
 
+	t.Run("billing.updated:one bespoke plan replaced by another resets retention and sends no email", func(t *testing.T) {
+		// A customer's bespoke contract is re-issued at different terms, so one
+		// bespoke plan expires as another activates. Both rank the same, which
+		// leaves no upgrade or downgrade to announce, but retention still has to
+		// follow the plan that just took effect.
+		defer cleanupAll(ctx, t)
+		withAutumnWebhookSecret(t, secret)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		userID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, userID, "bespoke-swap@test.com")
+		seedTeamMembership(ctx, t, teamID, userID, "owner")
+		seedApp(ctx, t, appID, teamID, 180)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: "acme_two_year"}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 365},
+				},
+			}, nil
+		})
+
+		payload := []byte(fmt.Sprintf(
+			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":"acme_two_year"}},{"action":"expired","subscription":{"plan_id":"acme_one_year"}}]}}`,
+			custID,
+		))
+		headers := signSvixWebhook(t, secret, "msg_bespoke_swap", payload)
+		c, w := webhookReq(payload, headers)
+		h.HandleAutumnWebhook(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		if got := getAppRetention(ctx, t, appID); got != 365 {
+			t.Errorf("retention after bespoke swap = %d, want 365", got)
+		}
+		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
+			t.Errorf("queued emails after bespoke swap = %d, want 0", got)
+		}
+	})
+
+	t.Run("billing.updated:the same bespoke plan re-attached resets retention and sends no email", func(t *testing.T) {
+		// Autumn re-attaches a plan to itself when a priced feature is added,
+		// putting the same plan id on both sides of the change. Writing the
+		// retention that plan grants is idempotent, and there is no transition
+		// to announce.
+		defer cleanupAll(ctx, t)
+		withAutumnWebhookSecret(t, secret)
+
+		teamID := uuid.New()
+		appID := uuid.New()
+		userID := uuid.New().String()
+		seedTeam(ctx, t, teamID, testTeamName)
+		seedUser(ctx, t, userID, "bespoke-reattach@test.com")
+		seedTeamMembership(ctx, t, teamID, userID, "owner")
+		seedApp(ctx, t, appID, teamID, measure.MIN_RETENTION_DAYS)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: "acme_one_year"}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 180},
+				},
+			}, nil
+		})
+
+		payload := []byte(fmt.Sprintf(
+			`{"type":"billing.updated","data":{"customer_id":%q,"plan_changes":[{"action":"activated","subscription":{"plan_id":"acme_one_year"}},{"action":"expired","subscription":{"plan_id":"acme_one_year"}}]}}`,
+			custID,
+		))
+		headers := signSvixWebhook(t, secret, "msg_bespoke_reattach", payload)
+		c, w := webhookReq(payload, headers)
+		h.HandleAutumnWebhook(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+		}
+		if got := getAppRetention(ctx, t, appID); got != 180 {
+			t.Errorf("retention after bespoke re-attach = %d, want 180", got)
+		}
+		if got := countQueuedTeamEmails(ctx, t, teamID); got != 0 {
+			t.Errorf("queued emails after bespoke re-attach = %d, want 0", got)
+		}
+	})
+
 	t.Run("billing.updated:scheduled alone is a no-op", func(t *testing.T) {
 		// A plan queued to start later has not taken effect, so neither
 		// retention nor an email should follow it.

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -191,6 +191,175 @@ func TestGetTeamBilling(t *testing.T) {
 		}
 	})
 
+	t.Run("reports a spent data purchase from the bytes breakdown", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		// The team holds the free plan alongside a plan sold as a one-off
+		// purchase whose grant is used up, so the pooled granted and usage read
+		// close to the limit while the monthly free grant still admits data.
+		startedAt := time.Now().Add(-time.Hour).UnixMilli()
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:        custID,
+				Purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: startedAt}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {
+						FeatureID: autumn.FeatureBytes,
+						Granted:   370_000_000_000,
+						Usage:     367_000_000_000,
+						Remaining: 3_000_000_000,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: measure.AutumnPlanFree, IncludedGrant: 5_000_000_000, Remaining: 3_000_000_000},
+							{PlanID: "acme_one_year", IncludedGrant: 365_000_000_000, Remaining: 0},
+						},
+					},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["data_purchase_spent"] != true {
+			t.Errorf("data_purchase_spent = %v, want true", got["data_purchase_spent"])
+		}
+		// The free grant still has bytes left, so data keeps flowing.
+		if got["ingestion_blocked"] != false {
+			t.Errorf("ingestion_blocked = %v, want false", got["ingestion_blocked"])
+		}
+	})
+
+	t.Run("reports no spent data purchase when the purchase has data left", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		startedAt := time.Now().Add(-time.Hour).UnixMilli()
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:        custID,
+				Purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: startedAt}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {
+						FeatureID: autumn.FeatureBytes,
+						Granted:   370_000_000_000,
+						Usage:     149_258_959_419,
+						Remaining: 220_741_040_581,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: measure.AutumnPlanFree, IncludedGrant: 5_000_000_000, Remaining: 0},
+							{PlanID: "acme_one_year", IncludedGrant: 365_000_000_000, Remaining: 220_741_040_581},
+						},
+					},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["data_purchase_spent"] != false {
+			t.Errorf("data_purchase_spent = %v, want false", got["data_purchase_spent"])
+		}
+		if got["ingestion_blocked"] != false {
+			t.Errorf("ingestion_blocked = %v, want false", got["ingestion_blocked"])
+		}
+	})
+
+	t.Run("reports ingestion blocked when the pooled balance is empty and overage is not allowed", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanFree}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {
+						FeatureID:      autumn.FeatureBytes,
+						Granted:        5_000_000_000,
+						Usage:          5_000_000_000,
+						Remaining:      0,
+						OverageAllowed: false,
+					},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["ingestion_blocked"] != true {
+			t.Errorf("ingestion_blocked = %v, want true", got["ingestion_blocked"])
+		}
+		if got["data_purchase_spent"] != false {
+			t.Errorf("data_purchase_spent = %v, want false", got["data_purchase_spent"])
+		}
+	})
+
+	t.Run("reports ingestion not blocked when the pooled balance is empty but overage is allowed", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: measure.AutumnPlanPro}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {
+						FeatureID:      autumn.FeatureBytes,
+						Granted:        25_000_000_000,
+						Usage:          25_000_000_000,
+						Remaining:      0,
+						OverageAllowed: true,
+					},
+				},
+			}, nil
+		})
+
+		c, w := newTestGinContext("GET", "/teams/"+teamID.String()+"/billing/info", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.GetTeamBilling(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		}
+		var got map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &got)
+		if got["ingestion_blocked"] != false {
+			t.Errorf("ingestion_blocked = %v, want false", got["ingestion_blocked"])
+		}
+	})
+
 	t.Run("includes agent token credit balance from autumn", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")

--- a/backend/api/handlers/billing_test.go
+++ b/backend/api/handlers/billing_test.go
@@ -622,6 +622,18 @@ func TestGetTeamBilling(t *testing.T) {
 	})
 }
 
+// enterpriseCustomer models the way the Autumn API reports a team on a bespoke
+// plan. Autumn auto-attaches the free plan as a recurring subscription when the
+// customer is created and leaves it in place, and the bespoke plan arrives
+// beside it as a one-off purchase under its own identifier.
+func enterpriseCustomer(custID string) *autumn.Customer {
+	return &autumn.Customer{
+		ID:            custID,
+		Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
+		Purchases:     []autumn.Purchase{{PlanID: "acme_one_year"}},
+	}
+}
+
 // --------------------------------------------------------------------------
 // CreateCheckoutSession
 // --------------------------------------------------------------------------
@@ -696,6 +708,30 @@ func TestCreateCheckoutSession(t *testing.T) {
 		_ = json.Unmarshal(w.Body.Bytes(), &got)
 		if got["already_upgraded"] != true {
 			t.Errorf("already_upgraded = %v, want true", got["already_upgraded"])
+		}
+	})
+
+	t.Run("on an enterprise plan → 403 (no attach attempted)", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return enterpriseCustomer(custID), nil
+		})
+		autumntest.MockAttach(t, func(_ context.Context, _ autumn.AttachRequest) (*autumn.AttachResponse, error) {
+			t.Errorf("autumn.Attach must not be called for an enterprise customer")
+			return nil, errors.New("unexpected")
+		})
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/checkout", body("https://s"))
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.CreateCheckoutSession(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 		}
 	})
 
@@ -871,12 +907,24 @@ func TestCancelAndDowngradeToFreePlan(t *testing.T) {
 		}
 	})
 
+	// mockProCustomer returns a customer object that satisfies the cancel
+	// pre-check (an active Pro subscription).
+	mockProCustomer := func(custID string) *autumn.Customer {
+		return &autumn.Customer{
+			ID:            custID,
+			Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanPro, Status: "active"}},
+		}
+	}
+
 	t.Run("happy path schedules cancellation at end of cycle", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
 		custID := uuid.New().String()
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return mockProCustomer(custID), nil
+		})
 		var gotReq autumn.UpdateRequest
 		autumntest.MockUpdate(t, func(_ context.Context, req autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
 			gotReq = req
@@ -908,6 +956,9 @@ func TestCancelAndDowngradeToFreePlan(t *testing.T) {
 		custID := uuid.New().String()
 		seedTeamAutumnCustomer(ctx, t, teamID, custID)
 
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return mockProCustomer(custID), nil
+		})
 		autumntest.MockUpdate(t, func(_ context.Context, _ autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
 			return nil, errors.New("boom")
 		})
@@ -919,6 +970,105 @@ func TestCancelAndDowngradeToFreePlan(t *testing.T) {
 
 		if w.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("on an enterprise plan → 403 (no update attempted)", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return enterpriseCustomer(custID), nil
+		})
+		autumntest.MockUpdate(t, func(_ context.Context, _ autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
+			t.Errorf("autumn.Update must not be called for an enterprise customer")
+			return nil, errors.New("unexpected")
+		})
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/downgrade", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.CancelAndDowngradeToFreePlan(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("on the free plan → 403 (no update attempted)", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: measure.AutumnPlanFree, Status: "active"}},
+			}, nil
+		})
+		autumntest.MockUpdate(t, func(_ context.Context, _ autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
+			t.Errorf("autumn.Update must not be called when there is no Pro plan to cancel")
+			return nil, errors.New("unexpected")
+		})
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/downgrade", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.CancelAndDowngradeToFreePlan(c)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("autumn unreachable on pre-check → 503", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return nil, &autumn.APIError{StatusCode: 503, Body: "unavailable"}
+		})
+		autumntest.MockUpdate(t, func(_ context.Context, _ autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
+			t.Errorf("autumn.Update must not be called when GetCustomer pre-check returned 5xx")
+			return nil, errors.New("unexpected")
+		})
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/downgrade", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.CancelAndDowngradeToFreePlan(c)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", w.Code)
+		}
+	})
+
+	t.Run("autumn 4xx on pre-check → 400 (no Update attempted)", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		userID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return nil, &autumn.APIError{StatusCode: 404, Body: "customer not found"}
+		})
+		autumntest.MockUpdate(t, func(_ context.Context, _ autumn.UpdateRequest) (*autumn.UpdateResponse, error) {
+			t.Errorf("autumn.Update must not be called when GetCustomer pre-check returned 4xx")
+			return nil, errors.New("unexpected")
+		})
+
+		c, w := newTestGinContext("PATCH", "/teams/"+teamID.String()+"/billing/downgrade", nil)
+		c.Set("userId", userID)
+		c.Params = gin.Params{{Key: "id", Value: teamID.String()}}
+		h.CancelAndDowngradeToFreePlan(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
 		}
 	})
 

--- a/backend/libs/autumn/cache.go
+++ b/backend/libs/autumn/cache.go
@@ -8,9 +8,9 @@ import (
 	valkey "github.com/valkey-io/valkey-go"
 )
 
-// CheckCacheTTLSeconds bounds how long a cached Check verdict is trusted.
-// Short enough that a plan transition (upgrade, downgrade, limit-reached)
-// surfaces within roughly a minute even without explicit invalidation.
+// CheckCacheTTLSeconds bounds how long a cached Check verdict is trusted. Short
+// enough that a plan change surfaces within about a minute with no explicit
+// invalidation.
 const CheckCacheTTLSeconds = 60
 
 // CheckCacheKey is the Valkey key holding a customer's cached Check verdict for
@@ -21,11 +21,10 @@ func CheckCacheKey(customerID, featureID string) string {
 }
 
 // CheckCached reports whether customerID is allowed to use featureID, reading
-// Valkey first and calling the Autumn API only on a miss. A nil client or any
-// Valkey error falls back to a direct Check — caching is best-effort.
-//
-// The error is non-nil only when the underlying Check fails; callers decide
-// whether to fail open or closed. Errors are never cached.
+// Valkey first and calling the Autumn API only on a miss. Caching is
+// best-effort, so a nil client or any Valkey trouble falls back to a direct
+// Check. The error is the underlying Check's and is never cached; callers
+// decide whether to fail open or closed.
 func CheckCached(ctx context.Context, vk valkey.Client, customerID, featureID string) (bool, error) {
 	if allowed, ok := GetCachedCheck(ctx, vk, customerID, featureID); ok {
 		return allowed, nil
@@ -38,8 +37,8 @@ func CheckCached(ctx context.Context, vk valkey.Client, customerID, featureID st
 	return resp.Allowed, nil
 }
 
-// GetCachedCheck returns (allowed, true) on a cache hit and (_, false) on a
-// miss, a nil client, or any Valkey error (logged, never surfaced).
+// GetCachedCheck returns a cached verdict and whether there was one. Valkey
+// trouble is logged and reported as a miss.
 func GetCachedCheck(ctx context.Context, vk valkey.Client, customerID, featureID string) (bool, bool) {
 	if vk == nil {
 		return false, false
@@ -61,8 +60,7 @@ func GetCachedCheck(ctx context.Context, vk valkey.Client, customerID, featureID
 	return str == "1", true
 }
 
-// SetCachedCheck caches allowed for customerID/featureID. A nil client is a
-// no-op; errors are logged but never surfaced.
+// SetCachedCheck caches allowed for customerID and featureID.
 func SetCachedCheck(ctx context.Context, vk valkey.Client, customerID, featureID string, allowed bool) {
 	if vk == nil {
 		return

--- a/backend/libs/autumn/client.go
+++ b/backend/libs/autumn/client.go
@@ -1,8 +1,7 @@
-// Package autumn is a thin REST client for useautumn.com's API.
+// Package autumn is a REST client for useautumn.com's API.
 //
-// Configure with Init() at startup, then use the package-level functions
-// (GetOrCreateCustomer, Attach, Track, Check, OpenCustomerPortal, GetCustomer).
-// Functions are exposed as package-level variables so tests can replace them.
+// Call Init() at startup, then the package-level functions. Those functions are
+// variables rather than plain funcs so tests can replace them.
 package autumn
 
 import (
@@ -22,7 +21,6 @@ import (
 
 var tracer = otel.Tracer("autumn-client")
 
-// Package state. Set via Init.
 var (
 	secretKey  string
 	apiURL     = "https://api.useautumn.com"
@@ -35,9 +33,9 @@ type Config struct {
 	SecretKey string
 }
 
-// Init wires up the package-level client. Call once at service startup.
-// The Autumn API environment (test vs live) is determined by the secret key
-// prefix (am_sk_test_… vs am_sk_live_…), so no URL override is needed.
+// Init wires up the package-level client. Call once at service startup. The
+// secret key prefix (am_sk_test_ vs am_sk_live_) picks the Autumn environment,
+// so there is no URL to override.
 func Init(cfg Config) {
 	secretKey = cfg.SecretKey
 }
@@ -52,11 +50,10 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("autumn API error: status=%d body=%s", e.StatusCode, e.Body)
 }
 
-// IsServerOrNetworkError reports whether err indicates Autumn is unreachable
-// (5xx, timeout, connection failure) or a 4xx client/config bug.
-// Fail-open call sites should branch on this so 4xx errors surface loudly
-// instead of being swallowed under the outage umbrella. Matches Autumn's
-// own SDKs, which only fail-open on 5xx/network.
+// IsServerOrNetworkError reports whether err is Autumn being unreachable (5xx,
+// timeout, connection failure) rather than a 4xx client or config bug.
+// Fail-open call sites branch on it so a 4xx surfaces loudly instead of being
+// swallowed as an outage.
 func IsServerOrNetworkError(err error) bool {
 	if err == nil {
 		return false
@@ -68,9 +65,9 @@ func IsServerOrNetworkError(err error) bool {
 	return true
 }
 
-// do performs a request against the Autumn API and decodes the JSON response
-// into out (if non-nil). Returns *APIError on non-2xx responses.
-// opName is used as the span name so every Autumn call appears in traces.
+// do calls the Autumn API and decodes the JSON response into out when non-nil.
+// A non-2xx response comes back as *APIError. opName names the span so every
+// Autumn call appears in traces.
 func do(ctx context.Context, opName, method, path string, body any, out any) (err error) {
 	ctx, span := tracer.Start(ctx, opName)
 	defer span.End()
@@ -129,10 +126,6 @@ func do(ctx context.Context, opName, method, path string, body any, out any) (er
 	return nil
 }
 
-// ----------------------------------------------------------------------------
-// Exported function variables. Replace in tests to stub out API calls.
-// ----------------------------------------------------------------------------
-
 var (
 	GetOrCreateCustomer = getOrCreateCustomer
 	GetCustomer         = getCustomer
@@ -144,10 +137,6 @@ var (
 	TrackTokens         = trackTokens
 	Check               = check
 )
-
-// ----------------------------------------------------------------------------
-// Customers
-// ----------------------------------------------------------------------------
 
 func getOrCreateCustomer(ctx context.Context, id, email, name string) (*Customer, error) {
 	req := createCustomerRequest{
@@ -170,8 +159,6 @@ func getCustomer(ctx context.Context, customerID string) (*Customer, error) {
 	return &out, nil
 }
 
-// updateCustomer changes the email on an existing Autumn customer. Invoices,
-// receipts and dunning notifications from Autumn/Stripe go to this address.
 func updateCustomer(ctx context.Context, customerID, email string) error {
 	req := updateCustomerRequest{
 		CustomerID: customerID,
@@ -179,10 +166,6 @@ func updateCustomer(ctx context.Context, customerID, email string) error {
 	}
 	return do(ctx, "autumn-update-customer", http.MethodPost, "/v1/customers.update", req, nil)
 }
-
-// ----------------------------------------------------------------------------
-// Billing (attach, portal)
-// ----------------------------------------------------------------------------
 
 func attach(ctx context.Context, req AttachRequest) (*AttachResponse, error) {
 	var out AttachResponse
@@ -209,10 +192,6 @@ func openCustomerPortal(ctx context.Context, customerID, returnURL string) (stri
 	}
 	return out.URL, nil
 }
-
-// ----------------------------------------------------------------------------
-// Balances (track, check)
-// ----------------------------------------------------------------------------
 
 func track(ctx context.Context, customerID, featureID string, value float64) error {
 	req := trackRequest{

--- a/backend/libs/autumn/client_test.go
+++ b/backend/libs/autumn/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -273,6 +274,101 @@ func TestOpenCustomerPortal(t *testing.T) {
 	}
 	if !strings.HasPrefix(url, "https://billing.") {
 		t.Errorf("unexpected portal URL: %s", url)
+	}
+}
+
+// TestGetCustomerDecodesRealResponse guards the decode itself. The client
+// unmarshals without rejecting unknown keys, so an array Autumn renames
+// decodes to a zero value while the call still reports success. Every other
+// test here answers with one of our own structs, which round-trips our own
+// tags and cannot catch that. The fixture keeps keys we do not model so the
+// whole response is exercised.
+func TestGetCustomerDecodesRealResponse(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/customer_get_response.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	cleanup := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/customers/cus_acme" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	})
+	defer cleanup()
+
+	cust, err := getCustomer(context.Background(), "cus_acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cust.ID != "cus_acme" {
+		t.Errorf("id = %q, want cus_acme", cust.ID)
+	}
+
+	if len(cust.Subscriptions) != 1 {
+		t.Fatalf("subscriptions = %d, want 1", len(cust.Subscriptions))
+	}
+	sub := cust.Subscriptions[0]
+	if sub.PlanID != "measure_free" {
+		t.Errorf("subscription plan_id = %q, want measure_free", sub.PlanID)
+	}
+	if sub.Status != "active" {
+		t.Errorf("subscription status = %q, want active", sub.Status)
+	}
+
+	if len(cust.Purchases) != 1 {
+		t.Fatalf("purchases = %d, want 1", len(cust.Purchases))
+	}
+	purchase := cust.Purchases[0]
+	if purchase.PlanID != "acme_one_year" {
+		t.Errorf("purchase plan_id = %q, want acme_one_year", purchase.PlanID)
+	}
+	if purchase.StartedAt != 1780300365589 {
+		t.Errorf("purchase started_at = %d, want 1780300365589", purchase.StartedAt)
+	}
+	if purchase.ExpiresAt != 0 {
+		t.Errorf("purchase expires_at = %d, want 0", purchase.ExpiresAt)
+	}
+
+	bytesBalance, ok := cust.Balances[FeatureBytes]
+	if !ok {
+		t.Fatalf("no %s balance, got %v", FeatureBytes, cust.Balances)
+	}
+	if bytesBalance.Granted != 370000000000 {
+		t.Errorf("bytes granted = %v, want 370000000000", bytesBalance.Granted)
+	}
+	if bytesBalance.Remaining != 220741040581 {
+		t.Errorf("bytes remaining = %v, want 220741040581", bytesBalance.Remaining)
+	}
+	if bytesBalance.Usage != 149258959419 {
+		t.Errorf("bytes usage = %v, want 149258959419", bytesBalance.Usage)
+	}
+	if len(bytesBalance.Breakdown) != 2 {
+		t.Fatalf("bytes breakdown = %d sources, want 2", len(bytesBalance.Breakdown))
+	}
+	if got := bytesBalance.Breakdown[0]; got.PlanID != "measure_free" || got.Remaining != 0 {
+		t.Errorf("bytes breakdown[0] = %+v, want measure_free with 0 remaining", got)
+	}
+	if got := bytesBalance.Breakdown[1]; got.PlanID != "acme_one_year" || got.Remaining != 220741040581 {
+		t.Errorf("bytes breakdown[1] = %+v, want acme_one_year with 220741040581 remaining", got)
+	}
+
+	retention, ok := cust.Balances[FeatureRetentionDays]
+	if !ok {
+		t.Fatalf("no %s balance, got %v", FeatureRetentionDays, cust.Balances)
+	}
+	if retention.Granted != 60 {
+		t.Errorf("retention granted = %v, want 60", retention.Granted)
+	}
+	if len(retention.Breakdown) != 2 {
+		t.Fatalf("retention breakdown = %d sources, want 2", len(retention.Breakdown))
+	}
+	if got := retention.Breakdown[0]; got.PlanID != "acme_one_year" || got.IncludedGrant != 30 {
+		t.Errorf("retention breakdown[0] = %+v, want acme_one_year granting 30", got)
+	}
+	if got := retention.Breakdown[1]; got.PlanID != "measure_free" || got.IncludedGrant != 30 {
+		t.Errorf("retention breakdown[1] = %+v, want measure_free granting 30", got)
 	}
 }
 

--- a/backend/libs/autumn/testdata/customer_get_response.json
+++ b/backend/libs/autumn/testdata/customer_get_response.json
@@ -1,0 +1,117 @@
+{
+  "id": "cus_acme",
+  "name": "Acme Corp",
+  "email": "billing@acme.example",
+  "created_at": 1777717487318,
+  "fingerprint": null,
+  "stripe_id": "cus_stripe_acme",
+  "env": "live",
+  "metadata": {},
+  "send_email_receipts": false,
+  "billing_controls": {},
+  "subscriptions": [
+    {
+      "id": "cus_prod_acme_free",
+      "plan_id": "measure_free",
+      "auto_enable": true,
+      "add_on": false,
+      "status": "active",
+      "past_due": false,
+      "canceled_at": null,
+      "expires_at": null,
+      "trial_ends_at": null,
+      "started_at": 1780828808783,
+      "current_period_start": null,
+      "current_period_end": null,
+      "quantity": 1,
+      "scope": "customer"
+    }
+  ],
+  "purchases": [
+    {
+      "plan_id": "acme_one_year",
+      "expires_at": null,
+      "started_at": 1780300365589,
+      "quantity": 1,
+      "scope": "customer"
+    }
+  ],
+  "licenses": [],
+  "balances": {
+    "bytes": {
+      "feature_id": "bytes",
+      "granted": 370000000000,
+      "remaining": 220741040581,
+      "usage": 149258959419,
+      "unlimited": false,
+      "overage_allowed": false,
+      "max_purchase": null,
+      "next_reset_at": 1788777608783,
+      "breakdown": [
+        {
+          "id": "cus_ent_acme_free_bytes",
+          "plan_id": "measure_free",
+          "included_grant": 5000000000,
+          "prepaid_grant": 0,
+          "remaining": 0,
+          "usage": 5000000000,
+          "unlimited": false,
+          "reset": { "interval": "month", "resets_at": 1788777608783 },
+          "price": null,
+          "expires_at": null
+        },
+        {
+          "id": "cus_ent_acme_purchase_bytes",
+          "plan_id": "acme_one_year",
+          "included_grant": 365000000000,
+          "prepaid_grant": 0,
+          "remaining": 220741040581,
+          "usage": 144258959419,
+          "unlimited": false,
+          "reset": { "interval": "one_off", "resets_at": null },
+          "price": null,
+          "expires_at": null
+        }
+      ]
+    },
+    "retention_days": {
+      "feature_id": "retention_days",
+      "granted": 60,
+      "remaining": 60,
+      "usage": 0,
+      "unlimited": false,
+      "overage_allowed": false,
+      "max_purchase": null,
+      "next_reset_at": null,
+      "breakdown": [
+        {
+          "id": "cus_ent_acme_purchase_retention",
+          "plan_id": "acme_one_year",
+          "included_grant": 30,
+          "prepaid_grant": 0,
+          "remaining": 30,
+          "usage": 0,
+          "unlimited": false,
+          "reset": null,
+          "price": null,
+          "expires_at": null
+        },
+        {
+          "id": "cus_ent_acme_free_retention",
+          "plan_id": "measure_free",
+          "included_grant": 30,
+          "prepaid_grant": 0,
+          "remaining": 30,
+          "usage": 0,
+          "unlimited": false,
+          "reset": null,
+          "price": null,
+          "expires_at": null
+        }
+      ]
+    }
+  },
+  "flags": {},
+  "config": {},
+  "processors": { "stripe": { "id": "cus_stripe_acme" } }
+}

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -65,13 +65,25 @@ type CustomerProduct struct {
 
 // Balance captures per-feature usage state on a customer.
 type Balance struct {
-	FeatureID      string  `json:"feature_id"`
-	Granted        float64 `json:"granted"`
-	Remaining      float64 `json:"remaining"`
-	Usage          float64 `json:"usage"`
-	Unlimited      bool    `json:"unlimited"`
-	OverageAllowed bool    `json:"overage_allowed"`
-	NextResetAt    int64   `json:"next_reset_at,omitempty"`
+	FeatureID      string          `json:"feature_id"`
+	Granted        float64         `json:"granted"`
+	Remaining      float64         `json:"remaining"`
+	Usage          float64         `json:"usage"`
+	Unlimited      bool            `json:"unlimited"`
+	OverageAllowed bool            `json:"overage_allowed"`
+	NextResetAt    int64           `json:"next_reset_at,omitempty"`
+	Breakdown      []BalanceSource `json:"breakdown,omitempty"`
+}
+
+// BalanceSource is one plan's contribution to a Balance. Autumn pools a
+// feature's grants from every plan a customer holds into the single Granted
+// number on the Balance, and the breakdown says what each plan granted on its
+// own, so a customer holding both the free plan and a bespoke plan has an
+// entry for each. IncludedGrant is what the plan itself grants, as opposed to
+// any extra quantity the customer bought on top of it.
+type BalanceSource struct {
+	PlanID        string  `json:"plan_id"`
+	IncludedGrant float64 `json:"included_grant"`
 }
 
 // createCustomerRequest is the payload for POST /v1/customers.

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -38,10 +38,10 @@ type Subscription struct {
 	ExpiresAt          int64  `json:"expires_at,omitempty"`
 }
 
-// Purchase is a one-off plan a customer bought outright, such as a bespoke plan
-// sold for a fixed term. Autumn returns these in their own array on the
-// customer, separate from the recurring plans in Subscriptions, so a customer
-// can hold both at once. A purchase carries no status field the way a
+// Purchase is a plan sold as a one-off purchase rather than as a recurring
+// subscription, such as a bespoke plan sold for a fixed term. Autumn returns
+// these in their own array on the customer, separate from the recurring plans
+// in Subscriptions, so a customer can hold both at once. A purchase carries no status field the way a
 // subscription does, and StartedAt and ExpiresAt are milliseconds since epoch,
 // so those two timestamps are what say whether the purchase is currently in
 // effect.

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -1,20 +1,17 @@
 package autumn
 
-// Feature IDs configured in the Autumn dashboard. Single source of truth for
-// every package that calls Autumn. Keep these aligned with the dashboard.
+// Feature IDs configured in the Autumn dashboard. Keep these in sync with it.
 const (
 	FeatureBytes         = "bytes"
 	FeatureRetentionDays = "retention_days"
 	FeatureAgentTokens   = "agent_tokens"
 )
 
-// Customer represents an Autumn customer, including their active subscriptions,
-// one-off purchases and balances. Returned by GetOrCreateCustomer and
-// GetCustomer.
+// Customer is an Autumn customer with their plans and balances.
 //
-// The API returns recurring plans in Subscriptions and plans sold as a one-off
-// purchase in Purchases, and a customer can hold both at once, so code that
-// determines the active plan has to read the two together.
+// Recurring plans arrive in Subscriptions and plans sold as a one-off purchase
+// arrive in Purchases, and a customer can hold both at once, so anything
+// deciding which plan a customer is on has to read the two together.
 type Customer struct {
 	ID            string             `json:"id"`
 	Email         string             `json:"email,omitempty"`
@@ -24,8 +21,8 @@ type Customer struct {
 	Balances      map[string]Balance `json:"balances,omitempty"`
 }
 
-// Subscription is an active billing subscription on a customer, as returned
-// by the API. PlanID is the external plan identifier (e.g. "measure_pro").
+// Subscription is a recurring plan on a customer. PlanID is the plan slug
+// configured in the Autumn dashboard (e.g. "measure_pro").
 type Subscription struct {
 	ID                 string `json:"id"`
 	PlanID             string `json:"plan_id"`
@@ -37,20 +34,19 @@ type Subscription struct {
 	ExpiresAt          int64  `json:"expires_at,omitempty"`
 }
 
-// Purchase is a plan sold as a one-off purchase rather than as a recurring
-// subscription, such as a bespoke plan sold for a fixed term. Autumn returns
-// these in their own array on the customer, separate from the recurring plans
-// in Subscriptions, so a customer can hold both at once. A purchase carries no status field the way a
-// subscription does, and StartedAt and ExpiresAt are milliseconds since epoch,
-// so those two timestamps are what say whether the purchase is currently in
-// effect.
+// Purchase is a plan sold as a one-off rather than as a recurring subscription,
+// such as an enterprise plan sold for a fixed term. It carries no status field
+// the way a subscription does, so StartedAt and ExpiresAt, both milliseconds
+// since epoch, are what say whether it is in effect.
 type Purchase struct {
 	PlanID    string `json:"plan_id"`
 	StartedAt int64  `json:"started_at,omitempty"`
 	ExpiresAt int64  `json:"expires_at,omitempty"`
 }
 
-// Balance captures per-feature usage state on a customer.
+// Balance is a customer's usage state for one feature. Autumn sums the feature's
+// grants across every plan the customer holds into Granted, and Breakdown says
+// what each plan granted on its own.
 type Balance struct {
 	FeatureID      string          `json:"feature_id"`
 	Granted        float64         `json:"granted"`
@@ -62,13 +58,9 @@ type Balance struct {
 	Breakdown      []BalanceSource `json:"breakdown,omitempty"`
 }
 
-// BalanceSource is one plan's contribution to a Balance. Autumn pools a
-// feature's grants from every plan a customer holds into the single Granted
-// number on the Balance, and the breakdown says what each plan granted on its
-// own, so a customer holding both the free plan and a bespoke plan has an
-// entry for each. IncludedGrant is what the plan itself grants, as opposed to
-// any extra quantity the customer bought on top of it, and Remaining is what
-// is left of this plan's own grant.
+// BalanceSource is one plan's own contribution to a pooled Balance.
+// IncludedGrant is what the plan grants, apart from any extra quantity bought on
+// top of it, and Remaining is what is left of that plan's grant.
 type BalanceSource struct {
 	PlanID        string  `json:"plan_id"`
 	IncludedGrant float64 `json:"included_grant"`
@@ -101,7 +93,7 @@ type AttachRequest struct {
 // AttachResponse is returned by POST /v1/billing.attach.
 type AttachResponse struct {
 	CustomerID string `json:"customer_id"`
-	// PaymentURL is set when checkout is required. Empty for in-place plan changes.
+	// PaymentURL is set when checkout is required, empty for in-place changes.
 	PaymentURL string `json:"payment_url,omitempty"`
 }
 
@@ -136,29 +128,24 @@ type openCustomerPortalResponse struct {
 	URL string `json:"url"`
 }
 
-// trackRequest is the payload for POST /v1/balances.track.
-//
-// Value has no omitempty: Autumn defaults Value to 1 when the field is
-// missing, which would silently misreport zero-byte ingests.
+// trackRequest is the payload for POST /v1/balances.track. Value has no
+// omitempty because Autumn defaults a missing Value to 1, which would
+// misreport zero-byte ingests.
 type trackRequest struct {
 	CustomerID string  `json:"customer_id"`
 	FeatureID  string  `json:"feature_id"`
 	Value      float64 `json:"value"`
 }
 
-// TrackTokensRequest is the payload for POST /v1/balances.track_tokens. It
-// records LLM token usage for one model call; Autumn prices it from its model
-// catalog and deducts from the token feature's balance. ModelID is
-// "provider/model" (for OpenRouter-served models, "openrouter/<provider>/<model>").
-// FeatureID names the token-billing feature; left empty, Autumn uses the
-// customer's sole token feature.
+// TrackTokensRequest is the payload for POST /v1/balances.track_tokens, one
+// model call's token usage, which Autumn prices from its model catalog. ModelID
+// is "provider/model", or "openrouter/<provider>/<model>" for OpenRouter-served
+// models. An empty FeatureID leaves Autumn to use the customer's sole token
+// feature.
 //
-// The token counts are exclusive pools, each priced at its own rate: InputTokens
-// is non-cached text input, OutputTokens is text output excluding reasoning, and
-// the cache and reasoning pools are billed separately. A token must appear in
-// exactly one pool, so the caller subtracts the cache and reasoning counts from
-// the prompt and completion totals before filling these in; otherwise those
-// tokens are billed twice.
+// The counts are exclusive pools, each priced at its own rate, so the caller
+// subtracts the cache and reasoning counts from the prompt and completion totals
+// before filling these in. A token counted in two pools is billed twice.
 type TrackTokensRequest struct {
 	CustomerID       string `json:"customer_id"`
 	ModelID          string `json:"model_id"`

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -8,17 +8,19 @@ const (
 	FeatureAgentTokens   = "agent_tokens"
 )
 
-// Customer represents an Autumn customer, including their active subscriptions
-// and balances. Returned by GetOrCreateCustomer and GetCustomer.
+// Customer represents an Autumn customer, including their active subscriptions,
+// one-off purchases and balances. Returned by GetOrCreateCustomer and
+// GetCustomer.
 //
-// The API's GET response populates Subscriptions; the webhook payload's
-// embedded customer object populates Products instead. Code that determines
-// the active plan should check both.
+// The API's GET response populates Subscriptions and Purchases; the webhook
+// payload's embedded customer object populates Products instead. Code that
+// determines the active plan should check all of them.
 type Customer struct {
 	ID            string             `json:"id"`
 	Email         string             `json:"email,omitempty"`
 	Name          string             `json:"name,omitempty"`
 	Subscriptions []Subscription     `json:"subscriptions,omitempty"`
+	Purchases     []Purchase         `json:"purchases,omitempty"`
 	Products      []CustomerProduct  `json:"products,omitempty"`
 	Balances      map[string]Balance `json:"balances,omitempty"`
 }
@@ -34,6 +36,19 @@ type Subscription struct {
 	CurrentPeriodEnd   int64  `json:"current_period_end,omitempty"`
 	CanceledAt         int64  `json:"canceled_at,omitempty"`
 	ExpiresAt          int64  `json:"expires_at,omitempty"`
+}
+
+// Purchase is a one-off plan a customer bought outright, such as a bespoke plan
+// sold for a fixed term. Autumn returns these in their own array on the
+// customer, separate from the recurring plans in Subscriptions, so a customer
+// can hold both at once. A purchase carries no status field the way a
+// subscription does, and StartedAt and ExpiresAt are milliseconds since epoch,
+// so those two timestamps are what say whether the purchase is currently in
+// effect.
+type Purchase struct {
+	PlanID    string `json:"plan_id"`
+	StartedAt int64  `json:"started_at,omitempty"`
+	ExpiresAt int64  `json:"expires_at,omitempty"`
 }
 
 // CustomerProduct is an Autumn product as it appears in webhook payloads

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -80,10 +80,12 @@ type Balance struct {
 // number on the Balance, and the breakdown says what each plan granted on its
 // own, so a customer holding both the free plan and a bespoke plan has an
 // entry for each. IncludedGrant is what the plan itself grants, as opposed to
-// any extra quantity the customer bought on top of it.
+// any extra quantity the customer bought on top of it, and Remaining is what
+// is left of this plan's own grant.
 type BalanceSource struct {
 	PlanID        string  `json:"plan_id"`
 	IncludedGrant float64 `json:"included_grant"`
+	Remaining     float64 `json:"remaining"`
 }
 
 // createCustomerRequest is the payload for POST /v1/customers.

--- a/backend/libs/autumn/types.go
+++ b/backend/libs/autumn/types.go
@@ -12,16 +12,15 @@ const (
 // one-off purchases and balances. Returned by GetOrCreateCustomer and
 // GetCustomer.
 //
-// The API's GET response populates Subscriptions and Purchases; the webhook
-// payload's embedded customer object populates Products instead. Code that
-// determines the active plan should check all of them.
+// The API returns recurring plans in Subscriptions and plans sold as a one-off
+// purchase in Purchases, and a customer can hold both at once, so code that
+// determines the active plan has to read the two together.
 type Customer struct {
 	ID            string             `json:"id"`
 	Email         string             `json:"email,omitempty"`
 	Name          string             `json:"name,omitempty"`
 	Subscriptions []Subscription     `json:"subscriptions,omitempty"`
 	Purchases     []Purchase         `json:"purchases,omitempty"`
-	Products      []CustomerProduct  `json:"products,omitempty"`
 	Balances      map[string]Balance `json:"balances,omitempty"`
 }
 
@@ -49,18 +48,6 @@ type Purchase struct {
 	PlanID    string `json:"plan_id"`
 	StartedAt int64  `json:"started_at,omitempty"`
 	ExpiresAt int64  `json:"expires_at,omitempty"`
-}
-
-// CustomerProduct is an Autumn product as it appears in webhook payloads
-// (customer.products[] and updated_product). The REST API uses Subscription
-// instead.
-type CustomerProduct struct {
-	ID        string         `json:"id"`
-	Name      string         `json:"name,omitempty"`
-	Status    string         `json:"status,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	StartedAt int64          `json:"started_at,omitempty"`
-	EndsAt    int64          `json:"ends_at,omitempty"`
 }
 
 // Balance captures per-feature usage state on a customer.

--- a/backend/libs/autumn/webhook.go
+++ b/backend/libs/autumn/webhook.go
@@ -29,9 +29,7 @@ type Event struct {
 	Data json.RawMessage `json:"data"`
 }
 
-// BillingUpdatedData is the data payload for billing.updated. plan_changes
-// carries the transitions in this event: each is one plan being activated,
-// scheduled, updated in place, or expired.
+// BillingUpdatedData is the data payload for billing.updated.
 type BillingUpdatedData struct {
 	CustomerID  string       `json:"customer_id"`
 	EntityID    string       `json:"entity_id,omitempty"`
@@ -40,27 +38,24 @@ type BillingUpdatedData struct {
 
 // PlanChange is one plan transition inside a billing.updated event. The plan
 // that changed is either a recurring subscription or a one-off purchase, so
-// Autumn fills in one of the two snapshots below and leaves the other empty.
-// Subscription reuses the shared Subscription type, whose
-// plan_id/started_at/status fields match the webhook's subscription object.
+// Autumn fills in one of the two snapshots and leaves the other empty.
 type PlanChange struct {
 	Action       string           `json:"action"`
 	Subscription Subscription     `json:"subscription"`
 	Purchase     PurchaseSnapshot `json:"purchase"`
 }
 
-// PurchaseSnapshot is a one-off purchase's state after a plan change. Autumn
-// sends a status here that the Purchase entries on a customer read from the
-// API do not carry, which is why the webhook has its own type.
+// PurchaseSnapshot is a one-off purchase's state after a plan change. It has
+// its own type because Autumn sends a status here that the Purchase entries on
+// a customer read from the API do not carry.
 type PurchaseSnapshot struct {
 	PlanID    string `json:"plan_id"`
 	Status    string `json:"status,omitempty"` // "active" | "scheduled" | "expired"
 	ExpiresAt int64  `json:"expires_at,omitempty"`
 }
 
-// PlanID returns the identifier of the plan this change is about. A plan change
-// describes either a recurring subscription or a one-off purchase and never
-// both, so the plan id has to be read from whichever of the two Autumn sent.
+// PlanID returns the identifier of the plan this change is about, from
+// whichever of the two snapshots Autumn filled in.
 func (pc PlanChange) PlanID() string {
 	if pc.Subscription.PlanID != "" {
 		return pc.Subscription.PlanID
@@ -90,11 +85,9 @@ type UsageAlert struct {
 	ThresholdType string  `json:"threshold_type"` // "usage" | "usage_percentage"
 }
 
-// VerifyWebhook validates the Svix signature on an Autumn webhook payload
-// and returns the parsed Event on success.
-//
-// The secret is Autumn's dashboard-provided webhook signing secret
-// (starts with "whsec_").
+// VerifyWebhook validates the Svix signature on an Autumn webhook payload and
+// returns the parsed Event. The secret is the webhook signing secret from the
+// Autumn dashboard, which starts with "whsec_".
 func VerifyWebhook(headers http.Header, body []byte, secret string) (*Event, error) {
 	wh, err := svix.NewWebhook(secret)
 	if err != nil {

--- a/backend/libs/autumn/webhook.go
+++ b/backend/libs/autumn/webhook.go
@@ -38,13 +38,34 @@ type BillingUpdatedData struct {
 	PlanChanges []PlanChange `json:"plan_changes"`
 }
 
-// PlanChange is one plan transition inside a billing.updated event.
-// Subscription is the plan's state after the change; it reuses the shared
-// Subscription type, whose plan_id/started_at/status fields match the webhook's
-// subscription object.
+// PlanChange is one plan transition inside a billing.updated event. The plan
+// that changed is either a recurring subscription or a one-off purchase, so
+// Autumn fills in one of the two snapshots below and leaves the other empty.
+// Subscription reuses the shared Subscription type, whose
+// plan_id/started_at/status fields match the webhook's subscription object.
 type PlanChange struct {
-	Action       string       `json:"action"`
-	Subscription Subscription `json:"subscription"`
+	Action       string           `json:"action"`
+	Subscription Subscription     `json:"subscription"`
+	Purchase     PurchaseSnapshot `json:"purchase"`
+}
+
+// PurchaseSnapshot is a one-off purchase's state after a plan change. Autumn
+// sends a status here that the Purchase entries on a customer read from the
+// API do not carry, which is why the webhook has its own type.
+type PurchaseSnapshot struct {
+	PlanID    string `json:"plan_id"`
+	Status    string `json:"status,omitempty"` // "active" | "scheduled" | "expired"
+	ExpiresAt int64  `json:"expires_at,omitempty"`
+}
+
+// PlanID returns the identifier of the plan this change is about. A plan change
+// describes either a recurring subscription or a one-off purchase and never
+// both, so the plan id has to be read from whichever of the two Autumn sent.
+func (pc PlanChange) PlanID() string {
+	if pc.Subscription.PlanID != "" {
+		return pc.Subscription.PlanID
+	}
+	return pc.Purchase.PlanID
 }
 
 // BalancesLimitReachedData is the data payload for balances.limit_reached.

--- a/backend/libs/autumn/webhook_test.go
+++ b/backend/libs/autumn/webhook_test.go
@@ -1,0 +1,64 @@
+package autumn
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPlanChangePlanID covers both snapshots a plan change can carry: a
+// recurring plan arrives under "subscription", a one-off plan under
+// "purchase", and the plan id has to come out of whichever one Autumn sent.
+func TestPlanChangePlanID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "subscription snapshot",
+			payload: `{"action":"activated","subscription":{"plan_id":"measure_pro"}}`,
+			want:    "measure_pro",
+		},
+		{
+			name:    "purchase snapshot",
+			payload: `{"action":"activated","purchase":{"plan_id":"acme_one_year","status":"active","expires_at":1790000000000}}`,
+			want:    "acme_one_year",
+		},
+		{
+			name:    "neither snapshot",
+			payload: `{"action":"updated"}`,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pc PlanChange
+			if err := json.Unmarshal([]byte(tt.payload), &pc); err != nil {
+				t.Fatalf("unmarshal plan change: %v", err)
+			}
+			if got := pc.PlanID(); got != tt.want {
+				t.Errorf("PlanID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPlanChangePurchaseFields verifies the purchase snapshot's own fields
+// decode, since the webhook sends a status that the API's Purchase does not.
+func TestPlanChangePurchaseFields(t *testing.T) {
+	var pc PlanChange
+	payload := `{"action":"activated","purchase":{"plan_id":"acme_one_year","status":"active","expires_at":1790000000000}}`
+	if err := json.Unmarshal([]byte(payload), &pc); err != nil {
+		t.Fatalf("unmarshal plan change: %v", err)
+	}
+	if pc.Purchase.Status != "active" {
+		t.Errorf("Purchase.Status = %q, want %q", pc.Purchase.Status, "active")
+	}
+	if pc.Purchase.ExpiresAt != 1790000000000 {
+		t.Errorf("Purchase.ExpiresAt = %d, want %d", pc.Purchase.ExpiresAt, int64(1790000000000))
+	}
+	if pc.Subscription.PlanID != "" {
+		t.Errorf("Subscription.PlanID = %q, want empty for a one-off change", pc.Subscription.PlanID)
+	}
+}

--- a/backend/libs/email/builders.go
+++ b/backend/libs/email/builders.go
@@ -105,7 +105,10 @@ func TeamDailySummaryEmail(teamName string, date time.Time, apps []AppDailySumma
 // UsageLimitEmail builds the usage limit threshold notification email.
 // Percentages are safe to include (they're plan-agnostic); absolute byte
 // counts are not, since the dashboard is the source of truth for plan limits.
-// isEnterprise swaps the Pro upgrade CTA for a contact-us mailto link.
+// isEnterprise swaps the Pro upgrade CTA for a contact-us mailto link and
+// drops the monthly framing, since an enterprise plan buys data for a term
+// rather than per month. The free allowance the team falls back on afterwards
+// is the monthly one the message at 100 names.
 func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int, isEnterprise bool) (subject, body string) {
 	ctaText := "Upgrade to Measure Pro"
 	ctaURL := fmt.Sprintf("%s/%s/usage", siteOrigin, teamId)
@@ -120,7 +123,7 @@ func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int, isEnter
 		subject = fmt.Sprintf("%s - Usage Limit Reached", teamName)
 		title = "Usage Limit Reached"
 		if isEnterprise {
-			message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Contact us to increase your limit.`, escape(teamName))
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has ingested all the data its plan allows.<br><br>Ingestion is paused and will resume when the monthly free allowance resets. Contact us if you need a higher limit.`, escape(teamName))
 		} else {
 			message = fmt.Sprintf(`Your team <strong>%s</strong> has reached its plan's data limit this month.<br><br>Data ingestion has been paused. Upgrade to Measure Pro to resume.`, escape(teamName))
 		}
@@ -128,7 +131,7 @@ func UsageLimitEmail(teamName, teamId, siteOrigin string, threshold int, isEnter
 		subject = fmt.Sprintf("%s - %d%% of Usage Limit Reached", teamName, threshold)
 		title = fmt.Sprintf("%d%% Usage Limit Reached", threshold)
 		if isEnterprise {
-			message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Contact us if you need a higher limit.`, escape(teamName), threshold)
+			message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit.<br><br>Contact us if you need a higher limit.`, escape(teamName), threshold)
 		} else {
 			message = fmt.Sprintf(`Your team <strong>%s</strong> has used <strong>%d%%</strong> of its plan's data limit this month.<br><br>Consider upgrading to Measure Pro for unlimited usage!`, escape(teamName), threshold)
 		}

--- a/backend/libs/email/email_test.go
+++ b/backend/libs/email/email_test.go
@@ -700,9 +700,9 @@ func TestUsageLimitEmail_Enterprise(t *testing.T) {
 		wantBodySubstr string
 		wantExtraCopy  string
 	}{
-		{75, "75% of Usage Limit Reached", "has used <strong>75%</strong>", "Contact us if you need a higher limit."},
-		{90, "90% of Usage Limit Reached", "has used <strong>90%</strong>", "Contact us if you need a higher limit."},
-		{100, "Usage Limit Reached", "has reached its plan's data limit", "Data ingestion has been paused. Contact us to increase your limit."},
+		{75, "75% of Usage Limit Reached", "has used <strong>75%</strong> of its plan's data limit.<br><br>", "Contact us if you need a higher limit."},
+		{90, "90% of Usage Limit Reached", "has used <strong>90%</strong> of its plan's data limit.<br><br>", "Contact us if you need a higher limit."},
+		{100, "Usage Limit Reached", "has ingested all the data its plan allows.<br><br>", "Ingestion is paused and will resume when the monthly free allowance resets. Contact us if you need a higher limit."},
 	}
 
 	for _, tt := range tests {
@@ -729,6 +729,11 @@ func TestUsageLimitEmail_Enterprise(t *testing.T) {
 			}
 			if strings.Contains(body, "team-abc/usage") {
 				t.Errorf("enterprise CTA should not link to the usage page")
+			}
+			// The enterprise limit itself is not monthly. The free
+			// allowance the message at 100 names is.
+			if strings.Contains(body, "this month") {
+				t.Errorf("enterprise body should not frame the limit as monthly")
 			}
 
 			mustNotContainByteNumbers(t, fmt.Sprintf("UsageLimitEmail(%d, enterprise)", tt.threshold), body)

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -123,21 +123,19 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 	return *customerID, nil
 }
 
-// DeterminePlan inspects a customer's active subscriptions, purchases and
-// products and returns the plan name we surface to the frontend (free, pro,
-// enterprise).
+// DeterminePlan inspects a customer's active subscriptions and purchases and
+// returns the plan name we surface to the frontend (free, pro, enterprise).
 //
-// API responses populate Subscriptions[].PlanID for recurring plans and
-// Purchases[].PlanID for plans sold as one-off purchases; webhook payloads
-// populate Products[].ID. We check all three so the same helper works on
-// either source.
+// Autumn returns recurring plans in Subscriptions[].PlanID and plans sold as
+// one-off purchases in Purchases[].PlanID, and a customer can hold both at
+// once, so both are checked.
 // Subscriptions with status != "active" (e.g. a Free that's "scheduled" to
 // take over after a Pro cancellation) are ignored — we only report on the
 // plan currently in effect.
 //
-// A customer can hold several active products at once: Autumn auto-attaches
-// the Free product on customer create, and attaching an enterprise plan from
-// the Autumn dashboard does not detach it unless the two share a product group.
+// A customer can hold several active plans at once: Autumn auto-attaches the
+// Free plan on customer create, and attaching an enterprise plan from the
+// Autumn dashboard does not detach it unless the two share a plan group.
 // The highest tier wins, using the same order as planRank: any non-free,
 // non-pro plan counts as enterprise and wins over Pro, which wins over Free.
 func DeterminePlan(c *autumn.Customer) string {
@@ -154,14 +152,6 @@ func DeterminePlan(c *autumn.Customer) string {
 			continue
 		}
 		activePlans = append(activePlans, p.PlanID)
-	}
-	for _, p := range c.Products {
-		// Webhook payloads sometimes omit status — treat empty as active
-		// for back-compat. Otherwise skip non-active (e.g. scheduled).
-		if p.Status != "" && p.Status != "active" {
-			continue
-		}
-		activePlans = append(activePlans, p.ID)
 	}
 
 	if slices.ContainsFunc(activePlans, func(id string) bool {

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -57,6 +57,17 @@ type BillingInfo struct {
 	// BytesOverageAllowed is true when the customer's plan permits going
 	// over BytesGranted (Pro: yes, Free: no, Enterprise: depends).
 	BytesOverageAllowed bool `json:"bytes_overage_allowed"`
+	// DataPurchaseSpent is true when a plan the team holds as a one-off
+	// purchase has no data left of its own grant, so the team is back on the
+	// limits of the free plan they hold alongside it even though BytesGranted
+	// and BytesUsed, which pool the two plans together, read close to the
+	// limit.
+	DataPurchaseSpent bool `json:"data_purchase_spent"`
+	// IngestionBlocked is true when the pooled bytes balance has nothing left
+	// on a plan that is neither unlimited nor permitted to go over, which
+	// mirrors the verdict Autumn gives the ingest path when it asks whether
+	// data may still be accepted.
+	IngestionBlocked bool `json:"ingestion_blocked"`
 	// TokenCreditsGranted and TokenCreditsUsed describe the agent_tokens
 	// feature balance from Autumn. agent_tokens is a credit system: token usage
 	// is priced through Autumn's model catalog into credits, so these are
@@ -139,14 +150,7 @@ func DeterminePlan(c *autumn.Customer) string {
 	}
 	now := time.Now().UnixMilli()
 	for _, p := range c.Purchases {
-		// A purchase carries no status field the way a subscription does, so its
-		// start and expiry timestamps are what tell us it is in effect right now.
-		// Without checking them, a purchase scheduled to begin later, or one whose
-		// term has already ended, would count as if the customer held it today.
-		if p.StartedAt > now {
-			continue
-		}
-		if p.ExpiresAt != 0 && p.ExpiresAt <= now {
+		if !purchaseInEffect(p, now) {
 			continue
 		}
 		activePlans = append(activePlans, p.PlanID)
@@ -169,6 +173,23 @@ func DeterminePlan(c *autumn.Customer) string {
 		return PlanPro
 	}
 	return PlanFree
+}
+
+// purchaseInEffect reports whether a purchase is running at nowMillis, which
+// callers pass as milliseconds since epoch to match the timestamps Autumn puts
+// on a purchase. A purchase carries no status field the way a subscription
+// does, so its start and expiry are the only thing saying it is in effect, and
+// Autumn returns purchases that have not begun yet alongside the running ones.
+// Without this test a purchase scheduled to begin later, or one whose term has
+// already ended, would count as if the customer held it today.
+func purchaseInEffect(p autumn.Purchase, nowMillis int64) bool {
+	if p.StartedAt > nowMillis {
+		return false
+	}
+	if p.ExpiresAt != 0 && p.ExpiresAt <= nowMillis {
+		return false
+	}
+	return true
 }
 
 // saveAutumnCustomerID persists an Autumn customer ID on the teams row.
@@ -319,6 +340,39 @@ func RetentionDaysFromBalance(b autumn.Balance) int {
 		longest = max(longest, source.IncludedGrant)
 	}
 	return int(longest)
+}
+
+// DataPurchaseSpent reports whether a team has used up the data granted by a
+// plan they hold as a one-off purchase. A team can hold the free plan, which
+// grants bytes every month, alongside such a purchase, which grants a large
+// fixed amount once, and Autumn pools both grants into the single bytes
+// balance, so the pooled numbers cannot say that the purchase is used up while
+// the monthly free grant still admits data. Matching the purchase against the
+// per-plan breakdown can, and knowing the difference is what lets the
+// dashboard tell the team they are now on free plan limits one their purchased
+// data ends.
+//
+// The purchase is identified by matching plan ids against the purchases the
+// customer holds today rather than read off the breakdown alone, because the
+// breakdown says nothing about when a plan's term runs and Autumn's customer
+// read includes purchases that are only scheduled to start.
+func DataPurchaseSpent(c *autumn.Customer) bool {
+	b, ok := c.Balances[autumn.FeatureBytes]
+	if !ok {
+		return false
+	}
+	now := time.Now().UnixMilli()
+	for _, source := range b.Breakdown {
+		if source.Remaining > 0 {
+			continue
+		}
+		if slices.ContainsFunc(c.Purchases, func(p autumn.Purchase) bool {
+			return p.PlanID == source.PlanID && purchaseInEffect(p, now)
+		}) {
+			return true
+		}
+	}
+	return false
 }
 
 func lookupTeamIDByAutumnCustomer(ctx context.Context, pg *pgxpool.Pool, customerID string) (uuid.UUID, error) {

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -299,7 +299,26 @@ func GetPlanRetentionDays(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 	if !ok || b.Granted <= 0 {
 		return 0, fmt.Errorf("retention_days feature not configured for customer %s", customerID)
 	}
-	return int(b.Granted), nil
+	return RetentionDaysFromBalance(b), nil
+}
+
+// RetentionDaysFromBalance returns the longest retention any single plan on
+// the balance grants. Autumn adds up a feature's grants across every plan the
+// customer holds, which is what we want for a data quota but not for
+// retention, where a team on the free plan alongside a bespoke plan would
+// otherwise get the two retention periods added together. The longest period
+// any one plan grants is the one the team is entitled to. Older balances, and
+// any the API returns without a per-plan breakdown, fall back to the pooled
+// Granted value.
+func RetentionDaysFromBalance(b autumn.Balance) int {
+	if len(b.Breakdown) == 0 {
+		return int(b.Granted)
+	}
+	longest := 0.0
+	for _, source := range b.Breakdown {
+		longest = max(longest, source.IncludedGrant)
+	}
+	return int(longest)
 }
 
 func lookupTeamIDByAutumnCustomer(ctx context.Context, pg *pgxpool.Pool, customerID string) (uuid.UUID, error) {

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -112,11 +112,14 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 	return *customerID, nil
 }
 
-// DeterminePlan inspects a customer's active subscriptions/products and
-// returns the plan name we surface to the frontend (free, pro, enterprise).
+// DeterminePlan inspects a customer's active subscriptions, purchases and
+// products and returns the plan name we surface to the frontend (free, pro,
+// enterprise).
 //
-// API responses populate Subscriptions[].PlanID; webhook payloads populate
-// Products[].ID. We check both so the same helper works on either source.
+// API responses populate Subscriptions[].PlanID for recurring plans and
+// Purchases[].PlanID for one-off plans bought outright; webhook payloads
+// populate Products[].ID. We check all three so the same helper works on
+// either source.
 // Subscriptions with status != "active" (e.g. a Free that's "scheduled" to
 // take over after a Pro cancellation) are ignored — we only report on the
 // plan currently in effect.
@@ -133,6 +136,20 @@ func DeterminePlan(c *autumn.Customer) string {
 			continue
 		}
 		activePlans = append(activePlans, s.PlanID)
+	}
+	now := time.Now().UnixMilli()
+	for _, p := range c.Purchases {
+		// A purchase carries no status field the way a subscription does, so its
+		// start and expiry timestamps are what tell us it is in effect right now.
+		// Without checking them, a purchase scheduled to begin later, or one whose
+		// term has already ended, would count as if the customer held it today.
+		if p.StartedAt > now {
+			continue
+		}
+		if p.ExpiresAt != 0 && p.ExpiresAt <= now {
+			continue
+		}
+		activePlans = append(activePlans, p.PlanID)
 	}
 	for _, p := range c.Products {
 		// Webhook payloads sometimes omit status — treat empty as active

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -337,8 +337,9 @@ func lookupTeamIDByAutumnCustomer(ctx context.Context, pg *pgxpool.Pool, custome
 // event. A transition is one plan activating in place of another expiring in the
 // same event; comparing their ranks tells an upgrade from a downgrade. A plan
 // activating or expiring on its own resets retention without announcing a
-// direction. In-place "updated"/"scheduled" changes and a same-rank swap (e.g.
-// re-attaching a plan when a priced feature is added) carry no transition.
+// direction. When the two plans rank the same, as two bespoke plans always do,
+// retention still follows the plan that activated while no upgrade or downgrade
+// is announced. In-place "updated"/"scheduled" changes carry no transition.
 func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, siteOrigin, txEmail string, data autumn.BillingUpdatedData) {
 	teamID, err := lookupTeamIDByAutumnCustomer(ctx, pg, data.CustomerID)
 	if err != nil {
@@ -369,14 +370,7 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 	// the change present there is no upgrade or downgrade to announce, so no
 	// email goes out.
 	if activated == nil || expired == nil {
-		retention, err := GetPlanRetentionDays(ctx, pg, billingEnabled, teamID)
-		if err != nil {
-			log.Printf("webhook: resolve retention for team %s failed: %v", teamID, err)
-			return
-		}
-		if err := resetAppsRetention(ctx, pg, nil, teamID, retention); err != nil {
-			log.Printf("webhook: reset retention for team %s failed: %v", teamID, err)
-		}
+		resetTeamRetentionFromPlan(ctx, pg, billingEnabled, teamID)
 		return
 	}
 
@@ -403,6 +397,33 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 			return
 		}
 		fireSubscriptionDowngradedEvent(teamID, owner, data.CustomerID, activated.Subscription)
+
+	default:
+		// planRank gives every bespoke plan the same rank, so a customer whose
+		// bespoke contract is replaced by a re-issued one at different terms
+		// arrives here, as does a plan Autumn re-attaches to itself when a
+		// priced feature is added. The team's retention has to follow the plan
+		// that activated, otherwise a renewal at new terms leaves the team on
+		// the retention its previous contract granted. Neither side outranks
+		// the other, so there is no upgrade or downgrade to report and no email
+		// goes out.
+		resetTeamRetentionFromPlan(ctx, pg, billingEnabled, teamID)
+	}
+}
+
+// resetTeamRetentionFromPlan re-reads the retention the team's current Autumn
+// plans grant and writes it to every app the team owns, without sending any
+// email. Callers use it for a plan change that has no direction to announce.
+// Both steps log their own failure rather than returning one, since the
+// webhook handler acks the event either way.
+func resetTeamRetentionFromPlan(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID) {
+	retention, err := GetPlanRetentionDays(ctx, pg, billingEnabled, teamID)
+	if err != nil {
+		log.Printf("webhook: resolve retention for team %s failed: %v", teamID, err)
+		return
+	}
+	if err := resetAppsRetention(ctx, pg, nil, teamID, retention); err != nil {
+		log.Printf("webhook: reset retention for team %s failed: %v", teamID, err)
 	}
 }
 

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -117,7 +117,7 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 // enterprise).
 //
 // API responses populate Subscriptions[].PlanID for recurring plans and
-// Purchases[].PlanID for one-off plans bought outright; webhook payloads
+// Purchases[].PlanID for plans sold as one-off purchases; webhook payloads
 // populate Products[].ID. We check all three so the same helper works on
 // either source.
 // Subscriptions with status != "active" (e.g. a Free that's "scheduled" to
@@ -335,10 +335,10 @@ func lookupTeamIDByAutumnCustomer(ctx context.Context, pg *pgxpool.Pool, custome
 
 // HandleBillingUpdated applies a plan transition from an Autumn billing.updated
 // event. A transition is one plan activating in place of another expiring in the
-// same event; comparing their ranks tells an upgrade from a downgrade. In-place
-// "updated"/"scheduled" changes, a same-rank swap (e.g. re-attaching a plan when
-// a priced feature is added), and a lone Free activation (new-team signup) carry
-// no transition.
+// same event; comparing their ranks tells an upgrade from a downgrade. A plan
+// activating or expiring on its own resets retention without announcing a
+// direction. In-place "updated"/"scheduled" changes and a same-rank swap (e.g.
+// re-attaching a plan when a priced feature is added) carry no transition.
 func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, siteOrigin, txEmail string, data autumn.BillingUpdatedData) {
 	teamID, err := lookupTeamIDByAutumnCustomer(ctx, pg, data.CustomerID)
 	if err != nil {
@@ -346,25 +346,42 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 		return
 	}
 
-	var activated, expired *autumn.Subscription
+	var activated, expired *autumn.PlanChange
 	for i := range data.PlanChanges {
 		pc := &data.PlanChanges[i]
 		switch pc.Action {
 		case autumn.ActionActivated:
-			activated = &pc.Subscription
+			activated = pc
 		case autumn.ActionExpired:
-			expired = &pc.Subscription
+			expired = pc
 		}
 	}
-	// Without both a plan starting and one ending there is no transition to
-	// apply: an in-place update (a priced feature added), a scheduled change, or
-	// a new team's first Free attach.
+	// With no plan starting and none ending there is nothing to apply: an
+	// in-place update (a priced feature added) or a scheduled change.
+	if activated == nil && expired == nil {
+		return
+	}
+
+	// Autumn expires a plan only when a recurring plan replaces it, so attaching
+	// a plan sold as a one-off purchase on top of the free plan a team already
+	// holds arrives here as a lone activation. The team's retention still has to follow the plans they
+	// now hold, so reset it from the plans Autumn reports; with only one side of
+	// the change present there is no upgrade or downgrade to announce, so no
+	// email goes out.
 	if activated == nil || expired == nil {
+		retention, err := GetPlanRetentionDays(ctx, pg, billingEnabled, teamID)
+		if err != nil {
+			log.Printf("webhook: resolve retention for team %s failed: %v", teamID, err)
+			return
+		}
+		if err := resetAppsRetention(ctx, pg, nil, teamID, retention); err != nil {
+			log.Printf("webhook: reset retention for team %s failed: %v", teamID, err)
+		}
 		return
 	}
 
 	switch {
-	case planRank(activated.PlanID) > planRank(expired.PlanID):
+	case planRank(activated.PlanID()) > planRank(expired.PlanID()):
 		if err := applyPlanTransition(ctx, pg, billingEnabled, teamID, func(ctx context.Context, tx pgx.Tx) error {
 			return notifyUpgrade(ctx, pg, tx, siteOrigin, txEmail, teamID)
 		}); err != nil {
@@ -374,10 +391,10 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 		if !ok {
 			return
 		}
-		firePurchaseEvent(teamID, owner, data.CustomerID, *activated)
-		fireSubscriptionUpgradedEvent(teamID, owner, data.CustomerID, *activated)
+		firePurchaseEvent(teamID, owner, data.CustomerID, activated.Subscription)
+		fireSubscriptionUpgradedEvent(teamID, owner, data.CustomerID, activated.Subscription)
 
-	case planRank(activated.PlanID) < planRank(expired.PlanID):
+	case planRank(activated.PlanID()) < planRank(expired.PlanID()):
 		applyPlanTransition(ctx, pg, billingEnabled, teamID, func(ctx context.Context, tx pgx.Tx) error {
 			return notifyDowngrade(ctx, pg, tx, siteOrigin, txEmail, teamID)
 		})
@@ -385,7 +402,7 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 		if !ok {
 			return
 		}
-		fireSubscriptionDowngradedEvent(teamID, owner, data.CustomerID, *activated)
+		fireSubscriptionDowngradedEvent(teamID, owner, data.CustomerID, activated.Subscription)
 	}
 }
 

--- a/backend/libs/measure/billing.go
+++ b/backend/libs/measure/billing.go
@@ -18,9 +18,9 @@ import (
 	"github.com/leporo/sqlf"
 )
 
-// Retention bounds enforced server-side. Per-plan retention values live in
-// Autumn (read via the retention_days feature); these constants only define
-// the floor we accept and the self-host default.
+// Retention bounds enforced server-side. Per-plan retention lives in Autumn's
+// retention_days feature; these only bound what we accept, and the minimum
+// doubles as the self-host default.
 const (
 	MIN_RETENTION_DAYS = 30
 	MAX_RETENTION_DAYS = 365
@@ -33,70 +33,48 @@ const (
 	PlanEnterprise = "enterprise"
 )
 
-// Autumn plan IDs — match the slugs configured in the Autumn dashboard.
+// Autumn plan IDs, matching the slugs configured in the Autumn dashboard.
 const (
 	AutumnPlanFree = "measure_free"
 	AutumnPlanPro  = "measure_pro"
 )
 
-// BillingInfo is the payload for GET /teams/{id}/billing/info.
-//
-// Single source for plan + bytes + subscription state used by the dashboard.
-// Subscription fields are only populated when the customer has at least one
-// Autumn subscription. CurrentPeriodStart/End are seconds since epoch (the
-// frontend multiplies by 1000 for JS Date).
+// BillingInfo is the payload for GET /teams/{id}/billing/info. Subscription
+// fields are filled in only when the customer has an Autumn subscription.
+// CurrentPeriodStart and CurrentPeriodEnd are seconds since epoch, which the
+// frontend multiplies by 1000 for JS Date.
 type BillingInfo struct {
-	TeamID           uuid.UUID `json:"team_id"`
-	Plan             string    `json:"plan"`
-	AutumnCustomerID *string   `json:"autumn_customer_id"`
-	BytesGranted     float64   `json:"bytes_granted"`
-	BytesUsed        float64   `json:"bytes_used"`
-	// BytesUnlimited is true when the customer's bytes feature is configured
-	// as unlimited in Autumn, typically only on enterprise plans.
-	BytesUnlimited bool `json:"bytes_unlimited"`
-	// BytesOverageAllowed is true when the customer's plan permits going
-	// over BytesGranted (Pro: yes, Free: no, Enterprise: depends).
-	BytesOverageAllowed bool `json:"bytes_overage_allowed"`
+	TeamID              uuid.UUID `json:"team_id"`
+	Plan                string    `json:"plan"`
+	AutumnCustomerID    *string   `json:"autumn_customer_id"`
+	BytesGranted        float64   `json:"bytes_granted"`
+	BytesUsed           float64   `json:"bytes_used"`
+	BytesUnlimited      bool      `json:"bytes_unlimited"`
+	BytesOverageAllowed bool      `json:"bytes_overage_allowed"`
 	// DataPurchaseSpent is true when a plan the team holds as a one-off
-	// purchase has no data left of its own grant, so the team is back on the
-	// limits of the free plan they hold alongside it even though BytesGranted
-	// and BytesUsed, which pool the two plans together, read close to the
-	// limit.
+	// purchase has no data left of its own grant, leaving the team on the
+	// limits of the free plan they hold alongside it.
 	DataPurchaseSpent bool `json:"data_purchase_spent"`
-	// IngestionBlocked is true when the pooled bytes balance has nothing left
-	// on a plan that is neither unlimited nor permitted to go over, which
-	// mirrors the verdict Autumn gives the ingest path when it asks whether
-	// data may still be accepted.
+	// IngestionBlocked mirrors the verdict Autumn gives the ingest path, so the
+	// dashboard does not have to infer it from a percentage.
 	IngestionBlocked bool `json:"ingestion_blocked"`
-	// TokenCreditsGranted and TokenCreditsUsed describe the agent_tokens
-	// feature balance from Autumn. agent_tokens is a credit system: token usage
-	// is priced through Autumn's model catalog into credits, so these are
-	// denominated in credits, not raw token counts.
-	TokenCreditsGranted float64 `json:"token_credits_granted,omitempty"`
-	TokenCreditsUsed    float64 `json:"token_credits_used,omitempty"`
-	// TokenCreditsUnlimited is true when the agent_tokens feature is configured
-	// as unlimited in Autumn.
-	TokenCreditsUnlimited bool `json:"token_credits_unlimited,omitempty"`
-	// TokenCreditsOverageAllowed is true when the customer's plan permits going
-	// over TokenCreditsGranted.
-	TokenCreditsOverageAllowed bool `json:"token_credits_overage_allowed,omitempty"`
-	// RetentionDays is the retention entitlement on the customer's current
-	// plan, read from the retention_days feature in Autumn. 0 when billing
-	// is disabled or the customer has no Autumn record yet.
+	// agent_tokens is an Autumn credit system: token usage is priced through
+	// Autumn's model catalog into credits, so these are credits rather than
+	// raw token counts.
+	TokenCreditsGranted        float64 `json:"token_credits_granted,omitempty"`
+	TokenCreditsUsed           float64 `json:"token_credits_used,omitempty"`
+	TokenCreditsUnlimited      bool    `json:"token_credits_unlimited,omitempty"`
+	TokenCreditsOverageAllowed bool    `json:"token_credits_overage_allowed,omitempty"`
+	// RetentionDays is 0 when billing is disabled or the customer has no Autumn
+	// record yet.
 	RetentionDays      int    `json:"retention_days,omitempty"`
 	Status             string `json:"status,omitempty"`
 	CurrentPeriodStart int64  `json:"current_period_start,omitempty"`
 	CurrentPeriodEnd   int64  `json:"current_period_end,omitempty"`
-	// CanceledAt is non-zero when a cancel_end_of_cycle is pending on the
-	// active subscription. The subscription remains usable until
-	// CurrentPeriodEnd; the frontend reads this to swap the downgrade button
-	// to "Undo Cancellation".
+	// CanceledAt is non-zero when a cancellation at end of cycle is pending on
+	// the active subscription, which stays usable until CurrentPeriodEnd.
 	CanceledAt int64 `json:"canceled_at,omitempty"`
 }
-
-// ----------------------------------------------------------------------------
-// Helpers
-// ----------------------------------------------------------------------------
 
 var ErrTeamNotFound = errors.New("team not found")
 
@@ -123,21 +101,13 @@ func GetAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UU
 	return *customerID, nil
 }
 
-// DeterminePlan inspects a customer's active subscriptions and purchases and
-// returns the plan name we surface to the frontend (free, pro, enterprise).
+// DeterminePlan returns the plan name we surface to the frontend (free, pro,
+// enterprise) for the plans a customer holds today.
 //
-// Autumn returns recurring plans in Subscriptions[].PlanID and plans sold as
-// one-off purchases in Purchases[].PlanID, and a customer can hold both at
-// once, so both are checked.
-// Subscriptions with status != "active" (e.g. a Free that's "scheduled" to
-// take over after a Pro cancellation) are ignored — we only report on the
-// plan currently in effect.
-//
-// A customer can hold several active plans at once: Autumn auto-attaches the
-// Free plan on customer create, and attaching an enterprise plan from the
-// Autumn dashboard does not detach it unless the two share a plan group.
-// The highest tier wins, using the same order as planRank: any non-free,
-// non-pro plan counts as enterprise and wins over Pro, which wins over Free.
+// Attaching an enterprise plan from the Autumn dashboard does not detach the
+// free plan unless the two share a plan group, so a customer can hold several
+// plans at once and the highest tier has to win. The order matches planRank:
+// any plan that is neither free nor pro counts as enterprise.
 func DeterminePlan(c *autumn.Customer) string {
 	var activePlans []string
 	for _, s := range c.Subscriptions {
@@ -165,13 +135,11 @@ func DeterminePlan(c *autumn.Customer) string {
 	return PlanFree
 }
 
-// purchaseInEffect reports whether a purchase is running at nowMillis, which
-// callers pass as milliseconds since epoch to match the timestamps Autumn puts
-// on a purchase. A purchase carries no status field the way a subscription
-// does, so its start and expiry are the only thing saying it is in effect, and
-// Autumn returns purchases that have not begun yet alongside the running ones.
-// Without this test a purchase scheduled to begin later, or one whose term has
-// already ended, would count as if the customer held it today.
+// purchaseInEffect reports whether a purchase is running at nowMillis, given in
+// milliseconds since epoch to match the timestamps on a purchase. Autumn returns
+// purchases that have not begun yet, and ones whose term has ended, alongside
+// the running ones, so without this test they would count as plans the customer
+// holds today.
 func purchaseInEffect(p autumn.Purchase, nowMillis int64) bool {
 	if p.StartedAt > nowMillis {
 		return false
@@ -182,8 +150,8 @@ func purchaseInEffect(p autumn.Purchase, nowMillis int64) bool {
 	return true
 }
 
-// saveAutumnCustomerID persists an Autumn customer ID on the teams row.
-// Accepts an optional transaction handle; pass nil to use the pool directly.
+// saveAutumnCustomerID persists an Autumn customer ID on the teams row. Pass a
+// non-nil tx to enroll the update in a caller-managed transaction.
 func saveAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, teamID uuid.UUID, customerID string) error {
 	stmt := sqlf.PostgreSQL.
 		Update("teams").
@@ -201,10 +169,9 @@ func saveAutumnCustomerID(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, te
 }
 
 // ProvisionAutumnCustomer creates an Autumn customer for the given team and
-// returns the newly created autumn_customer_id. Called inside the
-// team-creation transaction so that team creation fails if Autumn is
-// unreachable. Autumn auto-attaches the Free plan on customer create — no
-// explicit Attach call is needed.
+// returns the new autumn_customer_id. It runs inside the team-creation
+// transaction so team creation fails when Autumn is unreachable. Autumn
+// auto-attaches the free plan on customer create, so no Attach call follows.
 func ProvisionAutumnCustomer(ctx context.Context, billingEnabled bool, tx pgx.Tx, teamID uuid.UUID, teamName, ownerEmail string) (string, error) {
 	if !billingEnabled {
 		return "", nil
@@ -222,11 +189,10 @@ func ProvisionAutumnCustomer(ctx context.Context, billingEnabled bool, tx pgx.Tx
 
 // SyncBillingEmailOnOwnerExit points a team's Autumn customer email at a
 // remaining owner after the member it belonged to was removed or demoted.
-// The customer email is set at team creation to the creating owner's email,
-// and Autumn/Stripe send invoices, receipts and dunning notices there, so a
-// departed owner's address must not stay on the record. An email that does
-// not match the departing member (for example a finance inbox set through
-// the billing portal) is left alone.
+// Autumn and Stripe send invoices, receipts and dunning notices to that
+// address, so a departed owner's address must not stay on the record. An
+// address that does not match the departing member, a finance inbox set through
+// the billing portal for instance, is left alone.
 func SyncBillingEmailOnOwnerExit(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID, departedEmail string) error {
 	if !billingEnabled || departedEmail == "" {
 		return nil
@@ -236,8 +202,7 @@ func SyncBillingEmailOnOwnerExit(ctx context.Context, pg *pgxpool.Pool, billingE
 	if err != nil {
 		return err
 	}
-	// In self hosted environments, a team will have no autumn customer and no billing email,
-	// nothing to do, return
+	// A self-hosted team has no Autumn customer and so no billing email.
 	if customerID == "" {
 		return nil
 	}
@@ -279,18 +244,12 @@ func resetAppsRetention(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, team
 	return err
 }
 
-// ----------------------------------------------------------------------------
-// Retention checks (called from other handlers in this package)
-// ----------------------------------------------------------------------------
-
-// GetPlanRetentionDays returns the retention in days for a team's current
-// Autumn plan, read from the retention_days feature entitlement. In
-// self-hosted mode (billing disabled), returns the Free plan default — the
-// user controls retention directly in that mode.
+// GetPlanRetentionDays returns the retention in days a team's current Autumn
+// plans grant. With billing disabled the user controls retention directly, so
+// this returns the free plan default.
 //
-// Every plan in Autumn (Free, Pro, Enterprise) must have the retention_days
-// feature configured; if it's missing, this returns an error rather than
-// silently downgrading retention.
+// Every plan in Autumn must have the retention_days feature configured; a
+// missing one is an error rather than a silent downgrade to no retention.
 func GetPlanRetentionDays(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID) (int, error) {
 	if !billingEnabled {
 		return MIN_RETENTION_DAYS, nil
@@ -313,14 +272,15 @@ func GetPlanRetentionDays(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 	return RetentionDaysFromBalance(b), nil
 }
 
-// RetentionDaysFromBalance returns the longest retention any single plan on
-// the balance grants. Autumn adds up a feature's grants across every plan the
-// customer holds, which is what we want for a data quota but not for
-// retention, where a team on the free plan alongside a bespoke plan would
-// otherwise get the two retention periods added together. The longest period
-// any one plan grants is the one the team is entitled to. Older balances, and
-// any the API returns without a per-plan breakdown, fall back to the pooled
-// Granted value.
+// RetentionDaysFromBalance returns the longest retention any single plan on the
+// balance grants. The pooled Granted is right for a data quota and wrong for
+// retention: a team holding the free plan alongside an enterprise plan would get
+// the two retention periods added together. A balance the API returns without a
+// per-plan breakdown falls back to Granted.
+//
+// Retention follows the grant, not the balance, so a team that has spent an
+// enterprise plan's data keeps its retention until the plan is detached or
+// expires, indefinitely for a one-off enterprise plan that never expires.
 func RetentionDaysFromBalance(b autumn.Balance) int {
 	if len(b.Breakdown) == 0 {
 		return int(b.Granted)
@@ -333,19 +293,14 @@ func RetentionDaysFromBalance(b autumn.Balance) int {
 }
 
 // DataPurchaseSpent reports whether a team has used up the data granted by a
-// plan they hold as a one-off purchase. A team can hold the free plan, which
-// grants bytes every month, alongside such a purchase, which grants a large
-// fixed amount once, and Autumn pools both grants into the single bytes
-// balance, so the pooled numbers cannot say that the purchase is used up while
-// the monthly free grant still admits data. Matching the purchase against the
-// per-plan breakdown can, and knowing the difference is what lets the
-// dashboard tell the team they are now on free plan limits one their purchased
-// data ends.
+// plan they hold as a one-off purchase, which is what lets the dashboard tell
+// them they are back on free plan limits. The pooled bytes figures cannot
+// express "the purchase is spent while the monthly free grant still admits
+// data"; only the per-plan breakdown can.
 //
-// The purchase is identified by matching plan ids against the purchases the
-// customer holds today rather than read off the breakdown alone, because the
-// breakdown says nothing about when a plan's term runs and Autumn's customer
-// read includes purchases that are only scheduled to start.
+// The plan ids are matched against the purchases the customer holds today
+// rather than read off the breakdown alone, because the breakdown says nothing
+// about when a plan's term runs.
 func DataPurchaseSpent(c *autumn.Customer) bool {
 	b, ok := c.Balances[autumn.FeatureBytes]
 	if !ok {
@@ -378,12 +333,9 @@ func lookupTeamIDByAutumnCustomer(ctx context.Context, pg *pgxpool.Pool, custome
 }
 
 // HandleBillingUpdated applies a plan transition from an Autumn billing.updated
-// event. A transition is one plan activating in place of another expiring in the
-// same event; comparing their ranks tells an upgrade from a downgrade. A plan
-// activating or expiring on its own resets retention without announcing a
-// direction. When the two plans rank the same, as two bespoke plans always do,
-// retention still follows the plan that activated while no upgrade or downgrade
-// is announced. In-place "updated"/"scheduled" changes carry no transition.
+// event. A transition is one plan activating in place of another expiring in
+// the same event, and comparing their ranks tells an upgrade from a downgrade.
+// Anything else resets retention and announces nothing.
 func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, siteOrigin, txEmail string, data autumn.BillingUpdatedData) {
 	teamID, err := lookupTeamIDByAutumnCustomer(ctx, pg, data.CustomerID)
 	if err != nil {
@@ -401,18 +353,17 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 			expired = pc
 		}
 	}
-	// With no plan starting and none ending there is nothing to apply: an
-	// in-place update (a priced feature added) or a scheduled change.
+	// A change scheduled for later, or an in-place update such as a priced
+	// feature being added, has no plan starting and none ending.
 	if activated == nil && expired == nil {
 		return
 	}
 
 	// Autumn expires a plan only when a recurring plan replaces it, so attaching
 	// a plan sold as a one-off purchase on top of the free plan a team already
-	// holds arrives here as a lone activation. The team's retention still has to follow the plans they
-	// now hold, so reset it from the plans Autumn reports; with only one side of
-	// the change present there is no upgrade or downgrade to announce, so no
-	// email goes out.
+	// holds arrives as a lone activation. Retention still has to follow the
+	// plans the team now holds, but one side of a change on its own gives no
+	// direction to announce, so no email goes out.
 	if activated == nil || expired == nil {
 		resetTeamRetentionFromPlan(ctx, pg, billingEnabled, teamID)
 		return
@@ -443,23 +394,18 @@ func HandleBillingUpdated(ctx context.Context, pg *pgxpool.Pool, billingEnabled 
 		fireSubscriptionDowngradedEvent(teamID, owner, data.CustomerID, activated.Subscription)
 
 	default:
-		// planRank gives every bespoke plan the same rank, so a customer whose
-		// bespoke contract is replaced by a re-issued one at different terms
-		// arrives here, as does a plan Autumn re-attaches to itself when a
-		// priced feature is added. The team's retention has to follow the plan
-		// that activated, otherwise a renewal at new terms leaves the team on
-		// the retention its previous contract granted. Neither side outranks
-		// the other, so there is no upgrade or downgrade to report and no email
-		// goes out.
+		// Every enterprise plan shares a rank, so a contract re-issued at new
+		// terms ties, as does a plan Autumn re-attaches to itself. Retention
+		// still has to follow the plan that activated, and a tie gives no
+		// direction to announce, so no email goes out.
 		resetTeamRetentionFromPlan(ctx, pg, billingEnabled, teamID)
 	}
 }
 
 // resetTeamRetentionFromPlan re-reads the retention the team's current Autumn
-// plans grant and writes it to every app the team owns, without sending any
-// email. Callers use it for a plan change that has no direction to announce.
-// Both steps log their own failure rather than returning one, since the
-// webhook handler acks the event either way.
+// plans grant and writes it to every app the team owns, with no email. Failures
+// are logged rather than returned, since the webhook handler acks the event
+// either way.
 func resetTeamRetentionFromPlan(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID) {
 	retention, err := GetPlanRetentionDays(ctx, pg, billingEnabled, teamID)
 	if err != nil {
@@ -471,9 +417,9 @@ func resetTeamRetentionFromPlan(ctx context.Context, pg *pgxpool.Pool, billingEn
 	}
 }
 
-// planRank orders plans by tier so a transition's direction can be read from the
-// plans that activated and expired: Free < Pro < everything else (enterprise
-// plans).
+// planRank orders plans by tier so a transition's direction can be read from
+// the plans that activated and expired: free < pro < every enterprise plan,
+// which all share the top rank.
 func planRank(planID string) int {
 	switch planID {
 	case AutumnPlanFree:
@@ -485,15 +431,13 @@ func planRank(planID string) int {
 	}
 }
 
-// applyPlanTransition runs the retention reset and email enqueue for a real
-// plan change inside a single tx so they atomically commit. If either step
-// fails, the whole webhook ack stays 200 (Svix won't retry) but we don't
-// leave the database in a half-applied state — the next plan event will
-// reconcile retention, and the missed email is a soft failure.
+// applyPlanTransition runs the retention reset and email enqueue for a plan
+// change in one transaction so a failure in either leaves no half-applied
+// state. The webhook still acks 200 and Svix does not retry, so recovery is the
+// next plan event reconciling retention; the missed email is a soft failure.
 //
-// Returns the underlying error so callers can gate downstream side effects
-// (e.g. analytics events) on a successful transition. The error is already
-// logged here; callers should not log it again.
+// The returned error lets callers gate downstream side effects such as
+// analytics events. It is already logged here.
 func applyPlanTransition(ctx context.Context, pg *pgxpool.Pool, billingEnabled bool, teamID uuid.UUID, notify func(ctx context.Context, tx pgx.Tx) error) error {
 	retention, err := GetPlanRetentionDays(ctx, pg, billingEnabled, teamID)
 	if err != nil {
@@ -542,7 +486,7 @@ func HandleUsageAlert(ctx context.Context, pg *pgxpool.Pool, siteOrigin, txEmail
 }
 
 // isEnterpriseCustomer reports whether the Autumn customer is on an enterprise
-// plan. A failed lookup reports false so the email still goes out with the
+// plan. A failed lookup reports false so the email still goes out, with the
 // standard upgrade copy.
 func isEnterpriseCustomer(ctx context.Context, customerID string) bool {
 	cust, err := autumn.GetCustomer(ctx, customerID)
@@ -552,10 +496,6 @@ func isEnterpriseCustomer(ctx context.Context, customerID string) bool {
 	}
 	return DeterminePlan(cust) == PlanEnterprise
 }
-
-// ----------------------------------------------------------------------------
-// Email notifications
-// ----------------------------------------------------------------------------
 
 func teamName(ctx context.Context, pg *pgxpool.Pool, teamID uuid.UUID) string {
 	stmt := sqlf.PostgreSQL.Select("name").From("teams").Where("id = ?", teamID)

--- a/backend/libs/measure/billing_fixture_test.go
+++ b/backend/libs/measure/billing_fixture_test.go
@@ -1,0 +1,42 @@
+package measure
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"backend/libs/autumn"
+)
+
+// customerFixture is shared with the autumn package's decode test so the two
+// break together.
+const customerFixture = "../autumn/testdata/customer_get_response.json"
+
+// TestPlanAndRetentionFromCapturedCustomer runs both billing decisions over a
+// decoded response rather than a hand-built customer. The free plan and the
+// bespoke plan arrive in separate arrays, so DeterminePlan reaches enterprise
+// only if both decoded, and the retention grants pool to 60, so
+// RetentionDaysFromBalance reaches 30 only if the breakdown decoded. It lives
+// here because measure imports autumn.
+func TestPlanAndRetentionFromCapturedCustomer(t *testing.T) {
+	raw, err := os.ReadFile(customerFixture)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var cust autumn.Customer
+	if err := json.Unmarshal(raw, &cust); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	if got := DeterminePlan(&cust); got != PlanEnterprise {
+		t.Errorf("DeterminePlan = %q, want %q", got, PlanEnterprise)
+	}
+
+	retention, ok := cust.Balances[autumn.FeatureRetentionDays]
+	if !ok {
+		t.Fatalf("no %s balance, got %v", autumn.FeatureRetentionDays, cust.Balances)
+	}
+	if got := RetentionDaysFromBalance(retention); got != 30 {
+		t.Errorf("RetentionDaysFromBalance = %d, want 30", got)
+	}
+}

--- a/backend/libs/measure/billing_fixture_test.go
+++ b/backend/libs/measure/billing_fixture_test.go
@@ -14,7 +14,7 @@ const customerFixture = "../autumn/testdata/customer_get_response.json"
 
 // TestPlanAndRetentionFromCapturedCustomer runs both billing decisions over a
 // decoded response rather than a hand-built customer. The free plan and the
-// bespoke plan arrive in separate arrays, so DeterminePlan reaches enterprise
+// enterprise plan arrive in separate arrays, so DeterminePlan reaches enterprise
 // only if both decoded, and the retention grants pool to 60, so
 // RetentionDaysFromBalance reaches 30 only if the breakdown decoded. It lives
 // here because measure imports autumn.

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -115,52 +115,11 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanEnterprise,
 		},
 		{
-			name: "webhook-style products fallback (no subs) → pro",
+			name: "active pro sub + active enterprise sub → enterprise",
 			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
-			},
-			want: PlanPro,
-		},
-		{
-			name: "products with empty status treated as active (back-compat)",
-			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro, Status: ""}},
-			},
-			want: PlanPro,
-		},
-		{
-			name: "scheduled product is ignored, falls back to free",
-			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanFree, Status: "scheduled"}},
-			},
-			want: PlanFree,
-		},
-		{
-			name: "active free + scheduled pro in products → free (skip scheduled)",
-			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{
-					{ID: AutumnPlanPro, Status: "scheduled"},
-					{ID: AutumnPlanFree, Status: "active"},
-				},
-			},
-			want: PlanFree,
-		},
-		{
-			name: "active free + active enterprise product → enterprise",
-			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{
-					{ID: AutumnPlanFree, Status: "active"},
-					{ID: "acme_one_year", Status: "active"},
-				},
-			},
-			want: PlanEnterprise,
-		},
-		{
-			name: "active pro + active enterprise product → enterprise",
-			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{
-					{ID: AutumnPlanPro, Status: "active"},
-					{ID: "plan_ent_acme", Status: "active"},
+				Subscriptions: []autumn.Subscription{
+					{PlanID: AutumnPlanPro, Status: "active"},
+					{PlanID: "plan_ent_acme", Status: "active"},
 				},
 			},
 			want: PlanEnterprise,
@@ -176,11 +135,11 @@ func TestDeterminePlan(t *testing.T) {
 			want: PlanEnterprise,
 		},
 		{
-			name: "active free + scheduled enterprise product → free",
+			name: "active free sub + scheduled enterprise sub → free",
 			cust: autumn.Customer{
-				Products: []autumn.CustomerProduct{
-					{ID: AutumnPlanFree, Status: "active"},
-					{ID: "acme_one_year", Status: "scheduled"},
+				Subscriptions: []autumn.Subscription{
+					{PlanID: AutumnPlanFree, Status: "active"},
+					{PlanID: "acme_one_year", Status: "scheduled"},
 				},
 			},
 			want: PlanFree,
@@ -375,8 +334,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 90},
 				},
@@ -398,8 +357,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "plan_ent_acme"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "plan_ent_acme", Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 180},
 				},
@@ -421,8 +380,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: "plan_missing_feature"}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: "plan_missing_feature", Status: "active"}},
 				// no Balances["retention_days"]
 			}, nil
 		})
@@ -445,8 +404,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanFree}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: AutumnPlanFree, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {FeatureID: autumn.FeatureRetentionDays, Granted: 30},
 				},
@@ -526,8 +485,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {
 						FeatureID: autumn.FeatureRetentionDays,
@@ -555,8 +514,8 @@ func TestGetPlanRetentionDays(t *testing.T) {
 
 		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
 			return &autumn.Customer{
-				ID:       custID,
-				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
+				ID:            custID,
+				Subscriptions: []autumn.Subscription{{PlanID: AutumnPlanPro, Status: "active"}},
 				Balances: map[string]autumn.Balance{
 					autumn.FeatureRetentionDays: {
 						FeatureID: autumn.FeatureRetentionDays,

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -595,6 +595,82 @@ func TestGetPlanRetentionDays(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// DataPurchaseSpent
+// --------------------------------------------------------------------------
+
+func TestDataPurchaseSpent(t *testing.T) {
+	// Purchase timestamps are milliseconds since epoch and are compared against
+	// the current time, so the cases below anchor to now.
+	nowMillis := time.Now().UnixMilli()
+	pastMillis := nowMillis - time.Hour.Milliseconds()
+	futureMillis := nowMillis + time.Hour.Milliseconds()
+
+	freeSource := autumn.BalanceSource{PlanID: AutumnPlanFree, IncludedGrant: 5_000_000_000, Remaining: 2_000_000_000}
+	spentPurchaseSource := autumn.BalanceSource{PlanID: "acme_one_year", IncludedGrant: 365_000_000_000, Remaining: 0}
+
+	tests := []struct {
+		name      string
+		purchases []autumn.Purchase
+		breakdown []autumn.BalanceSource
+		want      bool
+	}{
+		{
+			name:      "purchase in effect with nothing left of its own grant",
+			purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: pastMillis, ExpiresAt: futureMillis}},
+			breakdown: []autumn.BalanceSource{freeSource, spentPurchaseSource},
+			want:      true,
+		},
+		{
+			name:      "purchase in effect with data left",
+			purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: pastMillis, ExpiresAt: futureMillis}},
+			breakdown: []autumn.BalanceSource{
+				{PlanID: AutumnPlanFree, IncludedGrant: 5_000_000_000, Remaining: 0},
+				{PlanID: "acme_one_year", IncludedGrant: 365_000_000_000, Remaining: 220_741_040_581},
+			},
+			want: false,
+		},
+		{
+			name:      "purchase that has not started yet",
+			purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: futureMillis}},
+			breakdown: []autumn.BalanceSource{freeSource, spentPurchaseSource},
+			want:      false,
+		},
+		{
+			name:      "purchase whose term has ended",
+			purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: pastMillis, ExpiresAt: pastMillis}},
+			breakdown: []autumn.BalanceSource{freeSource, spentPurchaseSource},
+			want:      false,
+		},
+		{
+			name:      "no purchases at all",
+			purchases: nil,
+			breakdown: []autumn.BalanceSource{{PlanID: AutumnPlanFree, IncludedGrant: 5_000_000_000, Remaining: 0}},
+			want:      false,
+		},
+		{
+			name:      "empty breakdown",
+			purchases: []autumn.Purchase{{PlanID: "acme_one_year", StartedAt: pastMillis, ExpiresAt: futureMillis}},
+			breakdown: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cust := &autumn.Customer{
+				Purchases: tt.purchases,
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureBytes: {FeatureID: autumn.FeatureBytes, Breakdown: tt.breakdown},
+				},
+			}
+			if got := DataPurchaseSpent(cust); got != tt.want {
+				t.Errorf("DataPurchaseSpent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
 // GetTeamBilling
 // --------------------------------------------------------------------------
 

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -418,7 +418,7 @@ func TestGetPlanRetentionDays(t *testing.T) {
 		}
 	})
 
-	t.Run("free plan alongside a bespoke plan → longest single grant, not the sum", func(t *testing.T) {
+	t.Run("free plan alongside an enterprise plan → longest single grant, not the sum", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		teamID := uuid.New()
 		seedTeam(ctx, t, teamID, testTeamName)

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -53,6 +53,12 @@ func signSvixWebhook(t *testing.T, secret, msgID string, payload []byte) http.He
 // --------------------------------------------------------------------------
 
 func TestDeterminePlan(t *testing.T) {
+	// Purchase timestamps are milliseconds since epoch, and DeterminePlan compares
+	// them against the current time, so the cases below anchor to now.
+	nowMillis := time.Now().UnixMilli()
+	pastMillis := nowMillis - time.Hour.Milliseconds()
+	futureMillis := nowMillis + time.Hour.Milliseconds()
+
 	cases := []struct {
 		name string
 		cust autumn.Customer
@@ -144,7 +150,7 @@ func TestDeterminePlan(t *testing.T) {
 			cust: autumn.Customer{
 				Products: []autumn.CustomerProduct{
 					{ID: AutumnPlanFree, Status: "active"},
-					{ID: "turtlemint_one_year", Status: "active"},
+					{ID: "acme_one_year", Status: "active"},
 				},
 			},
 			want: PlanEnterprise,
@@ -164,7 +170,7 @@ func TestDeterminePlan(t *testing.T) {
 			cust: autumn.Customer{
 				Subscriptions: []autumn.Subscription{
 					{PlanID: AutumnPlanFree, Status: "active"},
-					{PlanID: "turtlemint_one_year", Status: "active"},
+					{PlanID: "acme_one_year", Status: "active"},
 				},
 			},
 			want: PlanEnterprise,
@@ -174,7 +180,44 @@ func TestDeterminePlan(t *testing.T) {
 			cust: autumn.Customer{
 				Products: []autumn.CustomerProduct{
 					{ID: AutumnPlanFree, Status: "active"},
-					{ID: "turtlemint_one_year", Status: "scheduled"},
+					{ID: "acme_one_year", Status: "scheduled"},
+				},
+			},
+			want: PlanFree,
+		},
+		{
+			name: "active free sub + one-off enterprise purchase → enterprise",
+			cust: autumn.Customer{
+				Subscriptions: []autumn.Subscription{{PlanID: AutumnPlanFree, Status: "active"}},
+				Purchases: []autumn.Purchase{
+					{PlanID: "acme_one_year", StartedAt: pastMillis},
+				},
+			},
+			want: PlanEnterprise,
+		},
+		{
+			name: "one-off enterprise purchase with no subscriptions → enterprise",
+			cust: autumn.Customer{
+				Purchases: []autumn.Purchase{
+					{PlanID: "acme_one_year", StartedAt: pastMillis},
+				},
+			},
+			want: PlanEnterprise,
+		},
+		{
+			name: "purchase starting in the future is ignored → free",
+			cust: autumn.Customer{
+				Purchases: []autumn.Purchase{
+					{PlanID: "acme_one_year", StartedAt: futureMillis},
+				},
+			},
+			want: PlanFree,
+		},
+		{
+			name: "expired purchase is ignored → free",
+			cust: autumn.Customer{
+				Purchases: []autumn.Purchase{
+					{PlanID: "acme_one_year", StartedAt: pastMillis, ExpiresAt: pastMillis},
 				},
 			},
 			want: PlanFree,

--- a/backend/libs/measure/billing_test.go
+++ b/backend/libs/measure/billing_test.go
@@ -459,6 +459,120 @@ func TestGetPlanRetentionDays(t *testing.T) {
 		}
 	})
 
+	t.Run("free plan alongside a bespoke plan → longest single grant, not the sum", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID: custID,
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   60,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: "acme_one_year", IncludedGrant: 30},
+							{PlanID: AutumnPlanFree, IncludedGrant: 30},
+						},
+					},
+				},
+			}, nil
+		})
+
+		got, err := GetPlanRetentionDays(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), teamID)
+		if err != nil || got != 30 {
+			t.Errorf("want (30, nil), got (%d, %v)", got, err)
+		}
+	})
+
+	t.Run("plans granting different periods → the longest one", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID: custID,
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   395,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: AutumnPlanFree, IncludedGrant: 30},
+							{PlanID: "acme_one_year", IncludedGrant: 365},
+						},
+					},
+				},
+			}, nil
+		})
+
+		got, err := GetPlanRetentionDays(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), teamID)
+		if err != nil || got != 365 {
+			t.Errorf("want (365, nil), got (%d, %v)", got, err)
+		}
+	})
+
+	t.Run("single plan in the breakdown → that plan's grant", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   90,
+						Breakdown: []autumn.BalanceSource{
+							{PlanID: AutumnPlanPro, IncludedGrant: 90},
+						},
+					},
+				},
+			}, nil
+		})
+
+		got, err := GetPlanRetentionDays(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), teamID)
+		if err != nil || got != 90 {
+			t.Errorf("want (90, nil), got (%d, %v)", got, err)
+		}
+	})
+
+	t.Run("empty breakdown → falls back to the pooled grant", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+		teamID := uuid.New()
+		seedTeam(ctx, t, teamID, testTeamName)
+		custID := uuid.New().String()
+		seedTeamAutumnCustomer(ctx, t, teamID, custID)
+
+		autumntest.MockGetCustomer(t, func(_ context.Context, _ string) (*autumn.Customer, error) {
+			return &autumn.Customer{
+				ID:       custID,
+				Products: []autumn.CustomerProduct{{ID: AutumnPlanPro}},
+				Balances: map[string]autumn.Balance{
+					autumn.FeatureRetentionDays: {
+						FeatureID: autumn.FeatureRetentionDays,
+						Granted:   90,
+						Breakdown: []autumn.BalanceSource{},
+					},
+				},
+			}, nil
+		})
+
+		got, err := GetPlanRetentionDays(ctx, deps.PgPool, deps.Config.IsBillingEnabled(), teamID)
+		if err != nil || got != 90 {
+			t.Errorf("want (90, nil), got (%d, %v)", got, err)
+		}
+	})
+
 	t.Run("autumn.GetCustomer fails → 0 + error (no silent default)", func(t *testing.T) {
 		defer cleanupAll(ctx, t)
 		teamID := uuid.New()

--- a/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
+++ b/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
@@ -196,12 +196,12 @@ describe("UsageThresholdBanner", () => {
 
       expect(
         screen.getByText(
-          "100% of plan data limit used — event ingestion blocked.",
+          "100% of plan data limit used — ingestion paused until the monthly free allowance resets.",
         ),
       ).toBeInTheDocument();
 
       const banner = screen.getByText(
-        "100% of plan data limit used — event ingestion blocked.",
+        "100% of plan data limit used — ingestion paused until the monthly free allowance resets.",
       ).parentElement!;
       expect(banner).toHaveClass("bg-red-300");
 
@@ -218,7 +218,7 @@ describe("UsageThresholdBanner", () => {
       render(<UsageThresholdBanner teamId="team-1" />);
 
       const message = screen.getByText(
-        "100% of plan data limit used — event ingestion blocked.",
+        "100% of plan data limit used — ingestion paused until the monthly free allowance resets.",
       );
       expect(message).toBeInTheDocument();
       expect(message.parentElement!).toHaveClass("bg-red-300");
@@ -335,11 +335,13 @@ describe("UsageThresholdBanner", () => {
       render(<UsageThresholdBanner teamId="team-1" />);
 
       expect(
-        screen.getByText("100% of free plan used — event ingestion blocked."),
+        screen.getByText(
+          "100% of free plan used — ingestion paused until your allowance resets next month.",
+        ),
       ).toBeInTheDocument();
 
       const banner = screen.getByText(
-        "100% of free plan used — event ingestion blocked.",
+        "100% of free plan used — ingestion paused until your allowance resets next month.",
       ).parentElement!;
       expect(banner).toHaveClass("bg-red-300");
       expect(banner).toHaveClass("text-primary-foreground");

--- a/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
+++ b/frontend/dashboard/__tests__/components/usage_threshold_banner_test.tsx
@@ -61,6 +61,24 @@ function enterpriseAt(percent: number) {
   };
 }
 
+// Helper: build a billingInfo payload for a team holding the free plan
+// alongside a plan sold as a one-off purchase whose grant is used up. Autumn
+// pools both grants into the bytes figures, so the pooled percentage lands
+// wherever the two grants happen to put it while the monthly free grant keeps
+// admitting data, which is why the backend reports ingestion_blocked as false
+// here.
+function purchaseSpentAt(percent: number) {
+  const granted = 370_000_000_000;
+  return {
+    plan: "enterprise",
+    bytes_granted: granted,
+    bytes_used: granted * (percent / 100),
+    bytes_unlimited: false,
+    data_purchase_spent: true,
+    ingestion_blocked: false,
+  };
+}
+
 describe("UsageThresholdBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -172,7 +190,7 @@ describe("UsageThresholdBanner", () => {
 
     it("shows red banner with Contact Us mailto at 100%", () => {
       isBillingEnabled.mockReturnValue(true);
-      mockBillingInfo = enterpriseAt(100);
+      mockBillingInfo = { ...enterpriseAt(100), ingestion_blocked: true };
 
       render(<UsageThresholdBanner teamId="team-1" />);
 
@@ -189,6 +207,73 @@ describe("UsageThresholdBanner", () => {
 
       const link = screen.getByRole("link", { name: /Contact Us/i });
       expect(link).toHaveAttribute("href", "mailto:hello@measure.sh");
+    });
+  });
+
+  describe("When the backend reports ingestion blocked", () => {
+    it("takes priority over a spent data purchase", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = { ...purchaseSpentAt(100), ingestion_blocked: true };
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      const message = screen.getByText(
+        "100% of plan data limit used — event ingestion blocked.",
+      );
+      expect(message).toBeInTheDocument();
+      expect(message.parentElement!).toHaveClass("bg-red-300");
+    });
+  });
+
+  describe("When a one-off data purchase is spent", () => {
+    it("says usage is limited to free plan limits, with no percentage", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = purchaseSpentAt(98.6);
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      const message = screen.getByText(
+        "Your usage is limited to free plan limits.",
+      );
+      expect(message).toBeInTheDocument();
+      expect(message.textContent).not.toMatch(/%/);
+      expect(message.parentElement!).toHaveClass("bg-orange-300");
+
+      const link = screen.getByRole("link", { name: /Contact Us/i });
+      expect(link).toHaveAttribute("href", "mailto:hello@measure.sh");
+    });
+
+    it("still warns when the pooled percentage sits below 75", () => {
+      isBillingEnabled.mockReturnValue(true);
+      mockBillingInfo = purchaseSpentAt(60);
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      const message = screen.getByText(
+        "Your usage is limited to free plan limits.",
+      );
+      expect(message).toBeInTheDocument();
+      expect(message.parentElement!).toHaveClass("bg-orange-300");
+    });
+  });
+
+  describe("When the pool is at 100% and overage is allowed", () => {
+    it("reports the limit is reached without claiming ingestion stopped", () => {
+      isBillingEnabled.mockReturnValue(true);
+      // Overage keeps data flowing past the limit, so the backend reports
+      // ingestion_blocked as false.
+      mockBillingInfo = {
+        ...enterpriseAt(100),
+        bytes_overage_allowed: true,
+        ingestion_blocked: false,
+      };
+
+      render(<UsageThresholdBanner teamId="team-1" />);
+
+      const message = screen.getByText("100% of plan data limit used.");
+      expect(message).toBeInTheDocument();
+      expect(message.textContent).not.toMatch(/blocked/);
+      expect(message.parentElement!).toHaveClass("bg-red-300");
     });
   });
 
@@ -245,7 +330,7 @@ describe("UsageThresholdBanner", () => {
   describe("When usage is at or above 100%", () => {
     it("shows red banner with ingest blocked message", () => {
       isBillingEnabled.mockReturnValue(true);
-      mockBillingInfo = freeAt(100);
+      mockBillingInfo = { ...freeAt(100), ingestion_blocked: true };
 
       render(<UsageThresholdBanner teamId="team-1" />);
 
@@ -262,7 +347,7 @@ describe("UsageThresholdBanner", () => {
 
     it("shows Upgrade to Pro link pointing to usage page", () => {
       isBillingEnabled.mockReturnValue(true);
-      mockBillingInfo = freeAt(100);
+      mockBillingInfo = { ...freeAt(100), ingestion_blocked: true };
 
       render(<UsageThresholdBanner teamId="team-1" />);
 

--- a/frontend/dashboard/app/[teamId]/usage/page.tsx
+++ b/frontend/dashboard/app/[teamId]/usage/page.tsx
@@ -52,13 +52,8 @@ type AppMonthlyUsage = {
   bytes_in: number;
 };
 
-// formatDataLine renders the unified "Data" line shown on the user's
-// current plan card. All inputs come from BillingInfo (i.e. Autumn) so the
-// caller doesn't need plan-specific constants.
-//
-//   - bytes_unlimited           → "Unlimited"
-//   - else, with overage usage  → "X of Y used, Z overage"
-//   - else                      → "X of Y used"
+// Renders the "Data" line on the current plan card entirely from BillingInfo,
+// so the caller needs no plan-specific constants.
 function formatDataLine(billingInfo: {
   bytes_used?: number;
   bytes_granted?: number;
@@ -77,16 +72,8 @@ function formatDataLine(billingInfo: {
   return base;
 }
 
-// formatTokenCreditsLine renders the "Token credits" line shown on the current
-// plan card. agent_tokens is an Autumn credit system, so the balance is in
-// credits (token usage priced into credits), not raw token counts.
-// Mirrors formatDataLine; the caller only shows the line once credits have been
-// used, so the zero case never reaches here.
-//
-//   - token_credits_unlimited      → "Unlimited"
-//   - no granted allowance         → "X used"
-//   - else, with overage usage     → "X of Y used, Z overage"
-//   - else                         → "X of Y used"
+// Mirrors formatDataLine for the "Token credits" line. The caller renders the
+// line only once credits have been used, so a zero total never reaches here.
 function formatTokenCreditsLine(billingInfo: {
   token_credits_used?: number;
   token_credits_granted?: number;
@@ -142,7 +129,6 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
   const { theme } = useTheme();
   const chartColors = useChartColors();
 
-  // UI-only local state
   const [isUpgrading, setIsUpgrading] = useState(false);
   const [isDowngrading, setIsDowngrading] = useState(false);
   const [isUndoingDowngrade, setIsUndoingDowngrade] = useState(false);
@@ -150,18 +136,14 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
     useState(false);
   const [isLoadingPortal, setIsLoadingPortal] = useState(false);
 
-  // Month selection state
   const [selectedMonth, setSelectedMonth] = useState<string | undefined>(
     undefined,
   );
 
-  // After a successful Stripe redirect-back, rapid-poll the billing info
-  // query until Autumn confirms the upgrade. (Downgrade no longer polls — the
-  // /billing/downgrade endpoint returns synchronously and the next refetch
-  // reflects canceled_at.)
+  // Autumn confirms an upgrade some moments after the checkout redirect back,
+  // so the billing info query polls until the plan reads as pro.
   const [awaitingProConfirmation, setAwaitingProConfirmation] = useState(false);
 
-  // TanStack Query: reads
   const { data: usageData, status: usageStatus } = useUsageQuery(params.teamId);
   const { data: permissions } = useUsagePermissionsQuery(
     isBillingEnabled() ? params.teamId : undefined,
@@ -176,12 +158,10 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
   );
   const currentUserCanChangePlan = permissions?.canChangePlan === true;
 
-  // TanStack Query: mutations
   const upgradeMutation = useHandleUpgradeMutation();
   const downgradeMutation = useDowngradeToFreeMutation();
   const undoDowngradeMutation = useUndoDowngradeMutation();
 
-  // Derived data from usage
   const months = usageData ? parseMonths(usageData) : [];
 
   // Pin the selected month to the latest available month when usage data first
@@ -203,7 +183,8 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
       ? parseUsageForMonth(usageData, effectiveMonth)
       : [];
 
-  // Handle success/cancel from Autumn-driven checkout redirect
+  // Checkout sends the user back here with success or canceled in the query
+  // string.
   useEffect(() => {
     const timer = setTimeout(() => {
       const searchParams = new URLSearchParams(window.location.search);
@@ -223,14 +204,12 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
     return () => clearTimeout(timer);
   }, []);
 
-  // Stop polling once Autumn confirms Pro.
   if (awaitingProConfirmation && billingInfo?.plan === "pro") {
     setAwaitingProConfirmation(false);
   }
 
   const bytesGranted = billingInfo?.bytes_granted ?? 0;
   const bytesUsed = billingInfo?.bytes_used ?? 0;
-  // Capture "now" once at mount.
   const [now] = useState(() => Date.now());
   const cancellationScheduled =
     billingInfo?.plan === "pro" &&
@@ -362,7 +341,6 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
     );
   };
 
-  // Determine usage display status
   const usageIsError = usageStatus === "error";
   const usageIsLoading = usageStatus === "pending";
   const usageHasNoData = usageStatus === "success" && usageData === null;
@@ -536,7 +514,7 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
 
               {/* Plan Cards */}
               <div className="flex flex-col md:flex-row gap-8 w-full mt-12">
-                {/* Free Plan Card - only show when on free plan */}
+                {/* Free plan card */}
                 {billingInfo?.plan === "free" && (
                   <Card className="w-full md:w-1/2 relative">
                     {showCurrentPlanBadge()}
@@ -561,8 +539,9 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
                   </Card>
                 )}
 
-                {/* Pro Plan Card — visible to free (upgrade pitch) and pro (current plan).
-                    Enterprise users see the dedicated Enterprise card below instead. */}
+                {/* Pro plan card, an upgrade pitch on the free plan and the
+                    current plan on pro. Enterprise teams get their own card
+                    below instead. */}
                 {billingInfo?.plan !== "enterprise" && (
                   <Card
                     className={`${billingInfo?.plan === "pro" ? "w-full" : "w-full md:w-1/2"} bg-green-50 dark:bg-card border border-green-300 dark:border-border relative`}
@@ -722,9 +701,9 @@ export default function Usage(props: { params: Promise<{ teamId: string }> }) {
                   </Card>
                 )}
 
-                {/* Enterprise Plan Card — full-width, no price. Bytes can be
-                    unlimited; retention and plan length come from the
-                    enterprise plan configured in Autumn. */}
+                {/* Enterprise plan card. It shows no price because the terms,
+                    including retention and plan length, are whatever the
+                    enterprise plan in Autumn was configured with. */}
                 {billingInfo?.plan === "enterprise" && (
                   <Card className="w-full bg-green-50 dark:bg-card border border-green-300 dark:border-border relative">
                     {showCurrentPlanBadge()}

--- a/frontend/dashboard/app/components/usage_threshold_banner.tsx
+++ b/frontend/dashboard/app/components/usage_threshold_banner.tsx
@@ -10,9 +10,8 @@ type UsageThresholdBannerProps = {
 
 type BannerState = { message: string; className: string } | null;
 
-// Banner fires above 75% for the free plan and for enterprise plans with a
-// finite limit — Pro self-manages overages. Returns null when there is nothing
-// to say.
+// The banner fires above 75% on the free plan and on enterprise plans with a
+// finite limit. Pro self-manages overages, so it never gets one.
 function bannerState(
   billingInfo:
     | {

--- a/frontend/dashboard/app/components/usage_threshold_banner.tsx
+++ b/frontend/dashboard/app/components/usage_threshold_banner.tsx
@@ -8,37 +8,73 @@ type UsageThresholdBannerProps = {
   teamId: string;
 };
 
+type BannerState = { message: string; className: string } | null;
+
 // Banner fires above 75% for the free plan and for enterprise plans with a
-// finite limit — Pro self-manages overages.
-function thresholdFor(
+// finite limit — Pro self-manages overages. Returns null when there is nothing
+// to say.
+function bannerState(
   billingInfo:
     | {
         plan?: string;
         bytes_granted?: number;
         bytes_used?: number;
         bytes_unlimited?: boolean;
+        data_purchase_spent?: boolean;
+        ingestion_blocked?: boolean;
       }
     | undefined,
-): number {
+): BannerState {
   if (!billingInfo) {
-    return 0;
+    return null;
   }
   if (billingInfo.plan !== "free" && billingInfo.plan !== "enterprise") {
-    return 0;
+    return null;
   }
   if (billingInfo.bytes_unlimited) {
-    return 0;
+    return null;
   }
   const granted = billingInfo.bytes_granted ?? 0;
-  const used = billingInfo.bytes_used ?? 0;
   if (granted <= 0) {
-    return 0;
+    return null;
   }
-  const pct = (used / granted) * 100;
-  if (pct >= 100) return 100;
-  if (pct >= 90) return 90;
-  if (pct >= 75) return 75;
-  return 0;
+
+  const planLabel =
+    billingInfo.plan === "enterprise" ? "plan data limit" : "free plan";
+
+  if (billingInfo.ingestion_blocked) {
+    return {
+      message: `100% of ${planLabel} used — event ingestion blocked.`,
+      className: "bg-red-300 text-primary-foreground",
+    };
+  }
+  if (billingInfo.data_purchase_spent) {
+    return {
+      message: "Your usage is limited to free plan limits.",
+      className: "bg-orange-300 text-primary-foreground",
+    };
+  }
+
+  const pct = ((billingInfo.bytes_used ?? 0) / granted) * 100;
+  if (pct >= 100) {
+    return {
+      message: `100% of ${planLabel} used.`,
+      className: "bg-red-300 text-primary-foreground",
+    };
+  }
+  if (pct >= 90) {
+    return {
+      message: `90% of ${planLabel} used.`,
+      className: "bg-orange-300 text-primary-foreground",
+    };
+  }
+  if (pct >= 75) {
+    return {
+      message: `75% of ${planLabel} used.`,
+      className: "bg-yellow-300 text-primary-foreground",
+    };
+  }
+  return null;
 }
 
 export default function UsageThresholdBanner({
@@ -47,38 +83,23 @@ export default function UsageThresholdBanner({
   const { data: billingInfo } = useBillingInfoQuery(
     isBillingEnabled() ? teamId : undefined,
   );
-  const threshold = thresholdFor(billingInfo);
+  const banner = bannerState(billingInfo);
 
-  if (threshold === 0) {
+  if (!banner) {
     return null;
   }
 
   const isEnterprise = billingInfo?.plan === "enterprise";
-  const planLabel = isEnterprise ? "plan data limit" : "free plan";
   const linkHref = isEnterprise
     ? "mailto:hello@measure.sh"
     : `/${teamId}/usage`;
   const linkText = isEnterprise ? "Contact Us →" : "Upgrade to Pro →";
 
-  let message: string;
-  let bannerClass: string;
-
-  if (threshold >= 100) {
-    message = `100% of ${planLabel} used — event ingestion blocked.`;
-    bannerClass = "bg-red-300 text-primary-foreground";
-  } else if (threshold >= 90) {
-    message = `90% of ${planLabel} used.`;
-    bannerClass = "bg-orange-300 text-primary-foreground";
-  } else {
-    message = `75% of ${planLabel} used.`;
-    bannerClass = "bg-yellow-300 text-primary-foreground";
-  }
-
   return (
     <div
-      className={`w-full px-4 py-2 font-body text-sm flex items-center justify-between mb-8 ${bannerClass}`}
+      className={`w-full px-4 py-2 font-body text-sm flex items-center justify-between mb-8 ${banner.className}`}
     >
-      <span>{message}</span>
+      <span>{banner.message}</span>
       <Link
         href={linkHref}
         className="font-semibold underline ml-4 whitespace-nowrap"

--- a/frontend/dashboard/app/components/usage_threshold_banner.tsx
+++ b/frontend/dashboard/app/components/usage_threshold_banner.tsx
@@ -44,7 +44,10 @@ function bannerState(
 
   if (billingInfo.ingestion_blocked) {
     return {
-      message: `100% of ${planLabel} used — event ingestion blocked.`,
+      message:
+        billingInfo.plan === "enterprise"
+          ? "100% of plan data limit used — ingestion paused until the monthly free allowance resets."
+          : "100% of free plan used — ingestion paused until your allowance resets next month.",
       className: "bg-red-300 text-primary-foreground",
     };
   }


### PR DESCRIPTION
# Description

- Plan detection counts one-off purchases, so these teams resolve to enterprise instead of free
- Retention takes the longest grant any single plan gives rather than Autumn's pooled sum, which would adding the free plan's 30 days to the one off purchase
- Retention now follows plan changes that have only one side. Autumn expires a plan only when a recurring plan replaces it, so attaching a one-off arrived as a lone activation and never reached the retention reset. Two enterprise plans tie on rank, so a re-issued contract would also fail to reset retention.
- Usage banner distinguishes a spent purchase from a blocked team, and reports blocking from the balance rather than inferring it from a percentage
- Usage emails drop the monthly framing for enterprise, whose plan is bought for a term, and say ingestion resumes when the free allowance resets
- Checkout and cancel API routes reject enterprise plans
- Removes the products field, renamed by Autumn at API 2.0



