### PR TITLE
chore(rn): add patch attributes to native events

### DIFF
--- a/android/measure-android/measure/api/measure.api
+++ b/android/measure-android/measure/api/measure.api
@@ -25,6 +25,8 @@ public final class sh/measure/android/Measure {
 	public final fun internalAddLog (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun internalEncodeWebP ([BIILkotlin/jvm/functions/Function1;)V
 	public final fun internalGetAttachmentDirectory ()Ljava/lang/String;
+	public static final fun internalSetPatch (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun internalSetPatch$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun internalTrackEvent (Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun internalTrackEvent$default (Lsh/measure/android/Measure;Ljava/util/Map;Ljava/lang/String;JLjava/util/Map;Ljava/util/Map;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun internalTrackSpan (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJJILjava/util/Map;Ljava/util/Map;Ljava/util/Map;ZZ)V

--- a/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -154,6 +154,22 @@ object Measure {
     }
 
     /**
+     * An internal method that sets the patch ID and, optionally, the patch version for the
+     * current app instance. These are attached as attributes to every event and span generated
+     * after this point. This method is not intended for public usage.
+     *
+     * This is used internally by the React Native SDK to propagate the patch identifiers of an
+     * OTA update to the native SDK. The value is held in memory only and is not persisted across
+     * app launches.
+     */
+    @JvmStatic
+    fun internalSetPatch(patchId: String, patchVersion: String? = null) {
+        if (isInitialized) {
+            measure.internalSetPatch(patchId, patchVersion)
+        }
+    }
+
+    /**
      * Call when a screen is viewed by the user.
      *
      * Measure SDK automatically collects screen view events from the Jetpack Navigation library

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -12,10 +12,10 @@ import sh.measure.android.attributes.AttributeProcessor
 import sh.measure.android.attributes.DeviceAttributeProcessor
 import sh.measure.android.attributes.InstallationIdAttributeProcessor
 import sh.measure.android.attributes.NetworkStateAttributeProcessor
+import sh.measure.android.attributes.PatchAttributeProcessor
 import sh.measure.android.attributes.PowerStateAttributeProcessor
 import sh.measure.android.attributes.SessionAttributeProcessor
 import sh.measure.android.attributes.SpanDeviceAttributeProcessor
-import sh.measure.android.attributes.PatchAttributeProcessor
 import sh.measure.android.attributes.UserAttributeProcessor
 import sh.measure.android.bugreport.AccelerometerShakeDetector
 import sh.measure.android.bugreport.BugReportCollector

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -15,6 +15,7 @@ import sh.measure.android.attributes.NetworkStateAttributeProcessor
 import sh.measure.android.attributes.PowerStateAttributeProcessor
 import sh.measure.android.attributes.SessionAttributeProcessor
 import sh.measure.android.attributes.SpanDeviceAttributeProcessor
+import sh.measure.android.attributes.PatchAttributeProcessor
 import sh.measure.android.attributes.UserAttributeProcessor
 import sh.measure.android.bugreport.AccelerometerShakeDetector
 import sh.measure.android.bugreport.BugReportCollector
@@ -205,6 +206,7 @@ internal class MeasureInitializerImpl(
         prefsStorage,
         executorServiceRegistry.ioExecutor(),
     ),
+    override val patchAttributeProcessor: PatchAttributeProcessor = PatchAttributeProcessor(),
     private val deviceAttributeProcessor: DeviceAttributeProcessor = DeviceAttributeProcessor(
         context = application,
         localeProvider = localeProvider,
@@ -229,6 +231,7 @@ internal class MeasureInitializerImpl(
     ),
     private val attributeProcessors: List<AttributeProcessor> = listOf(
         userAttributeProcessor,
+        patchAttributeProcessor,
         deviceAttributeProcessor,
         appAttributeProcessor,
         installationIdAttributeProcessor,
@@ -364,6 +367,7 @@ internal class MeasureInitializerImpl(
     ),
     override val spanAttributeProcessors: List<AttributeProcessor> = listOf(
         userAttributeProcessor,
+        patchAttributeProcessor,
         spanDeviceAttributeProcessor,
         appAttributeProcessor,
         installationIdAttributeProcessor,
@@ -514,6 +518,7 @@ internal interface MeasureInitializer {
     val exporter: Exporter
     val workManagerAvailable: Boolean
     val userAttributeProcessor: UserAttributeProcessor
+    val patchAttributeProcessor: PatchAttributeProcessor
     val screenshotCollector: ScreenshotCollector
     val dataCleanupService: DataCleanupService
     val processInfoProvider: ProcessInfoProvider

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInternal.kt
@@ -166,6 +166,10 @@ internal class MeasureInternal(private val measure: MeasureInitializer) :
         measure.userAttributeProcessor.clearUserId()
     }
 
+    fun internalSetPatch(patchId: String, patchVersion: String?) {
+        measure.patchAttributeProcessor.setPatch(patchId, patchVersion)
+    }
+
     fun trackScreenView(screenName: String, attributes: Map<String, AttributeValue>) {
         measure.userTriggeredEventCollector.trackScreenView(screenName, attributes)
     }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/attributes/PatchAttributeProcessor.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/attributes/PatchAttributeProcessor.kt
@@ -1,0 +1,25 @@
+package sh.measure.android.attributes
+
+import sh.measure.android.attributes.Attribute.PATCH_ID_KEY
+import sh.measure.android.attributes.Attribute.PATCH_VERSION_KEY
+
+/**
+ * Maintains the state for the patch ID and patch version attributes. These are set once by the
+ * React Native SDK when it initializes and are attached to every event and span generated after
+ * that point, including native events. The values are held in memory only and are not persisted
+ * across app restarts.
+ */
+internal class PatchAttributeProcessor : AttributeProcessor {
+    private var patchId: String? = null
+    private var patchVersion: String? = null
+
+    override fun appendAttributes(attributes: MutableMap<String, Any?>) {
+        patchId?.let { attributes[PATCH_ID_KEY] = it }
+        patchVersion?.let { attributes[PATCH_VERSION_KEY] = it }
+    }
+
+    fun setPatch(patchId: String, patchVersion: String?) {
+        this.patchId = patchId
+        this.patchVersion = patchVersion
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/attributes/PatchAttributeProcessorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/attributes/PatchAttributeProcessorTest.kt
@@ -1,0 +1,42 @@
+package sh.measure.android.attributes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import sh.measure.android.attributes.Attribute.PATCH_ID_KEY
+import sh.measure.android.attributes.Attribute.PATCH_VERSION_KEY
+
+class PatchAttributeProcessorTest {
+    private val patchAttributeProcessor = PatchAttributeProcessor()
+
+    @Test
+    fun `does not append patch attributes when patch is not set`() {
+        val attributes = mutableMapOf<String, Any?>()
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        assertNull(attributes[PATCH_ID_KEY])
+        assertNull(attributes[PATCH_VERSION_KEY])
+    }
+
+    @Test
+    fun `appends patch id and version to attributes once set`() {
+        patchAttributeProcessor.setPatch("patch-id", "v1.0.3-hotfix")
+
+        val attributes = mutableMapOf<String, Any?>()
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        assertEquals("patch-id", attributes[PATCH_ID_KEY])
+        assertEquals("v1.0.3-hotfix", attributes[PATCH_VERSION_KEY])
+    }
+
+    @Test
+    fun `appends patch id without version when version is not set`() {
+        patchAttributeProcessor.setPatch("patch-id", null)
+
+        val attributes = mutableMapOf<String, Any?>()
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        assertEquals("patch-id", attributes[PATCH_ID_KEY])
+        assertNull(attributes[PATCH_VERSION_KEY])
+    }
+}

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		526D182D2D5A1913009A2E90 /* InstallationIdAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A12D5A1913009A2E90 /* InstallationIdAttributeProcessor.swift */; };
 		526D182E2D5A1913009A2E90 /* NetworkStateAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A22D5A1913009A2E90 /* NetworkStateAttributeProcessor.swift */; };
 		526D182F2D5A1913009A2E90 /* UserAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A32D5A1913009A2E90 /* UserAttributeProcessor.swift */; };
+		BA50390E3E74F7E03BAFC26D /* PatchAttributeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB572ECF81AD8F28A0EA9BE /* PatchAttributeProcessor.swift */; };
 		526D18302D5A1913009A2E90 /* ConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A52D5A1913009A2E90 /* ConfigProvider.swift */; };
 		526D18312D5A1913009A2E90 /* ClientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A62D5A1913009A2E90 /* ClientInfo.swift */; };
 		526D18322D5A1913009A2E90 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17A72D5A1913009A2E90 /* Config.swift */; };
@@ -120,6 +121,7 @@
 		52B7F1352D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */; };
 		52B7F1362D757F81001498BC /* InstallationIdAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */; };
 		52B7F1372D757F81001498BC /* UserAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */; };
