### PR TITLE
ci: bind workflow expressions to env to stop shell injection

### DIFF
--- a/.github/workflows/android-prepare-next.yml
+++ b/.github/workflows/android-prepare-next.yml
@@ -37,31 +37,41 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
             echo "Error: Version must match pattern x.y.z-SNAPSHOT (e.g. 1.2.3-SNAPSHOT)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_VERSION_NAME=.*/MEASURE_VERSION_NAME=${{ inputs.version }}/" gradle.properties
+          sed -i "s/MEASURE_VERSION_NAME=.*/MEASURE_VERSION_NAME=$VERSION/" gradle.properties
 
       - name: Update version in plugin libs.versions.toml
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           PATTERN="measure-android = \".*\""
-          REPLACEMENT="measure-android = \"${{ inputs.version }}\""
+          REPLACEMENT="measure-android = \"$VERSION\""
           sed -i "s/$PATTERN/$REPLACEMENT/" ../measure-gradle-plugin/gradle/libs.versions.toml
 
       - name: Update measure-android version in React Native SDK
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s|compileOnly(\"sh.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../react-native/android/build.gradle.kts
-          sed -i "s|implementation(\"sh.measure:measure-android:[^\"]*\")|implementation(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../react-native/example/rnExample/android/app/build.gradle
+          sed -i "s|compileOnly(\"sh.measure:measure-android:[^\"]*\")|compileOnly(\"sh.measure:measure-android:$VERSION\")|" ../../react-native/android/build.gradle.kts
+          sed -i "s|implementation(\"sh.measure:measure-android:[^\"]*\")|implementation(\"sh.measure:measure-android:$VERSION\")|" ../../react-native/example/rnExample/android/app/build.gradle
 
       - name: Update measure-android version in Flutter SDK
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s|api(\"sh.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:${{ inputs.version }}\")|" ../../flutter/packages/measure_flutter/android/build.gradle
+          sed -i "s|api(\"sh.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:$VERSION\")|" ../../flutter/packages/measure_flutter/android/build.gradle
 
       - name: Verify changes
         run: |

--- a/.github/workflows/android-prepare-release.yml
+++ b/.github/workflows/android-prepare-release.yml
@@ -41,25 +41,33 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
             echo "Error: Version must match semantic versioning pattern:"
             echo "  - x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_VERSION_NAME=.*/MEASURE_VERSION_NAME=${{ inputs.version }}/" gradle.properties
+          sed -i "s/MEASURE_VERSION_NAME=.*/MEASURE_VERSION_NAME=$VERSION/" gradle.properties
 
       - name: Update version in plugin libs.versions.toml
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/measure-android = \".*\"/measure-android = \"${{ inputs.version }}\"/" ../measure-gradle-plugin/gradle/libs.versions.toml
+          sed -i "s/measure-android = \".*\"/measure-android = \"$VERSION\"/" ../measure-gradle-plugin/gradle/libs.versions.toml
 
       - name: Update MEASURE_ANDROID_VERSION in KMP gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=${{ inputs.version }}/" ../../kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=$VERSION/" ../../kmp/measure-kmp/gradle.properties
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -68,10 +76,12 @@ jobs:
           args: --output android/measure-android/CHANGELOG.md --tag android-v${{ inputs.version }}
 
       - name: Update SDK version in getting started docs
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           cd ../../frontend/dashboard/content/docs
           KOTLIN_PATTERN='implementation("sh.measure:measure-android:.*")'
-          KOTLIN_REPLACEMENT='implementation("sh.measure:measure-android:${{ inputs.version }}")'
+          KOTLIN_REPLACEMENT="implementation(\"sh.measure:measure-android:$VERSION\")"
           sed -i "s/$KOTLIN_PATTERN/$KOTLIN_REPLACEMENT/" getting-started/android.mdx
 
       - name: Create Pull Request

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -59,20 +59,22 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.release-notes.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
-            --notes "${{ steps.release-notes.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag
 
       - name: Extract release metadata from PR
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           BODY=$(gh pr list --state merged --head "$TAG" --json body --jq '.[0].body' || true)
           NEXT_VERSION=$(echo "$BODY" | grep -oP '(?<=NEXT_VERSION=)\S+' || true)
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
@@ -81,6 +83,7 @@ jobs:
         if: steps.meta.outputs.next_version != ''
         env:
           GH_TOKEN: ${{ secrets.SDK_RELEASE }}
+          NEXT_VERSION: ${{ steps.meta.outputs.next_version }}
         run: |
           gh workflow run "Prepare Next Android Version" \
-            -f version="${{ steps.meta.outputs.next_version }}"
+            -f version="$NEXT_VERSION"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,9 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Print the changelog
-        run: cat "${{ steps.git-cliff.outputs.changelog }}"
+        env:
+          CHANGELOG_FILE: ${{ steps.git-cliff.outputs.changelog }}
+        run: cat "$CHANGELOG_FILE"
 
       - name: Commit the changelog
         run: |

--- a/.github/workflows/flutter-prepare-next.yml
+++ b/.github/workflows/flutter-prepare-next.yml
@@ -43,20 +43,25 @@ jobs:
 
       - name: Update measure_flutter
         if: inputs.package == 'measure_flutter'
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_SNAPSHOT_VERSION: ${{ inputs.android_snapshot_version }}
         run: |
           # Bump pubspec version
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_flutter/pubspec.yaml
+          sed -i "s/^version: .*/version: $VERSION/" flutter/packages/measure_flutter/pubspec.yaml
 
           # Revert Android SDK to snapshot
-          if [ -n "${{ inputs.android_snapshot_version }}" ]; then
-            sed -i 's/api("sh.measure:measure-android:.*")/api("sh.measure:measure-android:${{ inputs.android_snapshot_version }}")/' flutter/packages/measure_flutter/android/build.gradle
+          if [ -n "$ANDROID_SNAPSHOT_VERSION" ]; then
+            sed -i "s/api(\"sh.measure:measure-android:.*\")/api(\"sh.measure:measure-android:$ANDROID_SNAPSHOT_VERSION\")/" flutter/packages/measure_flutter/android/build.gradle
           fi
 
       - name: Update measure_dio
         if: inputs.package == 'measure_dio'
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # Bump pubspec version
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_dio/pubspec.yaml
+          sed -i "s/^version: .*/version: $VERSION/" flutter/packages/measure_dio/pubspec.yaml
 
           # Restore dependency_overrides section
           if ! grep -q "dependency_overrides:" flutter/packages/measure_dio/pubspec.yaml; then
@@ -65,8 +70,10 @@ jobs:
 
       - name: Update measure_build
         if: inputs.package == 'measure_build'
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_build/pubspec.yaml
+          sed -i "s/^version: .*/version: $VERSION/" flutter/packages/measure_build/pubspec.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/flutter-prepare-release.yml
+++ b/.github/workflows/flutter-prepare-release.yml
@@ -54,25 +54,32 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must match pattern x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Validate measure_flutter inputs
         if: inputs.package == 'measure_flutter'
+        env:
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+          IOS_SDK_VERSION: ${{ inputs.ios_sdk_version }}
         run: |
-          if [ -z "${{ inputs.android_sdk_version }}" ] || [ -z "${{ inputs.ios_sdk_version }}" ]; then
+          if [ -z "$ANDROID_SDK_VERSION" ] || [ -z "$IOS_SDK_VERSION" ]; then
             echo "Error: android_sdk_version and ios_sdk_version are required for measure_flutter"
             exit 1
           fi
 
       - name: Validate measure_dio inputs
         if: inputs.package == 'measure_dio'
+        env:
+          MEASURE_FLUTTER_VERSION: ${{ inputs.measure_flutter_version }}
         run: |
-          if [ -z "${{ inputs.measure_flutter_version }}" ]; then
+          if [ -z "$MEASURE_FLUTTER_VERSION" ]; then
             echo "Error: measure_flutter_version is required for measure_dio"
             exit 1
           fi
@@ -80,32 +87,41 @@ jobs:
       # measure_flutter steps
       - name: Update measure_flutter versions
         if: inputs.package == 'measure_flutter'
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+          IOS_SDK_VERSION: ${{ inputs.ios_sdk_version }}
         run: |
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_flutter/pubspec.yaml
-          sed -i "s/\(s.version *= *\).*/\1'${{ inputs.version }}'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
-          sed -i 's/api("sh.measure:measure-android:.*")/api("sh.measure:measure-android:${{ inputs.android_sdk_version }}")/' flutter/packages/measure_flutter/android/build.gradle
-          sed -i "s|branch: \"ios-v[0-9.]*\"|branch: \"ios-v${{ inputs.ios_sdk_version }}\"|" flutter/packages/measure_flutter/ios/measure_flutter/Package.swift
-          sed -i "s/s.dependency 'measure-sh', '~> [0-9.]*'/s.dependency 'measure-sh', '~> ${{ inputs.ios_sdk_version }}'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
-          sed -i "s/measure_flutter: ^.*/measure_flutter: ^${{ inputs.version }}/" flutter/packages/measure_flutter/README.md
-          sed -i "s/measure_flutter: ^.*/measure_flutter: ^${{ inputs.version }}/" frontend/dashboard/content/docs/getting-started/flutter.mdx
-          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.android_sdk_version }}/" frontend/dashboard/content/docs/getting-started/flutter.mdx
-          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.ios_sdk_version }}/" frontend/dashboard/content/docs/getting-started/flutter.mdx
+          sed -i "s/^version: .*/version: $VERSION/" flutter/packages/measure_flutter/pubspec.yaml
+          sed -i "s/\(s.version *= *\).*/\1'$VERSION'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
+          sed -i "s/api(\"sh.measure:measure-android:.*\")/api(\"sh.measure:measure-android:$ANDROID_SDK_VERSION\")/" flutter/packages/measure_flutter/android/build.gradle
+          sed -i "s|branch: \"ios-v[0-9.]*\"|branch: \"ios-v$IOS_SDK_VERSION\"|" flutter/packages/measure_flutter/ios/measure_flutter/Package.swift
+          sed -i "s/s.dependency 'measure-sh', '~> [0-9.]*'/s.dependency 'measure-sh', '~> $IOS_SDK_VERSION'/" flutter/packages/measure_flutter/ios/measure_flutter.podspec
+          sed -i "s/measure_flutter: ^.*/measure_flutter: ^$VERSION/" flutter/packages/measure_flutter/README.md
+          sed -i "s/measure_flutter: ^.*/measure_flutter: ^$VERSION/" frontend/dashboard/content/docs/getting-started/flutter.mdx
+          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/$ANDROID_SDK_VERSION/" frontend/dashboard/content/docs/getting-started/flutter.mdx
+          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/$IOS_SDK_VERSION/" frontend/dashboard/content/docs/getting-started/flutter.mdx
 
       # measure_dio steps
       - name: Update measure_dio versions
         if: inputs.package == 'measure_dio'
