### PR TITLE
fix(backend): round crash free percentages instead of rounding up

### DIFF
--- a/backend/libs/numeric/numeric.go
+++ b/backend/libs/numeric/numeric.go
@@ -24,7 +24,7 @@ func AbsInt(n int) int {
 // RoundTwoDecimalsFloat64 rounds the precision
 // part of a float64 value to 2 decimals.
 func RoundTwoDecimalsFloat64(x float64) float64 {
-	return math.Ceil(x*100) / 100
+	return math.Round(x*100) / 100
 }
 
 func FormatKMB(n int64) string {

--- a/backend/libs/numeric/numeric_test.go
+++ b/backend/libs/numeric/numeric_test.go
@@ -49,3 +49,37 @@ func TestFormatKMB(t *testing.T) {
 		})
 	}
 }
+
+// crashFreeRate runs the same division GetIssueFreeMetrics does, so the cases
+// below round a real float64 result rather than a folded constant.
+func crashFreeRate(issues, sessions uint64) float64 {
+	return (1 - (float64(issues) / float64(sessions))) * 100
+}
+
+func TestRoundTwoDecimalsFloat64(t *testing.T) {
+	cases := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"zero", 0, 0},
+		{"already at two decimals", 88.89, 88.89},
+		{"third decimal rounds down", 1.234, 1.23},
+		{"third decimal rounds up", 99.996, 100},
+		{"scaling by 100 overshoots", 0.07, 0.07},
+		{"negative", -1.236, -1.24},
+
+		{"41 crashes in 100 sessions", crashFreeRate(41, 100), 59},
+		{"23 crashes in 10000 sessions", crashFreeRate(23, 10000), 99.77},
+		{"3 crashes in 50000 sessions", crashFreeRate(3, 50000), 99.99},
+		{"1 crash in 10001 sessions", crashFreeRate(1, 10001), 99.99},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RoundTwoDecimalsFloat64(c.in); got != c.want {
+				t.Errorf("RoundTwoDecimalsFloat64(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

`RoundTwoDecimalsFloat64` uses `math.Ceil`, so the crash free and ANR free percentages round up rather than round. Its only callers are the eight lines in `GetIssueFreeMetrics` that build those four numbers, and the Overview card prints what it's handed.

Two effects. A rate already exact to two decimals gets bumped a whole 0.01 anyway, beacuse `(1 - issues/sessions) * 100` lands a hair above the nearest float64 and `Ceil` takes the next cent. And every positive rate over 99.99% reads as a flat 100%, so a handful of crashes in fifty thousand sessions shows 100% crash free next to a crash list that isnt empty.

| issues / sessions | raw | today | with `Round` |
| --- | --- | --- | --- |
| 41 / 100 | 59.00000000000001 | 59.01 | 59 |
| 23 / 10000 | 99.77000000000001 | 99.78 | 99.77 |
| 3 / 50000 | 99.994 | 100 | 99.99 |
| 1 / 10001 | 99.9900009999 | 100 | 99.99 |

41 crashes in 100 sessions is exactly 59% crash free and the dashboard says 59.01. `Round` still gives 100 from 99.995% up, which is just normal rounding - what stops is giving it to rates that dont round to 100. Every other percentage in the backend rounds already, and this was the only `math.Ceil` in it.

It doesnt make the second decimal exact, mind. 63 affected sessions in 160 is 60.625% free on the nose, the division lands at 60.62499999999999, and `Round` reads that as 60.62 where `Ceil` gets 60.63 by luck. Only working from the raw counts fixes that, and that's a much bigger change than this one. This just takes the upward bias off.

The helper had no test so there's a table one now, which makes it most of the diff. The ratios go through a small function rather than sitting there as constants, otherwise Go folds the expression at arbitrary precision and the intersting cases come out exact. The three integration assertions that pin a crash free value (88.89, 80, 90) come out the same under either version, though I worked that out on paper rather than running them - I've run `go test ./numeric/` and the module build, not the integration suite.

One knock-on: `metrics_card.tsx` compares this value to the app's configured threshold with a strict `>`, so a card sitting exactly on its line can change status icon.

## Related issue

None. CONTRIBUTING asks for one first, but this is a single line and I didn't want to make paperwork of it.
