### PR TITLE
fix(backend): group journey aggregates by session to bound memory

### DIFF
--- a/backend/libs/measure/journey.go
+++ b/backend/libs/measure/journey.go
@@ -18,9 +18,12 @@ import (
 
 const (
 	// journeyMaxSeconds bounds how long one journey aggregate may run.
-	journeyMaxSeconds = 30
+	journeyMaxSeconds = 60
 	// journeyMaxMemoryBytes bounds server memory for one journey aggregate.
 	journeyMaxMemoryBytes = 500 << 20
+	// journeyExternalGroupByBytes spills session aggregation to disk past this
+	// point, keeping a long range within the memory cap.
+	journeyExternalGroupByBytes = 200 << 20
 )
 
 // JourneyEdge is a directed transition between two journey nodes.
@@ -140,6 +143,7 @@ func journeyCtx(ctx context.Context, name string, bounded bool) context.Context 
 	if bounded {
 		settings["max_execution_time"] = journeyMaxSeconds
 		settings["max_memory_usage"] = journeyMaxMemoryBytes
+		settings["max_bytes_before_external_group_by"] = journeyExternalGroupByBytes
 	}
 
 	return chquery.WithSettings(ctx, settings)
@@ -223,34 +227,46 @@ func (a App) journeyNodes(ctx context.Context, rch driver.Conn, af *filter.AppFi
 	return
 }
 
-// journeyEdgesStmt builds the edge query. The partition by session id is what
-// keeps concurrent sessions from linking.
+// journeyEdgesPairs explodes each session sequence into consecutive node
+// pairs, carrying the source row's timestamp. It holds no placeholders, so
+// every edge arg stays inside the seqs CTE. An arrayJoin cannot sit in the
+// same select as the groupArray feeding it, hence the extra nesting.
+const journeyEdgesPairs = "(select session_id, arrayJoin(arrayZip(" +
+	"arrayMap(x -> x.3, arrayPopBack(seq)), " +
+	"arrayMap(x -> x.3, arrayPopFront(seq)), " +
+	"arrayMap(x -> x.1, arrayPopBack(seq)))) as step from seqs) as pairs"
+
+// journeyEdgesStmt builds the edge query. Grouping by session id keeps
+// concurrent sessions from linking. Empty names are filtered after the zip,
+// so a nameless row breaks the chain rather than being skipped over.
 func (a App) journeyEdgesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
-	steps := sqlf.
+	seqs := sqlf.
 		From("journey").
 		Select("session_id").
-		Select("timestamp").
-		Select(je.name.sql+" as name", je.name.args...).
-		Select("any(name) over (partition by session_id order by timestamp rows between 1 following and 1 following) as next_name")
+		Select("arraySort(groupArray((timestamp, id, "+je.name.sql+"))) as seq", je.name.args...).
+		GroupBy("session_id")
 
-	a.journeyBounds(steps, af)
-	steps.Where(je.nodeFilter.sql, je.nodeFilter.args...)
+	a.journeyBounds(seqs, af)
+	seqs.Where(je.nodeFilter.sql, je.nodeFilter.args...)
 
 	stmt := sqlf.
-		From("steps").
-		Select("name as source").
-		Select("next_name as target").
+		From(journeyEdgesPairs).
+		Select("step.1 as source").
+		Select("step.2 as target").
 		Select("uniqExact(session_id) as sessions").
-		Select("min(timestamp) as first_seen").
-		Where("next_name != ''").
-		Where("name != ''").
-		Where("next_name != name").
+		Select("min(step.3) as first_seen").
+		Where("source != ''").
+		Where("target != ''").
+		Where("target != source").
 		GroupBy("source").
 		GroupBy("target").
-		OrderBy("first_seen")
+		// first_seen order is load bearing, journey.buildEdges picks the
+		// surviving direction of a transition by arrival. Source & target
+		// break ties so that choice stays deterministic.
+		OrderBy("first_seen", "source", "target")
 
-	// With closes steps, so only stmt is ever closed by the caller.
-	return stmt.With("steps", steps)
+	// With closes seqs, so only stmt is ever closed by the caller.
+	return stmt.With("seqs", seqs)
 }
 
 // journeyEdges counts session transitions between consecutive nodes.