+        env:
+          VERSION: ${{ inputs.version }}
+          MEASURE_FLUTTER_VERSION: ${{ inputs.measure_flutter_version }}
         run: |
           cd flutter/packages/measure_dio
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" pubspec.yaml
-          sed -i "s/measure_flutter: ^.*/measure_flutter: ^${{ inputs.measure_flutter_version }}/" pubspec.yaml
+          sed -i "s/^version: .*/version: $VERSION/" pubspec.yaml
+          sed -i "s/measure_flutter: ^.*/measure_flutter: ^$MEASURE_FLUTTER_VERSION/" pubspec.yaml
           sed -i '/^dependency_overrides:/,/^[^ ]/{ /^[^ ]/!d; /^dependency_overrides:/d }' pubspec.yaml
 
       # measure_build steps
       - name: Update measure_build versions
         if: inputs.package == 'measure_build'
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/^version: .*/version: ${{ inputs.version }}/" flutter/packages/measure_build/pubspec.yaml
-          sed -i "s/measure_build: ^.*/measure_build: ^${{ inputs.version }}/" flutter/packages/measure_build/README.md
+          sed -i "s/^version: .*/version: $VERSION/" flutter/packages/measure_build/pubspec.yaml
+          sed -i "s/measure_build: ^.*/measure_build: ^$VERSION/" flutter/packages/measure_build/README.md
 
       # Shared steps
       - name: Generate changelog

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Determine package from tag
         id: package
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           if [[ "$TAG" == measure_flutter-v* ]]; then
             echo "name=measure_flutter" >> $GITHUB_OUTPUT
             echo "path=flutter/packages/measure_flutter" >> $GITHUB_OUTPUT
