### PR TITLE
chore(android): prepare sdk release 0.20.0

### DIFF
--- a/android/measure-android/CHANGELOG.md
+++ b/android/measure-android/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [android-v0.20.0] - 2026-09-02
+
+### :bug: Bug fixes
+
+- (**android**): Update config cache state on 304 responses (#4334) by @abhaysood in #4334
+
+### :hammer: Misc
+
+- (**android**): Support AGP 9 and lower the androidx deps versions (#4236) by @abhaysood in #4236
+- (**android**): Prepare next development version 0.20.0-SNAPSHOT by @abhaysood in #4118
+
+### :zap: Performance
+
+- (**android**): Show bug report screen before encoding screenshot (#4332) by @abhaysood in #4332
+
 ## [android-v0.19.0] - 2026-07-22
 
 ### :sparkles: New features
@@ -19,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :hammer: Misc
 
+- (**android**): Prepare sdk release 0.19.0 by @abhaysood in #4116
 - (**android**): Limit batch size to 10MB (#3984) by @abhaysood in #3984
 - (**android**): Remove layout snapshot API (#3983) by @abhaysood in #3983
 - (**android**): Remove platform attribute from events and spans (#3981) by @abhaysood in #3981
@@ -928,6 +944,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**android**): Add missing links to readme by @abhaysood
 - (**android**): Create a template for Android SDK documentation by @abhaysood
 
+[android-v0.20.0]: https://github.com/measure-sh/measure/compare/android-v0.19.0..android-v0.20.0
 [android-v0.19.0]: https://github.com/measure-sh/measure/compare/android-v0.18.0..android-v0.19.0
 [android-v0.18.0]: https://github.com/measure-sh/measure/compare/android-v0.17.0..android-v0.18.0
 [android-v0.17.0]: https://github.com/measure-sh/measure/compare/android-v0.16.1..android-v0.17.0

--- a/android/measure-android/gradle.properties
+++ b/android/measure-android/gradle.properties
@@ -15,6 +15,6 @@ kotlin.code.style=official
 
 GROUP=sh.measure
 MEASURE_ARTIFACT_ID=measure-android
-MEASURE_VERSION_NAME=0.20.0-SNAPSHOT
+MEASURE_VERSION_NAME=0.20.0
 
 RELEASE_SIGNING_ENABLED = true

--- a/android/measure-gradle-plugin/gradle/libs.versions.toml
+++ b/android/measure-gradle-plugin/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ squareup-okio = "3.7.0"
 kotlinx-serialization-json = "1.6.2"
 # Use the latest snapshot (local maven) version of measure-android for
 # gradle plugin functional tests.
-measure-android = "0.20.0-SNAPSHOT"
+measure-android = "0.20.0"
 semver = "1.1.2"
 junit = "4.13.2"
 junit-jupiter = "5.10.2"

--- a/frontend/dashboard/content/docs/getting-started/android.mdx
+++ b/frontend/dashboard/content/docs/getting-started/android.mdx
@@ -41,7 +41,7 @@ Create a new app in the _Apps_ section on the dashboard, copy its `API URL` and 
 ```kotlin
 // In your app/build.gradle.kts
 dependencies {
-    implementation("sh.measure:measure-android:0.19.0")
+    implementation("sh.measure:measure-android:0.20.0")
 }
 ```
 

--- a/kmp/measure-kmp/gradle.properties
+++ b/kmp/measure-kmp/gradle.properties
@@ -15,7 +15,7 @@ MEASURE_KMP_VERSION_NAME=0.1.0
 # standalone (e.g. published to Maven Central). For local development the
 # dependency is substituted with the in-repo Gradle project via
 # settings.gradle.kts (`includeBuild ../../android/measure-android`).
-MEASURE_ANDROID_VERSION=0.19.0
+MEASURE_ANDROID_VERSION=0.20.0
 
 # Native iOS SDK version the published cinterop bindings are built against.
 # Release pins bindings to this ios-v<version> tag; local builds use in-repo ios/.


### PR DESCRIPTION
This PR prepares the Android SDK for release version 0.20.0.

Changes:
- Updated version to 0.20.0 in gradle.properties
- Updated version to 0.20.0 in libs.versions.toml
- Updated MEASURE_ANDROID_VERSION to 0.20.0 in kmp/measure-kmp/gradle.properties
- Generated changelog for version 0.20.0
- Updated SDK version in the getting started docs

<!-- release-meta
NEXT_VERSION=0.21.0-SNAPSHOT
-->