### PR TITLE
refactor(frontend): keep expr filter state in the URL only

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import { useState } from "react";
+import type { ComponentProps } from "react";
 
-const mockUseAppsQuery = jest.fn();
 const mockUseFilterKeysQuery = jest.fn();
-const mockUseRootSpanNamesQuery = jest.fn();
 const mockToastNegative = jest.fn();
 
 jest.mock("@/app/components/toast", () => ({
@@ -15,26 +13,34 @@ jest.mock("@/app/components/toast", () => ({
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
   useFilterKeysQuery: (
     appId: string | undefined,
     entity: string,
     keyNames: string[],
   ) => mockUseFilterKeysQuery(appId, entity, keyNames),
-  useRootSpanNamesQuery: (app: unknown) => mockUseRootSpanNamesQuery(app),
 }));
 
-const { useStore } = jest.requireActual("zustand") as any;
-const { createFiltersStore } = jest.requireActual(
-  "@/app/stores/filters_store",
-) as any;
-
-let storeInstance: any;
-
-jest.mock("@/app/stores/provider", () => ({
+jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
-  useFiltersStore: (selector?: any) =>
-    useStore(storeInstance, selector ?? ((s: any) => s)),
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+jest.mock("@/app/components/dropdown_select", () => ({
+  __esModule: true,
+  DropdownSelectType: { SingleString: "SingleString" },
+  default: ({ items, initialSelected, onChangeSelected }: any) => (
+    <div data-testid="span-select" data-selected={initialSelected}>
+      {items.map((item: string) => (
+        <button
+          key={item}
+          data-testid={`pick-span-${item}`}
+          onClick={() => onChangeSelected(item)}
+        >
+          {item}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 jest.mock("@/app/components/filter_bar/app_select", () => ({
@@ -75,6 +81,18 @@ jest.mock("@/app/components/filter_bar/date_range_select", () => {
         >
           last week
         </button>
+        <button
+          data-testid="pick-custom-range"
+          onClick={() =>
+            onChange({
+              dateRange: "Custom Range",
+              startDate: "2026-02-01T00:00:00.000Z",
+              endDate: "2026-02-08T00:00:00.000Z",
+            })
+          }
+        >
+          custom
+        </button>
       </div>
     ),
   };
@@ -88,14 +106,13 @@ jest.mock("@/app/components/filter_bar/key_picker", () => ({
     selected,
     onSelect,
     onAddGroup,
+    onOpenChange,
     trigger,
     open,
   }: any) => (
     <div
       data-testid="key-picker"
       data-groups={keyGroups.join(",")}
-      // Only the picker for the whole filter is told when to open, so the
-      // attribute is absent on the pickers that open themselves.
       data-open={open === undefined ? undefined : String(open)}
     >
       {trigger}
@@ -103,14 +120,22 @@ jest.mock("@/app/components/filter_bar/key_picker", () => ({
         <button
           key={key.name}
           data-testid={`pick-key-${key.name}${selected ? "-in-row" : ""}`}
-          onClick={() => onSelect(key)}
+          onClick={() => {
+            onSelect(key);
+            onOpenChange?.(false);
+          }}
         >
-          {key.label}
+          pick {key.label}
         </button>
       ))}
       {onAddGroup && (
         <button data-testid="add-group" onClick={() => onAddGroup()}>
           group
+        </button>
+      )}
+      {onOpenChange && (
+        <button data-testid="close-keys" onClick={() => onOpenChange(false)}>
+          close
         </button>
       )}
     </div>
@@ -133,14 +158,29 @@ jest.mock("@/app/components/filter_bar/key_picker", () => ({
 
 jest.mock("@/app/components/filter_bar/value_picker", () => ({
   __esModule: true,
-  default: ({ onChange, trigger }: any) => (
-    <div data-testid="value-picker">
+  default: ({ selected, onChange, open, onOpenChange, trigger }: any) => (
+    <div data-testid="value-picker" data-open={String(open)}>
       {trigger}
       <button
         data-testid="pick-value"
-        onClick={() => onChange([{ text: "dsym" }])}
+        onClick={() => onChange([{ text: "dsym" }], false)}
       >
-        dsym
+        choose dsym
+      </button>
+      <button
+        data-testid="pick-another-value"
+        onClick={() => onChange([...selected, { text: "proguard" }], false)}
+      >
+        choose proguard
+      </button>
+      <button
+        data-testid="pick-one-value"
+        onClick={() => onChange([{ text: "dsym" }], true)}
+      >
+        choose dsym and finish
+      </button>
+      <button data-testid="close-values" onClick={() => onOpenChange(false)}>
+        close
       </button>
     </div>
   ),
@@ -148,11 +188,12 @@ jest.mock("@/app/components/filter_bar/value_picker", () => ({
 
 import type { App } from "@/app/api/api_calls";
 import type { FilterKey } from "@/app/api/filter_types";
-import { MAX_CONDITIONS } from "@/app/components/filter_bar/limits";
+import { toDateSelection } from "@/app/components/filter_bar/date_range_select";
 import FilterBar, {
-  type FilterRequest,
-  type FilterState,
+  type FilterChange,
+  type FilterSelection,
 } from "@/app/components/filter_bar/filter_bar";
+import { MAX_CONDITIONS } from "@/app/components/filter_bar/limits";
 
 const app = (id: string, name: string) => ({ id, name }) as App;
 const apps = [app("app-1", "Checkout"), app("app-2", "Wallet")];
@@ -164,7 +205,7 @@ const mappingTypeKey = {
   description: "The kind of mapping file",
   value_type: "string",
   value_suggestion_mode: "full_list",
-  operators: ["in", "not_in"],
+  operators: ["in", "not_in", "contains"],
 } as unknown as FilterKey;
 
 const versionKey = {
@@ -175,6 +216,16 @@ const versionKey = {
   value_type: "string",
   value_suggestion_mode: "full_list",
   operators: ["in", "not_in"],
+} as unknown as FilterKey;
+
+const patchKey = {
+  name: "patch_id",
+  label: "Patch",
+  key_group: "Build",
+  description: "Whether the build is a patch",
+  value_type: "string",
+  value_suggestion_mode: "none",
+  operators: ["is_set", "is_not_set"],
 } as unknown as FilterKey;
 
 // The server serves a user-defined attribute key with a `custom.` prefix on
@@ -199,98 +250,113 @@ const customPlanKey = {
   operators: ["in", "not_in", "contains"],
 } as unknown as FilterKey;
 
-function appsLoaded(loaded: App[] = apps) {
-  mockUseAppsQuery.mockReturnValue({
-    status: "success",
-    data: loaded,
-  } as any);
-}
+const keys = [mappingTypeKey, versionKey, patchKey];
+const keyGroups = ["Build", "Version"];
 
-function keysLoaded(
-  keys: FilterKey[] = [mappingTypeKey, versionKey],
-  keyGroups: string[] = ["Build", "Version"],
-) {
+function keysServed(served: FilterKey[] = keys) {
   mockUseFilterKeysQuery.mockReturnValue({
-    data: { keys, key_groups: keyGroups },
+    data: { keys: served, key_groups: keyGroups },
     isPending: false,
     isError: false,
-  } as any);
+  });
 }
 
-const nothingRequested = {
-  requestedAppId: null,
-  requestedDateRange: { dateRange: null, startDate: null, endDate: null },
-  requestedFilterExpr: null,
+const last6Hours = toDateSelection({
+  dateRange: "Last 6 Hours",
+  startDate: null,
+  endDate: null,
+})!;
+
+const settled: FilterSelection = {
+  app: apps[0],
+  date: last6Hours,
+  filterExpr: null,
+  rootSpanName: null,
+  discarded: false,
 };
 
-const propOfField = {
-  appId: "requestedAppId",
-  dateRange: "requestedDateRange",
-  filterExpr: "requestedFilterExpr",
-  rootSpanName: "requestedRootSpanName",
-} as const;
-
-// Stands in for the page. A pick is merged into the requested props, and a
-// new request from outside replaces it.
-function Host({
-  asked,
-  onFilterChange,
-}: {
-  asked: any;
-  onFilterChange: (state: FilterState) => void;
-}) {
-  const [pick, setPick] = useState<{ on: any; request: any } | null>(null);
-  const request = pick !== null && pick.on === asked ? pick.request : asked;
-
-  return (
-    <FilterBar
-      teamId="team-1"
-      entity="builds"
-      {...request}
-      onRequestChange={(change: Partial<FilterRequest>) =>
-        setPick({
-          on: asked,
-          request: {
-            ...request,
-            ...Object.fromEntries(
-              Object.entries(change).map(([field, value]) => [
-                propOfField[field as keyof FilterRequest],
-                value,
-              ]),
-            ),
-          },
-        })
-      }
-      onFilterChange={onFilterChange}
-    />
-  );
+function applyChange(
+  value: FilterSelection,
+  change: FilterChange,
+): FilterSelection {
+  return {
+    app:
+      change.appId === undefined
+        ? value.app
+        : apps.find((candidate) => candidate.id === change.appId)!,
+    date:
+      change.dateRange === undefined
+        ? value.date
+        : toDateSelection(change.dateRange)!,
+    filterExpr:
+      change.filterExpr === undefined ? value.filterExpr : change.filterExpr,
+    rootSpanName:
+      change.rootSpanName === undefined
+        ? value.rootSpanName
+        : change.rootSpanName,
+    discarded: false,
+  };
 }
 
-async function renderBar(props: any = {}) {
-  const onFilterChange = jest.fn();
-  const bar = (asked: any) => (
-    <Host
-      asked={{ ...nothingRequested, ...props, ...asked }}
-      onFilterChange={onFilterChange}
+type BarProps = Partial<ComponentProps<typeof FilterBar>>;
+
+async function renderBar(
+  initial: Partial<FilterSelection> | null = {},
+  props: BarProps = {},
+) {
+  let drawnValue: FilterSelection | null =
+    initial === null ? null : { ...settled, ...initial };
+  let liveValue = drawnValue;
+  let held = false;
+  let result!: ReturnType<typeof render>;
+  const onChange = jest.fn((change: FilterChange) => {
+    liveValue = applyChange(liveValue ?? settled, change);
+    if (!held) {
+      drawnValue = liveValue;
+      result.rerender(bar());
+    }
+  });
+  const bar = () => (
+    <FilterBar
+      entity="builds"
+      value={drawnValue}
+      apps={apps}
+      keys={keys}
+      keyGroups={keyGroups}
+      keysUnavailable={false}
+      onChange={onChange}
+      {...props}
     />
   );
 
-  let result: any;
   await act(async () => {
-    result = render(bar({}));
+    result = render(bar());
   });
 
-  const askAgain = async (asked: any) => {
+  const setValue = async (next: Partial<FilterSelection> | null) => {
+    drawnValue = next === null ? null : { ...(drawnValue ?? settled), ...next };
+    liveValue = drawnValue;
     await act(async () => {
-      result.rerender(bar(asked));
+      result.rerender(bar());
     });
   };
 
-  return { onFilterChange, ...result, askAgain };
+  const holdChanges = () => {
+    held = true;
+  };
+
+  const land = async () => {
+    drawnValue = liveValue;
+    await act(async () => {
+      result.rerender(bar());
+    });
+  };
+
+  return { onChange, setValue, holdChanges, land };
 }
 
-function lastState(onFilterChange: jest.Mock): FilterState {
-  const calls = onFilterChange.mock.calls as any[][];
+function lastChange(onChange: jest.Mock): FilterChange {
+  const calls = onChange.mock.calls as FilterChange[][];
   return calls[calls.length - 1][0];
 }
 
@@ -310,6 +376,10 @@ function wholeFilterPicker() {
 
 function groupPicker(group: HTMLElement) {
   return pickerOf(within(group).getByLabelText("Add a filter to this group"));
+}
+
+function valuePickers() {
+  return screen.queryAllByTestId("value-picker");
 }
 
 function marksInBar() {
@@ -332,266 +402,61 @@ async function addCondition(
 
 describe("FilterBar", () => {
   beforeEach(() => {
-    storeInstance = createFiltersStore();
-    appsLoaded();
-    keysLoaded();
-    // Most tests leave the root span selector off, so the bar passes null
-    // and the query stays in its disabled pending state.
-    mockUseRootSpanNamesQuery.mockReturnValue({
-      data: undefined,
-      isPending: true,
-      isError: false,
-      isSuccess: false,
-    });
+    keysServed();
+    mockUseFilterKeysQuery.mockClear();
     mockToastNegative.mockClear();
   });
 
-  describe("what it opens on", () => {
-    it("waits for the apps before reporting anything to filter by", async () => {
-      mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
-      const { onFilterChange } = await renderBar();
+  describe("what it draws", () => {
+    it("draws a skeleton until it has a value", async () => {
+      await renderBar(null);
 
-      expect(lastState(onFilterChange).status).toBe("pending");
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+      expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
     });
 
-    it("reports the app and range it settled on", async () => {
-      const { onFilterChange } = await renderBar();
+    it("draws a skeleton while the keys load", async () => {
+      await renderBar({}, { keys: null });
 
-      const state = lastState(onFilterChange);
-      expect(state).toMatchObject({ status: "ready", app: apps[0] });
-      expect(state.status === "ready" && state.date.dateRange).toBe(
-        "Last 6 Hours",
-      );
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+      expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
     });
 
-    it("takes the requested app", async () => {
-      const { onFilterChange } = await renderBar({ requestedAppId: "app-2" });
-
-      expect(lastState(onFilterChange)).toMatchObject({ app: apps[1] });
-    });
-
-    it("reports the request as applied when everything asked for is honoured", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedAppId: "app-2",
-        requestedDateRange: {
-          dateRange: "Last Week",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        appliedAsRequested: true,
-      });
-    });
-
-    it("keeps the app another page left on the store", async () => {
-      storeInstance.getState().setSelectedApp(apps[1]);
-      const { onFilterChange } = await renderBar();
-
-      expect(lastState(onFilterChange)).toMatchObject({ app: apps[1] });
-    });
-
-    it("toasts when the requested root span name is unknown to the app", async () => {
-      mockUseRootSpanNamesQuery.mockReturnValue({
-        data: ["checkout", "startup"],
-        isPending: false,
-        isError: false,
-        isSuccess: true,
-      });
-      const { onFilterChange } = await renderBar({
-        requestedAppId: "app-1",
-        showRootSpanSelector: true,
-        requestedRootSpanName: "gone",
-      });
-
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Some filters were invalid, page reset to defaults",
-      );
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        rootSpanName: "checkout",
-        appliedAsRequested: false,
-      });
-    });
-
-    it("resolves with no name when the app has never reported a trace", async () => {
-      mockUseRootSpanNamesQuery.mockReturnValue({
-        data: [],
-        isPending: false,
-        isError: false,
-        isSuccess: true,
-      });
-      const { onFilterChange } = await renderBar({
-        requestedAppId: "app-1",
-        showRootSpanSelector: true,
-      });
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        app: apps[0],
-        rootSpanName: null,
-        appliedAsRequested: true,
-      });
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("does not toast for a root span name with no requested app", async () => {
-      mockUseRootSpanNamesQuery.mockReturnValue({
-        data: ["checkout", "startup"],
-        isPending: false,
-        isError: false,
-        isSuccess: true,
-      });
-      // The link's name belongs to the app the link asked for; without a
-      // requested app the name is not judged against the selected app's list.
+    it("draws the app and range it is given", async () => {
       await renderBar({
-        showRootSpanSelector: true,
-        requestedRootSpanName: "gone",
-      });
-
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("ranks the requested app above the one another page left on the store", async () => {
-      storeInstance.getState().setSelectedApp(apps[1]);
-      const { onFilterChange } = await renderBar({ requestedAppId: "app-1" });
-
-      // Every ready state carries the requested app; a first report built
-      // from the remembered app would overwrite the link's app in the URL.
-      for (const [state] of onFilterChange.mock.calls) {
-        if (state.status === "ready") {
-          expect(state.app).toEqual(apps[0]);
-        }
-      }
-      expect(lastState(onFilterChange)).toMatchObject({ app: apps[0] });
-      expect(storeInstance.getState().selectedApp).toEqual(apps[0]);
-    });
-
-    it("falls back to the team's first app when the requested one is gone", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedAppId: "app-gone",
-      });
-
-      expect(lastState(onFilterChange)).toMatchObject({ app: apps[0] });
-    });
-
-    it("takes the requested range", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedDateRange: {
+        app: apps[1],
+        date: toDateSelection({
           dateRange: "Last Week",
           startDate: null,
           endDate: null,
-        },
+        })!,
       });
 
-      const state = lastState(onFilterChange);
-      expect(state.status === "ready" && state.date.dateRange).toBe(
+      expect(screen.getByTestId("app-select")).toHaveAttribute(
+        "data-selected",
+        "Wallet",
+      );
+      expect(screen.getByTestId("date-select")).toHaveAttribute(
+        "data-range",
         "Last Week",
       );
     });
 
-    it("keeps the stored range when the requested one cannot be read", async () => {
-      storeInstance.getState().setSelectedDateRange("Last 24 Hours");
-      const { onFilterChange } = await renderBar({
-        requestedDateRange: {
-          dateRange: "Last Fortnight",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      const state = lastState(onFilterChange);
-      expect(state.status === "ready" && state.date.dateRange).toBe(
-        "Last 24 Hours",
-      );
-    });
-
-    it("does not report the stored range before the requested one", async () => {
-      storeInstance.getState().setSelectedApp(apps[0]);
-      storeInstance.getState().setSelectedDateRange("Last 24 Hours");
-      const { onFilterChange } = await renderBar({
-        requestedDateRange: {
-          dateRange: "Last Week",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      const ranges = onFilterChange.mock.calls
-        .map(([state]: [FilterState]) => state)
-        .filter((state: FilterState) => state.status === "ready")
-        .map(
-          (state: FilterState & { status: "ready" }) => state.date.dateRange,
-        );
-      expect(ranges).toEqual(["Last Week"]);
-    });
-
-    it("puts the app and the range on the store for other pages", async () => {
-      await renderBar({ requestedAppId: "app-2" });
-
-      expect(storeInstance.getState().selectedApp).toEqual(apps[1]);
-      expect(storeInstance.getState().selectedDateRange).toBe("Last 6 Hours");
-    });
-  });
-
-  describe("when there is nothing to filter by", () => {
-    it("reports a team with no apps as an error", async () => {
-      appsLoaded([]);
-      const { onFilterChange } = await renderBar();
-
-      expect(lastState(onFilterChange)).toEqual({
-        status: "error",
-        message: expect.stringContaining("don't have any apps yet"),
-      });
-    });
-
-    it("reports an apps request that failed as an error", async () => {
-      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
-      const { onFilterChange } = await renderBar();
-
-      expect(lastState(onFilterChange)).toEqual({
-        status: "error",
-        message: expect.stringContaining("Error fetching apps"),
-      });
-    });
-
-    it("draws no message of its own", async () => {
-      appsLoaded([]);
-      await renderBar();
-
-      expect(screen.queryByText(/don't have any apps yet/)).toBeNull();
-      expect(screen.queryByTestId("filter-bar")).toBeNull();
-    });
-  });
-
-  describe("the requested expression", () => {
-    it("is drawn as conditions", async () => {
-      await renderBar({ requestedFilterExpr: "mapping_type:in:dsym" });
+    it("draws the filter as conditions", async () => {
+      await renderBar({ filterExpr: "mapping_type:in:dsym" });
 
       expect(screen.getByTestId("operator-picker")).toBeInTheDocument();
-      expect(screen.getByTestId("value-picker")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
       expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+      expect(screen.getByText("dsym")).toBeInTheDocument();
     });
 
-    it("stands in for the values an operator takes, one or many", async () => {
-      keysLoaded([
-        mappingTypeKey,
-        { ...versionKey, operators: ["contains"] } as FilterKey,
-      ]);
-      await renderBar();
-
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
-      expect(screen.getByText("<values>")).toBeInTheDocument();
-
-      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
-      expect(screen.getByText("<value>")).toBeInTheDocument();
-    });
-
-    it("draws the groups it was written with", async () => {
+    it("draws the groups the filter was written with", async () => {
       await renderBar({
-        requestedFilterExpr:
+        filterExpr:
           "mapping_type:in:dsym AND (version_name:in:1.0 OR version_name:in:1.1)",
       });
 
@@ -601,166 +466,815 @@ describe("FilterBar", () => {
       );
     });
 
-    it("reports again when the request changes, even to the same resolution", async () => {
-      const { onFilterChange, askAgain } = await renderBar({
-        requestedAppId: "app-1",
+    it("redraws when the value changes from outside", async () => {
+      const { setValue } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
       });
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        app: { id: "app-1" },
-      });
-      const settledCalls = onFilterChange.mock.calls.length;
 
-      // Dropping the app from the request resolves to the same app, date
-      // and filter as before.
-      await askAgain({ requestedAppId: null });
+      await setValue({ app: apps[1], filterExpr: "version_name:in:1.0" });
 
-      expect(onFilterChange.mock.calls.length).toBeGreaterThan(settledCalls);
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        app: { id: "app-1" },
-      });
+      expect(screen.getByTestId("app-select")).toHaveAttribute(
+        "data-selected",
+        "Wallet",
+      );
+      expect(screen.getByText("App version")).toBeInTheDocument();
+      expect(screen.queryByText("File type")).toBeNull();
     });
 
-    it("holds the page back until the keys can vouch for it", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: true,
-        isError: false,
-      } as any);
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-      });
+    it("stands in for the values an operator takes, one or many", async () => {
+      await renderBar({ filterExpr: "mapping_type:in:dsym" });
 
-      expect(lastState(onFilterChange).status).toBe("pending");
+      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+      expect(screen.getByText("<values>")).toBeInTheDocument();
+
+      await click(screen.getAllByTestId("pick-op-contains")[0]);
+      expect(screen.getByText("<value>")).toBeInTheDocument();
+      expect(screen.queryByText("<values>")).toBeNull();
     });
 
-    it("does not judge a request by another app's keys", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: { keys: [versionKey], key_groups: ["Version"] },
-        isPending: false,
-        isPlaceholderData: true,
-        isError: false,
-      } as any);
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-      });
+    it("shows the placeholder until there is a condition", async () => {
+      await renderBar({}, { placeholder: "Filter builds…" });
 
-      expect(lastState(onFilterChange).status).toBe("pending");
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("filters nothing when it is empty", async () => {
-      const { onFilterChange } = await renderBar({ requestedFilterExpr: "" });
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: null,
-      });
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("filters nothing when it cannot be read", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "nonsense:",
-      });
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: null,
-      });
-    });
-
-    it("keeps a custom key the keys listing left out", async () => {
-      // The app has more custom keys than the listing returns, so the
-      // server serves custom.plan only when the request specifies it.
-      mockUseFilterKeysQuery.mockImplementation(
-        (_appId: string | undefined, _entity: string, keyNames: string[]) => ({
-          data: {
-            keys: keyNames.includes("custom.plan")
-              ? [mappingTypeKey, versionKey, customPlanKey]
-              : [mappingTypeKey, versionKey],
-            key_groups: ["Build", "Version", "Custom"],
-          },
-          isPending: false,
-          isError: false,
-        }),
+      expect(screen.getByTestId("filter-input")).toHaveTextContent(
+        "Filter builds…",
       );
 
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "custom.plan:in:pro",
-      });
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
 
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: "custom.plan:in:pro",
-      });
-      expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(screen.getByTestId("filter-input")).toHaveTextContent("");
     });
 
-    it("filters nothing when it names a key this app does not have", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "device_cohort:in:new",
-      });
+    it("draws no span selector unless asked", async () => {
+      await renderBar();
 
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: null,
-      });
+      expect(screen.queryByTestId("span-select")).toBeNull();
+      expect(screen.queryByTestId("skeleton")).toBeNull();
     });
 
-    it("draws a condition with no value yet, and reports without it", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym AND version_name:in:",
-      });
+    it("draws a skeleton in place of the span selector while the names load", async () => {
+      await renderBar({}, { spanNames: null });
 
-      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
-      expect(screen.getByText("<values>")).toBeInTheDocument();
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: "mapping_type:in:dsym",
-        appliedAsRequested: true,
-      });
-      expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+      expect(screen.queryByTestId("span-select")).toBeNull();
+    });
+
+    it("draws nothing for the span selector when the app has no traces", async () => {
+      await renderBar({}, { spanNames: [] });
+
+      expect(screen.queryByTestId("span-select")).toBeNull();
+      expect(screen.queryByTestId("skeleton")).toBeNull();
+    });
+
+    it("draws the span selector on the value's name", async () => {
+      await renderBar(
+        { rootSpanName: "startup" },
+        { spanNames: ["checkout", "startup"] },
+      );
+
+      expect(screen.getByTestId("span-select")).toHaveAttribute(
+        "data-selected",
+        "startup",
+      );
     });
   });
 
-  describe("a request from outside", () => {
-    it("replaces a pick", async () => {
-      const { onFilterChange, askAgain } = await renderBar();
+  describe("when the keys cannot be fetched", () => {
+    it("keeps the bar drawn but refuses input", async () => {
+      await renderBar({}, { keysUnavailable: true });
 
-      await click(screen.getByTestId("pick-app-app-2"));
-      await addCondition();
-      expect(lastState(onFilterChange)).toMatchObject({
-        app: apps[1],
+      const bar = screen.getByTestId("filter-bar");
+      expect(bar).toHaveAttribute("aria-disabled", "true");
+      expect(bar.querySelectorAll("button")).toHaveLength(0);
+      expect(bar).toHaveTextContent("Filter…");
+      expect(screen.getByTestId("app-select")).toBeInTheDocument();
+    });
+  });
+
+  describe("what it sends", () => {
+    it("sends another app with the filter and span cleared, and empties the editor", async () => {
+      const { onChange } = await renderBar({
         filterExpr: "mapping_type:in:dsym",
       });
 
-      await askAgain({
-        requestedAppId: "app-1",
-        requestedFilterExpr: "version_name:in:1.0",
+      await click(screen.getByLabelText("Edit as text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: { value: "version_name:in:1.0" },
+        });
+      });
+      await click(screen.getByTestId("pick-app-app-2"));
+
+      expect(lastChange(onChange)).toEqual({
+        appId: "app-2",
+        filterExpr: null,
+        rootSpanName: null,
+      });
+      expect(screen.getByTestId("filter-text")).toHaveValue("");
+    });
+
+    it("sends a relative range as its label alone", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
       });
 
-      expect(lastState(onFilterChange)).toMatchObject({
-        app: apps[0],
-        filterExpr: "version_name:in:1.0",
+      await click(screen.getByTestId("pick-range"));
+
+      expect(lastChange(onChange)).toEqual({
+        dateRange: { dateRange: "Last Week", startDate: null, endDate: null },
       });
-      expect(screen.getByTestId("app-select")).toHaveAttribute(
-        "data-selected",
-        "Checkout",
+      expect(screen.getByTestId("date-select")).toHaveAttribute(
+        "data-range",
+        "Last Week",
+      );
+      expect(screen.getByText("dsym")).toBeInTheDocument();
+    });
+
+    it("sends a custom range with its timestamps", async () => {
+      const { onChange } = await renderBar();
+
+      await click(screen.getByTestId("pick-custom-range"));
+
+      expect(lastChange(onChange)).toEqual({
+        dateRange: {
+          dateRange: "Custom Range",
+          startDate: "2026-02-01T00:00:00.000Z",
+          endDate: "2026-02-08T00:00:00.000Z",
+        },
+      });
+    });
+
+    it("sends a span name only when it differs from the value's", async () => {
+      const { onChange } = await renderBar(
+        { rootSpanName: "checkout" },
+        { spanNames: ["checkout", "startup"] },
+      );
+
+      await click(screen.getByTestId("pick-span-checkout"));
+      expect(onChange).not.toHaveBeenCalled();
+
+      await click(screen.getByTestId("pick-span-startup"));
+      expect(lastChange(onChange)).toEqual({ rootSpanName: "startup" });
+    });
+
+    it("sends the filter without a removed condition, and null for the last", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getAllByLabelText("Remove condition")[1]);
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByLabelText("Remove condition"));
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
+    });
+
+    it("switches the whole filter between and and or", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getByTestId("filter-logical-operator"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym OR version_name:in:1.0",
+      });
+    });
+
+    it("keeps the values when the operator wants the same kind", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("pick-op-not_in"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:not_in:dsym",
+      });
+      expect(valuePickers()[0]).toHaveAttribute("data-open", "false");
+    });
+
+    it("applies a key whose operator takes no value at once", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("pick-key-patch_id-in-row"));
+
+      expect(lastChange(onChange)).toEqual({ filterExpr: "patch_id:is_set" });
+      expect(valuePickers()).toHaveLength(0);
+    });
+
+    it("clears every condition at once", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getByTestId("filter-clear"));
+
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
+      expect(screen.queryByTestId("filter-clear")).toBeNull();
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+    });
+
+    it("applies every toggle of a many-valued condition at once", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("pick-another-value"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:[dsym,proguard]",
+      });
+    });
+
+    it("draws what it sent before the value follows", async () => {
+      const { onChange, holdChanges, land } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      holdChanges();
+      await click(screen.getAllByLabelText("Remove condition")[1]);
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.queryByText("App version")).toBeNull();
+
+      await land();
+
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.queryByText("App version")).toBeNull();
+    });
+
+    it("draws the value instead once it moves elsewhere before what it sent lands", async () => {
+      const { holdChanges, setValue } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      holdChanges();
+      await click(screen.getAllByLabelText("Remove condition")[1]);
+      await setValue({ filterExpr: "patch_id:is_set" });
+
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.getByText("Patch")).toBeInTheDocument();
+      expect(screen.queryByText("File type")).toBeNull();
+    });
+
+    it("builds a second quick edit on the first while it is on its way", async () => {
+      const { onChange, holdChanges } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      holdChanges();
+      await click(screen.getAllByLabelText("Remove condition")[1]);
+      await click(screen.getByTestId("pick-op-not_in"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:not_in:dsym",
+      });
+    });
+  });
+
+  describe("a condition being built", () => {
+    it("starts with its key picked and its value picker open, sending nothing", async () => {
+      const { onChange } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText("<values>")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+      expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+    });
+
+    it("is sent once it has a value, and keeps its picker open for more", async () => {
+      const { onChange } = await renderBar();
+
+      await addCondition();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getByText("dsym")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await click(screen.getByTestId("pick-another-value"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:[dsym,proguard]",
+      });
+    });
+
+    it("keeps its picker open while the value it sent is on its way", async () => {
+      const { onChange, holdChanges, land } = await renderBar();
+
+      holdChanges();
+      await addCondition();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getByText("dsym")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await land();
+
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await click(screen.getByTestId("pick-another-value"));
+      await land();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:[dsym,proguard]",
+      });
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
       );
     });
 
-    it("drops a condition with no value yet", async () => {
-      const { onFilterChange, askAgain } = await renderBar();
+    it("closes its picker after a value that ends the selection", async () => {
+      const { onChange } = await renderBar();
 
       await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
-      expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+      await click(screen.getByTestId("pick-one-value"));
 
-      await askAgain({});
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
 
+    it("is dropped, picker and all, when the value moves elsewhere while what it sent is on its way", async () => {
+      const { holdChanges, setValue } = await renderBar();
+
+      holdChanges();
+      await addCondition();
+      await setValue({ filterExpr: "version_name:in:1.0" });
+
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.getByText("App version")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
+
+    it("leaves the picker of a condition drawn in its place closed once the value moves on", async () => {
+      const { setValue } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+      expect(valuePickers()[1]).toHaveAttribute("data-open", "true");
+
+      await setValue({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      expect(valuePickers()).toHaveLength(2);
+      expect(valuePickers()[1]).toHaveAttribute("data-open", "false");
+    });
+
+    it("goes at the end of the filter it was added to", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "version_name:in:1.0",
+      });
+
+      await addCondition();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0 AND mapping_type:in:dsym",
+      });
+    });
+
+    it("is dropped when its value picker closes without a value", async () => {
+      const { onChange } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await click(screen.getByTestId("close-values"));
+
+      expect(onChange).not.toHaveBeenCalled();
       expect(screen.queryByLabelText("Remove condition")).toBeNull();
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+      expect(document.activeElement).toBe(screen.getByTestId("filter-input"));
+    });
+
+    it("is dropped when the filter changes from outside", async () => {
+      const { onChange, setValue } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await setValue({ filterExpr: "version_name:in:1.0" });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.getByText("App version")).toBeInTheDocument();
+      expect(screen.queryByText("<values>")).toBeNull();
+    });
+
+    it("is dropped when the range changes from outside", async () => {
+      const { onChange, setValue } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await setValue({
+        date: toDateSelection({
+          dateRange: "Last Week",
+          startDate: null,
+          endDate: null,
+        })!,
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+      expect(valuePickers()).toHaveLength(0);
+    });
+
+    it("is dropped when the span changes from outside", async () => {
+      const { onChange, setValue } = await renderBar(
+        { rootSpanName: "span.first" },
+        { spanNames: ["span.first", "span.second"] },
+      );
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await setValue({ rootSpanName: "span.second" });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+      expect(valuePickers()).toHaveLength(0);
+    });
+
+    it("is dropped by an edit elsewhere in the filter", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await click(screen.getAllByTestId("filter-logical-operator")[0]);
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym OR version_name:in:1.0",
+      });
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
+      expect(screen.queryByText("<values>")).toBeNull();
+    });
+
+    it("is dropped when another app is picked", async () => {
+      const { onChange } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await click(screen.getByTestId("pick-app-app-2"));
+
+      expect(lastChange(onChange)).toEqual({
+        appId: "app-2",
+        filterExpr: null,
+        rootSpanName: null,
+      });
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+    });
+
+    it("is dropped when another condition is removed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "version_name:in:1.0",
+      });
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await click(screen.getAllByLabelText("Remove condition")[0]);
+
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+    });
+
+    it("is replaced by the next one started", async () => {
+      const { onChange } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
+      expect(screen.getByText("App version")).toBeInTheDocument();
+      expect(screen.queryByText("File type")).toBeNull();
+    });
+
+    it("starts again in its place when its key is changed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getAllByTestId("pick-key-version_name-in-row")[0]);
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0",
+      });
+      const rows = screen.getAllByLabelText("Remove condition");
+      expect(rows).toHaveLength(2);
+      expect(screen.getByText("<values>")).toBeInTheDocument();
+      expect(valuePickers()[0]).toHaveAttribute("data-open", "true");
+      expect(valuePickers()[1]).toHaveAttribute("data-open", "false");
+
+      await pickValue();
+    });
+
+    it("keeps its place once the changed key has a value", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getAllByTestId("pick-key-version_name-in-row")[0]);
+      await click(screen.getAllByTestId("pick-value")[0]);
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:dsym AND version_name:in:1.0",
+      });
+    });
+
+    it("starts again when the operator cannot keep the values", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("pick-op-contains"));
+
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
+      expect(screen.getByText("<value>")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await pickValue();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:contains:dsym",
+      });
+    });
+
+    it("puts the condition back when the restarted picker is dismissed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getByTestId("pick-op-contains"));
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0",
+      });
+
+      await click(screen.getAllByTestId("close-values")[0]);
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+      expect(screen.queryByText("<value>")).toBeNull();
+    });
+
+    it("drops the edit when the filter it sent was discarded", async () => {
+      const { setValue } = await renderBar();
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await setValue({ discarded: true });
+
+      expect(screen.queryByText("<values>")).toBeNull();
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+    });
+
+    it("keeps a pending row while the span names arrive", async () => {
+      const { setValue } = await renderBar(
+        { rootSpanName: null },
+        { spanNames: null },
+      );
+
+      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await setValue({ rootSpanName: "span.first" });
+
+      expect(screen.getByText("<values>")).toBeInTheDocument();
+    });
+
+    it("keeps the group it is the only condition of", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      const group = () => screen.getByRole("group", { name: "Filter group" });
+      await click(within(group()).getByTestId("pick-key-mapping_type-in-row"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(within(group()).getByText("<values>")).toBeInTheDocument();
+
+      await pickValue();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym AND (mapping_type:in:dsym)",
+      });
+    });
+
+    it("keeps the groups around it, however deep", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND ((version_name:in:1.0))",
+      });
+
+      const innermost = () => screen.getAllByRole("group").at(-1)!;
+      await click(
+        within(innermost()).getByTestId("pick-key-mapping_type-in-row"),
+      );
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getAllByRole("group")).toHaveLength(2);
+      expect(within(innermost()).getByText("<values>")).toBeInTheDocument();
+
+      await pickValue();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym AND ((mapping_type:in:dsym))",
+      });
+      expect(screen.getAllByRole("group")).toHaveLength(2);
+    });
+
+    it("is dropped from the group it started in when the value picker closes", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      const group = () => screen.getByRole("group", { name: "Filter group" });
+      await click(groupPicker(group()).getByTestId("pick-key-mapping_type"));
+      expect(
+        within(group()).getAllByLabelText("Remove condition"),
+      ).toHaveLength(2);
+
+      await click(screen.getAllByTestId("close-values").at(-1)!);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(
+        within(group()).getAllByLabelText("Remove condition"),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("grouping", () => {
+    const onlyGroup = () => screen.getByRole("group", { name: "Filter group" });
+
+    async function addGroup(picker = wholeFilterPicker()) {
+      await click(picker.getByTestId("add-group"));
+    }
+
+    it("opens the key list for the first condition of a group, sending nothing", async () => {
+      const { onChange } = await renderBar();
+
+      await addGroup();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(
+        within(onlyGroup())
+          .getByLabelText("Add a filter to this group")
+          .closest("[data-testid='key-picker']"),
+      ).toHaveAttribute("data-open", "true");
+      expect(groupPicker(onlyGroup()).queryByTestId("add-group")).toBeNull();
+    });
+
+    it("drops the group when its key list closes without a pick", async () => {
+      await renderBar();
+
+      await addGroup();
+      await click(groupPicker(onlyGroup()).getByTestId("close-keys"));
+
+      expect(screen.queryByRole("group")).toBeNull();
+    });
+
+    it("sends the group once its first condition has a value", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await addGroup();
+      await click(
+        groupPicker(onlyGroup()).getByTestId("pick-key-version_name"),
+      );
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(within(onlyGroup()).getByText("<values>")).toBeInTheDocument();
+
+      await pickValue();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:dsym)",
+      });
+    });
+
+    it("switches a group between and and or without touching the filter", async () => {
+      const { onChange } = await renderBar({
+        filterExpr:
+          "mapping_type:in:dsym AND (mapping_type:in:dsym AND version_name:in:1.0)",
+      });
+
+      await click(within(onlyGroup()).getByTestId("filter-logical-operator"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr:
+          "mapping_type:in:dsym AND (mapping_type:in:dsym OR version_name:in:1.0)",
+      });
+    });
+
+    it("drops a group and everything in it", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      await click(screen.getByLabelText("Remove group"));
+
+      expect(screen.queryByRole("group")).toBeNull();
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+    });
+
+    it("drops a group along with the last condition in it", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      await click(within(onlyGroup()).getByLabelText("Remove condition"));
+
+      expect(screen.queryByRole("group")).toBeNull();
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+    });
+
+    it("declines a group nested deeper than the server allows", async () => {
+      await renderBar({ filterExpr: "((mapping_type:in:dsym))" });
+
+      const innermost = () => screen.getAllByRole("group").at(-1)!;
+      await addGroup(groupPicker(innermost()));
+
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        "Filter groups cannot be nested deeper",
+      );
+      expect(screen.getAllByRole("group")).toHaveLength(2);
+    });
+  });
+
+  describe("where focus goes", () => {
+    it("moves to the condition before the one removed", async () => {
+      await renderBar({
+        filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
+      });
+
+      await click(screen.getAllByLabelText("Remove condition").at(-1)!);
+
+      expect(document.activeElement).toHaveTextContent("File type");
+    });
+
+    it("moves to the condition before the one removed inside a group", async () => {
+      await renderBar({
+        filterExpr:
+          "version_name:in:1.0 AND (mapping_type:in:dsym AND mapping_type:in:dsym)",
+      });
+      const group = screen.getByRole("group", { name: "Filter group" });
+
+      await click(within(group).getAllByLabelText("Remove condition").at(-1)!);
+
+      expect(document.activeElement).toHaveTextContent("File type");
+    });
+
+    it("leaves a group for the condition before it", async () => {
+      await renderBar({
+        filterExpr: "version_name:in:1.0 AND (mapping_type:in:dsym)",
+      });
+      const group = screen.getByRole("group", { name: "Filter group" });
+
+      await click(within(group).getByLabelText("Remove condition"));
+
+      expect(document.activeElement).toHaveTextContent("App version");
+    });
+
+    it("goes to the add control when nothing is drawn before", async () => {
+      await renderBar({ filterExpr: "mapping_type:in:dsym" });
+
+      await click(screen.getByLabelText("Remove condition"));
+
+      expect(document.activeElement).toBe(screen.getByTestId("filter-input"));
     });
   });
 