@@ -47,13 +48,17 @@ jobs:
           channel: stable
 
       - name: Setup pub.dev credentials
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_DEV_CREDENTIALS }}
         run: |
           mkdir -p "$HOME/.config/dart"
-          echo '${{ secrets.PUB_DEV_CREDENTIALS }}' > "$HOME/.config/dart/pub-credentials.json"
+          printf '%s' "$PUB_CREDENTIALS" > "$HOME/.config/dart/pub-credentials.json"
 
       - name: Publish to pub.dev
+        env:
+          PACKAGE_PATH: ${{ steps.package.outputs.path }}
         run: |
-          cd ${{ steps.package.outputs.path }}
+          cd "$PACKAGE_PATH"
           dart pub publish --force
 
       - name: Generate release notes
@@ -68,20 +73,22 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.release-notes.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || '' }} \
-            --notes "${{ steps.release-notes.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag
 
       - name: Extract release metadata from PR
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           BODY=$(gh pr list --state merged --head "$TAG" --json body --jq '.[0].body' || true)
           NEXT_VERSION=$(echo "$BODY" | grep -oP '(?<=NEXT_VERSION=)\S+' || true)
           ANDROID_SNAPSHOT=$(echo "$BODY" | grep -oP '(?<=ANDROID_SNAPSHOT_VERSION=)\S+' || true)