+		63EF5C2569D5F15F12CD4582 /* PatchAttributeProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D5BA19C6004B5314C8314 /* PatchAttributeProcessorTests.swift */; };
 		52B7F1382D757F81001498BC /* BaseConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E32D757F81001498BC /* BaseConfigProviderTests.swift */; };
 		52B7F1392D757F81001498BC /* BatchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E52D757F81001498BC /* BatchStoreTests.swift */; };
 		52B7F13A2D757F81001498BC /* DataCleanupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F0E62D757F81001498BC /* DataCleanupServiceTests.swift */; };
@@ -435,6 +437,7 @@
 		526D17A12D5A1913009A2E90 /* InstallationIdAttributeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstallationIdAttributeProcessor.swift; sourceTree = "<group>"; };
 		526D17A22D5A1913009A2E90 /* NetworkStateAttributeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkStateAttributeProcessor.swift; sourceTree = "<group>"; };
 		526D17A32D5A1913009A2E90 /* UserAttributeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAttributeProcessor.swift; sourceTree = "<group>"; };
+		4CB572ECF81AD8F28A0EA9BE /* PatchAttributeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchAttributeProcessor.swift; sourceTree = "<group>"; };
 		526D17A52D5A1913009A2E90 /* ConfigProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigProvider.swift; sourceTree = "<group>"; };
 		526D17A62D5A1913009A2E90 /* ClientInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientInfo.swift; sourceTree = "<group>"; };
 		526D17A72D5A1913009A2E90 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -530,6 +533,7 @@
 		52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComputeOnceAttributeProcessorTests.swift; sourceTree = "<group>"; };
 		52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstallationIdAttributeProcessorTests.swift; sourceTree = "<group>"; };
 		52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAttributeProcessorTests.swift; sourceTree = "<group>"; };
+		3F0D5BA19C6004B5314C8314 /* PatchAttributeProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchAttributeProcessorTests.swift; sourceTree = "<group>"; };
 		52B7F0E32D757F81001498BC /* BaseConfigProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseConfigProviderTests.swift; sourceTree = "<group>"; };
 		52B7F0E52D757F81001498BC /* BatchStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchStoreTests.swift; sourceTree = "<group>"; };
 		52B7F0E62D757F81001498BC /* DataCleanupServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCleanupServiceTests.swift; sourceTree = "<group>"; };
@@ -850,6 +854,7 @@
 				526D17A02D5A1913009A2E90 /* DeviceAttributeProcessor.swift */,
 				526D17A12D5A1913009A2E90 /* InstallationIdAttributeProcessor.swift */,
 				526D17A22D5A1913009A2E90 /* NetworkStateAttributeProcessor.swift */,