@@ -278,39 +294,45 @@ func (a App) journeyEdges(ctx context.Context, rch driver.Conn, af *filter.AppFi
 	return
 }
 
+// journeyIssuesAnchored carries the last non NULL anchor forward over each
+// session sequence & explodes it alongside the issue columns. The arrayFill
+// predicate tests null-ness only, so a row with an empty anchor name resets
+// the anchor & never inherits the previous one. It holds no placeholders, so
+// every CTE arg stays inside the seqs CTE.
+const journeyIssuesAnchored = "(select arrayJoin(arrayZip(" +
+	"arrayFill(x -> isNotNull(x), arrayMap(x -> x.4, seq)), " +
+	"arrayMap(x -> x.3, seq), " +
+	"arrayMap(x -> x.5, seq), " +
+	"arrayMap(x -> x.6, seq))) as row from seqs) as anchored"
+
 // journeyIssuesStmt builds the per node issue query. Each issue rides the last
-// anchor node seen in its session, anyLast skips the NULL non anchor rows. An
-// issue with no anchor yet in its session gets an empty node name, it stays
-// counted but attaches to no node. journeyNodesStmt filters empty names, so
-// that node never renders.
+// anchor node seen in its session. An issue with no anchor yet in its session
+// gets an empty node name, it stays counted but attaches to no node.
+// journeyNodesStmt filters empty names, so that node never renders. The tuple
+// selects anr.fingerprint for every OS family even though only Android reads
+// it, keeping every x.N index the same across families.
 func (a App) journeyIssuesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
-	anchored := sqlf.
+	seqs := sqlf.
 		From("journey").
-		Select("type").
-		Select("`exception.fingerprint` as ex_fp")
+		Select("arraySort(groupArray((timestamp, id, type, "+je.anchor.sql+", `exception.fingerprint`, `anr.fingerprint`))) as seq", je.anchor.args...).
+		GroupBy("session_id")
 
-	if je.withANR {
-		anchored.Select("`anr.fingerprint` as anr_fp")
-	}
+	a.journeyBounds(seqs, af)
+	seqs.Where(je.anchorFilter.sql, je.anchorFilter.args...)
 
-	anchored.Select("anyLast("+je.anchor.sql+") over (partition by session_id order by timestamp rows between unbounded preceding and current row) as node", je.anchor.args...)
-
-	a.journeyBounds(anchored, af)
-	anchored.Where(je.anchorFilter.sql, je.anchorFilter.args...)
-
-	fingerprint := journeyFrag{sql: "ex_fp"}
+	fingerprint := journeyFrag{sql: "row.3"}
 	isANR := journeyFrag{sql: "false"}
-	issueTypes := journeyFrag{sql: "(type = ?)", args: []any{event.TypeException}}
+	issueTypes := journeyFrag{sql: "(row.2 = ?)", args: []any{event.TypeException}}
 
 	if je.withANR {
-		fingerprint = journeyFrag{sql: "if(type = ?, anr_fp, ex_fp)", args: []any{event.TypeANR}}
-		isANR = journeyFrag{sql: "toBool(type = ?)", args: []any{event.TypeANR}}
-		issueTypes = journeyFrag{sql: "(type = ? or type = ?)", args: []any{event.TypeException, event.TypeANR}}
+		fingerprint = journeyFrag{sql: "if(row.2 = ?, row.4, row.3)", args: []any{event.TypeANR}}
+		isANR = journeyFrag{sql: "toBool(row.2 = ?)", args: []any{event.TypeANR}}
+		issueTypes = journeyFrag{sql: "(row.2 = ? or row.2 = ?)", args: []any{event.TypeException, event.TypeANR}}
 	}
 
 	stmt := sqlf.
-		From("anchored").
-		Select("ifNull(node, '') as node_name").
+		From(journeyIssuesAnchored).
+		Select("ifNull(row.1, '') as node_name").
 		Select(fingerprint.sql+" as fingerprint", fingerprint.args...).
 		Select(isANR.sql+" as is_anr", isANR.args...).
 		Select("count() as issue_count").