@@ -92,11 +99,10 @@ jobs:
         if: steps.meta.outputs.next_version != ''
         env:
           GH_TOKEN: ${{ secrets.SDK_RELEASE }}
+          PACKAGE: ${{ steps.package.outputs.name }}
+          NEXT: ${{ steps.meta.outputs.next_version }}
+          ANDROID_SNAPSHOT: ${{ steps.meta.outputs.android_snapshot }}
         run: |
-          PACKAGE="${{ steps.package.outputs.name }}"
-          NEXT="${{ steps.meta.outputs.next_version }}"
-          ANDROID_SNAPSHOT="${{ steps.meta.outputs.android_snapshot }}"
-
           if [ "$PACKAGE" = "measure_flutter" ] && [ -n "$ANDROID_SNAPSHOT" ]; then
             gh workflow run "Prepare Next Flutter Version" \
               -f package="$PACKAGE" \

--- a/.github/workflows/gradle-plugin-prepare-next.yml
+++ b/.github/workflows/gradle-plugin-prepare-next.yml
@@ -37,16 +37,20 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
             echo "Error: Version must match pattern x.y.z-SNAPSHOT (e.g. 1.2.3-SNAPSHOT)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_PLUGIN_VERSION_NAME=.*/MEASURE_PLUGIN_VERSION_NAME=${{ inputs.version }}/" gradle.properties
+          sed -i "s/MEASURE_PLUGIN_VERSION_NAME=.*/MEASURE_PLUGIN_VERSION_NAME=$VERSION/" gradle.properties
 
       - name: Print changes
         run: |

--- a/.github/workflows/gradle-plugin-prepare-release.yml
+++ b/.github/workflows/gradle-plugin-prepare-release.yml
@@ -41,17 +41,21 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
             echo "Error: Version must match semantic versioning pattern:"
             echo "  - x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_PLUGIN_VERSION_NAME=.*/MEASURE_PLUGIN_VERSION_NAME=${{ inputs.version }}/" gradle.properties
+          sed -i "s/MEASURE_PLUGIN_VERSION_NAME=.*/MEASURE_PLUGIN_VERSION_NAME=$VERSION/" gradle.properties
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -60,10 +64,12 @@ jobs:
           args: --output android/measure-gradle-plugin/CHANGELOG.md --tag android-gradle-plugin-v${{ inputs.version }}
 
       - name: Update plugin version in getting started docs
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           cd ../../frontend/dashboard/content/docs
           KOTLIN_PATTERN='id("sh.measure.android.gradle") version ".*"'
-          KOTLIN_REPLACEMENT='id("sh.measure.android.gradle") version "${{ inputs.version }}"'
+          KOTLIN_REPLACEMENT="id(\"sh.measure.android.gradle\") version \"$VERSION\""
           sed -i "s/$KOTLIN_PATTERN/$KOTLIN_REPLACEMENT/" getting-started/android.mdx
 
       - name: Create Pull Request

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -61,20 +61,22 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.release-notes.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
-            --notes "${{ steps.release-notes.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag
 
       - name: Extract release metadata from PR
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           BODY=$(gh pr list --state merged --head "$TAG" --json body --jq '.[0].body' || true)
           NEXT_VERSION=$(echo "$BODY" | grep -oP '(?<=NEXT_VERSION=)\S+' || true)
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
@@ -83,6 +85,7 @@ jobs:
         if: steps.meta.outputs.next_version != ''
         env:
           GH_TOKEN: ${{ secrets.SDK_RELEASE }}
