### PR TITLE
chore(rn): prepare release 0.3.0

### DIFF
--- a/frontend/dashboard/content/docs/getting-started/react-native.mdx
+++ b/frontend/dashboard/content/docs/getting-started/react-native.mdx
@@ -13,8 +13,8 @@ native Android and iOS SDKs, so their minimum requirements apply here too.
 | --------------- | -------- |
 | React Native    | `0.73.0` |
 | React           | `18.2.0` |
-| Measure Android | `0.18.0` |
-| Measure iOS     | `0.11.0` |
+| Measure Android | `0.20.0` |
+| Measure iOS     | `0.13.1` |
 
 ## 1. Get the credentials
 
@@ -31,7 +31,7 @@ create a new app on Measure with a different API key.
 
 ```sh
 # In your project root
-npm install @measuresh/react-native@0.2.0
+npm install @measuresh/react-native@0.3.0
 ```
 
 ## 3. Add the config plugin

--- a/react-native/CHANGELOG.md
+++ b/react-native/CHANGELOG.md
@@ -5,11 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [rn-v0.3.0] - 2026-09-02
+
+### :books: Documentation
+
+
+- (**rn**): Update link in upload build script (#4258) by @detj in #4258
+
+### :sparkles: New features
+
+
+- (**rn**): Collect expo update attributes for events and spans (#4197) by @adwinross in #4197
+
 ## [rn-v0.2.0] - 2026-07-24
 
 ### :hammer: Misc
 
 
+- (**rn**): Prepare release 0.2.0 (#4140) by @abhaysood in #4140
 - (**rn**): Add patch version parameter to upload patch script (#4135) by @adwinross in #4135
 - (**rn**): Add spm support for measure dependencies (#4029) by @adwinross in #4029
 - (**rn**): Add github workflow to prepare release (#3927) by @adwinross in #3927
@@ -86,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**rn**): Add exception tracking (#2628) by @adwinross in #2628
 - (**rn**): Add sdk initialization api (#2505) by @adwinross in #2505
 
+[rn-v0.3.0]: https://github.com/measure-sh/measure/compare/rn-v0.2.0..rn-v0.3.0
 [rn-v0.2.0]: https://github.com/measure-sh/measure/compare/rn-v0.1.1..rn-v0.2.0
 [rn-v0.1.1]: https://github.com/measure-sh/measure/compare/rn-v0.1.0..rn-v0.1.1
 

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -84,7 +84,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:0.13.0")
+        classpath("sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:0.14.0")
     }
 }
 ```
@@ -93,7 +93,7 @@ Add the SDK dependency and apply the plugin in your app-level `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation("sh.measure:measure-android:0.19.0")
+    implementation("sh.measure:measure-android:0.20.0")
 }
 
 apply plugin: "sh.measure.android.gradle"

--- a/react-native/android/build.gradle.kts
+++ b/react-native/android/build.gradle.kts
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     implementation("com.facebook.react:react-native:+")
-    api("sh.measure:measure-android:0.19.0")
+    api("sh.measure:measure-android:0.20.0")
 }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@measuresh/react-native",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "measureIosSdk": {
-    "version": "0.12.1",
+    "version": "0.13.1",
     "spmUrl": "https://github.com/measure-sh/measure.git",
-    "revision": "dddde1aea50f18fc0719544422697546f9dca23c"
+    "revision": "ea9d91aa78cfe25ed10c0be77b81c025c60802aa"
   },
   "react-native": "lib/module/index.js",
   "description": "Mobile apps break, get to the root cause faster",

--- a/react-native/plugin/index.js
+++ b/react-native/plugin/index.js
@@ -274,7 +274,7 @@ function withMeasureProjectBuildGradle(config) {
     // Add Measure Gradle plugin classpath
     mod.modResults.contents = mergeContents({
       src: mod.modResults.contents,
-      newSrc: '    classpath("sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:0.13.0")',
+      newSrc: '    classpath("sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:0.14.0")',
       tag: 'measure-classpath',
       anchor: /dependencies\s*\{/,
       offset: 1,
@@ -292,7 +292,7 @@ function withMeasureAppBuildGradle(config) {
     // Add measure-android dependency
     mod.modResults.contents = mergeContents({
       src: mod.modResults.contents,
-      newSrc: '    implementation("sh.measure:measure-android:0.19.0")',
+      newSrc: '    implementation("sh.measure:measure-android:0.20.0")',
       tag: 'measure-dependency',
       anchor: /dependencies\s*\{/,
       offset: 1,


### PR DESCRIPTION
This PR prepares the React Native SDK for release version 0.3.0.

Changes:
- Bumped version to 0.3.0
- Updated Measure Android SDK to 0.20.0
- Updated Measure iOS SDK to 0.13.1
- Updated Measure Android Gradle Plugin to 0.14.0
- Updated CHANGELOG.md