@@ -780,23 +1294,15 @@ describe("FilterBar", () => {
       expect(wholePicker()).toHaveAttribute("data-open", "true");
     });
 
-    it("opens it from the space left once conditions are on screen", async () => {
-      await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("filter-bar"));
-
-      expect(wholePicker()).toHaveAttribute("data-open", "true");
-    });
-
     it("leaves a click on a control to that control", async () => {
-      const { onFilterChange } = await renderBar();
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
 
-      await addCondition();
       await click(screen.getByLabelText("Remove condition"));
 
       expect(wholePicker()).toHaveAttribute("data-open", "false");
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
     });
 
     it("leaves the bar alone while the filter is edited as text", async () => {
@@ -806,297 +1312,6 @@ describe("FilterBar", () => {
       await click(screen.getByTestId("filter-bar"));
 
       expect(screen.getByTestId("filter-text")).toBeInTheDocument();
-    });
-  });
-
-  describe("editing", () => {
-    it("reports nothing for a condition that is still half built", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
-
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
-    });
-
-    it("reports the expression once a condition has a value", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym",
-      });
-    });
-
-    it("reports a pick the page handed back as applied", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        appliedAsRequested: true,
-      });
-    });
-
-    it("still filters by a condition changed while the server is refusing one", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-        filterExprIssues: [
-          { message: 'Key "mapping_type" has no value "dsym"' },
-        ],
-      });
-
-      expect(screen.getByTestId("filter-issue")).toBeInTheDocument();
-
-      await click(screen.getByTestId("pick-op-not_in"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:not_in:dsym",
-      });
-    });
-
-    it("clears the conditions when another app is picked", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("pick-app-app-2"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        app: apps[1],
-        filterExpr: null,
-      });
-    });
-
-    it("reports the new range, and keeps the expression", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("pick-range"));
-
-      const state = lastState(onFilterChange);
-      expect(state).toMatchObject({ filterExpr: "mapping_type:in:dsym" });
-      expect(state.status === "ready" && state.date.dateRange).toBe(
-        "Last Week",
-      );
-      expect(storeInstance.getState().selectedDateRange).toBe("Last Week");
-    });
-
-    it("switches the whole filter between and and or", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await addCondition();
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym AND mapping_type:in:dsym",
-      });
-
-      await click(screen.getByTestId("filter-logical-operator"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym OR mapping_type:in:dsym",
-      });
-    });
-
-    it("starts a condition again when its key is changed", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("pick-key-version_name-in-row"));
-
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
-    });
-
-    it("keeps the values when the operator wants the same kind", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("pick-op-not_in"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:not_in:dsym",
-      });
-    });
-
-    it("drops a condition that is removed", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await act(async () => {
-        fireEvent.click(screen.getByLabelText("Remove condition"));
-      });
-
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
-    });
-
-    it("clears every condition at once", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await click(screen.getByTestId("filter-clear"));
-
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
-      expect(screen.queryByTestId("filter-clear")).toBeNull();
-    });
-  });
-
-  describe("where focus goes", () => {
-    it("moves to the condition before the one removed", async () => {
-      await renderBar();
-
-      await addCondition();
-      await addCondition(wholeFilterPicker(), "version_name");
-
-      await click(screen.getAllByLabelText("Remove condition").at(-1)!);
-
-      expect(document.activeElement).toHaveTextContent("File type");
-    });
-
-    it("moves to the condition before the one removed inside a group", async () => {
-      await renderBar();
-
-      await addCondition(wholeFilterPicker(), "version_name");
-      await click(wholeFilterPicker().getByTestId("add-group"));
-      const group = () => screen.getByRole("group", { name: "Filter group" });
-      await addCondition(groupPicker(group()));
-      await addCondition(groupPicker(group()));
-
-      await click(
-        within(group()).getAllByLabelText("Remove condition").at(-1)!,
-      );
-
-      expect(document.activeElement).toHaveTextContent("File type");
-    });
-
-    it("leaves a group for the condition before it", async () => {
-      await renderBar();
-
-      await addCondition(wholeFilterPicker(), "version_name");
-      await click(wholeFilterPicker().getByTestId("add-group"));
-      const group = screen.getByRole("group", {
-        name: "Filter group",
-      });
-      await addCondition(groupPicker(group));
-
-      await click(within(group).getByLabelText("Remove condition"));
-
-      expect(document.activeElement).toHaveTextContent("App version");
-    });
-
-    it("goes to the add control when nothing is drawn before", async () => {
-      await renderBar();
-
-      await addCondition();
-      await click(screen.getByLabelText("Remove condition"));
-
-      expect(document.activeElement).toBe(screen.getByTestId("filter-input"));
-    });
-  });
-
-  describe("grouping", () => {
-    const onlyGroup = () => screen.getByRole("group", { name: "Filter group" });
-
-    async function addGroup(picker = wholeFilterPicker()) {
-      await click(picker.getByTestId("add-group"));
-    }
-
-    it("opens a group with nothing in it yet", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addGroup();
-
-      expect(
-        within(onlyGroup()).getByLabelText("Add a filter to this group"),
-      ).toBeInTheDocument();
-      expect(
-        within(onlyGroup()).queryByLabelText("Remove condition"),
-      ).toBeNull();
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
-    });
-
-    it("reports a group as its own part of the filter", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await addGroup();
-      await addCondition(groupPicker(onlyGroup()));
-      await addCondition(groupPicker(onlyGroup()));
-      await click(within(onlyGroup()).getByTestId("filter-logical-operator"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr:
-          "mapping_type:in:dsym AND (mapping_type:in:dsym OR mapping_type:in:dsym)",
-      });
-    });
-
-    it("switches a group between and and or without touching the filter", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await addCondition();
-      await addGroup();
-      await addCondition(groupPicker(onlyGroup()));
-      await addCondition(groupPicker(onlyGroup()));
-      await click(within(onlyGroup()).getByTestId("filter-logical-operator"));
-
-      const state = lastState(onFilterChange);
-      expect(state).toMatchObject({
-        filterExpr:
-          "mapping_type:in:dsym AND mapping_type:in:dsym AND (mapping_type:in:dsym OR mapping_type:in:dsym)",
-      });
-    });
-
-    it("keeps a group of one condition in what it reports", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await addGroup();
-      await addCondition(groupPicker(onlyGroup()));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym AND (mapping_type:in:dsym)",
-      });
-    });
-
-    it("drops a group and everything in it", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
-      await addGroup();
-      await addCondition(groupPicker(onlyGroup()));
-      await click(screen.getByLabelText("Remove group"));
-
-      expect(screen.queryByRole("group")).toBeNull();
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym",
-      });
-    });
-
-    it("drops a group along with the last condition in it", async () => {
-      await renderBar();
-
-      await addGroup();
-      await addCondition(groupPicker(onlyGroup()));
-      await click(within(onlyGroup()).getByLabelText("Remove condition"));
-
-      expect(screen.queryByRole("group")).toBeNull();
-    });
-
-    it("declines a group nested deeper than the server allows", async () => {
-      await renderBar();
-
-      const innermost = () => screen.getAllByRole("group").at(-1)!;
-
-      await addGroup();
-      await addGroup(groupPicker(innermost()));
-      expect(mockToastNegative).not.toHaveBeenCalled();
-
-      await addGroup(groupPicker(innermost()));
-
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Filter groups cannot be nested deeper",
-      );
-      expect(screen.getAllByRole("group")).toHaveLength(2);
     });
   });
 
@@ -1119,40 +1334,80 @@ describe("FilterBar", () => {
       });
     }
 
-    it("opens on the expression the conditions say", async () => {
-      await renderBar();
+    it("opens on the filter the value holds", async () => {
+      await renderBar({ filterExpr: "mapping_type:in:dsym" });
 
-      await addCondition();
       await startTyping();
 
       expect(textBox()).toHaveValue("mapping_type:in:dsym");
     });
 
-    it("shows a condition still waiting for its values", async () => {
-      await renderBar();
-
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
-      await startTyping();
-
-      expect(textBox()).toHaveValue("mapping_type:in:");
-    });
-
-    it("filters by what was typed once it is applied", async () => {
-      const { onFilterChange } = await renderBar();
+    it("sends what was typed, in canonical form, once it is applied", async () => {
+      const { onChange } = await renderBar();
 
       await startTyping();
-      await type("version_name:in:1.0");
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+      await type("version_name:in:[1.0]");
+      expect(onChange).not.toHaveBeenCalled();
 
       await pressEnter();
 
-      expect(lastState(onFilterChange)).toMatchObject({
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0",
+      });
+      expect(textBox()).toHaveValue("version_name:in:1.0");
+    });
+
+    it("keeps showing what it applied while the value follows", async () => {
+      const { onChange, holdChanges, land } = await renderBar();
+
+      holdChanges();
+      await startTyping();
+      await type("version_name:in:[1.0]");
+      await pressEnter();
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0",
+      });
+      expect(textBox()).toHaveValue("version_name:in:1.0");
+
+      await click(screen.getByLabelText("Edit as conditions"));
+
+      expect(screen.getByText("App version")).toBeInTheDocument();
+
+      await land();
+
+      expect(screen.getByText("App version")).toBeInTheDocument();
+    });
+
+    it("applies on blur too", async () => {
+      const { onChange } = await renderBar();
+
+      await startTyping();
+      await type("version_name:in:1.0");
+      await act(async () => {
+        fireEvent.blur(textBox());
+      });
+
+      expect(lastChange(onChange)).toEqual({
         filterExpr: "version_name:in:1.0",
       });
     });
 
-    it("says what is wrong and filters nothing while it is", async () => {
-      const { onFilterChange } = await renderBar();
+    it("sends nothing for text that only differs in form", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await startTyping();
+      await type("mapping_type:in:[dsym]");
+      await pressEnter();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(textBox()).toHaveValue("mapping_type:in:dsym");
+    });
+
+    it("says what is wrong and keeps the text instead of applying it", async () => {
+      const { onChange } = await renderBar();
 
       await startTyping();
       await type("version_name:in:1.0 AND");
@@ -1161,7 +1416,22 @@ describe("FilterBar", () => {
       expect(screen.getByTestId("filter-issue")).toHaveTextContent(
         "Filter ends where a condition was expected",
       );
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+      expect(onChange).not.toHaveBeenCalled();
+      expect(textBox()).toHaveValue("version_name:in:1.0 AND");
+    });
+
+    it("refuses a condition still waiting for its value", async () => {
+      const { onChange } = await renderBar();
+
+      await startTyping();
+      await type("version_name:in:");
+      await pressEnter();
+
+      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
+        "App version needs a value",
+      );
+      expect(marksInBar()).toEqual(["version_name", ":", "in"]);
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it("says so for a key this app does not have", async () => {
@@ -1179,32 +1449,10 @@ describe("FilterBar", () => {
       await renderBar();
 
       await startTyping();
-      await type("device_cohort:in:new AND another_missing:in:x");
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        "There is no filter named device_cohort (+1 more)",
-      );
-    });
-
-    it("counts the keys it cannot use alongside text it cannot read", async () => {
-      await renderBar();
-
-      await startTyping();
       await type("device_cohort:in:new AND another_missing:in:x)");
 
       expect(screen.getByTestId("filter-issue")).toHaveTextContent(
         "There is no filter named device_cohort (+2 more)",
-      );
-    });
-
-    it("names the issue that comes first in the text", async () => {
-      await renderBar();
-
-      await startTyping();
-      await type("mapping_type:in:proguard AND device_cohort:in:new)");
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        "There is no filter named device_cohort (+1 more)",
       );
     });
 
@@ -1217,97 +1465,6 @@ describe("FilterBar", () => {
       expect(screen.getByTestId("filter-issue")).toHaveTextContent(
         "File type cannot be compared with gt",
       );
-    });
-
-    it("discards a requested expression holding more conditions than the limit", async () => {
-      const tooMany = Array.from(
-        { length: MAX_CONDITIONS + 1 },
-        () => "mapping_type:in:dsym",
-      ).join(" AND ");
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: tooMany,
-      });
-
-      const state = lastState(onFilterChange);
-      expect(state.status === "ready" && state.filterExpr).toBeNull();
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Some filters were invalid, page reset to defaults",
-      );
-    });
-
-    it("marks the span the server refused", async () => {
-      await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-        filterExprIssues: [
-          {
-            message: 'Key "mapping_type" has no value "dsym"',
-            span: { start: 0, end: 20 },
-          },
-        ],
-      });
-
-      await click(screen.getByTestId("filter-toggle-text"));
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        'Key "mapping_type" has no value "dsym"',
-      );
-      expect(marksInBar()).toEqual(["mapping_type", ":", "in", ":", "dsym"]);
-    });
-
-    it("says what the server refused for text holding brackets and extra spaces", async () => {
-      await renderBar({
-        requestedFilterExpr: "mapping_type:in:[dsym]  AND version_name:in:1.0",
-        filterExprIssues: [
-          { message: 'Key "mapping_type" has no value "dsym"' },
-        ],
-      });
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        'Key "mapping_type" has no value "dsym"',
-      );
-    });
-
-    it("drops the message once the text would filter by something else", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-        filterExprIssues: [
-          {
-            message: 'Key "mapping_type" has no value "dsym"',
-            span: { start: 0, end: 20 },
-          },
-        ],
-      });
-
-      await click(screen.getByTestId("filter-toggle-text"));
-      await type("mapping_type:in:proguard");
-
-      expect(screen.queryByTestId("filter-issue")).not.toBeInTheDocument();
-
-      await pressEnter();
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:proguard",
-      });
-    });
-
-    it("keeps the message but drops the marks when only the spacing changed", async () => {
-      await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-        filterExprIssues: [
-          {
-            message: 'Key "mapping_type" has no value "dsym"',
-            span: { start: 0, end: 20 },
-          },
-        ],
-      });
-
-      await click(screen.getByTestId("filter-toggle-text"));
-      await type("  mapping_type:in:dsym");
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        'Key "mapping_type" has no value "dsym"',
-      );
-      expect(marksInBar()).toEqual([]);
     });
 
     it("refuses to go back to conditions while the text is wrong", async () => {
@@ -1323,40 +1480,16 @@ describe("FilterBar", () => {
       );
     });
 
-    it("goes back to conditions while the server is refusing a value", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym",
-        filterExprIssues: [
-          { message: 'Key "mapping_type" has no value "dsym"' },
-        ],
-      });
-
-      await click(screen.getByLabelText("Edit as text"));
-      const before = onFilterChange.mock.calls.length;
-      await click(screen.getByLabelText("Edit as conditions"));
-
-      expect(screen.queryByTestId("filter-text")).not.toBeInTheDocument();
-      expect(mockToastNegative).not.toHaveBeenCalled();
-      expect(onFilterChange.mock.calls.length).toBe(before);
-
-      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
-        'Key "mapping_type" has no value "dsym"',
-      );
-
-      await click(screen.getByTestId("pick-op-not_in"));
-
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:not_in:dsym",
-      });
-    });
-
     it("draws what was typed as conditions on the way back", async () => {
-      await renderBar();
+      const { onChange } = await renderBar();
 
       await startTyping();
       await type("version_name:in:1.0 AND (mapping_type:in:dsym)");
       await click(screen.getByLabelText("Edit as conditions"));
 
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "version_name:in:1.0 AND (mapping_type:in:dsym)",
+      });
       expect(screen.queryByTestId("filter-text")).toBeNull();
       expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
       expect(
@@ -1365,31 +1498,23 @@ describe("FilterBar", () => {
     });
 
     it("empties the editor when the filter is cleared", async () => {
-      const { onFilterChange } = await renderBar();
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
 
-      await addCondition();
       await startTyping();
       await type("version_name:in:1.0");
       await click(screen.getByTestId("filter-clear"));
 
       expect(textBox()).toHaveValue("");
-      expect(lastState(onFilterChange)).toMatchObject({ filterExpr: null });
+      expect(lastChange(onChange)).toEqual({ filterExpr: null });
     });
 
-    it("empties the editor when another app is picked", async () => {
-      await renderBar();
+    it("drops the text and closes on Escape", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
 
-      await startTyping();
-      await type("version_name:in:1.0");
-      await click(screen.getByTestId("pick-app-app-2"));
-
-      expect(textBox()).toHaveValue("");
-    });
-
-    it("puts back the filter the page is on when it is left without applying", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await addCondition();
       await startTyping();
       await type("version_name:in:1.0");
       await act(async () => {
@@ -1397,71 +1522,143 @@ describe("FilterBar", () => {
       });
 
       expect(screen.queryByTestId("filter-text")).toBeNull();
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "mapping_type:in:dsym",
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText("dsym")).toBeInTheDocument();
+    });
+  });
+
+  describe("issues the server sent back", () => {
+    const refused = [
+      {
+        message: 'Key "mapping_type" has no value "dsym"',
+        span: { start: 0, end: 20 },
+      },
+    ];
+
+    it("marks the span the server refused", async () => {
+      await renderBar(
+        { filterExpr: "mapping_type:in:dsym" },
+        { filterExprIssues: refused },
+      );
+
+      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
+        'Key "mapping_type" has no value "dsym"',
+      );
+
+      await click(screen.getByTestId("filter-toggle-text"));
+
+      expect(marksInBar()).toEqual(["mapping_type", ":", "in", ":", "dsym"]);
+    });
+
+    it("keeps the message but drops the marks when only the spacing changed", async () => {
+      await renderBar(
+        { filterExpr: "mapping_type:in:dsym" },
+        { filterExprIssues: refused },
+      );
+
+      await click(screen.getByTestId("filter-toggle-text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: { value: "  mapping_type:in:[dsym]" },
+        });
+      });
+
+      expect(screen.getByTestId("filter-issue")).toHaveTextContent(
+        'Key "mapping_type" has no value "dsym"',
+      );
+      expect(marksInBar()).toEqual([]);
+    });
+
+    it("drops the message once the text would filter by something else", async () => {
+      const { onChange } = await renderBar(
+        { filterExpr: "mapping_type:in:dsym" },
+        { filterExprIssues: refused },
+      );
+
+      await click(screen.getByTestId("filter-toggle-text"));
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("filter-text"), {
+          target: { value: "mapping_type:in:proguard" },
+        });
+      });
+
+      expect(screen.queryByTestId("filter-issue")).toBeNull();
+
+      await act(async () => {
+        fireEvent.keyDown(screen.getByTestId("filter-text"), { key: "Enter" });
+      });
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:proguard",
+      });
+    });
+
+    it("still applies a condition changed while the server is refusing one", async () => {
+      const { onChange } = await renderBar(
+        { filterExpr: "mapping_type:in:dsym" },
+        { filterExprIssues: refused },
+      );
+
+      await click(screen.getByLabelText("Edit as text"));
+      await click(screen.getByLabelText("Edit as conditions"));
+
+      expect(screen.queryByTestId("filter-text")).toBeNull();
+      expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+
+      await click(screen.getByTestId("pick-op-not_in"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:not_in:dsym",
       });
     });
   });
 
   describe("a user-defined key", () => {
     beforeEach(() => {
-      keysLoaded(
-        [mappingTypeKey, versionKey, customPremiumKey, customPlanKey],
-        ["Build", "Version", "Custom"],
-      );
+      keysServed([...keys, customPremiumKey, customPlanKey]);
     });
 
-    it("draws a requested custom condition and filters by it", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "custom.is_premium:eq:true",
-      });
+    const allKeys = { keys: [...keys, customPremiumKey, customPlanKey] };
 
-      expect(screen.getByTestId("operator-picker")).toBeInTheDocument();
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        filterExpr: "custom.is_premium:eq:true",
-      });
+    it("draws a custom condition by the raw attribute name", async () => {
+      await renderBar({ filterExpr: "custom.is_premium:eq:true" }, allKeys);
+
+      expect(screen.getByText("is_premium")).toBeInTheDocument();
     });
 
