### PR TITLE
test: fix ios e2e build, dsym upload and flutter bug report flow

### DIFF
--- a/e2e-tests/maestro/specs/bug_report/flutter/bug_report.yaml
+++ b/e2e-tests/maestro/specs/bug_report/flutter/bug_report.yaml
@@ -38,6 +38,14 @@ appId: ${APP_ID}
           optional: true
 - tapOn: "Send"
 
+# Gives the Flutter SDK time to encode the screenshot and hand the report to
+# the native SDK; iOS drops it if the app backgrounds first.
+- extendedWaitUntil:
+    visible:
+      text: "__upload_settle__"
+    timeout: 5000
+    optional: true
+
 - pressKey: "Home"
 - launchApp:
     stopApp: false

--- a/e2e-tests/playwright/pages/error_detail_page.ts
+++ b/e2e-tests/playwright/pages/error_detail_page.ts
@@ -13,7 +13,7 @@ export class ErrorDetailPage {
   readonly appVersionPill: Locator;
   readonly networkTypePill: Locator;
   readonly sessionReplayLink: Locator;
-  readonly copyAiContextButton: Locator;
+  readonly copyAgentPromptButton: Locator;
   readonly userDefinedAttribute: Locator;
   readonly screenshot: Locator;
 
@@ -36,8 +36,8 @@ export class ErrorDetailPage {
     this.sessionReplayLink = page.getByRole("link", {
       name: "View Session Replay",
     });
-    this.copyAiContextButton = page.getByRole("button", {
-      name: "Copy AI Context",
+    this.copyAgentPromptButton = page.getByRole("button", {
+      name: "Copy Agent Prompt",
     });
     this.userDefinedAttribute = page
       .getByTestId("exception-detail-attribute")

--- a/e2e-tests/playwright/specs/errors/errors.spec.ts
+++ b/e2e-tests/playwright/specs/errors/errors.spec.ts
@@ -47,7 +47,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -128,7 +128,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -210,7 +210,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -287,7 +287,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -366,7 +366,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -442,7 +442,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(anrPill)).toBeVisible();
         await expect(detail.selectErrorPill(fatalPill)).toBeVisible();
@@ -531,7 +531,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(unhandledPill)).toBeVisible();
@@ -612,7 +612,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(unhandledPill)).toBeVisible();
@@ -704,7 +704,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();
@@ -790,7 +790,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();
@@ -878,7 +878,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();
@@ -961,7 +961,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();
@@ -1040,7 +1040,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();
@@ -1121,7 +1121,7 @@ test.describe("errors", () => {
         await expect(detail.devicePill).toHaveText(/Device:\s+\S/);
         await expect(detail.appVersionPill).toHaveText(/App version:\s+\d/);
         await expect(detail.networkTypePill).toHaveText(/Network type:\s+\S/);
-        await expect(detail.copyAiContextButton).toBeVisible();
+        await expect(detail.copyAgentPromptButton).toBeVisible();
 
         await expect(detail.selectErrorPill(errorPill)).toBeVisible();
         await expect(detail.selectErrorPill(handledPill)).toBeVisible();

--- a/e2e-tests/runner/frank.ts
+++ b/e2e-tests/runner/frank.ts
@@ -57,6 +57,7 @@ export async function buildAndInstallIOS(repoRoot: string): Promise<void> {
   const label = "build: ios";
   const logger = log.scope(label);
   const iosDir = `${repoRoot}/samples/frank/ios`;
+  const flutterDir = `${repoRoot}/samples/frank/flutter`;
   const hostArch = process.arch === "arm64" ? "arm64" : "x86_64";
   // Rebuild the xcframework to ensure latest configuration is used for builds
   logger.info("clearing stale KMP xcframework build");
@@ -68,8 +69,19 @@ export async function buildAndInstallIOS(repoRoot: string): Promise<void> {
     "ios/Sources/MeasureSDK/Swift/XCDataModel/MeasureModel.xcdatamodeld/.xccurrentversion";
   logger.info("restoring CoreData model version");
   await runOrThrow(repoRoot, { label })`git checkout -- ${xccurrentversion}`;
+  // The generated Swift package holds a copy of each plugin's iOS package, so
+  // it goes stale when the measure_flutter plugin source changes.
+  logger.info("regenerating Flutter Swift package");
+  await runOrThrow(flutterDir, { label })`flutter pub get`;
+  // Without the Podfile, Flutter skips its CocoaPods fallback for plugins.
+  rmSync(`${flutterDir}/.ios/Podfile`, { force: true });
+  await runOrThrow(flutterDir, { label })`
+    flutter build swift-package --platform ios --no-codesign
+  `;
   logger.info("installing CocoaPods for Frankenstein iOS");
   await runOrThrow(iosDir, { label })`pod install`;
+  // The Debug configuration builds with DEBUG_INFORMATION_FORMAT=dwarf, which
+  // yields no dSYMs, so the upload phase would ship only the RN sourcemap.
   logger.info("building Frankenstein iOS (debug)");
   await runOrThrow(iosDir, { label })`
     xcodebuild
@@ -81,6 +93,7 @@ export async function buildAndInstallIOS(repoRoot: string): Promise<void> {
     CODE_SIGNING_ALLOWED=NO
     ARCHS=${hostArch}
     ONLY_ACTIVE_ARCH=YES
+    DEBUG_INFORMATION_FORMAT=dwarf-with-dsym
     clean build
   `;
   const appPath = `${iosDir}/build/Build/Products/Debug-iphonesimulator/FrankensteinApp.app`;

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.1.2 effective-5.10 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
-// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
-// swift-module-flags-ignorable: -no-verify-emitted-module-interface -interface-compiler-version 6.1.2
+// swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
+// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
 import AVKit
 import CoreData
 import CoreMotion
@@ -40,30 +40,30 @@ extension Measure.AttributeValue : Swift.Codable {
   public init(from decoder: any Swift.Decoder) throws
 }
 public typealias SessionObCoreDataClassSet = Foundation.NSSet
-@_inheritsConvenienceInitializers @objc(SessionOb) public class SessionOb : CoreData.NSManagedObject {
-  @objc override dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
+@_inheritsConvenienceInitializers @objc(SessionOb) nonisolated public class SessionOb : CoreData.NSManagedObject {
+  @objc override nonisolated dynamic public init(entity: CoreData.NSEntityDescription, insertInto context: CoreData.NSManagedObjectContext?)
   @objc deinit
 }
 public typealias SessionObCoreDataPropertiesSet = Foundation.NSSet
 extension Measure.SessionOb {
   @nonobjc public class func fetchRequest() -> CoreData.NSFetchRequest<Measure.SessionOb>
-  @objc @NSManaged dynamic public var crashed: Swift.Bool {
+  @objc @NSManaged nonisolated dynamic public var crashed: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var createdAt: Swift.Int64 {
+  @objc @NSManaged nonisolated dynamic public var createdAt: Swift.Int64 {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var needsReporting: Swift.Bool {
+  @objc @NSManaged nonisolated dynamic public var needsReporting: Swift.Bool {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var pid: Swift.Int32 {
+  @objc @NSManaged nonisolated dynamic public var pid: Swift.Int32 {
     @objc get
     @objc set
   }
-  @objc @NSManaged dynamic public var sessionId: Swift.String? {
+  @objc @NSManaged nonisolated dynamic public var sessionId: Swift.String? {
     @objc get
     @objc set
   }

--- a/samples/frank/ios/Podfile.lock
+++ b/samples/frank/ios/Podfile.lock
@@ -2019,8 +2019,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: dcd09090c4b0c46f48e12d8f40701e496b335d33
-  MeasureReactNative: 17f82320ef31bc144793585110c9d91e5d215f04
+  hermes-engine: 0d3f5af9c6b6e59a5e181d0472f0332b0185d247
+  MeasureReactNative: 5e490c8a5fe75e64c7e172737fb8a8f4c71e0c07
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
   RCTSwiftUI: afc0a0a635860da1040a0b894bfd529da06d7810
@@ -2029,7 +2029,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: eadae78bd39c561d8b0145a79a42b21aecd5705c
+  React-Core-prebuilt: 19d937ab5abd45db7edeae7d01ab0756c0598cc3
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: d196e6df0599d78360b3211367e28c5583054133
@@ -2090,9 +2090,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 9b5b6e3e47bc11814c207cdc06210e69627660fb
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 02f8aeed1e52af542a12178968dc48610ab3a754
+  ReactNativeDependencies: 2ae92dcff72f77096fdec77c230739694c7316bb
   Yoga: 846fbe6f595136be802ad81d05688ff748839764
 
-PODFILE CHECKSUM: e920b6d31ffef4e021d870409df3cc4f9fd8ee73
+PODFILE CHECKSUM: 41e7c81524f1325205beaddcd8ac9c6ed2ce6856
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
# Description

- Regenerate the Flutter Swift package before pod install so the measure_flutter plugin copy no longer goes stale
- Build with DEBUG_INFORMATION_FORMAT=dwarf-with-dsym so the upload phase ships app dSYMs and native/KMP crashes symbolicate
- Flutter bug report flow: settle before Home so iOS does not drop the report on background
- Update errors spec to match latest UI