@@ -319,8 +341,8 @@ func (a App) journeyIssuesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt 
 		GroupBy("fingerprint").
 		GroupBy("is_anr")
 
-	// With closes anchored, so only stmt is ever closed by the caller.
-	return stmt.With("anchored", anchored)
+	// With closes seqs, so only stmt is ever closed by the caller.
+	return stmt.With("seqs", seqs)
 }
 
 // journeyIssues counts exceptions & ANRs per node.

--- a/backend/libs/measure/journey_test.go
+++ b/backend/libs/measure/journey_test.go
@@ -21,6 +21,7 @@ const (
 	fpJourneyUnanchored = "000000000000000000000000000000f8"
 	fpJourneyAndroid    = "000000000000000000000000000000a1"
 	fpJourneyApple      = "000000000000000000000000000000b1"
+	fpJourneyEmptyName  = "000000000000000000000000000000c1"
 )
 
 // TestGetJourneyGraph drives journey_mv from raw events of two concurrent
@@ -36,20 +37,15 @@ func TestGetJourneyGraph(t *testing.T) {
 
 	at := func(offset int) time.Time { return ts.Add(time.Duration(offset) * time.Second) }
 
-	// A crash from a previous run lands first in its own session, so it has no
-	// anchor. It stays counted, attached to no node.
 	seedIssueEventInSession(f.ctx, t, team, app, sessionA, "exception", fpJourneyUnanchored, false, at(-1))
 
-	// Sessions interleave: A, B, A, B. No edge may cross the two.
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, "resumed", "HomeActivity", at(0))
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, "resumed", "CartActivity", at(1))
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, "resumed", "DetailActivity", at(2))
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, "resumed", "CheckoutActivity", at(3))
 
-	// Fatal crash on DetailActivity, handled one must not surface at all.
 	seedIssueEventInSession(f.ctx, t, team, app, sessionA, "exception", fpJourneyFatal, false, at(4))
 	seedIssueEventInSession(f.ctx, t, team, app, sessionA, "exception", fpJourneyHandled, true, at(5))
-	// ANR on CheckoutActivity.
 	seedIssueEventInSession(f.ctx, t, team, app, sessionB, "anr", fpJourneyANR, false, at(6))
 
 	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
@@ -70,8 +66,6 @@ func TestGetJourneyGraph(t *testing.T) {
 		}
 	}
 
-	// Concurrent sessions must not link, so HomeActivity -> CartActivity or
-	// DetailActivity -> CheckoutActivity would be wrong.
 	wantEdges := map[string]uint64{
 		"HomeActivity->DetailActivity":   1,
 		"CartActivity->CheckoutActivity": 1,
@@ -92,9 +86,8 @@ func TestGetJourneyGraph(t *testing.T) {
 	}
 
 	wantIssues := map[string]JourneyIssue{
-		fpJourneyFatal: {Node: "DetailActivity", Fingerprint: fpJourneyFatal, Count: 1},
-		fpJourneyANR:   {Node: "CheckoutActivity", Fingerprint: fpJourneyANR, IsANR: true, Count: 1},
-		// Empty node keeps it counted while attaching it nowhere.
+		fpJourneyFatal:      {Node: "DetailActivity", Fingerprint: fpJourneyFatal, Count: 1},
+		fpJourneyANR:        {Node: "CheckoutActivity", Fingerprint: fpJourneyANR, IsANR: true, Count: 1},
 		fpJourneyUnanchored: {Node: "", Fingerprint: fpJourneyUnanchored, Count: 1},
 	}
 	if len(g.Issues) != len(wantIssues) {
@@ -126,15 +119,11 @@ func TestGetJourneyGraphAndroidNodeTypes(t *testing.T) {
 
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, event.LifecycleActivityTypeResumed, "HomeActivity", at(0))
 	seedLifecycleFragmentInSession(f.ctx, t, team, app, sessionA, event.LifecycleFragmentTypeAttached, "CartFragment", at(10))
-	// Crash lands while the fragment is on screen, it must still anchor to the
-	// last activity.
 	seedIssueEventInSession(f.ctx, t, team, app, sessionA, "exception", fpJourneyAndroid, false, at(15))
-	// Same screen twice in a row, the collapse must drop the self edge.
 	seedScreenViewInSession(f.ctx, t, team, app, sessionA, "CheckoutScreen", at(20))
 	seedScreenViewInSession(f.ctx, t, team, app, sessionA, "CheckoutScreen", at(30))
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, event.LifecycleActivityTypeResumed, "PayActivity", at(40))
 
-	// Session B repeats the first transition so its session count reaches 2.
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "HomeActivity", at(1))
 	seedLifecycleFragmentInSession(f.ctx, t, team, app, sessionB, event.LifecycleFragmentTypeAttached, "CartFragment", at(11))
 