-    it("names the condition by the raw attribute name", async () => {
-      await renderBar();
-
-      await click(
-        wholeFilterPicker().getByTestId("pick-key-custom.is_premium"),
-      );
-
-      // The key control of the new condition takes focus, so the text on it is
-      // what the chip shows for this key.
-      expect(document.activeElement?.textContent).toBe("is_premium");
-    });
-
-    it("serializes a picked custom key under its full dotted name", async () => {
-      const { onFilterChange } = await renderBar();
+    it("sends a picked custom key under its full dotted name", async () => {
+      const { onChange } = await renderBar({}, allKeys);
 
       await addCondition(wholeFilterPicker(), "custom.plan");
 
-      expect(lastState(onFilterChange)).toMatchObject({
+      expect(lastChange(onChange)).toEqual({
         filterExpr: "custom.plan:in:dsym",
       });
     });
 
-    it("asks the keys query for a custom key typed by hand", async () => {
-      // The app has more custom keys than the listing returns, so the
-      // server serves custom.plan only when the request specifies it.
+    it("asks the keys query for the custom keys in the filter and the ones typed", async () => {
       mockUseFilterKeysQuery.mockImplementation(
         (_appId: string | undefined, _entity: string, keyNames: string[]) => ({
           data: {
             keys: keyNames.includes("custom.plan")
-              ? [mappingTypeKey, versionKey, customPlanKey]
-              : [mappingTypeKey, versionKey],
-            key_groups: ["Build", "Version", "Custom"],
+              ? [...keys, customPlanKey]
+              : keys,
+            key_groups: keyGroups,
           },
           isPending: false,
           isError: false,
         }),
       );
+      const { onChange } = await renderBar({
+        filterExpr: "custom.is_premium:eq:true",
+      });
 
-      const { onFilterChange } = await renderBar();
+      expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        ["custom.is_premium"],
+      );
 
       await click(screen.getByLabelText("Edit as text"));
       await act(async () => {
@@ -1473,15 +1670,15 @@ describe("FilterBar", () => {
       expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
         "app-1",
         "builds",
-        ["custom.plan"],
+        ["custom.is_premium", "custom.plan"],
       );
-      expect(screen.queryByTestId("filter-issue")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("filter-issue")).toBeNull();
 
       await act(async () => {
         fireEvent.keyDown(screen.getByTestId("filter-text"), { key: "Enter" });
       });
 
-      expect(lastState(onFilterChange)).toMatchObject({
+      expect(lastChange(onChange)).toEqual({
         filterExpr: "custom.plan:in:pro",
       });
     });
@@ -1497,233 +1694,40 @@ describe("FilterBar", () => {
       });
 
       expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
-        "app-1",
+        undefined,
         "builds",
         [],
       );
     });
-
-    it("round-trips a typed custom condition through the text editor", async () => {
-      const { onFilterChange } = await renderBar();
-
-      await click(screen.getByLabelText("Edit as text"));
-      await act(async () => {
-        fireEvent.change(screen.getByTestId("filter-text"), {
-          target: {
-            value: "custom.plan:in:pro AND custom.is_premium:eq:true",
-          },
-        });
-      });
-      await click(screen.getByLabelText("Edit as conditions"));
-
-      expect(screen.queryByTestId("filter-issue")).not.toBeInTheDocument();
-      expect(screen.getAllByLabelText("Remove condition")).toHaveLength(2);
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: "custom.plan:in:pro AND custom.is_premium:eq:true",
-      });
-    });
-  });
-
-  describe("while the keys are on their way", () => {
-    it("shows no bar to filter with", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: true,
-        isError: false,
-      } as any);
-      await renderBar();
-
-      expect(screen.queryByTestId("filter-bar")).toBeNull();
-    });
-
-    it("still reports what it is filtering by, so the page can fetch", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: true,
-        isError: false,
-      } as any);
-      const { onFilterChange } = await renderBar();
-
-      expect(lastState(onFilterChange).status).toBe("ready");
-    });
-  });
-
-  describe("when the keys cannot be fetched", () => {
-    it("keeps the bar drawn but refuses input", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: false,
-        isError: true,
-      } as any);
-      await renderBar();
-
-      expect(screen.getByTestId("filter-bar")).toHaveAttribute(
-        "aria-disabled",
-        "true",
-      );
-    });
-
-    it("leaves nothing a keyboard can reach", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: false,
-        isError: true,
-      } as any);
-      await renderBar();
-
-      const bar = screen.getByTestId("filter-bar");
-      expect(bar.querySelectorAll("button")).toHaveLength(0);
-      expect(bar).toHaveTextContent("Filter…");
-    });
-
-    it("draws no message of its own, and reports one for the page", async () => {
-      mockUseFilterKeysQuery.mockReturnValue({
-        data: undefined,
-        isPending: false,
-        isError: true,
-      } as any);
-      const { onFilterChange } = await renderBar();
-
-      expect(screen.queryByText(/Error fetching filters/)).toBeNull();
-      expect(lastState(onFilterChange)).toEqual({
-        status: "error",
-        message: expect.stringContaining("Error fetching filters"),
-      });
-    });
   });
 
   describe("when an edit would cross a limit", () => {
-    it("declines the edit and names the limit that stopped it", async () => {
-      const { onFilterChange } = await renderBar();
+    const full = Array.from(
+      { length: MAX_CONDITIONS },
+      () => "mapping_type:in:dsym",
+    ).join(" AND ");
 
-      for (let i = 0; i < MAX_CONDITIONS; i++) {
-        await addCondition();
-      }
-      const filled = lastState(onFilterChange);
+    it("declines the edit and names the limit that stopped it", async () => {
+      const { onChange } = await renderBar({ filterExpr: full });
+
       await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
 
       expect(mockToastNegative).toHaveBeenCalledWith(
         `A filter can hold at most ${MAX_CONDITIONS} conditions`,
       );
-      expect(lastState(onFilterChange)).toMatchObject({
-        filterExpr: (filled as any).filterExpr,
-      });
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByText("<values>")).toBeNull();
     });
 
     it("says nothing while the filter is still inside every limit", async () => {
-      await renderBar();
+      const { onChange } = await renderBar();
 
       for (let i = 0; i < MAX_CONDITIONS; i++) {
         await addCondition();
       }
 
       expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(lastChange(onChange)).toEqual({ filterExpr: full });
     });
-  });
-
-  describe("when something requested cannot be honoured", () => {
-    it("says so for an app the team no longer has", async () => {
-      await renderBar({ requestedAppId: "app-gone" });
-
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Some filters were invalid, page reset to defaults",
-      );
-    });
-
-    it("says so for a range that does not read back", async () => {
-      await renderBar({
-        requestedDateRange: {
-          dateRange: "Last Fortnight",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Some filters were invalid, page reset to defaults",
-      );
-    });
-
-    it("says so for an expression that cannot be read", async () => {
-      const { onFilterChange } = await renderBar({
-        requestedFilterExpr: "mapping_type:in:dsym AND",
-      });
-
-      expect(mockToastNegative).toHaveBeenCalledWith(
-        "Some filters were invalid, page reset to defaults",
-      );
-      expect(lastState(onFilterChange)).toMatchObject({
-        status: "ready",
-        appliedAsRequested: false,
-      });
-    });
-
-    it("says so once, however much was refused", async () => {
-      await renderBar({
-        requestedAppId: "app-gone",
-        requestedDateRange: {
-          dateRange: "Last Fortnight",
-          startDate: null,
-          endDate: null,
-        },
-        requestedFilterExpr: "mapping_type:in:dsym AND",
-      });
-
-      expect(mockToastNegative).toHaveBeenCalledTimes(1);
-    });
-
-    it("stays quiet when everything requested is honoured", async () => {
-      await renderBar({
-        requestedAppId: "app-2",
-        requestedDateRange: {
-          dateRange: "Last Week",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("stays quiet when nothing was requested", async () => {
-      await renderBar();
-
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-
-    it("stays quiet when the range asked for is the one it just reported", async () => {
-      const { askAgain } = await renderBar({
-        requestedDateRange: {
-          dateRange: "Last 6 Hours",
-          startDate: null,
-          endDate: null,
-        },
-      });
-
-      await click(screen.getByTestId("pick-range"));
-      await askAgain({
-        requestedDateRange: {
-          dateRange: "Last Week",
-          startDate: "2026-02-01T00:00:00.000Z",
-          endDate: "2026-02-08T00:00:00.000Z",
-        },
-      });
-
-      expect(mockToastNegative).not.toHaveBeenCalled();
-    });
-  });
-
-  it("shows the placeholder until there is a condition", async () => {
-    await renderBar({ placeholder: "Filter builds…" });
-
-    expect(screen.getByTestId("filter-input")).toHaveTextContent(
-      "Filter builds…",
-    );
-
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("pick-key-mapping_type"));
-    });
-
-    expect(screen.getByTestId("filter-input")).toHaveTextContent("");
   });
 });

--- a/frontend/dashboard/__tests__/components/filter_bar/parse_test.ts
+++ b/frontend/dashboard/__tests__/components/filter_bar/parse_test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import type { ExprTree } from "@/app/api/filter_types";
 import {
+  customKeyNamesIn,
   type ExprToken,
   formatFilterExpr,
   parseFilterExpr,
@@ -284,5 +285,24 @@ describe("the tokens a filter reads as", () => {
       ["key", "b"],
       ["punctuation", ":"],
     ]);
+  });
+});
+
+describe("the custom keys a filter names", () => {
+  const namesIn = (text: string) =>
+    customKeyNamesIn(parseFilterExpr(text, { draft: true }).tokens);
+
+  it("lists each once, sorted, leaving the built-in keys out", () => {
+    expect(
+      namesIn(
+        "custom.plan:in:pro AND version_name:in:1.0 AND (custom.age:gt:3 OR custom.plan:in:free)",
+      ),
+    ).toEqual(["custom.age", "custom.plan"]);
+  });
+
+  it("waits for a key's operator before counting it", () => {
+    expect(namesIn("custom.pl")).toEqual([]);
+    expect(namesIn("custom.plan:")).toEqual([]);
+    expect(namesIn("custom.plan:in")).toEqual(["custom.plan"]);
   });
 });

--- a/frontend/dashboard/__tests__/components/filter_bar/resolve_filters_test.ts
+++ b/frontend/dashboard/__tests__/components/filter_bar/resolve_filters_test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { App } from "@/app/api/api_calls";
+import type { FilterKey } from "@/app/api/filter_types";
+import { MAX_CONDITIONS } from "@/app/components/filter_bar/limits";
+import {
+  type AppsQueryState,
+  type KeysQueryState,
+  type SpanNamesQueryState,
+  type UrlFilters,
+  resolveApp,
+  resolveFilters,
+} from "@/app/components/filter_bar/resolve_filters";
+
+const app = (id: string, name: string) => ({ id, name }) as App;
+const apps = [app("app-1", "Checkout"), app("app-2", "Wallet")];
+
+const mappingTypeKey = {
+  name: "mapping_type",
+  label: "File type",
+  key_group: "Build",
+  description: "The kind of mapping file",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+} as unknown as FilterKey;
+
+const versionKey = {
+  name: "version_name",
+  label: "App version",
+  key_group: "Version",
+  description: "The version the build reports",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+} as unknown as FilterKey;
+
+const noDate = { dateRange: null, startDate: null, endDate: null };
+
+const bareUrl: UrlFilters = {
+  appId: null,
+  dateRange: noDate,
+  filterExpr: null,
+  rootSpanName: null,
+};
+
+const appsLoaded: AppsQueryState = { status: "success", data: apps };
+const appsPending: AppsQueryState = { status: "pending", data: undefined };
+const appsFailed: AppsQueryState = { status: "error", data: undefined };
+
+const keysLoaded: KeysQueryState = {
+  isPending: false,
+  isError: false,
+  isPlaceholderData: false,
+  data: {
+    keys: [mappingTypeKey, versionKey],
+    key_groups: ["Build", "Version"],
+  },
+};
+const keysPending: KeysQueryState = {
+  isPending: true,
+  isError: false,
+  isPlaceholderData: false,
+  data: undefined,
+};
+const keysOfPreviousApp: KeysQueryState = {
+  ...keysLoaded,
+  isPlaceholderData: true,
+};
+const keysFailed: KeysQueryState = {
+  isPending: false,
+  isError: true,
+  isPlaceholderData: false,
+  data: undefined,
+};
+
+const namesLoaded = (names: string[] | null): SpanNamesQueryState => ({
+  isError: false,
+  isSuccess: true,
+  data: names,
+});
+const namesPending: SpanNamesQueryState = {
+  isError: false,
+  isSuccess: false,
+  data: undefined,
+};
+const namesFailed: SpanNamesQueryState = {
+  isError: true,
+  isSuccess: false,
+  data: undefined,
+};
+
+const nothingRemembered = { appId: undefined, dateRange: noDate };
+
+function resolve(
+  overrides: Partial<Parameters<typeof resolveFilters>[0]> = {},
+  url: Partial<UrlFilters> = {},
+) {
+  return resolveFilters({
+    url: { ...bareUrl, ...url },
+    apps: appsLoaded,
+    keys: keysLoaded,
+    spanNames: null,
+    remembered: nothingRemembered,
+    ...overrides,
+  });
+}
+
+describe("resolveApp", () => {
+  it("takes the URL's app when the team has it", () => {
+    expect(resolveApp("app-2", apps, "app-1")).toEqual(apps[1]);
+  });
+
+  it("falls back to the remembered app, then the first", () => {
+    expect(resolveApp("app-gone", apps, "app-2")).toEqual(apps[1]);
+    expect(resolveApp("app-gone", apps, "app-gone")).toEqual(apps[0]);
+    expect(resolveApp(null, apps, undefined)).toEqual(apps[0]);
+  });
+
+  it("has nothing to offer before the apps load, or when there are none", () => {
+    expect(resolveApp("app-1", undefined, undefined)).toBeNull();
+    expect(resolveApp("app-1", [], undefined)).toBeNull();
+  });
+});
+
+describe("resolveFilters", () => {
+  describe("the app", () => {
+    it("settles on the URL's app", () => {
+      const resolution = resolve({}, { appId: "app-2" });
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.app).toEqual(apps[1]);
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("ranks the URL's app above the remembered one", () => {
+      const resolution = resolve(
+        { remembered: { appId: "app-2", dateRange: noDate } },
+        { appId: "app-1" },
+      );
+
+      expect(resolution.filters?.app).toEqual(apps[0]);
+    });
+
+    it("keeps the remembered app for a bare URL", () => {
+      const resolution = resolve({
+        remembered: { appId: "app-2", dateRange: noDate },
+      });
+
+      expect(resolution.filters?.app).toEqual(apps[1]);
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("discards an app the team no longer has", () => {
+      const resolution = resolve({}, { appId: "app-gone" });
+
+      expect(resolution.filters?.app).toEqual(apps[0]);
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("does not judge the URL's app before the apps load", () => {
+      const resolution = resolve({ apps: appsPending }, { appId: "app-gone" });
+
+      expect(resolution.status).toEqual({ kind: "loading" });
+      expect(resolution.filters).toBeNull();
+      expect(resolution.discarded).toBe(false);
+    });
+  });
+
+  describe("the date", () => {
+    it("takes the URL's label", () => {
+      const resolution = resolve(
+        {},
+        {
+          dateRange: { dateRange: "Last Week", startDate: null, endDate: null },
+        },
+      );
+
+      expect(resolution.date.dateRange).toBe("Last Week");
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("falls back to the remembered range, then the default", () => {
+      const remembered = {
+        appId: undefined,
+        dateRange: {
+          dateRange: "Last 24 Hours",
+          startDate: null,
+          endDate: null,
+        },
+      };
+
+      expect(resolve({ remembered }).date.dateRange).toBe("Last 24 Hours");
+      expect(resolve().date.dateRange).toBe("Last 6 Hours");
+    });
+
+    it("discards a label it cannot read", () => {
+      const resolution = resolve(
+        {},
+        {
+          dateRange: {
+            dateRange: "Last Fortnight",
+            startDate: null,
+            endDate: null,
+          },
+        },
+      );
+
+      expect(resolution.date.dateRange).toBe("Last 6 Hours");
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("keeps the timestamps of a custom range", () => {
+      const custom = {
+        dateRange: "Custom Range",
+        startDate: "2026-02-01T00:00:00.000Z",
+        endDate: "2026-02-02T00:00:00.000Z",
+      };
+
+      expect(resolve({}, { dateRange: custom }).date).toEqual(custom);
+    });
+
+    it("discards a custom range whose timestamps do not read back", () => {
+      const resolution = resolve(
+        {},
+        {
+          dateRange: {
+            dateRange: "Custom Range",
+            startDate: "yesterday",
+            endDate: null,
+          },
+        },
+      );
+
+      expect(resolution.date.dateRange).toBe("Last 6 Hours");
+      expect(resolution.discarded).toBe(true);
+    });
+  });
+
+  describe("the filter", () => {
+    it("keeps a filter the keys can vouch for, in its canonical form", () => {
+      const resolution = resolve({}, { filterExpr: "mapping_type:in:[dsym]" });
+
+      expect(resolution.filters?.filterExpr).toBe("mapping_type:in:dsym");
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("filters by nothing for an empty filter, without a discard", () => {
+      const resolution = resolve({}, { filterExpr: "" });
+
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("discards a filter it cannot read", () => {
+      const resolution = resolve(
+        {},
+        { filterExpr: "mapping_type:in:dsym AND" },
+      );
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("discards a filter naming a key this app does not have", () => {
+      const resolution = resolve({}, { filterExpr: "device_cohort:in:new" });
+
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("discards a condition without a value", () => {
+      const resolution = resolve(
+        {},
+        { filterExpr: "mapping_type:in:dsym AND version_name:in:" },
+      );
+
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("discards a filter past a limit", () => {
+      const tooMany = Array.from(
+        { length: MAX_CONDITIONS + 1 },
+        () => "mapping_type:in:dsym",
+      ).join(" AND ");
+      const resolution = resolve({}, { filterExpr: tooMany });
+
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("waits for the keys before judging a filter", () => {
+      const resolution = resolve(
+        { keys: keysPending },
+        { filterExpr: "mapping_type:in:dsym" },
+      );
+
+      expect(resolution.status).toEqual({ kind: "loading" });
+      expect(resolution.filters).toBeNull();
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("does not judge a filter by the previous app's keys", () => {
+      const resolution = resolve(
+        { keys: keysOfPreviousApp },
+        { filterExpr: "device_cohort:in:new" },
+      );
+
+      expect(resolution.status).toEqual({ kind: "loading" });
+      expect(resolution.filters).toBeNull();
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("is ready with the previous app's keys when there is no filter to judge", () => {
+      const resolution = resolve({ keys: keysOfPreviousApp });
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.filterExpr).toBeNull();
+    });
+
+    it("is ready before the keys load when there is no filter to judge", () => {
+      const resolution = resolve({ keys: keysPending });
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters).toEqual({
+        app: apps[0],
+        filterExpr: null,
+        rootSpanName: null,
+      });
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("leaves a filter unjudged when the keys cannot be fetched", () => {
+      const resolution = resolve(
+        { keys: keysFailed },
+        { filterExpr: "device_cohort:in:new" },
+      );
+
+      expect(resolution.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching filters"),
+      });
+      expect(resolution.filters?.filterExpr).toBeNull();
+      expect(resolution.discarded).toBe(false);
+    });
+  });
+
+  describe("the root span", () => {
+    const names = namesLoaded(["checkout", "startup"]);
+
+    it("stays null on a page without a span selector", () => {
+      expect(resolve().filters?.rootSpanName).toBeNull();
+    });
+
+    it("takes the URL's name when the app has it", () => {
+      const resolution = resolve(
+        { spanNames: names },
+        { appId: "app-1", rootSpanName: "startup" },
+      );
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.rootSpanName).toBe("startup");
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("falls back to the first name for a bare URL", () => {
+      const resolution = resolve({ spanNames: names });
+
+      expect(resolution.filters?.rootSpanName).toBe("checkout");
+      expect(resolution.discarded).toBe(false);
+    });
+
+    it("discards a name the app does not have", () => {
+      const resolution = resolve(
+        { spanNames: names },
+        { appId: "app-1", rootSpanName: "gone" },
+      );
+
+      expect(resolution.filters?.rootSpanName).toBe("checkout");
+      expect(resolution.discarded).toBe(true);
+    });
+
+    it("does not judge a name left over from another app", () => {
+      const resolution = resolve(
+        { spanNames: names },
+        { appId: "app-gone", rootSpanName: "gone" },
+      );
+
+      expect(resolution.filters?.rootSpanName).toBe("checkout");
+      expect(resolution.discarded).toBe(true);
+
+      const withoutApp = resolve(
+        { spanNames: names },
+        { rootSpanName: "gone" },
+      );
+
+      expect(withoutApp.filters?.rootSpanName).toBe("checkout");
+      expect(withoutApp.discarded).toBe(false);
+    });
+
+    it("is ready with no name when the app never reported a trace", () => {
+      for (const data of [[], null]) {
+        const resolution = resolve(
+          { spanNames: namesLoaded(data) },
+          { appId: "app-1" },
+        );
+
+        expect(resolution.status).toEqual({ kind: "ready" });
+        expect(resolution.filters?.rootSpanName).toBeNull();
+        expect(resolution.discarded).toBe(false);
+      }
+    });
+
+    it("keeps the app usable while the names load", () => {
+      const resolution = resolve({ spanNames: namesPending });
+
+      expect(resolution.status).toEqual({ kind: "loading" });
+      expect(resolution.filters).toEqual({
+        app: apps[0],
+        filterExpr: null,
+        rootSpanName: null,
+      });
+    });
+
+    it("reports names that could not be fetched", () => {
+      const resolution = resolve({ spanNames: namesFailed });
+
+      expect(resolution.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching traces list"),
+      });
+      expect(resolution.filters?.app).toEqual(apps[0]);
+    });
+  });
+
+  describe("errors, in order of precedence", () => {
+    it("reports apps that could not be fetched", () => {
+      const resolution = resolve({
+        apps: appsFailed,
+        keys: keysFailed,
+        spanNames: namesFailed,
+      });
+
+      expect(resolution.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching apps"),
+      });
+      expect(resolution.filters).toBeNull();
+    });
+
+    it("reports a team with no apps", () => {
+      const resolution = resolve({
+        apps: { status: "success", data: [] },
+        keys: keysFailed,
+        spanNames: namesFailed,
+      });
+
+      expect(resolution.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("don't have any apps yet"),
+      });
+      expect(resolution.filters).toBeNull();
+    });
+
+    it("reports keys that could not be fetched, with the app still settled", () => {
+      const resolution = resolve({ keys: keysFailed, spanNames: namesFailed });
+
+      expect(resolution.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching filters"),
+      });
+      expect(resolution.filters?.app).toEqual(apps[0]);
+    });
+  });
+});

--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -1,433 +1,655 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
 import { mockRouter } from "@/__tests__/helpers/mock_router";
 import type { App } from "@/app/api/api_calls";
-import type {
-  FilterRequest,
-  FilterState,
-} from "@/app/components/filter_bar/filter_bar";
-import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
+import type { FilterKey } from "@/app/api/filter_types";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import { act, render } from "@testing-library/react";
+import { DateTime } from "luxon";
 import { useEffect } from "react";
 
-const replaceMock = mockRouter.replaceMock;
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
+const mockUseRootSpanNamesQuery = jest.fn();
+const mockToastNegative = jest.fn();
 
 jest.mock("next/navigation", () =>
   require("@/__tests__/helpers/mock_router").nextNavigationMock(),
 );
 
-jest.mock("@/app/components/filter_bar/filter_bar", () => ({
-  __esModule: true,
-  filterExprUrlKey: "filter_expr",
-}));
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
 
-jest.mock("@/app/stores/filters_store", () => ({
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  urlFiltersKeyMap: {
-    appId: "a",
-    dateRange: "d",
-    startDate: "sd",
-    endDate: "ed",
-  },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
   paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: (app: unknown) => mockUseRootSpanNamesQuery(app),
 }));
 
-const app = { id: "app-1", name: "Sample" } as App;
-const last6Hours = {
-  dateRange: "Last 6 Hours",
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-01T06:00:00.000Z",
-};
-const custom = {
-  dateRange: "Custom Range",
-  startDate: "2026-02-01T00:00:00.000Z",
-  endDate: "2026-02-02T00:00:00.000Z",
-};
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 
-type Page = ReturnType<typeof useExprFilterPage>;
+const app = (id: string, name: string) => ({ id, name }) as App;
+const apps = [app("app-1", "Checkout"), app("app-2", "Wallet")];
 
-// The stub bar keeps the props of its latest render so a test can read what
-// the page handed it.
-let bar: {
-  requestedAppId: string | null;
-  requestedDateRange: { dateRange: string | null };
-  requestedFilterExpr: string | null;
-  requestedRootSpanName: string | null;
-  onRequestChange: (change: Partial<FilterRequest>) => void;
-  onFilterChange: (state: FilterState) => void;
-};
-let page: Page;
+const mappingTypeKey = {
+  name: "mapping_type",
+  label: "File type",
+  key_group: "Build",
+  description: "The kind of mapping file",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+} as unknown as FilterKey;
 
-function HostWithPageKey() {
-  const rendered = useExprFilterPage({
-    extraUrlKeys: { rootSpanName: "r" },
-    pageUrlKeys: ["jt"],
+function appsLoaded(loaded: App[] = apps) {
+  mockUseAppsQuery.mockReturnValue({ status: "success", data: loaded });
+}
+
+function keysPending() {
+  mockUseFilterKeysQuery.mockReturnValue({
+    data: undefined,
+    isPending: true,
+    isError: false,
+    isPlaceholderData: false,
   });
+}
+
+function keysLoaded(keys: FilterKey[] = [mappingTypeKey]) {
+  mockUseFilterKeysQuery.mockReturnValue({
+    data: { keys, key_groups: ["Build"] },
+    isPending: false,
+    isError: false,
+    isPlaceholderData: false,
+  });
+}
+
+function namesLoaded(names: string[] | null) {
+  mockUseRootSpanNamesQuery.mockReturnValue({
+    data: names,
+    isSuccess: true,
+    isError: false,
+  });
+}
+
+type Options = Parameters<typeof useExprFilterPage>[0];
+
+let page: ReturnType<typeof useExprFilterPage>;
+
+function Host(options: Options) {
+  const rendered = useExprFilterPage(options);
   useEffect(() => {
     page = rendered;
-    bar = {
-      requestedAppId: rendered.requestedFilters.appId,
-      requestedDateRange: rendered.requestedFilters.dateRange,
-      requestedFilterExpr: rendered.requestedFilters.filterExpr,
-      requestedRootSpanName: rendered.requestedFilters.rootSpanName,
-      onRequestChange: rendered.onRequestChange,
-      onFilterChange: rendered.onFilterChange,
-    };
   });
   return null;
 }
 
-function Host({ paginationLimit }: { paginationLimit?: number }) {
-  const rendered = useExprFilterPage({
-    paginationLimit,
-    extraUrlKeys: { rootSpanName: "r" },
+const paginated: Options = {
+  teamId: "team-1",
+  entity: "builds",
+  paginationLimit: 10,
+};
+
+async function renderPage(options: Options = paginated) {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<Host {...options} />);
   });
-  useEffect(() => {
-    page = rendered;
-    bar = {
-      requestedAppId: rendered.requestedFilters.appId,
-      requestedDateRange: rendered.requestedFilters.dateRange,
-      requestedFilterExpr: rendered.requestedFilters.filterExpr,
-      requestedRootSpanName: rendered.requestedFilters.rootSpanName,
-      onRequestChange: rendered.onRequestChange,
-      onFilterChange: rendered.onFilterChange,
-    };
-  });
-  return null;
+  return result;
 }
 
-const ready = (
-  overrides: Partial<Extract<FilterState, { status: "ready" }>> = {},
-): FilterState => ({
-  status: "ready",
-  app,
-  date: last6Hours,
-  filterExpr: null,
-  rootSpanName: "span.first",
-  appliedAsRequested: true,
-  ...overrides,
-});
-
-const request = (overrides: Partial<FilterRequest> = {}): FilterRequest => ({
-  appId: app.id,
-  dateRange: last6Hours,
-  filterExpr: null,
-  rootSpanName: "span.first",
-  ...overrides,
-});
-
-const settledParams = "a=app-1&d=Last+6+Hours&r=span.first";
-
-function renderPage(paginationLimit?: number) {
-  return render(<Host paginationLimit={paginationLimit} />);
-}
+const settled = { a: "app-1", d: "Last 6 Hours" };
 
 describe("useExprFilterPage", () => {
   beforeEach(() => {
     mockRouter.reset();
-  });
-
-  it("hands the bar its request before and after the write lands", async () => {
-    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
-    renderPage(10);
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-
-    mockRouter.deferReplace = true;
-    await act(async () => {
-      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
-    });
-    expect(bar.requestedFilterExpr).toBe("patch_id:");
-    expect(replaceMock).not.toHaveBeenCalled();
-
-    await act(async () => {
-      bar.onFilterChange(ready({ filterExpr: null }));
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?po=0&${settledParams}`, {
-      scroll: false,
-    });
-    expect(bar.requestedFilterExpr).toBe("patch_id:");
-
-    await act(async () => {
-      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
-    });
-    expect(bar.requestedFilterExpr).toBe("patch_id:");
-  });
-
-  it("hands the bar the URL after a search string the page did not write", async () => {
-    mockRouter.searchParams = new URLSearchParams(settledParams);
-    renderPage();
-    await act(async () => {
-      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
-    });
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    expect(bar.requestedFilterExpr).toBe("patch_id:");
-
-    await act(async () => {
-      mockRouter.applyReplaceUrl("?a=app-2&d=Last+Week&r=span.second");
-    });
-    expect(bar.requestedAppId).toBe("app-2");
-    expect(bar.requestedDateRange.dateRange).toBe("Last Week");
-    expect(bar.requestedFilterExpr).toBeNull();
-    expect(bar.requestedRootSpanName).toBe("span.second");
-  });
-
-  it("writes again after a navigation back to the search string a request was stored on", async () => {
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
-      scroll: false,
-    });
-    expect(bar.requestedAppId).toBe("app-1");
-    expect(bar.requestedRootSpanName).toBe("span.first");
-
-    await act(async () => {
-      mockRouter.applyReplaceUrl("?");
-    });
-    expect(bar.requestedAppId).toBeNull();
-
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    expect(replaceMock).toHaveBeenCalledTimes(2);
-    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
-      scroll: false,
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
+    mockUseFilterKeysQuery.mockClear();
+    appsLoaded();
+    keysLoaded();
+    mockUseRootSpanNamesQuery.mockReturnValue({
+      data: undefined,
+      isSuccess: false,
+      isError: false,
     });
   });
 
-  it("writes a navigation whose resolution equals the last written URL", async () => {
-    mockRouter.searchParams = new URLSearchParams(settledParams);
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    await act(async () => {
-      bar.onRequestChange({ filterExpr: "patch_id:1" });
-    });
-    await act(async () => {
-      bar.onFilterChange(ready({ filterExpr: "patch_id:1" }));
-    });
-    await act(async () => {
-      bar.onRequestChange({ filterExpr: null });
-    });
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
-      scroll: false,
+  describe("a bare URL", () => {
+    it("is filled in with what the page settled on, and fetched", async () => {
+      await renderPage();
+
+      expect(mockRouter.urlParams()).toEqual(settled);
+      expect(page.status).toEqual({ kind: "ready" });
+      expect(page.value).toMatchObject({
+        app: apps[0],
+        filterExpr: null,
+        rootSpanName: null,
+      });
+      expect(page.filterParams).toEqual({
+        appId: "app-1",
+        startDate: page.value!.date.startDate,
+        endDate: page.value!.date.endDate,
+        filterExpr: null,
+      });
+      expect(page.paginationOffset).toBe(0);
+      expect(mockToastNegative).not.toHaveBeenCalled();
     });
 
-    await act(async () => {
-      mockRouter.applyReplaceUrl("?");
+    it("keeps the app and range another page left on the store", async () => {
+      mockFiltersStore.store.getState().setSelectedApp(apps[1]);
+      mockFiltersStore.store.getState().setSelectedDateRange("Last Week");
+      await renderPage();
+
+      expect(mockRouter.urlParams()).toEqual({ a: "app-2", d: "Last Week" });
     });
-    await act(async () => {
-      bar.onFilterChange(ready());
+
+    it("puts the app, the range and the apps on the store for other pages", async () => {
+      await renderPage();
+
+      const state = mockFiltersStore.store.getState();
+      expect(state.selectedApp).toEqual(apps[0]);
+      expect(state.selectedDateRange).toBe("Last 6 Hours");
+      expect(state.selectedStartDate).toBe(page.value!.date.startDate);
+      expect(state.apps).toEqual(apps);
+      expect(state.appsState).toBe("loaded");
     });
-    expect(replaceMock).toHaveBeenCalledTimes(3);
-    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
-      scroll: false,
+
+    it("fetches nothing until the apps have loaded", async () => {
+      mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
+      await renderPage();
+
+      expect(page.status).toEqual({ kind: "loading" });
+      expect(page.value).toBeNull();
+      expect(page.filterParams).toBeNull();
+      expect(mockRouter.urlParams()).toEqual({});
+      expect(mockFiltersStore.store.getState().appsState).toBe("pending");
+    });
+
+    it("fetches before the keys load when there is no filter to judge, with no keys for the bar yet", async () => {
+      keysPending();
+      await renderPage();
+
+      expect(page.status).toEqual({ kind: "ready" });
+      expect(page.value).toMatchObject({ app: apps[0], filterExpr: null });
+      expect(page.keys).toBeNull();
+      expect(mockRouter.urlParams()).toEqual(settled);
+      expect(page.filterParams).toMatchObject({
+        appId: "app-1",
+        filterExpr: null,
+      });
+
+      keysLoaded();
+      await renderPage();
+
+      expect(page.keys).toEqual([mappingTypeKey]);
+      expect(page.filterParams).toMatchObject({
+        appId: "app-1",
+        filterExpr: null,
+      });
+    });
+
+    it("waits for the keys before fetching a URL that carries a filter", async () => {
+      mockRouter.setUrl("?filter_expr=mapping_type%3Ain%3Adsym");
+      keysPending();
+      await renderPage();
+
+      expect(page.status).toEqual({ kind: "loading" });
+      expect(page.value).toBeNull();
+      expect(page.filterParams).toBeNull();
+      expect(mockRouter.urlParams()).toEqual({
+        filter_expr: "mapping_type:in:dsym",
+      });
     });
   });
 
-  it("merges a change into the request it hands the bar", async () => {
-    mockRouter.searchParams = new URLSearchParams("r=span.checkout");
-    renderPage();
-    await act(async () => {
-      bar.onRequestChange({ dateRange: custom });
-    });
-    expect(bar.requestedDateRange.dateRange).toBe(custom.dateRange);
-    expect(bar.requestedRootSpanName).toBe("span.checkout");
-  });
+  describe("a URL it cannot honour", () => {
+    it("is rewritten from page one, with a toast", async () => {
+      mockRouter.setUrl(
+        "?a=app-gone&d=Last+Week&po=20&filter_expr=mapping_type%3Ain%3Adsym",
+      );
+      await renderPage();
 
-  it("keeps the request across a pagination write", async () => {
-    mockRouter.searchParams = new URLSearchParams(`po=0&${settledParams}`);
-    renderPage(10);
-    await act(async () => {
-      bar.onRequestChange(request({ filterExpr: "patch_id:" }));
-    });
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-
-    await act(async () => {
-      page.nextPage();
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?po=10&${settledParams}`, {
-      scroll: false,
-    });
-    expect(bar.requestedFilterExpr).toBe("patch_id:");
-  });
-
-  it("writes a relative label without timestamps and a custom range with them", async () => {
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready({ date: last6Hours }));
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?${settledParams}`, {
-      scroll: false,
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Last Week",
+        po: "0",
+        filter_expr: "mapping_type:in:dsym",
+      });
+      expect(mockToastNegative).toHaveBeenCalledTimes(1);
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        "Some filters were invalid, page reset to defaults",
+      );
+      expect(page.filterParams).toMatchObject({
+        appId: "app-1",
+        filterExpr: "mapping_type:in:dsym",
+      });
     });
 
-    await act(async () => {
-      bar.onFilterChange(ready({ date: custom, appliedAsRequested: false }));
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(
-      "?a=app-1&d=Custom+Range&sd=2026-02-01T00%3A00%3A00.000Z&ed=2026-02-02T00%3A00%3A00.000Z&r=span.first",
-      { scroll: false },
-    );
-  });
+    it("drops a filter the keys cannot vouch for", async () => {
+      mockRouter.setUrl("?po=20&filter_expr=device_cohort%3Ain%3Anew");
+      await renderPage();
 
-  it("gates a relative range on its label alone, with the state's timestamps", async () => {
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      `${settledParams}&sd=2020-01-01T00%3A00%3A00.000Z&ed=2020-01-02T00%3A00%3A00.000Z`,
-    );
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready());
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+      expect(mockToastNegative).toHaveBeenCalledTimes(1);
     });
 
-    expect(page.filterParams).toEqual({
-      appId: app.id,
-      startDate: last6Hours.startDate,
-      endDate: last6Hours.endDate,
-      filterExpr: null,
+    it("keeps the page for a filter that only needed its canonical form", async () => {
+      mockRouter.setUrl("?po=20&filter_expr=mapping_type%3Ain%3A%5Bdsym%5D");
+      await renderPage();
+
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "20",
+        filter_expr: "mapping_type:in:dsym",
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(page.paginationOffset).toBe(20);
+    });
+
+    it("says so once, however much was refused", async () => {
+      mockRouter.setUrl("?a=app-gone&d=Last+Fortnight&filter_expr=nonsense%3A");
+      await renderPage();
+
+      expect(mockToastNegative).toHaveBeenCalledTimes(1);
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
     });
   });
 
-  it("gates a custom range on its timestamps", async () => {
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      "a=app-1&d=Custom+Range&sd=2020-01-01T00%3A00%3A00.000Z&ed=2020-01-02T00%3A00%3A00.000Z&r=span.first",
-    );
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready({ date: custom, appliedAsRequested: false }));
-    });
-    expect(page.filterParams).toBeNull();
+  describe("a change from the bar", () => {
+    it("writes the filter from page one and carries the page's own keys", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=20&jt=Exceptions");
+      await renderPage();
 
-    await act(async () => {
-      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+      await act(async () => {
+        page.onChange({ filterExpr: "mapping_type:in:dsym" });
+      });
+
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        jt: "Exceptions",
+        filter_expr: "mapping_type:in:dsym",
+      });
+      expect(page.paginationOffset).toBe(0);
+      expect(page.filterParams).toMatchObject({
+        filterExpr: "mapping_type:in:dsym",
+      });
     });
-    expect(page.filterParams).toEqual({
-      appId: app.id,
-      startDate: custom.startDate,
-      endDate: custom.endDate,
-      filterExpr: null,
+
+    it("removes the keys a null value stands for", async () => {
+      mockRouter.setUrl(
+        "?a=app-1&d=Last+6+Hours&r=span.first&filter_expr=mapping_type%3Ain%3Adsym",
+      );
+      mockUseRootSpanNamesQuery.mockImplementation((app: App) =>
+        app.id === "app-1"
+          ? { data: ["span.first"], isSuccess: true, isError: false }
+          : { data: undefined, isSuccess: false, isError: false },
+      );
+      await renderPage({ ...paginated, entity: "spans", rootSpan: true });
+
+      await act(async () => {
+        page.onChange({ appId: "app-2", filterExpr: null, rootSpanName: null });
+      });
+
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-2",
+        d: "Last 6 Hours",
+        po: "0",
+      });
+      expect(page.status).toEqual({ kind: "loading" });
+    });
+
+    it("writes a relative range as its label alone, and a custom range with its timestamps", async () => {
+      mockRouter.setUrl(
+        "?a=app-1&d=Custom+Range&sd=2026-02-01T00%3A00%3A00.000Z&ed=2026-02-02T00%3A00%3A00.000Z",
+      );
+      await renderPage({ teamId: "team-1", entity: "journeys" });
+
+      await act(async () => {
+        page.onChange({
+          dateRange: { dateRange: "Last Week", startDate: null, endDate: null },
+        });
+      });
+      expect(mockRouter.urlParams()).toEqual({ a: "app-1", d: "Last Week" });
+
+      const custom = {
+        dateRange: "Custom Range",
+        startDate: DateTime.fromISO("2026-02-01T00:00:00.000Z").toISO()!,
+        endDate: DateTime.fromISO("2026-02-02T00:00:00.000Z").toISO()!,
+      };
+      await act(async () => {
+        page.onChange({ dateRange: custom });
+      });
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Custom Range",
+        sd: custom.startDate,
+        ed: custom.endDate,
+      });
+      expect(page.filterParams).toMatchObject({
+        startDate: custom.startDate,
+        endDate: custom.endDate,
+      });
+    });
+
+    it("keeps a write still in flight when the page writes one of its keys", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&jt=Paths");
+      await renderPage({ teamId: "team-1", entity: "journeys" });
+
+      mockRouter.deferReplace = true;
+      await act(async () => {
+        page.onChange({
+          dateRange: { dateRange: "Last Week", startDate: null, endDate: null },
+        });
+      });
+      await act(async () => {
+        page.setPageUrlKey("jt", "Exceptions");
+      });
+
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Last Week",
+        jt: "Exceptions",
+      });
+      expect(page.filterParams).toMatchObject({
+        startDate: page.value!.date.startDate,
+      });
+      expect(page.value!.date.dateRange).toBe("Last 6 Hours");
+
+      await act(async () => {
+        mockRouter.applyDeferredReplace();
+      });
+      expect(page.value!.date.dateRange).toBe("Last Week");
+      expect(page.filterParams).toMatchObject({
+        startDate: page.value!.date.startDate,
+      });
     });
   });
 
-  it("resets the offset after a pick and keeps it after an unchanged request", async () => {
-    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
-    renderPage(10);
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    expect(page.paginationOffset).toBe(20);
+  describe("the fetch", () => {
+    it("waits while the URL still says something else", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours");
+      await renderPage();
+      expect(page.filterParams).not.toBeNull();
 
-    await act(async () => {
-      bar.onRequestChange(request({ rootSpanName: "span.second" }));
+      await act(async () => {
+        mockRouter.setUrl("?a=app-gone&d=Last+6+Hours&po=10");
+        mockRouter.deferReplace = true;
+      });
+
+      expect(page.filterParams).toBeNull();
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+
+      await act(async () => {
+        mockRouter.applyDeferredReplace();
+      });
+      expect(page.filterParams).toMatchObject({ appId: "app-1" });
+      expect(page.paginationOffset).toBe(0);
     });
-    await act(async () => {
-      bar.onFilterChange(ready({ rootSpanName: "span.second" }));
+
+    it("does not write over a URL the router has not rendered yet", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours");
+      const rendered = await renderPage();
+
+      mockRouter.deferReplace = true;
+      mockRouter.setUrl("?a=app-2");
+      await act(async () => {
+        rendered.rerender(<Host {...paginated} />);
+      });
+
+      expect(mockRouter.urlParams()).toEqual({ a: "app-2" });
+      expect(page.filterParams).toMatchObject({ appId: "app-1" });
+
+      await act(async () => {
+        mockRouter.applyDeferredReplace();
+      });
+
+      expect(mockRouter.urlParams()).toEqual({ a: "app-2", d: "Last 6 Hours" });
+      expect(page.filterParams).toBeNull();
+
+      await act(async () => {
+        mockRouter.applyDeferredReplace();
+      });
+
+      expect(page.filterParams).toMatchObject({ appId: "app-2" });
     });
-    expect(replaceMock).toHaveBeenLastCalledWith(
-      "?po=0&a=app-1&d=Last+6+Hours&r=span.second",
-      { scroll: false },
-    );
-    expect(page.paginationOffset).toBe(0);
+
+    it("ignores timestamps the URL carries with a relative label", async () => {
+      mockRouter.setUrl(
+        "?a=app-1&d=Last+6+Hours&sd=2020-01-01T00%3A00%3A00.000Z&ed=2020-01-02T00%3A00%3A00.000Z",
+      );
+      await renderPage();
+
+      expect(page.filterParams).toMatchObject({
+        startDate: page.value!.date.startDate,
+        endDate: page.value!.date.endDate,
+      });
+      expect(page.filterParams!.startDate).not.toBe("2020-01-01T00:00:00.000Z");
+    });
+
+    it("asks the keys query for the custom keys the URL's filter names", async () => {
+      const customPlanKey = {
+        ...mappingTypeKey,
+        name: "custom.plan",
+        label: "plan",
+        key_group: "Custom",
+      };
+      mockUseFilterKeysQuery.mockImplementation(
+        (_appId: string | undefined, _entity: string, keyNames: string[]) => ({
+          data: {
+            keys: keyNames.includes("custom.plan")
+              ? [mappingTypeKey, customPlanKey]
+              : [mappingTypeKey],
+            key_groups: ["Build", "Custom"],
+          },
+          isPending: false,
+          isError: false,
+          isPlaceholderData: false,
+        }),
+      );
+      mockRouter.setUrl("?filter_expr=custom.plan%3Ain%3Apro");
+      await renderPage();
+
+      expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+        "app-1",
+        "builds",
+        ["custom.plan"],
+      );
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        filter_expr: "custom.plan:in:pro",
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
   });
 
-  it("keeps a pick made while an earlier write is still in flight", async () => {
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams("a=app-1&d=Last+6+Hours");
-    renderPage();
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    const firstWrite = mockRouter.deferredReplaceUrl!;
+  describe("when the keys cannot be fetched", () => {
+    it("reports the error, keeps the bar drawn, and leaves the URL alone", async () => {
+      mockRouter.setUrl("?po=10");
+      mockUseFilterKeysQuery.mockReturnValue({
+        data: undefined,
+        isPending: false,
+        isError: true,
+        isPlaceholderData: false,
+      });
+      await renderPage();
 
-    await act(async () => {
-      bar.onRequestChange({ rootSpanName: "span.second" });
+      expect(page.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching filters"),
+      });
+      expect(page.value).toMatchObject({ app: apps[0] });
+      expect(page.keysUnavailable).toBe(true);
+      expect(page.keys).toEqual([]);
+      expect(page.filterParams).toBeNull();
+      expect(mockRouter.urlParams()).toEqual({ po: "10" });
     });
-    expect(bar.requestedRootSpanName).toBe("span.second");
 
-    await act(async () => {
-      mockRouter.applyReplaceUrl(firstWrite);
+    it("does not toast for a filter it could not judge", async () => {
+      mockRouter.setUrl("?filter_expr=mapping_type%3Ain%3Adsym");
+      mockUseFilterKeysQuery.mockReturnValue({
+        data: undefined,
+        isPending: false,
+        isError: true,
+        isPlaceholderData: false,
+      });
+      await renderPage();
+
+      expect(page.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching filters"),
+      });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+      expect(mockRouter.urlParams()).toEqual({
+        filter_expr: "mapping_type:in:dsym",
+      });
     });
-    expect(bar.requestedRootSpanName).toBe("span.second");
   });
 
-  it("keeps a page key written just before a pick", async () => {
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(`${settledParams}&jt=Paths`);
-    const { unmount } = render(<HostWithPageKey />);
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    await act(async () => {
-      page.setPageUrlKey("jt", "Exceptions");
-    });
-    await act(async () => {
-      bar.onRequestChange({ dateRange: last6Hours });
-      bar.onRequestChange({ rootSpanName: "span.second" });
-    });
-    await act(async () => {
-      bar.onFilterChange(ready({ rootSpanName: "span.second" }));
+  describe("the root span", () => {
+    const traces: Options = {
+      teamId: "team-1",
+      entity: "spans",
+      paginationLimit: 5,
+      rootSpan: true,
+    };
+
+    it("settles on the first name and writes it", async () => {
+      namesLoaded(["span.first", "span.second"]);
+      await renderPage(traces);
+
+      expect(mockRouter.urlParams()).toEqual({ ...settled, r: "span.first" });
+      expect(page.value?.rootSpanName).toBe("span.first");
+      expect(page.spanNames).toEqual(["span.first", "span.second"]);
     });
 
-    expect(mockRouter.deferredReplaceUrl).toBe(
-      "?a=app-1&d=Last+6+Hours&r=span.second&jt=Exceptions",
-    );
-    unmount();
+    it("discards a name the app does not have", async () => {
+      mockRouter.setUrl("?a=app-1&r=span.gone&po=10");
+      namesLoaded(["span.first", "span.second"]);
+      await renderPage(traces);
+
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        r: "span.first",
+        po: "0",
+      });
+      expect(mockToastNegative).toHaveBeenCalledTimes(1);
+    });
+
+    it("is ready with no name when the app never reported a trace", async () => {
+      mockRouter.setUrl("?a=app-1&po=10");
+      namesLoaded(null);
+      await renderPage(traces);
+
+      expect(page.status).toEqual({ kind: "ready" });
+      expect(page.value?.rootSpanName).toBeNull();
+      expect(page.spanNames).toEqual([]);
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
+      expect(mockToastNegative).not.toHaveBeenCalled();
+    });
+
+    it("discards a name the URL carries for an app that never reported a trace", async () => {
+      mockRouter.setUrl("?a=app-1&r=span.first&po=10");
+      namesLoaded(null);
+      await renderPage(traces);
+
+      expect(page.status).toEqual({ kind: "ready" });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+      expect(mockToastNegative).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the app usable while the names load, without fetching", async () => {
+      await renderPage(traces);
+
+      expect(page.status).toEqual({ kind: "loading" });
+      expect(page.value).toMatchObject({ app: apps[0], rootSpanName: null });
+      expect(page.spanNames).toBeNull();
+      expect(page.filterParams).toBeNull();
+      expect(mockRouter.urlParams()).toEqual({});
+    });
+
+    it("reports names that could not be fetched", async () => {
+      mockUseRootSpanNamesQuery.mockReturnValue({
+        data: undefined,
+        isSuccess: false,
+        isError: true,
+      });
+      await renderPage(traces);
+
+      expect(page.status).toEqual({
+        kind: "error",
+        message: expect.stringContaining("Error fetching traces list"),
+      });
+      expect(page.spanNames).toEqual([]);
+      expect(page.filterParams).toBeNull();
+    });
+
+    it("stays null on a page without a span selector", async () => {
+      namesLoaded(["span.first"]);
+      await renderPage();
+
+      expect(mockUseRootSpanNamesQuery).toHaveBeenLastCalledWith(null);
+      expect(page.spanNames).toBeNull();
+      expect(page.value?.rootSpanName).toBeNull();
+    });
   });
 
-  it("ignores a change that leaves the request as it is", async () => {
-    mockRouter.searchParams = new URLSearchParams(`po=20&${settledParams}`);
-    renderPage(10);
-    await act(async () => {
-      bar.onFilterChange(ready());
-    });
-    await act(async () => {
-      bar.onRequestChange({ filterExpr: null });
-    });
-    await act(async () => {
-      bar.onFilterChange(ready());
+  describe("pagination", () => {
+    it("reads a negative or unreadable offset as zero", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=-5");
+      await renderPage();
+      expect(page.paginationOffset).toBe(0);
+
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=abc");
+      await renderPage();
+      expect(page.paginationOffset).toBe(0);
     });
 
-    expect(page.paginationOffset).toBe(20);
-  });
+    it("moves the offset by the page size, never below zero", async () => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=10");
+      await renderPage();
+      expect(page.paginationOffset).toBe(10);
 
-  it("reads the offset it wrote while that write is still in flight", async () => {
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      "po=10&a=not-an-app&d=Last+6+Hours&r=span.first",
-    );
-    renderPage(10);
-    await act(async () => {
-      bar.onFilterChange(ready({ appliedAsRequested: false }));
-    });
-    expect(replaceMock).toHaveBeenLastCalledWith(`?po=0&${settledParams}`, {
-      scroll: false,
-    });
-    expect(page.paginationOffset).toBe(0);
+      await act(async () => {
+        page.nextPage();
+      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "20" });
+      expect(page.paginationOffset).toBe(20);
 
-    await act(async () => {
-      bar.onFilterChange(ready());
+      await act(async () => {
+        page.prevPage();
+      });
+      await act(async () => {
+        page.prevPage();
+      });
+      await act(async () => {
+        page.prevPage();
+      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+      expect(page.paginationOffset).toBe(0);
     });
-    expect(replaceMock).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
-      mockRouter.applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+    it("has no offset on a page without pagination", async () => {
+      mockRouter.setUrl("?po=10");
+      await renderPage({ teamId: "team-1", entity: "journeys" });
+
+      await act(async () => {
+        page.nextPage();
+      });
+
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
+      expect(page.paginationOffset).toBe(0);
     });
-    expect(page.paginationOffset).toBe(0);
-    expect(page.filterParams).not.toBeNull();
   });
 });

--- a/frontend/dashboard/__tests__/components/filter_bar/validate_test.ts
+++ b/frontend/dashboard/__tests__/components/filter_bar/validate_test.ts
@@ -14,7 +14,7 @@ import {
 } from "@/app/components/filter_bar/limits";
 import {
   buildConditionGroup,
-  buildDraftTree,
+  buildExprTree,
 } from "@/app/components/filter_bar/conditions";
 import {
   formatFilterExpr,
@@ -185,6 +185,7 @@ describe("findFilterIssues", () => {
   const keys = [
     key("version_name", ["in", "not_in", "contains"]),
     key("mapping_type", ["in", "not_in"]),
+    key("patch_id", ["is_set", "is_not_set"]),
   ];
 
   function issuesIn(text: string) {
@@ -228,6 +229,46 @@ describe("findFilterIssues", () => {
     expect([issue.span?.start, issue.span?.end]).toEqual([13, 21]);
   });
 
+  it("reports a condition whose operator is still waiting for its value", () => {
+    for (const text of [
+      "version_name:in",
+      "version_name:in:",
+      "version_name:in: AND mapping_type:in:dsym",
+    ]) {
+      const [issue] = issuesIn(text);
+
+      expect(issue.message).toBe("version_name needs a value");
+      expect([issue.span?.start, issue.span?.end]).toEqual([0, 15]);
+    }
+    expect(issuesIn("version_name:in:[1.0.0,1.0.1]")).toEqual([]);
+    expect(issuesIn('version_name:in:"1.0.0 (beta)"')).toEqual([]);
+  });
+
+  it("reports several values given to an operator that takes one", () => {
+    const [issue] = issuesIn("version_name:contains:[1.0,1.1]");
+
+    expect(issue.message).toBe("version_name takes one value");
+    expect([issue.span?.start, issue.span?.end]).toEqual([22, 31]);
+    expect(issuesIn("version_name:contains:[1.0]")).toEqual([]);
+  });
+
+  it("reports a value given to an operator that takes none", () => {
+    const [issue] = issuesIn("patch_id:is_set:1.0");
+
+    expect(issue.message).toBe("patch_id takes no value");
+    expect([issue.span?.start, issue.span?.end]).toEqual([9, 19]);
+    expect(issuesIn("patch_id:is_set")).toEqual([]);
+  });
+
+  it("reports an unfinished value once", () => {
+    expect(issuesIn('version_name:in:"abc').map((it) => it.message)).toEqual([
+      "Quoted value is not closed",
+    ]);
+    expect(
+      issuesIn("version_name:contains:[1.0,1.1").map((it) => it.message),
+    ).toEqual(["List of values is not closed"]);
+  });
+
   it("keeps the keys it found alongside text it could not read", () => {
     const issues = issuesIn("device_cohort:in:new AND other:in:x)");
 
@@ -254,7 +295,7 @@ describe("findFilterIssues", () => {
         row("version_name", "in", "1"),
       ),
     );
-    const parsed = parseFilterExpr(formatFilterExpr(buildDraftTree(tooMany)), {
+    const parsed = parseFilterExpr(formatFilterExpr(buildExprTree(tooMany)), {
       draft: true,
     });
     const issues = findFilterIssues(parsed, keys, tooMany);

--- a/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
@@ -136,10 +136,10 @@ describe("ValuePicker", () => {
 
     fireEvent.click(screen.getByTestId("filter-value-1.0.1"));
 
-    expect(onChange).toHaveBeenCalledWith([
-      { text: "1.0.0" },
-      { text: "1.0.1" },
-    ]);
+    expect(onChange).toHaveBeenCalledWith(
+      [{ text: "1.0.0" }, { text: "1.0.1" }],
+      false,
+    );
   });
 
   it("takes a picked value back off the list", () => {
@@ -149,7 +149,7 @@ describe("ValuePicker", () => {
 
     fireEvent.click(screen.getByTestId("filter-value-1.0.0"));
 
-    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.1" }]);
+    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.1" }], false);
   });
 
   it("marks the values that are picked", () => {
@@ -165,7 +165,7 @@ describe("ValuePicker", () => {
     );
   });
 
-  it("replaces the selection and closes for a one-value operator", () => {
+  it("replaces the selection and reports it done for a one-value operator", () => {
     const { onChange, onOpenChange } = renderPicker({
       takesOneValue: true,
       selected: [{ text: "1.0.0" }],
@@ -173,8 +173,8 @@ describe("ValuePicker", () => {
 
     fireEvent.click(screen.getByTestId("filter-value-1.0.1"));
 
-    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.1" }]);
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.1" }], true);
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("offers what was typed when the list is only a sample", () => {
@@ -200,7 +200,7 @@ describe("ValuePicker", () => {
 
     fireEvent.click(screen.getByTestId("filter-value-9.9.9"));
 
-    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.0" }]);
+    expect(onChange).toHaveBeenCalledWith([{ text: "1.0.0" }], false);
   });
 
   it("shows a chosen value the sample left out, whatever its source", () => {
@@ -355,7 +355,7 @@ describe("ValuePicker", () => {
       );
     });
 
-    it("applies what was typed, trimmed, and closes", () => {
+    it("applies what was typed, trimmed, and reports it done", () => {
       const { onChange, onOpenChange } = renderPicker({
         valueSuggestionMode: "none",
       });
@@ -367,8 +367,8 @@ describe("ValuePicker", () => {
         screen.getByTestId("filter-value-input").closest("form")!,
       );
 
-      expect(onChange).toHaveBeenCalledWith([{ text: "1.0.2" }]);
-      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onChange).toHaveBeenCalledWith([{ text: "1.0.2" }], true);
+      expect(onOpenChange).not.toHaveBeenCalled();
     });
 
     it("applies nothing when the box is empty", () => {
@@ -409,8 +409,8 @@ describe("ValuePicker", () => {
 
       fireEvent.click(screen.getByTestId("filter-value-true"));
 
-      expect(onChange).toHaveBeenCalledWith([{ text: "true" }]);
-      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onChange).toHaveBeenCalledWith([{ text: "true" }], true);
+      expect(onOpenChange).not.toHaveBeenCalled();
     });
 
     it("asks for a string key's suggestions under its full dotted name", () => {

--- a/frontend/dashboard/__tests__/components/user_journeys_test.tsx
+++ b/frontend/dashboard/__tests__/components/user_journeys_test.tsx
@@ -2,18 +2,15 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 
-const mockRouterReplace = jest.fn();
 const mockRouterPush = jest.fn();
-const mockSetPageUrlKey = jest.fn();
+const mockUseExprFilterPage = jest.fn();
 
 jest.mock("next/navigation", () => ({
   __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
+  useRouter: () => ({ push: mockRouterPush }),
   useSearchParams: () => new URLSearchParams(),
 }));
 
-// The demo never renders the filter bar or fetches, but the component calls
-// the live page's hooks on every render, so they are stubbed to stay idle.
 jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   __esModule: true,
   default: () => <div data-testid="filter-bar" />,
@@ -21,17 +18,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => ({
 
 jest.mock("@/app/components/filter_bar/use_expr_filter_page", () => ({
   __esModule: true,
-  useExprFilterPage: () => ({
-    requestedFilters: {
-      appId: null,
-      dateRange: { dateRange: null, startDate: null, endDate: null },
-      filterExpr: null,
-    },
-    filterState: { status: "pending" },
-    filterParams: null,
-    onFilterChange: jest.fn(),
-    setPageUrlKey: mockSetPageUrlKey,
-  }),
+  useExprFilterPage: () => mockUseExprFilterPage(),
 }));
 
 jest.mock("@/app/query/hooks", () => ({
@@ -68,9 +55,8 @@ import UserJourneys from "@/app/components/user_journeys";
 
 describe("UserJourneys", () => {
   beforeEach(() => {
-    mockRouterReplace.mockClear();
     mockRouterPush.mockClear();
-    mockSetPageUrlKey.mockClear();
+    mockUseExprFilterPage.mockClear();
   });
 
   it("renders the title", () => {
@@ -83,13 +69,15 @@ describe("UserJourneys", () => {
     expect(screen.queryByText("User Journeys")).not.toBeInTheDocument();
   });
 
-  it("draws the demo journey without a search input", () => {
+  it("draws the demo journey without a search input, a filter bar or the page's hook", () => {
     render(<UserJourneys demo={true} />);
     expect(screen.getByTestId("sankey-node-MainActivity")).toBeInTheDocument();
     expect(
       screen.getByTestId("sankey-node-CheckoutActivity"),
     ).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("Search nodes...")).toBeNull();
+    expect(screen.queryByTestId("filter-bar")).toBeNull();
+    expect(mockUseExprFilterPage).not.toHaveBeenCalled();
   });
 
   it("starts on the Paths tab", () => {
@@ -110,13 +98,13 @@ describe("UserJourneys", () => {
       "bg-accent",
     );
     expect(screen.getByTestId("sankey-node-MainActivity")).toBeInTheDocument();
-    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("");
 
     fireEvent.click(screen.getByRole("button", { name: "Paths" }));
     expect(screen.getByRole("button", { name: "Paths" })).toHaveClass(
       "bg-accent",
     );
-    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("");
   });
 
   it("opens the issue panel on the Exceptions tab, with inert issue buttons", () => {

--- a/frontend/dashboard/__tests__/helpers/mock_filters_store.ts
+++ b/frontend/dashboard/__tests__/helpers/mock_filters_store.ts
@@ -1,0 +1,21 @@
+// The real filters store behind a jest.mock factory for "@/app/stores/provider".
+import {
+  createFiltersStore,
+  type FiltersStore,
+} from "@/app/stores/filters_store";
+import { useStore } from "zustand";
+
+export const mockFiltersStore = {
+  store: createFiltersStore(),
+  reset() {
+    mockFiltersStore.store = createFiltersStore();
+  },
+};
+
+export function filtersProviderMock() {
+  return {
+    __esModule: true,
+    useFiltersStore: (selector?: (state: FiltersStore) => unknown) =>
+      useStore(mockFiltersStore.store, selector ?? ((state) => state)),
+  };
+}

--- a/frontend/dashboard/__tests__/helpers/mock_router.ts
+++ b/frontend/dashboard/__tests__/helpers/mock_router.ts
@@ -1,48 +1,65 @@
 /**
- * A stateful stand-in for next/navigation, shared by the suites of the pages
- * that carry their filter state in the URL's query params.
+ * Stand-in for next/navigation. `history.replaceState` is patched like the
+ * app router's: jsdom updates `window.location` at once, then searchParams
+ * update and subscribers are notified, or not until `applyDeferredReplace`
+ * when `deferReplace` is set. A state already carrying `__NA` is passed
+ * through without notifying, as the router does with its own writes.
  *
- * The mocked router applies each replace back into the mocked searchParams
- * and notifies subscribers, the way the real router re-renders the page with
- * the URL it just wrote. The page's queries read the URL, so without this
- * they would never see what the bar settled on.
- *
- * jest.mock calls are hoisted per file, so each suite still declares its own
- * jest.mock("next/navigation", ...) whose factory requires this module and
- * returns nextNavigationMock(); the module registry hands the factory and
- * the suite's imports the same instance.
+ * Each suite declares its own jest.mock("next/navigation") whose factory
+ * returns nextNavigationMock(), since jest.mock calls are hoisted per file.
  */
 import { useSyncExternalStore } from "react";
 
 const subscribers = new Set<() => void>();
 
-const applyReplaceUrl = (url: string) => {
-  mockRouter.searchParams = new URLSearchParams(url.split("?")[1] ?? "");
+const jsdomReplaceState = window.history.replaceState.bind(window.history);
+
+const readSearchParams = () => {
+  mockRouter.searchParams = new URLSearchParams(window.location.search);
   subscribers.forEach((notify) => notify());
 };
 
-// With deferReplace set, a replace's URL is held for the test to apply
-// later, the way the real router updates searchParams only on a later render.
-const replaceMock = jest.fn((url: string, _options?: { scroll: boolean }) => {
-  if (mockRouter.deferReplace) {
-    mockRouter.deferredReplaceUrl = url;
+window.history.replaceState = (
+  state: unknown,
+  unused: string,
+  url?: string | URL | null,
+) => {
+  if ((state as { __NA?: boolean } | null)?.__NA) {
+    jsdomReplaceState(state, unused, url);
     return;
   }
-  applyReplaceUrl(url);
-});
+  jsdomReplaceState({ ...(state ?? {}), __NA: true }, unused, url);
+  if (mockRouter.deferReplace) {
+    mockRouter.replaceDeferred = true;
+    return;
+  }
+  readSearchParams();
+};
 
 export const mockRouter = {
-  searchParams: new URLSearchParams(),
+  searchParams: new URLSearchParams(window.location.search),
   deferReplace: false,
-  deferredReplaceUrl: null as string | null,
-  replaceMock,
+  replaceDeferred: false,
   pushMock: jest.fn(),
-  applyReplaceUrl,
+  setUrl(search: string) {
+    window.history.replaceState(
+      null,
+      "",
+      search.startsWith("?") ? search : `?${search}`,
+    );
+  },
+  urlParams() {
+    return Object.fromEntries(new URLSearchParams(window.location.search));
+  },
+  applyDeferredReplace() {
+    mockRouter.replaceDeferred = false;
+    readSearchParams();
+  },
   reset() {
+    jsdomReplaceState(null, "", "/");
     mockRouter.searchParams = new URLSearchParams();
     mockRouter.deferReplace = false;
-    mockRouter.deferredReplaceUrl = null;
-    mockRouter.replaceMock.mockClear();
+    mockRouter.replaceDeferred = false;
     mockRouter.pushMock.mockClear();
   },
 };
@@ -56,7 +73,6 @@ export function nextNavigationMock() {
   return {
     __esModule: true,
     useRouter: () => ({
-      replace: mockRouter.replaceMock,
       push: mockRouter.pushMock,
     }),
     useSearchParams: () =>

--- a/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/bug_reports_msw_test.tsx
@@ -39,7 +39,6 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = mockRouter.replaceMock;
 const mockRouterPush = mockRouter.pushMock;
 
 jest.mock("next/navigation", () => ({
@@ -111,7 +110,6 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
   mockRouterPush.mockClear();
 });
 afterAll(() => server.close());
@@ -145,7 +143,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockRouter.searchParams = new URLSearchParams();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -249,14 +247,12 @@ describe("Bug Reports Overview (MSW integration)", () => {
       renderPage();
       await waitForBugReports();
 
-      const written = new URLSearchParams(
-        mockRouterReplace.mock.calls[0][0].slice(1),
-      );
+      const written = new URLSearchParams(window.location.search);
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
       expect(written.get("sd")).toBeNull();
       expect(written.get("ed")).toBeNull();
-      expect(written.get("po")).toBe("0");
+      expect(written.get("po")).toBeNull();
     });
 
     it("offers the keys the entity has, in the groups the server named", async () => {
@@ -291,7 +287,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
   // ================================================================
   describe("a link carrying a filter", () => {
     it("filters the bug reports and the plot by it", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
       );
       const sent = recordBugReportsRequests();
@@ -318,7 +314,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
     });
 
     it("draws it as a condition a person can edit", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:open")}`,
       );
       renderPage();
@@ -331,7 +327,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
     });
 
     it("filters by nothing when it cannot be read", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("bug_report_status:in:")}`,
       );
       const sent = recordBugReportsRequests();
@@ -365,7 +361,6 @@ describe("Bug Reports Overview (MSW integration)", () => {
       fireEvent.click(
         await screen.findByTestId("filter-key-bug_report_status"),
       );
-      fireEvent.click(await screen.findByText("<values>"));
       fireEvent.click(await screen.findByTestId("filter-value-open"));
 
       await waitFor(() => expect(sent).toHaveLength(2));
@@ -430,11 +425,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
       expect(screen.queryByText("Page 2 bug report")).toBeNull();
 
       // URL reflects page 1
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      expect(url).toContain("po=0");
+      expect(window.location.search).toContain("po=0");
     });
 
     it("deep-link with po=5 renders page 2 data", async () => {
@@ -460,7 +451,7 @@ describe("Bug Reports Overview (MSW integration)", () => {
         }),
       );
 
-      mockRouter.searchParams = new URLSearchParams("po=5");
+      mockRouter.setUrl("po=5");
       renderPage();
       await waitFor(
         () => {

--- a/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/builds_msw_test.tsx
@@ -25,8 +25,6 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = mockRouter.replaceMock;
-
 jest.mock("next/navigation", () => ({
   ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/builds",
@@ -63,7 +61,6 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
 });
 afterAll(() => server.close());
 
@@ -95,7 +92,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockRouter.searchParams = new URLSearchParams();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -158,14 +155,12 @@ describe("Builds page (MSW integration)", () => {
       renderPage();
       await waitForBuilds();
 
-      const written = new URLSearchParams(
-        mockRouterReplace.mock.calls[0][0].slice(1),
-      );
+      const written = new URLSearchParams(window.location.search);
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
       expect(written.get("sd")).toBeNull();
       expect(written.get("ed")).toBeNull();
-      expect(written.get("po")).toBe("0");
+      expect(written.get("po")).toBeNull();
     });
 
     it("offers the keys the entity has, in the groups the server named", async () => {
@@ -188,7 +183,7 @@ describe("Builds page (MSW integration)", () => {
 
   describe("a link carrying a filter", () => {
     beforeEach(() => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("mapping_type:in:proguard")}`,
       );
     });
@@ -216,7 +211,7 @@ describe("Builds page (MSW integration)", () => {
     });
 
     it("filters by nothing when it cannot be read", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("mapping_type:in:")}`,
       );
       const sent = recordBuildsRequests();
@@ -245,7 +240,6 @@ describe("Builds page (MSW integration)", () => {
         target: { value: "File type" },
       });
       fireEvent.click(await screen.findByTestId("filter-key-mapping_type"));
-      fireEvent.click(await screen.findByText("<values>"));
       fireEvent.click(await screen.findByTestId("filter-value-dsym"));
 
       await waitFor(() => expect(sent).toHaveLength(2));

--- a/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/journeys_msw_test.tsx
@@ -34,7 +34,6 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = mockRouter.replaceMock;
 const mockRouterPush = mockRouter.pushMock;
 
 jest.mock("next/navigation", () => ({
@@ -95,7 +94,6 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
   mockRouterPush.mockClear();
 });
 afterAll(() => server.close());
@@ -128,7 +126,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockRouter.searchParams = new URLSearchParams();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -175,12 +173,7 @@ describe("Journeys page (MSW integration)", () => {
     );
   }
 
-  const lastWrittenUrl = () =>
-    new URLSearchParams(
-      mockRouterReplace.mock.calls[
-        mockRouterReplace.mock.calls.length - 1
-      ][0].slice(1),
-    );
+  const lastWrittenUrl = () => new URLSearchParams(window.location.search);
 
   describe("opening the page", () => {
     it("draws the journey the server sent", async () => {
@@ -220,9 +213,7 @@ describe("Journeys page (MSW integration)", () => {
       renderPage();
       await waitForChart();
 
-      const written = new URLSearchParams(
-        mockRouterReplace.mock.calls[0][0].slice(1),
-      );
+      const written = new URLSearchParams(window.location.search);
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
       expect(written.get("sd")).toBeNull();
@@ -245,7 +236,7 @@ describe("Journeys page (MSW integration)", () => {
 
   describe("a link carrying a filter", () => {
     it("filters the journey by it", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
       );
       const sent = recordJourneyRequests();
@@ -261,7 +252,7 @@ describe("Journeys page (MSW integration)", () => {
 
   describe("the plot type", () => {
     it("opens on the plot a link names and keeps it in the URL", async () => {
-      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      mockRouter.setUrl("jt=Exceptions");
       renderPage();
       await waitForChart();
 
@@ -325,7 +316,7 @@ describe("Journeys page (MSW integration)", () => {
     });
 
     it("shows a refused filter's issue in the bar, not the error message", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
       );
       server.use(

--- a/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/traces_msw_test.tsx
@@ -38,7 +38,6 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = mockRouter.replaceMock;
 const mockRouterPush = mockRouter.pushMock;
 
 jest.mock("next/navigation", () => ({
@@ -104,7 +103,6 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
   mockRouterPush.mockClear();
 });
 afterAll(() => server.close());
@@ -141,7 +139,7 @@ beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
   queryClient.clear();
-  mockRouter.searchParams = new URLSearchParams();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
@@ -237,23 +235,19 @@ describe("Traces Overview (MSW integration)", () => {
       renderPage();
       await waitForSpans();
 
-      const written = new URLSearchParams(
-        mockRouterReplace.mock.calls[0][0].slice(1),
-      );
+      const written = new URLSearchParams(window.location.search);
       expect(written.get("a")).toBe(appId);
       expect(written.get("d")).toBe("Last 6 Hours");
       expect(written.get("sd")).toBeNull();
       expect(written.get("ed")).toBeNull();
-      expect(written.get("po")).toBe("0");
+      expect(written.get("po")).toBeNull();
       expect(written.get("r")).toBe(firstRootSpanName);
     });
   });
 
   describe("root span selection", () => {
     it("restores the name a link asked for when its app matches", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        `po=0&a=${appId}&r=api_fetch_payments`,
-      );
+      mockRouter.setUrl(`po=0&a=${appId}&r=api_fetch_payments`);
       const sent = recordSpansRequests();
       renderPage();
       await waitForSpans();
@@ -277,19 +271,13 @@ describe("Traces Overview (MSW integration)", () => {
       expect(last.searchParams.get("span_name")).toBe("api_fetch_payments");
       expect(last.searchParams.get("offset")).toBe("0");
 
-      const written = new URLSearchParams(
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0].slice(1),
-      );
+      const written = new URLSearchParams(window.location.search);
       expect(written.get("r")).toBe("api_fetch_payments");
       expect(written.get("po")).toBe("0");
     });
 
     it("falls back to the first name when the link's app is not the selected one", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        `po=0&a=some-other-app&r=api_fetch_payments`,
-      );
+      mockRouter.setUrl(`po=0&a=some-other-app&r=api_fetch_payments`);
       const sent = recordSpansRequests();
       renderPage();
       await waitForSpans();
@@ -298,9 +286,7 @@ describe("Traces Overview (MSW integration)", () => {
     });
 
     it("falls back to the first name when the link names an unknown span", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        `po=0&a=${appId}&r=span.gone`,
-      );
+      mockRouter.setUrl(`po=0&a=${appId}&r=span.gone`);
       const sent = recordSpansRequests();
       renderPage();
       await waitForSpans();
@@ -325,7 +311,7 @@ describe("Traces Overview (MSW integration)", () => {
 
   describe("a link carrying a filter", () => {
     it("filters the spans and the plot by it", async () => {
-      mockRouter.searchParams = new URLSearchParams(
+      mockRouter.setUrl(
         `po=0&filter_expr=${encodeURIComponent("version_name:in:3.1.0")}`,
       );
       const sent = recordSpansRequests();
@@ -378,7 +364,7 @@ describe("Traces Overview (MSW integration)", () => {
         }),
       );
 
-      mockRouter.searchParams = new URLSearchParams("po=5");
+      mockRouter.setUrl("po=5");
       renderPage();
       await waitFor(
         () => {

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -1,34 +1,24 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
 import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import BugReportsOverview from "@/app/[teamId]/bug_reports/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const replaceMock = mockRouter.replaceMock;
 const pushMock = mockRouter.pushMock;
-const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
 jest.mock("next/navigation", () =>
   require("@/__tests__/helpers/mock_router").nextNavigationMock(),
 );
 
-jest.mock("@/app/api/api_calls", () => ({
-  __esModule: true,
-  emptyBugReportsOverviewResponse: {
-    meta: { next: false, previous: false },
-    results: [],
-  },
-}));
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
 
-jest.mock("@/app/stores/filters_store", () => ({
+const mockToastNegative = jest.fn();
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  urlFiltersKeyMap: {
-    appId: "a",
-    dateRange: "d",
-    startDate: "sd",
-    endDate: "ed",
-  },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
 const pendingQueryState = () => ({
@@ -38,6 +28,8 @@ const pendingQueryState = () => ({
   error: null as Error | null,
 });
 
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
 const mockUseBugReportsOverviewQuery = jest.fn(
   (_filter: any, _offset: number) => pendingQueryState(),
 );
@@ -47,93 +39,51 @@ const mockUseBugReportsOverviewPlotQuery = jest.fn((_filter: any) =>
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
+  paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
   useBugReportsOverviewQuery: (filter: any, offset: number) =>
     mockUseBugReportsOverviewQuery(filter, offset),
   useBugReportsOverviewPlotQuery: (filter: any) =>
     mockUseBugReportsOverviewPlotQuery(filter),
-  paginationOffsetUrlKey: "po",
 }));
 
-const mockReportedApp = { id: "app-1", name: "Sample" };
-const mockReportedDate = {
-  dateRange: "Last 6 Hours",
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-01T06:00:00.000Z",
-};
-
-// Makes the stub drop the URL's filter on mount, like the bar discarding
-// a filter it cannot read.
-let mockMountDiscardsFilter = false;
-
-// Like the real bar, this stub reports the request it is handed, on mount
-// and whenever it changes; its buttons hand the page a request the way a
-// pick does, or report a failure. Only a discarded mount report carries
-// appliedAsRequested false.
-jest.mock("@/app/components/filter_bar/filter_bar", () => {
-  const { useEffect } = require("react");
-
-  function FilterBarMock(props: any) {
-    const ready = (
-      filterExpr: string | null,
-      appliedAsRequested: boolean = false,
-    ) => ({
-      status: "ready",
-      app: mockReportedApp,
-      date: mockReportedDate,
-      filterExpr,
-      appliedAsRequested,
-    });
-    const request = (filterExpr: string | null) =>
-      props.onRequestChange({
-        appId: mockReportedApp.id,
-        dateRange: mockReportedDate,
-        filterExpr,
-        rootSpanName: null,
-      });
-
-    useEffect(() => {
-      if (mockMountDiscardsFilter) {
-        props.onFilterChange(ready(null, false));
-      } else {
-        props.onFilterChange(ready(props.requestedFilterExpr, true));
-      }
-    }, [props.requestedFilterExpr]);
-
-    return (
-      <div data-testid="filter-bar-mock">
-        <span data-testid="filter-bar-expr">
-          {props.requestedFilterExpr ?? "none"}
-        </span>
-        <button
-          data-testid="filter-bar-apply"
-          onClick={() => request("bug_report_status:in:open")}
-        >
-          apply
-        </button>
-        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
-          clear
-        </button>
-        <button
-          data-testid="filter-bar-fail"
-          onClick={() =>
-            props.onFilterChange({
-              status: "error",
-              message: "Error fetching apps, please refresh page to try again",
-            })
-          }
-        >
-          fail
-        </button>
-      </div>
-    );
-  }
-
-  return {
-    __esModule: true,
-    default: FilterBarMock,
-    filterExprUrlKey: "filter_expr",
-  };
-});
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-app">
+        {props.value?.app.name ?? "none"}
+      </span>
+      <span data-testid="filter-bar-expr">
+        {props.value?.filterExpr ?? "none"}
+      </span>
+      <button
+        data-testid="filter-bar-apply"
+        onClick={() =>
+          props.onChange({ filterExpr: "bug_report_status:in:open" })
+        }
+      >
+        apply
+      </button>
+      <button
+        data-testid="filter-bar-clear"
+        onClick={() => props.onChange({ filterExpr: null })}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
@@ -187,6 +137,20 @@ jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableTime: jest.fn(() => "12:00 AM"),
 }));
 
+import BugReportsOverview from "@/app/[teamId]/bug_reports/page";
+
+const mockApp = { id: "app-1", name: "Sample" };
+
+const statusKey = {
+  name: "bug_report_status",
+  label: "Bug report status",
+  key_group: "Bug Report",
+  description: "Whether the report is open",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+};
+
 const mockBugReportResult = {
   session_id: "session1",
   app_id: "app1",
@@ -220,11 +184,7 @@ function bugReportsLoaded(data: any = mockBugReportsData) {
   });
 }
 
-// What the stub bar reports, as the page writes it into the URL.
-const selectionParams = "a=app-1&d=Last+6+Hours";
-
-const selectionUrl = (offset: number, filterParam?: string) =>
-  `?po=${offset}&${selectionParams}${filterParam ? `&${filterParam}` : ""}`;
+const settled = { a: "app-1", d: "Last 6 Hours" };
 
 function renderPage() {
   return render(
@@ -235,7 +195,15 @@ function renderPage() {
 describe("BugReportsOverview page", () => {
   beforeEach(() => {
     mockRouter.reset();
-    mockMountDiscardsFilter = false;
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: [mockApp] });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [statusKey], key_groups: ["Bug Report"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
     mockUseBugReportsOverviewQuery.mockReset();
     mockUseBugReportsOverviewQuery.mockReturnValue(pendingQueryState());
     mockUseBugReportsOverviewPlotQuery.mockReset();
@@ -247,99 +215,82 @@ describe("BugReportsOverview page", () => {
     expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
   });
 
-  it("hands the bar the filter the URL opened on", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=0&filter_expr=bug_report_status%3Ain%3Aopen",
-    );
+  it("hands the bar the app and filter it settled on", () => {
+    mockRouter.setUrl("?po=0&filter_expr=bug_report_status%3Ain%3Aopen");
     bugReportsLoaded();
     renderPage();
 
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("Sample");
     expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
       "bug_report_status:in:open",
     );
   });
 
-  it("fetches nothing until the bar settles on an app and a range", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
-    );
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockRouter.setUrl("?po=20&filter_expr=bug_report_status%3Ain%3Aopen");
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
     bugReportsLoaded();
     renderPage();
 
-    expect(mockUseBugReportsOverviewQuery).toHaveBeenNthCalledWith(1, null, 20);
-    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenNthCalledWith(1, null);
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 20);
+    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenLastCalledWith(null);
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
   });
 
-  it("fetches the page the URL names, filtered by what the bar reported", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
-    );
+  it("fetches the page the URL names, filtered by what it settled on", () => {
+    mockRouter.setUrl("?po=20&filter_expr=bug_report_status%3Ain%3Aopen");
     bugReportsLoaded();
     renderPage();
 
     expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
-      {
-        appId: mockReportedApp.id,
-        startDate: mockReportedDate.startDate,
-        endDate: mockReportedDate.endDate,
+      expect.objectContaining({
+        appId: "app-1",
         filterExpr: "bug_report_status:in:open",
-      },
+      }),
       20,
     );
-    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenLastCalledWith({
-      appId: mockReportedApp.id,
-      startDate: mockReportedDate.startDate,
-      endDate: mockReportedDate.endDate,
-      filterExpr: "bug_report_status:in:open",
-    });
+    expect(mockUseBugReportsOverviewPlotQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        appId: "app-1",
+        filterExpr: "bug_report_status:in:open",
+      }),
+    );
   });
 
-  it("never fetches a filter the bar discarded on mount", async () => {
-    mockMountDiscardsFilter = true;
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      `po=30&filter_expr=bug_report_status%3Ain%3Aopen&${selectionParams}`,
+  it("never fetches a filter it discarded on mount", async () => {
+    mockRouter.setUrl(
+      "?po=30&filter_expr=device_cohort%3Ain%3Anew&a=app-1&d=Last+6+Hours",
     );
+    mockRouter.deferReplace = true;
     bugReportsLoaded();
     renderPage();
 
-    // The write has not landed, so the URL still holds the discarded
-    // filter and the queries stay disabled, at the offset the page wrote.
-    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 0);
+    expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 30);
+    expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
 
     await act(async () => {
-      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+      mockRouter.applyDeferredReplace();
     });
 
-    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-      scroll: false,
-    });
     expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
-      {
-        appId: mockReportedApp.id,
-        startDate: mockReportedDate.startDate,
-        endDate: mockReportedDate.endDate,
-        filterExpr: null,
-      },
+      expect.objectContaining({ appId: "app-1", filterExpr: null }),
       0,
     );
     for (const [params] of mockUseBugReportsOverviewQuery.mock.calls) {
-      expect(params?.filterExpr ?? null).not.toBe("bug_report_status:in:open");
+      expect(params?.filterExpr ?? null).not.toBe("device_cohort:in:new");
     }
   });
 
-  it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=bug_report_status%3Ain%3Aopen",
-    );
+  it("records what it settled on, keeping the page the link asked for", () => {
+    mockRouter.setUrl("?po=20&filter_expr=bug_report_status%3Ain%3Aopen");
     bugReportsLoaded();
     renderPage();
 
-    expect(replaceMock).toHaveBeenCalledTimes(1);
-    expect(replaceMock).toHaveBeenCalledWith(
-      selectionUrl(20, "filter_expr=bug_report_status%3Ain%3Aopen"),
-      { scroll: false },
-    );
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      po: "20",
+      filter_expr: "bug_report_status:in:open",
+    });
   });
 
   it("keeps the plot area up with paging disabled while the reports load", () => {
@@ -351,13 +302,11 @@ describe("BugReportsOverview page", () => {
     expect(screen.getByTestId("prev-button")).toBeDisabled();
   });
 
-  it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
+  it("shows the plot skeleton while what it settled on waits to reach the URL", () => {
     mockRouter.deferReplace = true;
     bugReportsLoaded();
     renderPage();
 
-    // The URL write has not landed, so the bar's report does not match the
-    // URL yet and the queries stay disabled with a null filter.
     expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 0);
     expect(
       screen.getByTestId("bug-reports-overview-plot-mock"),
@@ -516,51 +465,40 @@ describe("BugReportsOverview page", () => {
     expect(closedStatusBadge).toHaveClass("bg-indigo-100");
   });
 
-  describe("a filter the bar could not settle", () => {
+  describe("a filter it could not settle", () => {
     beforeEach(() => {
-      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      mockRouter.setUrl("?po=10&a=app-1&d=Last+6+Hours");
+      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
       bugReportsLoaded();
     });
 
-    it("is said by the page, in place of the list", async () => {
+    it("is said by the page, in place of the list", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(
         screen.getByText(
           "Error fetching apps, please refresh page to try again",
         ),
       ).toBeInTheDocument();
+      expect(screen.queryByText("Bug Report")).toBeNull();
     });
 
-    it("stops the page fetching anything", async () => {
+    it("stops the page fetching anything", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(null, 10);
     });
 
-    it("leaves the URL where the link had it", async () => {
+    it("leaves the URL where the link had it", () => {
       renderPage();
-      replaceMock.mockClear();
 
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
-
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
     });
   });
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockRouter.searchParams = new URLSearchParams(`po=0&${selectionParams}`);
+      mockRouter.setUrl("?po=0&a=app-1&d=Last+6+Hours");
       bugReportsLoaded();
       renderPage();
 
@@ -568,36 +506,27 @@ describe("BugReportsOverview page", () => {
         fireEvent.click(screen.getByTestId("next-button"));
       });
 
-      // Paging keeps everything else the URL was carrying.
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(5), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "5" });
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockRouter.searchParams = new URLSearchParams("po=5&a=app-1");
+      mockRouter.setUrl("?po=5&a=app-1");
       bugReportsLoaded();
       renderPage();
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("prev-button"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
 
-      mockRouter.searchParams = new URLSearchParams("po=0&a=app-1");
-      renderPage();
       await act(async () => {
-        fireEvent.click(screen.getAllByTestId("prev-button")[1]);
+        fireEvent.click(screen.getByTestId("prev-button"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockRouter.searchParams = new URLSearchParams("po=30&a=app-1");
+      mockRouter.setUrl("?po=30&a=app-1");
       bugReportsLoaded();
       renderPage();
 
@@ -605,13 +534,11 @@ describe("BugReportsOverview page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-apply"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "filter_expr=bug_report_status%3Ain%3Aopen"),
-        { scroll: false },
-      );
-      // The changed filter and the reset offset reach the query together,
-      // through the URL, so the new filter is never fetched at the page the
-      // old filter was on.
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        filter_expr: "bug_report_status:in:open",
+      });
       expect(mockUseBugReportsOverviewQuery).toHaveBeenLastCalledWith(
         expect.objectContaining({ filterExpr: "bug_report_status:in:open" }),
         0,
@@ -625,9 +552,7 @@ describe("BugReportsOverview page", () => {
     });
 
     it("goes back to the first page when the filter is cleared", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=30&filter_expr=bug_report_status%3Ain%3Aopen",
-      );
+      mockRouter.setUrl("?po=30&filter_expr=bug_report_status%3Ain%3Aopen");
       bugReportsLoaded();
       renderPage();
 
@@ -635,9 +560,7 @@ describe("BugReportsOverview page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-clear"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
     });
 
     it("cannot be used while a refetch is in flight", () => {

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -1,37 +1,32 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
 import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import Builds from "@/app/[teamId]/builds/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-
-const replaceMock = mockRouter.replaceMock;
-const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
 jest.mock("next/navigation", () =>
   require("@/__tests__/helpers/mock_router").nextNavigationMock(),
 );
 
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
+
 const downloadBuildFileMock = jest.fn();
 jest.mock("@/app/api/api_calls", () => ({
-  __esModule: true,
-  emptyBuildsResponse: {
-    meta: { next: false, previous: false },
-    results: [],
-  },
+  ...jest.requireActual("@/app/api/api_calls"),
   downloadBuildFile: (url: string) => downloadBuildFileMock(url),
 }));
 
-jest.mock("@/app/stores/filters_store", () => ({
+const mockToastNegative = jest.fn();
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  urlFiltersKeyMap: {
-    appId: "a",
-    dateRange: "d",
-    startDate: "sd",
-    endDate: "ed",
-  },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
 const mockUseBuildsQuery = jest.fn((_filter: any, _offset: number) => ({
   data: undefined as any,
   status: "pending" as string,
@@ -41,91 +36,50 @@ const mockUseBuildsQuery = jest.fn((_filter: any, _offset: number) => ({
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
+  paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
   useBuildsQuery: (filter: any, offset: number) =>
     mockUseBuildsQuery(filter, offset),
-  paginationOffsetUrlKey: "po",
 }));
 
-const mockReportedApp = { id: "app-1", name: "Sample" };
-const mockReportedDate = {
-  dateRange: "Last 6 Hours",
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-01T06:00:00.000Z",
-};
-
-// Makes the stub drop the URL's filter on mount, like the bar discarding
-// a filter it cannot read.
-let mockMountDiscardsFilter = false;
-
-// Like the real bar, this stub reports the request it is handed, on mount
-// and whenever it changes; its buttons hand the page a request the way a
-// pick does, or report a failure. Only a discarded mount report carries
-// appliedAsRequested false.
-jest.mock("@/app/components/filter_bar/filter_bar", () => {
-  const { useEffect } = require("react");
-
-  function FilterBarMock(props: any) {
-    const ready = (
-      filterExpr: string | null,
-      appliedAsRequested: boolean = false,
-    ) => ({
-      status: "ready",
-      app: mockReportedApp,
-      date: mockReportedDate,
-      filterExpr,
-      appliedAsRequested,
-    });
-    const request = (filterExpr: string | null) =>
-      props.onRequestChange({
-        appId: mockReportedApp.id,
-        dateRange: mockReportedDate,
-        filterExpr,
-        rootSpanName: null,
-      });
-
-    useEffect(() => {
-      if (mockMountDiscardsFilter) {
-        props.onFilterChange(ready(null, false));
-      } else {
-        props.onFilterChange(ready(props.requestedFilterExpr, true));
-      }
-    }, [props.requestedFilterExpr]);
-
-    return (
-      <div data-testid="filter-bar-mock">
-        <span data-testid="filter-bar-expr">
-          {props.requestedFilterExpr ?? "none"}
-        </span>
-        <button
-          data-testid="filter-bar-apply"
-          onClick={() => request("mapping_type:in:dsym")}
-        >
-          apply
-        </button>
-        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
-          clear
-        </button>
-        <button
-          data-testid="filter-bar-fail"
-          onClick={() =>
-            props.onFilterChange({
-              status: "error",
-              message: "Error fetching apps, please refresh page to try again",
-            })
-          }
-        >
-          fail
-        </button>
-      </div>
-    );
-  }
-
-  return {
-    __esModule: true,
-    default: FilterBarMock,
-    filterExprUrlKey: "filter_expr",
-  };
-});
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-app">
+        {props.value?.app.name ?? "none"}
+      </span>
+      <span data-testid="filter-bar-expr">
+        {props.value?.filterExpr ?? "none"}
+      </span>
+      <span data-testid="filter-bar-span-names">
+        {props.spanNames === undefined ? "hidden" : "shown"}
+      </span>
+      <button
+        data-testid="filter-bar-apply"
+        onClick={() => props.onChange({ filterExpr: "mapping_type:in:dsym" })}
+      >
+        apply
+      </button>
+      <button
+        data-testid="filter-bar-clear"
+        onClick={() => props.onChange({ filterExpr: null })}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock("@/app/components/paginator", () => ({
   __esModule: true,
@@ -158,6 +112,31 @@ jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableDateTime: jest.fn(() => "1 Jan, 2020, 12:00:00 AM"),
 }));
 
+import Builds from "@/app/[teamId]/builds/page";
+
+const mockApp = { id: "app-1", name: "Sample" };
+
+const keys = [
+  {
+    name: "mapping_type",
+    label: "File type",
+    key_group: "Build",
+    description: "The kind of mapping file",
+    value_type: "string",
+    value_suggestion_mode: "full_list",
+    operators: ["in", "not_in"],
+  },
+  {
+    name: "patch_id",
+    label: "Patch",
+    key_group: "Build",
+    description: "Whether the build is a patch",
+    value_type: "string",
+    value_suggestion_mode: "none",
+    operators: ["is_set", "is_not_set"],
+  },
+];
+
 const buildFile = (id: string, mappingType: string) => ({
   id,
   mapping_type: mappingType,
@@ -187,11 +166,7 @@ function loaded(data: any = mockBuildsData) {
   });
 }
 
-// What the stub bar reports, as the page writes it into the URL.
-const selectionParams = "a=app-1&d=Last+6+Hours";
-
-const selectionUrl = (offset: number, filterParam?: string) =>
-  `?po=${offset}&${selectionParams}${filterParam ? `&${filterParam}` : ""}`;
+const settled = { a: "app-1", d: "Last 6 Hours" };
 
 function renderPage() {
   return render(<Builds params={promiseParams({ teamId: "123" })} />);
@@ -200,8 +175,16 @@ function renderPage() {
 describe("Builds page", () => {
   beforeEach(() => {
     mockRouter.reset();
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
     downloadBuildFileMock.mockClear();
-    mockMountDiscardsFilter = false;
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: [mockApp] });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys, key_groups: ["Build"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
     mockUseBuildsQuery.mockReset();
     mockUseBuildsQuery.mockReturnValue({
       data: undefined,
@@ -211,97 +194,86 @@ describe("Builds page", () => {
     });
   });
 
-  it("renders the filter bar", () => {
+  it("renders the filter bar without a span selector", () => {
     renderPage();
     expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar-span-names")).toHaveTextContent(
+      "hidden",
+    );
   });
 
-  it("hands the bar the filter the URL opened on", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=0&filter_expr=patch_id%3Ais_set",
-    );
+  it("hands the bar the app and filter it settled on", () => {
+    mockRouter.setUrl("?po=0&filter_expr=patch_id%3Ais_set");
     loaded();
     renderPage();
 
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("Sample");
     expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
       "patch_id:is_set",
     );
   });
 
-  it("fetches nothing until the bar settles on an app and a range", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=patch_id%3Ais_set",
-    );
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockRouter.setUrl("?po=20&filter_expr=patch_id%3Ais_set");
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
     loaded();
     renderPage();
 
-    expect(mockUseBuildsQuery).toHaveBeenNthCalledWith(1, null, 20);
+    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 20);
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("none");
   });
 
-  it("fetches the page the URL names, filtered by what the bar reported", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=patch_id%3Ais_set",
-    );
+  it("fetches the page the URL names, filtered by what it settled on", () => {
+    mockRouter.setUrl("?po=20&filter_expr=patch_id%3Ais_set");
     loaded();
     renderPage();
 
     expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
-      {
-        appId: mockReportedApp.id,
-        startDate: mockReportedDate.startDate,
-        endDate: mockReportedDate.endDate,
+      expect.objectContaining({
+        appId: "app-1",
         filterExpr: "patch_id:is_set",
-      },
+      }),
       20,
     );
   });
 
-  it("never fetches a filter the bar discarded on mount", async () => {
-    mockMountDiscardsFilter = true;
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      `po=30&filter_expr=patch_id%3Ais_set&${selectionParams}`,
+  it("never fetches a filter it discarded on mount", async () => {
+    mockRouter.setUrl(
+      "?po=30&filter_expr=device_cohort%3Ain%3Anew&a=app-1&d=Last+6+Hours",
     );
+    mockRouter.deferReplace = true;
     loaded();
     renderPage();
 
-    // The write has not landed, so the URL still holds the discarded
-    // filter and the query stays disabled, at the offset the page wrote.
-    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 0);
+    expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 30);
+    expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+    expect(mockToastNegative).toHaveBeenCalledWith(
+      "Some filters were invalid, page reset to defaults",
+    );
 
     await act(async () => {
-      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+      mockRouter.applyDeferredReplace();
     });
 
-    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-      scroll: false,
-    });
     expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
-      {
-        appId: mockReportedApp.id,
-        startDate: mockReportedDate.startDate,
-        endDate: mockReportedDate.endDate,
-        filterExpr: null,
-      },
+      expect.objectContaining({ appId: "app-1", filterExpr: null }),
       0,
     );
     for (const [params] of mockUseBuildsQuery.mock.calls) {
-      expect(params?.filterExpr ?? null).not.toBe("patch_id:is_set");
+      expect(params?.filterExpr ?? null).not.toBe("device_cohort:in:new");
     }
   });
 
-  it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=patch_id%3Ais_set",
-    );
+  it("records what it settled on, keeping the page the link asked for", () => {
+    mockRouter.setUrl("?po=20&filter_expr=patch_id%3Ais_set");
     loaded();
     renderPage();
 
-    expect(replaceMock).toHaveBeenCalledTimes(1);
-    expect(replaceMock).toHaveBeenCalledWith(
-      selectionUrl(20, "filter_expr=patch_id%3Ais_set"),
-      { scroll: false },
-    );
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      po: "20",
+      filter_expr: "patch_id:is_set",
+    });
   });
 
   it("renders no list while the builds are still loading", () => {
@@ -474,18 +446,15 @@ describe("Builds page", () => {
     expect(loadingBarContainer).toHaveClass("invisible");
   });
 
-  describe("a filter the bar could not settle", () => {
+  describe("a filter it could not settle", () => {
     beforeEach(() => {
-      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
+      mockRouter.setUrl("?po=10&a=app-1&d=Last+6+Hours");
+      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
       loaded();
     });
 
-    it("is said by the page, in place of the list", async () => {
+    it("is said by the page, in place of the list", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(
         screen.getByText(
@@ -494,32 +463,23 @@ describe("Builds page", () => {
       ).toBeInTheDocument();
     });
 
-    it("stops the page fetching anything", async () => {
+    it("stops the page fetching anything", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(null, 10);
     });
 
-    it("leaves the URL where the link had it", async () => {
+    it("leaves the URL where the link had it", () => {
       renderPage();
-      replaceMock.mockClear();
 
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
-
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
     });
   });
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        `po=0&filter_expr=patch_id%3Ais_set&${selectionParams}`,
+      mockRouter.setUrl(
+        "?po=0&filter_expr=patch_id%3Ais_set&a=app-1&d=Last+6+Hours",
       );
       loaded();
       renderPage();
@@ -528,45 +488,43 @@ describe("Builds page", () => {
         fireEvent.click(screen.getByTestId("next-button"));
       });
 
-      // Paging keeps everything else the URL was carrying.
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(10, "filter_expr=patch_id%3Ais_set"),
-        { scroll: false },
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "10",
+        filter_expr: "patch_id:is_set",
+      });
+      expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ filterExpr: "patch_id:is_set" }),
+        10,
       );
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=10&filter_expr=patch_id%3Ais_set",
-      );
+      mockRouter.setUrl("?po=10&filter_expr=patch_id%3Ais_set");
       loaded();
       renderPage();
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("prev-button"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "filter_expr=patch_id%3Ais_set"),
-        { scroll: false },
-      );
-
-      mockRouter.searchParams = new URLSearchParams(
-        "po=0&filter_expr=patch_id%3Ais_set",
-      );
-      renderPage();
-      await act(async () => {
-        fireEvent.click(screen.getAllByTestId("prev-button")[1]);
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        filter_expr: "patch_id:is_set",
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "filter_expr=patch_id%3Ais_set"),
-        { scroll: false },
-      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("prev-button"));
+      });
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        filter_expr: "patch_id:is_set",
+      });
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=30&filter_expr=patch_id%3Ais_set",
-      );
+      mockRouter.setUrl("?po=30&filter_expr=patch_id%3Ais_set");
       loaded();
       renderPage();
 
@@ -574,13 +532,11 @@ describe("Builds page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-apply"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "filter_expr=mapping_type%3Ain%3Adsym"),
-        { scroll: false },
-      );
-      // The changed filter and the reset offset reach the query together,
-      // through the URL, so the new filter is never fetched at the page the
-      // old filter was on.
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        filter_expr: "mapping_type:in:dsym",
+      });
       expect(mockUseBuildsQuery).toHaveBeenLastCalledWith(
         expect.objectContaining({ filterExpr: "mapping_type:in:dsym" }),
         0,
@@ -606,9 +562,7 @@ describe("Builds page", () => {
     });
 
     it("goes back to the first page when the filter is cleared", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=30&filter_expr=patch_id%3Ais_set",
-      );
+      mockRouter.setUrl("?po=30&filter_expr=patch_id%3Ais_set");
       loaded();
       renderPage();
 
@@ -616,9 +570,7 @@ describe("Builds page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-clear"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
     });
   });
 });

--- a/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
@@ -1,26 +1,22 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
 import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import UserJourneysPage from "@/app/[teamId]/journeys/page";
-import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-
-const replaceMock = mockRouter.replaceMock;
-const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
 jest.mock("next/navigation", () =>
   require("@/__tests__/helpers/mock_router").nextNavigationMock(),
 );
 
-jest.mock("@/app/stores/filters_store", () => ({
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
+
+const mockToastNegative = jest.fn();
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  urlFiltersKeyMap: {
-    appId: "a",
-    dateRange: "d",
-    startDate: "sd",
-    endDate: "ed",
-  },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
 const pendingQueryState = () => ({
@@ -30,123 +26,78 @@ const pendingQueryState = () => ({
   error: null as Error | null,
 });
 
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
 const mockUseJourneyQuery = jest.fn((_filter: any) => pendingQueryState());
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useJourneyQuery: (filter: any) => mockUseJourneyQuery(filter),
   paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
+  useJourneyQuery: (filter: any) => mockUseJourneyQuery(filter),
 }));
 
-const mockReportedApp = { id: "app-1", name: "Sample" };
-const mockOtherApp = { id: "app-2", name: "Other" };
-const mockReportedDate = {
-  dateRange: "Last 6 Hours",
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-01T06:00:00.000Z",
-};
-
-// Makes the stub drop the URL's filter on mount, like the bar discarding
-// a filter it cannot read.
-let mockMountDiscardsFilter = false;
-
-// Like the real bar, this stub reports the request it is handed, on mount
-// and whenever it changes; its buttons hand the page a request the way a
-// pick does, or report a failure. Only a discarded mount report carries
-// appliedAsRequested false. The issues the page hands back are rendered so
-// tests can see them reach the bar.
-jest.mock("@/app/components/filter_bar/filter_bar", () => {
-  const { useEffect } = require("react");
-
-  function FilterBarMock(props: any) {
-    const ready = (
-      filterExpr: string | null,
-      appliedAsRequested: boolean = false,
-      app: { id: string; name: string } = mockReportedApp,
-    ) => ({
-      status: "ready",
-      app,
-      date: mockReportedDate,
-      filterExpr,
-      appliedAsRequested,
-    });
-    const requestedApp =
-      props.requestedAppId === mockOtherApp.id ? mockOtherApp : mockReportedApp;
-    const request = (filterExpr: string | null, appId = mockReportedApp.id) =>
-      props.onRequestChange({
-        appId,
-        dateRange: mockReportedDate,
-        filterExpr,
-        rootSpanName: null,
-      });
-
-    useEffect(() => {
-      if (mockMountDiscardsFilter) {
-        props.onFilterChange(ready(null, false));
-      } else {
-        props.onFilterChange(
-          ready(props.requestedFilterExpr, true, requestedApp),
-        );
-      }
-    }, [props.requestedAppId, props.requestedFilterExpr]);
-
-    return (
-      <div data-testid="filter-bar-mock">
-        <span data-testid="filter-bar-entity">{props.entity}</span>
-        <span data-testid="filter-bar-expr">
-          {props.requestedFilterExpr ?? "none"}
-        </span>
-        <span data-testid="filter-bar-issues">
-          {props.filterExprIssues
-            ? props.filterExprIssues
-                .map((issue: { message: string }) => issue.message)
-                .join(", ")
-            : "none"}
-        </span>
-        <button
-          data-testid="filter-bar-apply"
-          onClick={() => request("version_name:in:1.2.0")}
-        >
-          apply
-        </button>
-        <button data-testid="filter-bar-clear" onClick={() => request(null)}>
-          clear
-        </button>
-        <button
-          data-testid="filter-bar-switch-app"
-          onClick={() => request(props.requestedFilterExpr, mockOtherApp.id)}
-        >
-          switch app
-        </button>
-        <button
-          data-testid="filter-bar-fail"
-          onClick={() =>
-            props.onFilterChange({
-              status: "error",
-              message: "Error fetching apps, please refresh page to try again",
-            })
-          }
-        >
-          fail
-        </button>
-      </div>
-    );
-  }
-
-  return {
-    __esModule: true,
-    default: FilterBarMock,
-    filterExprUrlKey: "filter_expr",
-  };
-});
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-entity">{props.entity}</span>
+      <span data-testid="filter-bar-app">
+        {props.value?.app.name ?? "none"}
+      </span>
+      <span data-testid="filter-bar-expr">
+        {props.value?.filterExpr ?? "none"}
+      </span>
+      <span data-testid="filter-bar-issues">
+        {props.filterExprIssues
+          ? props.filterExprIssues
+              .map((issue: { message: string }) => issue.message)
+              .join(", ")
+          : "none"}
+      </span>
+      <button
+        data-testid="filter-bar-apply"
+        onClick={() => props.onChange({ filterExpr: "version_name:in:1.2.0" })}
+      >
+        apply
+      </button>
+      <button
+        data-testid="filter-bar-clear"
+        onClick={() => props.onChange({ filterExpr: null })}
+      >
+        clear
+      </button>
+      <button
+        data-testid="filter-bar-switch-app"
+        onClick={() =>
+          props.onChange({
+            appId: "app-2",
+            filterExpr: null,
+            rootSpanName: null,
+          })
+        }
+      >
+        switch app
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
   SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
 }));
 
-// The stub records the plot it was asked for, the search text, the query
-// status and the app the issue buttons would link to.
 jest.mock("@/app/components/journey", () => ({
   __esModule: true,
   JourneyType: { Paths: "Paths", Exceptions: "Exceptions" },
@@ -191,6 +142,22 @@ jest.mock("@/app/components/debounce_text_input", () => ({
   ),
 }));
 
+import UserJourneysPage from "@/app/[teamId]/journeys/page";
+import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
+
+const mockApp = { id: "app-1", name: "Sample" };
+const mockOtherApp = { id: "app-2", name: "Other" };
+
+const versionKey = {
+  name: "version_name",
+  label: "App version",
+  key_group: "Version",
+  description: "The app version",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+};
+
 const mockJourneyData = {
   nodes: [
     { id: "sh.measure.demo.MainActivity", issues: { crashes: [], anrs: [] } },
@@ -217,18 +184,7 @@ function journeyFailed(error: Error) {
   });
 }
 
-// What the stub bar reports, as the page writes it into the URL.
-const selectionParams = "a=app-1&d=Last+6+Hours";
-
-const selectionUrl = (...trailingParams: string[]) =>
-  `?${[selectionParams, ...trailingParams].join("&")}`;
-
-const reportedFilterParams = (filterExpr: string | null) => ({
-  appId: mockReportedApp.id,
-  startDate: mockReportedDate.startDate,
-  endDate: mockReportedDate.endDate,
-  filterExpr,
-});
+const settled = { a: "app-1", d: "Last 6 Hours" };
 
 function renderPage() {
   return render(<UserJourneysPage params={promiseParams({ teamId: "123" })} />);
@@ -237,7 +193,18 @@ function renderPage() {
 describe("UserJourneys page", () => {
   beforeEach(() => {
     mockRouter.reset();
-    mockMountDiscardsFilter = false;
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
+    mockUseAppsQuery.mockReturnValue({
+      status: "success",
+      data: [mockApp, mockOtherApp],
+    });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [versionKey], key_groups: ["Version"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
     mockUseJourneyQuery.mockReset();
     mockUseJourneyQuery.mockReturnValue(pendingQueryState());
   });
@@ -250,81 +217,72 @@ describe("UserJourneys page", () => {
     );
   });
 
-  it("hands the bar the filter the URL opened on", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "filter_expr=version_name%3Ain%3A1.2.0",
-    );
+  it("hands the bar the app and filter it settled on", () => {
+    mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
     journeyLoaded();
     renderPage();
 
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("Sample");
     expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
       "version_name:in:1.2.0",
     );
   });
 
-  it("fetches nothing until the bar settles on an app and a range", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "filter_expr=version_name%3Ain%3A1.2.0",
-    );
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
     journeyLoaded();
     renderPage();
 
-    expect(mockUseJourneyQuery).toHaveBeenNthCalledWith(1, null);
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(null);
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
   });
 
-  it("fetches the journey filtered by what the bar reported", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "filter_expr=version_name%3Ain%3A1.2.0",
-    );
+  it("fetches the journey filtered by what it settled on", () => {
+    mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
     journeyLoaded();
     renderPage();
 
     expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
-      reportedFilterParams("version_name:in:1.2.0"),
+      expect.objectContaining({
+        appId: "app-1",
+        filterExpr: "version_name:in:1.2.0",
+      }),
     );
   });
 
-  it("never fetches a filter the bar discarded on mount", async () => {
-    mockMountDiscardsFilter = true;
-    mockRouter.deferReplace = true;
-    mockRouter.searchParams = new URLSearchParams(
-      `filter_expr=version_name%3Ain%3A1.2.0&${selectionParams}`,
+  it("never fetches a filter it discarded on mount", async () => {
+    mockRouter.setUrl(
+      "?filter_expr=device_cohort%3Ain%3Anew&a=app-1&d=Last+6+Hours",
     );
+    mockRouter.deferReplace = true;
     journeyLoaded();
     renderPage();
 
-    // The write has not landed, so the URL still holds the discarded
-    // filter and the query stays disabled.
     expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(null);
+    expect(mockRouter.urlParams()).toEqual(settled);
 
     await act(async () => {
-      applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+      mockRouter.applyDeferredReplace();
     });
 
-    expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(), {
-      scroll: false,
-    });
     expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
-      reportedFilterParams(null),
+      expect.objectContaining({ appId: "app-1", filterExpr: null }),
     );
     for (const [params] of mockUseJourneyQuery.mock.calls) {
-      expect(params?.filterExpr ?? null).not.toBe("version_name:in:1.2.0");
+      expect(params?.filterExpr ?? null).not.toBe("device_cohort:in:new");
     }
   });
 
-  it("records what the bar settled on without a pagination offset", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "filter_expr=version_name%3Ain%3A1.2.0",
-    );
+  it("records what it settled on without a pagination offset", () => {
+    mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
     journeyLoaded();
     renderPage();
 
-    expect(replaceMock).toHaveBeenCalledTimes(1);
-    expect(replaceMock).toHaveBeenCalledWith(
-      selectionUrl("filter_expr=version_name%3Ain%3A1.2.0"),
-      { scroll: false },
-    );
-    expect(mockRouter.searchParams.has("po")).toBe(false);
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      filter_expr: "version_name:in:1.2.0",
+    });
   });
 
   it("renders the tabs, the search input and the journey once ready", () => {
@@ -350,13 +308,13 @@ describe("UserJourneys page", () => {
     );
   });
 
-  it("links the issue buttons to the team and app the bar settled on", () => {
+  it("links the issue buttons to the team and app it settled on", () => {
     journeyLoaded();
     renderPage();
 
     const journey = screen.getByTestId("journey-mock-Paths");
     expect(journey).toHaveAttribute("data-team", "123");
-    expect(journey).toHaveAttribute("data-app", mockReportedApp.id);
+    expect(journey).toHaveAttribute("data-app", mockApp.id);
   });
 
   it("passes the typed search text to the journey", async () => {
@@ -377,7 +335,7 @@ describe("UserJourneys page", () => {
 
   describe("the plot type", () => {
     it("opens on the plot the URL names", () => {
-      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      mockRouter.setUrl("?jt=Exceptions");
       journeyLoaded();
       renderPage();
 
@@ -389,22 +347,17 @@ describe("UserJourneys page", () => {
       expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
     });
 
-    it("survives the bar's report being written into the URL", () => {
-      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+    it("survives what the page settled on being written into the URL", () => {
+      mockRouter.setUrl("?jt=Exceptions");
       journeyLoaded();
       renderPage();
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl("jt=Exceptions"),
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({ ...settled, jt: "Exceptions" });
       expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
     });
 
     it("is written into the URL when a tab is clicked, keeping the filter", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "filter_expr=version_name%3Ain%3A1.2.0",
-      );
+      mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
       journeyLoaded();
       renderPage();
 
@@ -412,10 +365,11 @@ describe("UserJourneys page", () => {
         fireEvent.click(screen.getByTestId("tab-Exceptions"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Exceptions"),
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        filter_expr: "version_name:in:1.2.0",
+        jt: "Exceptions",
+      });
       expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
       expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
 
@@ -423,10 +377,11 @@ describe("UserJourneys page", () => {
         fireEvent.click(screen.getByTestId("tab-Paths"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Paths"),
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        filter_expr: "version_name:in:1.2.0",
+        jt: "Paths",
+      });
       expect(screen.getByTestId("journey-mock-Paths")).toBeInTheDocument();
     });
 
@@ -442,12 +397,14 @@ describe("UserJourneys page", () => {
       for (const [params] of mockUseJourneyQuery.mock.calls.slice(
         callsBefore,
       )) {
-        expect(params).toEqual(reportedFilterParams(null));
+        expect(params).toEqual(
+          expect.objectContaining({ appId: "app-1", filterExpr: null }),
+        );
       }
     });
 
     it("is kept when the filter changes", async () => {
-      mockRouter.searchParams = new URLSearchParams("jt=Exceptions");
+      mockRouter.setUrl("?jt=Exceptions");
       journeyLoaded();
       renderPage();
 
@@ -455,20 +412,19 @@ describe("UserJourneys page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-apply"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl("filter_expr=version_name%3Ain%3A1.2.0", "jt=Exceptions"),
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        filter_expr: "version_name:in:1.2.0",
+        jt: "Exceptions",
+      });
       expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
-        reportedFilterParams("version_name:in:1.2.0"),
+        expect.objectContaining({ filterExpr: "version_name:in:1.2.0" }),
       );
       expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
     });
 
     it("is kept when the filter is cleared", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "jt=Exceptions&filter_expr=version_name%3Ain%3A1.2.0",
-      );
+      mockRouter.setUrl("?jt=Exceptions&filter_expr=version_name%3Ain%3A1.2.0");
       journeyLoaded();
       renderPage();
 
@@ -476,10 +432,7 @@ describe("UserJourneys page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-clear"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl("jt=Exceptions"),
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({ ...settled, jt: "Exceptions" });
       expect(screen.getByTestId("journey-mock-Exceptions")).toBeInTheDocument();
     });
   });
@@ -492,14 +445,10 @@ describe("UserJourneys page", () => {
       fireEvent.click(screen.getByTestId("filter-bar-switch-app"));
     });
 
-    expect(replaceMock).toHaveBeenLastCalledWith(
-      `?${selectionParams.replace("a=app-1", "a=app-2")}`,
-      { scroll: false },
+    expect(mockRouter.urlParams()).toEqual({ a: "app-2", d: "Last 6 Hours" });
+    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ appId: mockOtherApp.id, filterExpr: null }),
     );
-    expect(mockUseJourneyQuery).toHaveBeenLastCalledWith({
-      ...reportedFilterParams(null),
-      appId: mockOtherApp.id,
-    });
     expect(screen.getByTestId("journey-mock-Paths")).toHaveAttribute(
       "data-app",
       mockOtherApp.id,
@@ -517,9 +466,7 @@ describe("UserJourneys page", () => {
     });
 
     it("hands a refused filter's issues to the bar in place of the message", () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "filter_expr=version_name%3Ain%3A1.2.0",
-      );
+      mockRouter.setUrl("?filter_expr=version_name%3Ain%3A1.2.0");
       journeyFailed(
         new ApiError(400, invalidFilterExpr, [
           { message: 'Unknown key "os_name"', span: { start: 0, end: 7 } },
@@ -535,18 +482,15 @@ describe("UserJourneys page", () => {
     });
   });
 
-  describe("a filter the bar could not settle", () => {
+  describe("a filter it could not settle", () => {
     beforeEach(() => {
-      mockRouter.searchParams = new URLSearchParams(selectionParams);
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours");
+      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
       journeyLoaded();
     });
 
-    it("is said by the page, in place of the journey", async () => {
+    it("is said by the page, in place of the journey", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(
         screen.getByText(
@@ -556,25 +500,16 @@ describe("UserJourneys page", () => {
       expect(screen.queryByTestId("journey-mock-Paths")).toBeNull();
     });
 
-    it("stops the page fetching anything", async () => {
+    it("stops the page fetching anything", () => {
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(mockUseJourneyQuery).toHaveBeenLastCalledWith(null);
     });
 
-    it("leaves the URL where the link had it", async () => {
+    it("leaves the URL where the link had it", () => {
       renderPage();
-      replaceMock.mockClear();
 
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
-
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(mockRouter.urlParams()).toEqual(settled);
     });
   });
 });

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -1,35 +1,24 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
 import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import TracesOverview from "@/app/[teamId]/traces/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const replaceMock = mockRouter.replaceMock;
 const pushMock = mockRouter.pushMock;
-const applyReplaceUrl = mockRouter.applyReplaceUrl;
 
 jest.mock("next/navigation", () =>
   require("@/__tests__/helpers/mock_router").nextNavigationMock(),
 );
 
-jest.mock("@/app/api/api_calls", () => ({
-  __esModule: true,
-  emptySpansResponse: {
-    meta: { next: false, previous: false },
-    results: [],
-  },
-}));
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
 
-jest.mock("@/app/stores/filters_store", () => ({
+const mockToastNegative = jest.fn();
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  urlFiltersKeyMap: {
-    appId: "a",
-    dateRange: "d",
-    startDate: "sd",
-    endDate: "ed",
-    rootSpanName: "r",
-  },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
 const pendingQueryState = () => ({
@@ -39,6 +28,9 @@ const pendingQueryState = () => ({
   error: null as Error | null,
 });
 
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
+const mockUseRootSpanNamesQuery = jest.fn();
 const mockUseSpansQuery = jest.fn(
   (_filter: any, _spanName: string | null, _offset: number) =>
     pendingQueryState(),
@@ -49,125 +41,61 @@ const mockUseSpanMetricsPlotQuery = jest.fn(
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
+  paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: (app: unknown) => mockUseRootSpanNamesQuery(app),
   useSpansQuery: (filter: any, spanName: string | null, offset: number) =>
     mockUseSpansQuery(filter, spanName, offset),
   useSpanMetricsPlotQuery: (filter: any, spanName: string | null) =>
     mockUseSpanMetricsPlotQuery(filter, spanName),
-  paginationOffsetUrlKey: "po",
 }));
 
-const mockReportedApp = { id: "app-1", name: "Sample" };
-const mockReportedDate = {
-  dateRange: "Last 6 Hours",
-  startDate: "2026-01-01T00:00:00.000Z",
-  endDate: "2026-01-01T06:00:00.000Z",
-};
-
-// Set before render to make the stub open with a trace name of its own in
-// place of the URL's, the way the real bar substitutes a default when the
-// app no longer has the requested name.
-let mockMountSubstitutesName = false;
-let mockAppHasNoTraces = false;
-
-// Like the real bar, this stub reports a resolved trace name for the request
-// it is handed, on mount and whenever it changes; its buttons hand the page a
-// request the way a pick does, or report a failure. Only a substituted report
-// carries appliedAsRequested false.
-jest.mock("@/app/components/filter_bar/filter_bar", () => {
-  const { useEffect } = require("react");
-
-  function FilterBarMock(props: any) {
-    const ready = (
-      filterExpr: string | null,
-      // The real bar restores the URL's name when it can, so the stub
-      // reports it back too and falls back to a first name of its own.
-      rootSpanName: string | null = props.requestedRootSpanName ?? "span.first",
-      appliedAsRequested: boolean = false,
-    ) => ({
-      status: "ready",
-      app: mockReportedApp,
-      date: mockReportedDate,
-      filterExpr,
-      rootSpanName,
-      appliedAsRequested,
-    });
-    const request = (filterExpr: string | null, rootSpanName: string) =>
-      props.onRequestChange({
-        appId: mockReportedApp.id,
-        dateRange: mockReportedDate,
-        filterExpr,
-        rootSpanName,
-      });
-
-    useEffect(() => {
-      if (mockMountSubstitutesName) {
-        props.onFilterChange(
-          ready(props.requestedFilterExpr, "span.substitute", false),
-        );
-      } else if (mockAppHasNoTraces) {
-        props.onFilterChange(ready(props.requestedFilterExpr, null, true));
-      } else {
-        props.onFilterChange(ready(props.requestedFilterExpr, undefined, true));
-      }
-    }, [props.requestedFilterExpr, props.requestedRootSpanName]);
-
-    return (
-      <div data-testid="filter-bar-mock">
-        <span data-testid="filter-bar-expr">
-          {props.requestedFilterExpr ?? "none"}
-        </span>
-        <span data-testid="filter-bar-requested-name">
-          {props.requestedRootSpanName ?? "none"}
-        </span>
-        <span data-testid="filter-bar-selector-shown">
-          {String(props.showRootSpanSelector ?? false)}
-        </span>
-        <button
-          data-testid="filter-bar-apply"
-          onClick={() =>
-            request(
-              "span_status:in:error",
-              props.requestedRootSpanName ?? "span.first",
-            )
-          }
-        >
-          apply
-        </button>
-        <button
-          data-testid="filter-bar-pick-name"
-          onClick={() => request(props.requestedFilterExpr, "span.second")}
-        >
-          pick name
-        </button>
-        <button
-          data-testid="filter-bar-fail"
-          onClick={() =>
-            props.onFilterChange({
-              status: "error",
-              message: "Error fetching apps, please refresh page to try again",
-            })
-          }
-        >
-          fail
-        </button>
-      </div>
-    );
-  }
-
-  return {
-    __esModule: true,
-    default: FilterBarMock,
-    filterExprUrlKey: "filter_expr",
-  };
-});
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-app">
+        {props.value?.app.name ?? "none"}
+      </span>
+      <span data-testid="filter-bar-expr">
+        {props.value?.filterExpr ?? "none"}
+      </span>
+      <span data-testid="filter-bar-name">
+        {props.value?.rootSpanName ?? "none"}
+      </span>
+      <span data-testid="filter-bar-span-names">
+        {props.spanNames === undefined
+          ? "hidden"
+          : props.spanNames === null
+            ? "loading"
+            : props.spanNames.join(",")}
+      </span>
+      <button
+        data-testid="filter-bar-apply"
+        onClick={() => props.onChange({ filterExpr: "span_status:in:error" })}
+      >
+        apply
+      </button>
+      <button
+        data-testid="filter-bar-pick-name"
+        onClick={() => props.onChange({ rootSpanName: "span.second" })}
+      >
+        pick name
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock("@/app/components/skeleton", () => ({
   __esModule: true,
   SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
 }));
 
-// The real plot shows a skeleton while its query is pending, so the stub
-// distinguishes that case for tests that check what fills the plot area.
 jest.mock("@/app/components/span_metrics_plot", () => ({
   __esModule: true,
   default: (props: any) => (
@@ -214,6 +142,20 @@ jest.mock("@/app/utils/time_utils", () => ({
   formatMillisToHumanReadable: jest.fn(() => "5s"),
 }));
 
+import TracesOverview from "@/app/[teamId]/traces/page";
+
+const mockApp = { id: "app-1", name: "Sample" };
+
+const spanStatusKey = {
+  name: "span_status",
+  label: "Status",
+  key_group: "Span",
+  description: "The status of the span",
+  value_type: "string",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+};
+
 const mockSpanData = {
   results: [
     {
@@ -245,16 +187,15 @@ function spansLoaded(data: any = mockSpanData) {
   });
 }
 
-// What the stub bar reports, as the page writes it into the URL.
-const selectionParams = "a=app-1&d=Last+6+Hours";
+function namesLoaded(names: string[] | null) {
+  mockUseRootSpanNamesQuery.mockReturnValue({
+    data: names,
+    isSuccess: true,
+    isError: false,
+  });
+}
 
-// The names in these tests are URL-safe, so they appear in the URL as-is.
-const selectionUrl = (
-  offset: number,
-  spanName = "span.first",
-  filterParam?: string,
-) =>
-  `?po=${offset}&${selectionParams}&r=${spanName}${filterParam ? `&${filterParam}` : ""}`;
+const settled = { a: "app-1", d: "Last 6 Hours", r: "span.first" };
 
 function renderPage() {
   return render(<TracesOverview params={promiseParams({ teamId: "123" })} />);
@@ -263,86 +204,90 @@ function renderPage() {
 describe("TracesOverview page", () => {
   beforeEach(() => {
     mockRouter.reset();
-    mockMountSubstitutesName = false;
-    mockAppHasNoTraces = false;
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: [mockApp] });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [spanStatusKey], key_groups: ["Span"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
+    namesLoaded(["span.first", "span.second"]);
     mockUseSpansQuery.mockReset();
     mockUseSpansQuery.mockReturnValue(pendingQueryState());
     mockUseSpanMetricsPlotQuery.mockReset();
     mockUseSpanMetricsPlotQuery.mockReturnValue(pendingQueryState());
   });
 
-  it("renders the filter bar", () => {
-    renderPage();
-    expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
-  });
-
-  it("asks the bar to show the trace name selector", () => {
-    renderPage();
-    expect(screen.getByTestId("filter-bar-selector-shown")).toHaveTextContent(
-      "true",
-    );
-  });
-
-  it("hands the bar the filter the URL opened on", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=0&filter_expr=span_status%3Ain%3Aerror",
-    );
+  it("renders the filter bar with the span names and what it settled on", () => {
+    mockRouter.setUrl("?po=0&filter_expr=span_status%3Ain%3Aerror");
     spansLoaded();
     renderPage();
 
+    expect(screen.getByTestId("filter-bar-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("Sample");
     expect(screen.getByTestId("filter-bar-expr")).toHaveTextContent(
       "span_status:in:error",
+    );
+    expect(screen.getByTestId("filter-bar-name")).toHaveTextContent(
+      "span.first",
+    );
+    expect(screen.getByTestId("filter-bar-span-names")).toHaveTextContent(
+      "span.first,span.second",
     );
   });
 
   it("hands the bar the trace name the URL opened on", () => {
-    mockRouter.searchParams = new URLSearchParams("po=0&a=app-1&r=span.second");
+    mockRouter.setUrl("?po=0&a=app-1&r=span.second");
     spansLoaded();
     renderPage();
 
-    expect(screen.getByTestId("filter-bar-requested-name")).toHaveTextContent(
+    expect(screen.getByTestId("filter-bar-name")).toHaveTextContent(
       "span.second",
     );
   });
 
-  it("fetches nothing until the bar settles on an app, a range and a name", () => {
+  it("fetches nothing until it settles on an app, a range and a name", () => {
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
     spansLoaded();
     renderPage();
 
-    expect(mockUseSpansQuery).toHaveBeenNthCalledWith(1, null, null, 0);
+    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 0);
+    expect(mockUseSpanMetricsPlotQuery).toHaveBeenLastCalledWith(null, null);
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
+    expect(mockRouter.urlParams()).toEqual({});
   });
 
-  it("fetches spans and the plot for the name the bar reported", () => {
+  it("fetches spans and the plot for the name it settled on", () => {
     spansLoaded();
     renderPage();
 
     expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
-      {
-        appId: mockReportedApp.id,
-        startDate: mockReportedDate.startDate,
-        endDate: mockReportedDate.endDate,
-        filterExpr: null,
-      },
+      expect.objectContaining({ appId: "app-1", filterExpr: null }),
       "span.first",
       0,
     );
     expect(mockUseSpanMetricsPlotQuery).toHaveBeenLastCalledWith(
-      expect.objectContaining({ appId: mockReportedApp.id }),
+      expect.objectContaining({ appId: "app-1" }),
       "span.first",
     );
   });
 
-  it("records what the bar settled on, keeping the page the link asked for", () => {
-    mockRouter.searchParams = new URLSearchParams(
-      "po=20&filter_expr=span_status%3Ain%3Aerror",
-    );
+  it("records what it settled on, keeping the page the link asked for", () => {
+    mockRouter.setUrl("?po=20&filter_expr=span_status%3Ain%3Aerror");
     spansLoaded();
     renderPage();
 
-    expect(replaceMock).toHaveBeenCalledTimes(1);
-    expect(replaceMock).toHaveBeenCalledWith(
-      selectionUrl(20, "span.first", "filter_expr=span_status%3Ain%3Aerror"),
-      { scroll: false },
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      po: "20",
+      filter_expr: "span_status:in:error",
+    });
+    expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ filterExpr: "span_status:in:error" }),
+      "span.first",
+      20,
     );
   });
 
@@ -353,13 +298,11 @@ describe("TracesOverview page", () => {
     expect(screen.getByTestId("prev-button")).toBeDisabled();
   });
 
-  it("shows the plot skeleton while the bar's report waits to reach the URL", () => {
+  it("shows the plot skeleton while what it settled on waits to reach the URL", () => {
     mockRouter.deferReplace = true;
     spansLoaded();
     renderPage();
 
-    // The URL write has not landed, so the bar's report does not match the
-    // URL yet and the queries stay disabled with a null filter.
     expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, "span.first", 0);
     expect(screen.getByTestId("span-metrics-plot-mock")).toBeInTheDocument();
     expect(screen.getByTestId("skeleton-plot-mock")).toBeInTheDocument();
@@ -478,77 +421,68 @@ describe("TracesOverview page", () => {
     expect(pushMock).toHaveBeenCalledWith("/123/traces/app1/trace1");
   });
 
-  describe("a filter the bar could not settle", () => {
-    beforeEach(() => {
-      mockRouter.searchParams = new URLSearchParams(`po=10&${selectionParams}`);
+  describe("a filter it could not settle", () => {
+    it("says there is no data for an app that never reported a trace, and still writes the URL", () => {
+      namesLoaded(null);
+      mockRouter.setUrl("?po=10&a=app-1");
       spansLoaded();
-    });
-
-    it("says there is no data for an app that never reported a trace, and still writes the URL", async () => {
-      mockAppHasNoTraces = true;
-      mockRouter.searchParams = new URLSearchParams(
-        `po=10&r=span.first&${selectionParams}`,
-      );
       renderPage();
 
       expect(
         screen.getByText("No traces received for this app yet"),
       ).toBeInTheDocument();
       expect(screen.queryByText("Trace")).toBeNull();
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        `?po=10&${selectionParams}`,
-        { scroll: false },
-      );
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Last 6 Hours",
+        po: "10",
+      });
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
         expect.anything(),
         null,
         10,
       );
+      expect(screen.getByTestId("filter-bar-span-names")).toHaveTextContent("");
     });
 
-    it("is said by the page, in place of the list", async () => {
+    it("says so in place of the list, fetches nothing and leaves the URL alone", () => {
+      mockRouter.setUrl("?po=10&a=app-1&d=Last+6+Hours");
+      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
+      spansLoaded();
       renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
 
       expect(
         screen.getByText(
           "Error fetching apps, please refresh page to try again",
         ),
       ).toBeInTheDocument();
-    });
-
-    it("stops the page fetching anything", async () => {
-      renderPage();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
-      });
-
-      // Without a ready report there is no resolved name, and the null
-      // filter keeps the query disabled.
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 10);
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Last 6 Hours",
+        po: "10",
+      });
     });
 
-    it("leaves the URL where the link had it", async () => {
-      renderPage();
-      replaceMock.mockClear();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId("filter-bar-fail"));
+    it("says so when the trace names cannot be fetched", () => {
+      mockUseRootSpanNamesQuery.mockReturnValue({
+        data: undefined,
+        isSuccess: false,
+        isError: true,
       });
+      spansLoaded();
+      renderPage();
 
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(
+        screen.getByText(/Error fetching traces list/),
+      ).toBeInTheDocument();
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(null, null, 0);
     });
   });
 
   describe("pagination", () => {
     it("moves the offset on by the page size when Next is clicked", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        `po=0&r=span.first&${selectionParams}`,
-      );
+      mockRouter.setUrl("?po=0&r=span.first&a=app-1&d=Last+6+Hours");
       spansLoaded();
       renderPage();
 
@@ -556,42 +490,32 @@ describe("TracesOverview page", () => {
         fireEvent.click(screen.getByTestId("next-button"));
       });
 
-      // Paging keeps everything else the URL was carrying.
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(5), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "5" });
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ appId: "app-1" }),
+        "span.first",
+        5,
+      );
     });
 
     it("moves the offset back when Prev is clicked, and never below zero", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=5&r=span.first&a=app-1",
-      );
+      mockRouter.setUrl("?po=5&r=span.first&a=app-1");
       spansLoaded();
       renderPage();
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("prev-button"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
 
-      mockRouter.searchParams = new URLSearchParams(
-        "po=0&r=span.first&a=app-1",
-      );
-      renderPage();
       await act(async () => {
-        fireEvent.click(screen.getAllByTestId("prev-button")[1]);
+        fireEvent.click(screen.getByTestId("prev-button"));
       });
-      expect(replaceMock).toHaveBeenLastCalledWith(selectionUrl(0), {
-        scroll: false,
-      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
     });
 
     it("goes back to the first page when the filter changes", async () => {
-      mockRouter.searchParams = new URLSearchParams(
-        "po=30&a=app-1&r=span.first",
-      );
+      mockRouter.setUrl("?po=30&a=app-1&r=span.first");
       spansLoaded();
       renderPage();
 
@@ -599,14 +523,25 @@ describe("TracesOverview page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-apply"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "span.first", "filter_expr=span_status%3Ain%3Aerror"),
-        { scroll: false },
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        po: "0",
+        filter_expr: "span_status:in:error",
+      });
+      expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ filterExpr: "span_status:in:error" }),
+        "span.first",
+        0,
       );
+      for (const [filter, , offset] of mockUseSpansQuery.mock.calls) {
+        if (filter?.filterExpr === "span_status:in:error") {
+          expect(offset).toBe(0);
+        }
+      }
     });
 
-    it("goes back to the first page when the bar reports another name", async () => {
-      mockRouter.searchParams = new URLSearchParams(`po=30&${selectionParams}`);
+    it("goes back to the first page when another name is picked", async () => {
+      mockRouter.setUrl("?po=30&a=app-1&d=Last+6+Hours");
       spansLoaded();
       renderPage();
 
@@ -614,13 +549,11 @@ describe("TracesOverview page", () => {
         fireEvent.click(screen.getByTestId("filter-bar-pick-name"));
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "span.second"),
-        { scroll: false },
-      );
-      // The changed name and the reset offset reach the queries together,
-      // through the URL, so the new name is never fetched at the page the
-      // old name was on.
+      expect(mockRouter.urlParams()).toEqual({
+        ...settled,
+        r: "span.second",
+        po: "0",
+      });
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
         expect.anything(),
         "span.second",
@@ -633,44 +566,35 @@ describe("TracesOverview page", () => {
       }
     });
 
-    it("goes back to the first page when the bar opens on a substituted name", async () => {
-      mockMountSubstitutesName = true;
+    it("goes back to the first page when the URL names a span the app does not have", async () => {
+      mockRouter.setUrl("?po=30&r=span.gone&a=app-1&d=Last+6+Hours");
       mockRouter.deferReplace = true;
-      mockRouter.searchParams = new URLSearchParams(
-        `po=30&r=span.gone&${selectionParams}`,
-      );
       spansLoaded();
       renderPage();
 
-      // The write has not landed, so the URL still holds the dead name
-      // and the queries stay disabled, at the offset the page wrote.
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
         null,
-        "span.substitute",
-        0,
+        "span.first",
+        30,
+      );
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        "Some filters were invalid, page reset to defaults",
       );
 
       await act(async () => {
-        applyReplaceUrl(mockRouter.deferredReplaceUrl!);
+        mockRouter.applyDeferredReplace();
       });
 
-      expect(replaceMock).toHaveBeenLastCalledWith(
-        selectionUrl(0, "span.substitute"),
-        { scroll: false },
-      );
-      // The substituted name is never fetched at the page the URL's name
-      // was on.
       expect(mockUseSpansQuery).toHaveBeenLastCalledWith(
-        expect.anything(),
-        "span.substitute",
+        expect.objectContaining({ appId: "app-1" }),
+        "span.first",
         0,
       );
       for (const [filter, spanName, offset] of mockUseSpansQuery.mock.calls) {
-        if (spanName === "span.substitute" && filter !== null) {
+        if (filter !== null) {
+          expect(spanName).toBe("span.first");
           expect(offset).toBe(0);
-        }
-        if (spanName === "span.gone") {
-          expect(filter).toBeNull();
         }
       }
     });

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -38,16 +38,23 @@ export default function BugReportsOverview(props: {
   const router = useRouter();
 
   const {
-    requestedFilters,
-    paginationOffset,
-    filterState,
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status: filterStatus,
     filterParams,
-    onRequestChange,
-    onFilterChange,
+    paginationOffset,
+    onChange,
     nextPage,
     prevPage,
-  } = useExprFilterPage({ paginationLimit: PAGINATION_LIMIT });
-  const readyFilter = filterState.status === "ready" ? filterState : null;
+  } = useExprFilterPage({
+    teamId: params.teamId,
+    entity: "bug_reports",
+    paginationLimit: PAGINATION_LIMIT,
+  });
+  const readyValue = filterStatus.kind === "ready" ? value : null;
 
   const bugReportsQuery = useBugReportsOverviewQuery(
     filterParams,
@@ -70,25 +77,25 @@ export default function BugReportsOverview(props: {
       <div className="py-4" />
 
       <FilterBar
-        teamId={params.teamId}
         entity="bug_reports"
         placeholder="Filter bug reports…"
-        requestedAppId={requestedFilters.appId}
-        requestedDateRange={requestedFilters.dateRange}
-        requestedFilterExpr={requestedFilters.filterExpr}
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
-        onRequestChange={onRequestChange}
-        onFilterChange={onFilterChange}
+        onChange={onChange}
       />
       <div className="py-4" />
 
-      {filterState.status === "error" && (
-        <p className="text-lg font-display">{filterState.message}</p>
+      {filterStatus.kind === "error" && (
+        <p className="text-lg font-display">{filterStatus.message}</p>
       )}
 
-      {filterState.status === "pending" && <SkeletonListPage />}
+      {filterStatus.kind === "loading" && <SkeletonListPage />}
 
-      {readyFilter !== null &&
+      {readyValue !== null &&
         status === "error" &&
         filterExprIssues === null && (
           <p className="text-lg font-display">
@@ -97,12 +104,12 @@ export default function BugReportsOverview(props: {
           </p>
         )}
 
-      {readyFilter !== null &&
+      {readyValue !== null &&
         (status === "success" || status === "pending") && (
           <div className="flex flex-col items-center w-full">
             <BugReportsOverviewPlot
-              startDate={readyFilter.date.startDate}
-              endDate={readyFilter.date.endDate}
+              startDate={readyValue.date.startDate}
+              endDate={readyValue.date.endDate}
               query={bugReportsPlotQuery}
             />
             <div className="self-end">

--- a/frontend/dashboard/app/[teamId]/builds/builds_results.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/builds_results.tsx
@@ -7,7 +7,7 @@ import {
   emptyBuildsResponse,
 } from "@/app/api/api_calls";
 import { Button } from "@/app/components/button";
-import type { FilterState } from "@/app/components/filter_bar/filter_bar";
+import type { FilterStatus } from "@/app/components/filter_bar/use_expr_filter_page";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import { SkeletonListPage } from "@/app/components/skeleton";
@@ -23,13 +23,13 @@ import type { useBuildsQuery } from "@/app/query/hooks";
 import { formatDateToHumanReadableDateTime } from "@/app/utils/time_utils";
 
 export default function BuildsResults({
-  filterState,
+  status,
   query,
   filterExprHasIssues,
   onNextPage,
   onPrevPage,
 }: {
-  filterState: FilterState;
+  status: FilterStatus;
   query: ReturnType<typeof useBuildsQuery>;
   filterExprHasIssues: boolean;
   onNextPage: () => void;
@@ -39,11 +39,11 @@ export default function BuildsResults({
 
   return (
     <>
-      {filterState.status === "error" && (
-        <p className="text-lg font-display">{filterState.message}</p>
+      {status.kind === "error" && (
+        <p className="text-lg font-display">{status.message}</p>
       )}
 
-      {filterState.status !== "error" && query.status === "pending" && (
+      {status.kind !== "error" && query.status === "pending" && (
         <SkeletonListPage />
       )}
 

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -13,15 +13,22 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
   const params = use(props.params);
 
   const {
-    requestedFilters,
-    paginationOffset,
-    filterState,
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status,
     filterParams,
-    onRequestChange,
-    onFilterChange,
+    paginationOffset,
+    onChange,
     nextPage,
     prevPage,
-  } = useExprFilterPage({ paginationLimit: PAGINATION_LIMIT });
+  } = useExprFilterPage({
+    teamId: params.teamId,
+    entity: "builds",
+    paginationLimit: PAGINATION_LIMIT,
+  });
 
   const buildsQuery = useBuildsQuery(filterParams, paginationOffset);
 
@@ -32,20 +39,20 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
       <div className="py-4" />
 
       <FilterBar
-        teamId={params.teamId}
         entity="builds"
         placeholder="Filter builds…"
-        requestedAppId={requestedFilters.appId}
-        requestedDateRange={requestedFilters.dateRange}
-        requestedFilterExpr={requestedFilters.filterExpr}
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
-        onRequestChange={onRequestChange}
-        onFilterChange={onFilterChange}
+        onChange={onChange}
       />
       <div className="py-4" />
 
       <BuildsResults
-        filterState={filterState}
+        status={status}
         query={buildsQuery}
         filterExprHasIssues={filterExprIssues !== null}
         onNextPage={nextPage}

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -18,7 +18,6 @@ import {
   TableRow,
 } from "@/app/components/table";
 import { useSpanMetricsPlotQuery, useSpansQuery } from "@/app/query/hooks";
-import { urlFiltersKeyMap } from "@/app/stores/filters_store";
 import {
   formatDateToHumanReadableDate,
   formatDateToHumanReadableTime,
@@ -37,20 +36,26 @@ export default function TracesOverview(props: {
   const router = useRouter();
 
   const {
-    requestedFilters,
-    paginationOffset,
-    filterState,
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    spanNames,
+    status: filterStatus,
     filterParams,
-    onRequestChange,
-    onFilterChange,
+    paginationOffset,
+    onChange,
     nextPage,
     prevPage,
   } = useExprFilterPage({
+    teamId: params.teamId,
+    entity: "spans",
     paginationLimit: PAGINATION_LIMIT,
-    extraUrlKeys: { rootSpanName: urlFiltersKeyMap.rootSpanName },
+    rootSpan: true,
   });
-  const readyFilter = filterState.status === "ready" ? filterState : null;
-  const rootSpanName = readyFilter?.rootSpanName ?? null;
+  const readyValue = filterStatus.kind === "ready" ? value : null;
+  const rootSpanName = value?.rootSpanName ?? null;
 
   const spansQuery = useSpansQuery(
     filterParams,
@@ -73,33 +78,32 @@ export default function TracesOverview(props: {
       <div className="py-4" />
 
       <FilterBar
-        teamId={params.teamId}
         entity="spans"
         placeholder="Filter traces…"
-        requestedAppId={requestedFilters.appId}
-        requestedDateRange={requestedFilters.dateRange}
-        requestedFilterExpr={requestedFilters.filterExpr}
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
+        spanNames={spanNames}
         filterExprIssues={filterExprIssues}
-        showRootSpanSelector
-        requestedRootSpanName={requestedFilters.rootSpanName}
-        onRequestChange={onRequestChange}
-        onFilterChange={onFilterChange}
+        onChange={onChange}
       />
       <div className="py-4" />
 
-      {filterState.status === "error" && (
-        <p className="text-lg font-display">{filterState.message}</p>
+      {filterStatus.kind === "error" && (
+        <p className="text-lg font-display">{filterStatus.message}</p>
       )}
 
-      {filterState.status === "pending" && <SkeletonListPage />}
+      {filterStatus.kind === "loading" && <SkeletonListPage />}
 
-      {readyFilter !== null && readyFilter.rootSpanName === null && (
+      {readyValue !== null && readyValue.rootSpanName === null && (
         <p className="text-lg font-display">
           No traces received for this app yet
         </p>
       )}
 
-      {readyFilter !== null &&
+      {readyValue !== null &&
         status === "error" &&
         filterExprIssues === null && (
           <p className="text-lg font-display">
@@ -108,13 +112,13 @@ export default function TracesOverview(props: {
           </p>
         )}
 
-      {readyFilter !== null &&
-        readyFilter.rootSpanName !== null &&
+      {readyValue !== null &&
+        readyValue.rootSpanName !== null &&
         (status === "success" || status === "pending") && (
           <div className="flex flex-col items-center w-full">
             <SpanMetricsPlot
-              startDate={readyFilter.date.startDate}
-              endDate={readyFilter.date.endDate}
+              startDate={readyValue.date.startDate}
+              endDate={readyValue.date.endDate}
               query={spanMetricsPlotQuery}
             />
             <div className="self-end">

--- a/frontend/dashboard/app/components/filter_bar/conditions.ts
+++ b/frontend/dashboard/app/components/filter_bar/conditions.ts
@@ -6,12 +6,8 @@ import type {
 } from "../../api/filter_types";
 import { operatorTakesOneValue, operatorTakesValues } from "./operators";
 
-// The conditions and groups the filter bar draws. They are derived rather than
-// saved: the bar keeps the filter as text and rebuilds these rows from it after
-// every change.
-//
 // A row is only drawn after its key is selected, so `key` and `operator` are
-// always set. The operator starts as the first one offered for that key.
+// always set.
 export type ConditionRow = {
   id: string;
   key: FilterKey;
@@ -63,44 +59,36 @@ export function isRowComplete(row: ConditionRow): boolean {
   return !operatorTakesOneValue(row.operator) || row.values.length === 1;
 }
 
-/**
- * The tree a request carries. Conditions that are not complete are left out,
- * so that a filter the user is midway through building is not considered.
- */
+// Incomplete conditions and empty groups are left out.
 export function buildExprTree(filter: ConditionGroup): ExprTree | null {
-  const children = buildChildren(filter, false);
+  const children = buildChildren(filter);
   if (children.length === 0) {
     return null;
   }
   return { logical_operator: filter.logicalOperator, children };
 }
 
-/**
- * The tree behind the text the bar holds, covering everything on screen,
- * including the unfinished conditions and empty groups buildExprTree leaves
- * out.
- */
-export function buildDraftTree(filter: ConditionGroup): ExprTree {
-  return {
-    logical_operator: filter.logicalOperator,
-    children: buildChildren(filter, true),
-  };
-}
-
-function buildChildren(group: ConditionGroup, draft: boolean): ExprTree[] {
+function buildChildren(group: ConditionGroup): ExprTree[] {
   const children: ExprTree[] = [];
 
   for (const child of group.children) {
     if (!isConditionGroup(child)) {
-      const condition = buildCondition(child, draft);
-      if (condition) {
-        children.push(condition);
+      if (isRowComplete(child)) {
+        children.push({
+          condition: {
+            key_name: child.key.name,
+            operator: child.operator,
+            values: operatorTakesValues(child.operator)
+              ? child.values
+              : undefined,
+          },
+        });
       }
       continue;
     }
 
-    const inner = buildChildren(child, draft);
-    if (draft || inner.length > 0) {
+    const inner = buildChildren(child);
+    if (inner.length > 0) {
       children.push({
         logical_operator: child.logicalOperator,
         children: inner,
@@ -109,19 +97,6 @@ function buildChildren(group: ConditionGroup, draft: boolean): ExprTree[] {
   }
 
   return children;
-}
-
-function buildCondition(row: ConditionRow, draft: boolean): ExprTree | null {
-  if (!draft && !isRowComplete(row)) {
-    return null;
-  }
-  return {
-    condition: {
-      key_name: row.key.name,
-      operator: row.operator,
-      values: operatorTakesValues(row.operator) ? row.values : undefined,
-    },
-  };
 }
 
 // ─── Expression tree to conditions ───────────────────────────────────────

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -11,32 +11,19 @@ import {
 } from "react";
 import { type App } from "../../api/api_calls";
 import type { FilterExprIssue } from "../../api/api_error";
-import {
-  type FilterKey,
-  type FilterOperator,
-  type FilterValue,
-} from "../../api/filter_types";
-import {
-  useAppsQuery,
-  useFilterKeysQuery,
-  useRootSpanNamesQuery,
-} from "../../query/hooks";
+import { type FilterKey, type FilterOperator } from "../../api/filter_types";
+import { useFilterKeysQuery } from "../../query/hooks";
 import { toastNegative } from "../toast";
-import { useFiltersStore } from "../../stores/provider";
 import { Skeleton } from "../skeleton";
 import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
 import AppSelect from "./app_select";
 import DateRangeSelect, {
   DateRange,
   type DateSelection,
-  isValidDateRange,
   type UncheckedDateRange,
-  pickDateRange,
-  toDateSelection,
 } from "./date_range_select";
 import {
   buildConditionGroup,
-  buildDraftTree,
   buildExprTree,
   childId,
   type ConditionGroup,
@@ -44,6 +31,7 @@ import {
   type ConditionRow,
   dropById,
   isConditionGroup,
+  isRowComplete,
   rowBefore,
   updateGroup,
   updateRow,
@@ -55,314 +43,250 @@ import {
   operatorTakesValues,
   valuesAfterOperatorChange,
 } from "./operators";
-import {
-  findFilterIssues,
-  findUnusableConditions,
-  validateLimits,
-} from "./validate";
+import { findFilterIssues, validateLimits } from "./validate";
 import KeyPicker, { OperatorPicker } from "./key_picker";
-import { formatFilterExpr, parseFilterExpr } from "./parse";
+import { customKeyNamesIn, formatFilterExpr, parseFilterExpr } from "./parse";
 import FilterTextEditor from "./filter_text_editor";
 import ValuePicker from "./value_picker";
 
-export const filterExprUrlKey = "filter_expr";
-
 const SHOWN_VALUE_COUNT = 2;
 
-const noKeys: FilterKey[] = [];
+export type FilterSelection = {
+  app: App;
+  date: DateSelection;
+  filterExpr: string | null;
+  rootSpanName: string | null;
+  discarded: boolean;
+};
+
+export type FilterChange = Partial<{
+  appId: string;
+  dateRange: UncheckedDateRange;
+  filterExpr: string | null;
+  rootSpanName: string | null;
+}>;
+
+interface FilterBarProps {
+  entity: string;
+  placeholder?: string;
+  value: FilterSelection | null;
+  apps: App[];
+  keys: FilterKey[] | null;
+  keyGroups: string[];
+  keysUnavailable: boolean;
+  spanNames?: string[] | null;
+  filterExprIssues?: FilterExprIssue[] | null;
+  onChange: (change: FilterChange) => void;
+}
+
+type OpenPicker =
+  | { kind: "keys"; groupId: string }
+  | { kind: "values"; rowId: string };
+
+type PendingEdit = {
+  appId: string;
+  date: DateSelection;
+  rootSpanName: string | null;
+  tree: ConditionGroup;
+  from: string | null;
+  to: string | null;
+  picker: OpenPicker | null;
+  // Changing the key or operator of a complete condition empties its values
+  // and opens the value picker. Dismissing that picker without a value puts
+  // the filter back to this text, so the condition is not lost.
+  revert?: string | null;
+};
 
 function writeFilterExpr(conditions: ConditionGroup): string | null {
   const tree = buildExprTree(conditions);
   return tree ? formatFilterExpr(tree) : null;
 }
 
-export type ReadyFilterState = Extract<FilterState, { status: "ready" }>;
+function sameDate(a: DateSelection, b: DateSelection): boolean {
+  if (a.dateRange !== b.dateRange) {
+    return false;
+  }
+  return (
+    a.dateRange !== DateRange.Custom ||
+    (a.startDate === b.startDate && a.endDate === b.endDate)
+  );
+}
 
-export type FilterState =
-  | { status: "pending" }
-  | { status: "error"; message: string }
-  | {
-      status: "ready";
-      app: App;
-      date: DateSelection;
-      filterExpr: string | null;
-      rootSpanName: string | null;
-      // True when nothing requested was discarded.
-      appliedAsRequested: boolean;
-    };
+function settle(edit: PendingEdit, value: FilterSelection): PendingEdit | null {
+  const filterExpr = value.filterExpr;
+  if (
+    value.discarded ||
+    edit.appId !== value.app.id ||
+    !sameDate(edit.date, value.date) ||
+    (edit.rootSpanName !== null && edit.rootSpanName !== value.rootSpanName)
+  ) {
+    return null;
+  }
+  if (edit.from !== filterExpr && edit.to !== filterExpr) {
+    return null;
+  }
+  if (edit.to === filterExpr && edit.picker === null) {
+    return null;
+  }
+  if (edit.from === filterExpr) {
+    return edit;
+  }
+  return { ...edit, from: edit.to };
+}
 
-export type FilterRequest = {
-  appId: string | null;
-  dateRange: UncheckedDateRange;
-  // The filter as drawn, which can hold a condition with no value yet.
-  filterExpr: string | null;
-  rootSpanName: string | null;
-};
+function rowIn(tree: ConditionGroup, rowId: string): ConditionRow | null {
+  for (const child of tree.children) {
+    if (child.id === rowId && !isConditionGroup(child)) {
+      return child;
+    }
+    if (isConditionGroup(child)) {
+      const found = rowIn(child, rowId);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
 
-interface FilterBarProps {
-  teamId: string;
-  entity: string;
-  placeholder?: string;
-  requestedAppId: string | null;
-  requestedDateRange: UncheckedDateRange;
-  requestedFilterExpr: string | null;
-  filterExprIssues?: FilterExprIssue[] | null;
-  showRootSpanSelector?: boolean;
-  requestedRootSpanName?: string | null;
-  onRequestChange: (change: Partial<FilterRequest>) => void;
-  onFilterChange: (state: FilterState) => void;
+function withPickerClosed(
+  tree: ConditionGroup,
+  picker: OpenPicker | null,
+): ConditionGroup {
+  if (picker === null) {
+    return tree;
+  }
+  if (picker.kind === "keys") {
+    return dropById(tree, picker.groupId);
+  }
+  const row = rowIn(tree, picker.rowId);
+  return row !== null && !isRowComplete(row)
+    ? dropById(tree, picker.rowId)
+    : tree;
+}
+
+function appendTo(
+  tree: ConditionGroup,
+  groupId: string,
+  make: (id: string) => ConditionOrGroup,
+): { tree: ConditionGroup; id: string } {
+  let id = groupId;
+  const next = updateGroup(tree, groupId, (group) => {
+    id = childId(group.id, group.children.length);
+    return { ...group, children: [...group.children, make(id)] };
+  });
+  return { tree: next, id };
 }
 
 export default function FilterBar({
-  teamId,
   entity,
   placeholder = "Filter…",
-  requestedAppId,
-  requestedDateRange,
-  requestedFilterExpr,
+  value,
+  apps,
+  keys,
+  keyGroups,
+  keysUnavailable,
+  spanNames,
   filterExprIssues,
-  showRootSpanSelector = false,
-  requestedRootSpanName = null,
-  onRequestChange,
-  onFilterChange,
+  onChange,
 }: FilterBarProps) {
-  const store = useFiltersStore();
-  const rememberedAppId = useFiltersStore((s) => s.selectedApp?.id);
-
   const [keyListOpen, setKeyListOpen] = useState(false);
+  const [edit, setEdit] = useState<PendingEdit | null>(null);
   const [editingAsText, setEditingAsText] = useState(false);
   const [focusedId, setFocusedId] = useState<string | null>(null);
-
   const [typedText, setTypedText] = useState<string | null>(null);
 
-  // Focus follows a condition as it is added, and moves to the preceding
-  // condition when it is removed.
   const focusedControlRef = useRef<HTMLButtonElement>(null);
   const addConditionButtonRef = useRef<HTMLButtonElement>(null);
 
-  const appsQuery = useAppsQuery(teamId);
-  const apps = useMemo(() => appsQuery.data ?? [], [appsQuery.data]);
+  const filterExpr = value?.filterExpr ?? null;
 
-  const selectedApp =
-    apps.find((app) => app.id === requestedAppId) ??
-    apps.find((app) => app.id === rememberedAppId) ??
-    apps[0] ??
-    null;
-
-  useEffect(() => {
-    if (selectedApp && selectedApp.id !== rememberedAppId) {
-      store.setSelectedApp(selectedApp);
-    }
-  }, [selectedApp?.id]);
-
-  const parsedRequestedFilter = useMemo(
-    () =>
-      requestedFilterExpr
-        ? parseFilterExpr(requestedFilterExpr, { draft: true })
-        : null,
-    [requestedFilterExpr],
+  const parsedFilter = useMemo(
+    () => (filterExpr ? parseFilterExpr(filterExpr, { draft: true }) : null),
+    [filterExpr],
   );
 
-  // The keys listing caps how many custom keys it returns, so a custom key
-  // the requested expression specifies can be missing from it. Asking the query
-  // for those names resolves them, and the discard check below then keeps
-  // the expression.
-  const requestedCustomKeyNames = useMemo(() => {
-    const names = (parsedRequestedFilter?.tokens ?? [])
-      .filter(
-        (token) => token.kind === "key" && token.text.startsWith("custom."),
-      )
-      .map((token) => token.text);
-    return [...new Set(names)].sort();
-  }, [parsedRequestedFilter]);
-
-  // A custom key typed into the text editor can be beyond the listing cap
-  // as well, so names in the draft join the request. A draft name is only
-  // sent once its condition has an operator, which keeps the query key
-  // stable while the user is still typing the key name itself.
-  const queriedCustomKeyNames = useMemo(() => {
-    const parsedDraft =
-      typedText !== null ? parseFilterExpr(typedText, { draft: true }) : null;
-    const draftNames = (parsedDraft?.tokens ?? [])
-      .filter(
-        (token, index, tokens) =>
-          token.kind === "key" &&
-          token.text.startsWith("custom.") &&
-          tokens[index + 2]?.kind === "operator",
-      )
-      .map((token) => token.text);
-    return [...new Set([...requestedCustomKeyNames, ...draftNames])].sort();
-  }, [typedText, requestedCustomKeyNames]);
-
-  const keysQuery = useFilterKeysQuery(
-    selectedApp?.id,
-    entity,
-    queriedCustomKeyNames,
-  );
-
-  const rootSpanNamesQuery = useRootSpanNamesQuery(
-    showRootSpanSelector ? selectedApp : null,
-  );
-  // The server answers null when the app has never
-  // reported a trace; both mean there is nothing to select.
-  const rootSpanNames = useMemo(
-    () => rootSpanNamesQuery.data ?? [],
-    [rootSpanNamesQuery.data],
-  );
-
-  const resolvedRootSpanName = useMemo(() => {
-    if (!showRootSpanSelector || rootSpanNames.length === 0) {
-      return null;
-    }
-    if (
-      requestedAppId === selectedApp?.id &&
-      requestedRootSpanName &&
-      rootSpanNames.includes(requestedRootSpanName)
-    ) {
-      return requestedRootSpanName;
-    }
-    return rootSpanNames[0];
-  }, [
-    showRootSpanSelector,
-    rootSpanNames,
-    requestedAppId,
-    requestedRootSpanName,
-    selectedApp?.id,
-  ]);
-
-  // The requested date range takes precedence over the persisted store range.
-  const pickedDateRange = pickDateRange(requestedDateRange, {
-    dateRange: store.selectedDateRange,
-    startDate: store.selectedStartDate,
-    endDate: store.selectedEndDate,
-  });
-  // A relative range is counted back from now, so the window is computed
-  // once per label and does not move between renders.
-  const customDateRange = pickedDateRange.dateRange === DateRange.Custom;
-  const date = useMemo(
-    () => toDateSelection(pickedDateRange)!,
-    [
-      pickedDateRange.dateRange,
-      customDateRange ? pickedDateRange.startDate : null,
-      customDateRange ? pickedDateRange.endDate : null,
-    ],
-  );
-
-  useEffect(() => {
-    store.setSelectedDateRange(date.dateRange);
-    store.setSelectedStartDate(date.startDate);
-    store.setSelectedEndDate(date.endDate);
-  }, [date]);
-
-  useEffect(() => {
-    if (appsQuery.status === "pending") {
-      store.setApps([], "pending");
-      return;
-    }
-    if (appsQuery.status === "error") {
-      store.setApps([], "error");
-      return;
-    }
-
-    const loaded = appsQuery.data;
-    store.setApps(loaded, loaded.length === 0 ? "no-apps" : "loaded");
-  }, [appsQuery.status, appsQuery.data]);
-
-  const keys = keysQuery.data?.keys ?? noKeys;
-  const keyGroups = keysQuery.data?.key_groups ?? [];
-
-  // Keys of the previous app are shown while the requested app's load, and
-  // a request must not be judged by them.
-  const keysSettled = !keysQuery.isPending && !keysQuery.isPlaceholderData;
-  const checkingRequestedFilter =
-    parsedRequestedFilter !== null && !keysSettled;
-
-  // A condition with no value yet is drawn but not filtered by.
-  const requestConditions = useMemo(
+  const conditions = useMemo(
     () =>
       buildConditionGroup(
-        parsedRequestedFilter?.ok ? parsedRequestedFilter.tree : null,
-        keys,
+        parsedFilter?.ok ? parsedFilter.tree : null,
+        keys ?? [],
       ),
-    [parsedRequestedFilter, keys],
+    [parsedFilter, keys],
   );
 
-  const requestedFilterDiscarded = useMemo(
+  const pending = edit === null || value === null ? edit : settle(edit, value);
+  if (pending !== edit) {
+    setEdit(pending);
+  }
+
+  const drawn = pending?.tree ?? conditions;
+  const drawnText = pending !== null ? pending.to : filterExpr;
+  const draftText = typedText ?? drawnText ?? "";
+
+  const parsedDraft = useMemo(
+    () => parseFilterExpr(draftText, { draft: true }),
+    [draftText],
+  );
+
+  const urlCustomKeyNames = useMemo(
+    () => customKeyNamesIn(parsedFilter?.tokens ?? []),
+    [parsedFilter],
+  );
+
+  const typedCustomKeyNames = useMemo(
     () =>
-      parsedRequestedFilter !== null &&
-      keysSettled &&
-      (!parsedRequestedFilter.ok ||
-        findUnusableConditions(parsedRequestedFilter.tokens, keys).length > 0 ||
-        validateLimits(requestConditions) !== null),
-    [parsedRequestedFilter, keys, keysSettled, requestConditions],
+      typedText === null
+        ? urlCustomKeyNames
+        : [
+            ...new Set([
+              ...urlCustomKeyNames,
+              ...customKeyNamesIn(parsedDraft.tokens),
+            ]),
+          ].sort(),
+    [typedText, urlCustomKeyNames, parsedDraft],
   );
 
-  const draftFilterExpr =
-    typedText ?? (requestedFilterDiscarded ? "" : (requestedFilterExpr ?? ""));
-
-  const parsedDraftFilter = useMemo(
-    () => parseFilterExpr(draftFilterExpr, { draft: true }),
-    [draftFilterExpr],
+  const draftKeysQuery = useFilterKeysQuery(
+    typedCustomKeyNames.length > 0 ? value?.app.id : undefined,
+    entity,
+    typedCustomKeyNames,
   );
+  const draftKeys = draftKeysQuery.data?.keys ?? keys ?? [];
 
   const draftConditions = useMemo(
     () =>
-      buildConditionGroup(
-        parsedDraftFilter.ok ? parsedDraftFilter.tree : null,
-        keys,
-      ),
-    [parsedDraftFilter, keys],
+      buildConditionGroup(parsedDraft.ok ? parsedDraft.tree : null, draftKeys),
+    [parsedDraft, draftKeys],
   );
 
-  const currentFilterExpr = useMemo(
-    () =>
-      requestedFilterDiscarded ? null : writeFilterExpr(requestConditions),
-    [requestedFilterDiscarded, requestConditions],
-  );
-
-  // The canonical form of the draft. This makes filters that differ only in
-  // spacing or in brackets around a single value compare equal.
-  const draftAppliedExpr = useMemo(
+  const draftFilterExpr = useMemo(
     () => writeFilterExpr(draftConditions),
     [draftConditions],
   );
 
-  // Case                           |  Bar                 |  Page
-  // -----------------------------------------------------------------------------
-  // draft fault the bar catches    |  message, marks       | keeps its rows
-  // server refuses the filter      |  message              | blank
-  // builds request fails otherwise |  nothing              | fetch error
-  // apps or keys cannot be fetched |  skeleton or disabled | fetch error
-  // the team has no apps           |  skeleton             | a prompt to add one
-  // request names one it can't use |  falls back to default| rows as normal, toast
-  //
-  // The filter is cleared only in the last case.
   const ownFilterIssues = useMemo(
     () =>
-      draftFilterExpr.trim() === ""
+      draftText.trim() === ""
         ? []
-        : findFilterIssues(parsedDraftFilter, keys, draftConditions),
-    [draftFilterExpr, parsedDraftFilter, keys, draftConditions],
+        : findFilterIssues(parsedDraft, draftKeys, draftConditions),
+    [draftText, parsedDraft, draftKeys, draftConditions],
   );
 
-  // Server issues belong to the submitted expression. Clear them when the draft
-  // changes semantically, and keep their spans only while the submitted text is unchanged.
   const serverIssues = useMemo<FilterExprIssue[]>(() => {
-    if (!filterExprIssues?.length || draftAppliedExpr !== currentFilterExpr) {
+    if (!filterExprIssues?.length || draftFilterExpr !== filterExpr) {
       return [];
     }
-
     return filterExprIssues.map((issue) => ({
       ...issue,
-      span: draftFilterExpr === currentFilterExpr ? issue.span : undefined,
+      span: draftText === filterExpr ? issue.span : undefined,
     }));
-  }, [filterExprIssues, draftFilterExpr, draftAppliedExpr, currentFilterExpr]);
+  }, [filterExprIssues, draftText, draftFilterExpr, filterExpr]);
 
-  // Prefer local validation; server issues apply only when local validation pass.
   const draftFilterIssues =
     ownFilterIssues.length > 0 ? ownFilterIssues : serverIssues;
 
-  const parserStopped = ownFilterIssues.length > 0 && !parsedDraftFilter.ok;
+  const parserStopped = ownFilterIssues.length > 0 && !parsedDraft.ok;
 
   const draftIssueMessage = useMemo(() => {
     const [first, ...rest] = draftFilterIssues;
@@ -374,213 +298,178 @@ export default function FilterBar({
       : `${first.message} (+${rest.length} more)`;
   }, [draftFilterIssues]);
 
-  // The requested app, date, filter expression and root span name can each
-  // be invalid for this app. We discard those, use defaults instead and we
-  // inform the user via a toast.
-  const appDiscarded =
-    requestedAppId !== null &&
-    appsQuery.status === "success" &&
-    !appsQuery.data.some((app: App) => app.id === requestedAppId);
-
-  const dateDiscarded =
-    requestedDateRange.dateRange !== null &&
-    !isValidDateRange(requestedDateRange);
-
-  const rootSpanNameDiscarded =
-    showRootSpanSelector &&
-    requestedRootSpanName !== null &&
-    requestedAppId === selectedApp?.id &&
-    rootSpanNamesQuery.isSuccess &&
-    !rootSpanNames.includes(requestedRootSpanName);
-
-  const anythingDiscarded =
-    appDiscarded ||
-    dateDiscarded ||
-    rootSpanNameDiscarded ||
-    requestedFilterDiscarded;
-
-  const appliedAsRequested = !anythingDiscarded;
-
-  // The readiness of the app, date and filter expression, before the root
-  // span selector is considered. The bar's own controls render once this is
-  // ready, so a slow or failed root span names fetch leaves the app select
-  // usable.
-  const baseFilterState = useMemo<
-    | { status: "pending" }
-    | { status: "error"; message: string }
-    | {
-        status: "ready";
-        app: App;
-        date: DateSelection;
-        filterExpr: string | null;
-        appliedAsRequested: boolean;
-      }
-  >(() => {
-    if (appsQuery.status === "error") {
-      return {
-        status: "error",
-        message: "Error fetching apps, please refresh page to try again",
-      };
-    }
-    if (appsQuery.status === "success" && appsQuery.data.length === 0) {
-      return {
-        status: "error",
-        message:
-          "Looks like you don't have any apps yet. Get started by creating your first app!",
-      };
-    }
-    if (keysQuery.isError) {
-      return {
-        status: "error",
-        message: "Error fetching filters, please refresh page to try again",
-      };
-    }
-
-    // A requested expression can only be checked once the keys have loaded.
-    // Applying an expression the server would reject would waste a request and
-    // replace the page content with an error.
-    if (!selectedApp || checkingRequestedFilter) {
-      return { status: "pending" };
-    }
-    return {
-      status: "ready",
-      app: selectedApp,
-      date,
-      filterExpr: currentFilterExpr,
-      appliedAsRequested,
-    };
-  }, [
-    appsQuery.status,
-    appsQuery.data,
-    keysQuery.isError,
-    selectedApp,
-    date,
-    checkingRequestedFilter,
-    currentFilterExpr,
-    appliedAsRequested,
-  ]);
-
-  // With the selector shown, the ready state is held back until a name has
-  // resolved, because the page's span queries cannot run without one.
-  const filterState: FilterState = useMemo(() => {
-    if (baseFilterState.status !== "ready") {
-      return baseFilterState;
-    }
-    if (!showRootSpanSelector) {
-      return { ...baseFilterState, rootSpanName: null };
-    }
-    if (rootSpanNamesQuery.isError) {
-      return {
-        status: "error",
-        message:
-          "Error fetching traces list, please refresh page or select a different app to try again",
-      };
-    }
-    // An app that has never reported a trace has nothing to select, and the
-    // app and date it resolved with are still written.
-    if (rootSpanNamesQuery.isSuccess && rootSpanNames.length === 0) {
-      return { ...baseFilterState, rootSpanName: null };
-    }
-    if (resolvedRootSpanName === null) {
-      return { status: "pending" };
-    }
-    return { ...baseFilterState, rootSpanName: resolvedRootSpanName };
-  }, [
-    baseFilterState,
-    showRootSpanSelector,
-    rootSpanNamesQuery.isError,
-    rootSpanNamesQuery.isSuccess,
-    rootSpanNames,
-    resolvedRootSpanName,
-  ]);
-
-  // Every request gets a report, even when it resolves to the same
-  // values as the previous request. For example, after a request for
-  // app 1, a request with no app also resolves to app 1. Reporting
-  // only changed resolutions would leave that second request with no report.
-  useEffect(() => {
-    onFilterChange(filterState);
-  }, [
-    filterState,
-    requestedAppId,
-    requestedDateRange.dateRange,
-    requestedDateRange.startDate,
-    requestedDateRange.endDate,
-    requestedFilterExpr,
-    requestedRootSpanName,
-  ]);
-
-  useEffect(() => {
-    if (anythingDiscarded) {
-      toastNegative("Some filters were invalid, page reset to defaults");
-    }
-  }, [anythingDiscarded]);
-
   useEffect(() => {
     focusedControlRef.current?.focus();
   }, [focusedId]);
 
-  function setApp(app: App) {
-    // Clear filters on app change
-    onRequestChange({ appId: app.id, filterExpr: null, rootSpanName: null });
-    setTypedText(null);
+  if (value === null || keys === null) {
+    return (
+      <div className="flex flex-wrap gap-4 items-center w-full">
+        <Skeleton className="h-9 w-37.5" />
+        <Skeleton className="h-9 w-37.5" />
+        <Skeleton className="h-9 flex-1 min-w-64" />
+      </div>
+    );
+  }
+  const { app, date, rootSpanName } = value;
+
+  function baseFor(id: string | null): ConditionGroup {
+    const picker = pending?.picker ?? null;
+    if (picker === null) {
+      return drawn;
+    }
+    const own =
+      picker.kind === "keys" ? picker.groupId === id : picker.rowId === id;
+    return own ? drawn : withPickerClosed(drawn, picker);
   }
 
-  // Turns an edit to the conditions back into request text.
-  function setConditions(next: ConditionGroup) {
-    const limit = validateLimits(next);
+  function send(
+    tree: ConditionGroup,
+    picker: OpenPicker | null,
+    revert?: string | null,
+  ) {
+    const limit = validateLimits(tree);
     if (limit) {
       toastNegative(limit);
       return;
     }
-
-    onRequestChange({ filterExpr: formatFilterExpr(buildDraftTree(next)) });
+    const text = writeFilterExpr(tree);
+    if (text !== drawnText) {
+      onChange({ filterExpr: text });
+    }
+    setEdit({
+      appId: app.id,
+      date,
+      rootSpanName,
+      tree,
+      from: pending !== null ? pending.from : filterExpr,
+      to: text,
+      picker,
+      revert,
+    });
   }
 
-  function setRow(rowId: string, patch: Partial<ConditionRow>) {
-    setConditions(updateRow(draftConditions, rowId, patch));
+  function setApp(app: App) {
+    onChange({ appId: app.id, filterExpr: null, rootSpanName: null });
+    setEdit(null);
+    setTypedText(null);
   }
 
-  function removeById(id: string) {
-    const previous = rowBefore(draftConditions, id);
-    setConditions(dropById(draftConditions, id));
+  function focusBefore(id: string) {
+    const previous = rowBefore(drawn, id);
     setFocusedId(previous?.id ?? null);
     if (!previous) {
       addConditionButtonRef.current?.focus();
     }
   }
 
-  // A condition or group is added at the end of the group it goes in, so its
-  // id is that group's id and an index equal to the number of children
-  // already there.
-  function addToGroup(groupId: string, make: (id: string) => ConditionOrGroup) {
-    let addedId = groupId;
-    const next = updateGroup(draftConditions, groupId, (group) => {
-      addedId = childId(group.id, group.children.length);
-      return { ...group, children: [...group.children, make(addedId)] };
-    });
-
-    setConditions(next);
-    setFocusedId(addedId);
+  function removeById(id: string) {
+    send(dropById(baseFor(id), id), null);
+    focusBefore(id);
   }
 
-  function addRow(groupId: string, key: FilterKey) {
-    addToGroup(groupId, (id) => ({
-      id,
+  function startRow(groupId: string, key: FilterKey) {
+    const operator = key.operators[0];
+    const { tree, id } = appendTo(baseFor(groupId), groupId, (rowId) => ({
+      id: rowId,
       key,
-      operator: key.operators[0],
+      operator,
       values: [],
     }));
+    send(
+      tree,
+      operatorTakesValues(operator) ? { kind: "values", rowId: id } : null,
+    );
+    setFocusedId(id);
   }
 
-  function addGroup(groupId: string) {
-    addToGroup(groupId, (id) => ({ id, logicalOperator: "and", children: [] }));
+  function startGroup(parentId: string) {
+    const { tree, id } = appendTo(baseFor(null), parentId, (groupId) => ({
+      id: groupId,
+      logicalOperator: "and",
+      children: [],
+    }));
+    send(tree, { kind: "keys", groupId: id });
   }
 
-  // The text editor applies its text when it loses focus, so while it is
-  // open the focus is left with it, or the text just cleared would be applied.
+  function closeKeys(groupId: string) {
+    setEdit((current) =>
+      current?.picker?.kind === "keys" && current.picker.groupId === groupId
+        ? {
+            ...current,
+            tree: withPickerClosed(current.tree, current.picker),
+            picker: null,
+          }
+        : current,
+    );
+  }
+
+  function changeKey(row: ConditionRow, key: FilterKey) {
+    const operator = key.operators[0];
+    const opensPicker = operatorTakesValues(operator);
+    send(
+      updateRow(baseFor(row.id), row.id, { key, operator, values: [] }),
+      opensPicker ? { kind: "values", rowId: row.id } : null,
+      opensPicker && isRowComplete(row) ? drawnText : undefined,
+    );
+  }
+
+  function changeOperator(row: ConditionRow, operator: FilterOperator) {
+    const values = valuesAfterOperatorChange(
+      row.operator,
+      operator,
+      row.values,
+    );
+    const opensPicker = operatorTakesValues(operator) && values.length === 0;
+    send(
+      updateRow(baseFor(row.id), row.id, { operator, values }),
+      opensPicker ? { kind: "values", rowId: row.id } : null,
+      opensPicker && isRowComplete(row) ? drawnText : undefined,
+    );
+  }
+
+  function changeValues(
+    row: ConditionRow,
+    values: ConditionRow["values"],
+    done: boolean,
+  ) {
+    send(
+      updateRow(baseFor(row.id), row.id, { values }),
+      done ? null : { kind: "values", rowId: row.id },
+    );
+  }
+
+  function openValues(row: ConditionRow) {
+    send(baseFor(row.id), { kind: "values", rowId: row.id });
+  }
+
+  function closeValues(row: ConditionRow) {
+    if (pending?.picker?.kind !== "values" || pending.picker.rowId !== row.id) {
+      return;
+    }
+    if (!isRowComplete(row) && pending.revert !== undefined) {
+      const parsed = pending.revert
+        ? parseFilterExpr(pending.revert, { draft: true })
+        : null;
+      send(
+        buildConditionGroup(parsed?.ok ? parsed.tree : null, keys ?? []),
+        null,
+      );
+      setFocusedId(row.id);
+      return;
+    }
+    setEdit({
+      ...pending,
+      tree: withPickerClosed(pending.tree, pending.picker),
+      picker: null,
+    });
+    if (!isRowComplete(row)) {
+      focusBefore(row.id);
+    }
+  }
+
   function clearFilter() {
-    onRequestChange({ filterExpr: null });
+    send({ ...drawn, children: [] }, null);
     setTypedText(null);
     setFocusedId(null);
     if (!editingAsText) {
@@ -589,25 +478,20 @@ export default function FilterBar({
   }
 
   function toggleLogicalOperator(groupId: string) {
-    setConditions(
-      updateGroup(draftConditions, groupId, (group) => ({
+    send(
+      updateGroup(baseFor(null), groupId, (group) => ({
         ...group,
         logicalOperator: group.logicalOperator === "and" ? "or" : "and",
       })),
+      null,
     );
   }
 
-  // Typing redraws the bar at once, while what the page is filtered by stays
-  // as it is until the text is applied.
-  function changeFilterText(text: string) {
-    setTypedText(text);
-  }
-
   function applyFilterText() {
-    if (draftIssueMessage || typedText === null) {
+    if (typedText === null || draftIssueMessage) {
       return;
     }
-    onRequestChange({ filterExpr: typedText });
+    send(draftConditions, null);
     setTypedText(null);
   }
 
@@ -621,9 +505,6 @@ export default function FilterBar({
       setEditingAsText(true);
       return;
     }
-    // Server-rejected values still retain a valid key/operator, so conditions can
-    // be rendered while the value picker lets the user fix the invalid value.
-    // applyFilterText prevents applying the draft while any issue remains.
     if (draftIssueMessage && ownFilterIssues.length > 0) {
       toastNegative(draftIssueMessage);
       return;
@@ -632,43 +513,36 @@ export default function FilterBar({
     setEditingAsText(false);
   }
 
-  const keysUnavailable = keysQuery.isError;
-
-  if (
-    !selectedApp ||
-    (!keysUnavailable &&
-      (baseFilterState.status !== "ready" || keysQuery.isPending))
-  ) {
-    return (
-      <div className="flex flex-wrap gap-4 items-center w-full">
-        <Skeleton className="h-9 w-37.5" />
-        <Skeleton className="h-9 w-37.5" />
-        <Skeleton className="h-9 flex-1 min-w-64" />
-      </div>
-    );
-  }
-
   const editor: FilterEditor = {
     keys,
     keyGroups,
-    selectedAppId: selectedApp.id,
+    appId: app.id,
     entity,
     focusedId,
     focusedControlRef,
-    onChangeRow: setRow,
+    openKeysGroupId:
+      pending?.picker?.kind === "keys" ? pending.picker.groupId : null,
+    openValuesRowId:
+      pending?.picker?.kind === "values" ? pending.picker.rowId : null,
+    onChangeKey: changeKey,
+    onChangeOperator: changeOperator,
+    onChangeValues: changeValues,
+    onOpenValues: openValues,
+    onCloseValues: closeValues,
+    onCloseKeys: closeKeys,
     onRemove: removeById,
-    onAddRow: addRow,
-    onAddGroup: addGroup,
+    onStartRow: startRow,
+    onStartGroup: startGroup,
     onToggleLogicalOperator: toggleLogicalOperator,
   };
 
   return (
     <div className="flex flex-wrap gap-4 items-start w-full">
-      <AppSelect apps={apps} selected={selectedApp} onChange={setApp} />
+      <AppSelect apps={apps} selected={app} onChange={setApp} />
       <DateRangeSelect
-        selection={date}
+        selection={value.date}
         onChange={(selection) =>
-          onRequestChange({
+          onChange({
             dateRange:
               selection.dateRange === DateRange.Custom
                 ? selection
@@ -676,19 +550,19 @@ export default function FilterBar({
           })
         }
       />
-      {showRootSpanSelector &&
-        (rootSpanNamesQuery.isPending ? (
+      {spanNames !== undefined &&
+        (spanNames === null ? (
           <Skeleton className="h-9 w-37.5" />
-        ) : resolvedRootSpanName !== null ? (
+        ) : spanNames.length > 0 ? (
           <DropdownSelect
             title="Trace Name"
             type={DropdownSelectType.SingleString}
-            items={rootSpanNames}
-            initialSelected={resolvedRootSpanName}
+            items={spanNames}
+            initialSelected={value.rootSpanName ?? spanNames[0]}
             onChangeSelected={(item) => {
               const name = item as string;
-              if (name !== resolvedRootSpanName) {
-                onRequestChange({ rootSpanName: name });
+              if (name !== value.rootSpanName) {
+                onChange({ rootSpanName: name });
               }
             }}
           />
@@ -724,18 +598,17 @@ export default function FilterBar({
           <div className="pl-8 pr-16">
             {editingAsText ? (
               <FilterTextEditor
-                value={draftFilterExpr}
-                tokens={parsedDraftFilter.tokens}
+                value={draftText}
+                tokens={parsedDraft.tokens}
                 issues={draftFilterIssues}
                 parserStopped={parserStopped}
                 placeholder={placeholder}
-                onChange={changeFilterText}
+                onChange={setTypedText}
                 onApply={applyFilterText}
                 onCancel={cancelTextEditing}
               />
             ) : (
               <div className="flex flex-wrap items-center gap-1.5 py-1.5 min-h-9 max-h-32 overflow-y-auto">
-                {/* Without keys the bar is rendered as a placeholder with no interaction */}
                 {keysUnavailable && (
                   <span className="flex-1 min-w-24 h-6 font-body text-sm text-muted-foreground select-none">
                     {placeholder}
@@ -743,7 +616,7 @@ export default function FilterBar({
                 )}
 
                 {!keysUnavailable && (
-                  <GroupChildren group={draftConditions} editor={editor} />
+                  <GroupChildren group={drawn} editor={editor} />
                 )}
 
                 {!keysUnavailable && (
@@ -754,8 +627,8 @@ export default function FilterBar({
                     open={keyListOpen}
                     onOpenChange={setKeyListOpen}
                     focusOnClose={focusedControlRef}
-                    onSelect={(key) => addRow(draftConditions.id, key)}
-                    onAddGroup={() => addGroup(draftConditions.id)}
+                    onSelect={(key) => startRow(drawn.id, key)}
+                    onAddGroup={() => startGroup(drawn.id)}
                     trigger={
                       <button
                         type="button"
@@ -766,14 +639,12 @@ export default function FilterBar({
                         // Without conditions, fill the bar to center the placeholder.
                         // With conditions, stay compact and anchor the key list.
                         className={`self-stretch min-h-2 text-left outline-none font-body text-sm text-muted-foreground ${
-                          draftConditions.children.length === 0
+                          drawn.children.length === 0
                             ? "flex-1"
                             : "flex-none w-4"
                         }`}
                       >
-                        {draftConditions.children.length === 0
-                          ? placeholder
-                          : ""}
+                        {drawn.children.length === 0 ? placeholder : ""}
                       </button>
                     }
                   />
@@ -803,7 +674,7 @@ export default function FilterBar({
               </button>
             )}
 
-            {draftFilterExpr !== "" && (
+            {draftText !== "" && (
               <button
                 type="button"
                 aria-label="Clear filter"
@@ -835,14 +706,25 @@ export default function FilterBar({
 interface FilterEditor {
   keys: FilterKey[];
   keyGroups: string[];
-  selectedAppId: string;
+  appId: string;
   entity: string;
   focusedId: string | null;
   focusedControlRef: RefObject<HTMLButtonElement | null>;
-  onChangeRow: (rowId: string, patch: Partial<ConditionRow>) => void;
+  openKeysGroupId: string | null;
+  openValuesRowId: string | null;
+  onChangeKey: (row: ConditionRow, key: FilterKey) => void;
+  onChangeOperator: (row: ConditionRow, operator: FilterOperator) => void;
+  onChangeValues: (
+    row: ConditionRow,
+    values: ConditionRow["values"],
+    done: boolean,
+  ) => void;
+  onOpenValues: (row: ConditionRow) => void;
+  onCloseValues: (row: ConditionRow) => void;
+  onCloseKeys: (groupId: string) => void;
   onRemove: (id: string) => void;
-  onAddRow: (groupId: string, key: FilterKey) => void;
-  onAddGroup: (groupId: string) => void;
+  onStartRow: (groupId: string, key: FilterKey) => void;
+  onStartGroup: (groupId: string) => void;
   onToggleLogicalOperator: (groupId: string) => void;
 }
 
@@ -883,6 +765,8 @@ function FilterGroup({
   group: ConditionGroup;
   editor: FilterEditor;
 }) {
+  const pickingFirstKey = group.id === editor.openKeysGroupId;
+
   return (
     <span
       role="group"
@@ -896,14 +780,24 @@ function FilterGroup({
         keys={editor.keys}
         keyGroups={editor.keyGroups}
         selected={null}
+        open={pickingFirstKey ? true : undefined}
+        onOpenChange={
+          pickingFirstKey
+            ? (open) => {
+                if (!open) {
+                  editor.onCloseKeys(group.id);
+                }
+              }
+            : undefined
+        }
         focusOnClose={editor.focusedControlRef}
-        onSelect={(key) => editor.onAddRow(group.id, key)}
-        onAddGroup={() => editor.onAddGroup(group.id)}
+        onSelect={(key) => editor.onStartRow(group.id, key)}
+        onAddGroup={
+          pickingFirstKey ? undefined : () => editor.onStartGroup(group.id)
+        }
         trigger={
           <button
             type="button"
-            // A group starts empty, so after it is added, this button receives focus
-            // and is where its first condition is selected.
             ref={
               group.id === editor.focusedId
                 ? editor.focusedControlRef
@@ -936,16 +830,8 @@ function FilterRow({
   row: ConditionRow;
   editor: FilterEditor;
 }) {
-  const {
-    keys,
-    keyGroups,
-    selectedAppId,
-    entity,
-    focusedId,
-    focusedControlRef,
-    onChangeRow,
-    onRemove,
-  } = editor;
+  const { keys, keyGroups, appId, entity, focusedId, focusedControlRef } =
+    editor;
 
   return (
     <span className="inline-flex items-stretch h-6 max-w-full min-w-0 overflow-hidden rounded-sm border border-input bg-accent/80 font-display text-xs">
@@ -953,13 +839,7 @@ function FilterRow({
         keys={keys}
         keyGroups={keyGroups}
         selected={row.key}
-        onSelect={(key) =>
-          onChangeRow(row.id, {
-            key,
-            operator: key.operators[0],
-            values: [],
-          })
-        }
+        onSelect={(key) => editor.onChangeKey(row, key)}
         trigger={
           <button
             type="button"
@@ -976,14 +856,7 @@ function FilterRow({
         selected={row.operator}
         operatorLabels={operatorLabels}
         onSelect={(operator) =>
-          onChangeRow(row.id, {
-            operator: operator as FilterOperator,
-            values: valuesAfterOperatorChange(
-              row.operator,
-              operator as FilterOperator,
-              row.values,
-            ),
-          })
+          editor.onChangeOperator(row, operator as FilterOperator)
         }
         trigger={
           <button
@@ -997,7 +870,7 @@ function FilterRow({
 
       {operatorTakesValues(row.operator) && (
         <ValuePicker
-          appId={selectedAppId}
+          appId={appId}
           entity={entity}
           keyName={row.key.name}
           valueType={row.key.value_type}
@@ -1005,7 +878,15 @@ function FilterRow({
           takesTypedText={operatorTakesTypedText(row.operator)}
           takesOneValue={operatorTakesOneValue(row.operator)}
           selected={row.values}
-          onChange={(values) => onChangeRow(row.id, { values })}
+          onChange={(values, done) => editor.onChangeValues(row, values, done)}
+          open={row.id === editor.openValuesRowId}
+          onOpenChange={(open) => {
+            if (open) {
+              editor.onOpenValues(row);
+            } else {
+              editor.onCloseValues(row);
+            }
+          }}
           trigger={
             <button
               type="button"
@@ -1020,7 +901,7 @@ function FilterRow({
       <button
         type="button"
         aria-label="Remove condition"
-        onClick={() => onRemove(row.id)}
+        onClick={() => editor.onRemove(row.id)}
         className="px-1 rounded-r-sm border-l border-input text-muted-foreground hover:bg-accent hover:text-foreground shrink-0"
       >
         <X className="h-3 w-3" />
@@ -1033,7 +914,7 @@ function SelectedValues({
   values,
   operator,
 }: {
-  values: FilterValue[];
+  values: ConditionRow["values"];
   operator: FilterOperator | null;
 }) {
   if (values.length === 0) {

--- a/frontend/dashboard/app/components/filter_bar/parse.ts
+++ b/frontend/dashboard/app/components/filter_bar/parse.ts
@@ -105,6 +105,20 @@ export function parseFilterExpr(
   }
 }
 
+// A key counts once its condition has an operator, so a name still being
+// typed is left out.
+export function customKeyNamesIn(tokens: ExprToken[]): string[] {
+  const names = tokens
+    .filter(
+      (token, index) =>
+        token.kind === "key" &&
+        token.text.startsWith("custom.") &&
+        tokens[index + 2]?.kind === "operator",
+    )
+    .map((token) => token.text);
+  return [...new Set(names)].sort();
+}
+
 // Quotes text for an error message the way Go's %q does, so both parsers
 // report the same message for the same input.
 function quote(text: string): string {

--- a/frontend/dashboard/app/components/filter_bar/resolve_filters.ts
+++ b/frontend/dashboard/app/components/filter_bar/resolve_filters.ts
@@ -1,0 +1,196 @@
+import type { App } from "../../api/api_calls";
+import type { FilterKey, FilterKeysResponse } from "../../api/filter_types";
+import { buildConditionGroup, buildExprTree } from "./conditions";
+import {
+  isValidDateRange,
+  pickDateRange,
+  type UncheckedDateRange,
+} from "./date_range_select";
+import { formatFilterExpr, parseFilterExpr } from "./parse";
+import { findUnusableConditions, validateLimits } from "./validate";
+
+export type UrlFilters = {
+  appId: string | null;
+  dateRange: UncheckedDateRange;
+  filterExpr: string | null;
+  rootSpanName: string | null;
+};
+
+export type AppsQueryState = {
+  status: "pending" | "error" | "success";
+  data: App[] | undefined;
+};
+
+export type KeysQueryState = {
+  isPending: boolean;
+  isError: boolean;
+  isPlaceholderData: boolean;
+  data: FilterKeysResponse | undefined;
+};
+
+export type SpanNamesQueryState = {
+  isError: boolean;
+  isSuccess: boolean;
+  data: string[] | null | undefined;
+};
+
+export type RememberedFilters = {
+  appId: string | undefined;
+  dateRange: UncheckedDateRange;
+};
+
+export type FilterStatus =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ready" };
+
+export type ResolvedFilters = {
+  app: App;
+  filterExpr: string | null;
+  rootSpanName: string | null;
+};
+
+export type FilterResolution = {
+  status: FilterStatus;
+  date: UncheckedDateRange;
+  filters: ResolvedFilters | null;
+  discarded: boolean;
+};
+
+const appsErrorMessage =
+  "Error fetching apps, please refresh page to try again";
+const noAppsMessage =
+  "Looks like you don't have any apps yet. Get started by creating your first app!";
+const keysErrorMessage =
+  "Error fetching filters, please refresh page to try again";
+const spanNamesErrorMessage =
+  "Error fetching traces list, please refresh page or select a different app to try again";
+
+export function resolveApp(
+  urlAppId: string | null,
+  apps: App[] | undefined,
+  rememberedAppId: string | undefined,
+): App | null {
+  const loaded = apps ?? [];
+  return (
+    loaded.find((app) => app.id === urlAppId) ??
+    loaded.find((app) => app.id === rememberedAppId) ??
+    loaded[0] ??
+    null
+  );
+}
+
+function resolveFilterExpr(
+  text: string | null,
+  keys: FilterKey[],
+): { filterExpr: string | null; discarded: boolean } {
+  if (!text) {
+    return { filterExpr: null, discarded: false };
+  }
+  const parsed = parseFilterExpr(text, { draft: true });
+  if (!parsed.ok || findUnusableConditions(parsed.tokens, keys).length > 0) {
+    return { filterExpr: null, discarded: true };
+  }
+  const conditions = buildConditionGroup(parsed.tree, keys);
+  if (validateLimits(conditions) !== null) {
+    return { filterExpr: null, discarded: true };
+  }
+  const tree = buildExprTree(conditions);
+  return {
+    filterExpr: tree ? formatFilterExpr(tree) : null,
+    discarded: false,
+  };
+}
+
+export function resolveFilters({
+  url,
+  apps,
+  keys,
+  spanNames,
+  remembered,
+}: {
+  url: UrlFilters;
+  apps: AppsQueryState;
+  keys: KeysQueryState;
+  spanNames: SpanNamesQueryState | null;
+  remembered: RememberedFilters;
+}): FilterResolution {
+  const app = resolveApp(url.appId, apps.data, remembered.appId);
+  const date = pickDateRange(url.dateRange, remembered.dateRange);
+
+  const appDiscarded =
+    url.appId !== null &&
+    apps.status === "success" &&
+    !(apps.data ?? []).some((loaded) => loaded.id === url.appId);
+  const dateDiscarded =
+    url.dateRange.dateRange !== null && !isValidDateRange(url.dateRange);
+
+  // Placeholder keys are the previous app's and must not judge the filter.
+  const keysSettled = !keys.isPending && !keys.isPlaceholderData;
+  const filter =
+    keysSettled && !keys.isError
+      ? resolveFilterExpr(url.filterExpr, keys.data?.keys ?? [])
+      : { filterExpr: null, discarded: false };
+
+  const urlAppSelected = app !== null && url.appId === app.id;
+  const names = spanNames?.isSuccess ? (spanNames.data ?? []) : null;
+  const urlNameKnown =
+    urlAppSelected &&
+    url.rootSpanName !== null &&
+    names !== null &&
+    names.includes(url.rootSpanName);
+  const rootSpanName =
+    names === null || names.length === 0
+      ? null
+      : urlNameKnown
+        ? url.rootSpanName
+        : names[0];
+  const rootSpanNameDiscarded =
+    spanNames !== null &&
+    spanNames.isSuccess &&
+    urlAppSelected &&
+    url.rootSpanName !== null &&
+    !urlNameKnown;
+
+  const discarded =
+    appDiscarded || dateDiscarded || rootSpanNameDiscarded || filter.discarded;
+
+  const resolution = (
+    status: FilterStatus,
+    filters: ResolvedFilters | null,
+  ): FilterResolution => ({ status, date, filters, discarded });
+
+  if (apps.status === "error") {
+    return resolution({ kind: "error", message: appsErrorMessage }, null);
+  }
+  if (apps.status === "success" && (apps.data ?? []).length === 0) {
+    return resolution({ kind: "error", message: noAppsMessage }, null);
+  }
+  if (app === null) {
+    return resolution({ kind: "loading" }, null);
+  }
+  if (keys.isError) {
+    return resolution(
+      { kind: "error", message: keysErrorMessage },
+      { app, filterExpr: null, rootSpanName },
+    );
+  }
+  if (url.filterExpr !== null && !keysSettled) {
+    return resolution({ kind: "loading" }, null);
+  }
+
+  const filters = { app, filterExpr: filter.filterExpr, rootSpanName };
+  if (spanNames === null) {
+    return resolution({ kind: "ready" }, filters);
+  }
+  if (spanNames.isError) {
+    return resolution(
+      { kind: "error", message: spanNamesErrorMessage },
+      filters,
+    );
+  }
+  if (!spanNames.isSuccess) {
+    return resolution({ kind: "loading" }, filters);
+  }
+  return resolution({ kind: "ready" }, filters);
+}

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -1,292 +1,327 @@
 "use client";
 
-import {
-  type FilterRequest,
-  type FilterState,
-  type ReadyFilterState,
-  filterExprUrlKey,
-} from "@/app/components/filter_bar/filter_bar";
+import type { App } from "@/app/api/api_calls";
+import type { FilterKey } from "@/app/api/filter_types";
 import {
   DateRange,
+  toDateSelection,
   type UncheckedDateRange,
 } from "@/app/components/filter_bar/date_range_select";
-import { type FilterParams, paginationOffsetUrlKey } from "@/app/query/hooks";
+import type {
+  FilterChange,
+  FilterSelection,
+} from "@/app/components/filter_bar/filter_bar";
+import {
+  customKeyNamesIn,
+  parseFilterExpr,
+} from "@/app/components/filter_bar/parse";
+import {
+  resolveApp,
+  resolveFilters,
+  type FilterStatus,
+} from "@/app/components/filter_bar/resolve_filters";
+import { toastNegative } from "@/app/components/toast";
+import {
+  type FilterParams,
+  paginationOffsetUrlKey,
+  useAppsQuery,
+  useFilterKeysQuery,
+  useRootSpanNamesQuery,
+} from "@/app/query/hooks";
 import { urlFiltersKeyMap } from "@/app/stores/filters_store";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useFiltersStore } from "@/app/stores/provider";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo } from "react";
+
+export type { FilterStatus };
+
+export const filterExprUrlKey = "filter_expr";
 
 const {
   appId: appIdUrlKey,
   dateRange: dateRangeUrlKey,
   startDate: startDateUrlKey,
   endDate: endDateUrlKey,
+  rootSpanName: rootSpanNameUrlKey,
 } = urlFiltersKeyMap;
 
-// A relative label is counted back from now, so its timestamps are not part
-// of a request.
-function withoutRelativeTimestamps(
-  range: UncheckedDateRange,
-): UncheckedDateRange {
-  return range.dateRange === DateRange.Custom
-    ? range
-    : { dateRange: range.dateRange, startDate: null, endDate: null };
+const noApps: App[] = [];
+const noKeys: FilterKey[] = [];
+const noKeyGroups: string[] = [];
+
+type UrlEntry = [key: string, value: string | null];
+
+function dateUrlEntries(range: UncheckedDateRange): UrlEntry[] {
+  const custom = range.dateRange === DateRange.Custom;
+  return [
+    [dateRangeUrlKey, range.dateRange],
+    [startDateUrlKey, custom ? range.startDate : null],
+    [endDateUrlKey, custom ? range.endDate : null],
+  ];
 }
 
-function sameRequest(a: FilterRequest, b: FilterRequest): boolean {
-  return (
-    a.appId === b.appId &&
-    a.filterExpr === b.filterExpr &&
-    a.rootSpanName === b.rootSpanName &&
-    a.dateRange.dateRange === b.dateRange.dateRange &&
-    a.dateRange.startDate === b.dateRange.startDate &&
-    a.dateRange.endDate === b.dateRange.endDate
+function valueUrlEntries(
+  value: FilterSelection,
+  rootSpan: boolean,
+): UrlEntry[] {
+  const entries: UrlEntry[] = [
+    [appIdUrlKey, value.app.id],
+    ...dateUrlEntries(value.date),
+    [filterExprUrlKey, value.filterExpr],
+  ];
+  if (rootSpan) {
+    entries.push([rootSpanNameUrlKey, value.rootSpanName]);
+  }
+  return entries;
+}
+
+// Timestamps of a relative label are not compared.
+function urlHolds(
+  params: { get: (key: string) => string | null },
+  value: FilterSelection,
+  rootSpan: boolean,
+): boolean {
+  const custom = value.date.dateRange === DateRange.Custom;
+  return valueUrlEntries(value, rootSpan).every(
+    ([key, expected]) =>
+      (!custom && (key === startDateUrlKey || key === endDateUrlKey)) ||
+      params.get(key) === expected,
   );
 }
 
-/**
- * The URL-driven filter mechanics shared by the pages that pair a FilterBar
- * with paginated queries. The URL is the source of truth: the bar shows what
- * it is handed, its resolved report is written into the URL, and the queries
- * read the filter and the pagination offset back from it.
- *
- * A user's pick is held here as the request the bar shows until the URL
- * carries it. The page tells its own write from a navigation by the search
- * string it was on when the request was stored and the one it wrote; any
- * other search string is a navigation and the URL wins. The request is kept
- * after the write, because a condition with no value yet is not written into
- * the URL.
- *
- * A page with a root span selection in the URL declares its key in
- * `extraUrlKeys`. A page without pagination leaves `paginationLimit` out.
- * URL state the bar knows nothing about, such as which plot is shown, is
- * listed in `pageUrlKeys` and written through `setPageUrlKey`; a filter
- * write carries those values over.
- */
+function applyEntries(params: URLSearchParams, entries: UrlEntry[]) {
+  for (const [key, value] of entries) {
+    if (value === null) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+  }
+}
+
+// Starts from the live URL, since the rendered searchParams lag one
+// transition behind. The state must be a fresh object: Next passes through a
+// state carrying its own markers without updating searchParams.
+function writeUrl(edit: (params: URLSearchParams) => void) {
+  const params = new URLSearchParams(window.location.search);
+  edit(params);
+  window.history.replaceState({}, "", `?${params}`);
+}
+
 export function useExprFilterPage({
+  teamId,
+  entity,
   paginationLimit,
-  extraUrlKeys,
-  pageUrlKeys = [],
+  rootSpan = false,
 }: {
+  teamId: string;
+  entity: string;
   paginationLimit?: number;
-  extraUrlKeys?: { rootSpanName: string };
-  pageUrlKeys?: string[];
+  rootSpan?: boolean;
 }) {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const search = searchParams.toString();
+  const rememberedAppId = useFiltersStore((s) => s.selectedApp?.id);
+  const rememberedDateRange = useFiltersStore((s) => s.selectedDateRange);
+  const rememberedStartDate = useFiltersStore((s) => s.selectedStartDate);
+  const rememberedEndDate = useFiltersStore((s) => s.selectedEndDate);
+  const setSelectedApp = useFiltersStore((s) => s.setSelectedApp);
+  const setSelectedDateRange = useFiltersStore((s) => s.setSelectedDateRange);
+  const setSelectedStartDate = useFiltersStore((s) => s.setSelectedStartDate);
+  const setSelectedEndDate = useFiltersStore((s) => s.setSelectedEndDate);
+  const setApps = useFiltersStore((s) => s.setApps);
 
-  const [request, setRequest] = useState<{
-    filters: FilterRequest;
-    urlBefore: string | null;
-    urlWritten: string | null;
-    awaitingWrite: boolean;
-  } | null>(null);
-  const [filterState, setFilterState] = useState<FilterState>({
-    status: "pending",
+  const url = useMemo(
+    () => ({
+      appId: searchParams.get(appIdUrlKey),
+      dateRange: {
+        dateRange: searchParams.get(dateRangeUrlKey),
+        startDate: searchParams.get(startDateUrlKey),
+        endDate: searchParams.get(endDateUrlKey),
+      },
+      filterExpr: searchParams.get(filterExprUrlKey),
+      rootSpanName: rootSpan ? searchParams.get(rootSpanNameUrlKey) : null,
+    }),
+    [search, rootSpan],
+  );
+
+  const appsQuery = useAppsQuery(teamId);
+  const app = resolveApp(url.appId, appsQuery.data, rememberedAppId);
+
+  const urlCustomKeyNames = useMemo(
+    () =>
+      url.filterExpr
+        ? customKeyNamesIn(
+            parseFilterExpr(url.filterExpr, { draft: true }).tokens,
+          )
+        : [],
+    [url.filterExpr],
+  );
+  const keysQuery = useFilterKeysQuery(app?.id, entity, urlCustomKeyNames);
+  const spanNamesQuery = useRootSpanNamesQuery(rootSpan ? app : null);
+
+  const {
+    status,
+    date: dateRange,
+    filters,
+    discarded,
+  } = resolveFilters({
+    url,
+    apps: appsQuery,
+    keys: keysQuery,
+    spanNames: rootSpan ? spanNamesQuery : null,
+    remembered: {
+      appId: rememberedAppId,
+      dateRange: {
+        dateRange: rememberedDateRange,
+        startDate: rememberedStartDate,
+        endDate: rememberedEndDate,
+      },
+    },
   });
 
-  // The search string from before the write is only the page's own until
-  // the written one is seen. After that it can only come from a navigation,
-  // such as the same sidebar link clicked again, so it is forgotten.
-  if (
-    request !== null &&
-    request.urlBefore !== null &&
-    search === request.urlWritten
-  ) {
-    setRequest({ ...request, urlBefore: null });
-  }
+  const customDate = dateRange.dateRange === DateRange.Custom;
+  const date = useMemo(
+    () => toDateSelection(dateRange)!,
+    [
+      dateRange.dateRange,
+      customDate ? dateRange.startDate : null,
+      customDate ? dateRange.endDate : null,
+    ],
+  );
 
-  const writeInFlight =
-    request !== null &&
-    request.urlBefore !== null &&
-    search === request.urlBefore;
+  const value = useMemo<FilterSelection | null>(
+    () =>
+      filters === null
+        ? null
+        : {
+            app: filters.app,
+            date,
+            filterExpr: filters.filterExpr,
+            rootSpanName: filters.rootSpanName,
+            discarded,
+          },
+    [filters?.app, date, filters?.filterExpr, filters?.rootSpanName, discarded],
+  );
 
-  // Until the router reports the written search string, the page reads back
-  // the one it wrote, not the one from before.
-  const knownParams =
-    writeInFlight && request.urlWritten !== null
-      ? new URLSearchParams(request.urlWritten)
-      : searchParams;
+  useEffect(() => {
+    if (app !== null && app.id !== rememberedAppId) {
+      setSelectedApp(app);
+    }
+  }, [app?.id]);
+
+  useEffect(() => {
+    setSelectedDateRange(date.dateRange);
+    setSelectedStartDate(date.startDate);
+    setSelectedEndDate(date.endDate);
+  }, [date]);
+
+  useEffect(() => {
+    if (appsQuery.status === "pending") {
+      setApps([], "pending");
+      return;
+    }
+    if (appsQuery.status === "error") {
+      setApps([], "error");
+      return;
+    }
+    const loaded = appsQuery.data;
+    setApps(loaded, loaded.length === 0 ? "no-apps" : "loaded");
+  }, [appsQuery.status, appsQuery.data]);
+
+  // Writes only while the rendered URL is still the live one, so a
+  // navigation the router has not rendered yet is not overwritten.
+  useEffect(() => {
+    if (status.kind !== "ready" || value === null) {
+      return;
+    }
+    const live = new URLSearchParams(window.location.search);
+    if (live.toString() !== search || urlHolds(live, value, rootSpan)) {
+      return;
+    }
+    if (discarded) {
+      toastNegative("Some filters were invalid, page reset to defaults");
+    }
+    writeUrl((params) => {
+      applyEntries(params, valueUrlEntries(value, rootSpan));
+      if (discarded && paginationLimit !== undefined) {
+        params.set(paginationOffsetUrlKey, "0");
+      }
+    });
+  });
+
+  const filterParams: FilterParams | null =
+    status.kind === "ready" &&
+    value !== null &&
+    urlHolds(searchParams, value, rootSpan)
+      ? {
+          appId: value.app.id,
+          startDate: value.date.startDate,
+          endDate: value.date.endDate,
+          filterExpr: value.filterExpr,
+        }
+      : null;
 
   const paginationOffset =
     paginationLimit === undefined
       ? 0
-      : Number(knownParams.get(paginationOffsetUrlKey)) || 0;
+      : Math.max(0, Number(searchParams.get(paginationOffsetUrlKey)) || 0);
 
-  const fromUrl: FilterRequest = {
-    appId: searchParams.get(appIdUrlKey),
-    dateRange: {
-      dateRange: searchParams.get(dateRangeUrlKey),
-      startDate: searchParams.get(startDateUrlKey),
-      endDate: searchParams.get(endDateUrlKey),
-    },
-    filterExpr: searchParams.get(filterExprUrlKey),
-    rootSpanName:
-      extraUrlKeys === undefined
-        ? null
-        : searchParams.get(extraUrlKeys.rootSpanName),
-  };
-
-  const fromReadyState = (state: ReadyFilterState): FilterRequest => ({
-    appId: state.app.id,
-    dateRange: withoutRelativeTimestamps(state.date),
-    filterExpr: state.filterExpr,
-    rootSpanName: state.rootSpanName,
-  });
-
-  const requestedFilters =
-    request !== null && (writeInFlight || search === request.urlWritten)
-      ? request.filters
-      : fromUrl;
-
-  // A relative label is counted back from now, so its timestamps are not
-  // written and any the URL holds are ignored.
-  const filterUrlEntries = (filter: ReadyFilterState) => {
-    const entries: [string, string | null][] = [
-      [appIdUrlKey, filter.app.id],
-      [dateRangeUrlKey, filter.date.dateRange],
-    ];
-    if (filter.date.dateRange === DateRange.Custom) {
-      entries.push(
-        [startDateUrlKey, filter.date.startDate],
-        [endDateUrlKey, filter.date.endDate],
-      );
-    }
-    if (extraUrlKeys !== undefined) {
-      entries.push([extraUrlKeys.rootSpanName, filter.rootSpanName]);
-    }
-    entries.push([filterExprUrlKey, filter.filterExpr]);
-    return entries;
-  };
-
-  // The filter is null until the URL matches the bar's report, root span
-  // included, so a value the bar discarded is never fetched.
-  const filterParams: FilterParams | null =
-    filterState.status === "ready" &&
-    filterUrlEntries(filterState).every(
-      ([key, value]) => searchParams.get(key) === value,
-    )
-      ? {
-          appId: filterState.app.id,
-          startDate: filterState.date.startDate,
-          endDate: filterState.date.endDate,
-          filterExpr: filterState.filterExpr,
-        }
-      : null;
-
-  const buildFilterUrl = (filter: ReadyFilterState, offset: number) => {
-    const urlParams = new URLSearchParams();
-    if (paginationLimit !== undefined) {
-      urlParams.set(paginationOffsetUrlKey, String(offset));
-    }
-    for (const [key, value] of filterUrlEntries(filter)) {
-      if (value !== null) {
-        urlParams.set(key, value);
+  const onChange = (change: FilterChange) => {
+    writeUrl((params) => {
+      const entries: UrlEntry[] = [];
+      if (change.appId !== undefined) {
+        entries.push([appIdUrlKey, change.appId]);
       }
-    }
-    for (const key of pageUrlKeys) {
-      const value = knownParams.get(key);
-      if (value !== null) {
-        urlParams.set(key, value);
+      if (change.dateRange !== undefined) {
+        entries.push(...dateUrlEntries(change.dateRange));
       }
-    }
-    return urlParams.toString();
-  };
-
-  // A pick keeps the last written URL, since a write of it can still be on
-  // its way and must be read as the page's own when it is applied.
-  const onRequestChange = (change: Partial<FilterRequest>) => {
-    const filters = { ...requestedFilters, ...change };
-    if (sameRequest(filters, requestedFilters)) {
-      return;
-    }
-    setRequest({
-      filters,
-      urlBefore: search,
-      urlWritten: request?.urlWritten ?? null,
-      awaitingWrite: true,
+      if (change.filterExpr !== undefined) {
+        entries.push([filterExprUrlKey, change.filterExpr]);
+      }
+      if (change.rootSpanName !== undefined) {
+        entries.push([rootSpanNameUrlKey, change.rootSpanName]);
+      }
+      if (paginationLimit !== undefined) {
+        entries.push([paginationOffsetUrlKey, "0"]);
+      }
+      applyEntries(params, entries);
     });
   };
 
-  const onFilterChange = (newFilterState: FilterState) => {
-    setFilterState(newFilterState);
-
-    if (newFilterState.status !== "ready") {
-      return;
-    }
-    // The URL's pagination offset is kept only when the bar applied the
-    // request unchanged and that request is already in the URL. A new pick,
-    // or a substitution, starts back at page one.
-    const pickAwaitingWrite = request !== null && request.awaitingWrite;
-    const offset =
-      newFilterState.appliedAsRequested && !pickAwaitingWrite
-        ? paginationOffset
-        : 0;
-    const params = buildFilterUrl(newFilterState, offset);
-    // Stored as resolved, so a navigation back to the search string it came
-    // from changes the bar's props and the bar reports again. The filter text
-    // is kept as asked, since a condition with no value yet is not resolved.
-    setRequest({
-      filters: {
-        ...fromReadyState(newFilterState),
-        filterExpr: newFilterState.appliedAsRequested
-          ? requestedFilters.filterExpr
-          : newFilterState.filterExpr,
-      },
-      urlBefore: search,
-      urlWritten: params,
-      awaitingWrite: false,
-    });
-    // The bar reports again before the router applies a write; the same
-    // write is not issued twice.
-    if (
-      params !== search &&
-      !(writeInFlight && params === request.urlWritten)
-    ) {
-      router.replace(`?${params}`, { scroll: false });
-    }
+  const setPageUrlKey = (key: string, pageValue: string) => {
+    writeUrl((params) => params.set(key, pageValue));
   };
 
-  // Replaces one key in the URL and leaves everything else the URL carries
-  // as it is. The write is recorded so the bar keeps showing the request.
-  const setPageUrlKey = (key: string, value: string) => {
-    const urlParams = new URLSearchParams(knownParams);
-    urlParams.set(key, value);
-    const params = urlParams.toString();
-    setRequest({
-      filters: requestedFilters,
-      urlBefore: search,
-      urlWritten: params,
-      awaitingWrite: request !== null && request.awaitingWrite,
-    });
-    router.replace(`?${params}`, { scroll: false });
-  };
-
-  const navigateToOffset = (offset: number) =>
-    setPageUrlKey(paginationOffsetUrlKey, String(offset));
-
-  const nextPage = () => {
+  const movePage = (by: number) => {
     if (paginationLimit === undefined) {
       return;
     }
-    navigateToOffset(paginationOffset + paginationLimit);
-  };
-  const prevPage = () => {
-    if (paginationLimit === undefined) {
-      return;
-    }
-    navigateToOffset(Math.max(0, paginationOffset - paginationLimit));
+    writeUrl((params) => {
+      const offset = Number(params.get(paginationOffsetUrlKey)) || 0;
+      params.set(paginationOffsetUrlKey, String(Math.max(0, offset + by)));
+    });
   };
 
   return {
-    requestedFilters,
-    paginationOffset,
-    filterState,
+    value,
+    apps: appsQuery.data ?? noApps,
+    keys:
+      keysQuery.isPending || keysQuery.isPlaceholderData
+        ? null
+        : (keysQuery.data?.keys ?? noKeys),
+    keyGroups: keysQuery.data?.key_groups ?? noKeyGroups,
+    keysUnavailable: keysQuery.isError,
+    spanNames:
+      rootSpan && (spanNamesQuery.isSuccess || spanNamesQuery.isError)
+        ? (spanNamesQuery.data ?? [])
+        : null,
+    status,
     filterParams,
-    onRequestChange,
-    onFilterChange,
+    paginationOffset,
+    onChange,
     setPageUrlKey,
-    nextPage,
-    prevPage,
+    nextPage: () => movePage(paginationLimit ?? 0),
+    prevPage: () => movePage(-(paginationLimit ?? 0)),
   };
 }

--- a/frontend/dashboard/app/components/filter_bar/validate.ts
+++ b/frontend/dashboard/app/components/filter_bar/validate.ts
@@ -1,5 +1,9 @@
 import type { FilterKey, FilterOperator } from "../../api/filter_types";
-import { operatorLabels } from "./operators";
+import {
+  operatorLabels,
+  operatorTakesOneValue,
+  operatorTakesValues,
+} from "./operators";
 import {
   buildExprTree,
   type ConditionGroup,
@@ -78,6 +82,7 @@ export type KeyIssue = {
 export function findUnusableConditions(
   tokens: ExprToken[],
   keys: FilterKey[],
+  valuesReadable = true,
 ): KeyIssue[] {
   const byName = new Map(keys.map((key) => [key.name, key]));
   const issues: KeyIssue[] = [];
@@ -121,10 +126,70 @@ export function findUnusableConditions(
         start: operator.start,
         end: operator.end,
       });
+      return;
+    }
+
+    if (!valuesReadable) {
+      return;
+    }
+
+    const colon = tokens[index + 3];
+    const first = tokens[index + 4];
+    const listed = first?.kind === "punctuation" && first.text === "[";
+
+    if (!operatorTakesValues(operatorName)) {
+      if (colon?.text === ":" && first !== undefined) {
+        issues.push({
+          message: `${key.label} takes no value`,
+          start: operator.start,
+          end: listed ? listEnd(tokens, index + 5) : first.end,
+        });
+      }
+      return;
+    }
+
+    if (colon?.text !== ":" || !(first?.kind === "value" || listed)) {
+      issues.push({
+        message: `${key.label} needs a value`,
+        start: token.start,
+        end: operator.end,
+      });
+      return;
+    }
+
+    if (!listed || !operatorTakesOneValue(operatorName)) {
+      return;
+    }
+    let count = 0;
+    for (const listToken of tokens.slice(index + 5)) {
+      if (listToken.kind === "value") {
+        count++;
+      }
+      if (listToken.kind === "punctuation" && listToken.text === "]") {
+        break;
+      }
+    }
+    if (count > 1) {
+      issues.push({
+        message: `${key.label} takes one value`,
+        start: first.start,
+        end: listEnd(tokens, index + 5),
+      });
     }
   });
 
   return issues;
+}
+
+function listEnd(tokens: ExprToken[], from: number): number {
+  let end = tokens[from - 1].end;
+  for (const token of tokens.slice(from)) {
+    end = token.end;
+    if (token.kind === "punctuation" && token.text === "]") {
+      break;
+    }
+  }
+  return end;
 }
 
 /**
@@ -150,7 +215,11 @@ export function findFilterIssues(
     });
   }
 
-  for (const keyIssue of findUnusableConditions(parsed.tokens, keys)) {
+  for (const keyIssue of findUnusableConditions(
+    parsed.tokens,
+    keys,
+    parsed.ok,
+  )) {
     inOrder.push({
       at: keyIssue.start,
       issue: {

--- a/frontend/dashboard/app/components/filter_bar/value_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/value_picker.tsx
@@ -25,7 +25,8 @@ interface ValuePickerProps {
   // A one-value operator replaces its selection instead of adding to it.
   takesOneValue: boolean;
   selected: FilterValue[];
-  onChange: (values: FilterValue[]) => void;
+  // `done` marks a pick that ends the selection; the owner of `open` closes.
+  onChange: (values: FilterValue[], done: boolean) => void;
   trigger: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -62,15 +63,18 @@ export default function ValuePicker({
 
   const toggle = (value: FilterValue) => {
     if (takesOneValue) {
-      onChange([value]);
-      setOpen(false);
+      onChange([value], true);
+      setInternalOpen(false);
       return;
     }
     if (isSelected(value)) {
-      onChange(selected.filter((chosen) => chosen.text !== value.text));
+      onChange(
+        selected.filter((chosen) => chosen.text !== value.text),
+        false,
+      );
       return;
     }
-    onChange([...selected, value]);
+    onChange([...selected, value], false);
   };
 
   return (
@@ -96,8 +100,8 @@ export default function ValuePicker({
             initial={selected[0]?.text ?? ""}
             valueType={valueType}
             onApply={(text) => {
-              onChange([{ text }]);
-              setOpen(false);
+              onChange([{ text }], true);
+              setInternalOpen(false);
             }}
           />
         )}

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -14,7 +14,7 @@ import TabSelect from "@/app/components/tab_select";
 import { useJourneyQuery } from "@/app/query/hooks";
 import { Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 
 const journeyTypeUrlKey = "jt";
 
@@ -33,26 +33,49 @@ export default function UserJourneys({
   demo = false,
   hideDemoTitle = false,
 }: UserJourneysProps) {
+  if (demo) {
+    return <DemoUserJourneys hideTitle={hideDemoTitle} />;
+  }
+  return <TeamUserJourneys teamId={params.teamId} />;
+}
+
+function DemoUserJourneys({ hideTitle }: { hideTitle: boolean }) {
+  const [plotType, setPlotType] = useState(PlotType.Paths);
+
+  return (
+    <div className="flex flex-col items-start">
+      <p className="font-display text-4xl max-w-6xl text-center">
+        {hideTitle ? "" : "User Journeys"}
+      </p>
+      <div className="py-4" />
+
+      <JourneyPlot
+        plotType={plotType}
+        onChangePlotType={setPlotType}
+        query={demoJourneyQuery}
+      />
+    </div>
+  );
+}
+
+function TeamUserJourneys({ teamId }: { teamId: string }) {
   const searchParams = useSearchParams();
 
   const {
-    requestedFilters,
-    filterState,
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status: filterStatus,
     filterParams,
-    onRequestChange,
-    onFilterChange,
+    onChange,
     setPageUrlKey,
-  } = useExprFilterPage({ pageUrlKeys: [journeyTypeUrlKey] });
-  const readyFilter = filterState.status === "ready" ? filterState : null;
+  } = useExprFilterPage({ teamId, entity: "journeys" });
+  const readyValue = filterStatus.kind === "ready" ? value : null;
 
-  // The demo keeps its plot type in local state, so tab clicks on the
-  // marketing page don't change its URL. The live page reads the plot
-  // type from the URL on each render, so links open the specified plot and
-  // tab clicks update the URL.
-  const [demoPlotType, setDemoPlotType] = useState(PlotType.Paths);
-  const plotType = demo
-    ? demoPlotType
-    : searchParams.get(journeyTypeUrlKey) === PlotType.Exceptions
+  const plotType =
+    searchParams.get(journeyTypeUrlKey) === PlotType.Exceptions
       ? PlotType.Exceptions
       : PlotType.Paths;
   const [searchText, setSearchText] = useState("");
@@ -63,41 +86,30 @@ export default function UserJourneys({
 
   const { status } = journeyQuery;
 
-  const journeyType =
-    plotType === PlotType.Paths ? JourneyType.Paths : JourneyType.Exceptions;
-
   return (
     <div className="flex flex-col items-start">
-      <p className="font-display text-4xl max-w-6xl text-center">
-        {demo ? (hideDemoTitle ? "" : "User Journeys") : ""}
-      </p>
       <div className="py-4" />
 
-      {!demo && (
-        <>
-          <FilterBar
-            teamId={params.teamId}
-            entity="journeys"
-            placeholder="Filter journeys…"
-            requestedAppId={requestedFilters.appId}
-            requestedDateRange={requestedFilters.dateRange}
-            requestedFilterExpr={requestedFilters.filterExpr}
-            filterExprIssues={filterExprIssues}
-            onRequestChange={onRequestChange}
-            onFilterChange={onFilterChange}
-          />
-          <div className="py-4" />
-        </>
+      <FilterBar
+        entity="journeys"
+        placeholder="Filter journeys…"
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
+        filterExprIssues={filterExprIssues}
+        onChange={onChange}
+      />
+      <div className="py-4" />
+
+      {filterStatus.kind === "error" && (
+        <p className="text-lg font-display">{filterStatus.message}</p>
       )}
 
-      {!demo && filterState.status === "error" && (
-        <p className="text-lg font-display">{filterState.message}</p>
-      )}
+      {filterStatus.kind === "loading" && <SkeletonListPage />}
 
-      {!demo && filterState.status === "pending" && <SkeletonListPage />}
-
-      {!demo &&
-        readyFilter !== null &&
+      {readyValue !== null &&
         status === "error" &&
         filterExprIssues === null && (
           <p className="text-lg font-display">
@@ -106,14 +118,12 @@ export default function UserJourneys({
           </p>
         )}
 
-      {(demo ||
-        (readyFilter !== null &&
-          (status === "success" || status === "pending"))) && (
-        <>
-          <div className="w-full flex items-center justify-between pb-2 pr-2">
-            {demo ? (
-              <div />
-            ) : (
+      {readyValue !== null &&
+        (status === "success" || status === "pending") && (
+          <JourneyPlot
+            plotType={plotType}
+            onChangePlotType={(type) => setPageUrlKey(journeyTypeUrlKey, type)}
+            search={
               <div className="relative w-64">
                 <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground pointer-events-none" />
                 <DebounceTextInput
@@ -124,40 +134,59 @@ export default function UserJourneys({
                   onChange={(it) => setSearchText(it)}
                 />
               </div>
-            )}
-            <TabSelect
-              items={Object.values(PlotType)}
-              selected={plotType}
-              onChangeSelected={(item) => {
-                if (demo) {
-                  setDemoPlotType(item as PlotType);
-                } else {
-                  setPageUrlKey(journeyTypeUrlKey, item);
-                }
-              }}
-            />
-          </div>
-
-          <div className="w-full h-200">
-            <div className="py-4" />
-
-            {/* Keyed on the plot type so switching tabs mounts a fresh
-                chart, which closes any issue panel the previous one had
-                open. */}
-            <Journey
-              key={plotType}
-              journeyType={journeyType}
-              searchText={searchText}
-              query={demo ? demoJourneyQuery : journeyQuery}
-              errorDetailContext={
-                demo || readyFilter === null
-                  ? undefined
-                  : { teamId: params.teamId, appId: readyFilter.app.id }
-              }
-            />
-          </div>
-        </>
-      )}
+            }
+            searchText={searchText}
+            query={journeyQuery}
+            errorDetailContext={{ teamId, appId: readyValue.app.id }}
+          />
+        )}
     </div>
+  );
+}
+
+function JourneyPlot({
+  plotType,
+  onChangePlotType,
+  search,
+  searchText,
+  query,
+  errorDetailContext,
+}: {
+  plotType: PlotType;
+  onChangePlotType: (plotType: PlotType) => void;
+  search?: ReactNode;
+  searchText?: string;
+  query: ComponentProps<typeof Journey>["query"];
+  errorDetailContext?: ComponentProps<typeof Journey>["errorDetailContext"];
+}) {
+  const journeyType =
+    plotType === PlotType.Paths ? JourneyType.Paths : JourneyType.Exceptions;
+
+  return (
+    <>
+      <div className="w-full flex items-center justify-between pb-2 pr-2">
+        {search ?? <div />}
+        <TabSelect
+          items={Object.values(PlotType)}
+          selected={plotType}
+          onChangeSelected={(item) => onChangePlotType(item as PlotType)}
+        />
+      </div>
+
+      <div className="w-full h-200">
+        <div className="py-4" />
+
+        {/* Keyed on the plot type so switching tabs mounts a fresh
+            chart, which closes any issue panel the previous one had
+            open. */}
+        <Journey
+          key={plotType}
+          journeyType={journeyType}
+          searchText={searchText}
+          query={query}
+          errorDetailContext={errorDetailContext}
+        />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
# Description

State held in the filter bar or the page hook could win over the URL after Back or a sidebar click.  A previous commit fixed this statefully but this commit eliminates that state: page derives everything from the URL and its queries each render, and the bar is a value + onChange control that keeps only what is being edited.

- `useExprFilterPage` owns the queries, resolution, URL writes and the fetch decision, with no React state
- FilterBar takes a value and reports edits; typed text and one pending edit are its only state, dropped when the URL changes
- URL writes use history.replaceState, so selection shows in the URL at once with no server round trip

## Related issue
References #4371



