### PR TITLE
ci(rn): upgrade release action versions

### DIFF
--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

This PR upgrades the third party actions in the React Native release workflow. Removes CI related deprecation notices & improves overall security posture.

## Tasks

- [x] Upgrade to `actions/checkout@v7`
- [x] Upgrade to `actions/setup-node@v7`