+				4CB572ECF81AD8F28A0EA9BE /* PatchAttributeProcessor.swift */,
 				CF35CE082F559E4D006D7A0D /* SessionAttributeProcessor.swift */,
 				526D17A32D5A1913009A2E90 /* UserAttributeProcessor.swift */,
 			);
@@ -1167,6 +1172,7 @@
 				52B7F0DF2D757F81001498BC /* ComputeOnceAttributeProcessorTests.swift */,
 				CFE1A0012FD000010000AA01 /* ExpoAttributeTests.swift */,
 				52B7F0E02D757F81001498BC /* InstallationIdAttributeProcessorTests.swift */,
+				3F0D5BA19C6004B5314C8314 /* PatchAttributeProcessorTests.swift */,
 				52B7F0E12D757F81001498BC /* UserAttributeProcessorTests.swift */,
 			);
 			path = Attribute;
@@ -2023,6 +2029,7 @@
 				526D183C2D5A1913009A2E90 /* DataCleanupService.swift in Sources */,
 				CF893DD52E950BF000D99D45 /* EventToAttachmentMigrationPolicy.swift in Sources */,
 				526D182F2D5A1913009A2E90 /* UserAttributeProcessor.swift in Sources */,
+				BA50390E3E74F7E03BAFC26D /* PatchAttributeProcessor.swift in Sources */,
 				526D18482D5A1913009A2E90 /* CustomEventCollector.swift in Sources */,
 				AB10C0022F62000000000002 /* LogData.swift in Sources */,
 				AB10C0042F62000000000004 /* LogSeverity.swift in Sources */,
