### PR TITLE
Migrate journeys to expression filters

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -420,7 +420,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_filter_keys
 		newTool(&mcpsdk.Tool{
 			Name:        "get_filter_keys",
-			Description: "List the filter keys of an entity (spans, bug_reports or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
+			Description: "List the filter keys of an entity (spans, bug_reports, journeys or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
 			InputSchema: mcpMustInferSchema[mcpGetFilterKeysInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFilterKeysInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetFilterKeys(ctx, in)
@@ -609,8 +609,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_journey
 		newTool(&mcpsdk.Tool{
 			Name:        "get_journey",
-			Description: "Get an app's journey as a graph of screens. Each link is a transition between consecutive screens within a session, valued by the number of sessions that made that transition. Covers all app versions unless versions/version_codes narrow it; get_filters lists the versions.",
-			InputSchema: mcpMustInferSchema[mcpGetJourneyInput](),
+			Description: "Get an app's journey as a graph of screens. Each link is a transition between consecutive screens within a session, valued by the number of sessions that made that transition. Covers every session unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.JourneysEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetJourneyInput](mcpJourneysFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetJourneyInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetJourney(ctx, in)
 		}),
@@ -682,9 +682,15 @@ func mcpFilterExprToolsHint(entity exprfilter.Entity) string {
 // backend/libs/exprfilter/parse.go, shared as the filter_expr property's
 // schema description by every tool that takes one. The prose names the
 // entity being narrowed and the example is written in that entity's keys.
+// Custom keys are mentioned only for an entity that stores user-defined
+// attributes, since any other entity rejects the custom. prefix as unknown.
 func mcpFilterExprGrammar(entity exprfilter.Entity, example string) string {
 	noun := strings.ReplaceAll(entity.Name, "_", " ")
-	return "Filter expression narrowing the " + noun + ". A condition is key:operator:value or key:operator:[v1,v2]; a no-value operator like is_set is written key:operator. Conditions join with AND / OR, parentheses group, and AND binds tighter than OR. A value holding a space, comma, bracket, colon or quote is written in double quotes. Example: " + example + ". User-defined attribute keys appear under the Custom key group and carry the custom. prefix, as in custom.is_premium:eq:true. " + mcpFilterExprToolsHint(entity)
+	grammar := "Filter expression narrowing the " + noun + ". A condition is key:operator:value or key:operator:[v1,v2]; a no-value operator like is_set is written key:operator. Conditions join with AND / OR, parentheses group, and AND binds tighter than OR. A value holding a space, comma, bracket, colon or quote is written in double quotes. Example: " + example + ". "
+	if entity.CustomKeys != nil {
+		grammar += "User-defined attribute keys appear under the Custom key group and carry the custom. prefix, as in custom.is_premium:eq:true. "
+	}
+	return grammar + mcpFilterExprToolsHint(entity)
 }
 
 // The grammar text each entity's tools advertise, built from the shared
@@ -692,6 +698,7 @@ func mcpFilterExprGrammar(entity exprfilter.Entity, example string) string {
 var (
 	mcpSpansFilterExprGrammar      = mcpFilterExprGrammar(exprfilter.SpansEntity, "version_name:in:[1.2.0,1.1.9] AND span_status:in:error")
 	mcpBugReportsFilterExprGrammar = mcpFilterExprGrammar(exprfilter.BugReportsEntity, "version_name:in:[1.2.0] AND bug_report_status:in:open")
+	mcpJourneysFilterExprGrammar   = mcpFilterExprGrammar(exprfilter.JourneysEntity, "version_name:in:[1.2.0] AND version_code:in:[120]")
 )
 
 // mcpMustInferFilterExprSchema infers a JSON schema from a Go type and sets
@@ -792,12 +799,12 @@ type mcpGetFiltersInput struct {
 }
 type mcpGetFilterKeysInput struct {
 	AppID  string   `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports or builds"`
+	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys or builds"`
 	Keys   []string `json:"keys,omitempty" jsonschema:"Key names you already know, for example from the user's request, to include in the result even when the listing is truncated"`
 }
 type mcpGetFilterValuesInput struct {
 	AppID   string `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports or builds"`
+	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys or builds"`
 	KeyName string `json:"key_name" jsonschema:"Name of the filter key to list values for, as get_filter_keys returns it"`
 	Search  string `json:"search,omitempty" jsonschema:"Return only values containing this text"`
 	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum number of values to return (default: 50, max: 200)"`
@@ -911,11 +918,10 @@ type mcpGetAlertsInput struct {
 	Offset int    `json:"offset,omitempty" jsonschema:"Number of alerts to skip for pagination (default: 0)"`
 }
 type mcpGetJourneyInput struct {
-	AppID        string   `json:"app_id" jsonschema:"UUID of the app to query"`
-	From         string   `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
-	To           string   `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
-	Versions     []string `json:"versions,omitempty" jsonschema:"Filter by app version strings. Pass together with version_codes as same-length index-aligned pairs; get_filters lists both"`
-	VersionCodes []string `json:"version_codes,omitempty" jsonschema:"Filter by app version codes. Pass together with versions as same-length index-aligned pairs; get_filters lists both"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
 }
 type mcpGetErrorCommonPathInput struct {
 	AppID        string `json:"app_id" jsonschema:"UUID of the app to query"`
@@ -2025,23 +2031,10 @@ func (c *Config) mcpGetAlerts(ctx context.Context, in mcpGetAlertsInput) (*mcpsd
 
 func (c *Config) mcpGetJourney(ctx context.Context, in mcpGetJourneyInput) (*mcpsdk.CallToolResult, any, error) {
 	deps := c.Deps
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.JourneysEntity, in.AppID, in.From, in.To, in.FilterExpr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	cf := mcpCommonFilters{
-		AppID:        in.AppID,
-		From:         in.From,
-		To:           in.To,
-		Versions:     in.Versions,
-		VersionCodes: in.VersionCodes,
-	}
-	af, err := c.mcpBuildAppFilter(ctx, appID, cf)
-	if err != nil {
-		return nil, nil, err
-	}
-	af.Limit = filter.DefaultPaginationLimit
 
 	app := &measure.App{ID: &appID, TeamId: teamID}
 	if err := app.Populate(ctx, deps.PgPool); err != nil {
@@ -2049,7 +2042,7 @@ func (c *Config) mcpGetJourney(ctx context.Context, in mcpGetJourneyInput) (*mcp
 	}
 	journeyCtx := ambient.WithTeamId(ctx, teamID)
 
-	g, journeyErr := app.GetJourneyGraph(journeyCtx, deps.RchPool, af)
+	g, journeyErr := app.GetJourneyGraph(journeyCtx, deps.RchPool, ef)
 	if journeyErr != nil {
 		return nil, nil, fmt.Errorf("failed to get journey: %v", journeyErr)
 	}

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -3926,7 +3926,7 @@ func TestMCPGetAlerts(t *testing.T) {
 
 func TestMCPGetJourney(t *testing.T) {
 	ctx := context.Background()
-	setupToolTest := func(t *testing.T, email string) (uuid.UUID, string) {
+	setupToolTest := func(t *testing.T, email string) (uuid.UUID, uuid.UUID, string) {
 		cleanupAll(ctx, t)
 		userID := uuid.New()
 		seedUser(ctx, t, userID.String(), email)
@@ -3937,8 +3937,11 @@ func TestMCPGetJourney(t *testing.T) {
 		seedApp(ctx, t, appID, teamID, 30)
 		rawToken := "msr_" + email
 		seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
-		return appID, rawToken
+		return appID, teamID, rawToken
 	}
+	now := time.Now().UTC()
+	from := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	to := now.Format(time.RFC3339)
 
 	t.Run("missing app_id", func(t *testing.T) {
 		cleanupAll(ctx, t)
@@ -3952,9 +3955,8 @@ func TestMCPGetJourney(t *testing.T) {
 		}
 	})
 	t.Run("valid call", func(t *testing.T) {
-		appID, rawToken := setupToolTest(t, "journey2@mcp.test")
-		now := time.Now().UTC()
-		resp := callMCPTool(t, rawToken, "get_journey", map[string]any{"app_id": appID.String(), "from": now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "to": now.Format(time.RFC3339)})
+		appID, _, rawToken := setupToolTest(t, "journey2@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_journey", map[string]any{"app_id": appID.String(), "from": from, "to": to})
 		if isToolError(resp) {
 			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
 		}
@@ -3962,6 +3964,62 @@ func TestMCPGetJourney(t *testing.T) {
 		var result map[string]any
 		if err := json.Unmarshal([]byte(content), &result); err != nil {
 			t.Errorf("response is not JSON object: %v\ncontent: %s", err, content)
+		}
+	})
+	t.Run("filter_expr narrows results", func(t *testing.T) {
+		appID, teamID, rawToken := setupToolTest(t, "journeyexpr@mcp.test")
+		// The seeded screens carry app version v1 with build 1.
+		sessionID := uuid.NewString()
+		th.SeedLifecycleActivityInSession(ctx, t, teamID.String(), appID.String(), sessionID, "resumed", "HomeActivity", now.Add(-time.Hour))
+		th.SeedLifecycleActivityInSession(ctx, t, teamID.String(), appID.String(), sessionID, "resumed", "CartActivity", now.Add(-time.Hour).Add(time.Second))
+
+		nodes := func(t *testing.T, filterExpr string) []any {
+			t.Helper()
+			args := map[string]any{"app_id": appID.String(), "from": from, "to": to}
+			if filterExpr != "" {
+				args["filter_expr"] = filterExpr
+			}
+			resp := callMCPTool(t, rawToken, "get_journey", args)
+			if isToolError(resp) {
+				t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+			}
+			var result struct {
+				Nodes []any `json:"nodes"`
+			}
+			if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+				t.Fatalf("unmarshal journey: %v", err)
+			}
+			return result.Nodes
+		}
+
+		if got := nodes(t, ""); len(got) != 2 {
+			t.Fatalf("want 2 nodes with no filter, got %v", got)
+		}
+		if got := nodes(t, "version_name:in:v1 AND version_code:in:1"); len(got) != 2 {
+			t.Fatalf("want 2 nodes for the seeded version, got %v", got)
+		}
+		if got := nodes(t, "version_name:in:v9"); len(got) != 0 {
+			t.Fatalf("want no nodes for a version never seen, got %v", got)
+		}
+	})
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "journeyexprbad@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_journey", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "os_name:in:android"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for a key the journeys entity does not have")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "os_name") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+	t.Run("unparseable filter_expr returns the parse error", func(t *testing.T) {
+		appID, _, rawToken := setupToolTest(t, "journeyexprparse@mcp.test")
+		resp := callMCPTool(t, rawToken, "get_journey", map[string]any{"app_id": appID.String(), "from": from, "to": to, "filter_expr": "version_name:in:v1 AND"})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unparseable filter")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "filter_expr could not be parsed") || !strings.Contains(text, "at position") {
+			t.Errorf("error text %q should report the parse failure and its position", text)
 		}
 	})
 }

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -53,121 +53,41 @@ func presignConfig(deps *server.Deps) event.PreSignConfig {
 
 func (h Handlers) GetAppJourney(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `app id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": msg,
-		})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.JourneysEntity,
+		appScope: *measure.ScopeAppRead,
+		logRoot:  logcomment.Journeys,
+		logName:  "journey",
+	})
+	if !ok {
 		return
-	}
-
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		fmt.Println(err.Error())
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "app journey request validation failed"
-
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	app := measure.App{
-		ID: &id,
 	}
 
 	if err := app.Populate(ctx, deps.PgPool); err != nil {
 		msg := `failed to fetch app details`
 		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-			msg = fmt.Sprintf(`app with id %q does not exist`, app.ID)
-		}
-
-		c.JSON(status, gin.H{
+		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": msg,
 		})
-
 		return
 	}
 
-	team := &measure.Team{
-		ID: &app.TeamId,
+	// bigraph keeps both directions of a transition; an absent value leaves
+	// the graph one-directional.
+	var graphOptions struct {
+		BiGraph bool `form:"bigraph"`
 	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+	if err := c.ShouldBindQuery(&graphOptions); err != nil {
+		fmt.Println(err.Error())
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
+	ctx = ambient.WithTeamId(ctx, app.TeamId)
 
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
+	msg := `failed to compute app's journey`
 
-	ctx = ambient.WithTeamId(ctx, *team.ID)
-
-	msg = `failed to compute app's journey`
-
-	g, err := app.GetJourneyGraph(ctx, deps.RchPool, &af)
+	g, err := app.GetJourneyGraph(ctx, deps.RchPool, &ef)
 	if err != nil {
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -187,7 +107,7 @@ func (h Handlers) GetAppJourney(c *gin.Context) {
 
 	ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "fatal_exception_groups"))
 
-	exceptionGroups, err := group.GetExceptionGroupsFromFingerprints(ctx, deps.RchPool, &af, crashFingerprints)
+	exceptionGroups, err := group.GetExceptionGroupsFromFingerprints(ctx, deps.RchPool, &ef, crashFingerprints)
 	if err != nil {
 		fmt.Println(msg, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -207,7 +127,7 @@ func (h Handlers) GetAppJourney(c *gin.Context) {
 	if app.Family() == opsys.Android {
 		ctx = chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, "anr_groups"))
 
-		anrGroups, err := group.GetANRGroupsFromFingerprints(ctx, deps.RchPool, &af, anrFingerprints)
+		anrGroups, err := group.GetANRGroupsFromFingerprints(ctx, deps.RchPool, &ef, anrFingerprints)
 		if err != nil {
 			fmt.Println(msg, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -223,7 +143,7 @@ func (h Handlers) GetAppJourney(c *gin.Context) {
 	}
 
 	result := journey.Build(g, &journey.Options{
-		BiGraph: af.BiGraph,
+		BiGraph: graphOptions.BiGraph,
 	})
 
 	var nodes []journeyNode

--- a/backend/libs/exprfilter/bugreports.go
+++ b/backend/libs/exprfilter/bugreports.go
@@ -1,9 +1,5 @@
 package exprfilter
 
-// BugReportsEntity is an app's bug reports. Filtering and value lists both
-// read the bug_reports table in ClickHouse, which stores every attribute as a
-// flat column, and its user-defined attributes are the user_def_attrs rows
-// flagged bug_report.
 var BugReportsEntity = Entity{
 	Name:                  "bug_reports",
 	Keys:                  bugReportsKeys,
@@ -32,9 +28,6 @@ var bugReportsKeys = []Key{
 	country,
 }
 
-// The column expression each bug report key compares against. The bug_reports
-// table stores every attribute as a flat column and holds the app and os
-// versions as (name, version) tuples.
 var bugReportsTableColumns = map[string]string{
 	versionName.Name:          "tupleElement(app_version, 1)",
 	versionCode.Name:          "tupleElement(app_version, 2)",
@@ -55,8 +48,6 @@ var bugReportsTableColumns = map[string]string{
 	country.Name:              "country_code",
 }
 
-// bugReportStatusCodes maps the status names a filter carries to the integer
-// codes the status column stores.
 var bugReportStatusCodes = map[string]uint8{
 	"open":   0,
 	"closed": 1,
@@ -67,17 +58,14 @@ var bugReportsKeyBindingOverrides = map[string]columnKeyBinding{
 	patchID.Name:         bindUUIDKey,
 }
 
-// Fixed-key value suggestions read the bug_reports table itself
 var bugReportFixedKeyValues = fixedKeyValueSource{
 	table:       "bug_reports",
 	columns:     bugReportsTableColumns,
 	recencyExpr: "max(timestamp)",
 }
 
-// The custom keys of bug reports are the user-defined attributes an app set
-// on the session a report was filed in. The user_def_attrs table holds
-// attribute rows for several event kinds, with bug report rows flagged
-// bug_report.
+// The custom keys are the user-defined attributes set on the session a
+// report was filed in.
 var bugReportCustomKeys = customKeyStore{
 	table:      "user_def_attrs",
 	idColumn:   "event_id",

--- a/backend/libs/exprfilter/columnbinding.go
+++ b/backend/libs/exprfilter/columnbinding.go
@@ -13,6 +13,16 @@ import (
 // overrides map can be rebound against any table that has the key.
 type columnKeyBinding func(column string, condition Condition) (*sqlf.Stmt, error)
 
+// bindingForEachKey lists one binding under every key in keys, the per-key
+// form a query's override map takes.
+func bindingForEachKey(keys []Key, binding KeyBinding) map[string]KeyBinding {
+	bindings := make(map[string]KeyBinding, len(keys))
+	for _, key := range keys {
+		bindings[key.Name] = binding
+	}
+	return bindings
+}
+
 // bindKeysToColumns builds a KeyBinding that compares each key against the
 // column expression the mapping names for it, answering the full set of text
 // operators. Which of them a key actually accepts is decided by the key's

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -68,6 +68,8 @@ func FindByName(name string) (Entity, error) {
 		return SpansEntity, nil
 	case BugReportsEntity.Name:
 		return BugReportsEntity, nil
+	case JourneysEntity.Name:
+		return JourneysEntity, nil
 	}
 
 	return Entity{}, fmt.Errorf("Unknown filter entity %q", name)

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity}
+var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity, JourneysEntity}
 
 func sampleValues(t *testing.T, key Key, operator Operator) []Value {
 	t.Helper()
@@ -363,6 +363,66 @@ func TestBugReportStatusBindsTheColumnCodes(t *testing.T) {
 		Values:   []Value{{Text: "resolved"}},
 	}); err == nil {
 		t.Error("want a status name the column does not store refused")
+	}
+}
+
+func TestJourneysEntityOffersEveryJourneyKey(t *testing.T) {
+	byName := IndexKeysByName(JourneysEntity.Keys)
+
+	wanted := []string{"version_name", "version_code", "patch_version", "patch_id"}
+	for _, name := range wanted {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("want a %q key on the journeys entity", name)
+		}
+	}
+	if len(JourneysEntity.Keys) != len(wanted) {
+		t.Errorf("want %d journey keys, got %d", len(wanted), len(JourneysEntity.Keys))
+	}
+}
+
+func TestJourneysBindKeyRefusesAKeyTheEntityDoesNotHave(t *testing.T) {
+	_, err := JourneysEntity.BindKey(Condition{
+		KeyName:  "os_name",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "android"}},
+	})
+
+	if err == nil {
+		t.Fatal("want a key the journeys entity does not have refused")
+	}
+	if !strings.Contains(err.Error(), "os_name") {
+		t.Errorf("want the key named, got %q", err)
+	}
+}
+
+// Asserts the overrides compare the version keys against the
+// flat attribute columns of the events table, where the journey
+// table itself holds them as a tuple.
+func TestJourneyEventsKeyBindingsReadTheEventsColumns(t *testing.T) {
+	ef := &ExprFilter{Entity: JourneysEntity, FilterExpr: "version_name:in:1.2.0 AND version_code:in:120"}
+	if err := ef.BuildExprTree(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	onJourney, err := ef.Predicate(nil)
+	if err != nil {
+		t.Fatalf("predicate on the journey table: %v", err)
+	}
+	defer onJourney.Close()
+	if got := onJourney.String(); got != "((tupleElement(app_version, 1) in ?) and (tupleElement(app_version, 2) in ?))" {
+		t.Errorf("want the tuple columns compared, got %q", got)
+	}
+
+	onEvents, err := ef.Predicate(JourneyEventsKeyBindings)
+	if err != nil {
+		t.Fatalf("predicate on the events table: %v", err)
+	}
+	defer onEvents.Close()
+	if got := onEvents.String(); got != "((attribute.app_version in ?) and (attribute.app_build in ?))" {
+		t.Errorf("want the attribute columns compared, got %q", got)
+	}
+	if args := onEvents.Args(); len(args) != 2 || !slices.Equal(args[0].([]string), []string{"1.2.0"}) || !slices.Equal(args[1].([]string), []string{"120"}) {
+		t.Errorf("want the version values bound, got %v", args)
 	}
 }
 

--- a/backend/libs/exprfilter/journeys.go
+++ b/backend/libs/exprfilter/journeys.go
@@ -1,0 +1,47 @@
+package exprfilter
+
+var JourneysEntity = Entity{
+	Name:                  "journeys",
+	Keys:                  journeysKeys,
+	BindKey:               bindKeysToColumns(journeyTableColumns, journeysKeyBindingOverrides),
+	SuggestFixedKeyValues: suggestFixedKeyValuesFromClickHouse(journeyFixedKeyValues),
+}
+
+var journeysKeys = []Key{
+	versionName,
+	versionCode,
+	patchVersion,
+	patchID,
+}
+
+var (
+	journeyTableColumns = map[string]string{
+		versionName.Name:  "tupleElement(app_version, 1)",
+		versionCode.Name:  "tupleElement(app_version, 2)",
+		patchVersion.Name: "patch_version",
+		patchID.Name:      "patch_id",
+	}
+
+	journeyEventsColumns = map[string]string{
+		versionName.Name:  "attribute.app_version",
+		versionCode.Name:  "attribute.app_build",
+		patchVersion.Name: "attribute.patch_version",
+		patchID.Name:      "attribute.patch_id",
+	}
+)
+
+var journeysKeyBindingOverrides = map[string]columnKeyBinding{
+	patchID.Name: bindUUIDKey,
+}
+
+// app_filters keeps one row per attribute combination per month, so values
+// seen in the same month order alphabetically.
+var journeyFixedKeyValues = fixedKeyValueSource{
+	table:       "app_filters",
+	columns:     journeyTableColumns,
+	recencyExpr: "max(end_of_month)",
+}
+
+// JourneyEventsKeyBindings rebinds the journey keys onto the events table for
+// the issue lookups that read it.
+var JourneyEventsKeyBindings = bindingForEachKey(journeysKeys, bindKeysToColumns(journeyEventsColumns, journeysKeyBindingOverrides))

--- a/backend/libs/exprfilter/journeys_values_test.go
+++ b/backend/libs/exprfilter/journeys_values_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package exprfilter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+// seedJourneyEvents writes fully attributed events, which is what the rollup
+// requires to emit a row. Two events ran OTA patches; one of those names a
+// patch version.
+func seedJourneyEvents(ctx context.Context, t *testing.T) (teamID, appID, otherAppID uuid.UUID, patchOne, patchTwo uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+	otherAppID = uuid.New()
+	patchOne = uuid.New()
+	patchTwo = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "journey values team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "journey values app", 90)
+	th.SeedApp(ctx, t, otherAppID.String(), teamID.String(), "another journey app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	fullyAttributed := func(row testinfra.EventRow) testinfra.EventRow {
+		row.Timestamp = base
+		row.OSName = "Android"
+		row.OSVersion = "14"
+		row.CountryCode = "US"
+		row.NetworkProvider = "carrier"
+		row.NetworkType = "wifi"
+		row.NetworkGeneration = "4g"
+		row.DeviceLocale = "en-US"
+		row.DeviceManufacturer = "TestCo"
+		row.DeviceName = "pixel"
+		return row
+	}
+
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, fullyAttributed(testinfra.EventRow{
+		AppVersion: "1.2.0", AppBuild: "120", PatchID: patchOne, PatchVersion: "1.2.0-patch.3",
+	}))
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, fullyAttributed(testinfra.EventRow{
+		AppVersion: "1.1.0", AppBuild: "110", PatchID: patchTwo,
+	}))
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, fullyAttributed(testinfra.EventRow{
+		AppVersion: "1.2.0", AppBuild: "120",
+	}))
+	th.SeedEventRows(ctx, t, teamID.String(), otherAppID.String(), 1, fullyAttributed(testinfra.EventRow{
+		AppVersion: "9.0.0", AppBuild: "900", PatchID: uuid.New(), PatchVersion: "9.0.0-patch.1",
+	}))
+
+	return teamID, appID, otherAppID, patchOne, patchTwo
+}
+
+func TestJourneysValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, _, patchOne, patchTwo := seedJourneyEvents(ctx, t)
+
+	byName := IndexKeysByName(JourneysEntity.Keys)
+
+	list := func(t *testing.T, keyName string, valueRequest ValueRequest) ([]Value, bool) {
+		t.Helper()
+		valueList, err := JourneysEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName[keyName], valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		return valueList.Values, valueList.Truncated
+	}
+
+	texts := func(values []Value) []string {
+		out := make([]string, len(values))
+		for i, value := range values {
+			out[i] = value.Text
+		}
+		return out
+	}
+
+	t.Run("version names come from the rollup, once each", func(t *testing.T) {
+		// Both versions appear in the same month, so the alphabetical
+		// tiebreak orders them.
+		values, truncated := list(t, "version_name", ValueRequest{})
+		if truncated {
+			t.Error("want the whole list for two version names")
+		}
+		if got := texts(values); len(got) != 2 || got[0] != "1.1.0" || got[1] != "1.2.0" {
+			t.Errorf("want [1.1.0 1.2.0], got %v", got)
+		}
+	})
+
+	t.Run("version codes are read from the version tuple", func(t *testing.T) {
+		values, _ := list(t, "version_code", ValueRequest{})
+		if got := texts(values); len(got) != 2 || got[0] != "110" || got[1] != "120" {
+			t.Errorf("want [110 120], got %v", got)
+		}
+	})
+
+	t.Run("patch ids leave out events without a patch", func(t *testing.T) {
+		values, _ := list(t, "patch_id", ValueRequest{})
+		got := texts(values)
+		if len(got) != 2 {
+			t.Fatalf("want the two patches, got %v", got)
+		}
+		want := []string{patchOne.String(), patchTwo.String()}
+		if want[0] > want[1] {
+			want[0], want[1] = want[1], want[0]
+		}
+		if got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("want %v, got %v", want, got)
+		}
+		for _, text := range got {
+			if text == uuid.Nil.String() {
+				t.Error("want the nil patch id of unpatched events left out")
+			}
+		}
+	})
+
+	t.Run("patch versions leave out the patch that named none", func(t *testing.T) {
+		values, _ := list(t, "patch_version", ValueRequest{})
+		if got := texts(values); len(got) != 1 || got[0] != "1.2.0-patch.3" {
+			t.Errorf("want only the named patch version, got %v", got)
+		}
+	})
+
+	t.Run("another app's events stay out", func(t *testing.T) {
+		values, _ := list(t, "version_name", ValueRequest{})
+		for _, text := range texts(values) {
+			if text == "9.0.0" {
+				t.Error("want the other app's version left out")
+			}
+		}
+	})
+
+	t.Run("typing narrows the list", func(t *testing.T) {
+		values, _ := list(t, "version_name", ValueRequest{Search: "1.2"})
+		if got := texts(values); len(got) != 1 || got[0] != "1.2.0" {
+			t.Errorf("want [1.2.0], got %v", got)
+		}
+	})
+}

--- a/backend/libs/exprfilter/spans.go
+++ b/backend/libs/exprfilter/spans.go
@@ -4,11 +4,6 @@ import (
 	"time"
 )
 
-// SpansEntity is an app's performance trace spans. Its filtering reads the
-// spans table in ClickHouse and its fixed-key value lists read the
-// span_filters rollup. The span_metrics rollup stores the same fields
-// as flat columns, which SpanMetricsKeyBindings maps for queries that
-// aggregate over it.
 var SpansEntity = Entity{
 	Name:                  "spans",
 	Keys:                  spansKeys,
@@ -89,8 +84,6 @@ var (
 	}
 )
 
-// spanStatusCodes maps the status names a filter carries to the integer codes
-// the status column stores.
 var spanStatusCodes = map[string]int8{
 	"unset": 0,
 	"ok":    1,
@@ -102,9 +95,8 @@ var spansKeyBindingOverrides = map[string]columnKeyBinding{
 	patchID.Name:    bindUUIDKey,
 }
 
-// Fixed-key value suggestions read the span_filters rollup, which stores the
-// distinct attribute combinations seen per month. Recency therefore carries
-// month granularity, so values seen in the same month order alphabetically.
+// span_filters keeps one row per attribute combination per month, so values
+// seen in the same month order alphabetically.
 var spanFixedKeyValues = fixedKeyValueSource{
 	table:       "span_filters",
 	columns:     spanFilterColumns,
@@ -116,14 +108,6 @@ var spanCustomKeys = customKeyStore{
 	idColumn: "span_id",
 }
 
-// SpanMetricsKeyBindings maps every fixed spans key onto the flat columns of
-// the span_metrics rollup, as Predicate overrides for queries that read that
-// table.
-func SpanMetricsKeyBindings() map[string]KeyBinding {
-	binding := bindKeysToColumns(spanMetricsTableColumns, spansKeyBindingOverrides)
-	overrides := make(map[string]KeyBinding, len(spansKeys))
-	for _, key := range spansKeys {
-		overrides[key.Name] = binding
-	}
-	return overrides
-}
+// SpanMetricsKeyBindings rebinds the fixed spans keys onto the span_metrics
+// rollup for the queries that aggregate over it.
+var SpanMetricsKeyBindings = bindingForEachKey(spansKeys, bindKeysToColumns(spanMetricsTableColumns, spansKeyBindingOverrides))

--- a/backend/libs/exprfilter/valuesuggestions_test.go
+++ b/backend/libs/exprfilter/valuesuggestions_test.go
@@ -95,6 +95,30 @@ func TestSuggestionSQL(t *testing.T) {
 			wantArgs: []any{teamID, appID, uuid.Nil.String(), DefaultValueLimit + 1},
 		},
 		{
+			name: "journey fixed key values read the app_filters rollup by month",
+			run: func(recorder *sqlRecorder) {
+				byName := IndexKeysByName(JourneysEntity.Keys)
+				_, _ = JourneysEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, byName["version_name"], ValueRequest{Search: "1.2"})
+			},
+			wantSQL: "SELECT tupleElement(app_version, 1) as suggested_value, max(end_of_month) as recency" +
+				" FROM app_filters" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND tupleElement(app_version, 1) <> '' AND tupleElement(app_version, 1) ilike ?" +
+				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
+			wantArgs: []any{teamID, appID, "%1.2%", DefaultValueLimit + 1},
+		},
+		{
+			name: "journey version code values read the second tuple element",
+			run: func(recorder *sqlRecorder) {
+				byName := IndexKeysByName(JourneysEntity.Keys)
+				_, _ = JourneysEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, byName["version_code"], ValueRequest{})
+			},
+			wantSQL: "SELECT tupleElement(app_version, 2) as suggested_value, max(end_of_month) as recency" +
+				" FROM app_filters" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND tupleElement(app_version, 2) <> ''" +
+				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
+			wantArgs: []any{teamID, appID, DefaultValueLimit + 1},
+		},
+		{
 			name: "span custom key values read span_user_def_attrs by key and type",
 			run: func(recorder *sqlRecorder) {
 				_, _ = SpansEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, CustomKey("plan", ValueTypeString), ValueRequest{})

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -212,10 +212,6 @@ type AppFilter struct {
 	// be applied to events or sessions pertaining
 	// to user interactions, like gesture events.
 	UserInteraction bool `form:"user_interaction"`
-
-	// BiGraph represents if journey plot
-	// constructions should be bidirectional.
-	BiGraph bool `form:"bigraph"`
 }
 
 const (

--- a/backend/libs/group/group.go
+++ b/backend/libs/group/group.go
@@ -12,7 +12,7 @@ import (
 	"backend/libs/chrono"
 	"backend/libs/config"
 	"backend/libs/event"
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -326,9 +326,10 @@ func SortANRGroups(groups []ANRGroup) {
 	})
 }
 
-// GetExceptionGroupsFromFingerprints fetches exception groups
-// matched by app filter(s) & exception fingerprint.
-func GetExceptionGroupsFromFingerprints(ctx context.Context, conn driver.Conn, af *filter.AppFilter, input []string) (exceptionGroups []ExceptionGroup, err error) {
+// GetExceptionGroupsFromFingerprints fetches the exception groups with the
+// given fingerprints in the journey filter's app and time range, each with
+// its event count under the filter.
+func GetExceptionGroupsFromFingerprints(ctx context.Context, conn driver.Conn, ef *exprfilter.ExprFilter, input []string) (exceptionGroups []ExceptionGroup, err error) {
 	fingerprints := unique(input)
 
 	if len(fingerprints) == 0 {
@@ -350,9 +351,9 @@ func GetExceptionGroupsFromFingerprints(ctx context.Context, conn driver.Conn, a
 		Select("argMax(file_name, timestamp) as file_name").
 		Select("argMax(line_number, timestamp) as line_number").
 		Where("team_id = toUUID(?)", teamId).
-		Where("app_id = toUUID(?)", af.AppID).
-		Where("timestamp >= toDateTime64(?, 3, 'UTC')", af.From).
-		Where("timestamp <= toDateTime64(?, 3, 'UTC')", af.To).
+		Where("app_id = toUUID(?)", ef.AppID).
+		Where("timestamp >= toDateTime64(?, 3, 'UTC')", ef.From).
+		Where("timestamp <= toDateTime64(?, 3, 'UTC')", ef.To).
 		Where("id").In(fingerprints).
 		GroupBy("id")
 
@@ -361,18 +362,23 @@ func GetExceptionGroupsFromFingerprints(ctx context.Context, conn driver.Conn, a
 		Select("`exception.fingerprint` as id").
 		Select("count() as event_count").
 		Where("team_id = toUUID(?)", teamId).
-		Where("app_id = toUUID(?)", af.AppID).
-		Where("timestamp >= toDateTime(?, 3, 'UTC')", af.From).
-		Where("timestamp <= toDateTime(?, 3, 'UTC')", af.To).
+		Where("app_id = toUUID(?)", ef.AppID).
+		Where("timestamp >= toDateTime(?, 3, 'UTC')", ef.From).
+		Where("timestamp <= toDateTime(?, 3, 'UTC')", ef.To).
 		Where("type = ?", event.TypeException).
 		// fatal only: matches the fatal_exception_groups this joins against
 		Where(config.FatalExceptionExpr).
 		Where("exception.fingerprint").In(fingerprints).
 		GroupBy("`exception.fingerprint`")
 
-	if af.HasVersions() {
-		countsStmt.Where("attribute.app_version").In(af.Versions)
-		countsStmt.Where("attribute.app_build").In(af.VersionCodes)
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(exprfilter.JourneyEventsKeyBindings)
+		if errPredicate != nil {
+			err = errPredicate
+			return
+		}
+		defer predicate.Close()
+		countsStmt.Where(predicate.String(), predicate.Args()...)
 	}
 
 	stmt := sqlf.
@@ -418,9 +424,10 @@ func GetExceptionGroupsFromFingerprints(ctx context.Context, conn driver.Conn, a
 	return
 }
 
-// GetANRGroupsFromFingerprints fetches ANR groups
-// matched by app filter(s) & ANR fingerprint.
-func GetANRGroupsFromFingerprints(ctx context.Context, conn driver.Conn, af *filter.AppFilter, input []string) (anrGroups []ANRGroup, err error) {
+// GetANRGroupsFromFingerprints fetches the ANR groups with the given
+// fingerprints in the journey filter's app and time range, each with its
+// event count under the filter.
+func GetANRGroupsFromFingerprints(ctx context.Context, conn driver.Conn, ef *exprfilter.ExprFilter, input []string) (anrGroups []ANRGroup, err error) {
 	fingerprints := unique(input)
 
 	if len(fingerprints) == 0 {
@@ -442,9 +449,9 @@ func GetANRGroupsFromFingerprints(ctx context.Context, conn driver.Conn, af *fil
 		Select("argMax(file_name, timestamp) as file_name").
 		Select("argMax(line_number, timestamp) as line_number").
 		Where("team_id = toUUID(?)", teamId).
-		Where("app_id = toUUID(?)", af.AppID).
-		Where("timestamp >= toDateTime64(?, 3, 'UTC')", af.From).
-		Where("timestamp <= toDateTime64(?, 3, 'UTC')", af.To).
+		Where("app_id = toUUID(?)", ef.AppID).
+		Where("timestamp >= toDateTime64(?, 3, 'UTC')", ef.From).
+		Where("timestamp <= toDateTime64(?, 3, 'UTC')", ef.To).
 		Where("id").In(fingerprints).
 		GroupBy("id")
 
@@ -453,16 +460,21 @@ func GetANRGroupsFromFingerprints(ctx context.Context, conn driver.Conn, af *fil
 		Select("`anr.fingerprint` as id").
 		Select("count() as event_count").
 		Where("team_id = toUUID(?)", teamId).
-		Where("app_id = toUUID(?)", af.AppID).
-		Where("timestamp >= toDateTime(?, 3, 'UTC')", af.From).
-		Where("timestamp <= toDateTime(?, 3, 'UTC')", af.To).
+		Where("app_id = toUUID(?)", ef.AppID).
+		Where("timestamp >= toDateTime(?, 3, 'UTC')", ef.From).
+		Where("timestamp <= toDateTime(?, 3, 'UTC')", ef.To).
 		Where("type = ?", event.TypeANR).
 		Where("anr.fingerprint").In(fingerprints).
 		GroupBy("`anr.fingerprint`")
 
-	if af.HasVersions() {
-		countsStmt.Where("attribute.app_version").In(af.Versions)
-		countsStmt.Where("attribute.app_build").In(af.VersionCodes)
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(exprfilter.JourneyEventsKeyBindings)
+		if errPredicate != nil {
+			err = errPredicate
+			return
+		}
+		defer predicate.Close()
+		countsStmt.Where(predicate.String(), predicate.Args()...)
 	}
 
 	stmt := sqlf.

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -2396,7 +2396,7 @@ func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver
 	defer stmt.Close()
 
 	if ef.HasFilterExpr() {
-		predicate, errPredicate := ef.Predicate(exprfilter.SpanMetricsKeyBindings())
+		predicate, errPredicate := ef.Predicate(exprfilter.SpanMetricsKeyBindings)
 		if errPredicate != nil {
 			return nil, errPredicate
 		}

--- a/backend/libs/measure/journey.go
+++ b/backend/libs/measure/journey.go
@@ -7,7 +7,7 @@ import (
 	"backend/libs/chquery"
 	"backend/libs/config"
 	"backend/libs/event"
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
 	"backend/libs/logcomment"
 	"backend/libs/opsys"
 
@@ -149,24 +149,32 @@ func journeyCtx(ctx context.Context, name string, bounded bool) context.Context 
 	return chquery.WithSettings(ctx, settings)
 }
 
-// journeyBounds applies the scope & window filters every graph query shares.
-func (a App) journeyBounds(stmt *sqlf.Stmt, af *filter.AppFilter) *sqlf.Stmt {
+// journeyBounds applies the scope & window filters every graph query shares,
+// plus the filter expression when the request carries one. A filter whose
+// keys cannot be bound is reported as an error rather than dropped, which
+// would widen the graph past what was asked for.
+func (a App) journeyBounds(stmt *sqlf.Stmt, ef *exprfilter.ExprFilter) error {
 	stmt.
 		Where("team_id = toUUID(?)", a.TeamId).
-		Where("app_id = toUUID(?)", a.ID)
+		Where("app_id = toUUID(?)", a.ID).
+		Where("timestamp >= ? and timestamp <= ?", ef.From, ef.To)
 
-	if af.HasVersions() {
-		stmt.Where("app_version.1 in ?", af.Versions)
-		stmt.Where("app_version.2 in ?", af.VersionCodes)
+	if ef.HasFilterExpr() {
+		predicate, err := ef.Predicate(nil)
+		if err != nil {
+			return err
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
 	}
 
-	return stmt.Where("timestamp >= ? and timestamp <= ?", af.From, af.To)
+	return nil
 }
 
 // GetJourneyGraph aggregates the implicit navigational journey of an app into
 // nodes, edges & per node issues. All grouping happens in ClickHouse, only the
 // bounded result set crosses the wire.
-func (a App) GetJourneyGraph(ctx context.Context, rch driver.Conn, af *filter.AppFilter) (g JourneyGraph, err error) {
+func (a App) GetJourneyGraph(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter) (g JourneyGraph, err error) {
 	je, ok := journeyExprFor(a.Family())
 	if !ok {
 		return
@@ -174,37 +182,43 @@ func (a App) GetJourneyGraph(ctx context.Context, rch driver.Conn, af *filter.Ap
 
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
 
-	if g.Nodes, err = a.journeyNodes(ctx, rch, af, je); err != nil {
+	if g.Nodes, err = a.journeyNodes(ctx, rch, ef, je); err != nil {
 		return
 	}
 
-	if g.Edges, err = a.journeyEdges(ctx, rch, af, je); err != nil {
+	if g.Edges, err = a.journeyEdges(ctx, rch, ef, je); err != nil {
 		return
 	}
 
-	g.Issues, err = a.journeyIssues(ctx, rch, af, je)
+	g.Issues, err = a.journeyIssues(ctx, rch, ef, je)
 
 	return
 }
 
 // journeyNodesStmt builds the node name query, ordered by first appearance.
-func (a App) journeyNodesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
+func (a App) journeyNodesStmt(ef *exprfilter.ExprFilter, je journeyExpr) (*sqlf.Stmt, error) {
 	stmt := sqlf.
 		From("journey").
 		Select(je.name.sql+" as name", je.name.args...)
 
-	a.journeyBounds(stmt, af)
+	if err := a.journeyBounds(stmt, ef); err != nil {
+		stmt.Close()
+		return nil, err
+	}
 	stmt.Where(je.nodeFilter.sql, je.nodeFilter.args...)
 
 	return stmt.
 		Where("name != ''").
 		GroupBy("name").
-		OrderBy("min(timestamp)")
+		OrderBy("min(timestamp)"), nil
 }
 
 // journeyNodes lists the node names in the window, first appearance first.
-func (a App) journeyNodes(ctx context.Context, rch driver.Conn, af *filter.AppFilter, je journeyExpr) (nodes []string, err error) {
-	stmt := a.journeyNodesStmt(af, je)
+func (a App) journeyNodes(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter, je journeyExpr) (nodes []string, err error) {
+	stmt, err := a.journeyNodesStmt(ef, je)
+	if err != nil {
+		return
+	}
 
 	defer stmt.Close()
 
@@ -239,14 +253,17 @@ const journeyEdgesPairs = "(select session_id, arrayJoin(arrayZip(" +
 // journeyEdgesStmt builds the edge query. Grouping by session id keeps
 // concurrent sessions from linking. Empty names are filtered after the zip,
 // so a nameless row breaks the chain rather than being skipped over.
-func (a App) journeyEdgesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
+func (a App) journeyEdgesStmt(ef *exprfilter.ExprFilter, je journeyExpr) (*sqlf.Stmt, error) {
 	seqs := sqlf.
 		From("journey").
 		Select("session_id").
 		Select("arraySort(groupArray((timestamp, id, "+je.name.sql+"))) as seq", je.name.args...).
 		GroupBy("session_id")
 
-	a.journeyBounds(seqs, af)
+	if err := a.journeyBounds(seqs, ef); err != nil {
+		seqs.Close()
+		return nil, err
+	}
 	seqs.Where(je.nodeFilter.sql, je.nodeFilter.args...)
 
 	stmt := sqlf.
@@ -266,12 +283,15 @@ func (a App) journeyEdgesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
 		OrderBy("first_seen", "source", "target")
 
 	// With closes seqs, so only stmt is ever closed by the caller.
-	return stmt.With("seqs", seqs)
+	return stmt.With("seqs", seqs), nil
 }
 
 // journeyEdges counts session transitions between consecutive nodes.
-func (a App) journeyEdges(ctx context.Context, rch driver.Conn, af *filter.AppFilter, je journeyExpr) (edges []JourneyEdge, err error) {
-	stmt := a.journeyEdgesStmt(af, je)
+func (a App) journeyEdges(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter, je journeyExpr) (edges []JourneyEdge, err error) {
+	stmt, err := a.journeyEdgesStmt(ef, je)
+	if err != nil {
+		return
+	}
 
 	defer stmt.Close()
 
@@ -311,13 +331,16 @@ const journeyIssuesAnchored = "(select arrayJoin(arrayZip(" +
 // journeyNodesStmt filters empty names, so that node never renders. The tuple
 // selects anr.fingerprint for every OS family even though only Android reads
 // it, keeping every x.N index the same across families.
-func (a App) journeyIssuesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt {
+func (a App) journeyIssuesStmt(ef *exprfilter.ExprFilter, je journeyExpr) (*sqlf.Stmt, error) {
 	seqs := sqlf.
 		From("journey").
 		Select("arraySort(groupArray((timestamp, id, type, "+je.anchor.sql+", `exception.fingerprint`, `anr.fingerprint`))) as seq", je.anchor.args...).
 		GroupBy("session_id")
 
-	a.journeyBounds(seqs, af)
+	if err := a.journeyBounds(seqs, ef); err != nil {
+		seqs.Close()
+		return nil, err
+	}
 	seqs.Where(je.anchorFilter.sql, je.anchorFilter.args...)
 
 	fingerprint := journeyFrag{sql: "row.3"}
@@ -342,12 +365,15 @@ func (a App) journeyIssuesStmt(af *filter.AppFilter, je journeyExpr) *sqlf.Stmt 
 		GroupBy("is_anr")
 
 	// With closes seqs, so only stmt is ever closed by the caller.
-	return stmt.With("seqs", seqs)
+	return stmt.With("seqs", seqs), nil
 }
 
 // journeyIssues counts exceptions & ANRs per node.
-func (a App) journeyIssues(ctx context.Context, rch driver.Conn, af *filter.AppFilter, je journeyExpr) (issues []JourneyIssue, err error) {
-	stmt := a.journeyIssuesStmt(af, je)
+func (a App) journeyIssues(ctx context.Context, rch driver.Conn, ef *exprfilter.ExprFilter, je journeyExpr) (issues []JourneyIssue, err error) {
+	stmt, err := a.journeyIssuesStmt(ef, je)
+	if err != nil {
+		return
+	}
 
 	defer stmt.Close()
 

--- a/backend/libs/measure/journey_stmt_test.go
+++ b/backend/libs/measure/journey_stmt_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
 	"backend/libs/opsys"
 
 	"github.com/google/uuid"
@@ -17,11 +17,14 @@ import (
 // edited without its args silently shifts every later bind.
 func TestJourneyStmtArgsAlign(t *testing.T) {
 	id := uuid.New()
-	af := &filter.AppFilter{
-		From:         time.Now().Add(-24 * time.Hour),
-		To:           time.Now(),
-		Versions:     []string{"1.0"},
-		VersionCodes: []string{"100"},
+	ef := &exprfilter.ExprFilter{
+		Entity:     exprfilter.JourneysEntity,
+		From:       time.Now().Add(-24 * time.Hour),
+		To:         time.Now(),
+		FilterExpr: "version_name:in:1.0 AND version_code:in:100",
+	}
+	if err := ef.BuildExprTree(); err != nil {
+		t.Fatalf("build filter expression: %v", err)
 	}
 
 	for _, family := range []string{opsys.Android, opsys.AppleFamily} {
@@ -31,14 +34,17 @@ func TestJourneyStmtArgsAlign(t *testing.T) {
 			t.Fatalf("%s: no journey expressions", family)
 		}
 
-		builders := map[string]func(*filter.AppFilter, journeyExpr) *sqlf.Stmt{
+		builders := map[string]func(*exprfilter.ExprFilter, journeyExpr) (*sqlf.Stmt, error){
 			"nodes":  a.journeyNodesStmt,
 			"edges":  a.journeyEdgesStmt,
 			"issues": a.journeyIssuesStmt,
 		}
 
 		for name, build := range builders {
-			stmt := build(af, je)
+			stmt, err := build(ef, je)
+			if err != nil {
+				t.Fatalf("%s/%s: %v", family, name, err)
+			}
 			sql, args := stmt.String(), stmt.Args()
 			stmt.Close()
 

--- a/backend/libs/measure/journey_test.go
+++ b/backend/libs/measure/journey_test.go
@@ -8,7 +8,9 @@ import (
 
 	"backend/libs/ambient"
 	"backend/libs/event"
+	"backend/libs/exprfilter"
 	"backend/libs/group"
+	"backend/testinfra"
 
 	"github.com/google/uuid"
 )
@@ -48,10 +50,10 @@ func TestGetJourneyGraph(t *testing.T) {
 	seedIssueEventInSession(f.ctx, t, team, app, sessionA, "exception", fpJourneyHandled, true, at(5))
 	seedIssueEventInSession(f.ctx, t, team, app, sessionB, "anr", fpJourneyANR, false, at(6))
 
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	ef := f.journeyExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), nil)
 	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
 
-	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, ef)
 	if err != nil {
 		t.Fatalf("GetJourneyGraph: %v", err)
 	}
@@ -127,10 +129,10 @@ func TestGetJourneyGraphAndroidNodeTypes(t *testing.T) {
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "HomeActivity", at(1))
 	seedLifecycleFragmentInSession(f.ctx, t, team, app, sessionB, event.LifecycleFragmentTypeAttached, "CartFragment", at(11))
 
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	ef := f.journeyExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), nil)
 	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
 
-	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, ef)
 	if err != nil {
 		t.Fatalf("GetJourneyGraph: %v", err)
 	}
@@ -186,10 +188,10 @@ func TestGetJourneyGraphApple(t *testing.T) {
 	seedScreenViewInSession(f.ctx, t, team, app, sessionID, "HelpScreen", at(20))
 	seedIssueEventInSession(f.ctx, t, team, app, sessionID, "exception", fpJourneyApple, false, at(25))
 
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	ef := f.journeyExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), nil)
 	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"iOS"}}
 
-	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, ef)
 	if err != nil {
 		t.Fatalf("GetJourneyGraph: %v", err)
 	}
@@ -238,10 +240,10 @@ func TestGetJourneyGraphEmptyAnchorResets(t *testing.T) {
 	seedScreenViewInSession(f.ctx, t, team, app, sessionID, "", at(1))
 	seedIssueEventInSession(f.ctx, t, team, app, sessionID, event.TypeException, fpJourneyEmptyName, false, at(2))
 
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	ef := f.journeyExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), nil)
 	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
 
-	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, ef)
 	if err != nil {
 		t.Fatalf("GetJourneyGraph: %v", err)
 	}
@@ -272,10 +274,10 @@ func TestGetJourneyGraphTieOrderIsStable(t *testing.T) {
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "PayActivity", at(0))
 	seedLifecycleActivityInSession(f.ctx, t, team, app, sessionB, event.LifecycleActivityTypeResumed, "SettingsActivity", at(1))
 
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "UTC", "")
+	ef := f.journeyExprFilter(ts.Add(-time.Hour), ts.Add(time.Hour), nil)
 	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
 
-	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, af)
+	g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, ef)
 	if err != nil {
 		t.Fatalf("GetJourneyGraph: %v", err)
 	}
@@ -309,9 +311,9 @@ func TestGetExceptionGroupsFromFingerprintsCountsFatalOnly(t *testing.T) {
 	seedIssueEvent(f.ctx, t, team, app, "exception", fp, true, ts) // legacy handled
 
 	ctx := ambient.WithTeamId(f.ctx, f.teamID)
-	af := f.appFilter(ts.Add(-time.Hour), ts.Add(time.Hour), "", "")
+	from, to := ts.Add(-time.Hour), ts.Add(time.Hour)
 
-	groups, err := group.GetExceptionGroupsFromFingerprints(ctx, deps.RchPool, af, []string{fp})
+	groups, err := group.GetExceptionGroupsFromFingerprints(ctx, deps.RchPool, f.journeyExprFilter(from, to, nil), []string{fp})
 	if err != nil {
 		t.Fatalf("GetExceptionGroupsFromFingerprints: %v", err)
 	}
@@ -320,5 +322,75 @@ func TestGetExceptionGroupsFromFingerprintsCountsFatalOnly(t *testing.T) {
 	}
 	if want := uint64(2); groups[0].Count != want {
 		t.Errorf("event_count = %d, want %d (fatal only)", groups[0].Count, want)
+	}
+
+	// The seeded events carry app version v1, so a filter on another version
+	// must reach the events columns and leave the group with nothing counted.
+	exprTree := leaf("version_name", exprfilter.OperatorIn, "v9")
+	groups, err = group.GetExceptionGroupsFromFingerprints(ctx, deps.RchPool, f.journeyExprFilter(from, to, &exprTree), []string{fp})
+	if err != nil {
+		t.Fatalf("GetExceptionGroupsFromFingerprints with version filter: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group with version filter, got %d: %+v", len(groups), groups)
+	}
+	if groups[0].Count != 0 {
+		t.Errorf("event_count = %d, want 0 for a version the events do not carry", groups[0].Count)
+	}
+}
+
+// TestGetJourneyGraphFiltersByPatch asserts a patch filter keeps only the
+// screens of sessions that ran the patch.
+func TestGetJourneyGraphFiltersByPatch(t *testing.T) {
+	f := newPlotFixture(t)
+	ts := time.Date(2026, 1, 10, 10, 0, 0, 0, time.UTC)
+	team, app := f.teamIDStr(), f.appIDStr()
+	patchID := uuid.New()
+	patched, unpatched := uuid.NewString(), uuid.NewString()
+
+	screen := func(sessionID, className string, offset int, patch uuid.UUID, patchVersion string) testinfra.EventRow {
+		return testinfra.EventRow{
+			Type:                       "lifecycle_activity",
+			SessionID:                  sessionID,
+			Timestamp:                  ts.Add(time.Duration(offset) * time.Second),
+			LifecycleActivityType:      "resumed",
+			LifecycleActivityClassName: className,
+			PatchID:                    patch,
+			PatchVersion:               patchVersion,
+		}
+	}
+	th.SeedEventRows(f.ctx, t, team, app, 1, screen(patched, "HomeActivity", 0, patchID, "1.0-patch.2"))
+	th.SeedEventRows(f.ctx, t, team, app, 1, screen(patched, "DetailActivity", 1, patchID, "1.0-patch.2"))
+	th.SeedEventRows(f.ctx, t, team, app, 1, screen(unpatched, "CartActivity", 2, uuid.Nil, ""))
+
+	a := App{ID: f.app.ID, TeamId: f.teamID, OSNames: []string{"Android"}}
+	from, to := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	nodes := func(t *testing.T, exprTree *exprfilter.ExprTree) []string {
+		t.Helper()
+		g, err := a.GetJourneyGraph(f.ctx, deps.RchPool, f.journeyExprFilter(from, to, exprTree))
+		if err != nil {
+			t.Fatalf("GetJourneyGraph: %v", err)
+		}
+		return g.Nodes
+	}
+
+	if got := nodes(t, nil); len(got) != 3 {
+		t.Fatalf("unfiltered nodes = %v, want all three screens", got)
+	}
+
+	byPatchID := leaf("patch_id", exprfilter.OperatorIn, patchID.String())
+	if got := nodes(t, &byPatchID); len(got) != 2 || got[0] != "HomeActivity" || got[1] != "DetailActivity" {
+		t.Errorf("patch_id filter nodes = %v, want the patched session's screens", got)
+	}
+
+	byPatchVersion := leaf("patch_version", exprfilter.OperatorIn, "1.0-patch.2")
+	if got := nodes(t, &byPatchVersion); len(got) != 2 {
+		t.Errorf("patch_version filter nodes = %v, want the patched session's screens", got)
+	}
+
+	noPatch := leaf("patch_id", exprfilter.OperatorIsNotSet)
+	if got := nodes(t, &noPatch); len(got) != 1 || got[0] != "CartActivity" {
+		t.Errorf("is_not_set filter nodes = %v, want only the unpatched session's screen", got)
 	}
 }

--- a/backend/libs/measure/plot_test.go
+++ b/backend/libs/measure/plot_test.go
@@ -73,6 +73,18 @@ func (f plotFixture) spanExprFilter(from, to time.Time, timezone, plotTimeGroup 
 	}
 }
 
+func (f plotFixture) journeyExprFilter(from, to time.Time, exprTree *exprfilter.ExprTree) *exprfilter.ExprFilter {
+	return &exprfilter.ExprFilter{
+		AppID:    f.appID,
+		TeamID:   f.teamID,
+		Entity:   exprfilter.JourneysEntity,
+		From:     from,
+		To:       to,
+		Limit:    exprfilter.DefaultPaginationLimit,
+		ExprTree: exprTree,
+	}
+}
+
 func (f plotFixture) bugReportExprFilter(from, to time.Time, timezone, plotTimeGroup string) *exprfilter.ExprFilter {
 	return &exprfilter.ExprFilter{
 		AppID:         f.appID,

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -241,6 +241,11 @@ type EventRow struct {
 	ExceptionsJSON string
 	IsCustom       bool
 
+	// Payload of a Type "lifecycle_activity" event, written only when the
+	// class name is set.
+	LifecycleActivityType      string
+	LifecycleActivityClassName string
+
 	// Description is the bug report text, written only for Type "bug_report".
 	// For those events the seed also writes '[]' into the attachments column,
 	// the value real ingestion stores for a report without attachments.
@@ -355,6 +360,11 @@ func (h *TestHelper) SeedEventRows(ctx context.Context, t *testing.T, teamID, ap
 	if row.Type == "bug_report" {
 		cols = append(cols, "`bug_report.description`", "attachments")
 		vals = append(vals, quote(row.Description), "'[]'")
+	}
+
+	if row.LifecycleActivityClassName != "" {
+		cols = append(cols, "`lifecycle_activity.type`", "`lifecycle_activity.class_name`")
+		vals = append(vals, quote(row.LifecycleActivityType), quote(row.LifecycleActivityClassName))
 	}
 
 	if row.OSName != "" {

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -547,41 +547,41 @@ describe("fetch functions that use applyGenericFiltersToUrl", () => {
 // fetchJourneyFromServer
 // ========================================================================
 describe("fetchJourneyFromServer", () => {
-  it("hits /journey for Paths", async () => {
+  const call = (filterExpr: string | null = null) =>
+    fetchJourneyFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      filterExpr,
+    );
+
+  it("sends the range and timezone in the URL", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchJourneyFromServer(false, makeFilters());
-    expect(lastFetchUrl()).toContain("/api/apps/app-a/journey");
+    await call();
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/journey");
+    expect(url.searchParams.get("from")).toBe("2026-04-01T00:00:00.000Z");
+    expect(url.searchParams.get("to")).toBe("2026-04-10T00:00:00.000Z");
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    expect(url.searchParams.has("filter_expr")).toBe(false);
+    expect(url.searchParams.has("bigraph")).toBe(false);
   });
 
-  // NOTE: bidirectional (bigraph) is currently DROPPED by
-  // `applyGenericFiltersToUrl` — it overwrites `u.search` with a fresh
-  // URLSearchParams containing only the generic filter params. This pins
-  // the current buggy behaviour; fixing the underlying issue should flip
-  // these assertions to check for bigraph=1/0.
-  it("passes bidirectional=true path through (bigraph dropped by URL rebuild)", async () => {
+  it("sends the filter expression when one is given", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchJourneyFromServer(true, makeFilters());
-    expect(lastFetchUrl()).toContain("/api/apps/app-a/journey");
-  });
-
-  it("passes bidirectional=false path through", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
-    await fetchJourneyFromServer(false, makeFilters());
-    expect(lastFetchUrl()).toContain("/api/apps/app-a/journey");
+    await call("version_name:in:1.2.0");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe("version_name:in:1.2.0");
   });
 
   it("throws on non-ok", async () => {
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    await expect(fetchJourneyFromServer(false, makeFilters())).rejects.toThrow(
-      ApiError,
-    );
+    await expect(call()).rejects.toThrow(ApiError);
   });
 
   it("throws on exception", async () => {
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    await expect(fetchJourneyFromServer(false, makeFilters())).rejects.toThrow(
-      RequestError,
-    );
+    await expect(call()).rejects.toThrow(RequestError);
   });
 });
 
@@ -1513,7 +1513,13 @@ describe("fetch functions: failure paths", () => {
   const cases: Array<[string, () => Promise<unknown>]> = [
     [
       "fetchJourneyFromServer",
-      () => fetchJourneyFromServer(false, makeFilters()),
+      () =>
+        fetchJourneyFromServer(
+          "app-a",
+          "2026-04-01T00:00:00.000Z",
+          "2026-04-10T00:00:00.000Z",
+          null,
+        ),
     ],
     ["fetchMetricsFromServer", () => fetchMetricsFromServer(makeFilters())],
     [

--- a/frontend/dashboard/__tests__/components/journey_test.tsx
+++ b/frontend/dashboard/__tests__/components/journey_test.tsx
@@ -21,24 +21,12 @@ jest.mock("@/app/api/api_calls", () => ({
   emptyJourney: { links: [], nodes: [], totalIssues: 0 },
 }));
 
-// The component reads the selected app and date range to build the error
-// detail URLs pushed when a crash or ANR row is clicked.
-const mockFilters = {
-  app: { id: "app-1" },
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-31T00:00:00.000Z",
+// The team and app the crash and ANR buttons build their error detail URLs
+// from.
+const errorDetailContext = {
+  teamId: "test-team",
+  appId: "app-1",
 };
-
-jest.mock("@/app/stores/provider", () => ({
-  __esModule: true,
-  useFiltersStore: (selector: any) => selector({ filters: mockFilters }),
-}));
-
-const mockUseJourneyQuery = jest.fn();
-jest.mock("@/app/query/hooks", () => ({
-  __esModule: true,
-  useJourneyQuery: (...args: any[]) => mockUseJourneyQuery(...args),
-}));
 
 // The real Sankey needs DOM layout that jsdom does not provide. The stub
 // renders each node and link as a clickable span so tests can assert what
@@ -76,6 +64,9 @@ jest.mock("@nivo/sankey", () => ({
 }));
 
 import Journey, { JourneyType } from "@/app/components/journey";
+
+// What the page's journey query reports, handed to the component as a prop.
+let journeyQuery: ComponentProps<typeof Journey>["query"];
 
 // Four screens where MainActivity links to ProductListActivity and
 // SearchActivity, and ProductListActivity links on to CartActivity.
@@ -207,9 +198,9 @@ function makeJourneyWithMixedIssues() {
 function renderJourney(props: Partial<ComponentProps<typeof Journey>> = {}) {
   return render(
     <Journey
-      teamId="test-team"
-      bidirectional={false}
       journeyType={JourneyType.Paths}
+      query={journeyQuery}
+      errorDetailContext={errorDetailContext}
       {...props}
     />,
   );
@@ -217,10 +208,10 @@ function renderJourney(props: Partial<ComponentProps<typeof Journey>> = {}) {
 
 beforeEach(() => {
   mockRouterPush.mockClear();
-  mockUseJourneyQuery.mockReturnValue({
+  journeyQuery = {
     status: "success",
     data: makeJourney(),
-  });
+  };
 });
 
 describe("Journey — chart rendering", () => {
@@ -244,20 +235,20 @@ describe("Journey — chart rendering", () => {
   });
 
   it('shows "No journey data" when the journey has no nodes', () => {
-    mockUseJourneyQuery.mockReturnValue({
+    journeyQuery = {
       status: "success",
       data: { nodes: [], links: [], totalIssues: 0 },
-    });
+    };
     renderJourney();
     expect(screen.getByText("No journey data")).toBeInTheDocument();
     expect(screen.queryByTestId("nivo-sankey")).not.toBeInTheDocument();
   });
 
   it("shows loading skeleton while the query is pending", () => {
-    mockUseJourneyQuery.mockReturnValue({
+    journeyQuery = {
       status: "pending",
       data: undefined,
-    });
+    };
     renderJourney();
     expect(document.querySelector('[data-slot="skeleton"]')).toBeTruthy();
     expect(screen.queryByTestId("nivo-sankey")).not.toBeInTheDocument();
@@ -266,10 +257,10 @@ describe("Journey — chart rendering", () => {
 
 describe("Journey — exceptions panel", () => {
   beforeEach(() => {
-    mockUseJourneyQuery.mockReturnValue({
+    journeyQuery = {
       status: "success",
       data: makeJourneyWithExceptions(),
-    });
+    };
   });
 
   function renderExceptions() {
@@ -376,7 +367,7 @@ describe("Journey — exceptions panel", () => {
     expect(target).toContain("/test-team/errors/app-1/anr-001/");
   });
 
-  it("crash link includes start_date and end_date query params", () => {
+  it("crash link carries no query string", () => {
     renderExceptions();
     fireEvent.click(screen.getByTestId("sankey-node-ProductListActivity"));
     fireEvent.click(
@@ -385,19 +376,22 @@ describe("Journey — exceptions panel", () => {
         .closest("button")!,
     );
 
-    const href = mockRouterPush.mock.calls[0][0];
-    expect(href).toContain(`start_date=${mockFilters.startDate}`);
-    expect(href).toContain(`end_date=${mockFilters.endDate}`);
+    expect(mockRouterPush.mock.calls[0][0]).not.toContain("?");
   });
 
-  it("ANR link includes start_date and end_date query params", () => {
-    renderExceptions();
-    fireEvent.click(screen.getByTestId("sankey-node-CartActivity"));
-    fireEvent.click(screen.getByText(/ANR in CartActivity/).closest("button")!);
+  it("without an error detail context, clicking a crash item navigates nowhere", () => {
+    renderJourney({
+      journeyType: JourneyType.Exceptions,
+      errorDetailContext: undefined,
+    });
+    fireEvent.click(screen.getByTestId("sankey-node-ProductListActivity"));
+    fireEvent.click(
+      screen
+        .getByText(/NullPointerException at ProductList/)
+        .closest("button")!,
+    );
 
-    const href = mockRouterPush.mock.calls[0][0];
-    expect(href).toContain(`start_date=${mockFilters.startDate}`);
-    expect(href).toContain(`end_date=${mockFilters.endDate}`);
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it("clicking a node in Paths mode does not open the panel", () => {
@@ -409,10 +403,10 @@ describe("Journey — exceptions panel", () => {
 
 describe("Journey — exceptions panel tabs", () => {
   beforeEach(() => {
-    mockUseJourneyQuery.mockReturnValue({
+    journeyQuery = {
       status: "success",
       data: makeJourneyWithMixedIssues(),
-    });
+    };
   });
 
   it("Crashes tab shows crashes and ANRs tab shows ANRs", () => {
@@ -468,9 +462,8 @@ describe("Journey — node search", () => {
   it("clearing searchText shows all nodes again", () => {
     const { rerender } = render(
       <Journey
-        teamId="test-team"
-        bidirectional={false}
         journeyType={JourneyType.Paths}
+        query={journeyQuery}
         searchText="Cart"
       />,
     );
@@ -478,9 +471,8 @@ describe("Journey — node search", () => {
 
     rerender(
       <Journey
-        teamId="test-team"
-        bidirectional={false}
         journeyType={JourneyType.Paths}
+        query={journeyQuery}
         searchText=""
       />,
     );

--- a/frontend/dashboard/__tests__/components/user_journeys_test.tsx
+++ b/frontend/dashboard/__tests__/components/user_journeys_test.tsx
@@ -1,200 +1,133 @@
-import UserJourneys from "@/app/components/user_journeys";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockRouterReplace = jest.fn();
-let mockSearchParams = new URLSearchParams();
+const mockRouterPush = jest.fn();
+const mockSetPageUrlKey = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: mockRouterReplace }),
-  useSearchParams: () => mockSearchParams,
+  __esModule: true,
+  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
-jest.mock("next/link", () => ({
+// The demo never renders the filter bar or fetches, but the component calls
+// the live page's hooks on every render, so they are stubbed to stay idle.
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   __esModule: true,
-  default: ({ href, children, className }: any) => (
-    <a href={href} className={className}>
-      {children}
-    </a>
-  ),
+  default: () => <div data-testid="filter-bar" />,
 }));
 
-jest.mock("@/app/api/api_calls", () => ({
+jest.mock("@/app/components/filter_bar/use_expr_filter_page", () => ({
   __esModule: true,
-  FilterSource: { Events: 0 },
+  useExprFilterPage: () => ({
+    requestedFilters: {
+      app: null,
+      dateRange: { dateRange: null, startDate: null, endDate: null },
+      filterExpr: null,
+    },
+    filterState: { status: "pending" },
+    filterParams: null,
+    onFilterChange: jest.fn(),
+    setPageUrlKey: mockSetPageUrlKey,
+  }),
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  const userJourneysStore = create((set: any) => ({
-    plotType: "Paths",
-    searchText: "",
-    setPlotType: (type: string) => set({ plotType: type }),
-    setSearchText: (text: string) => set({ searchText: text }),
-    reset: jest.fn(),
-  }));
-  return {
-    __esModule: true,
-    useFiltersStore: filtersStore,
-    useUserJourneysStore: userJourneysStore,
-  };
-});
-
-jest.mock("@/app/components/filters", () => ({
+jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { Latest: "latest", All: "all" },
+  useJourneyQuery: () => ({ status: "pending", data: undefined, error: null }),
 }));
 
-jest.mock("@/app/components/journey", () => ({
+jest.mock("next-themes", () => ({
   __esModule: true,
-  default: ({ journeyType, demo }: any) => (
-    <div data-testid={`journey-${journeyType}`} data-demo={demo} />
-  ),
-  JourneyType: { Paths: "Paths", Exceptions: "Exceptions" },
+  useTheme: () => ({ theme: "light" }),
 }));
 
-jest.mock("@/app/components/tab_select", () => ({
+// The real Sankey needs DOM layout that jsdom does not provide. The stub
+// renders each node as a clickable span so tests can see which data reached
+// the chart and open the issue panel.
+jest.mock("@nivo/sankey", () => ({
   __esModule: true,
-  default: ({ items, selected, onChangeSelected }: any) => (
-    <div data-testid="tab-select">
-      {items.map((item: string) => (
-        <button
-          key={item}
-          data-testid={`tab-${item}`}
-          onClick={() => onChangeSelected(item)}
-          className={selected === item ? "selected" : ""}
+  ResponsiveSankey: ({ data, onClick }: any) => (
+    <div data-testid="nivo-sankey">
+      {data?.nodes?.map((node: any) => (
+        <span
+          key={node.id}
+          data-testid={`sankey-node-${node.id.split(".").pop()}`}
+          onClick={() => onClick?.(node)}
         >
-          {item}
-        </button>
+          {node.id.split(".").pop()}
+        </span>
       ))}
     </div>
   ),
 }));
 
-jest.mock("@/app/components/debounce_text_input", () => ({
-  __esModule: true,
-  default: ({ id, placeholder, onChange }: any) => (
-    <input
-      data-testid={`debounce-input-${id}`}
-      placeholder={placeholder}
-      onChange={(e) => onChange(e.target.value)}
-    />
-  ),
-}));
-
-jest.mock("@/app/utils/shared_styles", () => ({
-  underlineLinkStyle: "underline",
-}));
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
+import UserJourneys from "@/app/components/user_journeys";
 
 describe("UserJourneys", () => {
   beforeEach(() => {
-    mockSearchParams = new URLSearchParams();
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
+    mockRouterReplace.mockClear();
+    mockRouterPush.mockClear();
+    mockSetPageUrlKey.mockClear();
   });
 
-  describe("Rendering", () => {
-    it("renders title in demo mode", () => {
-      render(<UserJourneys demo={true} />);
-      expect(screen.getByText("User Journeys")).toBeInTheDocument();
-    });
-
-    it("hides title in demo mode when hideDemoTitle is true", () => {
-      render(<UserJourneys demo={true} hideDemoTitle={true} />);
-      expect(screen.queryByText("User Journeys")).not.toBeInTheDocument();
-    });
-
-    it("renders Filters when not in demo mode", () => {
-      render(<UserJourneys params={{ teamId: "team-1" }} />);
-      expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
-    });
-
-    it("does not render Filters in demo mode", () => {
-      render(<UserJourneys demo={true} />);
-      expect(screen.queryByTestId("filters-mock")).not.toBeInTheDocument();
-    });
+  it("renders the title", () => {
+    render(<UserJourneys demo={true} />);
+    expect(screen.getByText("User Journeys")).toBeInTheDocument();
   });
 
-  describe("Demo mode", () => {
-    it("renders tab select and journey without waiting for filters", () => {
-      render(<UserJourneys demo={true} />);
-      expect(screen.getByTestId("tab-select")).toBeInTheDocument();
-      expect(screen.getByTestId("journey-Paths")).toBeInTheDocument();
-    });
-
-    it("does not render search input in demo mode", () => {
-      render(<UserJourneys demo={true} />);
-      expect(
-        screen.queryByTestId("debounce-input-free-text"),
-      ).not.toBeInTheDocument();
-    });
+  it("hides the title when asked", () => {
+    render(<UserJourneys demo={true} hideDemoTitle={true} />);
+    expect(screen.queryByText("User Journeys")).not.toBeInTheDocument();
   });
 
-  describe("Tab switching", () => {
-    it("defaults to Paths tab", () => {
-      render(<UserJourneys demo={true} />);
-      expect(screen.getByTestId("journey-Paths")).toBeInTheDocument();
-      expect(
-        screen.queryByTestId("journey-Exceptions"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("switches to Exceptions journey when Exceptions tab is clicked", () => {
-      render(<UserJourneys demo={true} />);
-      fireEvent.click(screen.getByTestId("tab-Exceptions"));
-      expect(screen.getByTestId("journey-Exceptions")).toBeInTheDocument();
-      expect(screen.queryByTestId("journey-Paths")).not.toBeInTheDocument();
-    });
-
-    it("switches back to Paths journey", () => {
-      render(<UserJourneys demo={true} />);
-      fireEvent.click(screen.getByTestId("tab-Exceptions"));
-      fireEvent.click(screen.getByTestId("tab-Paths"));
-      expect(screen.getByTestId("journey-Paths")).toBeInTheDocument();
-    });
-
-    it("starts on Exceptions tab when the URL has jt=Exceptions", () => {
-      mockSearchParams = new URLSearchParams({ jt: "Exceptions" });
-      render(<UserJourneys demo={true} />);
-      expect(screen.getByTestId("journey-Exceptions")).toBeInTheDocument();
-      expect(screen.queryByTestId("journey-Paths")).not.toBeInTheDocument();
-    });
+  it("draws the demo journey without a search input", () => {
+    render(<UserJourneys demo={true} />);
+    expect(screen.getByTestId("sankey-node-MainActivity")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("sankey-node-CheckoutActivity"),
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search nodes...")).toBeNull();
   });
 
-  describe("Non-demo mode", () => {
-    it("shows journey only after filters become ready", async () => {
-      render(<UserJourneys params={{ teamId: "team-1" }} />);
-      // Journey should not render before filters are ready
-      expect(screen.queryByTestId("tab-select")).not.toBeInTheDocument();
+  it("starts on the Paths tab", () => {
+    render(<UserJourneys demo={true} />);
+    expect(screen.getByRole("button", { name: "Paths" })).toHaveClass(
+      "bg-accent",
+    );
+    expect(screen.getByRole("button", { name: "Exceptions" })).not.toHaveClass(
+      "bg-accent",
+    );
+  });
 
-      // Simulate filters becoming ready
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: { ready: true, serialisedFilters: "a=app-1" },
-        });
-      });
-      expect(screen.getByTestId("tab-select")).toBeInTheDocument();
-      expect(screen.getByTestId("journey-Paths")).toBeInTheDocument();
-    });
+  it("switches tabs locally, writing nothing to the URL", () => {
+    render(<UserJourneys demo={true} />);
+    fireEvent.click(screen.getByRole("button", { name: "Exceptions" }));
 
-    it("renders search input after filters ready", async () => {
-      render(<UserJourneys params={{ teamId: "team-1" }} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: { ready: true, serialisedFilters: "a=app-1" },
-        });
-      });
-      expect(
-        screen.getByTestId("debounce-input-free-text"),
-      ).toBeInTheDocument();
-    });
+    expect(screen.getByRole("button", { name: "Exceptions" })).toHaveClass(
+      "bg-accent",
+    );
+    expect(screen.getByTestId("sankey-node-MainActivity")).toBeInTheDocument();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Paths" }));
+    expect(screen.getByRole("button", { name: "Paths" })).toHaveClass(
+      "bg-accent",
+    );
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+
+  it("opens the issue panel on the Exceptions tab, with inert issue buttons", () => {
+    render(<UserJourneys demo={true} />);
+    fireEvent.click(screen.getByRole("button", { name: "Exceptions" }));
+    fireEvent.click(screen.getByTestId("sankey-node-CheckoutActivity"));
+
+    const crash = screen
+      .getByText(/retrofit2.HttpException@CheckoutService.kt/)
+      .closest("button")!;
+    fireEvent.click(crash);
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });

--- a/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
@@ -1,11 +1,14 @@
 /**
  * Integration tests for the User Journeys page.
  *
- * These cover the wiring between the page, the filters store, and the
- * journey API: refetches on filter and tab changes, request parameters,
- * URL sync, demo mode, and caching. Chart rendering, the exceptions
- * panel, and node search are covered by component unit tests.
+ * These cover the wiring between the page, the FilterBar and the journey
+ * API: the request the page sends for what the bar settled on, the filter
+ * expression a link carries, the plot type in the URL, and the error and
+ * empty states. Chart rendering, the exceptions panel and node search are
+ * covered by the component unit tests.
  */
+import { mockRouter } from "@/__tests__/helpers/mock_router";
+import { promiseParams } from "@/__tests__/helpers/promise_params";
 import {
   afterAll,
   afterEach,
@@ -31,13 +34,11 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
-const mockRouterPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
+const mockRouterReplace = mockRouter.replaceMock;
+const mockRouterPush = mockRouter.pushMock;
+
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/journeys",
 }));
 
@@ -72,6 +73,18 @@ jest.mock("@nivo/sankey", () => ({
   ),
 }));
 
+// The filter pickers are Radix popovers, which need a resize observer and
+// pointer capture that jsdom does not have.
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn(() => false);
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
+
 // --- MSW ---
 import { makeAppFixture, makeJourneyFixture } from "../msw/fixtures";
 import { server } from "../msw/server";
@@ -87,15 +100,15 @@ afterEach(() => {
 });
 afterAll(() => server.close());
 
-// --- Store imports ---
-import UserJourneys from "@/app/components/user_journeys";
+// --- Store/component imports ---
+import UserJourneysPage from "@/app/[teamId]/journeys/page";
+import { queryClient } from "@/app/query/query_client";
 import { createFiltersStore } from "@/app/stores/filters_store";
 import { createOnboardingStore } from "@/app/stores/onboarding_store";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 let filtersStore = createFiltersStore();
 let onboardingStore = createOnboardingStore();
-let testQueryClient: QueryClient;
 
 jest.mock("@/app/stores/provider", () => {
   const { useStore } = require("zustand");
@@ -109,379 +122,256 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
+const appId = makeAppFixture().id;
+
 beforeEach(() => {
-  const { queryClient: singletonClient } = require("@/app/query/query_client");
-  singletonClient.clear();
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
-  testQueryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  filtersStore.getState().reset();
-  for (const key of [...mockSearchParams.keys()]) mockSearchParams.delete(key);
+  queryClient.clear();
+  mockRouter.searchParams = new URLSearchParams();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(
-    <QueryClientProvider client={testQueryClient}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   );
 }
 
-// ====================================================================
-// PAGE LOAD
-// ====================================================================
-describe("Journeys page — page load", () => {
-  it("shows error when journey API returns 500", async () => {
-    server.use(
-      http.get("*/api/apps/:appId/journey", () => {
-        return new HttpResponse(null, { status: 500 });
-      }),
+describe("Journeys page (MSW integration)", () => {
+  function renderPage() {
+    return renderWithProviders(
+      <UserJourneysPage params={promiseParams({ teamId: "test-team" })} />,
     );
+  }
 
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => {
-        expect(screen.getByText(/Error fetching journey/)).toBeTruthy();
-      },
-      { timeout: 5000 },
-    );
-  });
-});
-
-// ====================================================================
-// FILTERS — app/version/date (same 3 as overview)
-// ====================================================================
-describe("Journeys page — filters", () => {
-  const { AppVersion } = require("@/app/api/api_calls");
-
-  let journeyRequests: { url: string }[];
-  let shortFilterBodies: any[];
-
-  beforeEach(() => {
-    journeyRequests = [];
-    shortFilterBodies = [];
+  function recordJourneyRequests() {
+    const sent: URL[] = [];
     server.use(
       http.get("*/api/apps/:appId/journey", ({ request }) => {
-        journeyRequests.push({ url: request.url });
+        sent.push(new URL(request.url));
         return HttpResponse.json(makeJourneyFixture());
       }),
-      http.post("*/api/apps/:appId/shortFilters", async ({ request }) => {
-        shortFilterBodies.push(await request.json());
-        return HttpResponse.json({
-          filter_short_code: `code-${shortFilterBodies.length}`,
-        });
+    );
+    return sent;
+  }
+
+  function recordKeysRequests() {
+    const sent: URL[] = [];
+    server.use(
+      http.get("*/api/apps/:appId/filters/keys", ({ request }) => {
+        sent.push(new URL(request.url));
+        return;
       }),
     );
-  });
+    return sent;
+  }
 
-  async function renderAndWaitForChart() {
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
+  async function waitForChart() {
     await waitFor(
       () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
       { timeout: 5000 },
     );
   }
 
-  it("version change triggers journey refetch", async () => {
-    await renderAndWaitForChart();
-    journeyRequests.length = 0;
+  const lastWrittenUrl = () =>
+    new URLSearchParams(
+      mockRouterReplace.mock.calls[
+        mockRouterReplace.mock.calls.length - 1
+      ][0].slice(1),
+    );
 
-    await act(async () => {
-      filtersStore
-        .getState()
-        .setSelectedVersions([new AppVersion("3.0.2", "302")]);
+  describe("opening the page", () => {
+    it("draws the journey the server sent", async () => {
+      renderPage();
+      await waitForChart();
+
+      expect(screen.getByTestId("sankey-node-MainActivity")).toBeTruthy();
+      expect(screen.getByTestId("sankey-node-CartActivity")).toBeTruthy();
     });
 
-    await waitFor(() => expect(journeyRequests.length).toBeGreaterThan(0), {
-      timeout: 5000,
+    it("asks for the journey over the range it settled on", async () => {
+      const sent = recordJourneyRequests();
+      renderPage();
+      await waitForChart();
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].pathname).toBe(`/api/apps/${appId}/journey`);
+      expect(sent[0].searchParams.get("from")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("to")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("timezone")).toBeTruthy();
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+      expect(sent[0].searchParams.has("bigraph")).toBe(false);
+      expect(sent[0].searchParams.has("versions")).toBe(false);
+      expect(sent[0].searchParams.has("filter_short_code")).toBe(false);
+    });
+
+    it("asks the keys endpoint for the journeys entity", async () => {
+      const sent = recordKeysRequests();
+      renderPage();
+      await waitForChart();
+
+      await waitFor(() => expect(sent.length).toBeGreaterThan(0));
+      expect(sent[0].searchParams.get("entity")).toBe("journeys");
+    });
+
+    it("records the app and range it settled on in the URL, with no offset", async () => {
+      renderPage();
+      await waitForChart();
+
+      const written = new URLSearchParams(
+        mockRouterReplace.mock.calls[0][0].slice(1),
+      );
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(written.get("sd")).toBeTruthy();
+      expect(written.get("ed")).toBeTruthy();
+      expect(written.has("po")).toBe(false);
+      expect(written.has("jt")).toBe(false);
+    });
+
+    it("shows the tabs and the search input with the chart", async () => {
+      renderPage();
+      await waitForChart();
+
+      expect(screen.getByRole("button", { name: "Paths" }).className).toContain(
+        "bg-accent",
+      );
+      expect(screen.getByRole("button", { name: "Exceptions" })).toBeTruthy();
+      expect(screen.getByPlaceholderText("Search nodes...")).toBeTruthy();
     });
   });
 
-  it("version change sends new version in shortFilters POST", async () => {
-    await renderAndWaitForChart();
-    shortFilterBodies.length = 0;
+  describe("a link carrying a filter", () => {
+    it("filters the journey by it", async () => {
+      mockRouter.searchParams = new URLSearchParams(
+        `filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
+      );
+      const sent = recordJourneyRequests();
+      renderPage();
+      await waitForChart();
 
-    await act(async () => {
-      filtersStore
-        .getState()
-        .setSelectedVersions([new AppVersion("3.0.1", "301")]);
-    });
-
-    await waitFor(() => expect(shortFilterBodies.length).toBeGreaterThan(0), {
-      timeout: 5000,
-    });
-    expect(
-      shortFilterBodies[shortFilterBodies.length - 1].filters.versions,
-    ).toEqual(["3.0.1"]);
-  });
-
-  it("date change triggers journey refetch", async () => {
-    await renderAndWaitForChart();
-    journeyRequests.length = 0;
-
-    await act(async () => {
-      const now = new Date();
-      filtersStore.getState().setSelectedDateRange("Last Week");
-      filtersStore
-        .getState()
-        .setSelectedStartDate(
-          new Date(now.getTime() - 7 * 86400000).toISOString(),
-        );
-      filtersStore.getState().setSelectedEndDate(now.toISOString());
-    });
-
-    await waitFor(() => expect(journeyRequests.length).toBeGreaterThan(0), {
-      timeout: 5000,
+      expect(sent[0].searchParams.get("filter_expr")).toBe(
+        "version_name:in:3.1.0",
+      );
+      expect(lastWrittenUrl().get("filter_expr")).toBe("version_name:in:3.1.0");
     });
   });
 
-  it("filter_short_code appears in journey data-fetch URL", async () => {
-    server.use(
-      http.post("*/api/apps/:appId/shortFilters", () => {
-        return HttpResponse.json({ filter_short_code: "journey-code-xyz" });
-      }),
-    );
+  describe("the plot type", () => {
+    it("opens on the plot a link names and keeps it in the URL", async () => {
+      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      renderPage();
+      await waitForChart();
 
-    await renderAndWaitForChart();
-
-    await waitFor(
-      () => {
-        const urlWithCode = journeyRequests.find((r) =>
-          r.url.includes("filter_short_code="),
-        );
-        expect(urlWithCode?.url).toContain(
-          "filter_short_code=journey-code-xyz",
-        );
-      },
-      { timeout: 5000 },
-    );
-  });
-
-  it("journey URL includes from/to/timezone params", async () => {
-    await renderAndWaitForChart();
-
-    expect(journeyRequests.length).toBeGreaterThan(0);
-    const url = journeyRequests[0].url;
-    expect(url).toContain("from=");
-    expect(url).toContain("to=");
-    expect(url).toContain("timezone=");
-  });
-});
-
-// ====================================================================
-// URL SYNC
-// ====================================================================
-describe("Journeys page — URL sync", () => {
-  it("version change updates URL with version param", async () => {
-    const { AppVersion } = require("@/app/api/api_calls");
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    mockRouterReplace.mockClear();
-
-    await act(async () => {
-      filtersStore
-        .getState()
-        .setSelectedVersions([new AppVersion("3.0.1", "301")]);
+      expect(
+        screen.getByRole("button", { name: "Exceptions" }).className,
+      ).toContain("bg-accent");
+      expect(lastWrittenUrl().get("jt")).toBe("Exceptions");
+      expect(lastWrittenUrl().get("a")).toBe(appId);
     });
 
-    await waitFor(
-      () => {
-        expect(mockRouterReplace).toHaveBeenCalled();
-        const url =
-          mockRouterReplace.mock.calls[
-            mockRouterReplace.mock.calls.length - 1
-          ][0];
-        expect(url).toContain("v=");
-      },
-      { timeout: 5000 },
-    );
-  });
-});
+    it("a tab click writes the plot type into the URL without refetching", async () => {
+      const sent = recordJourneyRequests();
+      renderPage();
+      await waitForChart();
 
-// ====================================================================
-// DEMO MODE
-// ====================================================================
-describe("Journeys page — demo mode", () => {
-  it("renders without API calls", async () => {
-    const apiCalls: string[] = [];
-    server.use(
-      http.get("*", ({ request }) => {
-        apiCalls.push(request.url);
-        return HttpResponse.json({});
-      }),
-      http.post("*", ({ request }) => {
-        apiCalls.push(request.url);
-        return HttpResponse.json({});
-      }),
-    );
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Exceptions" }));
+      });
 
-    renderWithProviders(<UserJourneys demo={true} />);
-    expect(screen.getByText("User Journeys")).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Exceptions" }).className,
+      ).toContain("bg-accent");
+      const written = lastWrittenUrl();
+      expect(written.get("jt")).toBe("Exceptions");
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(screen.getByTestId("sankey-node-MainActivity")).toBeTruthy();
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 200));
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 200));
+      });
+      expect(sent).toHaveLength(1);
     });
-    expect(apiCalls.length).toBe(0);
-  });
-});
-
-// ====================================================================
-// STORE CACHE
-// ====================================================================
-describe("Journeys page — caching", () => {
-  it("re-mount still shows data", async () => {
-    const { unmount } = renderWithProviders(
-      <UserJourneys params={{ teamId: "test-team" }} />,
-    );
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    unmount();
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
   });
 
-  it("Paths→Exceptions→Paths: each switch refetches (single-value cache)", async () => {
-    // The journey store uses a single cachedFetchKey (not a map),
-    // so switching back to Paths after Exceptions is a cache MISS
-    // because the Exceptions fetch overwrote the cached key.
-    // This pins the current behavior.
-    let fetchCount = 0;
-    server.use(
-      http.get("*/api/apps/:appId/journey", () => {
-        fetchCount++;
-        return HttpResponse.json(makeJourneyFixture());
-      }),
-    );
+  describe("when the server answers with nothing", () => {
+    it("says there is no journey data", async () => {
+      server.use(
+        http.get("*/api/apps/:appId/journey", () => {
+          return HttpResponse.json({ nodes: [], links: [], totalIssues: 0 });
+        }),
+      );
+      renderPage();
 
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    expect(fetchCount).toBe(1); // Initial Paths
-
-    await act(async () => {
-      fireEvent.click(screen.getByText("Exceptions"));
+      expect(await screen.findByText("No journey data")).toBeTruthy();
+      expect(screen.queryByTestId("nivo-sankey")).toBeNull();
     });
-    await waitFor(() => expect(fetchCount).toBe(2), { timeout: 5000 }); // Exceptions
-
-    await act(async () => {
-      fireEvent.click(screen.getByText("Paths"));
-    });
-    await waitFor(() => expect(fetchCount).toBe(3), { timeout: 5000 }); // Paths again (cache miss)
   });
-});
 
-// ====================================================================
-// DIFFERENT DATA PER APP
-// ====================================================================
-describe("Journeys page — different journey data per app", () => {
-  it("switching app renders different nodes", async () => {
-    const app1 = makeAppFixture({ id: "app-1", name: "Alpha" });
-    const app2 = makeAppFixture({ id: "app-2", name: "Beta" });
+  describe("when the server fails", () => {
+    it("shows the error message", async () => {
+      server.use(
+        http.get("*/api/apps/:appId/journey", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      renderPage();
 
-    server.use(
-      http.get("*/api/teams/:teamId/apps", () => {
-        return HttpResponse.json([app1, app2]);
-      }),
-      http.get("*/api/apps/:appId/journey", ({ params }) => {
-        if (params.appId === "app-2") {
-          return HttpResponse.json({
-            nodes: [
-              { id: "com.beta.ScreenA", issues: { crashes: [], anrs: [] } },
-              { id: "com.beta.ScreenB", issues: { crashes: [], anrs: [] } },
-            ],
-            links: [
-              {
-                source: "com.beta.ScreenA",
-                target: "com.beta.ScreenB",
-                value: 100,
-              },
-            ],
-            totalIssues: 0,
-          });
-        }
-        return HttpResponse.json(makeJourneyFixture());
-      }),
-    );
-
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    // App 1 has 4 nodes
-    expect(screen.getByTestId("sankey-node-MainActivity")).toBeTruthy();
-
-    // Switch to app 2
-    await act(async () => {
-      filtersStore.getState().setSelectedApp(app2 as any);
+      expect(await screen.findByText(/Error fetching journey/)).toBeTruthy();
+      expect(screen.queryByTestId("nivo-sankey")).toBeNull();
     });
 
-    await waitFor(
-      () => {
-        // App 2 has different nodes
-        expect(screen.getByTestId("sankey-node-ScreenA")).toBeTruthy();
-        expect(screen.getByTestId("sankey-node-ScreenB")).toBeTruthy();
-      },
-      { timeout: 5000 },
-    );
+    it("shows a refused filter's issue in the bar, not the error message", async () => {
+      mockRouter.searchParams = new URLSearchParams(
+        `filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
+      );
+      server.use(
+        http.get("*/api/apps/:appId/journey", () => {
+          return HttpResponse.json(
+            {
+              error: "invalid_filter_expr",
+              filter_expr_issues: [
+                {
+                  message: 'Key "version_name" has no value "3.1.0"',
+                  span: { start: 0, end: 21 },
+                },
+              ],
+            },
+            { status: 400 },
+          );
+        }),
+      );
+      renderPage();
 
-    // App 1 nodes should be gone
-    expect(screen.queryByTestId("sankey-node-MainActivity")).toBeNull();
+      expect((await screen.findByTestId("filter-issue")).textContent).toContain(
+        'Key "version_name" has no value "3.1.0"',
+      );
+      expect(screen.queryByText(/Error fetching journey/)).toBeNull();
+    });
+
+    it("says so when the team's apps cannot be fetched", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      renderPage();
+
+      expect(await screen.findByText(/Error fetching apps/)).toBeTruthy();
+    });
   });
-});
 
-// ====================================================================
-// DATE CHANGE does NOT fire shortFilters POST
-// ====================================================================
-describe("Journeys page — date change and shortFilters", () => {
-  it("date change does NOT fire a new shortFilters POST", async () => {
-    const shortFilterBodies: any[] = [];
-    server.use(
-      http.post("*/api/apps/:appId/shortFilters", async ({ request }) => {
-        shortFilterBodies.push(await request.json());
-        return HttpResponse.json({
-          filter_short_code: `code-${shortFilterBodies.length}`,
-        });
-      }),
-    );
+  describe("re-render", () => {
+    it("re-render still shows data", async () => {
+      const { unmount } = renderPage();
+      await waitForChart();
 
-    renderWithProviders(<UserJourneys params={{ teamId: "test-team" }} />);
-    await waitFor(
-      () => expect(screen.getByTestId("nivo-sankey")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    const postsBefore = shortFilterBodies.length;
-
-    await act(async () => {
-      const now = new Date();
-      filtersStore.getState().setSelectedDateRange("Last Month");
-      filtersStore
-        .getState()
-        .setSelectedStartDate(
-          new Date(now.getTime() - 30 * 86400000).toISOString(),
-        );
-      filtersStore.getState().setSelectedEndDate(now.toISOString());
+      unmount();
+      renderPage();
+      await waitForChart();
     });
-
-    // Wait for journey refetch to settle
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 300));
-    });
-    expect(shortFilterBodies.length).toBe(postsBefore);
   });
 });

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -1474,6 +1474,56 @@ export function makeBugReportsFilterKeysFixture(
   };
 }
 
+// --- Filter keys for the journeys entity ---
+// The journey table carries only the app version, so these are its only keys.
+
+export function makeJourneysFilterKeysFixture(
+  overrides: Record<string, any> = {},
+) {
+  return {
+    keys: [
+      {
+        name: "version_name",
+        label: "App version",
+        description: "The app version the session ran on",
+        key_group: "Version",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "version_code",
+        label: "App build",
+        description: "The app build the session ran on",
+        key_group: "Version",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "patch_version",
+        label: "Patch version",
+        description: "The version of an Over-The-Air patch.",
+        key_group: "Version",
+        value_type: "string",
+        value_suggestion_mode: "sample",
+        operators: ["in", "not_in", "contains"],
+      },
+      {
+        name: "patch_id",
+        label: "Patch id",
+        description: "The id of an Over-The-Air patch.",
+        key_group: "Version",
+        value_type: "uuid",
+        value_suggestion_mode: "sample",
+        operators: ["in", "not_in", "is_set", "is_not_set"],
+      },
+    ],
+    key_groups: ["Version"],
+    ...overrides,
+  };
+}
+
 // --- Filter values (GET /apps/:appId/filters/values) ---
 
 export function makeFilterValuesFixture(overrides: Record<string, any> = {}) {

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -19,6 +19,7 @@ import {
   makeBillingInfoFixture,
   makeBugReportDetailFixture,
   makeBugReportsFilterKeysFixture,
+  makeJourneysFilterKeysFixture,
   makeBugReportsOverviewFixture,
   makeBugReportsPlotFixture,
   makeBuildsFixture,
@@ -415,6 +416,9 @@ export const handlers = [
     const entity = new URL(request.url).searchParams.get("entity");
     if (entity === "bug_reports") {
       return HttpResponse.json(makeBugReportsFilterKeysFixture());
+    }
+    if (entity === "journeys") {
+      return HttpResponse.json(makeJourneysFilterKeysFixture());
     }
     return HttpResponse.json(makeFilterKeysFixture());
   }),

--- a/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
@@ -1,59 +1,168 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import UserJourneys from "@/app/[teamId]/journeys/page";
+import UserJourneysPage from "@/app/[teamId]/journeys/page";
+import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const replaceMock = jest.fn();
+const replaceMock = mockRouter.replaceMock;
+const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
-// Mock next/navigation hooks
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-  }),
-  useSearchParams: () => new URLSearchParams(),
-}));
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
-// Mock API calls and constants
-jest.mock("@/app/api/api_calls", () => ({
+jest.mock("@/app/stores/filters_store", () => ({
   __esModule: true,
-  FilterSource: { Events: "events" },
+  urlFiltersKeyMap: {
+    appId: "a",
+    dateRange: "d",
+    startDate: "sd",
+    endDate: "ed",
+  },
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
+const pendingQueryState = () => ({
+  data: undefined as any,
+  status: "pending" as string,
+  isFetching: true,
+  error: null as Error | null,
 });
 
-// Mock Filters component
-jest.mock("@/app/components/filters", () => ({
+const mockUseJourneyQuery = jest.fn((_filter: any) => pendingQueryState());
+
+jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { Latest: "latest", All: "all" },
+  useJourneyQuery: (filter: any) => mockUseJourneyQuery(filter),
+  paginationOffsetUrlKey: "po",
 }));
 
-const { useFiltersStore } = require("@/app/stores/provider") as any;
+const mockReportedApp = { id: "app-1", name: "Sample" };
+const mockOtherApp = { id: "app-2", name: "Other" };
+const mockReportedDate = {
+  dateRange: "Last 6 Hours",
+  startDate: "2026-01-01T00:00:00.000Z",
+  endDate: "2026-01-01T06:00:00.000Z",
+};
 
-// Mock DebounceTextInput
-jest.mock("@/app/components/debounce_text_input", () => ({
+// Makes the stub drop the URL's filter on mount, like the bar discarding
+// a filter it cannot read.
+let mockMountDiscardsFilter = false;
+
+// Like the real bar, this stub reports an app, a range and a filter as it
+// mounts, and offers buttons that report a changed filter, a cleared filter,
+// another app, or a failure. Only the mount report carries appliedAsRequested
+// true, and only when the URL's filter was not discarded; a report from a
+// button models a user edit. The issues the page hands back are rendered so
+// tests can see them reach the bar.
+jest.mock("@/app/components/filter_bar/filter_bar", () => {
+  const { useEffect } = require("react");
+
+  function FilterBarMock(props: any) {
+    const ready = (
+      filterExpr: string | null,
+      appliedAsRequested: boolean = false,
+      app: { id: string; name: string } = mockReportedApp,
+    ) => ({
+      status: "ready",
+      app,
+      date: mockReportedDate,
+      filterExpr,
+      appliedAsRequested,
+    });
+
+    useEffect(() => {
+      if (mockMountDiscardsFilter) {
+        props.onFilterChange(ready(null, false));
+      } else {
+        props.onFilterChange(ready(props.requestedFilterExpr, true));
+      }
+    }, []);
+
+    return (
+      <div data-testid="filter-bar-mock">
+        <span data-testid="filter-bar-entity">{props.entity}</span>
+        <span data-testid="filter-bar-expr">
+          {props.requestedFilterExpr ?? "none"}
+        </span>
+        <span data-testid="filter-bar-issues">
+          {props.filterExprIssues
+            ? props.filterExprIssues
+                .map((issue: { message: string }) => issue.message)
+                .join(", ")
+            : "none"}
+        </span>
+        <button
+          data-testid="filter-bar-apply"
+          onClick={() => props.onFilterChange(ready("version_name:in:1.2.0"))}
+        >
+          apply
+        </button>
+        <button
+          data-testid="filter-bar-clear"
+          onClick={() => props.onFilterChange(ready(null))}
+        >
+          clear
+        </button>
+        <button
+          data-testid="filter-bar-switch-app"
+          onClick={() =>
+            props.onFilterChange(
+              ready(props.requestedFilterExpr, false, mockOtherApp),
+            )
+          }
+        >
+          switch app
+        </button>
+        <button
+          data-testid="filter-bar-fail"
+          onClick={() =>
+            props.onFilterChange({
+              status: "error",
+              message: "Error fetching apps, please refresh page to try again",
+            })
+          }
+        >
+          fail
+        </button>
+      </div>
+    );
+  }
+
+  return {
+    __esModule: true,
+    default: FilterBarMock,
+    filterExprUrlKey: "filter_expr",
+  };
+});
+
+jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
+}));
+
+// The stub records the plot it was asked for, the search text, the query
+// status and the app the issue buttons would link to.
+jest.mock("@/app/components/journey", () => ({
+  __esModule: true,
+  JourneyType: { Paths: "Paths", Exceptions: "Exceptions" },
+  PlotType: { Paths: "Paths", Exceptions: "Exceptions" },
   default: (props: any) => (
-    <input
-      data-testid="debounce-text-input-mock"
-      value={props.initialValue}
-      onChange={(e) => props.onChange(e.target.value)}
-    />
+    <div
+      data-testid={`journey-mock-${props.journeyType}`}
+      data-search-text={props.searchText}
+      data-status={props.query.status}
+      data-app={props.errorDetailContext.appId}
+      data-team={props.errorDetailContext.teamId}
+    >{`Journey Rendered: ${props.journeyType}`}</div>
   ),
 }));
 
-// Mock TabSelect
 jest.mock("@/app/components/tab_select", () => ({
   __esModule: true,
   default: (props: any) => (
-    <div data-testid="tab-select-mock">
+    <div data-testid="tab-select-mock" data-selected={props.selected}>
       {props.items.map((item: string) => (
         <button
           key={item}
@@ -67,177 +176,403 @@ jest.mock("@/app/components/tab_select", () => ({
   ),
 }));
 
-// Mock Journey component
-jest.mock("@/app/components/journey", () => ({
+jest.mock("@/app/components/debounce_text_input", () => ({
   __esModule: true,
-  JourneyType: { Paths: "Paths", Exceptions: "Exceptions" },
   default: (props: any) => (
-    <div
-      data-testid={`journey-mock-${props.journeyType}`}
-      data-search-text={props.searchText}
-    >{`Journey Rendered: ${props.journeyType}`}</div>
+    <input
+      data-testid="debounce-text-input-mock"
+      placeholder={props.placeholder}
+      defaultValue={props.initialValue}
+      onChange={(e) => props.onChange(e.target.value)}
+    />
   ),
 }));
 
-// Helper to mock useSearchParams with custom query
-const getSearchParamsMock = (params: Record<string, string>) => {
-  return () => new URLSearchParams(params);
+const mockJourneyData = {
+  nodes: [
+    { id: "sh.measure.demo.MainActivity", issues: { crashes: [], anrs: [] } },
+  ],
+  links: [],
+  totalIssues: 0,
 };
 
-describe("UserJourneys Page", () => {
+function journeyLoaded(data: any = mockJourneyData) {
+  mockUseJourneyQuery.mockReturnValue({
+    data,
+    status: "success",
+    isFetching: false,
+    error: null,
+  });
+}
+
+function journeyFailed(error: Error) {
+  mockUseJourneyQuery.mockReturnValue({
+    data: undefined,
+    status: "error",
+    isFetching: false,
+    error,
+  });
+}
+
+// What the stub bar reports, as the page writes it into the URL.
+const selectionParams =
+  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+
+const selectionUrl = (...trailingParams: string[]) =>
+  `?${[selectionParams, ...trailingParams].join("&")}`;
+
+const reportedFilterParams = (filterExpr: string | null) => ({
+  appId: mockReportedApp.id,
+  startDate: mockReportedDate.startDate,
+  endDate: mockReportedDate.endDate,
+  filterExpr,
+});
+
+function renderPage() {
+  return render(<UserJourneysPage params={promiseParams({ teamId: "123" })} />);
+}
+
+describe("UserJourneys page", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
+    mockRouter.reset();
+    mockMountDiscardsFilter = false;
+    mockUseJourneyQuery.mockReset();
+    mockUseJourneyQuery.mockReturnValue(pendingQueryState());
   });
 
-  it("renders the Filters component", () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
-    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
+  it("renders the filter bar for the journeys entity", () => {
+    renderPage();
+    expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar-entity")).toHaveTextContent(
+      "journeys",
+    );
   });
 
-  it("does not render Journey, TabSelect or DebounceTextInput when filters are not ready", () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
-    expect(screen.queryByTestId("tab-select-mock")).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("debounce-text-input-mock"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId("journey-mock-Paths")).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("journey-mock-Exceptions"),
-    ).not.toBeInTheDocument();
+  it("hands the bar the filter the URL opened on", () => {
+    mockRouter.searchParams = new URLSearchParams(
+      "filter_expr=version_name%3Ain%3A1.2.0",
+    );
+    journeyLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
+      "version_name:in:1.2.0",
+    );
   });
 
-  it("renders TabSelect, DebounceTextInput, and Journey (Paths) when filters become ready and updates URL", async () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
+  it("fetches nothing until the bar settles on an app and a range", () => {
+    mockRouter.searchParams = new URLSearchParams(
+      "filter_expr=version_name%3Ain%3A1.2.0",
+    );
+    journeyLoaded();
+    renderPage();
+
+    expect(mockUseJourneyQuery).toHaveBeenNthCalledWith(1, null);
+  });
+
+  it("fetches the journey filtered by what the bar reported", () => {
+    mockRouter.searchParams = new URLSearchParams(
+      "filter_expr=version_name%3Ain%3A1.2.0",
+    );
+    journeyLoaded();
+    renderPage();
+
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
+      reportedFilterParams("version_name:in:1.2.0"),
+    );
+  });
+
+  it("never fetches a filter the bar discarded on mount", async () => {
+    mockMountDiscardsFilter = true;
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
+      `filter_expr=version_name%3Ain%3A1.2.0&${selectionParams}`,
+    );
+    journeyLoaded();
+    renderPage();
+
+    // The write has not landed, so the URL still holds the discarded
+    // filter and the query stays disabled.
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(null);
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
+      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
     });
 
-    expect(await screen.findByTestId("tab-select-mock")).toBeInTheDocument();
-    expect(
-      await screen.findByTestId("debounce-text-input-mock"),
-    ).toBeInTheDocument();
-    expect(await screen.findByTestId("journey-mock-Paths")).toBeInTheDocument();
-    expect(replaceMock).toHaveBeenCalledWith("?jt=Paths&updated", {
+    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(), {
       scroll: false,
     });
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
+      reportedFilterParams(null),
+    );
+    for (const [params] of mockUseJourneyQuery.mock.calls) {
+      expect(params?.filterExpr ?? null).not.toBe("version_name:in:1.2.0");
+    }
   });
 
-  it("renders Journey (Exceptions) when Exceptions tab is selected", async () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
+  it("records what the bar settled on without a pagination offset", () => {
+    mockRouter.searchParams = new URLSearchParams(
+      "filter_expr=version_name%3Ain%3A1.2.0",
+    );
+    journeyLoaded();
+    renderPage();
+
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).toHaveBeenCalledWith(
+      selectionUrl("filter_expr=version_name%3Ain%3A1.2.0"),
+      { scroll: false },
+    );
+    expect(mockRouter.searchParams.has("po")).toBe(false);
+  });
+
+  it("renders the tabs, the search input and the journey once ready", () => {
+    journeyLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("tab-select-mock")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search nodes...")).toBeInTheDocument();
+    expect(screen.getByTestId("journey-mock-Paths")).toHaveAttribute(
+      "data-status",
+      "success",
+    );
+    expect(screen.queryByTestId("journey-mock-Exceptions")).toBeNull();
+  });
+
+  it("keeps the tabs and the journey up while the journey loads", () => {
+    renderPage();
+
+    expect(screen.getByTestId("tab-select-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("journey-mock-Paths")).toHaveAttribute(
+      "data-status",
+      "pending",
+    );
+  });
+
+  it("links the issue buttons to the team and app the bar settled on", () => {
+    journeyLoaded();
+    renderPage();
+
+    const journey = screen.getByTestId("journey-mock-Paths");
+    expect(journey).toHaveAttribute("data-team", "123");
+    expect(journey).toHaveAttribute("data-app", mockReportedApp.id);
+  });
+
+  it("passes the typed search text to the journey", async () => {
+    journeyLoaded();
+    renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
+      fireEvent.change(screen.getByPlaceholderText("Search nodes..."), {
+        target: { value: "search term" },
       });
     });
 
-    const exceptionsTab = await screen.findByTestId("tab-Exceptions");
-    await act(async () => {
-      fireEvent.click(exceptionsTab);
-    });
-
-    expect(
-      await screen.findByTestId("journey-mock-Exceptions"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders Journey (Paths) by default and switches to Exceptions when tab is selected", async () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
-
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
-
-    // Initially, Paths journey should be rendered
-    expect(await screen.findByTestId("journey-mock-Paths")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("journey-mock-Exceptions"),
-    ).not.toBeInTheDocument();
-
-    // Switch to Exceptions tab
-    const exceptionsTab = await screen.findByTestId("tab-Exceptions");
-    await act(async () => {
-      fireEvent.click(exceptionsTab);
-    });
-
-    // Now, Exceptions journey should be rendered
-    expect(
-      await screen.findByTestId("journey-mock-Exceptions"),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("journey-mock-Paths")).not.toBeInTheDocument();
-  });
-
-  it("sets jt query param in URL when tab is changed", async () => {
-    // Patch useSearchParams to return empty initially
-    jest.mock("next/navigation", () => ({
-      useRouter: () => ({ replace: replaceMock }),
-      useSearchParams: getSearchParamsMock({}),
-    }));
-    // Re-import UserJourneys to use the new mock
-    const {
-      default: UserJourneysPatched,
-    } = require("@/app/[teamId]/journeys/page");
-    render(<UserJourneysPatched params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
-    const exceptionsTab = await screen.findByTestId("tab-Exceptions");
-    await act(async () => {
-      fireEvent.click(exceptionsTab);
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith("?jt=Exceptions&updated", {
-      scroll: false,
-    });
-  });
-
-  it("updates searchText when DebounceTextInput changes", async () => {
-    render(<UserJourneys params={promiseParams({ teamId: "123" })} />);
-
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
-
-    const input = await screen.findByTestId("debounce-text-input-mock");
-    await act(async () => {
-      fireEvent.change(input, { target: { value: "search term" } });
-    });
-    // The page holds searchText in state and passes it to Journey, so the
-    // typed value must reach the rendered Journey as its searchText prop.
     expect(screen.getByTestId("journey-mock-Paths")).toHaveAttribute(
       "data-search-text",
       "search term",
     );
+  });
+
+  describe("the plot type", () => {
+    it("opens on the plot the URL names", () => {
+      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      journeyLoaded();
+      renderPage();
+
+      expect(screen.getByTestId("tab-select-mock")).toHaveAttribute(
+        "data-selected",
+        "Exceptions",
+      );
+      expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
+      expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
+    });
+
+    it("survives the bar's report being written into the URL", () => {
+      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      journeyLoaded();
+      renderPage();
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl("jt=Exceptions"),
+        { scroll: false },
+      );
+      expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
+    });
+
+    it("is written into the URL when a tab is clicked, keeping the filter", async () => {
+      mockRouter.searchParams = new URLSearchParams(
+        "filter_expr=version_name%3Ain%3A1.2.0",
+      );
+      journeyLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("tab-Exceptions"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Exceptions"),
+        { scroll: false },
+      );
+      expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
+      expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("tab-Paths"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Paths"),
+        { scroll: false },
+      );
+      expect(screen.getByTestId("journey-mock-Paths")).toBeInTheDocument();
+    });
+
+    it("does not change the query when a tab is clicked", async () => {
+      journeyLoaded();
+      renderPage();
+      const callsBefore = mockUseJourneyQuery.mock.calls.length;
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("tab-Exceptions"));
+      });
+
+      for (const [params] of mockUseJourneyQuery.mock.calls.slice(
+        callsBefore,
+      )) {
+        expect(params).toEqual(reportedFilterParams(null));
+      }
+    });
+
+    it("is kept when the filter changes", async () => {
+      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      journeyLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-apply"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Exceptions"),
+        { scroll: false },
+      );
+      expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
+        reportedFilterParams("version_name:in:1.2.0"),
+      );
+      expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
+    });
+
+    it("is kept when the filter is cleared", async () => {
+      mockRouter.searchParams = new URLSearchParams(
+        "jt=Exceptions&filter_expr=version_name%3Ain%3A1.2.0",
+      );
+      journeyLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-clear"));
+      });
+
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        selectionUrl("jt=Exceptions"),
+        { scroll: false },
+      );
+      expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
+    });
+  });
+
+  it("refetches for the app the bar switches to", async () => {
+    journeyLoaded();
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("filter-bar-switch-app"));
+    });
+
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      `?${selectionParams.replace("a=app-1", "a=app-2")}`,
+      { scroll: false },
+    );
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith({
+      ...reportedFilterParams(null),
+      appId: mockOtherApp.id,
+    });
+    expect(screen.getByTestId("journey-mock-Paths")).toHaveAttribute(
+      "data-app",
+      mockOtherApp.id,
+    );
+  });
+
+  describe("when the journey request fails", () => {
+    it("shows the error message", () => {
+      journeyFailed(new Error("fail"));
+      renderPage();
+
+      expect(screen.getByText(/Error fetching journey/)).toBeInTheDocument();
+      expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
+      expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent("none");
+    });
+
+    it("hands a refused filter's issues to the bar in place of the message", () => {
+      mockRouter.searchParams = new URLSearchParams(
+        "filter_expr=version_name%3Ain%3A1.2.0",
+      );
+      journeyFailed(
+        new ApiError(400, invalidFilterExpr, [
+          { message: 'Unknown key "os_name"', span: { start: 0, end: 7 } },
+        ]),
+      );
+      renderPage();
+
+      expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent(
+        'Unknown key "os_name"',
+      );
+      expect(screen.queryByText(/Error fetching journey/)).toBeNull();
+      expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
+    });
+  });
+
+  describe("a filter the bar could not settle", () => {
+    beforeEach(() => {
+      mockRouter.searchParams = new URLSearchParams(selectionParams);
+      journeyLoaded();
+    });
+
+    it("is said by the page, in place of the journey", async () => {
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
+      });
+
+      expect(
+        screen.getByText(
+          "Error fetching apps, please refresh page to try again",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
+    });
+
+    it("stops the page fetching anything", async () => {
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
+      });
+
+      expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(null);
+    });
+
+    it("leaves the URL where the link had it", async () => {
+      renderPage();
+      replaceMock.mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-fail"));
+      });
+
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1171,19 +1171,23 @@ export const fetchAppHealthPlotFromServer = async (filters: Filters) => {
 };
 
 export const fetchJourneyFromServer = async (
-  bidirectional: boolean,
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
 ) => {
-  let url = `/api/apps/${filters.app!.id}/journey?`;
+  const params = new URLSearchParams({
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+  });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
 
-  // Append bidirectional value
-  url = url + `bigraph=${bidirectional ? "1&" : "0&"}`;
-
-  url = await applyGenericFiltersToUrl(url, filters, null, null);
-
-  const data = await request(url, { failsWith: "Failed to fetch journey" });
-
-  return data;
+  return await request(`/api/apps/${appId}/journey?${params.toString()}`, {
+    failsWith: "Failed to fetch journey",
+  });
 };
 
 export const fetchMetricsFromServer = async (filters: Filters) => {

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -723,7 +723,7 @@ export default function FilterBar({
           />
         ) : null)}
 
-      <div className="flex-1 min-w-64">
+      <div className="flex-auto min-w-64">
         <div
           data-testid="filter-bar"
           aria-disabled={keysUnavailable}

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -45,13 +45,24 @@ type ExtraFilterField = Exclude<
  * ready report to the URL key that carries it. The hook then reads the
  * requested value, includes the field in the URL-vs-report equality gate, and
  * writes it into the URL with the rest of the filter.
+ *
+ * A page that queries without pagination leaves `paginationLimit` out: the
+ * URL then never carries the offset and `paginationOffset` stays zero.
+ *
+ * A page with URL state the bar knows nothing about, such as which plot is
+ * shown, lists those keys in `pageUrlKeys` and writes them through
+ * `setPageUrlKey`. When the bar's report is written into the URL, the values
+ * those keys currently hold are carried over, so a filter change does not
+ * reset them.
  */
 export function useExprFilterPage<Extra extends ExtraFilterField = never>({
   paginationLimit,
   extraUrlKeys,
+  pageUrlKeys = [],
 }: {
-  paginationLimit: number;
+  paginationLimit?: number;
   extraUrlKeys?: Record<Extra, string>;
+  pageUrlKeys?: string[];
 }) {
   const extras = Object.entries(extraUrlKeys ?? {}) as [Extra, string][];
 
@@ -59,7 +70,9 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
   const searchParams = useSearchParams();
 
   const paginationOffset =
-    Number(searchParams.get(paginationOffsetUrlKey)) || 0;
+    paginationLimit === undefined
+      ? 0
+      : Number(searchParams.get(paginationOffsetUrlKey)) || 0;
 
   const requestedFilters = {
     app: searchParams.get(appIdUrlKey),
@@ -97,7 +110,9 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
 
   const buildFilterUrl = (filter: ReadyFilterState, offset: number) => {
     const urlParams = new URLSearchParams();
-    urlParams.set(paginationOffsetUrlKey, String(offset));
+    if (paginationLimit !== undefined) {
+      urlParams.set(paginationOffsetUrlKey, String(offset));
+    }
     urlParams.set(appIdUrlKey, filter.app.id);
     urlParams.set(dateRangeUrlKey, filter.date.dateRange);
     urlParams.set(startDateUrlKey, filter.date.startDate);
@@ -110,6 +125,12 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
     }
     if (filter.filterExpr) {
       urlParams.set(filterExprUrlKey, filter.filterExpr);
+    }
+    for (const key of pageUrlKeys) {
+      const value = searchParams.get(key);
+      if (value !== null) {
+        urlParams.set(key, value);
+      }
     }
     return `?${urlParams.toString()}`;
   };
@@ -126,15 +147,29 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
     router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
   };
 
-  const navigateToOffset = (offset: number) => {
+  // Replaces one key in the URL and leaves everything else the URL carries
+  // as it is.
+  const setPageUrlKey = (key: string, value: string) => {
     const urlParams = new URLSearchParams(searchParams);
-    urlParams.set(paginationOffsetUrlKey, String(offset));
+    urlParams.set(key, value);
     router.replace(`?${urlParams.toString()}`, { scroll: false });
   };
 
-  const nextPage = () => navigateToOffset(paginationOffset + paginationLimit);
-  const prevPage = () =>
+  const navigateToOffset = (offset: number) =>
+    setPageUrlKey(paginationOffsetUrlKey, String(offset));
+
+  const nextPage = () => {
+    if (paginationLimit === undefined) {
+      return;
+    }
+    navigateToOffset(paginationOffset + paginationLimit);
+  };
+  const prevPage = () => {
+    if (paginationLimit === undefined) {
+      return;
+    }
     navigateToOffset(Math.max(0, paginationOffset - paginationLimit));
+  };
 
   return {
     requestedFilters,
@@ -143,6 +178,7 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
     filterState,
     filterParams,
     onFilterChange,
+    setPageUrlKey,
     nextPage,
     prevPage,
   };

--- a/frontend/dashboard/app/components/journey.tsx
+++ b/frontend/dashboard/app/components/journey.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useJourneyQuery } from "@/app/query/hooks";
-import { useFiltersStore } from "@/app/stores/provider";
+import { type useJourneyQuery } from "@/app/query/hooks";
 import { ResponsiveSankey } from "@nivo/sankey";
 import { X } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -17,7 +16,7 @@ import TabSelect from "./tab_select";
 const CRASHES_TAB = "Crashes";
 const ANRS_TAB = "ANRs";
 
-const demoJourney: InputJourneyData = {
+export const demoJourney: InputJourneyData = {
   links: [
     // From MainActivity (home)
     {
@@ -365,14 +364,21 @@ const demoJourney: InputJourneyData = {
 };
 
 interface JourneyProps {
-  teamId: string;
-  bidirectional: boolean;
   journeyType: JourneyType;
   searchText?: string;
-  demo?: boolean;
+  query: Pick<ReturnType<typeof useJourneyQuery>, "status" | "data">;
+  errorDetailContext?: {
+    teamId: string;
+    appId: string;
+  };
 }
 
 export { JourneyType } from "../api/api_calls";
+
+export enum PlotType {
+  Paths = "Paths",
+  Exceptions = "Exceptions",
+}
 
 type Link = {
   source: string;
@@ -567,18 +573,15 @@ function transformData(
 }
 
 const Journey: React.FC<JourneyProps> = ({
-  teamId,
-  bidirectional: bidirectionalProp,
   journeyType: journeyTypeProp,
   searchText = "",
-  demo = false,
+  query: journeyQuery,
+  errorDetailContext,
 }) => {
   const { theme } = useTheme();
   const chartColor = useChartColor();
   const chartColors = useChartColors();
   const router = useRouter();
-  const filters = useFiltersStore((state) => state.filters);
-  const journeyQuery = useJourneyQuery(journeyTypeProp, bidirectionalProp);
 
   const [selectedNode, setSelectedNode] = useState<JourneyNode | undefined>(
     undefined,
@@ -598,18 +601,14 @@ const Journey: React.FC<JourneyProps> = ({
 
   const journeyType = journeyTypeProp;
   const rawJourney = journeyQuery.data ?? emptyJourney;
-  const transformedJourney = demo
-    ? transformData(journeyType, demoJourney, chartColor)
-    : journeyQuery.status === "success"
+  const transformedJourney =
+    journeyQuery.status === "success"
       ? transformData(journeyType, rawJourney, chartColor)
       : transformData(journeyType, emptyJourney, chartColor);
   const journey = transformedJourney;
 
   // Derive effective API status: if query says success but transformed data has no nodes, treat as no data
   const effectiveStatus = (() => {
-    if (demo) {
-      return "success" as const;
-    }
     if (journeyQuery.status === "success" && journeyQuery.data === null) {
       return "nodata" as const;
     }
@@ -813,14 +812,14 @@ const Journey: React.FC<JourneyProps> = ({
                               key={title}
                               type="button"
                               onClick={
-                                demo
+                                errorDetailContext === undefined
                                   ? undefined
                                   : () =>
                                       router.push(
-                                        `/${teamId}/errors/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`,
+                                        `/${errorDetailContext.teamId}/errors/${errorDetailContext.appId}/${id}/${title}`,
                                       )
                               }
-                              className={`block w-full text-left px-3 py-2 border-b border-border/40 last:border-b-0 text-xs wrap-break-word font-body transition-colors ${demo ? "cursor-default" : "hover:bg-accent cursor-pointer"}`}
+                              className={`block w-full text-left px-3 py-2 border-b border-border/40 last:border-b-0 text-xs wrap-break-word font-body transition-colors ${errorDetailContext === undefined ? "cursor-default" : "hover:bg-accent cursor-pointer"}`}
                             >
                               <span className="block">{title}</span>
                               <span className="block text-[10px] text-muted-foreground mt-0.5">
@@ -842,14 +841,14 @@ const Journey: React.FC<JourneyProps> = ({
                               key={title}
                               type="button"
                               onClick={
-                                demo
+                                errorDetailContext === undefined
                                   ? undefined
                                   : () =>
                                       router.push(
-                                        `/${teamId}/errors/${filters.app!.id}/${id}/${title}?start_date=${filters.startDate}&end_date=${filters.endDate}`,
+                                        `/${errorDetailContext.teamId}/errors/${errorDetailContext.appId}/${id}/${title}`,
                                       )
                               }
-                              className={`block w-full text-left px-3 py-2 border-b border-border/40 last:border-b-0 text-xs wrap-break-word font-body transition-colors ${demo ? "cursor-default" : "hover:bg-accent cursor-pointer"}`}
+                              className={`block w-full text-left px-3 py-2 border-b border-border/40 last:border-b-0 text-xs wrap-break-word font-body transition-colors ${errorDetailContext === undefined ? "cursor-default" : "hover:bg-accent cursor-pointer"}`}
                             >
                               <span className="block">{title}</span>
                               <span className="block text-[10px] text-muted-foreground mt-0.5">

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -1,23 +1,26 @@
 "use client";
 
-import { FilterSource } from "@/app/api/api_calls";
+import { filterExprIssuesIn } from "@/app/api/api_error";
 import DebounceTextInput from "@/app/components/debounce_text_input";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
-import Journey, { JourneyType } from "@/app/components/journey";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
+import Journey, {
+  JourneyType,
+  PlotType,
+  demoJourney,
+} from "@/app/components/journey";
+import { SkeletonListPage } from "@/app/components/skeleton";
 import TabSelect from "@/app/components/tab_select";
-import { useFiltersStore } from "@/app/stores/provider";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { Skeleton, SkeletonPlot } from "../components/skeleton";
-
-export enum PlotType {
-  Paths = "Paths",
-  Exceptions = "Exceptions",
-}
+import { useJourneyQuery } from "@/app/query/hooks";
+import { Search } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 const journeyTypeUrlKey = "jt";
+
+// Stands in for the journey query on the marketing pages, where nothing is
+// fetched and the chart draws the demo data as a completed query.
+const demoJourneyQuery = { status: "success" as const, data: demoJourney };
 
 interface UserJourneysProps {
   params?: { teamId: string };
@@ -30,26 +33,37 @@ export default function UserJourneys({
   demo = false,
   hideDemoTitle = false,
 }: UserJourneysProps) {
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const filters = useFiltersStore((state) => state.filters);
 
-  // Derive the initial plot type from the URL once.
-  const [plotType, setPlotType] = useState<PlotType>(() =>
-    searchParams.get(journeyTypeUrlKey) === PlotType.Exceptions
+  const {
+    requestedFilters,
+    filterState,
+    filterParams,
+    onFilterChange,
+    setPageUrlKey,
+  } = useExprFilterPage({ pageUrlKeys: [journeyTypeUrlKey] });
+  const readyFilter = filterState.status === "ready" ? filterState : null;
+
+  // The demo keeps its plot type in local state, so tab clicks on the
+  // marketing page don't change its URL. The live page reads the plot
+  // type from the URL on each render, so links open the specified plot and
+  // tab clicks update the URL.
+  const [demoPlotType, setDemoPlotType] = useState(PlotType.Paths);
+  const plotType = demo
+    ? demoPlotType
+    : searchParams.get(journeyTypeUrlKey) === PlotType.Exceptions
       ? PlotType.Exceptions
-      : PlotType.Paths,
-  );
+      : PlotType.Paths;
   const [searchText, setSearchText] = useState("");
 
-  // Sync filters and plot type to URL
-  useEffect(() => {
-    if (!filters.ready) {
-      return;
-    }
-    const queryParams = `${journeyTypeUrlKey}=${encodeURIComponent(plotType)}&${filters.serialisedFilters!}`;
-    router.replace(`?${queryParams}`, { scroll: false });
-  }, [filters.ready, filters.serialisedFilters, plotType]);
+  const journeyQuery = useJourneyQuery(filterParams);
+
+  const filterExprIssues = filterExprIssuesIn(journeyQuery.error);
+
+  const { status } = journeyQuery;
+
+  const journeyType =
+    plotType === PlotType.Paths ? JourneyType.Paths : JourneyType.Exceptions;
 
   return (
     <div className="flex flex-col items-start">
@@ -59,75 +73,86 @@ export default function UserJourneys({
       <div className="py-4" />
 
       {!demo && (
-        <Filters
-          teamId={params.teamId}
-          filterSource={FilterSource.Events}
-          appVersionsInitialSelectionType={
-            AppVersionsInitialSelectionType.Latest
-          }
-        />
-      )}
-
-      {!demo && filters.loading && (
         <>
-          <div className="w-full flex justify-end pb-2 pr-2">
-            <Skeleton className="h-9 w-40" />
-          </div>
-          <div className="w-full h-200">
-            <div className="py-2" />
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-3 w-72 mt-4" />
-            <div className="py-4" />
-            <SkeletonPlot showAxes={false} />
-          </div>
+          <FilterBar
+            teamId={params.teamId}
+            entity="journeys"
+            placeholder="Filter journeys…"
+            requestedAppId={requestedFilters.app}
+            requestedDateRange={requestedFilters.dateRange}
+            requestedFilterExpr={requestedFilters.filterExpr}
+            filterExprIssues={filterExprIssues}
+            onFilterChange={onFilterChange}
+          />
+          <div className="py-4" />
         </>
       )}
 
-      {(demo || filters.ready) && (
+      {!demo && filterState.status === "error" && (
+        <p className="text-lg font-display">{filterState.message}</p>
+      )}
+
+      {!demo && filterState.status === "pending" && <SkeletonListPage />}
+
+      {!demo &&
+        readyFilter !== null &&
+        status === "error" &&
+        filterExprIssues === null && (
+          <p className="text-lg font-display">
+            Error fetching journey. Please refresh page or change filters to try
+            again.
+          </p>
+        )}
+
+      {(demo ||
+        (readyFilter !== null &&
+          (status === "success" || status === "pending"))) && (
         <>
-          {/* TabSelect for plot type */}
-          <div className="w-full flex justify-end pb-2 pr-2">
+          <div className="w-full flex items-center justify-between pb-2 pr-2">
+            {demo ? (
+              <div />
+            ) : (
+              <div className="relative w-64">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground pointer-events-none" />
+                <DebounceTextInput
+                  className="pl-8"
+                  id="free-text"
+                  placeholder="Search nodes..."
+                  initialValue={""}
+                  onChange={(it) => setSearchText(it)}
+                />
+              </div>
+            )}
             <TabSelect
               items={Object.values(PlotType)}
               selected={plotType}
               onChangeSelected={(item) => {
-                setPlotType(item as PlotType);
+                if (demo) {
+                  setDemoPlotType(item as PlotType);
+                } else {
+                  setPageUrlKey(journeyTypeUrlKey, item);
+                }
               }}
             />
           </div>
 
-          {/* Main content area */}
           <div className="w-full h-200">
-            {!demo && <div className="py-2" />}
-            {!demo && (
-              <DebounceTextInput
-                className="w-full"
-                id="free-text"
-                placeholder="Search nodes..."
-                initialValue={""}
-                onChange={(it) => setSearchText(it)}
-              />
-            )}
             <div className="py-4" />
 
-            {plotType === PlotType.Paths && (
-              <Journey
-                teamId={params.teamId}
-                bidirectional={false}
-                journeyType={JourneyType.Paths}
-                searchText={searchText}
-                demo={demo}
-              />
-            )}
-            {plotType === PlotType.Exceptions && (
-              <Journey
-                teamId={params.teamId}
-                bidirectional={false}
-                journeyType={JourneyType.Exceptions}
-                searchText={searchText}
-                demo={demo}
-              />
-            )}
+            {/* Keyed on the plot type so switching tabs mounts a fresh
+                chart, which closes any issue panel the previous one had
+                open. */}
+            <Journey
+              key={plotType}
+              journeyType={journeyType}
+              searchText={searchText}
+              query={demo ? demoJourneyQuery : journeyQuery}
+              errorDetailContext={
+                demo || readyFilter === null
+                  ? undefined
+                  : { teamId: params.teamId, appId: readyFilter.app.id }
+              }
+            />
           </div>
         </>
       )}

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  JourneyType,
   SdkConfig,
   Team,
   changeAppApiKeyFromServer,
@@ -462,20 +461,24 @@ export function useAppThresholdPrefsQuery(appId: string | undefined) {
 
 // ─── Journey ─────────────────────────────────────────────────────────────
 
-export function useJourneyQuery(
-  journeyType: JourneyType,
-  bidirectional: boolean,
-) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useJourneyQuery(params: FilterParams | null) {
   return useQuery({
     queryKey: [
       "journey",
-      journeyType,
-      bidirectional,
-      filters.serialisedFilters,
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
     ] as const,
-    queryFn: () => fetchJourneyFromServer(bidirectional, filters),
-    enabled: filters.ready,
+    queryFn: () =>
+      fetchJourneyFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+      ),
+    enabled: params !== null,
+    retry: false,
   });
 }
 

--- a/frontend/dashboard/content/docs/mcp.mdx
+++ b/frontend/dashboard/content/docs/mcp.mdx
@@ -47,7 +47,7 @@ Get available filter options (versions, OS, countries, devices, etc.) for an app
 
 ### `get_filter_keys`
 
-List the filter keys of an entity (spans, bug_reports or builds): the vocabulary a filter expression is written with.
+List the filter keys of an entity (spans, bug_reports, journeys or builds): the vocabulary a filter expression is written with.
 
 ### `get_filter_values`
 
@@ -135,4 +135,4 @@ Get alerts for an app, ordered by most recent first.
 
 ### `get_journey`
 
-Get an app's journey as a graph of screens. Each link is a transition between consecutive screens within a session, valued by the number of sessions that made that transition.
+Get user journeys for an app as a graph of screens.

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -371,9 +371,9 @@ paths:
         - Apps
       summary: Fetch an app's issue journey map
       description: |
-        Fetch an app's issue journey map. Filter time range using `from` & `to`
-        query string parameters. Filter versions using `versions` &
-        `version_codes` query string parameters.
+        Fetch an app's issue journey map, optionally narrowed by a filter
+        expression. Filter time range using `from` & `to` query string
+        parameters.
       parameters:
         - name: id
           in: path
@@ -384,22 +384,11 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings to return only matching issues.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version codes to return only matching issues.
-          schema:
-            type: string
+        - $ref: "#/components/parameters/FilterExpr"
         - name: bigraph
           in: query
           required: false
-          description: Choose journey's directionality. `0` computes a unidirectional graph. Default is `1`.
+          description: Choose journey's directionality. `1` or `true` keeps both directions of a transition. Default is `0`, a unidirectional graph.
           schema:
             type: string
       responses:
@@ -1005,6 +994,7 @@ paths:
               - builds
               - spans
               - bug_reports
+              - journeys
         - name: key
           in: query
           required: false
@@ -1127,6 +1117,7 @@ paths:
               - builds
               - spans
               - bug_reports
+              - journeys
         - name: key_name
           in: query
           required: true

--- a/self-host/clickhouse/20260902100000_alter_app_filters_table.sql
+++ b/self-host/clickhouse/20260902100000_alter_app_filters_table.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+alter table app_filters
+  add column if not exists `patch_id` UUID comment 'OTA patch id' CODEC(ZSTD(3)),
+  modify order by (team_id, app_id, end_of_month, exception, anr, network_type, network_generation, os_version, app_version, country_code, device_manufacturer, device_locale, network_provider, device_name, patch_version, patch_id);
+
+-- migrate:down
+alter table app_filters
+  modify order by (team_id, app_id, end_of_month, exception, anr, network_type, network_generation, os_version, app_version, country_code, device_manufacturer, device_locale, network_provider, device_name, patch_version);
+
+-- migrate:up
+select 1;
+
+-- migrate:down
+alter table app_filters
+  drop column if exists `patch_id`;

--- a/self-host/clickhouse/20260902100100_alter_app_filters_mv.sql
+++ b/self-host/clickhouse/20260902100100_alter_app_filters_mv.sql
@@ -1,0 +1,87 @@
+-- migrate:up
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max(type = 'exception')                               as exception,
+    max(type = 'anr')                                     as anr,
+    attribute.patch_version                               as patch_version,
+    attribute.patch_id                                    as patch_id
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    patch_version,
+    patch_id;
+
+-- migrate:down
+alter table app_filters_mv modify query
+select
+    team_id,
+    app_id,
+    toLastDayOfMonth(timestamp)                           as end_of_month,
+    (attribute.app_version, attribute.app_build)          as app_version,
+    (attribute.os_name, attribute.os_version)             as os_version,
+    inet.country_code                                     as country_code,
+    attribute.network_provider                            as network_provider,
+    attribute.network_type                                as network_type,
+    attribute.network_generation                          as network_generation,
+    attribute.device_locale                               as device_locale,
+    attribute.device_manufacturer                         as device_manufacturer,
+    attribute.device_name                                 as device_name,
+    max(type = 'exception')                               as exception,
+    max(type = 'anr')                                     as anr,
+    attribute.patch_version                               as patch_version
+from events
+where attribute.os_name != ''
+  and attribute.os_version != ''
+  and inet.country_code != ''
+  and attribute.network_provider != ''
+  and attribute.network_type != ''
+  and attribute.network_generation != ''
+  and attribute.device_locale != ''
+  and attribute.device_manufacturer != ''
+  and attribute.device_name != ''
+group by
+    team_id,
+    app_id,
+    end_of_month,
+    app_version,
+    os_version,
+    country_code,
+    network_provider,
+    network_type,
+    network_generation,
+    device_locale,
+    device_manufacturer,
+    device_name,
+    patch_version;

--- a/self-host/clickhouse/20260902110000_alter_journey_table.sql
+++ b/self-host/clickhouse/20260902110000_alter_journey_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table journey
+  add column if not exists `patch_version` LowCardinality(String) comment 'OTA patch version' CODEC(ZSTD(3)) after `app_version`,
+  add column if not exists `patch_id` UUID comment 'OTA patch id' CODEC(ZSTD(3)) after `patch_version`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table journey
+  drop column if exists `patch_id`,
+  drop column if exists `patch_version`
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260902110100_alter_journey_mv.sql
+++ b/self-host/clickhouse/20260902110100_alter_journey_mv.sql
@@ -1,0 +1,75 @@
+-- migrate:up
+alter table journey_mv
+modify query
+select
+  id,
+  team_id,
+  app_id,
+  session_id,
+  timestamp,
+  inserted_at,
+  type,
+  (attribute.app_version, attribute.app_build) as app_version,
+  attribute.patch_version as patch_version,
+  attribute.patch_id as patch_id,
+  exception.handled,
+  exception.severity,
+  exception.fingerprint,
+  anr.fingerprint,
+  lifecycle_activity.type,
+  lifecycle_activity.class_name,
+  lifecycle_fragment.type,
+  lifecycle_fragment.class_name,
+  lifecycle_fragment.parent_activity,
+  lifecycle_fragment.parent_fragment,
+  lifecycle_view_controller.type,
+  lifecycle_view_controller.class_name,
+  lifecycle_swift_ui.type,
+  lifecycle_swift_ui.class_name,
+  screen_view.name
+from events
+where type = 'lifecycle_activity'
+      or type = 'lifecycle_fragment'
+      or type = 'lifecycle_view_controller'
+      or type = 'lifecycle_swift_ui'
+      or type = 'screen_view'
+      or type = 'exception'
+      or type = 'anr'
+;
+
+-- migrate:down
+alter table journey_mv
+modify query
+select
+  id,
+  team_id,
+  app_id,
+  session_id,
+  timestamp,
+  inserted_at,
+  type,
+  (attribute.app_version, attribute.app_build) as app_version,
+  exception.handled,
+  exception.severity,
+  exception.fingerprint,
+  anr.fingerprint,
+  lifecycle_activity.type,
+  lifecycle_activity.class_name,
+  lifecycle_fragment.type,
+  lifecycle_fragment.class_name,
+  lifecycle_fragment.parent_activity,
+  lifecycle_fragment.parent_fragment,
+  lifecycle_view_controller.type,
+  lifecycle_view_controller.class_name,
+  lifecycle_swift_ui.type,
+  lifecycle_swift_ui.class_name,
+  screen_view.name
+from events
+where type = 'lifecycle_activity'
+      or type = 'lifecycle_fragment'
+      or type = 'lifecycle_view_controller'
+      or type = 'lifecycle_swift_ui'
+      or type = 'screen_view'
+      or type = 'exception'
+      or type = 'anr'
+;


### PR DESCRIPTION
# Description

- Journeys page, API and MCP tool move to expression filters with app version, build number and OTA patch keys
- Migrations: patch_id on app_filters and its view; patch_version and patch_id on journey and its view
- Small fix: Filter bar wraps to its own line before growing down



