### PR TITLE
fix(backend): handle null app columns in app populate

### DIFF
--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -3012,6 +3012,10 @@ func (a *App) GetTeam(ctx context.Context, pg *pgxpool.Pool) (*Team, error) {
 // Populate fills in all app values
 // for the app.
 func (a *App) Populate(ctx context.Context, pg *pgxpool.Pool) (err error) {
+	var uniqueId pgtype.Text
+	var firstVersion pgtype.Text
+	var onboardedAt pgtype.Timestamptz
+
 	stmt := sqlf.PostgreSQL.From("apps").
 		Select("team_id::UUID").
 		Select("unique_identifier").
@@ -3026,7 +3030,23 @@ func (a *App) Populate(ctx context.Context, pg *pgxpool.Pool) (err error) {
 
 	defer stmt.Close()
 
-	return pg.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&a.TeamId, &a.UniqueId, &a.AppName, &a.OSNames, &a.FirstVersion, &a.Onboarded, &a.OnboardedAt, &a.CreatedAt, &a.UpdatedAt)
+	if err = pg.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&a.TeamId, &uniqueId, &a.AppName, &a.OSNames, &firstVersion, &a.Onboarded, &onboardedAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		return
+	}
+
+	if uniqueId.Valid {
+		a.UniqueId = uniqueId.String
+	}
+
+	if firstVersion.Valid {
+		a.FirstVersion = firstVersion.String
+	}
+
+	if onboardedAt.Valid {
+		a.OnboardedAt = onboardedAt.Time
+	}
+
+	return
 }
 
 // GetSessionEvents fetches all the events of an app's session.

--- a/backend/libs/measure/app_test.go
+++ b/backend/libs/measure/app_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// A never-ingested app has NULL unique_identifier, first_version & onboarded_at.
+// Populate must scan these into zero values instead of failing on NULL.
+func TestPopulateNeverIngestedApp(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+
+	appID := uuid.New()
+	now := time.Now()
+	_, err := th.PgPool.Exec(ctx, `
+		insert into apps (id, team_id, app_name, os_names, onboarded, unique_identifier, first_version, onboarded_at, created_at, updated_at)
+		values ($1, $2, $3, '{}', false, null, null, null, $4, $4)
+	`, appID, teamID, "never-ingested", now)
+	if err != nil {
+		t.Fatalf("seed app: %v", err)
+	}
+
+	app := App{ID: &appID}
+	if err := app.Populate(ctx, th.PgPool); err != nil {
+		t.Fatalf("Populate: %v", err)
+	}
+
+	if app.UniqueId != "" {
+		t.Errorf("UniqueId = %q, want empty", app.UniqueId)
+	}
+	if app.FirstVersion != "" {
+		t.Errorf("FirstVersion = %q, want empty", app.FirstVersion)
+	}
+	if !app.OnboardedAt.IsZero() {
+		t.Errorf("OnboardedAt = %v, want zero", app.OnboardedAt)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a 500 error on the Journeys & Overview pages, along with the `get_journey` & `get_metrics` MCP tools, for an app that has been created but has not sent any data yet. `App.Populate` now reads the nullable `apps` columns as nullable, matching the other app readers, so such an app resolves to an empty result instead of a failed row scan.

## Tasks

- [x] Scan `unique_identifier`, `first_version` & `onboarded_at` as nullable
- [x] Add an integration test covering a never-ingested app

## See also

- fixes #4359