@@ -2062,6 +2069,7 @@
 				CF1BB4F52DDEFCCB00588506 /* ShakeBugReportCollectorTests.swift in Sources */,
 				CFD88D792DAFDA530095115E /* MockSpanStore.swift in Sources */,
 				52B7F1372D757F81001498BC /* UserAttributeProcessorTests.swift in Sources */,
+				63EF5C2569D5F15F12CD4582 /* PatchAttributeProcessorTests.swift in Sources */,
 				CFF77E672FB6CEE600564FDA /* AttachmentProcessorTests.swift in Sources */,
 				CF123F8B2FAA121C0053856F /* MsrObjCSpanBuilderTests.swift in Sources */,
 				CF123F8C2FAA121C0053856F /* MsrObjCSpanTests.swift in Sources */,

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -371,6 +371,7 @@ extension Measure.Measure {
   @objc public static func trackScreenView(_ screenName: Swift.String, attributes: [Swift.String : Any]?)
   @objc public static func setUserId(_ userId: Swift.String)
   @objc public static func clearUserId()
+  @objc public static func internalSetPatch(_ patchId: Swift.String, patchVersion: Swift.String?)
   @objc public static func getCurrentTime() -> Swift.Int64
   public static func startSpan(name: Swift.String) -> any Measure.Span
   public static func startSpan(name: Swift.String, timestamp: Swift.Int64) -> any Measure.Span

--- a/ios/Sources/MeasureSDK/Swift/Attribute/PatchAttributeProcessor.swift
+++ b/ios/Sources/MeasureSDK/Swift/Attribute/PatchAttributeProcessor.swift
@@ -1,0 +1,25 @@
+//
+//  PatchAttributeProcessor.swift
+//  MeasureSDK
+//
+
+import Foundation
+
+/// Maintains the state for the patch ID and patch version attributes. These are set once by the
+/// React Native SDK when it initializes and are attached to every event and span generated after
+/// that point, including native events. The values are held in memory only and are not persisted
+/// across app launches.
+final class PatchAttributeProcessor: AttributeProcessor {
+    private var patchId: String?
+    private var patchVersion: String?
+
+    func appendAttributes(_ attributes: Attributes) {
+        attributes.patchId = patchId
+        attributes.patchVersion = patchVersion
+    }
+
+    func setPatch(_ patchId: String, patchVersion: String?) {
+        self.patchId = patchId
+        self.patchVersion = patchVersion
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/Measure.swift
+++ b/ios/Sources/MeasureSDK/Swift/Measure.swift
@@ -182,6 +182,11 @@ import UIKit
         measureInternal.clearUserId()
     }
 
+    @objc func internalSetPatch(_ patchId: String, patchVersion: String?) {
+        guard let measureInternal = measureInternal else { return }
+        measureInternal.internalSetPatch(patchId, patchVersion: patchVersion)
+    }
+
     @objc func getCurrentTime() -> Int64 {
         guard let measureInternal = self.measureInternal else { return 0 }
         return measureInternal.timeProvider.now()
@@ -713,6 +718,21 @@ extension Measure {
     /// ```
     @objc public static func clearUserId() {
         Measure.shared.clearUserId()
+    }
+
+    /// An internal method that sets the patch ID and, optionally, the patch version for the
+    /// current app instance. These are attached as attributes to every event and span generated
+    /// after this point. This method is not intended for public usage.
+    ///
+    /// This is used internally by the React Native SDK to propagate the patch identifiers of an
+    /// OTA update to the native SDK. The value is held in memory only and is not persisted across
+    /// app launches.
+    ///
+    /// - Parameters:
+    ///   - patchId: The patch ID string.
+    ///   - patchVersion: An optional, human-readable patch version label.
+    @objc public static func internalSetPatch(_ patchId: String, patchVersion: String?) {
+        Measure.shared.internalSetPatch(patchId, patchVersion: patchVersion)
     }
 
     /// Returns the current time in milliseconds since epoch.

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -23,6 +23,7 @@ protocol MeasureInitializer {
     var installationIdAttributeProcessor: InstallationIdAttributeProcessor { get }
     var networkStateAttributeProcessor: NetworkStateAttributeProcessor { get }
     var userAttributeProcessor: UserAttributeProcessor { get }
+    var patchAttributeProcessor: PatchAttributeProcessor { get }
     var sessionAttributeProcessor: SessionAttributeProcessor { get }
     var attributeProcessors: [AttributeProcessor] { get }
     var signalProcessor: SignalProcessor { get }
@@ -160,6 +161,7 @@ final class BaseMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
     let installationIdAttributeProcessor: InstallationIdAttributeProcessor
     let networkStateAttributeProcessor: NetworkStateAttributeProcessor
     let userAttributeProcessor: UserAttributeProcessor
+    let patchAttributeProcessor: PatchAttributeProcessor
     let sessionAttributeProcessor: SessionAttributeProcessor
     let attributeProcessors: [AttributeProcessor]
     let signalProcessor: SignalProcessor
@@ -280,12 +282,14 @@ final class BaseMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
         self.networkStateAttributeProcessor = NetworkStateAttributeProcessor(measureDispatchQueue: measureDispatchQueue)
         self.userAttributeProcessor = UserAttributeProcessor(userDefaultStorage: userDefaultStorage,
                                                              measureDispatchQueue: measureDispatchQueue)
+        self.patchAttributeProcessor = PatchAttributeProcessor()
         self.sessionAttributeProcessor = SessionAttributeProcessor(sessionManager: sessionManager, timeProvider: timeProvider)
         self.attributeProcessors = [appAttributeProcessor,
                                     deviceAttributeProcessor,
                                     installationIdAttributeProcessor,
                                     networkStateAttributeProcessor,
                                     userAttributeProcessor,
+                                    patchAttributeProcessor,
                                     sessionAttributeProcessor]
         self.crashDataPersistence = BaseCrashDataPersistence(logger: logger,
                                                              systemFileManager: systemFileManager)

--- a/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInternal.swift
@@ -50,6 +50,9 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
     private var userAttributeProcessor: UserAttributeProcessor {
         return measureInitializer.userAttributeProcessor
     }
+    private var patchAttributeProcessor: PatchAttributeProcessor {
+        return measureInitializer.patchAttributeProcessor
+    }
     private var userDefaultStorage: UserDefaultStorage {
         return measureInitializer.userDefaultStorage
     }
@@ -336,6 +339,10 @@ final class MeasureInternal { // swiftlint:disable:this type_body_length
 
     func clearUserId() {
         userAttributeProcessor.clearUserId()
+    }
+
+    func internalSetPatch(_ patchId: String, patchVersion: String?) {
+        patchAttributeProcessor.setPatch(patchId, patchVersion: patchVersion)
     }
 
     func createSpan(name: String) -> SpanBuilder? {

--- a/ios/Tests/MeasureSDKTests/Attribute/PatchAttributeProcessorTests.swift
+++ b/ios/Tests/MeasureSDKTests/Attribute/PatchAttributeProcessorTests.swift
@@ -1,0 +1,49 @@
+//
+//  PatchAttributeProcessorTests.swift
+//  MeasureSDKTests
+//
+
+import XCTest
+@testable import Measure
+
+final class PatchAttributeProcessorTests: XCTestCase {
+    private var patchAttributeProcessor: PatchAttributeProcessor!
+    private var attributes: Attributes!
+
+    override func setUp() {
+        super.setUp()
+        patchAttributeProcessor = PatchAttributeProcessor()
+        attributes = Attributes()
+    }
+
+    override func tearDown() {
+        patchAttributeProcessor = nil
+        attributes = nil
+        super.tearDown()
+    }
+
+    func testDoesNotAppendPatchAttributesWhenPatchIsNotSet() {
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        XCTAssertNil(attributes.patchId)
+        XCTAssertNil(attributes.patchVersion)
+    }
+
+    func testAppendsPatchIdAndVersionToAttributesOnceSet() {
+        patchAttributeProcessor.setPatch("patch-id", patchVersion: "v1.0.3-hotfix")
+
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        XCTAssertEqual("patch-id", attributes.patchId)
+        XCTAssertEqual("v1.0.3-hotfix", attributes.patchVersion)
+    }
+
+    func testAppendsPatchIdWithoutVersionWhenVersionIsNotSet() {
+        patchAttributeProcessor.setPatch("patch-id", patchVersion: nil)
+
+        patchAttributeProcessor.appendAttributes(attributes)
+
+        XCTAssertEqual("patch-id", attributes.patchId)
+        XCTAssertNil(attributes.patchVersion)
+    }
+}

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -24,6 +24,7 @@ final class MockMeasureInitializer: MeasureInitializer {
     let installationIdAttributeProcessor: InstallationIdAttributeProcessor
     let networkStateAttributeProcessor: NetworkStateAttributeProcessor
     let userAttributeProcessor: UserAttributeProcessor
+    let patchAttributeProcessor: PatchAttributeProcessor
     let sessionAttributeProcessor: SessionAttributeProcessor
     let attributeProcessors: [AttributeProcessor]
     let signalProcessor: SignalProcessor
@@ -126,6 +127,7 @@ final class MockMeasureInitializer: MeasureInitializer {
          networkStateAttributeProcessor: NetworkStateAttributeProcessor? = nil,
          sessionAttributeProcessor: SessionAttributeProcessor? = nil,
          userAttributeProcessor: UserAttributeProcessor? = nil,
+         patchAttributeProcessor: PatchAttributeProcessor? = nil,
          randomizer: Randomizer? = nil,
          spanProcessor: SpanProcessor? = nil,
          spanCollector: SpanCollector? = nil,
@@ -194,6 +196,7 @@ final class MockMeasureInitializer: MeasureInitializer {
         self.networkStateAttributeProcessor = networkStateAttributeProcessor ?? NetworkStateAttributeProcessor(measureDispatchQueue: self.measureDispatchQueue)
         self.userAttributeProcessor = userAttributeProcessor ?? UserAttributeProcessor(userDefaultStorage: self.userDefaultStorage,
                                                              measureDispatchQueue: self.measureDispatchQueue)
+        self.patchAttributeProcessor = patchAttributeProcessor ?? PatchAttributeProcessor()
         self.sessionAttributeProcessor = sessionAttributeProcessor ?? SessionAttributeProcessor(sessionManager: self.sessionManager, timeProvider: self.timeProvider)
         self.attributeProcessors = [
             self.appAttributeProcessor,
@@ -201,6 +204,7 @@ final class MockMeasureInitializer: MeasureInitializer {
             self.installationIdAttributeProcessor,
             self.networkStateAttributeProcessor,
             self.userAttributeProcessor,
+            self.patchAttributeProcessor,
             self.sessionAttributeProcessor
         ]
         self.crashDataPersistence = crashDataPersistence ?? BaseCrashDataPersistence(logger: logger ?? MockLogger(),

--- a/react-native/android/build.gradle.kts
+++ b/react-native/android/build.gradle.kts
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     implementation("com.facebook.react:react-native:+")
-    api("sh.measure:measure-android:0.20.0")
+    api("sh.measure:measure-android:0.21.0-SNAPSHOT")
 }

--- a/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
+++ b/react-native/android/src/main/java/sh/measure/rn/MeasureModule.kt
@@ -167,6 +167,16 @@ class MeasureModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun internalSetPatch(patchId: String, patchVersion: String?, promise: Promise) {
+        try {
+            Measure.internalSetPatch(patchId, patchVersion)
+            promise.resolve("Patch set successfully")
+        } catch (e: Exception) {
+            promise.reject("SET_PATCH_ERROR", "Failed to set patch", e)
+        }
+    }
+
+    @ReactMethod
     fun getSessionId(promise: Promise) {
         try {
             val sessionId = Measure.getSessionId()

--- a/react-native/ios/ObjC/MeasureModuleBridge.m
+++ b/react-native/ios/ObjC/MeasureModuleBridge.m
@@ -38,6 +38,10 @@ RCT_EXTERN_METHOD(setUserId:(NSString *)userId
                   rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(clearUserId:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(internalSetPatch:(NSString *)patchId
+                  patchVersion:(NSString * _Nullable)patchVersion
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(trackHttpEvent:
                   (NSString *)url
                   method:(NSString *)method

--- a/react-native/ios/Swift/MeasureModule.swift
+++ b/react-native/ios/Swift/MeasureModule.swift
@@ -114,6 +114,15 @@ class MeasureModule: NSObject, RCTBridgeModule {
         resolve("User ID cleared successfully")
     }
 
+    @objc(internalSetPatch:patchVersion:resolver:rejecter:)
+    func internalSetPatch(_ patchId: NSString,
+                  patchVersion: NSString?,
+                  resolver resolve: @escaping RCTPromiseResolveBlock,
+                  rejecter reject: @escaping RCTPromiseRejectBlock) {
+        Measure.internalSetPatch(patchId as String, patchVersion: patchVersion as String?)
+        resolve("Patch set successfully")
+    }
+
     @objc(trackHttpEvent:method:startTime:endTime:statusCode:error:requestHeaders:responseHeaders:requestBody:responseBody:client:resolver:rejecter:)
     func trackHttpEvent(
         url: String,

--- a/react-native/src/__tests__/measureInternal.test.ts
+++ b/react-native/src/__tests__/measureInternal.test.ts
@@ -26,6 +26,7 @@ function makeMockInitializer() {
   return {
     logger: { internalLog: jest.fn(), log: jest.fn() },
     signalProcessor: { setFrameworkAttributes: jest.fn() },
+    nativeApiProcessor: { internalSetPatch: jest.fn() },
     configLoader: { loadDynamicConfig: jest.fn(() => Promise.resolve(null)) },
     configProvider: { setDynamicConfig: jest.fn() },
     spanProcessor: { onConfigLoaded: jest.fn() },
@@ -251,7 +252,18 @@ describe('MeasureInternal.init framework attributes', () => {
     });
   });
 
-  it('combines Expo attributes with the OTA patch identifiers', async () => {
+  it('does not set patch on the native SDK when neither config nor Metro provide one', async () => {
+    const initializer = makeMockInitializer();
+    const sdk = new MeasureInternal(initializer);
+
+    await sdk.init({ config: { autoStart: false } as any });
+
+    expect(
+      initializer.nativeApiProcessor.internalSetPatch
+    ).not.toHaveBeenCalled();
+  });
+
+  it('sets patch id and version on the native SDK, separately from Expo attributes', async () => {
     (collectExpoAttributes as jest.Mock).mockReturnValue({
       expo_update_id: 'update-id',
     });
@@ -270,27 +282,10 @@ describe('MeasureInternal.init framework attributes', () => {
       initializer.signalProcessor.setFrameworkAttributes
     ).toHaveBeenCalledWith({
       expo_update_id: 'update-id',
-      patch_id: 'patch-id',
-      patch_version: 'v1.0.3-hotfix',
     });
-  });
-
-  it('keeps expo_update_id and patch_id separate', async () => {
-    (collectExpoAttributes as jest.Mock).mockReturnValue({
-      expo_update_id: 'update-id',
-    });
-    const initializer = makeMockInitializer();
-    const sdk = new MeasureInternal(initializer);
-
-    await sdk.init({
-      config: { autoStart: false, patchId: 'patch-id' } as any,
-    });
-
-    const attributes = (
-      initializer.signalProcessor.setFrameworkAttributes as jest.Mock
-    ).mock.calls[0][0];
-    expect(attributes.expo_update_id).toBe('update-id');
-    expect(attributes.patch_id).toBe('patch-id');
+    expect(
+      initializer.nativeApiProcessor.internalSetPatch
+    ).toHaveBeenCalledWith('patch-id', 'v1.0.3-hotfix');
   });
 
   it('falls back to the Metro-injected patch id', async () => {
@@ -301,8 +296,8 @@ describe('MeasureInternal.init framework attributes', () => {
     await sdk.init({ config: { autoStart: false } as any });
 
     expect(
-      initializer.signalProcessor.setFrameworkAttributes
-    ).toHaveBeenCalledWith({ patch_id: 'metro-patch-id' });
+      initializer.nativeApiProcessor.internalSetPatch
+    ).toHaveBeenCalledWith('metro-patch-id', undefined);
   });
 
   it('prefers config.patchId over the Metro-injected patch id', async () => {
@@ -315,8 +310,8 @@ describe('MeasureInternal.init framework attributes', () => {
     });
 
     expect(
-      initializer.signalProcessor.setFrameworkAttributes
-    ).toHaveBeenCalledWith({ patch_id: 'config-patch-id' });
+      initializer.nativeApiProcessor.internalSetPatch
+    ).toHaveBeenCalledWith('config-patch-id', undefined);
   });
 
   it('sets framework attributes before starting the native SDK', async () => {

--- a/react-native/src/events/nativeApiProcessor.ts
+++ b/react-native/src/events/nativeApiProcessor.ts
@@ -1,9 +1,14 @@
-import { clearUserId, setUserId } from '../native/measureBridge';
+import {
+  clearUserId,
+  internalSetPatch,
+  setUserId,
+} from '../native/measureBridge';
 import type { Logger } from '../utils/logger';
 
 export interface INativeApiProcessor {
   setUserId(userId: string): void;
   clearUserId(): void;
+  internalSetPatch(patchId: string, patchVersion?: string): void;
 }
 
 export class NativeApiProcessor implements INativeApiProcessor {
@@ -49,6 +54,30 @@ export class NativeApiProcessor implements INativeApiProcessor {
       this.logger.log(
         'error',
         `[NativeApiProcessor] clearUserId threw synchronously: ${err}`
+      );
+    }
+  }
+
+  internalSetPatch(patchId: string, patchVersion?: string): void {
+    if (typeof patchId !== 'string' || patchId.trim().length === 0) {
+      this.logger.log(
+        'warning',
+        '[NativeApiProcessor] internalSetPatch called with invalid patchId.'
+      );
+      return;
+    }
+
+    try {
+      internalSetPatch(patchId, patchVersion).catch((err: any) => {
+        this.logger.log(
+          'error',
+          `[NativeApiProcessor] Failed to set patch in native SDK: ${err}`
+        );
+      });
+    } catch (err) {
+      this.logger.log(
+        'error',
+        `[NativeApiProcessor] internalSetPatch threw synchronously: ${err}`
       );
     }
   }

--- a/react-native/src/measureInternal.ts
+++ b/react-native/src/measureInternal.ts
@@ -17,9 +17,6 @@ import type { Span } from './tracing/span';
 import type { SpanBuilder } from './tracing/spanBuilder';
 import type { ValidAttributeValue } from './utils/attributeValueValidator';
 
-export const PATCH_ID_KEY = 'patch_id';
-export const PATCH_VERSION_KEY = 'patch_version';
-
 export class MeasureInternal {
   private measureInitializer: MeasureInitializer;
   private shakeHandler?: (() => void) | null;
@@ -74,24 +71,28 @@ export class MeasureInternal {
         this.measureInitializer.spanProcessor.onConfigLoaded();
       });
 
-    // Framework level attributes are attached to every RN-originated event and
-    // span by the signal processor, keeping them scoped to the React Native
-    // layer.
+    // Framework level attributes (e.g. Expo attributes) are attached to every
+    // RN-originated event and span by the signal processor, keeping them
+    // scoped to the React Native layer.
+    const frameworkAttributes: Record<string, any> = collectExpoAttributes();
+    if (Object.keys(frameworkAttributes).length > 0) {
+      this.measureInitializer.signalProcessor.setFrameworkAttributes(
+        frameworkAttributes
+      );
+    }
+
+    // patch_id/patch_version are set on the native SDK so they're attached to
+    // every event and span generated after this point, including native
+    // events, not just RN-originated ones.
     //
     // config.patchId takes priority (manual / CodePush approach).
     // Falls back to global.__measurePatchId injected by withMeasureConfig()
     // in metro.config.js (automated approach).
-    const frameworkAttributes: Record<string, any> = collectExpoAttributes();
     const patchId = config?.patchId ?? (global as any).__measurePatchId;
     if (patchId) {
-      frameworkAttributes[PATCH_ID_KEY] = patchId;
-    }
-    if (config?.patchVersion) {
-      frameworkAttributes[PATCH_VERSION_KEY] = config.patchVersion;
-    }
-    if (Object.keys(frameworkAttributes).length > 0) {
-      this.measureInitializer.signalProcessor.setFrameworkAttributes(
-        frameworkAttributes
+      this.measureInitializer.nativeApiProcessor.internalSetPatch(
+        patchId,
+        config?.patchVersion
       );
     }
 

--- a/react-native/src/native/measureBridge.ts
+++ b/react-native/src/native/measureBridge.ts
@@ -136,6 +136,18 @@ export function clearUserId(): Promise<any> {
   return MeasureModule.clearUserId();
 }
 
+export function internalSetPatch(
+  patchId: string,
+  patchVersion?: string
+): Promise<any> {
+  if (!MeasureModule.internalSetPatch || isDisabled()) {
+    return Promise.reject(
+      new Error('internalSetPatch native method not available.')
+    );
+  }
+  return MeasureModule.internalSetPatch(patchId, patchVersion ?? null);
+}
+
 export function trackHttpEvent(
   url: string,
   method: string,


### PR DESCRIPTION
# Description

This PR contains below changes:

- Attach `patch_id` and `patch_version` to native SDK events
- Add `PatchAttributeProcessor` on Android and iOS
- Remove JS-only framework-attribute patch injection

`patch_id` and `patch_version` attributes will only be applied to native events that are triggered after react native initialises the measure package.

## Related issue
Closes #4403 