### PR TITLE
Fix filter bar url bugs

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
@@ -315,6 +315,10 @@ describe("DateRangeSelect", () => {
     fireEvent.change(start, { target: { value: "2026-01-03T00:00" } });
 
     expect(onChange).not.toHaveBeenCalled();
+    // The value stays while the other segments may still be edited, and is
+    // put back on blur.
+    expect(start).toHaveValue("2026-01-03T00:00");
+    fireEvent.blur(start);
     expect(start).toHaveValue(
       formatIsoDateForDateTimeInputField(custom.startDate),
     );
@@ -328,6 +332,7 @@ describe("DateRangeSelect", () => {
     fireEvent.change(end, { target: { value: "2025-12-31T00:00" } });
 
     expect(onChange).not.toHaveBeenCalled();
+    fireEvent.blur(end);
     expect(end).toHaveValue(formatIsoDateForDateTimeInputField(custom.endDate));
   });
 

--- a/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
@@ -271,11 +271,15 @@ describe("DateRangeSelect", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("keeps the timestamps when Custom Range is picked", () => {
+  it("keeps the timestamps, cut to the minute, when Custom Range is picked", () => {
     const onChange = jest.fn();
     render(
       <DateRangeSelect
-        selection={storedRange(DateRange.LastWeek)}
+        selection={storedRange(
+          DateRange.LastWeek,
+          "2026-01-01T10:42:17.123Z",
+          "2026-01-02T10:42:17.123Z",
+        )}
         onChange={onChange}
       />,
     );
@@ -284,8 +288,8 @@ describe("DateRangeSelect", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       dateRange: DateRange.Custom,
-      startDate: "2026-01-01T00:00:00.000Z",
-      endDate: "2026-01-02T00:00:00.000Z",
+      startDate: DateTime.fromISO("2026-01-01T10:42:00.000Z").toISO(),
+      endDate: DateTime.fromISO("2026-01-02T10:42:00.000Z").toISO(),
     });
   });
 

--- a/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
@@ -331,6 +331,23 @@ describe("DateRangeSelect", () => {
     expect(end).toHaveValue(formatIsoDateForDateTimeInputField(custom.endDate));
   });
 
+  it("shows the range it is re-rendered with", () => {
+    const { rerender } = render(
+      <DateRangeSelect selection={custom} onChange={jest.fn()} />,
+    );
+    rerender(
+      <DateRangeSelect
+        selection={{ ...custom, endDate: "2026-01-05T00:00:00.000Z" }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    const [, end] = timestampInputs();
+    expect(end).toHaveValue(
+      formatIsoDateForDateTimeInputField("2026-01-05T00:00:00.000Z"),
+    );
+  });
+
   it("refuses an end in the future", () => {
     const onChange = jest.fn();
     render(<DateRangeSelect selection={custom} onChange={onChange} />);

--- a/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/date_range_select_test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { DateTime } from "luxon";
+import { formatIsoDateForDateTimeInputField } from "@/app/utils/time_utils";
 
 jest.mock("@/app/components/dropdown_select", () => ({
   __esModule: true,
@@ -30,7 +31,8 @@ import DateRangeSelect, {
   DateRange,
   type DateSelection,
   isValidDateRange,
-  pickInitialDateSelection,
+  pickDateRange,
+  toDateSelection,
 } from "@/app/components/filter_bar/date_range_select";
 
 const noStoredRange: DateSelection = {
@@ -89,49 +91,13 @@ describe("isValidDateRange", () => {
   });
 });
 
-describe("pickInitialDateSelection", () => {
-  it("takes the range that was asked for", () => {
-    const selection = pickInitialDateSelection(
-      { ...noRequestedRange, dateRange: DateRange.LastWeek },
-      storedRange(DateRange.LastHour),
-    );
-
-    expect(selection.dateRange).toBe(DateRange.LastWeek);
-  });
-
-  it("falls back to the range another page left on the store", () => {
-    const selection = pickInitialDateSelection(
-      noRequestedRange,
-      storedRange(DateRange.LastWeek),
-    );
-
-    expect(selection.dateRange).toBe(DateRange.LastWeek);
-  });
-
-  it("falls back to the last six hours when neither names a range", () => {
-    const selection = pickInitialDateSelection(noRequestedRange, noStoredRange);
-
-    expect(selection.dateRange).toBe(DateRange.Last6Hours);
-  });
-
-  it("drops a range name no range goes by", () => {
-    const selection = pickInitialDateSelection(
-      { ...noRequestedRange, dateRange: "Last 7 Fortnights" },
-      noStoredRange,
-    );
-
-    expect(selection.dateRange).toBe(DateRange.Last6Hours);
-  });
-
+describe("toDateSelection", () => {
   it("counts a named range back from now rather than trusting the dates given", () => {
-    const selection = pickInitialDateSelection(
-      {
-        dateRange: DateRange.LastHour,
-        startDate: "1999-01-01T00:00:00.000Z",
-        endDate: "1999-01-02T00:00:00.000Z",
-      },
-      noStoredRange,
-    );
+    const selection = toDateSelection({
+      dateRange: DateRange.LastHour,
+      startDate: "1999-01-01T00:00:00.000Z",
+      endDate: "1999-01-02T00:00:00.000Z",
+    })!;
 
     const start = DateTime.fromISO(selection.startDate);
     const end = DateTime.fromISO(selection.endDate);
@@ -140,14 +106,11 @@ describe("pickInitialDateSelection", () => {
   });
 
   it("keeps the timestamps a custom range was given", () => {
-    const selection = pickInitialDateSelection(
-      {
-        dateRange: DateRange.Custom,
-        startDate: "2026-01-01T00:00:00.000Z",
-        endDate: "2026-01-02T00:00:00.000Z",
-      },
-      noStoredRange,
-    );
+    const selection = toDateSelection({
+      dateRange: DateRange.Custom,
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-01-02T00:00:00.000Z",
+    })!;
 
     expect(selection.dateRange).toBe(DateRange.Custom);
     expect(DateTime.fromISO(selection.startDate).toUTC().toISO()).toBe(
@@ -156,6 +119,61 @@ describe("pickInitialDateSelection", () => {
     expect(DateTime.fromISO(selection.endDate).toUTC().toISO()).toBe(
       "2026-01-02T00:00:00.000Z",
     );
+  });
+
+  it("reads as nothing for a range name no range goes by", () => {
+    expect(
+      toDateSelection({ ...noRequestedRange, dateRange: "Last 7 Fortnights" }),
+    ).toBeNull();
+  });
+});
+
+describe("pickDateRange", () => {
+  it("takes the range that was asked for", () => {
+    const picked = pickDateRange(
+      { ...noRequestedRange, dateRange: DateRange.LastWeek },
+      storedRange(DateRange.LastHour),
+    );
+
+    expect(picked.dateRange).toBe(DateRange.LastWeek);
+  });
+
+  it("falls back to the range another page left on the store", () => {
+    const picked = pickDateRange(
+      noRequestedRange,
+      storedRange(DateRange.LastWeek),
+    );
+
+    expect(picked.dateRange).toBe(DateRange.LastWeek);
+  });
+
+  it("falls back to the last six hours when neither names a range", () => {
+    const picked = pickDateRange(noRequestedRange, noStoredRange);
+
+    expect(picked).toEqual({
+      dateRange: DateRange.Last6Hours,
+      startDate: null,
+      endDate: null,
+    });
+  });
+
+  it("drops a range name no range goes by", () => {
+    const picked = pickDateRange(
+      { ...noRequestedRange, dateRange: "Last 7 Fortnights" },
+      noStoredRange,
+    );
+
+    expect(picked.dateRange).toBe(DateRange.Last6Hours);
+  });
+
+  it("keeps a custom range as it was given", () => {
+    const requested = {
+      dateRange: DateRange.Custom,
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-01-02T00:00:00.000Z",
+    };
+
+    expect(pickDateRange(requested, noStoredRange)).toEqual(requested);
   });
 
   it.each([
@@ -168,33 +186,30 @@ describe("pickInitialDateSelection", () => {
     ],
     ["no timestamps at all", null, null],
   ])("drops a custom range with %s", (_case, startDate, endDate) => {
-    const selection = pickInitialDateSelection(
+    const picked = pickDateRange(
       { dateRange: DateRange.Custom, startDate, endDate },
       noStoredRange,
     );
 
-    expect(selection.dateRange).toBe(DateRange.Last6Hours);
+    expect(picked.dateRange).toBe(DateRange.Last6Hours);
   });
 
   it("falls back to the store when the custom range asked for cannot be read", () => {
-    const selection = pickInitialDateSelection(
+    const picked = pickDateRange(
       { dateRange: DateRange.Custom, startDate: "yesterday", endDate: null },
       storedRange(DateRange.LastWeek),
     );
 
-    expect(selection.dateRange).toBe(DateRange.LastWeek);
+    expect(picked.dateRange).toBe(DateRange.LastWeek);
   });
 
   it("keeps a custom range another page left on the store", () => {
-    const selection = pickInitialDateSelection(
+    const picked = pickDateRange(
       noRequestedRange,
       storedRange(DateRange.Custom),
     );
 
-    expect(selection.dateRange).toBe(DateRange.Custom);
-    expect(DateTime.fromISO(selection.startDate).toUTC().toISO()).toBe(
-      "2026-01-01T00:00:00.000Z",
-    );
+    expect(picked).toEqual(storedRange(DateRange.Custom));
   });
 });
 
@@ -290,6 +305,30 @@ describe("DateRangeSelect", () => {
     const reported = (onChange.mock.calls[0] as any[])[0] as DateSelection;
     expect(DateTime.fromISO(reported.startDate).hour).toBe(6);
     expect(reported.endDate).toBe(custom.endDate);
+  });
+
+  it("refuses a start after the end", () => {
+    const onChange = jest.fn();
+    render(<DateRangeSelect selection={custom} onChange={onChange} />);
+
+    const [start] = timestampInputs();
+    fireEvent.change(start, { target: { value: "2026-01-03T00:00" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(start).toHaveValue(
+      formatIsoDateForDateTimeInputField(custom.startDate),
+    );
+  });
+
+  it("refuses an end before the start", () => {
+    const onChange = jest.fn();
+    render(<DateRangeSelect selection={custom} onChange={onChange} />);
+
+    const [, end] = timestampInputs();
+    fireEvent.change(end, { target: { value: "2025-12-31T00:00" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(end).toHaveValue(formatIsoDateForDateTimeInputField(custom.endDate));
   });
 
   it("refuses an end in the future", () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 
 const mockUseAppsQuery = jest.fn();
 const mockUseFilterKeysQuery = jest.fn();
@@ -149,6 +150,7 @@ import type { App } from "@/app/api/api_calls";
 import type { FilterKey } from "@/app/api/filter_types";
 import { MAX_CONDITIONS } from "@/app/components/filter_bar/limits";
 import FilterBar, {
+  type FilterRequest,
   type FilterState,
 } from "@/app/components/filter_bar/filter_bar";
 
@@ -221,15 +223,54 @@ const nothingRequested = {
   requestedFilterExpr: null,
 };
 
-async function renderBar(props: any = {}) {
-  const onFilterChange = jest.fn();
-  const bar = (asked: any) => (
+const propOfField = {
+  appId: "requestedAppId",
+  dateRange: "requestedDateRange",
+  filterExpr: "requestedFilterExpr",
+  rootSpanName: "requestedRootSpanName",
+} as const;
+
+// Stands in for the page. A pick is merged into the requested props, and a
+// new request from outside replaces it.
+function Host({
+  asked,
+  onFilterChange,
+}: {
+  asked: any;
+  onFilterChange: (state: FilterState) => void;
+}) {
+  const [pick, setPick] = useState<{ on: any; request: any } | null>(null);
+  const request = pick !== null && pick.on === asked ? pick.request : asked;
+
+  return (
     <FilterBar
       teamId="team-1"
       entity="builds"
-      {...nothingRequested}
-      {...props}
-      {...asked}
+      {...request}
+      onRequestChange={(change: Partial<FilterRequest>) =>
+        setPick({
+          on: asked,
+          request: {
+            ...request,
+            ...Object.fromEntries(
+              Object.entries(change).map(([field, value]) => [
+                propOfField[field as keyof FilterRequest],
+                value,
+              ]),
+            ),
+          },
+        })
+      }
+      onFilterChange={onFilterChange}
+    />
+  );
+}
+
+async function renderBar(props: any = {}) {
+  const onFilterChange = jest.fn();
+  const bar = (asked: any) => (
+    <Host
+      asked={{ ...nothingRequested, ...props, ...asked }}
       onFilterChange={onFilterChange}
     />
   );
@@ -631,6 +672,60 @@ describe("FilterBar", () => {
         filterExpr: null,
       });
     });
+
+    it("draws a condition with no value yet, and reports without it", async () => {
+      const { onFilterChange } = await renderBar({
+        requestedFilterExpr: "mapping_type:in:dsym AND version_name:in:",
+      });
+
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
+      expect(screen.getByText("<values>")).toBeInTheDocument();
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        filterExpr: "mapping_type:in:dsym",
+        appliedAsRequested: true,
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("a request from outside", () => {
+    it("replaces a pick", async () => {
+      const { onFilterChange, askAgain } = await renderBar();
+
+      await click(screen.getByTestId("pick-app-app-2"));
+      await addCondition();
+      expect(lastState(onFilterChange)).toMatchObject({
+        app: apps[1],
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await askAgain({
+        requestedAppId: "app-1",
+        requestedFilterExpr: "version_name:in:1.0",
+      });
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        app: apps[0],
+        filterExpr: "version_name:in:1.0",
+      });
+      expect(screen.getByTestId("app-select")).toHaveAttribute(
+        "data-selected",
+        "Checkout",
+      );
+    });
+
+    it("drops a condition with no value yet", async () => {
+      const { onFilterChange, askAgain } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+
+      await askAgain({});
+
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+    });
   });
 
   describe("opening the key list from the bar", () => {
@@ -697,17 +792,13 @@ describe("FilterBar", () => {
       });
     });
 
-    it("no longer reports the request as applied once the filter is edited", async () => {
+    it("reports a pick the page handed back as applied", async () => {
       const { onFilterChange } = await renderBar();
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        appliedAsRequested: true,
-      });
 
       await addCondition();
 
       expect(lastState(onFilterChange)).toMatchObject({
-        appliedAsRequested: false,
+        appliedAsRequested: true,
       });
     });
 
@@ -1237,6 +1328,27 @@ describe("FilterBar", () => {
       ).toBeInTheDocument();
     });
 
+    it("empties the editor when the filter is cleared", async () => {
+      await renderBar();
+
+      await addCondition();
+      await startTyping();
+      await type("version_name:in:1.0");
+      await click(screen.getByTestId("filter-clear"));
+
+      expect(textBox()).toHaveValue("");
+    });
+
+    it("empties the editor when another app is picked", async () => {
+      await renderBar();
+
+      await startTyping();
+      await type("version_name:in:1.0");
+      await click(screen.getByTestId("pick-app-app-2"));
+
+      expect(textBox()).toHaveValue("");
+    });
+
     it("puts back the filter the page is on when it is left without applying", async () => {
       const { onFilterChange } = await renderBar();
 
@@ -1497,7 +1609,7 @@ describe("FilterBar", () => {
 
     it("says so for an expression that cannot be read", async () => {
       const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:",
+        requestedFilterExpr: "mapping_type:in:dsym AND",
       });
 
       expect(mockToastNegative).toHaveBeenCalledWith(
@@ -1517,7 +1629,7 @@ describe("FilterBar", () => {
           startDate: null,
           endDate: null,
         },
-        requestedFilterExpr: "mapping_type:in:",
+        requestedFilterExpr: "mapping_type:in:dsym AND",
       });
 
       expect(mockToastNegative).toHaveBeenCalledTimes(1);

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -635,6 +635,21 @@ describe("FilterBar", () => {
       expect(lastState(onFilterChange).status).toBe("pending");
     });
 
+    it("does not judge a request by another app's keys", async () => {
+      mockUseFilterKeysQuery.mockReturnValue({
+        data: { keys: [versionKey], key_groups: ["Version"] },
+        isPending: false,
+        isPlaceholderData: true,
+        isError: false,
+      } as any);
+      const { onFilterChange } = await renderBar({
+        requestedFilterExpr: "mapping_type:in:dsym",
+      });
+
+      expect(lastState(onFilterChange).status).toBe("pending");
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+
     it("filters nothing when it is empty", async () => {
       const { onFilterChange } = await renderBar({ requestedFilterExpr: "" });
 

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -1365,7 +1365,7 @@ describe("FilterBar", () => {
     });
 
     it("empties the editor when the filter is cleared", async () => {
-      await renderBar();
+      const { onFilterChange } = await renderBar();
 
       await addCondition();
       await startTyping();
@@ -1373,6 +1373,7 @@ describe("FilterBar", () => {
       await click(screen.getByTestId("filter-clear"));
 
       expect(textBox()).toHaveValue("");
+      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
     });
 
     it("empties the editor when another app is picked", async () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -416,6 +416,27 @@ describe("FilterBar", () => {
       });
     });
 
+    it("resolves with no name when the app has never reported a trace", async () => {
+      mockUseRootSpanNamesQuery.mockReturnValue({
+        data: [],
+        isPending: false,
+        isError: false,
+        isSuccess: true,
+      });
+      const { onFilterChange } = await renderBar({
+        requestedAppId: "app-1",
+        showRootSpanSelector: true,
+      });
+
+      expect(lastState(onFilterChange)).toMatchObject({
+        status: "ready",
+        app: apps[0],
+        rootSpanName: null,
+        appliedAsRequested: true,
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+
     it("does not toast for a root span name with no requested app", async () => {
       mockUseRootSpanNamesQuery.mockReturnValue({
         data: ["checkout", "startup"],

--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -389,6 +389,22 @@ describe("useExprFilterPage", () => {
     unmount();
   });
 
+  it("ignores a change that leaves the request as it is", async () => {
+    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
+    renderPage(10);
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    await act(async () => {
+      bar.onRequestChange({ filterExpr: null });
+    });
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+
+    expect(page.paginationOffset).toBe(20);
+  });
+
   it("reads the offset it wrote while that write is still in flight", async () => {
     mockRouter.deferReplace = true;
     mockRouter.searchParams = new URLSearchParams(

--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -1,0 +1,354 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
+import type { App } from "@/app/api/api_calls";
+import type {
+  FilterRequest,
+  FilterState,
+} from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+
+const replaceMock = mockRouter.replaceMock;
+
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
+
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
+  __esModule: true,
+  filterExprUrlKey: "filter_expr",
+}));
+
+jest.mock("@/app/stores/filters_store", () => ({
+  __esModule: true,
+  urlFiltersKeyMap: {
+    appId: "a",
+    dateRange: "d",
+    startDate: "sd",
+    endDate: "ed",
+  },
+}));
+
+jest.mock("@/app/query/hooks", () => ({
+  __esModule: true,
+  paginationOffsetUrlKey: "po",
+}));
+
+const app = { id: "app-1", name: "Sample" } as App;
+const last6Hours = {
+  dateRange: "Last 6 Hours",
+  startDate: "2026-01-01T00:00:00.000Z",
+  endDate: "2026-01-01T06:00:00.000Z",
+};
+const custom = {
+  dateRange: "Custom Range",
+  startDate: "2026-02-01T00:00:00.000Z",
+  endDate: "2026-02-02T00:00:00.000Z",
+};
+
+type Page = ReturnType<typeof useExprFilterPage>;
+
+// The stub bar keeps the props of its latest render so a test can read what
+// the page handed it.
+let bar: {
+  requestedAppId: string | null;
+  requestedDateRange: { dateRange: string | null };
+  requestedFilterExpr: string | null;
+  requestedRootSpanName: string | null;
+  onRequestChange: (change: Partial<FilterRequest>) => void;
+  onFilterChange: (state: FilterState) => void;
+};
+let page: Page;
+
+function Host({ paginationLimit }: { paginationLimit?: number }) {
+  const rendered = useExprFilterPage({
+    paginationLimit,
+    extraUrlKeys: { rootSpanName: "r" },
+  });
+  useEffect(() => {
+    page = rendered;
+    bar = {
+      requestedAppId: rendered.requestedFilters.appId,
+      requestedDateRange: rendered.requestedFilters.dateRange,
+      requestedFilterExpr: rendered.requestedFilters.filterExpr,
+      requestedRootSpanName: rendered.requestedFilters.rootSpanName,
+      onRequestChange: rendered.onRequestChange,
+      onFilterChange: rendered.onFilterChange,
+    };
+  });
+  return null;
+}
+
+const ready = (
+  overrides: Partial<Extract<FilterState, { status: "ready" }>> = {},
+): FilterState => ({
+  status: "ready",
+  app,
+  date: last6Hours,
+  filterExpr: null,
+  rootSpanName: "span.first",
+  appliedAsRequested: true,
+  ...overrides,
+});
+
+const request = (overrides: Partial<FilterRequest> = {}): FilterRequest => ({
+  appId: app.id,
+  dateRange: last6Hours,
+  filterExpr: null,
+  rootSpanName: "span.first",
+  ...overrides,
+});
+
+const settledParams = "a=app-1&d=Last+6+Hours&r=span.first";
+
+function renderPage(paginationLimit?: number) {
+  return render(<Host paginationLimit={paginationLimit} />);
+}
+
+describe("useExprFilterPage", () => {
+  beforeEach(() => {
+    mockRouter.reset();
+  });
+
+  it("hands the bar its request before and after the write lands", async () => {
+    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
+    renderPage(10);
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+
+    mockRouter.deferReplace = true;
+    await act(async () => {
+      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
+    });
+    expect(bar.requestedFilterExpr).toBe("patch_id:");
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      bar.onFilterChange(ready({ filterExpr: null }));
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?po=0&${settledParams}`, {
+      scroll: false,
+    });
+    expect(bar.requestedFilterExpr).toBe("patch_id:");
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+    });
+    expect(bar.requestedFilterExpr).toBe("patch_id:");
+  });
+
+  it("hands the bar the URL after a search string the page did not write", async () => {
+    mockRouter.searchParams = new URLSearchParams(settledParams);
+    renderPage();
+    await act(async () => {
+      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
+    });
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(bar.requestedFilterExpr).toBe("patch_id:");
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl("?a=app-2&d=Last+Week&r=span.second");
+    });
+    expect(bar.requestedAppId).toBe("app-2");
+    expect(bar.requestedDateRange.dateRange).toBe("Last Week");
+    expect(bar.requestedFilterExpr).toBeNull();
+    expect(bar.requestedRootSpanName).toBe("span.second");
+  });
+
+  it("writes again after a navigation back to the search string a request was stored on", async () => {
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
+      scroll: false,
+    });
+    expect(bar.requestedAppId).toBe("app-1");
+    expect(bar.requestedRootSpanName).toBe("span.first");
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl("?");
+    });
+    expect(bar.requestedAppId).toBeNull();
+
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(replaceMock).toHaveBeenCalledTimes(2);
+    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
+      scroll: false,
+    });
+  });
+
+  it("writes a navigation whose resolution equals the last written URL", async () => {
+    mockRouter.searchParams = new URLSearchParams(settledParams);
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    await act(async () => {
+      bar.onRequestChange({ filterExpr: "patch_id:1" });
+    });
+    await act(async () => {
+      bar.onFilterChange(ready({ filterExpr: "patch_id:1" }));
+    });
+    await act(async () => {
+      bar.onRequestChange({ filterExpr: null });
+    });
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
+      scroll: false,
+    });
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl("?");
+    });
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(replaceMock).toHaveBeenCalledTimes(3);
+    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
+      scroll: false,
+    });
+  });
+
+  it("merges a change into the request it hands the bar", async () => {
+    mockRouter.searchParams = new URLSearchParams("r=span.checkout");
+    renderPage();
+    await act(async () => {
+      bar.onRequestChange({ dateRange: custom });
+    });
+    expect(bar.requestedDateRange.dateRange).toBe(custom.dateRange);
+    expect(bar.requestedRootSpanName).toBe("span.checkout");
+  });
+
+  it("keeps the request across a pagination write", async () => {
+    mockRouter.searchParams = new URLSearchParams(`po=0&${settledParams}`);
+    renderPage(10);
+    await act(async () => {
+      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
+    });
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+
+    await act(async () => {
+      page.nextPage();
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?po=10&${settledParams}`, {
+      scroll: false,
+    });
+    expect(bar.requestedFilterExpr).toBe("patch_id:");
+  });
+
+  it("writes a relative label without timestamps and a custom range with them", async () => {
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready({ date: last6Hours }));
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
+      scroll: false,
+    });
+
+    await act(async () => {
+      bar.onFilterChange(ready({ date: custom, appliedAsRequested: false }));
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      "?a=app-1&d=Custom+Range&sd=2026-02-01T00%3A00%3A00.000Z&ed=2026-02-02T00%3A00%3A00.000Z&r=span.first",
+      { scroll: false },
+    );
+  });
+
+  it("gates a relative range on its label alone, with the state's timestamps", async () => {
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
+      `${settledParams}&sd=2020-01-01T00%3A00%3A00.000Z&ed=2020-01-02T00%3A00%3A00.000Z`,
+    );
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+
+    expect(page.filterParams).toEqual({
+      appId: app.id,
+      startDate: last6Hours.startDate,
+      endDate: last6Hours.endDate,
+      filterExpr: null,
+    });
+  });
+
+  it("gates a custom range on its timestamps", async () => {
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
+      "a=app-1&d=Custom+Range&sd=2020-01-01T00%3A00%3A00.000Z&ed=2020-01-02T00%3A00%3A00.000Z&r=span.first",
+    );
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready({ date: custom, appliedAsRequested: false }));
+    });
+    expect(page.filterParams).toBeNull();
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+    });
+    expect(page.filterParams).toEqual({
+      appId: app.id,
+      startDate: custom.startDate,
+      endDate: custom.endDate,
+      filterExpr: null,
+    });
+  });
+
+  it("resets the offset after a pick and keeps it after an unchanged request", async () => {
+    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
+    renderPage(10);
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(page.paginationOffset).toBe(20);
+
+    await act(async () => {
+      bar.onRequestChange(request({ rootSpanName: "span.second" }));
+    });
+    await act(async () => {
+      bar.onFilterChange(ready({ rootSpanName: "span.second" }));
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      "?po=0&a=app-1&d=Last+6+Hours&r=span.second",
+      { scroll: false },
+    );
+    expect(page.paginationOffset).toBe(0);
+  });
+
+  it("reads the offset it wrote while that write is still in flight", async () => {
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(
+      "po=10&a=not-an-app&d=Last+6+Hours&r=span.first",
+    );
+    renderPage(10);
+    await act(async () => {
+      bar.onFilterChange(ready({ appliedAsRequested: false }));
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(`?po=0&${settledParams}`, {
+      scroll: false,
+    });
+    expect(page.paginationOffset).toBe(0);
+
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+    });
+    expect(page.paginationOffset).toBe(0);
+    expect(page.filterParams).not.toBeNull();
+  });
+});

--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -61,6 +61,25 @@ let bar: {
 };
 let page: Page;
 
+function HostWithPageKey() {
+  const rendered = useExprFilterPage({
+    extraUrlKeys: { rootSpanName: "r" },
+    pageUrlKeys: ["jt"],
+  });
+  useEffect(() => {
+    page = rendered;
+    bar = {
+      requestedAppId: rendered.requestedFilters.appId,
+      requestedDateRange: rendered.requestedFilters.dateRange,
+      requestedFilterExpr: rendered.requestedFilters.filterExpr,
+      requestedRootSpanName: rendered.requestedFilters.rootSpanName,
+      onRequestChange: rendered.onRequestChange,
+      onFilterChange: rendered.onFilterChange,
+    };
+  });
+  return null;
+}
+
 function Host({ paginationLimit }: { paginationLimit?: number }) {
   const rendered = useExprFilterPage({
     paginationLimit,
@@ -324,6 +343,50 @@ describe("useExprFilterPage", () => {
       { scroll: false },
     );
     expect(page.paginationOffset).toBe(0);
+  });
+
+  it("keeps a pick made while an earlier write is still in flight", async () => {
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams("a=app-1&d=Last+6+Hours");
+    renderPage();
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    const firstWrite = mockRouter.deferredReplaceUrl!;
+
+    await act(async () => {
+      bar.onRequestChange({ rootSpanName: "span.second" });
+    });
+    expect(bar.requestedRootSpanName).toBe("span.second");
+
+    await act(async () => {
+      mockRouter.applyReplaceUrl(firstWrite);
+    });
+    expect(bar.requestedRootSpanName).toBe("span.second");
+  });
+
+  it("keeps a page key written just before a pick", async () => {
+    mockRouter.deferReplace = true;
+    mockRouter.searchParams = new URLSearchParams(`${settledParams}&jt=Paths`);
+    const { unmount } = render(<HostWithPageKey />);
+    await act(async () => {
+      bar.onFilterChange(ready());
+    });
+    await act(async () => {
+      page.setPageUrlKey("jt", "Exceptions");
+    });
+    await act(async () => {
+      bar.onRequestChange({ dateRange: last6Hours });
+      bar.onRequestChange({ rootSpanName: "span.second" });
+    });
+    await act(async () => {
+      bar.onFilterChange(ready({ rootSpanName: "span.second" }));
+    });
+
+    expect(mockRouter.deferredReplaceUrl).toBe(
+      "?a=app-1&d=Last+6+Hours&r=span.second&jt=Exceptions",
+    );
+    unmount();
   });
 
   it("reads the offset it wrote while that write is still in flight", async () => {

--- a/frontend/dashboard/__tests__/components/user_journeys_test.tsx
+++ b/frontend/dashboard/__tests__/components/user_journeys_test.tsx
@@ -23,7 +23,7 @@ jest.mock("@/app/components/filter_bar/use_expr_filter_page", () => ({
   __esModule: true,
   useExprFilterPage: () => ({
     requestedFilters: {
-      app: null,
+      appId: null,
       dateRange: { dateRange: null, startDate: null, endDate: null },
       filterExpr: null,
     },

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -254,8 +254,8 @@ describe("Bug Reports Overview (MSW integration)", () => {
       );
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
-      expect(written.get("sd")).toBeTruthy();
-      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("sd")).toBeNull();
+      expect(written.get("ed")).toBeNull();
       expect(written.get("po")).toBe("0");
     });
 

--- a/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
@@ -163,8 +163,8 @@ describe("Builds page (MSW integration)", () => {
       );
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
-      expect(written.get("sd")).toBeTruthy();
-      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("sd")).toBeNull();
+      expect(written.get("ed")).toBeNull();
       expect(written.get("po")).toBe("0");
     });
 

--- a/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
@@ -225,8 +225,8 @@ describe("Journeys page (MSW integration)", () => {
       );
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
-      expect(written.get("sd")).toBeTruthy();
-      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("sd")).toBeNull();
+      expect(written.get("ed")).toBeNull();
       expect(written.has("po")).toBe(false);
       expect(written.has("jt")).toBe(false);
     });

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -242,8 +242,8 @@ describe("Traces Overview (MSW integration)", () => {
       );
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
-      expect(written.get("sd")).toBeTruthy();
-      expect(written.get("ed")).toBeTruthy();
+      expect(written.get("sd")).toBeNull();
+      expect(written.get("ed")).toBeNull();
       expect(written.get("po")).toBe("0");
       expect(written.get("r")).toBe(firstRootSpanName);
     });

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -65,11 +65,10 @@ const mockReportedDate = {
 // a filter it cannot read.
 let mockMountDiscardsFilter = false;
 
-// Like the real bar, this stub reports an app, a range and a filter as it
-// mounts, and offers buttons that report a changed filter, a cleared filter,
-// or a failure. Only the mount report carries appliedAsRequested true, and
-// only when the URL's filter was not discarded; a report from a button
-// models a user edit.
+// Like the real bar, this stub reports the request it is handed, on mount
+// and whenever it changes; its buttons hand the page a request the way a
+// pick does, or report a failure. Only a discarded mount report carries
+// appliedAsRequested false.
 jest.mock("@/app/components/filter_bar/filter_bar", () => {
   const { useEffect } = require("react");
 
@@ -84,6 +83,13 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       filterExpr,
       appliedAsRequested,
     });
+    const request = (filterExpr: string | null) =>
+      props.onRequestChange({
+        appId: mockReportedApp.id,
+        dateRange: mockReportedDate,
+        filterExpr,
+        rootSpanName: null,
+      });
 
     useEffect(() => {
       if (mockMountDiscardsFilter) {
@@ -91,7 +97,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       } else {
         props.onFilterChange(ready(props.requestedFilterExpr, true));
       }
-    }, []);
+    }, [props.requestedFilterExpr]);
 
     return (
       <div data-testid="filter-bar-mock">
@@ -100,16 +106,11 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
         </span>
         <button
           data-testid="filter-bar-apply"
-          onClick={() =>
-            props.onFilterChange(ready("bug_report_status:in:open"))
-          }
+          onClick={() => request("bug_report_status:in:open")}
         >
           apply
         </button>
-        <button
-          data-testid="filter-bar-clear"
-          onClick={() => props.onFilterChange(ready(null))}
-        >
+        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
           clear
         </button>
         <button
@@ -220,8 +221,7 @@ function bugReportsLoaded(data: any = mockBugReportsData) {
 }
 
 // What the stub bar reports, as the page writes it into the URL.
-const selectionParams =
-  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+const selectionParams = "a=app-1&d=Last+6+Hours";
 
 const selectionUrl = (offset: number, filterParam?: string) =>
   `?po=${offset}&${selectionParams}${filterParam ? `&${filterParam}` : ""}`;
@@ -304,8 +304,8 @@ describe("BugReportsOverview page", () => {
     renderPage();
 
     // The write has not landed, so the URL still holds the discarded
-    // filter and the queries stay disabled.
-    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 30);
+    // filter and the queries stay disabled, at the offset the page wrote.
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 0);
 
     await act(async () => {
       applyReplaceUrl(mockRouter.deferredReplaceUrl!);

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -57,8 +57,10 @@ const mockReportedDate = {
 // a filter it cannot read.
 let mockMountDiscardsFilter = false;
 
-// Only an undiscarded mount report carries appliedAsRequested true; a
-// report from a button models a user edit.
+// Like the real bar, this stub reports the request it is handed, on mount
+// and whenever it changes; its buttons hand the page a request the way a
+// pick does, or report a failure. Only a discarded mount report carries
+// appliedAsRequested false.
 jest.mock("@/app/components/filter_bar/filter_bar", () => {
   const { useEffect } = require("react");
 
@@ -73,6 +75,13 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       filterExpr,
       appliedAsRequested,
     });
+    const request = (filterExpr: string | null) =>
+      props.onRequestChange({
+        appId: mockReportedApp.id,
+        dateRange: mockReportedDate,
+        filterExpr,
+        rootSpanName: null,
+      });
 
     useEffect(() => {
       if (mockMountDiscardsFilter) {
@@ -80,7 +89,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       } else {
         props.onFilterChange(ready(props.requestedFilterExpr, true));
       }
-    }, []);
+    }, [props.requestedFilterExpr]);
 
     return (
       <div data-testid="filter-bar-mock">
@@ -89,14 +98,11 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
         </span>
         <button
           data-testid="filter-bar-apply"
-          onClick={() => props.onFilterChange(ready("mapping_type:in:dsym"))}
+          onClick={() => request("mapping_type:in:dsym")}
         >
           apply
         </button>
-        <button
-          data-testid="filter-bar-clear"
-          onClick={() => props.onFilterChange(ready(null))}
-        >
+        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
           clear
         </button>
         <button
@@ -182,8 +188,7 @@ function loaded(data: any = mockBuildsData) {
 }
 
 // What the stub bar reports, as the page writes it into the URL.
-const selectionParams =
-  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+const selectionParams = "a=app-1&d=Last+6+Hours";
 
 const selectionUrl = (offset: number, filterParam?: string) =>
   `?po=${offset}&${selectionParams}${filterParam ? `&${filterParam}` : ""}`;
@@ -261,8 +266,8 @@ describe("Builds page", () => {
     renderPage();
 
     // The write has not landed, so the URL still holds the discarded
-    // filter and the query stays disabled.
-    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 30);
+    // filter and the query stays disabled, at the offset the page wrote.
+    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 0);
 
     await act(async () => {
       applyReplaceUrl(mockRouter.deferredReplaceUrl!);

--- a/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
@@ -50,11 +50,10 @@ const mockReportedDate = {
 // a filter it cannot read.
 let mockMountDiscardsFilter = false;
 
-// Like the real bar, this stub reports an app, a range and a filter as it
-// mounts, and offers buttons that report a changed filter, a cleared filter,
-// another app, or a failure. Only the mount report carries appliedAsRequested
-// true, and only when the URL's filter was not discarded; a report from a
-// button models a user edit. The issues the page hands back are rendered so
+// Like the real bar, this stub reports the request it is handed, on mount
+// and whenever it changes; its buttons hand the page a request the way a
+// pick does, or report a failure. Only a discarded mount report carries
+// appliedAsRequested false. The issues the page hands back are rendered so
 // tests can see them reach the bar.
 jest.mock("@/app/components/filter_bar/filter_bar", () => {
   const { useEffect } = require("react");
@@ -71,14 +70,25 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       filterExpr,
       appliedAsRequested,
     });
+    const requestedApp =
+      props.requestedAppId === mockOtherApp.id ? mockOtherApp : mockReportedApp;
+    const request = (filterExpr: string | null, appId = mockReportedApp.id) =>
+      props.onRequestChange({
+        appId,
+        dateRange: mockReportedDate,
+        filterExpr,
+        rootSpanName: null,
+      });
 
     useEffect(() => {
       if (mockMountDiscardsFilter) {
         props.onFilterChange(ready(null, false));
       } else {
-        props.onFilterChange(ready(props.requestedFilterExpr, true));
+        props.onFilterChange(
+          ready(props.requestedFilterExpr, true, requestedApp),
+        );
       }
-    }, []);
+    }, [props.requestedAppId, props.requestedFilterExpr]);
 
     return (
       <div data-testid="filter-bar-mock">
@@ -95,23 +105,16 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
         </span>
         <button
           data-testid="filter-bar-apply"
-          onClick={() => props.onFilterChange(ready("version_name:in:1.2.0"))}
+          onClick={() => request("version_name:in:1.2.0")}
         >
           apply
         </button>
-        <button
-          data-testid="filter-bar-clear"
-          onClick={() => props.onFilterChange(ready(null))}
-        >
+        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
           clear
         </button>
         <button
           data-testid="filter-bar-switch-app"
-          onClick={() =>
-            props.onFilterChange(
-              ready(props.requestedFilterExpr, false, mockOtherApp),
-            )
-          }
+          onClick={() => request(props.requestedFilterExpr, mockOtherApp.id)}
         >
           switch app
         </button>
@@ -215,8 +218,7 @@ function journeyFailed(error: Error) {
 }
 
 // What the stub bar reports, as the page writes it into the URL.
-const selectionParams =
-  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+const selectionParams = "a=app-1&d=Last+6+Hours";
 
 const selectionUrl = (...trailingParams: string[]) =>
   `?${[selectionParams, ...trailingParams].join("&")}`;

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -68,11 +68,10 @@ const mockReportedDate = {
 // app no longer has the requested name.
 let mockMountSubstitutesName = false;
 
-// Like the real bar, this stub reports an app, a range and a resolved trace
-// name as it mounts, and offers buttons that report a changed filter, a
-// changed trace name, or a failure. Only the mount report carries
-// appliedAsRequested true, and only when nothing was substituted; a report
-// from a button models a user edit.
+// Like the real bar, this stub reports a resolved trace name for the request
+// it is handed, on mount and whenever it changes; its buttons hand the page a
+// request the way a pick does, or report a failure. Only a substituted report
+// carries appliedAsRequested false.
 jest.mock("@/app/components/filter_bar/filter_bar", () => {
   const { useEffect } = require("react");
 
@@ -91,6 +90,13 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       rootSpanName,
       appliedAsRequested,
     });
+    const request = (filterExpr: string | null, rootSpanName: string) =>
+      props.onRequestChange({
+        appId: mockReportedApp.id,
+        dateRange: mockReportedDate,
+        filterExpr,
+        rootSpanName,
+      });
 
     useEffect(() => {
       if (mockMountSubstitutesName) {
@@ -100,7 +106,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       } else {
         props.onFilterChange(ready(props.requestedFilterExpr, undefined, true));
       }
-    }, []);
+    }, [props.requestedFilterExpr, props.requestedRootSpanName]);
 
     return (
       <div data-testid="filter-bar-mock">
@@ -115,17 +121,18 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
         </span>
         <button
           data-testid="filter-bar-apply"
-          onClick={() => props.onFilterChange(ready("span_status:in:error"))}
+          onClick={() =>
+            request(
+              "span_status:in:error",
+              props.requestedRootSpanName ?? "span.first",
+            )
+          }
         >
           apply
         </button>
         <button
           data-testid="filter-bar-pick-name"
-          onClick={() =>
-            props.onFilterChange(
-              ready(props.requestedFilterExpr, "span.second"),
-            )
-          }
+          onClick={() => request(props.requestedFilterExpr, "span.second")}
         >
           pick name
         </button>
@@ -236,8 +243,7 @@ function spansLoaded(data: any = mockSpanData) {
 }
 
 // What the stub bar reports, as the page writes it into the URL.
-const selectionParams =
-  "a=app-1&d=Last+6+Hours&sd=2026-01-01T00%3A00%3A00.000Z&ed=2026-01-01T06%3A00%3A00.000Z";
+const selectionParams = "a=app-1&d=Last+6+Hours";
 
 // The names in these tests are URL-safe, so they appear in the URL as-is.
 const selectionUrl = (
@@ -350,7 +356,7 @@ describe("TracesOverview page", () => {
 
     // The URL write has not landed, so the bar's report does not match the
     // URL yet and the queries stay disabled with a null filter.
-    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 0);
+    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, "span.first", 0);
     expect(screen.getByTestId("span-metrics-plot-mock")).toBeInTheDocument();
     expect(screen.getByTestId("skeleton-plot-mock")).toBeInTheDocument();
   });
@@ -495,13 +501,9 @@ describe("TracesOverview page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-fail"));
       });
 
-      // The name stays readable from the URL, but the null filter keeps the
-      // query disabled.
-      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
-        null,
-        "span.first",
-        10,
-      );
+      // Without a ready report there is no resolved name, and the null
+      // filter keeps the query disabled.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 10);
     });
 
     it("leaves the URL where the link had it", async () => {
@@ -615,8 +617,12 @@ describe("TracesOverview page", () => {
       renderPage();
 
       // The write has not landed, so the URL still holds the dead name
-      // and the queries stay disabled.
-      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, "span.gone", 30);
+      // and the queries stay disabled, at the offset the page wrote.
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        null,
+        "span.substitute",
+        0,
+      );
 
       await act(async () => {
         applyReplaceUrl(mockRouter.deferredReplaceUrl!);
@@ -634,7 +640,7 @@ describe("TracesOverview page", () => {
         0,
       );
       for (const [filter, spanName, offset] of mockUseSpansQuery.mock.calls) {
-        if (spanName === "span.substitute") {
+        if (spanName === "span.substitute" && filter !== null) {
           expect(offset).toBe(0);
         }
         if (spanName === "span.gone") {

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -67,6 +67,7 @@ const mockReportedDate = {
 // place of the URL's, the way the real bar substitutes a default when the
 // app no longer has the requested name.
 let mockMountSubstitutesName = false;
+let mockAppHasNoTraces = false;
 
 // Like the real bar, this stub reports a resolved trace name for the request
 // it is handed, on mount and whenever it changes; its buttons hand the page a
@@ -80,7 +81,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
       filterExpr: string | null,
       // The real bar restores the URL's name when it can, so the stub
       // reports it back too and falls back to a first name of its own.
-      rootSpanName: string = props.requestedRootSpanName ?? "span.first",
+      rootSpanName: string | null = props.requestedRootSpanName ?? "span.first",
       appliedAsRequested: boolean = false,
     ) => ({
       status: "ready",
@@ -103,6 +104,8 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => {
         props.onFilterChange(
           ready(props.requestedFilterExpr, "span.substitute", false),
         );
+      } else if (mockAppHasNoTraces) {
+        props.onFilterChange(ready(props.requestedFilterExpr, null, true));
       } else {
         props.onFilterChange(ready(props.requestedFilterExpr, undefined, true));
       }
@@ -261,6 +264,7 @@ describe("TracesOverview page", () => {
   beforeEach(() => {
     mockRouter.reset();
     mockMountSubstitutesName = false;
+    mockAppHasNoTraces = false;
     mockUseSpansQuery.mockReset();
     mockUseSpansQuery.mockReturnValue(pendingQueryState());
     mockUseSpanMetricsPlotQuery.mockReset();
@@ -478,6 +482,28 @@ describe("TracesOverview page", () => {
     beforeEach(() => {
       mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
       spansLoaded();
+    });
+
+    it("says there is no data for an app that never reported a trace, and still writes the URL", async () => {
+      mockAppHasNoTraces = true;
+      mockRouter.searchParams = new URLSearchParams(
+        `po=10&r=span.first&${selectionParams}`,
+      );
+      renderPage();
+
+      expect(
+        screen.getByText("No traces received for this app yet"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Trace")).toBeNull();
+      expect(replaceMock).toHaveBeenLastCalledWith(
+        `?po=10&${selectionParams}`,
+        { scroll: false },
+      );
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        expect.anything(),
+        null,
+        10,
+      );
     });
 
     it("is said by the page, in place of the list", async () => {

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -42,6 +42,7 @@ export default function BugReportsOverview(props: {
     paginationOffset,
     filterState,
     filterParams,
+    onRequestChange,
     onFilterChange,
     nextPage,
     prevPage,
@@ -72,10 +73,11 @@ export default function BugReportsOverview(props: {
         teamId={params.teamId}
         entity="bug_reports"
         placeholder="Filter bug reports…"
-        requestedAppId={requestedFilters.app}
+        requestedAppId={requestedFilters.appId}
         requestedDateRange={requestedFilters.dateRange}
         requestedFilterExpr={requestedFilters.filterExpr}
         filterExprIssues={filterExprIssues}
+        onRequestChange={onRequestChange}
         onFilterChange={onFilterChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -17,6 +17,7 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
     paginationOffset,
     filterState,
     filterParams,
+    onRequestChange,
     onFilterChange,
     nextPage,
     prevPage,
@@ -34,10 +35,11 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
         teamId={params.teamId}
         entity="builds"
         placeholder="Filter builds…"
-        requestedAppId={requestedFilters.app}
+        requestedAppId={requestedFilters.appId}
         requestedDateRange={requestedFilters.dateRange}
         requestedFilterExpr={requestedFilters.filterExpr}
         filterExprIssues={filterExprIssues}
+        onRequestChange={onRequestChange}
         onFilterChange={onFilterChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -38,10 +38,10 @@ export default function TracesOverview(props: {
 
   const {
     requestedFilters,
-    requestedExtras,
     paginationOffset,
     filterState,
     filterParams,
+    onRequestChange,
     onFilterChange,
     nextPage,
     prevPage,
@@ -50,7 +50,7 @@ export default function TracesOverview(props: {
     extraUrlKeys: { rootSpanName: urlFiltersKeyMap.rootSpanName },
   });
   const readyFilter = filterState.status === "ready" ? filterState : null;
-  const rootSpanName = requestedExtras.rootSpanName;
+  const rootSpanName = readyFilter?.rootSpanName ?? null;
 
   const spansQuery = useSpansQuery(
     filterParams,
@@ -76,12 +76,13 @@ export default function TracesOverview(props: {
         teamId={params.teamId}
         entity="spans"
         placeholder="Filter traces…"
-        requestedAppId={requestedFilters.app}
+        requestedAppId={requestedFilters.appId}
         requestedDateRange={requestedFilters.dateRange}
         requestedFilterExpr={requestedFilters.filterExpr}
         filterExprIssues={filterExprIssues}
         showRootSpanSelector
-        requestedRootSpanName={requestedExtras.rootSpanName}
+        requestedRootSpanName={requestedFilters.rootSpanName}
+        onRequestChange={onRequestChange}
         onFilterChange={onFilterChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -93,6 +93,12 @@ export default function TracesOverview(props: {
 
       {filterState.status === "pending" && <SkeletonListPage />}
 
+      {readyFilter !== null && readyFilter.rootSpanName === null && (
+        <p className="text-lg font-display">
+          No traces received for this app yet
+        </p>
+      )}
+
       {readyFilter !== null &&
         status === "error" &&
         filterExprIssues === null && (
@@ -103,6 +109,7 @@ export default function TracesOverview(props: {
         )}
 
       {readyFilter !== null &&
+        readyFilter.rootSpanName !== null &&
         (status === "success" || status === "pending") && (
           <div className="flex flex-col items-center w-full">
             <SpanMetricsPlot

--- a/frontend/dashboard/app/components/filter_bar/custom_date_input.tsx
+++ b/frontend/dashboard/app/components/filter_bar/custom_date_input.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { DateTime } from "luxon";
+import { useState } from "react";
+import {
+  formatIsoDateForDateTimeInputField,
+  isValidTimestamp,
+} from "../../utils/time_utils";
+import { Input } from "../input";
+
+export default function CustomDateTimeInput({
+  timestamp,
+  min,
+  max,
+  onChange,
+}: {
+  timestamp: string;
+  min?: string;
+  max?: string;
+  onChange: (timestamp: string) => void;
+}) {
+  const [label, setLabel] = useState(
+    formatIsoDateForDateTimeInputField(timestamp),
+  );
+  const [value, setValue] = useState(timestamp);
+  if (timestamp !== value) {
+    setValue(timestamp);
+    setLabel(formatIsoDateForDateTimeInputField(timestamp));
+  }
+
+  return (
+    <Input
+      type="datetime-local"
+      value={label}
+      min={
+        min === undefined ? undefined : formatIsoDateForDateTimeInputField(min)
+      }
+      max={
+        max === undefined ? undefined : formatIsoDateForDateTimeInputField(max)
+      }
+      onChange={(e) => {
+        const typed = e.target.value;
+        if (!isValidTimestamp(typed)) {
+          setLabel(typed);
+          return;
+        }
+        const time = DateTime.fromISO(typed);
+        const inRange =
+          (min === undefined || time >= DateTime.fromISO(min)) &&
+          (max === undefined || time <= DateTime.fromISO(max));
+        setLabel(inRange ? typed : formatIsoDateForDateTimeInputField(value));
+        if (inRange) {
+          onChange(time.toISO()!);
+        }
+      }}
+    />
+  );
+}

--- a/frontend/dashboard/app/components/filter_bar/custom_date_input.tsx
+++ b/frontend/dashboard/app/components/filter_bar/custom_date_input.tsx
@@ -48,11 +48,15 @@ export default function CustomDateTimeInput({
         const inRange =
           (min === undefined || time >= DateTime.fromISO(min)) &&
           (max === undefined || time <= DateTime.fromISO(max));
-        setLabel(inRange ? typed : formatIsoDateForDateTimeInputField(value));
+        setLabel(typed);
         if (inRange) {
           onChange(time.toISO()!);
         }
       }}
+      // A value outside the range stays while the user edits the other
+      // segments, and is put back on blur, so the input shows the range in
+      // force and typing the same value again counts as a change.
+      onBlur={() => setLabel(formatIsoDateForDateTimeInputField(value))}
     />
   );
 }

--- a/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
+++ b/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
@@ -152,9 +152,14 @@ export default function DateRangeSelect({
             return;
           }
 
-          // Custom Range keeps its timestamps until they are edited.
+          // Custom Range keeps its timestamps until they are edited, cut to
+          // the minute the inputs work in.
           if (range === DateRange.Custom) {
-            onChange({ ...selection, dateRange: range });
+            onChange({
+              dateRange: range,
+              startDate: DateTime.fromISO(startDate).startOf("minute").toISO()!,
+              endDate: DateTime.fromISO(endDate).startOf("minute").toISO()!,
+            });
             return;
           }
 

--- a/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
+++ b/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
@@ -95,7 +95,9 @@ function countBackFromNow(dateRange: DateRange): DateSelection {
   };
 }
 
-function toDateSelection(range: UncheckedDateRange): DateSelection | null {
+export function toDateSelection(
+  range: UncheckedDateRange,
+): DateSelection | null {
   if (!isKnownDateRange(range.dateRange)) {
     return null;
   }
@@ -118,15 +120,17 @@ export function isValidDateRange(range: UncheckedDateRange): boolean {
   return toDateSelection(range) !== null;
 }
 
-export function pickInitialDateSelection(
+export function pickDateRange(
   requestedDateRange: UncheckedDateRange,
   storedDateRange: UncheckedDateRange,
-): DateSelection {
-  return (
-    toDateSelection(requestedDateRange) ??
-    toDateSelection(storedDateRange) ??
-    countBackFromNow(DateRange.Last6Hours)
-  );
+): UncheckedDateRange {
+  if (isValidDateRange(requestedDateRange)) {
+    return requestedDateRange;
+  }
+  if (isValidDateRange(storedDateRange)) {
+    return storedDateRange;
+  }
+  return { dateRange: DateRange.Last6Hours, startDate: null, endDate: null };
 }
 
 export default function DateRangeSelect({
@@ -174,11 +178,20 @@ export default function DateRangeSelect({
             defaultValue={formatIsoDateForDateTimeInputField(startDate)}
             max={formatIsoDateForDateTimeInputField(endDate)}
             onChange={(e) => {
-              if (isValidTimestamp(e.target.value)) {
+              if (!isValidTimestamp(e.target.value)) {
+                return;
+              }
+              // A refused value is put back, since one left on screen could
+              // not be entered again.
+              if (
+                DateTime.fromISO(e.target.value) <= DateTime.fromISO(endDate)
+              ) {
                 onChange({
                   ...selection,
                   startDate: DateTime.fromISO(e.target.value).toISO()!,
                 });
+              } else {
+                e.target.value = formatIsoDateForDateTimeInputField(startDate);
               }
             }}
           />
@@ -189,15 +202,17 @@ export default function DateRangeSelect({
             min={formatIsoDateForDateTimeInputField(startDate)}
             max={formatIsoDateForDateTimeInputField(DateTime.now().toISO())}
             onChange={(e) => {
-              if (isValidTimestamp(e.target.value)) {
-                if (DateTime.fromISO(e.target.value) <= DateTime.now()) {
-                  onChange({
-                    ...selection,
-                    endDate: DateTime.fromISO(e.target.value).toISO()!,
-                  });
-                } else {
-                  e.target.value = formatIsoDateForDateTimeInputField(endDate);
-                }
+              if (!isValidTimestamp(e.target.value)) {
+                return;
+              }
+              const end = DateTime.fromISO(e.target.value);
+              if (end >= DateTime.fromISO(startDate) && end <= DateTime.now()) {
+                onChange({
+                  ...selection,
+                  endDate: end.toISO()!,
+                });
+              } else {
+                e.target.value = formatIsoDateForDateTimeInputField(endDate);
               }
             }}
           />

--- a/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
+++ b/frontend/dashboard/app/components/filter_bar/date_range_select.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { DateTime } from "luxon";
-import {
-  formatIsoDateForDateTimeInputField,
-  isValidTimestamp,
-} from "../../utils/time_utils";
 import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
-import { Input } from "../input";
+import CustomDateTimeInput from "./custom_date_input";
 
 export enum DateRange {
   Last15Mins = "Last 15 Minutes",
@@ -173,48 +169,17 @@ export default function DateRangeSelect({
       {dateRange === DateRange.Custom && (
         <>
           <p className="font-display px-2">:</p>
-          <Input
-            type="datetime-local"
-            defaultValue={formatIsoDateForDateTimeInputField(startDate)}
-            max={formatIsoDateForDateTimeInputField(endDate)}
-            onChange={(e) => {
-              if (!isValidTimestamp(e.target.value)) {
-                return;
-              }
-              // A refused value is put back, since one left on screen could
-              // not be entered again.
-              if (
-                DateTime.fromISO(e.target.value) <= DateTime.fromISO(endDate)
-              ) {
-                onChange({
-                  ...selection,
-                  startDate: DateTime.fromISO(e.target.value).toISO()!,
-                });
-              } else {
-                e.target.value = formatIsoDateForDateTimeInputField(startDate);
-              }
-            }}
+          <CustomDateTimeInput
+            timestamp={startDate}
+            max={endDate}
+            onChange={(start) => onChange({ ...selection, startDate: start })}
           />
           <p className="font-display px-2">to</p>
-          <Input
-            type="datetime-local"
-            defaultValue={formatIsoDateForDateTimeInputField(endDate)}
-            min={formatIsoDateForDateTimeInputField(startDate)}
-            max={formatIsoDateForDateTimeInputField(DateTime.now().toISO())}
-            onChange={(e) => {
-              if (!isValidTimestamp(e.target.value)) {
-                return;
-              }
-              const end = DateTime.fromISO(e.target.value);
-              if (end >= DateTime.fromISO(startDate) && end <= DateTime.now()) {
-                onChange({
-                  ...selection,
-                  endDate: end.toISO()!,
-                });
-              } else {
-                e.target.value = formatIsoDateForDateTimeInputField(endDate);
-              }
-            }}
+          <CustomDateTimeInput
+            timestamp={endDate}
+            min={startDate}
+            max={DateTime.now().toISO()!}
+            onChange={(end) => onChange({ ...selection, endDate: end })}
           />
         </>
       )}

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -69,6 +69,8 @@ export const filterExprUrlKey = "filter_expr";
 
 const SHOWN_VALUE_COUNT = 2;
 
+const noKeys: FilterKey[] = [];
+
 function writeFilterExpr(conditions: ConditionGroup): string | null {
   const tree = buildExprTree(conditions);
   return tree ? formatFilterExpr(tree) : null;
@@ -266,11 +268,14 @@ export default function FilterBar({
     store.setApps(loaded, loaded.length === 0 ? "no-apps" : "loaded");
   }, [appsQuery.status, appsQuery.data]);
 
-  const keys = keysQuery.data?.keys ?? [];
+  const keys = keysQuery.data?.keys ?? noKeys;
   const keyGroups = keysQuery.data?.key_groups ?? [];
 
+  // Keys of the previous app are shown while the requested app's load, and
+  // a request must not be judged by them.
+  const keysSettled = !keysQuery.isPending && !keysQuery.isPlaceholderData;
   const checkingRequestedFilter =
-    parsedRequestedFilter !== null && keysQuery.isPending;
+    parsedRequestedFilter !== null && !keysSettled;
 
   // A condition with no value yet is drawn but not filtered by.
   const requestConditions = useMemo(
@@ -285,11 +290,11 @@ export default function FilterBar({
   const requestedFilterDiscarded = useMemo(
     () =>
       parsedRequestedFilter !== null &&
-      !keysQuery.isPending &&
+      keysSettled &&
       (!parsedRequestedFilter.ok ||
         findUnusableConditions(parsedRequestedFilter.tokens, keys).length > 0 ||
         validateLimits(requestConditions) !== null),
-    [parsedRequestedFilter, keys, keysQuery.isPending, requestConditions],
+    [parsedRequestedFilter, keys, keysSettled, requestConditions],
   );
 
   const draftFilterExpr =

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -471,11 +471,10 @@ export default function FilterBar({
           "Error fetching traces list, please refresh page or select a different app to try again",
       };
     }
+    // An app that has never reported a trace has nothing to select, and the
+    // app and date it resolved with are still written.
     if (rootSpanNamesQuery.isSuccess && rootSpanNames.length === 0) {
-      return {
-        status: "error",
-        message: "No traces received for this app yet",
-      };
+      return { ...baseFilterState, rootSpanName: null };
     }
     if (resolvedRootSpanName === null) {
       return { status: "pending" };

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -577,11 +577,15 @@ export default function FilterBar({
     addToGroup(groupId, (id) => ({ id, logicalOperator: "and", children: [] }));
   }
 
+  // The text editor applies its text when it loses focus, so while it is
+  // open the focus is left with it, or the text just cleared would be applied.
   function clearFilter() {
     onRequestChange({ filterExpr: null });
     setTypedText(null);
     setFocusedId(null);
-    addConditionButtonRef.current?.focus();
+    if (!editingAsText) {
+      addConditionButtonRef.current?.focus();
+    }
   }
 
   function toggleLogicalOperator(groupId: string) {
@@ -804,6 +808,7 @@ export default function FilterBar({
                 type="button"
                 aria-label="Clear filter"
                 data-testid="filter-clear"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={clearFilter}
                 className="h-6 w-6 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
               >

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -658,7 +658,14 @@ export default function FilterBar({
       <AppSelect apps={apps} selected={selectedApp} onChange={setApp} />
       <DateRangeSelect
         selection={date}
-        onChange={(selection) => onRequestChange({ dateRange: selection })}
+        onChange={(selection) =>
+          onRequestChange({
+            dateRange:
+              selection.dateRange === DateRange.Custom
+                ? selection
+                : { ...selection, startDate: null, endDate: null },
+          })
+        }
       />
       {showRootSpanSelector &&
         (rootSpanNamesQuery.isPending ? (

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -27,10 +27,12 @@ import { Skeleton } from "../skeleton";
 import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
 import AppSelect from "./app_select";
 import DateRangeSelect, {
+  DateRange,
   type DateSelection,
   isValidDateRange,
   type UncheckedDateRange,
-  pickInitialDateSelection,
+  pickDateRange,
+  toDateSelection,
 } from "./date_range_select";
 import {
   buildConditionGroup,
@@ -72,20 +74,6 @@ function writeFilterExpr(conditions: ConditionGroup): string | null {
   return tree ? formatFilterExpr(tree) : null;
 }
 
-function normalizeFilterExpr(
-  text: string | null,
-  keys: FilterKey[],
-): string | null {
-  if (!text) {
-    return null;
-  }
-  const parsed = parseFilterExpr(text, { draft: true });
-  if (!parsed.ok) {
-    return null;
-  }
-  return writeFilterExpr(buildConditionGroup(parsed.tree, keys));
-}
-
 export type ReadyFilterState = Extract<FilterState, { status: "ready" }>;
 
 export type FilterState =
@@ -97,11 +85,17 @@ export type FilterState =
       date: DateSelection;
       filterExpr: string | null;
       rootSpanName: string | null;
-      // True when the caller's request was applied unchanged: the user made no
-      // edits and nothing requested was discarded. Unrequested fields count as
-      // honored.
+      // True when nothing requested was discarded.
       appliedAsRequested: boolean;
     };
+
+export type FilterRequest = {
+  appId: string | null;
+  dateRange: UncheckedDateRange;
+  // The filter as drawn, which can hold a condition with no value yet.
+  filterExpr: string | null;
+  rootSpanName: string | null;
+};
 
 interface FilterBarProps {
   teamId: string;
@@ -113,6 +107,7 @@ interface FilterBarProps {
   filterExprIssues?: FilterExprIssue[] | null;
   showRootSpanSelector?: boolean;
   requestedRootSpanName?: string | null;
+  onRequestChange: (change: Partial<FilterRequest>) => void;
   onFilterChange: (state: FilterState) => void;
 }
 
@@ -126,6 +121,7 @@ export default function FilterBar({
   filterExprIssues,
   showRootSpanSelector = false,
   requestedRootSpanName = null,
+  onRequestChange,
   onFilterChange,
 }: FilterBarProps) {
   const store = useFiltersStore();
@@ -135,17 +131,7 @@ export default function FilterBar({
   const [editingAsText, setEditingAsText] = useState(false);
   const [focusedId, setFocusedId] = useState<string | null>(null);
 
-  // The filter the bar holds after the user changes it, and null until then.
-  // Both parts initially come from the expression the page was asked for.
-  //
-  // `draftExpr` is everything on screen, including conditions still being
-  // built, while `appliedExpr` is the subset complete enough to filter by.
-  const [editedFilter, setEditedFilter] = useState<{
-    draftExpr: string;
-    appliedExpr: string | null;
-  } | null>(null);
-
-  const [editedDate, setEditedDate] = useState<DateSelection | null>(null);
+  const [typedText, setTypedText] = useState<string | null>(null);
 
   // Focus follows a condition as it is added, and moves to the preceding
   // condition when it is removed.
@@ -155,11 +141,7 @@ export default function FilterBar({
   const appsQuery = useAppsQuery(teamId);
   const apps = useMemo(() => appsQuery.data ?? [], [appsQuery.data]);
 
-  const [editedApp, setEditedApp] = useState<App | null>(null);
-  // The user's pick wins, then the app requested, then the app
-  // from store, then the first app as fallback
   const selectedApp =
-    apps.find((app) => app.id === editedApp?.id) ??
     apps.find((app) => app.id === requestedAppId) ??
     apps.find((app) => app.id === rememberedAppId) ??
     apps[0] ??
@@ -172,7 +154,10 @@ export default function FilterBar({
   }, [selectedApp?.id]);
 
   const parsedRequestedFilter = useMemo(
-    () => (requestedFilterExpr ? parseFilterExpr(requestedFilterExpr) : null),
+    () =>
+      requestedFilterExpr
+        ? parseFilterExpr(requestedFilterExpr, { draft: true })
+        : null,
     [requestedFilterExpr],
   );
 
@@ -194,9 +179,8 @@ export default function FilterBar({
   // sent once its condition has an operator, which keeps the query key
   // stable while the user is still typing the key name itself.
   const queriedCustomKeyNames = useMemo(() => {
-    const parsedDraft = editedFilter
-      ? parseFilterExpr(editedFilter.draftExpr, { draft: true })
-      : null;
+    const parsedDraft =
+      typedText !== null ? parseFilterExpr(typedText, { draft: true }) : null;
     const draftNames = (parsedDraft?.tokens ?? [])
       .filter(
         (token, index, tokens) =>
@@ -206,7 +190,7 @@ export default function FilterBar({
       )
       .map((token) => token.text);
     return [...new Set([...requestedCustomKeyNames, ...draftNames])].sort();
-  }, [editedFilter, requestedCustomKeyNames]);
+  }, [typedText, requestedCustomKeyNames]);
 
   const keysQuery = useFilterKeysQuery(
     selectedApp?.id,
@@ -224,16 +208,9 @@ export default function FilterBar({
     [rootSpanNamesQuery.data],
   );
 
-  const [selectedRootSpanName, setSelectedRootSpanName] = useState<
-    string | null
-  >(null);
   const resolvedRootSpanName = useMemo(() => {
     if (!showRootSpanSelector || rootSpanNames.length === 0) {
       return null;
-    }
-    // An app switch replaces the list
-    if (selectedRootSpanName && rootSpanNames.includes(selectedRootSpanName)) {
-      return selectedRootSpanName;
     }
     if (
       requestedAppId === selectedApp?.id &&
@@ -246,24 +223,28 @@ export default function FilterBar({
   }, [
     showRootSpanSelector,
     rootSpanNames,
-    selectedRootSpanName,
     requestedAppId,
     requestedRootSpanName,
     selectedApp?.id,
   ]);
 
   // The requested date range takes precedence over the persisted store range.
-  const initialDate = useMemo(
-    () =>
-      pickInitialDateSelection(requestedDateRange, {
-        dateRange: store.selectedDateRange,
-        startDate: store.selectedStartDate,
-        endDate: store.selectedEndDate,
-      }),
-    [],
+  const pickedDateRange = pickDateRange(requestedDateRange, {
+    dateRange: store.selectedDateRange,
+    startDate: store.selectedStartDate,
+    endDate: store.selectedEndDate,
+  });
+  // A relative range is counted back from now, so the window is computed
+  // once per label and does not move between renders.
+  const customDateRange = pickedDateRange.dateRange === DateRange.Custom;
+  const date = useMemo(
+    () => toDateSelection(pickedDateRange)!,
+    [
+      pickedDateRange.dateRange,
+      customDateRange ? pickedDateRange.startDate : null,
+      customDateRange ? pickedDateRange.endDate : null,
+    ],
   );
-
-  const date = editedDate ?? initialDate;
 
   useEffect(() => {
     store.setSelectedDateRange(date.dateRange);
@@ -289,23 +270,30 @@ export default function FilterBar({
   const keyGroups = keysQuery.data?.key_groups ?? [];
 
   const checkingRequestedFilter =
-    editedFilter === null &&
-    parsedRequestedFilter !== null &&
-    keysQuery.isPending;
+    parsedRequestedFilter !== null && keysQuery.isPending;
 
-  const requestedFilterDiscarded =
-    editedFilter === null &&
-    parsedRequestedFilter !== null &&
-    !keysQuery.isPending &&
-    (!parsedRequestedFilter.ok ||
-      findUnusableConditions(parsedRequestedFilter.tokens, keys).length > 0 ||
-      validateLimits(
-        buildConditionGroup(parsedRequestedFilter.tree ?? null, keys),
-      ) !== null);
+  // A condition with no value yet is drawn but not filtered by.
+  const requestConditions = useMemo(
+    () =>
+      buildConditionGroup(
+        parsedRequestedFilter?.ok ? parsedRequestedFilter.tree : null,
+        keys,
+      ),
+    [parsedRequestedFilter, keys],
+  );
+
+  const requestedFilterDiscarded = useMemo(
+    () =>
+      parsedRequestedFilter !== null &&
+      !keysQuery.isPending &&
+      (!parsedRequestedFilter.ok ||
+        findUnusableConditions(parsedRequestedFilter.tokens, keys).length > 0 ||
+        validateLimits(requestConditions) !== null),
+    [parsedRequestedFilter, keys, keysQuery.isPending, requestConditions],
+  );
 
   const draftFilterExpr =
-    editedFilter?.draftExpr ??
-    (requestedFilterDiscarded ? "" : (requestedFilterExpr ?? ""));
+    typedText ?? (requestedFilterDiscarded ? "" : (requestedFilterExpr ?? ""));
 
   const parsedDraftFilter = useMemo(
     () => parseFilterExpr(draftFilterExpr, { draft: true }),
@@ -321,21 +309,17 @@ export default function FilterBar({
     [parsedDraftFilter, keys],
   );
 
-  const currentFilterExpr = editedFilter
-    ? editedFilter.appliedExpr
-    : requestedFilterDiscarded
-      ? null
-      : requestedFilterExpr || null;
+  const currentFilterExpr = useMemo(
+    () =>
+      requestedFilterDiscarded ? null : writeFilterExpr(requestConditions),
+    [requestedFilterDiscarded, requestConditions],
+  );
 
-  // The canonical form of the draft and applied filters. This makes filters that
-  // differ only in spacing or in brackets around a single value compare equal.
+  // The canonical form of the draft. This makes filters that differ only in
+  // spacing or in brackets around a single value compare equal.
   const draftAppliedExpr = useMemo(
     () => writeFilterExpr(draftConditions),
     [draftConditions],
-  );
-  const appliedExprAsWritten = useMemo(
-    () => normalizeFilterExpr(currentFilterExpr, keys),
-    [currentFilterExpr, keys],
   );
 
   // Case                           |  Bar                 |  Page
@@ -359,10 +343,7 @@ export default function FilterBar({
   // Server issues belong to the submitted expression. Clear them when the draft
   // changes semantically, and keep their spans only while the submitted text is unchanged.
   const serverIssues = useMemo<FilterExprIssue[]>(() => {
-    if (
-      !filterExprIssues?.length ||
-      draftAppliedExpr !== appliedExprAsWritten
-    ) {
+    if (!filterExprIssues?.length || draftAppliedExpr !== currentFilterExpr) {
       return [];
     }
 
@@ -370,13 +351,7 @@ export default function FilterBar({
       ...issue,
       span: draftFilterExpr === currentFilterExpr ? issue.span : undefined,
     }));
-  }, [
-    filterExprIssues,
-    draftFilterExpr,
-    draftAppliedExpr,
-    appliedExprAsWritten,
-    currentFilterExpr,
-  ]);
+  }, [filterExprIssues, draftFilterExpr, draftAppliedExpr, currentFilterExpr]);
 
   // Prefer local validation; server issues apply only when local validation pass.
   const draftFilterIssues =
@@ -419,19 +394,7 @@ export default function FilterBar({
     rootSpanNameDiscarded ||
     requestedFilterDiscarded;
 
-  // The ready state is the caller's unchanged request, as long as the
-  // user has made no edits and nothing was discarded. The app is checked
-  // by ID because a requested app may no longer be available, in which
-  // case it is replaced with a fallback.
-  const appliedAsRequested =
-    editedApp === null &&
-    editedDate === null &&
-    editedFilter === null &&
-    selectedRootSpanName === null &&
-    !dateDiscarded &&
-    !requestedFilterDiscarded &&
-    !rootSpanNameDiscarded &&
-    (requestedAppId === null || selectedApp?.id === requestedAppId);
+  const appliedAsRequested = !anythingDiscarded;
 
   // The readiness of the app, date and filter expression, before the root
   // span selector is considered. The bar's own controls render once this is
@@ -554,13 +517,12 @@ export default function FilterBar({
   }, [focusedId]);
 
   function setApp(app: App) {
-    setEditedApp(app);
     // Clear filters on app change
-    setEditedFilter({ draftExpr: "", appliedExpr: null });
-    setSelectedRootSpanName(null);
+    onRequestChange({ appId: app.id, filterExpr: null, rootSpanName: null });
+    setTypedText(null);
   }
 
-  // Turns an edit to the conditions back into the text the bar holds.
+  // Turns an edit to the conditions back into request text.
   function setConditions(next: ConditionGroup) {
     const limit = validateLimits(next);
     if (limit) {
@@ -568,10 +530,7 @@ export default function FilterBar({
       return;
     }
 
-    setEditedFilter({
-      draftExpr: formatFilterExpr(buildDraftTree(next)),
-      appliedExpr: writeFilterExpr(next),
-    });
+    onRequestChange({ filterExpr: formatFilterExpr(buildDraftTree(next)) });
   }
 
   function setRow(rowId: string, patch: Partial<ConditionRow>) {
@@ -615,7 +574,8 @@ export default function FilterBar({
   }
 
   function clearFilter() {
-    setEditedFilter({ draftExpr: "", appliedExpr: null });
+    onRequestChange({ filterExpr: null });
+    setTypedText(null);
     setFocusedId(null);
     addConditionButtonRef.current?.focus();
   }
@@ -632,26 +592,19 @@ export default function FilterBar({
   // Typing redraws the bar at once, while what the page is filtered by stays
   // as it is until the text is applied.
   function changeFilterText(text: string) {
-    setEditedFilter({ draftExpr: text, appliedExpr: currentFilterExpr });
+    setTypedText(text);
   }
 
   function applyFilterText() {
-    if (draftIssueMessage) {
+    if (draftIssueMessage || typedText === null) {
       return;
     }
-    setEditedFilter({
-      draftExpr: draftFilterExpr,
-      appliedExpr: draftAppliedExpr,
-    });
+    onRequestChange({ filterExpr: typedText });
+    setTypedText(null);
   }
 
-  // Leaving the editor restores the filter currently applied to the page, so
-  // unapplied text is not left behind for the conditions to render.
   function cancelTextEditing() {
-    setEditedFilter({
-      draftExpr: currentFilterExpr ?? "",
-      appliedExpr: currentFilterExpr,
-    });
+    setTypedText(null);
     setEditingAsText(false);
   }
 
@@ -704,7 +657,10 @@ export default function FilterBar({
   return (
     <div className="flex flex-wrap gap-4 items-start w-full">
       <AppSelect apps={apps} selected={selectedApp} onChange={setApp} />
-      <DateRangeSelect selection={date} onChange={setEditedDate} />
+      <DateRangeSelect
+        selection={date}
+        onChange={(selection) => onRequestChange({ dateRange: selection })}
+      />
       {showRootSpanSelector &&
         (rootSpanNamesQuery.isPending ? (
           <Skeleton className="h-9 w-37.5" />
@@ -717,7 +673,7 @@ export default function FilterBar({
             onChangeSelected={(item) => {
               const name = item as string;
               if (name !== resolvedRootSpanName) {
-                setSelectedRootSpanName(name);
+                onRequestChange({ rootSpanName: name });
               }
             }}
           />

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -1,10 +1,12 @@
 "use client";
 
 import {
+  type FilterRequest,
   type FilterState,
   type ReadyFilterState,
   filterExprUrlKey,
 } from "@/app/components/filter_bar/filter_bar";
+import { DateRange } from "@/app/components/filter_bar/date_range_select";
 import { type FilterParams, paginationOffsetUrlKey } from "@/app/query/hooks";
 import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -18,93 +20,132 @@ const {
 } = urlFiltersKeyMap;
 
 /**
- * Fields of the bar's ready report that a page may carry in the URL beyond
- * the app, date range and filter expression: the nullable string fields,
- * minus the filter expression the hook already owns.
- */
-type ExtraFilterField = Exclude<
-  {
-    [P in keyof ReadyFilterState]: ReadyFilterState[P] extends string | null
-      ? null extends ReadyFilterState[P]
-        ? P
-        : never
-      : never;
-  }[keyof ReadyFilterState],
-  "filterExpr"
->;
-
-/**
  * The URL-driven filter mechanics shared by the pages that pair a FilterBar
- * with paginated queries. The URL is the single source of truth: the bar's
- * report is written into the URL, and the queries read the filter and the
- * pagination offset back from it, so each fetch uses one searchParams
- * snapshot.
+ * with paginated queries. The URL is the source of truth: the bar shows what
+ * it is handed, its resolved report is written into the URL, and the queries
+ * read the filter and the pagination offset back from it.
  *
- * A page with a selection of its own carried in the URL, such as a root span
- * name, declares it in `extraUrlKeys` as a map from the field of the bar's
- * ready report to the URL key that carries it. The hook then reads the
- * requested value, includes the field in the URL-vs-report equality gate, and
- * writes it into the URL with the rest of the filter.
+ * A user's pick is held here as the request the bar shows until the URL
+ * carries it. The page tells its own write from a navigation by the search
+ * string it was on when the request was stored and the one it wrote; any
+ * other search string is a navigation and the URL wins. The request is kept
+ * after the write, because a condition with no value yet is not written into
+ * the URL.
  *
- * A page that queries without pagination leaves `paginationLimit` out: the
- * URL then never carries the offset and `paginationOffset` stays zero.
- *
- * A page with URL state the bar knows nothing about, such as which plot is
- * shown, lists those keys in `pageUrlKeys` and writes them through
- * `setPageUrlKey`. When the bar's report is written into the URL, the values
- * those keys currently hold are carried over, so a filter change does not
- * reset them.
+ * A page with a root span selection in the URL declares its key in
+ * `extraUrlKeys`. A page without pagination leaves `paginationLimit` out.
+ * URL state the bar knows nothing about, such as which plot is shown, is
+ * listed in `pageUrlKeys` and written through `setPageUrlKey`; a filter
+ * write carries those values over.
  */
-export function useExprFilterPage<Extra extends ExtraFilterField = never>({
+export function useExprFilterPage({
   paginationLimit,
   extraUrlKeys,
   pageUrlKeys = [],
 }: {
   paginationLimit?: number;
-  extraUrlKeys?: Record<Extra, string>;
+  extraUrlKeys?: { rootSpanName: string };
   pageUrlKeys?: string[];
 }) {
-  const extras = Object.entries(extraUrlKeys ?? {}) as [Extra, string][];
-
   const router = useRouter();
   const searchParams = useSearchParams();
+  const search = searchParams.toString();
+
+  const [request, setRequest] = useState<{
+    filters: FilterRequest;
+    urlBefore: string | null;
+    urlWritten: string | null;
+  } | null>(null);
+  const [filterState, setFilterState] = useState<FilterState>({
+    status: "pending",
+  });
+
+  // The search string from before the write is only the page's own until
+  // the written one is seen. After that it can only come from a navigation,
+  // such as the same sidebar link clicked again, so it is forgotten.
+  if (
+    request !== null &&
+    request.urlBefore !== null &&
+    search === request.urlWritten
+  ) {
+    setRequest({ ...request, urlBefore: null });
+  }
+
+  const writeInFlight =
+    request !== null &&
+    request.urlBefore !== null &&
+    search === request.urlBefore;
+
+  // Until the router reports the written search string, the page reads back
+  // the one it wrote, not the one from before.
+  const knownParams =
+    writeInFlight && request.urlWritten !== null
+      ? new URLSearchParams(request.urlWritten)
+      : searchParams;
 
   const paginationOffset =
     paginationLimit === undefined
       ? 0
-      : Number(searchParams.get(paginationOffsetUrlKey)) || 0;
+      : Number(knownParams.get(paginationOffsetUrlKey)) || 0;
 
-  const requestedFilters = {
-    app: searchParams.get(appIdUrlKey),
+  const fromUrl: FilterRequest = {
+    appId: searchParams.get(appIdUrlKey),
     dateRange: {
       dateRange: searchParams.get(dateRangeUrlKey),
       startDate: searchParams.get(startDateUrlKey),
       endDate: searchParams.get(endDateUrlKey),
     },
     filterExpr: searchParams.get(filterExprUrlKey),
+    rootSpanName:
+      extraUrlKeys === undefined
+        ? null
+        : searchParams.get(extraUrlKeys.rootSpanName),
   };
-  const requestedExtras = Object.fromEntries(
-    extras.map(([field, urlKey]) => [field, searchParams.get(urlKey)]),
-  ) as Record<Extra, string | null>;
 
-  const [filterState, setFilterState] = useState<FilterState>({
-    status: "pending",
+  const fromReadyState = (state: ReadyFilterState): FilterRequest => ({
+    appId: state.app.id,
+    dateRange: state.date,
+    filterExpr: state.filterExpr,
+    rootSpanName: state.rootSpanName,
   });
 
-  // The filter is null until the URL matches the bar's report, extras
+  const requestedFilters =
+    request !== null && (writeInFlight || search === request.urlWritten)
+      ? request.filters
+      : fromUrl;
+
+  // A relative label is counted back from now, so its timestamps are not
+  // written and any the URL holds are ignored.
+  const filterUrlEntries = (filter: ReadyFilterState) => {
+    const entries: [string, string | null][] = [
+      [appIdUrlKey, filter.app.id],
+      [dateRangeUrlKey, filter.date.dateRange],
+    ];
+    if (filter.date.dateRange === DateRange.Custom) {
+      entries.push(
+        [startDateUrlKey, filter.date.startDate],
+        [endDateUrlKey, filter.date.endDate],
+      );
+    }
+    if (extraUrlKeys !== undefined) {
+      entries.push([extraUrlKeys.rootSpanName, filter.rootSpanName]);
+    }
+    entries.push([filterExprUrlKey, filter.filterExpr]);
+    return entries;
+  };
+
+  // The filter is null until the URL matches the bar's report, root span
   // included, so a value the bar discarded is never fetched.
   const filterParams: FilterParams | null =
     filterState.status === "ready" &&
-    requestedFilters.app === filterState.app.id &&
-    requestedFilters.dateRange.startDate === filterState.date.startDate &&
-    requestedFilters.dateRange.endDate === filterState.date.endDate &&
-    requestedFilters.filterExpr === filterState.filterExpr &&
-    extras.every(([field]) => requestedExtras[field] === filterState[field])
+    filterUrlEntries(filterState).every(
+      ([key, value]) => searchParams.get(key) === value,
+    )
       ? {
-          appId: requestedFilters.app,
-          startDate: requestedFilters.dateRange.startDate,
-          endDate: requestedFilters.dateRange.endDate,
-          filterExpr: requestedFilters.filterExpr,
+          appId: filterState.app.id,
+          startDate: filterState.date.startDate,
+          endDate: filterState.date.endDate,
+          filterExpr: filterState.filterExpr,
         }
       : null;
 
@@ -113,26 +154,26 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
     if (paginationLimit !== undefined) {
       urlParams.set(paginationOffsetUrlKey, String(offset));
     }
-    urlParams.set(appIdUrlKey, filter.app.id);
-    urlParams.set(dateRangeUrlKey, filter.date.dateRange);
-    urlParams.set(startDateUrlKey, filter.date.startDate);
-    urlParams.set(endDateUrlKey, filter.date.endDate);
-    for (const [field, urlKey] of extras) {
-      const value: string | null = filter[field];
-      if (value !== null) {
-        urlParams.set(urlKey, value);
-      }
-    }
-    if (filter.filterExpr) {
-      urlParams.set(filterExprUrlKey, filter.filterExpr);
-    }
-    for (const key of pageUrlKeys) {
-      const value = searchParams.get(key);
+    for (const [key, value] of filterUrlEntries(filter)) {
       if (value !== null) {
         urlParams.set(key, value);
       }
     }
-    return `?${urlParams.toString()}`;
+    for (const key of pageUrlKeys) {
+      const value = knownParams.get(key);
+      if (value !== null) {
+        urlParams.set(key, value);
+      }
+    }
+    return urlParams.toString();
+  };
+
+  const onRequestChange = (change: Partial<FilterRequest>) => {
+    setRequest({
+      filters: { ...requestedFilters, ...change },
+      urlBefore: search,
+      urlWritten: null,
+    });
   };
 
   const onFilterChange = (newFilterState: FilterState) => {
@@ -141,18 +182,50 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
     if (newFilterState.status !== "ready") {
       return;
     }
-    // The URL's pagination offset is kept only when the bar applied the URL's
-    // request unchanged. Any edit or substitution starts back at page one.
-    const offset = newFilterState.appliedAsRequested ? paginationOffset : 0;
-    router.replace(buildFilterUrl(newFilterState, offset), { scroll: false });
+    // The URL's pagination offset is kept only when the bar applied the
+    // request unchanged and that request is already in the URL. A new pick,
+    // or a substitution, starts back at page one.
+    const pickAwaitingWrite = request !== null && request.urlWritten === null;
+    const offset =
+      newFilterState.appliedAsRequested && !pickAwaitingWrite
+        ? paginationOffset
+        : 0;
+    const params = buildFilterUrl(newFilterState, offset);
+    // Stored as resolved, so a navigation back to the search string it came
+    // from changes the bar's props and the bar reports again. The filter text
+    // is kept as asked, since a condition with no value yet is not resolved.
+    setRequest({
+      filters: {
+        ...fromReadyState(newFilterState),
+        filterExpr: newFilterState.appliedAsRequested
+          ? requestedFilters.filterExpr
+          : newFilterState.filterExpr,
+      },
+      urlBefore: search,
+      urlWritten: params,
+    });
+    // The bar reports again before the router applies a write; the same
+    // write is not issued twice.
+    if (
+      params !== search &&
+      !(writeInFlight && params === request.urlWritten)
+    ) {
+      router.replace(`?${params}`, { scroll: false });
+    }
   };
 
   // Replaces one key in the URL and leaves everything else the URL carries
-  // as it is.
+  // as it is. The write is recorded so the bar keeps showing the request.
   const setPageUrlKey = (key: string, value: string) => {
-    const urlParams = new URLSearchParams(searchParams);
+    const urlParams = new URLSearchParams(knownParams);
     urlParams.set(key, value);
-    router.replace(`?${urlParams.toString()}`, { scroll: false });
+    const params = urlParams.toString();
+    setRequest({
+      filters: requestedFilters,
+      urlBefore: search,
+      urlWritten: params,
+    });
+    router.replace(`?${params}`, { scroll: false });
   };
 
   const navigateToOffset = (offset: number) =>
@@ -173,10 +246,10 @@ export function useExprFilterPage<Extra extends ExtraFilterField = never>({
 
   return {
     requestedFilters,
-    requestedExtras,
     paginationOffset,
     filterState,
     filterParams,
+    onRequestChange,
     onFilterChange,
     setPageUrlKey,
     nextPage,

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -55,6 +55,7 @@ export function useExprFilterPage({
     filters: FilterRequest;
     urlBefore: string | null;
     urlWritten: string | null;
+    awaitingWrite: boolean;
   } | null>(null);
   const [filterState, setFilterState] = useState<FilterState>({
     status: "pending",
@@ -168,11 +169,14 @@ export function useExprFilterPage({
     return urlParams.toString();
   };
 
+  // A pick keeps the last written URL, since a write of it can still be on
+  // its way and must be read as the page's own when it is applied.
   const onRequestChange = (change: Partial<FilterRequest>) => {
     setRequest({
       filters: { ...requestedFilters, ...change },
       urlBefore: search,
-      urlWritten: null,
+      urlWritten: request?.urlWritten ?? null,
+      awaitingWrite: true,
     });
   };
 
@@ -185,7 +189,7 @@ export function useExprFilterPage({
     // The URL's pagination offset is kept only when the bar applied the
     // request unchanged and that request is already in the URL. A new pick,
     // or a substitution, starts back at page one.
-    const pickAwaitingWrite = request !== null && request.urlWritten === null;
+    const pickAwaitingWrite = request !== null && request.awaitingWrite;
     const offset =
       newFilterState.appliedAsRequested && !pickAwaitingWrite
         ? paginationOffset
@@ -203,6 +207,7 @@ export function useExprFilterPage({
       },
       urlBefore: search,
       urlWritten: params,
+      awaitingWrite: false,
     });
     // The bar reports again before the router applies a write; the same
     // write is not issued twice.
@@ -224,6 +229,7 @@ export function useExprFilterPage({
       filters: requestedFilters,
       urlBefore: search,
       urlWritten: params,
+      awaitingWrite: request !== null && request.awaitingWrite,
     });
     router.replace(`?${params}`, { scroll: false });
   };

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -6,7 +6,10 @@ import {
   type ReadyFilterState,
   filterExprUrlKey,
 } from "@/app/components/filter_bar/filter_bar";
-import { DateRange } from "@/app/components/filter_bar/date_range_select";
+import {
+  DateRange,
+  type UncheckedDateRange,
+} from "@/app/components/filter_bar/date_range_select";
 import { type FilterParams, paginationOffsetUrlKey } from "@/app/query/hooks";
 import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -18,6 +21,16 @@ const {
   startDate: startDateUrlKey,
   endDate: endDateUrlKey,
 } = urlFiltersKeyMap;
+
+// A relative label is counted back from now, so its timestamps are not part
+// of a request.
+function withoutRelativeTimestamps(
+  range: UncheckedDateRange,
+): UncheckedDateRange {
+  return range.dateRange === DateRange.Custom
+    ? range
+    : { dateRange: range.dateRange, startDate: null, endDate: null };
+}
 
 function sameRequest(a: FilterRequest, b: FilterRequest): boolean {
   return (
@@ -116,7 +129,7 @@ export function useExprFilterPage({
 
   const fromReadyState = (state: ReadyFilterState): FilterRequest => ({
     appId: state.app.id,
-    dateRange: state.date,
+    dateRange: withoutRelativeTimestamps(state.date),
     filterExpr: state.filterExpr,
     rootSpanName: state.rootSpanName,
   });

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -19,6 +19,17 @@ const {
   endDate: endDateUrlKey,
 } = urlFiltersKeyMap;
 
+function sameRequest(a: FilterRequest, b: FilterRequest): boolean {
+  return (
+    a.appId === b.appId &&
+    a.filterExpr === b.filterExpr &&
+    a.rootSpanName === b.rootSpanName &&
+    a.dateRange.dateRange === b.dateRange.dateRange &&
+    a.dateRange.startDate === b.dateRange.startDate &&
+    a.dateRange.endDate === b.dateRange.endDate
+  );
+}
+
 /**
  * The URL-driven filter mechanics shared by the pages that pair a FilterBar
  * with paginated queries. The URL is the source of truth: the bar shows what
@@ -172,8 +183,12 @@ export function useExprFilterPage({
   // A pick keeps the last written URL, since a write of it can still be on
   // its way and must be read as the page's own when it is applied.
   const onRequestChange = (change: Partial<FilterRequest>) => {
+    const filters = { ...requestedFilters, ...change };
+    if (sameRequest(filters, requestedFilters)) {
+      return;
+    }
     setRequest({
-      filters: { ...requestedFilters, ...change },
+      filters,
       urlBefore: search,
       urlWritten: request?.urlWritten ?? null,
       awaitingWrite: true,

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -39,6 +39,7 @@ export default function UserJourneys({
     requestedFilters,
     filterState,
     filterParams,
+    onRequestChange,
     onFilterChange,
     setPageUrlKey,
   } = useExprFilterPage({ pageUrlKeys: [journeyTypeUrlKey] });
@@ -78,10 +79,11 @@ export default function UserJourneys({
             teamId={params.teamId}
             entity="journeys"
             placeholder="Filter journeys…"
-            requestedAppId={requestedFilters.app}
+            requestedAppId={requestedFilters.appId}
             requestedDateRange={requestedFilters.dateRange}
             requestedFilterExpr={requestedFilters.filterExpr}
             filterExprIssues={filterExprIssues}
+            onRequestChange={onRequestChange}
             onFilterChange={onFilterChange}
           />
           <div className="py-4" />


### PR DESCRIPTION
# Description

- The bar no longer keeps picks over the URL after a same-page sidebar click or Back; it shows what the URL says.
- sd and ed are written only for a custom range; a relative label is counted back from now on load.
- Switching to an app with no traces writes its URL.
- The custom date inputs follow the URL after Back and Forward.
- The custom date inputs refuse a start after the end and an end before the start, and keep a value until the input loses focus.
- Custom Range picked from a relative range works in minutes, so an end in the same minute as the start is accepted.
- A pick made while an earlier URL write is still in flight is kept.
- A pick that changes nothing no longer resets the pagination offset.
- A requested filter is not judged by the previous app's keys while the new app's load.
- Clearing the filter while typing in the text editor no longer applies the typed text.
- The traces page reads the span name from the resolved state.

## Related issue
Fixes #4371



