### PR TITLE
chore(ios): prepare sdk release 0.13.1

### DIFF
--- a/frontend/dashboard/content/docs/getting-started/ios.mdx
+++ b/frontend/dashboard/content/docs/getting-started/ios.mdx
@@ -35,7 +35,7 @@ Create a new app in the _Apps_ section on the dashboard and copy its `API URL` a
 
 ```swift
 // In Package.swift
-.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.13.0")
+.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.13.1")
 ```
 
 </Tab>

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ios-v0.13.1] - 2026-09-02
+
+### :bug: Bug fixes
+
+
+- (**ios**): Clamp unsafe numeric narrowing conversions (#4337) by @adwinross in #4337
+- (**ios**): Parse cache control header for config refresh window (#4349) by @adwinross in #4349
+- (**ios**): Pause shake detector when app moves background (#4336) by @adwinross in #4336
+
 ## [ios-v0.13.0] - 2026-08-28
 
 ### :bug: Bug fixes
@@ -17,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :hammer: Misc
 
 
+- (**ios**): Prepare sdk release 0.13.0 (#4308) by @abhaysood in #4308
 - (**ios**): Stop dropping crash reports before export (#4298) by @adwinross in #4298
 - (**ios**): Raise minimum deployment target to ios 13 (#4295) by @adwinross in #4295
 - (**ios**): Update json serialisation logic (#4270) by @adwinross in #4270
@@ -472,6 +482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**ios**): Expose API to get current session ID (#1677) by @adwinross in #1677
 - (**ios**): Initial project setup  (#1034) by @adwinross in #1034
 
+[ios-v0.13.1]: https://github.com/measure-sh/measure/compare/ios-v0.13.0..ios-v0.13.1
 [ios-v0.13.0]: https://github.com/measure-sh/measure/compare/ios-v0.12.1..ios-v0.13.0
 [ios-v0.12.1]: https://github.com/measure-sh/measure/compare/ios-v0.12.0..ios-v0.12.1
 [ios-v0.12.0]: https://github.com/measure-sh/measure/compare/ios-v0.11.0..ios-v0.12.0

--- a/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
+++ b/ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct FrameworkInfo {
-    static let version = "0.13.0"
+    static let version = "0.13.1"
 }

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "measure-sh"
   spec.module_name  = "Measure"
-  spec.version      = "0.13.0"
+  spec.version      = "0.13.1"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
   spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }


### PR DESCRIPTION
This PR prepares the iOS SDK for release version 0.13.1.

Changes:
- Updated version to 0.13.1 in FrameworkInfo.swift
- Updated version to 0.13.1 in measure-sh.podspec
- Updated version in frontend/dashboard/content/docs/getting-started/ios.mdx
- Generated changelog for version 0.13.1