+          NEXT_VERSION: ${{ steps.meta.outputs.next_version }}
         run: |
           gh workflow run "Prepare Next Android Gradle Plugin Version" \
-            -f version="${{ steps.meta.outputs.next_version }}"
+            -f version="$NEXT_VERSION"

--- a/.github/workflows/ios-prepare-release.yml
+++ b/.github/workflows/ios-prepare-release.yml
@@ -40,12 +40,14 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
             echo "Error: Version must match semantic versioning pattern:"
             echo "  - x.y.z (e.g. 1.2.3)"
             echo "  - x.y.z-alpha.N or x.y.z-beta.N"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
@@ -70,18 +72,24 @@ jobs:
             -parallel-testing-enabled NO
 
       - name: Update version in FrameworkInfo.swift
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i '' 's/static let version = ".*"/static let version = "${{ inputs.version }}"/' \
+          sed -i '' "s/static let version = \".*\"/static let version = \"$VERSION\"/" \
             ios/Sources/MeasureSDK/Swift/FrameworkInfo.swift
 
       - name: Update version in measure-sh.podspec
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -E -i '' 's/(spec\.version[[:space:]]*=[[:space:]]*")[^"]*/\1${{ inputs.version }}/' \
+          sed -E -i '' "s/(spec\.version[[:space:]]*=[[:space:]]*\")[^\"]*/\1$VERSION/" \
             measure-sh.podspec
 
       - name: Update version in docs
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -E -i '' 's|(\.package\(url: "https://github\.com/measure-sh/measure\.git", branch: "ios-v)[^"]*|\1${{ inputs.version }}|g' \
+          sed -E -i '' "s|(\.package\(url: \"https://github\.com/measure-sh/measure\.git\", branch: \"ios-v)[^\"]*|\1$VERSION|g" \
             frontend/dashboard/content/docs/getting-started/ios.mdx
 
       - name: Generate changelog

--- a/.github/workflows/kmp-prepare-next.yml
+++ b/.github/workflows/kmp-prepare-next.yml
@@ -30,16 +30,20 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate input version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
             echo "Error: Version must match pattern x.y.z-SNAPSHOT (e.g. 1.2.3-SNAPSHOT)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/MEASURE_KMP_VERSION_NAME=.*/MEASURE_KMP_VERSION_NAME=${{ inputs.version }}/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_KMP_VERSION_NAME=.*/MEASURE_KMP_VERSION_NAME=$VERSION/" kmp/measure-kmp/gradle.properties
 
       - name: Verify changes
         run: |

--- a/.github/workflows/kmp-prepare-release.yml
+++ b/.github/workflows/kmp-prepare-release.yml
@@ -42,21 +42,25 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_VERSION: ${{ inputs.android_version }}
+          IOS_VERSION: ${{ inputs.ios_version }}
         run: |