@@ -231,6 +220,74 @@ func TestGetJourneyGraphApple(t *testing.T) {
 	}
 	if g.Issues[0] != wantIssue {
 		t.Errorf("issue = %+v, want %+v", g.Issues[0], wantIssue)
+	}
+}
+
+// TestGetJourneyGraphEmptyAnchorResets asserts a screen view with an empty
+// name resets the anchor. The anchor fill tests null-ness, so an empty name
+// stays empty & the issue after it attaches to no node.
+func TestGetJourneyGraphEmptyAnchorResets(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+	sessionID := uuid.NewString()
+
+	at := func(offset int) time.Time { return ts.Add(time.Duration(offset) * time.Second) }
+
+	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionID, event.LifecycleActivityTypeResumed, "HomeActivity", at(0))
+	seedScreenViewInSession(f.ctx, t, team, app, sessionID, "", at(1))
+	seedIssueEventInSession(f.ctx, t, team, app, sessionID, event.TypeException, fpJourneyEmptyName, false, at(2))
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
+
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	if err != nil {
+		t.Fatalf("GetJourneyGraph: %v", err)
+	}
+
+	wantIssue := JourneyIssue{Node: "", Fingerprint: fpJourneyEmptyName, Count: 1}
+	if len(g.Issues) != 1 {
+		t.Fatalf("issues = %+v, want %+v", g.Issues, wantIssue)
+	}
+	if g.Issues[0] != wantIssue {
+		t.Errorf("issue = %+v, want %+v (empty anchor resets)", g.Issues[0], wantIssue)
+	}
+}
+
+// TestGetJourneyGraphTieOrderIsStable asserts two edges sharing one first_seen
+// come back in source & target order. journey.buildEdges picks the surviving
+// direction of a transition by arrival, so without the tiebreak the graph
+// changes between refreshes of identical data.
+func TestGetJourneyGraphTieOrderIsStable(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+	sessionA, sessionB := uuid.NewString(), uuid.NewString()
+
+	at := func(offset int) time.Time { return ts.Add(time.Duration(offset) * time.Second) }
+
+	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, event.LifecycleActivityTypeResumed, "HomeActivity", at(0))
+	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionA, event.LifecycleActivityTypeResumed, "CartActivity", at(1))
+	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "PayActivity", at(0))
+	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "SettingsActivity", at(1))
+
+	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
+
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	if err != nil {
+		t.Fatalf("GetJourneyGraph: %v", err)
+	}
+
+	wantEdges := []string{"HomeActivity->CartActivity", "PayActivity->SettingsActivity"}
+	if len(g.Edges) != len(wantEdges) {
+		t.Fatalf("edges = %+v, want %v", g.Edges, wantEdges)
+	}
+	for i, want := range wantEdges {
+		if got := g.Edges[i].Source + "->" + g.Edges[i].Target; got != want {
+			t.Errorf("edge %d = %s, want %s (tie broken by source & target)", i, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR reworks the journey graph aggregation to group by session instead of partitioning with window functions, so a long timeframe completes within the ClickHouse query memory cap. Session aggregation spills to disk once it crosses a threshold, keeping memory bounded by that threshold rather than by the size of the range. Edge ordering is now stable, so the same data returns the same graph on every run.

## Tasks

- [x] Group journey edges & issues by session
- [x] Spill session aggregation to disk past a memory threshold
- [x] Raise the journey query time cap to 60s
- [x] Order edges by source & target on a `first_seen` tie
- [x] Carry the issue anchor on null-ness, so an empty screen name resets it
- [x] Cover the empty anchor & edge tie order in tests
