### PR TITLE
chore(kmp): prepare sdk release 0.2.0

### DIFF
--- a/frontend/dashboard/content/docs/getting-started/kotlin-multiplatform.mdx
+++ b/frontend/dashboard/content/docs/getting-started/kotlin-multiplatform.mdx
@@ -12,8 +12,8 @@ wrapper over the native Android and iOS SDKs, so their minimum requirements appl
 | Name            | Version  |
 | --------------- | -------- |
 | Kotlin          | `2.x`    |
-| Measure Android | `0.18.0` |
-| Measure iOS     | `0.11.0` |
+| Measure Android | `0.20.0` |
+| Measure iOS     | `0.13.1` |
 
 ## 1. Get the credentials
 
@@ -33,7 +33,7 @@ create a new app on Measure with a different API key.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("sh.measure:measure-kmp:0.1.0")
+            implementation("sh.measure:measure-kmp:0.2.0")
         }
     }
 }
@@ -71,7 +71,7 @@ Add the native Measure iOS SDK to your iOS app using Swift Package Manager. See 
 
 ```swift
 // In Package.swift, or via Xcode's package manager
-.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.11.0")
+.package(url: "https://github.com/measure-sh/measure.git", branch: "ios-v0.13.1")
 ```
 
 Initialize the SDK in your `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)`:

--- a/kmp/CHANGELOG.md
+++ b/kmp/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kmp-v0.2.0] - 2026-09-03
+
+### :sparkles: New features
+
+- (**kmp**): Implement logging (#4021) by @abhaysood
+
+### :hammer: Misc
+
+- (**kmp**): Make log severity shorthands members of Measure by @abhaysood in #4151
+
+## [kmp-v0.1.0] - 2026-06-22
+
+### :hammer: Misc
+
+- (**kmp**): Prepare sdk release 0.1.0 (#3959) by @abhaysood in #3959
+
 ## [kmp-v0.1.0-alpha.1] - 2026-06-19
 
 ### :sparkles: New features
@@ -18,4 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**kmp**): Prepare sdk release 0.1.0-alpha.1 (#3932) by @abhaysood in #3932
 - (**kmp**): Update documentation and improve release workflow (#3930) by @abhaysood in #3930
 
+[kmp-v0.2.0]: https://github.com/measure-sh/measure/compare/kmp-v0.1.0..kmp-v0.2.0
+[kmp-v0.1.0]: https://github.com/measure-sh/measure/compare/kmp-v0.1.0-alpha.1..kmp-v0.1.0
 

--- a/kmp/measure-kmp/gradle.properties
+++ b/kmp/measure-kmp/gradle.properties
@@ -9,7 +9,7 @@ kotlin.code.style=official
 kotlin.mpp.enableCInteropCommonization=true
 
 GROUP=sh.measure
-MEASURE_KMP_VERSION_NAME=0.1.0
+MEASURE_KMP_VERSION_NAME=0.2.0
 
 # Version of sh.measure:measure-android resolved when this module is built
 # standalone (e.g. published to Maven Central). For local development the
@@ -19,4 +19,4 @@ MEASURE_ANDROID_VERSION=0.20.0
 
 # Native iOS SDK version the published cinterop bindings are built against.
 # Release pins bindings to this ios-v<version> tag; local builds use in-repo ios/.
-MEASURE_IOS_VERSION=0.11.0
+MEASURE_IOS_VERSION=0.13.1


### PR DESCRIPTION
This PR prepares the KMP SDK for release version 0.2.0.

Changes:
- Updated version to 0.2.0 in gradle.properties
- Pinned native Android SDK version to 0.20.0 (android-v0.20.0)
- Pinned native iOS SDK version to 0.13.1 (ios-v0.13.1)
- Updated measure-kmp version and the pinned native versions in frontend/dashboard/content/docs/getting-started/kotlin-multiplatform.mdx
- Generated changelog for version 0.2.0

<!-- release-meta
NEXT_VERSION=0.3.0-SNAPSHOT
-->