### PR TITLE
chore(rn): update android dependency version correctly

### DIFF
--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Update android/build.gradle.kts
         run: |
-          sed -i "s|compileOnly(\"sh\.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
+          sed -i "s|api(\"sh\.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
 
       - name: Update plugin/index.js
         run: |


### PR DESCRIPTION
# Description

The current RN release workflow does not update the android measure package version in build.gradle.kts. This PR fixes that issue.

## Related Issue

Closes #4392 