### PR TITLE
fix(backend): return 404 for a missing app in get app filters

### DIFF
--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -612,7 +612,14 @@ func (h Handlers) GetAppFilters(c *gin.Context) {
 	if err != nil {
 		msg := "failed to select app"
 		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
+		status := http.StatusInternalServerError
+
+		if errors.Is(err, measure.ErrAppNotFound) {
+			status = http.StatusNotFound
+			msg = fmt.Sprintf(`app with id %q does not exist`, id)
+		}
+
+		c.JSON(status, gin.H{
 			"error":   msg,
 			"details": err.Error(),
 		})

--- a/backend/api/handlers/app_test.go
+++ b/backend/api/handlers/app_test.go
@@ -32,6 +32,25 @@ func newRenameAppContext(callerID string, appID uuid.UUID, body string) (*gin.Co
 	return c, w
 }
 
+func TestGetAppFiltersMissingApp(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	ownerID, _ := seedTeamAndMemberWithRole(t, ctx, "owner")
+	appID := uuid.New()
+
+	c, w := newTestGinContext("GET", "/apps/"+appID.String()+"/filters", nil)
+	c.Set("userId", ownerID)
+	c.Params = gin.Params{{Key: "id", Value: appID.String()}}
+
+	h.GetAppFilters(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+	}
+	wantJSONContains(t, w, "error", "does not exist")
+}
+
 func TestRenameApp(t *testing.T) {
 	ctx := context.Background()
 

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -3804,6 +3804,9 @@ func NewApp(teamId uuid.UUID) *App {
 	}
 }
 
+// ErrAppNotFound is returned when no app exists for the given id.
+var ErrAppNotFound = errors.New("app not found")
+
 // SelectApp selects app by its id.
 func SelectApp(ctx context.Context, pg *pgxpool.Pool, id uuid.UUID) (app *App, err error) {
 	var onboarded pgtype.Bool
@@ -3828,7 +3831,7 @@ func SelectApp(ctx context.Context, pg *pgxpool.Pool, id uuid.UUID) (app *App, e
 
 	if err := pg.QueryRow(ctx, stmt.String(), stmt.Args()...).Scan(&app.ID, &app.TeamId, &onboarded, &uniqueId, &app.OSNames, &firstVersion); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
+			return nil, ErrAppNotFound
 		} else {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

This PR makes the app filters API return 404 for an app id that does not exist. `SelectApp` now reports a missing app as an `ErrAppNotFound` error instead of an empty result, so callers get a clear not-found signal rather than an unusable value.

## Tasks

- [x] Add `ErrAppNotFound` & return it from `SelectApp`
- [x] Map the sentinel to 404 in `GetAppFilters`
- [x] Add a handler test for an unknown app id
