### PR TITLE
fix: bind invitee emails to stop SQL injection

### DIFF
--- a/backend/api/handlers/team_test.go
+++ b/backend/api/handlers/team_test.go
@@ -835,6 +835,24 @@ func TestInviteMembers(t *testing.T) {
 			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
 		}
 	})
+
+	t.Run("sql injection in email gets 400", func(t *testing.T) {
+		defer cleanupAll(ctx, t)
+
+		ownerID, teamID := seedTeamAndMemberWithRole(t, ctx, "owner")
+
+		body := `[{"email":"z') UNION SELECT id::text, email FROM users-- ","role":"viewer"}]`
+
+		c, w := newInviteContext(ownerID, teamID, body)
+		h.InviteMembers(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+		}
+		if n := countInvitesForTeam(ctx, t, teamID); n != 0 {
+			t.Errorf("invites = %d, want 0", n)
+		}
+	})
 }
 
 // --------------------------------------------------------------------------

--- a/backend/libs/measure/team.go
+++ b/backend/libs/measure/team.go
@@ -25,7 +25,7 @@ type Team struct {
 
 type Invitee struct {
 	ID    uuid.UUID `json:"id"`
-	Email string    `json:"email"`
+	Email string    `json:"email" binding:"required,email"`
 	Role  Rank      `json:"role"`
 }
 

--- a/backend/libs/measure/user.go
+++ b/backend/libs/measure/user.go
@@ -251,23 +251,25 @@ func (u *User) GetUserDetails(ctx context.Context, pg *pgxpool.Pool) (err error)
 func GetExistingAndNewInvitees(pg *pgxpool.Pool, invitees []Invitee) ([]Invitee, []Invitee, error) {
 	var existingInvitees []Invitee
 	var newInvitees []Invitee
-	var emailList string
 
-	var emails []string
+	emails := make([]string, 0, len(invitees))
 	for _, invitee := range invitees {
-		emails = append(emails, fmt.Sprintf("'%s'", invitee.Email))
+		emails = append(emails, invitee.Email)
 	}
-	emailList = strings.Join(emails, ", ")
 
 	stmt := sqlf.PostgreSQL.
 		Select("id, email").
 		From("users").
-		Where(fmt.Sprintf("email in (%s)", emailList)).
+		Where("email = any(?)", emails).
 		Where("confirmed_at is not null")
 
 	defer stmt.Close()
 
-	rows, _ := pg.Query(context.Background(), stmt.String())
+	rows, err := pg.Query(context.Background(), stmt.String(), stmt.Args()...)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	users, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (User, error) {
 		var user User
 		err := row.Scan(&user.ID, &user.Email)

--- a/backend/libs/measure/user_test.go
+++ b/backend/libs/measure/user_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// sqlInjectionEmail is a crafted invitee email that closes the quote & appends
+// a UNION selecting every user, if the email is interpolated into the SQL.
+const sqlInjectionEmail = `z') UNION SELECT id::text, email FROM users-- `
+
+// confirmUser sets users.confirmed_at, which GetExistingAndNewInvitees
+// requires for a user to count as existing.
+func confirmUser(ctx context.Context, t *testing.T, userID string) {
+	t.Helper()
+	if _, err := th.PgPool.Exec(ctx, `UPDATE users SET confirmed_at = now() WHERE id = $1`, userID); err != nil {
+		t.Fatalf("confirm user: %v", err)
+	}
+}
+
+func TestGetExistingAndNewInviteesRejectsSQLInjection(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	realID := uuid.New().String()
+	seedUser(ctx, t, realID, "real@test.com")
+	confirmUser(ctx, t, realID)
+
+	otherID := uuid.New().String()
+	seedUser(ctx, t, otherID, "other@test.com")
+	confirmUser(ctx, t, otherID)
+
+	invitees := []Invitee{
+		{Email: "real@test.com", Role: viewer},
+		{Email: sqlInjectionEmail, Role: viewer},
+	}
+
+	existing, new, err := GetExistingAndNewInvitees(deps.PgPool, invitees)
+	if err != nil {
+		t.Fatalf("GetExistingAndNewInvitees: %v", err)
+	}
+
+	if len(existing) != 1 {
+		t.Fatalf("existing = %d %v, want 1 (only real@test.com)", len(existing), existing)
+	}
+	if existing[0].Email != "real@test.com" {
+		t.Errorf("existing[0].Email = %q, want real@test.com", existing[0].Email)
+	}
+
+	if len(new) != 1 {
+		t.Fatalf("new = %d %v, want 1 (the injection string)", len(new), new)
+	}
+	if new[0].Email != sqlInjectionEmail {
+		t.Errorf("new[0].Email = %q, want the injection string", new[0].Email)
+	}
+}

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -1032,6 +1032,13 @@ describe("team management mutations", () => {
     expect(body[0].role).toBe("admin"); // lowercased
   });
 
+  it("inviteMemberFromServer trims the email", async () => {
+    mockApiClientFetch.mockResolvedValueOnce(successResponse({}));
+    await inviteMemberFromServer("t1", "  bob@example.com  ", "Admin");
+    const body = JSON.parse(lastFetchOpts().body);
+    expect(body[0].email).toBe("bob@example.com");
+  });
+
   it("inviteMemberFromServer throws the server error message", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       mockResponse(false, 400, { error: "bad" }),

--- a/frontend/dashboard/__tests__/pages/team_test.tsx
+++ b/frontend/dashboard/__tests__/pages/team_test.tsx
@@ -261,7 +261,7 @@ jest.mock("@/app/query/hooks", () => ({
         if (result) {
           opts?.onSuccess?.();
         } else {
-          opts?.onError?.();
+          opts?.onError?.(new Error("Failed to invite member"));
         }
       },
       isPending: s.inviteMemberState === "loading",
@@ -944,7 +944,7 @@ describe("Team Page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Invite" }));
 
     await waitFor(() => {
-      expect(mockToastNegative).toHaveBeenCalledWith("Error inviting member");
+      expect(mockToastNegative).toHaveBeenCalledWith("Failed to invite member");
     });
   });
 

--- a/frontend/dashboard/app/[teamId]/team/page.tsx
+++ b/frontend/dashboard/app/[teamId]/team/page.tsx
@@ -419,8 +419,8 @@ export default function TeamOverview(props: {
           toastPositive(inviteMemberEmail + " has been invited");
           setInviteMemberEmail("");
         },
-        onError: () => {
-          toastNegative("Error inviting member");
+        onError: (error) => {
+          toastNegative(error.message);
         },
       },
     );

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1446,12 +1446,13 @@ export const inviteMemberFromServer = async (
   role: string,
 ) => {
   const lowerCaseRole = role.toLocaleLowerCase();
+  const trimmedEmail = email.trim();
   await request(`/api/teams/${teamId}/invite`, {
     method: "POST",
     headers: {
       "Content-Type": `application/json`,
     },
-    body: JSON.stringify([{ email: email, role: lowerCaseRole }]),
+    body: JSON.stringify([{ email: trimmedEmail, role: lowerCaseRole }]),
     failsWith: "Failed to invite member",
   });
 };


### PR DESCRIPTION
## Summary

This PR fixes a SQL injection in the team invite flow, where an invitee email reached the database as SQL. Emails are now bound as a query parameter, the email format is validated at the API boundary & the UI passes on what the API reports.

## Tasks

- [x] Bind invitee emails as a query parameter in the invitee lookup
- [x] Validate invitee email format at the API boundary
- [x] Return the invitee lookup query error
- [x] Add backend regression tests for invitee email handling
- [x] Trim the invite email before sending from the UI
- [x] Surface the server's error message in the invite failure toast
- [x] Add frontend tests for the trimmed email & error message