-          if ! [[ ${{ inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
-            echo "Error: version must match x.y.z or x.y.z-(alpha|beta).n. Got: ${{ inputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-((alpha|beta)\.[0-9]+))?$ ]]; then
+            echo "Error: version must match x.y.z or x.y.z-(alpha|beta).n. Got: $VERSION"
             exit 1
           fi
-          if ! [[ ${{ inputs.android_version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: android_version must match x.y.z. Got: ${{ inputs.android_version }}"
+          if ! [[ "$ANDROID_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: android_version must match x.y.z. Got: $ANDROID_VERSION"
             exit 1
           fi
-          if ! [[ ${{ inputs.ios_version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: ios_version must match x.y.z. Got: ${{ inputs.ios_version }}"
+          if ! [[ "$IOS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: ios_version must match x.y.z. Got: $IOS_VERSION"
             exit 1
           fi
           # The KMP release must pin published native versions to build against.
-          for tag in "android-v${{ inputs.android_version }}" "ios-v${{ inputs.ios_version }}"; do
+          for tag in "android-v$ANDROID_VERSION" "ios-v$IOS_VERSION"; do
             if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
               echo "Error: tag $tag does not exist."
               exit 1
@@ -64,22 +68,30 @@ jobs:
           done
 
       - name: Update version in gradle.properties
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_VERSION: ${{ inputs.android_version }}
+          IOS_VERSION: ${{ inputs.ios_version }}
         run: |
-          sed -i "s/MEASURE_KMP_VERSION_NAME=.*/MEASURE_KMP_VERSION_NAME=${{ inputs.version }}/" kmp/measure-kmp/gradle.properties
-          sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=${{ inputs.android_version }}/" kmp/measure-kmp/gradle.properties
-          sed -i "s/MEASURE_IOS_VERSION=.*/MEASURE_IOS_VERSION=${{ inputs.ios_version }}/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_KMP_VERSION_NAME=.*/MEASURE_KMP_VERSION_NAME=$VERSION/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_ANDROID_VERSION=.*/MEASURE_ANDROID_VERSION=$ANDROID_VERSION/" kmp/measure-kmp/gradle.properties
+          sed -i "s/MEASURE_IOS_VERSION=.*/MEASURE_IOS_VERSION=$IOS_VERSION/" kmp/measure-kmp/gradle.properties
 
       - name: Update version in getting started docs
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_VERSION: ${{ inputs.android_version }}
+          IOS_VERSION: ${{ inputs.ios_version }}
         run: |
           # The onboarding snippet in the dashboard reads this version at build
           # time (scripts/extract_sdk_versions.js), so keep it in sync here.
           GUIDE=frontend/dashboard/content/docs/getting-started/kotlin-multiplatform.mdx
           KOTLIN_PATTERN='implementation("sh.measure:measure-kmp:.*")'
-          KOTLIN_REPLACEMENT='implementation("sh.measure:measure-kmp:${{ inputs.version }}")'
+          KOTLIN_REPLACEMENT="implementation(\"sh.measure:measure-kmp:$VERSION\")"
           sed -i "s/$KOTLIN_PATTERN/$KOTLIN_REPLACEMENT/" "$GUIDE"
-          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.android_version }}/" "$GUIDE"
-          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.ios_version }}/" "$GUIDE"
-          sed -i -E 's|(\.package\(url: "https://github\.com/measure-sh/measure\.git", branch: "ios-v)[^"]*|\1${{ inputs.ios_version }}|' "$GUIDE"
+          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/$ANDROID_VERSION/" "$GUIDE"
+          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/$IOS_VERSION/" "$GUIDE"
+          sed -i -E "s|(\.package\(url: \"https://github\.com/measure-sh/measure\.git\", branch: \"ios-v)[^\"]*|\1$IOS_VERSION|" "$GUIDE"
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4

--- a/.github/workflows/kmp-release.yml
+++ b/.github/workflows/kmp-release.yml
@@ -86,20 +86,22 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.release-notes.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
-            --notes "${{ steps.release-notes.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag
 
       - name: Extract release metadata from PR
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           BODY=$(gh pr list --state merged --head "$TAG" --json body --jq '.[0].body' || true)
           NEXT_VERSION=$(echo "$BODY" | grep -oP '(?<=NEXT_VERSION=)\S+' || true)
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
@@ -108,6 +110,7 @@ jobs:
         if: steps.meta.outputs.next_version != ''
         env:
           GH_TOKEN: ${{ secrets.SDK_RELEASE }}
+          NEXT_VERSION: ${{ steps.meta.outputs.next_version }}
         run: |
           gh workflow run kmp-prepare-next.yml \
-            -f version="${{ steps.meta.outputs.next_version }}"
+            -f version="$NEXT_VERSION"

--- a/.github/workflows/react-native-prepare-release.yml
+++ b/.github/workflows/react-native-prepare-release.yml
@@ -42,20 +42,26 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must match pattern x.y.z (e.g. 1.2.3)"
-            echo "Got: ${{ inputs.version }}"
+            echo "Got: $VERSION"
             exit 1
           fi
 
       - name: Update package.json version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          jq --arg v "${{ inputs.version }}" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
+          jq --arg v "$VERSION" '.version = $v' react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
 
       - name: Pin Measure iOS SDK (SPM revision)
+        env:
+          IOS_SDK_VERSION: ${{ inputs.ios_sdk_version }}
         run: |
-          VER="${{ inputs.ios_sdk_version }}"
+          VER="$IOS_SDK_VERSION"
           URL="https://github.com/measure-sh/measure.git"
           # Resolve the commit the iOS release tag points to (no clone). Dereference annotated
           # tags with ^{}; fall back to the lightweight-tag form.
@@ -68,25 +74,37 @@ jobs:
             react-native/package.json > /tmp/pkg.json && mv /tmp/pkg.json react-native/package.json
 
       - name: Update android/build.gradle.kts
+        env:
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
         run: |
-          sed -i "s|api(\"sh\.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:${{ inputs.android_sdk_version }}\")| " react-native/android/build.gradle.kts
+          sed -i "s|api(\"sh\.measure:measure-android:[^\"]*\")|api(\"sh.measure:measure-android:$ANDROID_SDK_VERSION\")| " react-native/android/build.gradle.kts
 
       - name: Update plugin/index.js
+        env:
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+          ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version }}
         run: |
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/plugin/index.js
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/plugin/index.js
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:$ANDROID_GRADLE_PLUGIN_VERSION|g" react-native/plugin/index.js
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:$ANDROID_SDK_VERSION|g" react-native/plugin/index.js
 
       - name: Update react-native/README.md
+        env:
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+          ANDROID_GRADLE_PLUGIN_VERSION: ${{ inputs.android_gradle_plugin_version }}
         run: |
-          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:${{ inputs.android_sdk_version }}|g" react-native/README.md
-          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:${{ inputs.android_gradle_plugin_version }}|g" react-native/README.md
+          sed -i "s|sh\.measure:measure-android:[0-9]*\.[0-9]*\.[0-9]*|sh.measure:measure-android:$ANDROID_SDK_VERSION|g" react-native/README.md
+          sed -i "s|sh\.measure\.android\.gradle:sh\.measure\.android\.gradle\.gradle\.plugin:[0-9]*\.[0-9]*\.[0-9]*|sh.measure.android.gradle:sh.measure.android.gradle.gradle.plugin:$ANDROID_GRADLE_PLUGIN_VERSION|g" react-native/README.md
 
       - name: Update React Native getting started guide
+        env:
+          VERSION: ${{ inputs.version }}
+          ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+          IOS_SDK_VERSION: ${{ inputs.ios_sdk_version }}
         run: |
           GUIDE=frontend/dashboard/content/docs/getting-started/react-native.mdx
-          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@${{ inputs.version }}|g" "$GUIDE"
-          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.android_sdk_version }}/" "$GUIDE"
-          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/${{ inputs.ios_sdk_version }}/" "$GUIDE"
+          sed -i "s|@measuresh/react-native@[0-9]*\.[0-9]*\.[0-9]*|@measuresh/react-native@$VERSION|g" "$GUIDE"
+          sed -i "/^| Measure Android/ s/[0-9]*\.[0-9]*\.[0-9]*/$ANDROID_SDK_VERSION/" "$GUIDE"
+          sed -i "/^| Measure iOS/ s/[0-9]*\.[0-9]*\.[0-9]*/$IOS_SDK_VERSION/" "$GUIDE"
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4

--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -66,10 +66,12 @@ jobs:
         if: ${{ inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.release-notes.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --draft \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
-            --notes "${{ steps.release-notes.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.git-cliff.outputs.content }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             ${{ contains(github.ref_name, '-') && '--prerelease' || ''}} \
-            --notes "${{ steps.git-cliff.outputs.content }}" \
+            --notes "$NOTES" \
             --verify-tag


### PR DESCRIPTION
## Summary

This PR hardens the release workflows so that values expanded by GitHub Actions reach the shell as data rather than as script source. Action outputs, pull request body values & `workflow_dispatch` inputs are now bound in each step's `env:` block & read back as quoted variables, closing a command injection path into jobs that hold publishing credentials for Maven Central, the Gradle Plugin Portal, pub.dev & NPM.

## Tasks

- [x] Bind `git-cliff` release notes through `env:` in every release workflow
- [x] Bind tag & pull request body values used by the SDK release jobs
- [x] Bind `workflow_dispatch` inputs used in the version bump `sed` commands
- [x] Pass `PUB_DEV_CREDENTIALS` through `env:` with `printf`
- [x] Confirm the rendered commands stay byte identical
