### PR TITLE
Migrate alerts to expression filters

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -914,7 +914,7 @@ type mcpGetAlertsInput struct {
 	AppID  string `json:"app_id" jsonschema:"UUID of the app to query"`
 	From   string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
 	To     string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
-	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of alerts to return (default: 25)"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of alerts to return (default: 10)"`
 	Offset int    `json:"offset,omitempty" jsonschema:"Number of alerts to skip for pagination (default: 0)"`
 }
 type mcpGetJourneyInput struct {
@@ -1998,30 +1998,22 @@ func (c *Config) mcpGetTrace(ctx context.Context, in mcpGetTraceInput) (*mcpsdk.
 
 func (c *Config) mcpGetAlerts(ctx context.Context, in mcpGetAlertsInput) (*mcpsdk.CallToolResult, any, error) {
 	deps := c.Deps
-	appID, _, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	_, _, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.AlertsEntity, in.AppID, in.From, in.To, "", func(ef *exprfilter.ExprFilter) {
+		limit := in.Limit
+		if limit <= 0 {
+			limit = 10
+		}
+		if limit > 30 {
+			limit = 30
+		}
+		ef.Limit = limit
+		ef.Offset = in.Offset
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	af := &filter.AppFilter{AppID: appID}
-
-	from, to, parseErr := mcpParseTimeRangeStrings(in.From, in.To)
-	if parseErr != nil {
-		return nil, nil, parseErr
-	}
-	af.From, af.To = from, to
-
-	limit := in.Limit
-	if limit <= 0 {
-		limit = 10
-	}
-	if limit > 30 {
-		limit = 30
-	}
-	af.Limit = limit
-	af.Offset = in.Offset
-
-	alerts, _, _, alertErr := measure.GetAlertsWithFilter(ctx, deps.PgPool, af)
+	alerts, _, _, alertErr := measure.GetAlertsWithFilter(ctx, deps.PgPool, ef)
 	if alertErr != nil {
 		return nil, nil, fmt.Errorf("failed to get alerts: %v", alertErr)
 	}

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -3081,108 +3081,17 @@ func (h Handlers) UpdateBugReportStatus(c *gin.Context) {
 
 func (h Handlers) GetAlertsOverview(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+	_, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.AlertsEntity,
+		appScope: *measure.ScopeAppRead,
+		logRoot:  logcomment.Alerts,
+		logName:  "list",
+	})
+	if !ok {
 		return
 	}
 
-	af := filter.AppFilter{
-		AppID: id,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "alerts overview request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
-
-	alerts, next, previous, err := measure.GetAlertsWithFilter(ctx, deps.PgPool, &af)
+	alerts, next, previous, err := measure.GetAlertsWithFilter(ctx, deps.PgPool, &ef)
 	if err != nil {
 		msg := "failed to get app's alerts"
 		fmt.Println(msg, err)

--- a/backend/libs/exprfilter/alerts.go
+++ b/backend/libs/exprfilter/alerts.go
@@ -1,0 +1,10 @@
+package exprfilter
+
+// Alerts are scoped by app and time only, so the entity offers no keys and
+// any filter_expr fails validation. Keys is empty rather than nil so a key
+// listing encodes as an empty array.
+var AlertsEntity = Entity{
+	Name:    "alerts",
+	Keys:    []Key{},
+	BindKey: bindKeysToColumns(nil, nil),
+}

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -70,6 +70,8 @@ func FindByName(name string) (Entity, error) {
 		return BugReportsEntity, nil
 	case JourneysEntity.Name:
 		return JourneysEntity, nil
+	case AlertsEntity.Name:
+		return AlertsEntity, nil
 	}
 
 	return Entity{}, fmt.Errorf("Unknown filter entity %q", name)

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -1,6 +1,7 @@
 package exprfilter
 
 import (
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -9,7 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity, JourneysEntity}
+var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity, JourneysEntity, AlertsEntity}
 
 func sampleValues(t *testing.T, key Key, operator Operator) []Value {
 	t.Helper()
@@ -50,13 +51,10 @@ func TestEntitiesFillEveryField(t *testing.T) {
 			if entity.Name == "" {
 				t.Error("an entity with no name cannot be asked for by a request")
 			}
-			if len(entity.Keys) == 0 {
-				t.Error("an entity with no keys can be filtered by nothing")
-			}
 			if entity.BindKey == nil {
 				t.Error("an entity with no BindKey cannot write a filter")
 			}
-			if entity.SuggestFixedKeyValues == nil {
+			if len(entity.Keys) > 0 && entity.SuggestFixedKeyValues == nil {
 				t.Error("an entity with no SuggestFixedKeyValues cannot list what a fixed key can be set to")
 			}
 		})
@@ -423,6 +421,39 @@ func TestJourneyEventsKeyBindingsReadTheEventsColumns(t *testing.T) {
 	}
 	if args := onEvents.Args(); len(args) != 2 || !slices.Equal(args[0].([]string), []string{"1.2.0"}) || !slices.Equal(args[1].([]string), []string{"120"}) {
 		t.Errorf("want the version values bound, got %v", args)
+	}
+}
+
+func TestAlertsEntityCannotBeFiltered(t *testing.T) {
+	if len(AlertsEntity.Keys) != 0 {
+		t.Errorf("want no keys on the alerts entity, got %d", len(AlertsEntity.Keys))
+	}
+
+	ef := &ExprFilter{
+		AppID:      uuid.New(),
+		Entity:     AlertsEntity,
+		Limit:      10,
+		FilterExpr: "version_name:in:1.2.0",
+	}
+	if err := ef.BuildExprTree(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	err := ef.Validate()
+	var invalid *ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("want a filter on the alerts entity refused, got %v", err)
+	}
+	if len(invalid.Issues) != 1 || !strings.Contains(invalid.Issues[0].Message, "version_name") {
+		t.Errorf("want the unknown key named, got %v", invalid.Issues)
+	}
+
+	if _, err := AlertsEntity.BindKey(Condition{
+		KeyName:  "version_name",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "1.2.0"}},
+	}); !errors.Is(err, ErrKeyNotSupported) {
+		t.Errorf("want ErrKeyNotSupported, got %v", err)
 	}
 }
 

--- a/backend/libs/logcomment/doc.go
+++ b/backend/libs/logcomment/doc.go
@@ -32,6 +32,7 @@
 //   - `Filters = "filters"`
 //   - `Metrics = "metrics"`
 //   - `Journeys = "journeys"`
+//   - `Alerts = "alerts"`
 //
 // ## ClickHouse Integration
 //

--- a/backend/libs/logcomment/keys.go
+++ b/backend/libs/logcomment/keys.go
@@ -51,3 +51,7 @@ const BugReports = "bug_reports"
 // Network is the root key for the `network`
 // logcomment.
 const Network = "network"
+
+// Alerts is the root key for the `alerts`
+// logcomment.
+const Alerts = "alerts"

--- a/backend/libs/measure/alerts.go
+++ b/backend/libs/measure/alerts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/leporo/sqlf"
 
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
 )
 
 type Alert struct {
@@ -23,7 +23,7 @@ type Alert struct {
 	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
 }
 
-func GetAlertsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFilter) (alerts []Alert, next, previous bool, err error) {
+func GetAlertsWithFilter(ctx context.Context, pg *pgxpool.Pool, ef *exprfilter.ExprFilter) (alerts []Alert, next, previous bool, err error) {
 	stmt := sqlf.PostgreSQL.From("alerts").
 		Select("id").
 		Select("team_id").
@@ -34,16 +34,16 @@ func GetAlertsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 		Select("url").
 		Select("created_at").
 		Select("updated_at").
-		Where("app_id = ?", af.AppID).
-		Where("created_at >= ?", af.From).
-		Where("created_at <= ?", af.To)
+		Where("app_id = ?", ef.AppID).
+		Where("created_at >= ?", ef.From).
+		Where("created_at <= ?", ef.To)
 
-	if af.Limit > 0 {
-		stmt.Limit(uint64(af.Limit) + 1)
+	if ef.Limit > 0 {
+		stmt.Limit(uint64(ef.Limit) + 1)
 	}
 
-	if af.Offset >= 0 {
-		stmt.Offset(uint64(af.Offset))
+	if ef.Offset >= 0 {
+		stmt.Offset(uint64(ef.Offset))
 	}
 
 	stmt.OrderBy("created_at DESC")
@@ -77,11 +77,11 @@ func GetAlertsWithFilter(ctx context.Context, pg *pgxpool.Pool, af *filter.AppFi
 	resultLen := len(alerts)
 
 	// Set pagination next & previous flags
-	if resultLen > af.Limit {
+	if resultLen > ef.Limit {
 		alerts = alerts[:resultLen-1]
 		next = true
 	}
-	if af.Offset > 0 {
+	if ef.Offset > 0 {
 		previous = true
 	}
 

--- a/backend/libs/measure/alerts_test.go
+++ b/backend/libs/measure/alerts_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package measure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/libs/exprfilter"
+
+	"github.com/google/uuid"
+)
+
+func seedAlert(ctx context.Context, t *testing.T, teamID, appID uuid.UUID, message string, createdAt time.Time) {
+	t.Helper()
+
+	_, err := th.PgPool.Exec(ctx, `
+		insert into alerts (id, team_id, app_id, entity_id, type, message, url, created_at, updated_at)
+		values ($1, $2, $3, $4, 'new_crash', $5, 'https://example.com/alert', $6, $6)
+	`, uuid.New(), teamID, appID, uuid.New().String(), message, createdAt)
+	if err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+}
+
+func TestGetAlertsWithFilter(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	seedTeam(ctx, t, teamID, testTeamName)
+	seedApp(ctx, t, appID, teamID, 30)
+
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	seedAlert(ctx, t, teamID, appID, "oldest", base.Add(-2*time.Hour))
+	seedAlert(ctx, t, teamID, appID, "middle", base)
+	seedAlert(ctx, t, teamID, appID, "newest", base.Add(time.Hour))
+
+	exprFilter := func(offset int) *exprfilter.ExprFilter {
+		return &exprfilter.ExprFilter{
+			AppID:  appID,
+			TeamID: teamID,
+			Entity: exprfilter.AlertsEntity,
+			From:   base.Add(-time.Hour),
+			To:     base.Add(2 * time.Hour),
+			Limit:  1,
+			Offset: offset,
+		}
+	}
+
+	alerts, next, previous, err := GetAlertsWithFilter(ctx, th.PgPool, exprFilter(0))
+	if err != nil {
+		t.Fatalf("GetAlertsWithFilter: %v", err)
+	}
+	if len(alerts) != 1 || alerts[0].Message != "newest" {
+		t.Fatalf("want the newest alert in range, got %v", alerts)
+	}
+	if !next || previous {
+		t.Errorf("want next true and previous false, got next %v previous %v", next, previous)
+	}
+
+	alerts, _, previous, err = GetAlertsWithFilter(ctx, th.PgPool, exprFilter(1))
+	if err != nil {
+		t.Fatalf("GetAlertsWithFilter: %v", err)
+	}
+	if len(alerts) != 1 || alerts[0].Message != "middle" {
+		t.Fatalf("want the second alert in range, got %v", alerts)
+	}
+	if !previous {
+		t.Error("want previous true past the first page")
+	}
+}

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -864,10 +864,22 @@ describe("sessions, bug reports, alerts", () => {
     expect(lastFetchOpts().method).toBe("PATCH");
   });
 
-  it("fetchAlertsOverviewFromServer hits /alerts with filters", async () => {
+  it("fetchAlertsOverviewFromServer hits /alerts with the range and pagination", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
-    await fetchAlertsOverviewFromServer(makeFilters(), 20, 0);
-    expect(lastFetchUrl()).toContain("/api/apps/app-a/alerts");
+    await fetchAlertsOverviewFromServer(
+      "app-a",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-10T00:00:00.000Z",
+      20,
+      0,
+    );
+    const url = lastFetchUrl();
+    expect(url).toContain("/api/apps/app-a/alerts");
+    expect(url).toContain("from=");
+    expect(url).toContain("to=");
+    expect(url).toContain("limit=20");
+    expect(url).toContain("offset=0");
+    expect(url).not.toContain("filter_short_code=");
   });
 
   it("fetchBuildsFromServer hits /builds with the range, expression and pagination", async () => {
@@ -1559,7 +1571,14 @@ describe("fetch functions: failure paths", () => {
     ["fetchBugReportFromServer", () => fetchBugReportFromServer("a", "b")],
     [
       "fetchAlertsOverviewFromServer",
-      () => fetchAlertsOverviewFromServer(makeFilters(), 20, 0),
+      () =>
+        fetchAlertsOverviewFromServer(
+          "app-a",
+          "2026-04-01T00:00:00.000Z",
+          "2026-04-10T00:00:00.000Z",
+          20,
+          0,
+        ),
     ],
     [
       "fetchPendingInvitesFromServer",

--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -442,6 +442,20 @@ describe("FilterBar", () => {
       );
     });
 
+    it("draws the app and range alone when the filter is not offered", async () => {
+      await renderBar({}, { showFilterExpr: false });
+
+      expect(screen.getByTestId("app-select")).toBeInTheDocument();
+      expect(screen.getByTestId("date-select")).toBeInTheDocument();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+    });
+
+    it("draws the filter editor when nothing says otherwise", async () => {
+      await renderBar();
+
+      expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
+    });
+
     it("draws the filter as conditions", async () => {
       await renderBar({ filterExpr: "mapping_type:in:dsym" });
 

--- a/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/alerts_msw_test.tsx
@@ -1,15 +1,9 @@
 /**
- * Integration tests for Alerts Overview page.
- *
- * The alerts page is a list-only page (no detail page, no plot) with
- * minimal filters (app selector + date range only). Each alert row
- * links to an external URL (crash/ANR detail page) via the `url` field
- * from the API.
- *
- * Tests cover the page/API wiring: error propagation, the real Filters
- * configuration, pagination round-trips and deep-links, URL
- * serialisation, and the request URL parameters sent to the alerts API.
+ * Wiring between the Alerts page and the server: request parameters, the
+ * app and date controls, pagination and error responses. Row rendering is
+ * covered by the unit tests.
  */
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
 import {
   afterAll,
@@ -20,7 +14,6 @@ import {
   expect,
   it,
 } from "@jest/globals";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   fireEvent,
@@ -37,13 +30,10 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
-const mockRouterPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
+const mockRouterPush = mockRouter.pushMock;
+
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/alerts",
 }));
 
@@ -61,6 +51,17 @@ jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light" }),
 }));
 
+// Radix popovers need a resize observer and pointer capture jsdom lacks.
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn(() => false);
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
+
 // --- MSW ---
 import { makeAlertsOverviewFixture, makeAppFixture } from "../msw/fixtures";
 import { server } from "../msw/server";
@@ -71,19 +72,19 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
   mockRouterPush.mockClear();
 });
 afterAll(() => server.close());
 
 // --- Store/component imports ---
 import AlertsOverview from "@/app/[teamId]/alerts/page";
+import { queryClient } from "@/app/query/query_client";
 import { createFiltersStore } from "@/app/stores/filters_store";
 import { createOnboardingStore } from "@/app/stores/onboarding_store";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 let filtersStore = createFiltersStore();
 let onboardingStore = createOnboardingStore();
-let testQueryClient: QueryClient;
 
 jest.mock("@/app/stores/provider", () => {
   const { useStore } = require("zustand");
@@ -97,315 +98,225 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
+const appId = makeAppFixture().id;
+const secondApp = makeAppFixture({
+  id: "c6a4f9b2-7d3e-4a0b-9f8c-2b3c4d5e6f70",
+  name: "measure spare",
+});
+
 beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
-  testQueryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  filtersStore.getState().reset();
-  for (const key of [...mockSearchParams.keys()]) mockSearchParams.delete(key);
+  queryClient.clear();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
 });
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(
-    <QueryClientProvider client={testQueryClient}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   );
 }
 
-// ====================================================================
-// ALERTS OVERVIEW
-// ====================================================================
 describe("Alerts Overview (MSW integration)", () => {
-  async function renderAndWaitForData() {
-    renderWithProviders(
+  const firstAlert =
+    "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity";
+
+  function renderPage() {
+    return renderWithProviders(
       <AlertsOverview params={promiseParams({ teamId: "test-team" })} />,
-    );
-    await waitFor(
-      () => {
-        expect(
-          screen.getByText(
-            "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity",
-          ),
-        ).toBeTruthy();
-      },
-      { timeout: 5000 },
     );
   }
 
-  // ================================================================
-  // PAGE LOAD
-  // ================================================================
-  describe("page load", () => {
-    it("shows error when API returns 500", async () => {
+  function recordAlertsRequests(page2?: any) {
+    const sent: URL[] = [];
+    server.use(
+      http.get("*/api/apps/:appId/alerts", ({ request }) => {
+        const url = new URL(request.url);
+        sent.push(url);
+        if (page2 && url.searchParams.get("offset") === "5") {
+          return HttpResponse.json(page2);
+        }
+        return HttpResponse.json(makeAlertsOverviewFixture());
+      }),
+    );
+    return sent;
+  }
+
+  async function waitForAlerts() {
+    await waitFor(() => expect(screen.getByText(firstAlert)).toBeTruthy(), {
+      timeout: 5000,
+    });
+  }
+
+  describe("opening the page", () => {
+    it("lists the alerts the server sent", async () => {
+      renderPage();
+      await waitForAlerts();
+
+      expect(screen.getByText("ID: alert-001")).toBeTruthy();
+    });
+
+    it("asks for the app's alerts over the range it settled on", async () => {
+      const sent = recordAlertsRequests();
+      renderPage();
+      await waitForAlerts();
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].pathname).toBe(`/api/apps/${appId}/alerts`);
+      expect(sent[0].searchParams.get("from")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("to")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("timezone")).toBeTruthy();
+      expect(sent[0].searchParams.get("limit")).toBe("5");
+      expect(sent[0].searchParams.get("offset")).toBe("0");
+      expect(sent[0].searchParams.has("filter_short_code")).toBe(false);
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+    });
+
+    it("offers the app and the date range, and nothing else to filter by", async () => {
+      renderPage();
+      await waitForAlerts();
+
+      expect(screen.getByText("measure demo")).toBeTruthy();
+      expect(screen.getByText("Last 6 Hours")).toBeTruthy();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+      expect(screen.queryByText("App versions")).toBeNull();
+      expect(screen.queryByText("OS versions")).toBeNull();
+      expect(screen.queryByText("Countries")).toBeNull();
+    });
+
+    it("records the app and range it settled on in the URL", async () => {
+      renderPage();
+      await waitForAlerts();
+
+      const written = new URLSearchParams(window.location.search);
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(written.get("sd")).toBeNull();
+      expect(written.get("ed")).toBeNull();
+    });
+  });
+
+  describe("pagination", () => {
+    const page2Fixture = makeAlertsOverviewFixture({
+      meta: { next: false, previous: true },
+      results: [
+        {
+          id: "alert-page2",
+          team_id: "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
+          app_id: "b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f",
+          entity_id: "crash-group-page2",
+          type: "crash_spike",
+          message: "Page 2 alert: OutOfMemoryError spike",
+          url: "/test-team/errors/b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f/crash-group-page2",
+          created_at: "2026-04-08T12:00:00Z",
+          updated_at: "2026-04-08T12:00:00Z",
+        },
+      ],
+    });
+
+    it("clicking Next renders page 2 data, Previous returns to page 1", async () => {
+      recordAlertsRequests(page2Fixture);
+      renderPage();
+      await waitForAlerts();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Next").closest("button")!);
+      });
+      await waitFor(
+        () =>
+          expect(
+            screen.getByText("Page 2 alert: OutOfMemoryError spike"),
+          ).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      expect(screen.queryByText(firstAlert)).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Previous").closest("button")!);
+      });
+      await waitForAlerts();
+      expect(
+        screen.queryByText("Page 2 alert: OutOfMemoryError spike"),
+      ).toBeNull();
+      expect(window.location.search).toContain("po=0");
+    });
+
+    it("deep-link with po=5 renders page 2 data", async () => {
+      recordAlertsRequests(page2Fixture);
+      mockRouter.setUrl("po=5");
+      renderPage();
+
+      await waitFor(
+        () =>
+          expect(
+            screen.getByText("Page 2 alert: OutOfMemoryError spike"),
+          ).toBeTruthy(),
+        { timeout: 8000 },
+      );
+      expect(screen.queryByText(firstAlert)).toBeNull();
+    });
+
+    it("goes back to the first page when another app is picked", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () =>
+          HttpResponse.json([makeAppFixture(), secondApp]),
+        ),
+      );
+      const sent = recordAlertsRequests(page2Fixture);
+      mockRouter.setUrl("po=5");
+      renderPage();
+      await waitFor(
+        () =>
+          expect(
+            screen.getByText("Page 2 alert: OutOfMemoryError spike"),
+          ).toBeTruthy(),
+        { timeout: 8000 },
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("measure demo").closest("button")!);
+      });
+      await act(async () => {
+        fireEvent.click(await screen.findByText(secondApp.name));
+      });
+
+      await waitFor(
+        () =>
+          expect(sent[sent.length - 1].pathname).toBe(
+            `/api/apps/${secondApp.id}/alerts`,
+          ),
+        { timeout: 5000 },
+      );
+      expect(sent[sent.length - 1].searchParams.get("offset")).toBe("0");
+      expect(new URLSearchParams(window.location.search).get("po")).toBe("0");
+    });
+  });
+
+  describe("when the server fails", () => {
+    it("shows error when the alerts API returns 500", async () => {
       server.use(
         http.get("*/api/apps/:appId/alerts", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       );
 
-      renderWithProviders(
-        <AlertsOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(/Error fetching list of alerts/),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-    });
-
-    it("only shows app selector and date range filters", async () => {
-      await renderAndWaitForData();
-      // App selector and date range are shown
-      expect(screen.getByText("measure demo")).toBeTruthy();
-      expect(screen.getByText("Last 6 Hours")).toBeTruthy();
-      // Other filters should NOT be present
-      expect(screen.queryByText("App versions")).toBeNull();
-      expect(screen.queryByText("OS versions")).toBeNull();
-      expect(screen.queryByText("Countries")).toBeNull();
-    });
-  });
-
-  // ================================================================
-  // PAGINATION
-  // ================================================================
-  describe("pagination", () => {
-    it("clicking Next renders page 2 data, Previous returns to page 1", async () => {
-      const page2Fixture = makeAlertsOverviewFixture({
-        meta: { next: false, previous: true },
-        results: [
-          {
-            id: "alert-page2",
-            team_id: "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
-            app_id: "b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f",
-            entity_id: "crash-group-page2",
-            type: "crash_spike",
-            message: "Page 2 alert: OutOfMemoryError spike",
-            url: "/test-team/errors/b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f/crash-group-page2",
-            created_at: "2026-04-08T12:00:00Z",
-            updated_at: "2026-04-08T12:00:00Z",
-          },
-        ],
-      });
-
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          const url = new URL(request.url);
-          const offset = url.searchParams.get("offset");
-          if (offset === "5") return HttpResponse.json(page2Fixture);
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
+      renderPage();
       expect(
-        screen.getByText(
-          "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity",
-        ),
+        await screen.findByText(/Error fetching list of alerts/),
       ).toBeTruthy();
-
-      // Navigate to page 2
-      const nextBtn = screen.getByText("Next").closest("button")!;
-      await act(async () => {
-        fireEvent.click(nextBtn);
-      });
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText("Page 2 alert: OutOfMemoryError spike"),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      expect(
-        screen.queryByText(
-          "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity",
-        ),
-      ).toBeNull();
-
-      // Navigate back to page 1
-      const prevBtn = screen.getByText("Previous").closest("button")!;
-      await act(async () => {
-        fireEvent.click(prevBtn);
-      });
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(
-              "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity",
-            ),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      expect(
-        screen.queryByText("Page 2 alert: OutOfMemoryError spike"),
-      ).toBeNull();
-
-      // URL reflects page 1
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      expect(url).toContain("po=0");
     });
 
-    it("deep-link with po=5 renders page 2 data", async () => {
-      const page2Fixture = makeAlertsOverviewFixture({
-        meta: { next: false, previous: true },
-        results: [
-          {
-            id: "alert-page2",
-            team_id: "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
-            app_id: "b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f",
-            entity_id: "crash-group-page2",
-            type: "crash_spike",
-            message: "Deep-linked page 2 alert",
-            url: "/test-team/errors/b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f/crash-group-page2",
-            created_at: "2026-04-08T12:00:00Z",
-            updated_at: "2026-04-08T12:00:00Z",
-          },
-        ],
-      });
-
+    it("says so when the team's apps cannot be fetched", async () => {
       server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          const url = new URL(request.url);
-          const offset = url.searchParams.get("offset");
-          if (offset === "5") return HttpResponse.json(page2Fixture);
-          return HttpResponse.json(makeAlertsOverviewFixture());
+        http.get("*/api/teams/:teamId/apps", () => {
+          return new HttpResponse(null, { status: 500 });
         }),
       );
 
-      mockSearchParams.set("po", "5");
-      renderWithProviders(
-        <AlertsOverview params={promiseParams({ teamId: "test-team" })} />,
-      );
-      await waitFor(
-        () => {
-          expect(screen.getByText("Deep-linked page 2 alert")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-
-      expect(
-        screen.queryByText(
-          "Crash rate spiked to 5.2% for NullPointerException in CheckoutActivity",
-        ),
-      ).toBeNull();
-    });
-  });
-
-  // ================================================================
-  // URL SYNC
-  // ================================================================
-  describe("URL sync", () => {
-    it("serialises app and date filters into URL", async () => {
-      await renderAndWaitForData();
-      expect(mockRouterReplace).toHaveBeenCalled();
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      expect(url).toContain("a=");
-      expect(url).toContain("sd=");
-      expect(url).toContain("ed=");
-    });
-  });
-
-  // ================================================================
-  // REQUEST URL PARAMS
-  // ================================================================
-  describe("request URL params", () => {
-    it("sends limit=5 and offset in request URL", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          requestUrls.push(new URL(request.url).toString());
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("limit=5");
-      expect(lastUrl).toContain("offset=0");
-    });
-
-    it("sends from and to date params", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          requestUrls.push(new URL(request.url).toString());
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      const lastUrl = requestUrls[requestUrls.length - 1];
-      expect(lastUrl).toContain("from=");
-      expect(lastUrl).toContain("to=");
-      expect(lastUrl).toContain("timezone=");
-    });
-
-    it("request URL contains correct app ID from filters", async () => {
-      const requestPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          requestPaths.push(new URL(request.url).pathname);
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      expect(requestPaths[requestPaths.length - 1]).toContain(
-        `/apps/${makeAppFixture().id}/alerts`,
-      );
-    });
-
-    it("offset updates in request URL after nextPage", async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          requestUrls.push(new URL(request.url).toString());
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      requestUrls.length = 0;
-
-      const nextBtn = screen.getByText("Next").closest("button")!;
-      await act(async () => {
-        fireEvent.click(nextBtn);
-      });
-      await waitFor(() => expect(requestUrls.length).toBeGreaterThan(0), {
-        timeout: 5000,
-      });
-      expect(requestUrls[requestUrls.length - 1]).toContain("offset=5");
-    });
-  });
-
-  // ================================================================
-  // API PATH VERIFICATION
-  // ================================================================
-  describe("API paths", () => {
-    it("fetches from /alerts path", async () => {
-      const requestPaths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/alerts", ({ request }) => {
-          requestPaths.push(new URL(request.url).pathname);
-          return HttpResponse.json(makeAlertsOverviewFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      expect(requestPaths.some((p) => p.includes("/alerts"))).toBe(true);
+      renderPage();
+      expect(await screen.findByText(/Error fetching apps/)).toBeTruthy();
     });
   });
 });

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -420,6 +420,13 @@ export const handlers = [
     if (entity === "journeys") {
       return HttpResponse.json(makeJourneysFilterKeysFixture());
     }
+    if (entity === "alerts") {
+      return HttpResponse.json({
+        keys: [],
+        key_groups: [],
+        keys_truncated: false,
+      });
+    }
     return HttpResponse.json(makeFilterKeysFixture());
   }),
 

--- a/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
@@ -1,62 +1,99 @@
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { promiseParams } from "@/__tests__/helpers/promise_params";
-import AlertsOverview from "@/app/[teamId]/alerts/page";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-// Global replace mock for router.replace
-const replaceMock = jest.fn();
-const pushMock = jest.fn();
+const pushMock = mockRouter.pushMock;
 
-// Mock next/navigation hooks
-let mockSearchParams = new URLSearchParams();
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-    push: pushMock,
-  }),
-  // By default, return empty search params.
-  useSearchParams: () => mockSearchParams,
-}));
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
-// Mock API calls and constants
-jest.mock("@/app/api/api_calls", () => ({
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
+
+const mockToastNegative = jest.fn();
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  emptyAlertsOverviewResponse: {
-    meta: { next: false, previous: false },
-    results: [],
-  },
-  FilterSource: { Events: "events" },
+  toastNegative: (text: string) => mockToastNegative(text),
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
-});
-
-const mockUseAlertsOverviewQuery = jest.fn(() => ({
+const pendingQueryState = () => ({
   data: undefined as any,
   status: "pending" as string,
   isFetching: true,
   error: null as Error | null,
-}));
+});
+
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
+const mockUseAlertsOverviewQuery = jest.fn((_filter: any, _offset: number) =>
+  pendingQueryState(),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useAlertsOverviewQuery: () => mockUseAlertsOverviewQuery(),
   paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
+  useAlertsOverviewQuery: (filter: any, offset: number) =>
+    mockUseAlertsOverviewQuery(filter, offset),
 }));
 
-jest.mock("@/app/components/filters", () => ({
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { All: "all" },
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-app">
+        {props.value?.app.name ?? "none"}
+      </span>
+      <span data-testid="filter-bar-date">
+        {props.value?.date.dateRange ?? "none"}
+      </span>
+      <span data-testid="filter-bar-show-expr">
+        {String(props.showFilterExpr)}
+      </span>
+      <button
+        data-testid="filter-bar-other-app"
+        onClick={() => props.onChange({ appId: props.apps[1].id })}
+      >
+        pick the other app
+      </button>
+      <button
+        data-testid="filter-bar-last-week"
+        onClick={() =>
+          props.onChange({
+            dateRange: {
+              dateRange: "Last Week",
+              startDate: null,
+              endDate: null,
+            },
+          })
+        }
+      >
+        last week
+      </button>
+    </div>
+  ),
 }));
 
-// Updated Paginator mock renders Next and Prev buttons.
+jest.mock("@/app/components/skeleton", () => ({
+  __esModule: true,
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
+}));
+
 jest.mock("@/app/components/paginator", () => ({
   __esModule: true,
   default: (props: any) => (
@@ -80,398 +117,315 @@ jest.mock("@/app/components/paginator", () => ({
   ),
 }));
 
-// Mock LoadingBar component.
 jest.mock("@/app/components/loading_bar", () => () => (
   <div data-testid="loading-bar-mock">LoadingBar Rendered</div>
 ));
 
-// Mock time utils
 jest.mock("@/app/utils/time_utils", () => ({
   formatDateToHumanReadableDate: jest.fn(() => "Jan 1, 2020"),
   formatDateToHumanReadableTime: jest.fn(() => "12:00 AM"),
 }));
 
-const { useFiltersStore } = require("@/app/stores/provider") as any;
+import AlertsOverview from "@/app/[teamId]/alerts/page";
 
-const mockAlertData = {
-  results: [
-    {
-      id: "alert1",
-      team_id: "team1",
-      app_id: "app1",
-      entity_id: "crash1",
-      type: "crash_spike",
-      message: "message1",
-      url: "http://example.com/alert1",
-      created_at: "2020-01-01T00:00:00Z",
-      updated_at: "2020-01-01T00:00:00Z",
-    },
-  ],
+const mockApps = [
+  { id: "app-1", name: "Sample" },
+  { id: "app-2", name: "Second" },
+];
+
+const mockAlertResult = {
+  id: "alert1",
+  team_id: "team1",
+  app_id: "app1",
+  entity_id: "crash1",
+  type: "crash_spike",
+  message: "message1",
+  url: "http://example.com/alert1",
+  created_at: "2020-01-01T00:00:00Z",
+  updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockAlertsData = {
+  results: [mockAlertResult],
   meta: { previous: true, next: true },
 };
 
-describe("AlertsOverview Component", () => {
+function alertsLoaded(data: any = mockAlertsData) {
+  mockUseAlertsOverviewQuery.mockReturnValue({
+    data,
+    status: "success",
+    isFetching: false,
+    error: null,
+  });
+}
+
+const settled = { a: "app-1", d: "Last 6 Hours" };
+
+function renderPage() {
+  return render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
+}
+
+describe("AlertsOverview page", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
-    pushMock.mockClear();
-    mockSearchParams = new URLSearchParams();
+    mockRouter.reset();
+    mockFiltersStore.reset();
+    mockToastNegative.mockClear();
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: mockApps });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [], key_groups: [] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
     mockUseAlertsOverviewQuery.mockReset();
-    mockUseAlertsOverviewQuery.mockReturnValue({
+    mockUseAlertsOverviewQuery.mockReturnValue(pendingQueryState());
+  });
+
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("none");
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
+    expect(mockUseAlertsOverviewQuery).toHaveBeenLastCalledWith(null, 0);
+  });
+
+  it("hands the bar the app and range it settled on", () => {
+    alertsLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-app")).toHaveTextContent("Sample");
+    expect(screen.getByTestId("filter-bar-date")).toHaveTextContent(
+      "Last 6 Hours",
+    );
+  });
+
+  it("asks the bar for the app and range alone", () => {
+    alertsLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("filter-bar-show-expr")).toHaveTextContent(
+      "false",
+    );
+  });
+
+  it("asks for the alerts entity's keys, and says so when they cannot be fetched", () => {
+    mockUseFilterKeysQuery.mockReturnValue({
       data: undefined,
-      status: "pending" as string,
-      isFetching: true,
-      error: null,
+      isPending: false,
+      isError: true,
+      isPlaceholderData: false,
     });
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
+    renderPage();
+
+    expect(mockUseFilterKeysQuery).toHaveBeenCalledWith("app-1", "alerts", []);
+    expect(
+      screen.getByText(
+        "Error fetching filters, please refresh page to try again",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Alert")).not.toBeInTheDocument();
   });
 
-  it("renders the Filters component", () => {
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
+  it("fetches the alerts of the app and range it settled on", () => {
+    alertsLoaded();
+    renderPage();
+
+    expect(mockUseAlertsOverviewQuery).toHaveBeenLastCalledWith(
+      {
+        appId: "app-1",
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+        filterExpr: null,
+      },
+      0,
+    );
   });
 
-  it("does not render main alerts UI when filters are not ready", () => {
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    expect(screen.queryByTestId("paginator-mock")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("loading-bar-mock")).not.toBeInTheDocument();
-    expect(screen.queryByText("Alert Id")).not.toBeInTheDocument();
+  it("records the app and range it settled on in the URL", () => {
+    alertsLoaded();
+    renderPage();
+
+    expect(mockRouter.urlParams()).toEqual(settled);
   });
 
-  it("renders main bug reports UI, updates URL when filters become ready, and renders table headers", async () => {
-    mockUseAlertsOverviewQuery.mockReturnValue({
-      data: mockAlertData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("fetches the page the URL names", () => {
+    mockRouter.setUrl("?po=5&a=app-1&d=Last+6+Hours");
+    alertsLoaded();
+    renderPage();
 
-    // Check URL update.
-    expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-      scroll: false,
-    });
-
-    // Verify main UI components are rendered.
-    expect(await screen.findByTestId("paginator-mock")).toBeInTheDocument();
-    // Check that the table header cells are rendered.
-    expect(screen.getByText("Alert")).toBeInTheDocument();
-    expect(screen.getByText("Time")).toBeInTheDocument();
+    expect(mockUseAlertsOverviewQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ appId: "app-1" }),
+      5,
+    );
   });
 
-  it("displays alert data correctly when API returns results", async () => {
-    mockUseAlertsOverviewQuery.mockReturnValue({
-      data: mockAlertData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("discards a filter expression a link carried, and starts from page one", () => {
+    mockRouter.setUrl(
+      "?po=30&a=app-1&d=Last+6+Hours&filter_expr=version_name%3Ain%3A1.0",
+    );
+    alertsLoaded();
+    renderPage();
 
-    // Verify the alert data is displayed
-    expect(screen.getByText("message1")).toBeInTheDocument();
-    expect(screen.getByText("Jan 1, 2020")).toBeInTheDocument();
-    expect(screen.getByText("12:00 AM")).toBeInTheDocument();
-    expect(screen.getByText("ID: alert1")).toBeInTheDocument();
+    expect(mockToastNegative).toHaveBeenCalledWith(
+      "Some filters were invalid, page reset to defaults",
+    );
+    expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+    for (const [params] of mockUseAlertsOverviewQuery.mock.calls) {
+      expect(params?.filterExpr ?? null).toBeNull();
+    }
   });
 
-  it("shows error message when API returns error status", async () => {
+  it("shows an error message when the alerts request fails", () => {
     mockUseAlertsOverviewQuery.mockReturnValue({
       data: undefined,
       status: "error",
       isFetching: false,
       error: new Error("fail"),
     });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+    renderPage();
 
-    // Check that error message is displayed
     expect(
       screen.getByText(/Error fetching list of alerts/),
     ).toBeInTheDocument();
   });
 
-  it("renders appropriate link for each alert ", async () => {
-    mockUseAlertsOverviewQuery.mockReturnValue({
-      data: mockAlertData,
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("renders the table headers and the alerts the server sent", () => {
+    alertsLoaded();
+    renderPage();
 
-    // Check that the alert link is rendered with the correct href and accessible name
+    expect(screen.getByText("Alert")).toBeInTheDocument();
+    expect(screen.getByText("Time")).toBeInTheDocument();
+    expect(screen.getByText("ID: alert1")).toBeInTheDocument();
+    expect(screen.getByText("message1")).toBeInTheDocument();
+    expect(screen.getByText("Jan 1, 2020")).toBeInTheDocument();
+    expect(screen.getByText("12:00 AM")).toBeInTheDocument();
+  });
+
+  it("links each alert to where it happened, by click and by keyboard", async () => {
+    alertsLoaded();
+    renderPage();
+
     const link = screen.getByRole("link", { name: /ID: alert1/i });
-    expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "http://example.com/alert1");
 
-    // Find the table row that contains this link
     const row = link.closest("tr");
-    expect(row).toBeInTheDocument();
-
-    // Simulate keyboard navigation (Enter) on the row
     await act(async () => {
       fireEvent.keyDown(row!, { key: "Enter" });
     });
     expect(pushMock).toHaveBeenCalledWith("http://example.com/alert1");
 
-    // Simulate keyboard navigation (Space) on the row
     await act(async () => {
       fireEvent.keyDown(row!, { key: " " });
     });
     expect(pushMock).toHaveBeenCalledWith("http://example.com/alert1");
   });
 
-  it("renders the table shell with both paginator buttons disabled when results are empty", async () => {
-    mockUseAlertsOverviewQuery.mockReturnValue({
-      data: { results: [], meta: { previous: false, next: false } },
-      status: "success",
-      isFetching: false,
-      error: null,
-    });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
+  it("renders the table shell with paging off when there are no alerts", () => {
+    alertsLoaded({ results: [], meta: { previous: false, next: false } });
+    renderPage();
 
     expect(screen.getByText("Alert")).toBeInTheDocument();
-    expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.queryByText(/ID:/)).not.toBeInTheDocument();
     expect(screen.getByTestId("prev-button")).toBeDisabled();
     expect(screen.getByTestId("next-button")).toBeDisabled();
   });
 
-  describe("Pagination offset handling", () => {
-    it("initializes pagination offset to 0 when no offset is provided", async () => {
-      mockUseAlertsOverviewQuery.mockReturnValue({
-        data: mockAlertData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
+  describe("pagination", () => {
+    it("moves the offset on by the page size when Next is clicked", async () => {
+      mockRouter.setUrl("?po=0&a=app-1&d=Last+6+Hours");
+      alertsLoaded();
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("next-button"));
       });
-      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-        scroll: false,
+
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "5" });
+    });
+
+    it("moves the offset back when Prev is clicked, and never below zero", async () => {
+      mockRouter.setUrl("?po=5&a=app-1&d=Last+6+Hours");
+      alertsLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("prev-button"));
+      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("prev-button"));
+      });
+      expect(mockRouter.urlParams()).toEqual({ ...settled, po: "0" });
+    });
+
+    it("goes back to the first page when another app is picked", async () => {
+      mockRouter.setUrl("?po=30&a=app-1&d=Last+6+Hours");
+      alertsLoaded();
+      renderPage();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("filter-bar-other-app"));
+      });
+
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-2",
+        d: "Last 6 Hours",
+        po: "0",
       });
     });
 
-    it("increments pagination offset when Next is clicked", async () => {
-      mockUseAlertsOverviewQuery.mockReturnValue({
-        data: mockAlertData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
+    it("goes back to the first page when another range is picked", async () => {
+      mockRouter.setUrl("?po=30&a=app-1&d=Last+6+Hours");
+      alertsLoaded();
+      renderPage();
+
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
+        fireEvent.click(screen.getByTestId("filter-bar-last-week"));
       });
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      // The pagination limit is 5 so offset should be 5.
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
+
+      expect(mockRouter.urlParams()).toEqual({
+        a: "app-1",
+        d: "Last Week",
+        po: "0",
       });
     });
 
-    it("decrements pagination offset when Prev is clicked, but not below 0", async () => {
+    it("cannot be used while a refetch is in flight", () => {
       mockUseAlertsOverviewQuery.mockReturnValue({
-        data: mockAlertData,
+        data: mockAlertsData,
         status: "success",
-        isFetching: false,
+        isFetching: true,
         error: null,
       });
-      render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
-      });
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
-      const prevButton = await screen.findByTestId("prev-button");
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-      await act(async () => {
-        fireEvent.click(prevButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-    });
+      renderPage();
 
-    it("resets pagination offset to 0 when filters change (if previous filters were non-default)", async () => {
-      mockUseAlertsOverviewQuery.mockReturnValue({
-        data: mockAlertData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-
-      render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated",
-            app: { id: "app-1" },
-          },
-        });
-      });
-      expect(replaceMock).toHaveBeenCalledWith("?po=0&updated", {
-        scroll: false,
-      });
-
-      // Click Next twice to get to offset 10.
-      const nextButton = await screen.findByTestId("next-button");
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=5&updated", {
-        scroll: false,
-      });
-
-      await act(async () => {
-        fireEvent.click(nextButton);
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=10&updated", {
-        scroll: false,
-      });
-
-      // Now simulate a filter change with a different value.
-      await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            serialisedFilters: "updated2",
-            app: { id: "app-1" },
-          },
-        });
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-      expect(replaceMock).toHaveBeenLastCalledWith("?po=0&updated2", {
-        scroll: false,
-      });
+      expect(screen.getByTestId("next-button")).toBeDisabled();
+      expect(screen.getByTestId("prev-button")).toBeDisabled();
     });
   });
 
-  it("correctly toggles loading bar visibility based on API status", async () => {
-    // Start with pending status
+  it("shows the loading bar only while a refetch is in flight", async () => {
     mockUseAlertsOverviewQuery.mockReturnValue({
-      data: undefined,
-      status: "pending" as string,
+      data: mockAlertsData,
+      status: "success",
       isFetching: true,
       error: null,
     });
-    render(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
+    const { rerender } = renderPage();
 
-    // Set loading state
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
-    });
-
-    // Test the loading state - loading bar should be visible
     const loadingBarContainer =
       screen.getByTestId("loading-bar-mock").parentElement;
     expect(loadingBarContainer).toHaveClass("visible");
     expect(loadingBarContainer).not.toHaveClass("invisible");
 
-    // Set success state
     await act(async () => {
-      mockUseAlertsOverviewQuery.mockReturnValue({
-        data: mockAlertData,
-        status: "success",
-        isFetching: false,
-        error: null,
-      });
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          serialisedFilters: "updated",
-          app: { id: "app-1" },
-        },
-      });
+      alertsLoaded();
+      rerender(<AlertsOverview params={promiseParams({ teamId: "123" })} />);
     });
 
-    // After loading, the loading bar should be invisible
+    await screen.findByText("message1");
     expect(loadingBarContainer).not.toHaveClass("visible");
     expect(loadingBarContainer).toHaveClass("invisible");
   });

--- a/frontend/dashboard/app/[teamId]/alerts/page.tsx
+++ b/frontend/dashboard/app/[teamId]/alerts/page.tsx
@@ -1,10 +1,8 @@
 "use client";
-import { useFiltersStore } from "@/app/stores/provider";
 
-import { FilterSource, emptyAlertsOverviewResponse } from "@/app/api/api_calls";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import { emptyAlertsOverviewResponse } from "@/app/api/api_calls";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import LoadingBar from "@/app/components/loading_bar";
 import Paginator from "@/app/components/paginator";
 import { SkeletonListPage } from "@/app/components/skeleton";
@@ -16,17 +14,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/components/table";
-import {
-  paginationOffsetUrlKey,
-  useAlertsOverviewQuery,
-} from "@/app/query/hooks";
+import { useAlertsOverviewQuery } from "@/app/query/hooks";
 import {
   formatDateToHumanReadableDate,
   formatDateToHumanReadableTime,
 } from "@/app/utils/time_utils";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { use, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { use } from "react";
 
 const PAGINATION_LIMIT = 5;
 
@@ -35,76 +30,64 @@ export default function AlertsOverview(props: {
 }) {
   const params = use(props.params);
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const filters = useFiltersStore((state) => state.filters);
-
-  // Pagination is component-local state, initialized from URL
-  const [paginationOffset, setPaginationOffset] = useState(() => {
-    const po = searchParams.get(paginationOffsetUrlKey);
-    return po ? parseInt(po) : 0;
+  const {
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status: filterStatus,
+    filterParams,
+    paginationOffset,
+    onChange,
+    nextPage,
+    prevPage,
+  } = useExprFilterPage({
+    teamId: params.teamId,
+    entity: "alerts",
+    paginationLimit: PAGINATION_LIMIT,
   });
-
-  // Reset pagination when filters change (skip pre-ready transitions)
-  const prevFiltersRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!filters.ready) return;
-    if (
-      prevFiltersRef.current !== null &&
-      prevFiltersRef.current !== filters.serialisedFilters
-    ) {
-      setPaginationOffset(0);
-    }
-    prevFiltersRef.current = filters.serialisedFilters;
-  }, [filters.ready, filters.serialisedFilters]);
-
-  // URL sync
-  useEffect(() => {
-    if (!filters.ready) {
-      return;
-    }
-    router.replace(
-      `?${paginationOffsetUrlKey}=${encodeURIComponent(paginationOffset)}&${filters.serialisedFilters!}`,
-      { scroll: false },
-    );
-  }, [paginationOffset, filters.ready, filters.serialisedFilters]);
+  const readyValue = filterStatus.kind === "ready" ? value : null;
 
   const {
     data: alertsOverview = emptyAlertsOverviewResponse,
     status,
     isFetching,
-  } = useAlertsOverviewQuery(paginationOffset);
-
-  const nextPage = () => setPaginationOffset((o) => o + PAGINATION_LIMIT);
-  const prevPage = () =>
-    setPaginationOffset((o) => Math.max(0, o - PAGINATION_LIMIT));
+  } = useAlertsOverviewQuery(filterParams, paginationOffset);
 
   return (
     <div className="flex flex-col items-start">
       <div className="py-4" />
 
-      <Filters
-        teamId={params.teamId}
-        filterSource={FilterSource.Events}
-        appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-        showAppVersions={false}
+      <FilterBar
+        entity="alerts"
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
+        showFilterExpr={false}
+        onChange={onChange}
       />
       <div className="py-4" />
 
-      {filters.loading && (
+      {filterStatus.kind === "error" && (
+        <p className="text-lg font-display">{filterStatus.message}</p>
+      )}
+
+      {filterStatus.kind === "loading" && (
         <SkeletonListPage showPlot={false} tableColumns={2} />
       )}
 
-      {/* Error state for alerts fetch */}
-      {filters.ready && status === "error" && (
+      {readyValue !== null && status === "error" && (
         <p className="text-lg font-display">
           Error fetching list of alerts, please change filters, refresh page or
           select a different app to try again
         </p>
       )}
 
-      {/* Main alerts list UI */}
-      {filters.ready && (status === "success" || status === "pending") && (
+      {readyValue !== null && status !== "error" && (
         <div className="flex flex-col items-center w-full">
           <div className="self-end">
             <Paginator

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -1888,19 +1888,23 @@ export const fetchSpanMetricsPlotFromServer = async (
 };
 
 export const fetchAlertsOverviewFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
   limit: number,
   offset: number,
 ) => {
-  var url = `/api/apps/${filters.app!.id}/alerts?`;
-
-  url = await applyGenericFiltersToUrl(url, filters, limit, offset);
-
-  const data = await request(url, {
-    failsWith: "Failed to fetch alerts overview",
+  const params = new URLSearchParams({
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+    limit: String(limit),
+    offset: String(offset),
   });
 
-  return data;
+  return await request(`/api/apps/${appId}/alerts?${params.toString()}`, {
+    failsWith: "Failed to fetch alerts overview",
+  });
 };
 
 export const fetchSdkConfigFromServer = async (appId: String) => {

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -76,6 +76,9 @@ interface FilterBarProps {
   keysUnavailable: boolean;
   spanNames?: string[] | null;
   filterExprIssues?: FilterExprIssue[] | null;
+  // False hides the filter expression editor and keeps the app and date
+  // range controls.
+  showFilterExpr?: boolean;
   onChange: (change: FilterChange) => void;
 }
 
@@ -188,6 +191,7 @@ export default function FilterBar({
   keysUnavailable,
   spanNames,
   filterExprIssues,
+  showFilterExpr = true,
   onChange,
 }: FilterBarProps) {
   const [keyListOpen, setKeyListOpen] = useState(false);
@@ -307,7 +311,7 @@ export default function FilterBar({
       <div className="flex flex-wrap gap-4 items-center w-full">
         <Skeleton className="h-9 w-37.5" />
         <Skeleton className="h-9 w-37.5" />
-        <Skeleton className="h-9 flex-1 min-w-64" />
+        {showFilterExpr && <Skeleton className="h-9 flex-1 min-w-64" />}
       </div>
     );
   }
@@ -568,137 +572,134 @@ export default function FilterBar({
           />
         ) : null)}
 
-      <div className="flex-auto min-w-64">
-        <div
-          data-testid="filter-bar"
-          aria-disabled={keysUnavailable}
-          // Ring on keyboard focus only: focus returns here after every pick.
-          className={`relative rounded-md border border-input bg-transparent dark:bg-input/30 shadow-xs has-focus-visible:border-ring has-focus-visible:ring-ring/50 has-focus-visible:ring-[3px] ${
-            keysUnavailable ? "opacity-50 select-none" : ""
-          } ${!editingAsText && !keysUnavailable ? "cursor-pointer" : ""}`}
-          // The conditions never cover the whole bar: the padding around them,
-          // the room left at the end of a line a condition was too wide to join,
-          // and the space after the last one are all empty. A click on any of it
-          // opens the key list, so every empty part of the bar adds a condition
-          // rather than only the part the button behind them happens to cover.
-          // Each control in the bar is a button, so a click that reaches one is
-          // left for it to handle.
-          onClick={(e) => {
-            if (editingAsText || keysUnavailable) {
-              return;
-            }
-            if ((e.target as HTMLElement).closest("button")) {
-              return;
-            }
-            setKeyListOpen(true);
-          }}
-        >
-          <SlidersHorizontal className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground pointer-events-none z-10" />
-
-          <div className="pl-8 pr-16">
-            {editingAsText ? (
-              <FilterTextEditor
-                value={draftText}
-                tokens={parsedDraft.tokens}
-                issues={draftFilterIssues}
-                parserStopped={parserStopped}
-                placeholder={placeholder}
-                onChange={setTypedText}
-                onApply={applyFilterText}
-                onCancel={cancelTextEditing}
-              />
-            ) : (
-              <div className="flex flex-wrap items-center gap-1.5 py-1.5 min-h-9 max-h-32 overflow-y-auto">
-                {keysUnavailable && (
-                  <span className="flex-1 min-w-24 h-6 font-body text-sm text-muted-foreground select-none">
-                    {placeholder}
-                  </span>
-                )}
-
-                {!keysUnavailable && (
-                  <GroupChildren group={drawn} editor={editor} />
-                )}
-
-                {!keysUnavailable && (
-                  <KeyPicker
-                    keys={keys}
-                    keyGroups={keyGroups}
-                    selected={null}
-                    open={keyListOpen}
-                    onOpenChange={setKeyListOpen}
-                    focusOnClose={focusedControlRef}
-                    onSelect={(key) => startRow(drawn.id, key)}
-                    onAddGroup={() => startGroup(drawn.id)}
-                    trigger={
-                      <button
-                        type="button"
-                        ref={addConditionButtonRef}
-                        data-testid="filter-input"
-                        aria-label="Add a filter"
-                        // Match the height of adjacent conditions.
-                        // Without conditions, fill the bar to center the placeholder.
-                        // With conditions, stay compact and anchor the key list.
-                        className={`self-stretch min-h-2 text-left outline-none font-body text-sm text-muted-foreground ${
-                          drawn.children.length === 0
-                            ? "flex-1"
-                            : "flex-none w-4"
-                        }`}
-                      >
-                        {drawn.children.length === 0 ? placeholder : ""}
-                      </button>
-                    }
-                  />
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="absolute right-2 top-1.5 flex items-center gap-0.5">
-            {!keysUnavailable && (
-              <button
-                type="button"
-                aria-label={
-                  editingAsText ? "Edit as conditions" : "Edit as text"
-                }
-                aria-pressed={editingAsText}
-                data-testid="filter-toggle-text"
-                title={editingAsText ? "Edit as conditions" : "Edit as text"}
-                onClick={toggleTextEditing}
-                className={`h-6 w-6 inline-flex items-center justify-center rounded hover:bg-accent hover:text-foreground ${
-                  editingAsText
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground"
-                }`}
-              >
-                <Type className="h-3 w-3" />
-              </button>
-            )}
-
-            {draftText !== "" && (
-              <button
-                type="button"
-                aria-label="Clear filter"
-                data-testid="filter-clear"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={clearFilter}
-                className="h-6 w-6 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            )}
-          </div>
-        </div>
-
-        {draftIssueMessage && (
-          <p
-            role="alert"
-            data-testid="filter-issue"
-            className="mt-2 font-body text-xs text-muted-foreground"
+      {showFilterExpr && (
+        <div className="flex-auto min-w-64">
+          <div
+            data-testid="filter-bar"
+            aria-disabled={keysUnavailable}
+            // The focus ring shows on keyboard focus only, since focus returns
+            // here after every pick.
+            className={`relative rounded-md border border-input bg-transparent dark:bg-input/30 shadow-xs has-focus-visible:border-ring has-focus-visible:ring-ring/50 has-focus-visible:ring-[3px] ${
+              keysUnavailable ? "opacity-50 select-none" : ""
+            } ${!editingAsText && !keysUnavailable ? "cursor-pointer" : ""}`}
+            // A click on empty space anywhere in the bar opens the key list.
+            // A click that reaches a button is left to that button.
+            onClick={(e) => {
+              if (editingAsText || keysUnavailable) {
+                return;
+              }
+              if ((e.target as HTMLElement).closest("button")) {
+                return;
+              }
+              setKeyListOpen(true);
+            }}
           >
-            {draftIssueMessage}
-          </p>
-        )}
-      </div>
+            <SlidersHorizontal className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground pointer-events-none z-10" />
+
+            <div className="pl-8 pr-16">
+              {editingAsText ? (
+                <FilterTextEditor
+                  value={draftText}
+                  tokens={parsedDraft.tokens}
+                  issues={draftFilterIssues}
+                  parserStopped={parserStopped}
+                  placeholder={placeholder}
+                  onChange={setTypedText}
+                  onApply={applyFilterText}
+                  onCancel={cancelTextEditing}
+                />
+              ) : (
+                <div className="flex flex-wrap items-center gap-1.5 py-1.5 min-h-9 max-h-32 overflow-y-auto">
+                  {keysUnavailable && (
+                    <span className="flex-1 min-w-24 h-6 font-body text-sm text-muted-foreground select-none">
+                      {placeholder}
+                    </span>
+                  )}
+
+                  {!keysUnavailable && (
+                    <GroupChildren group={drawn} editor={editor} />
+                  )}
+
+                  {!keysUnavailable && (
+                    <KeyPicker
+                      keys={keys}
+                      keyGroups={keyGroups}
+                      selected={null}
+                      open={keyListOpen}
+                      onOpenChange={setKeyListOpen}
+                      focusOnClose={focusedControlRef}
+                      onSelect={(key) => startRow(drawn.id, key)}
+                      onAddGroup={() => startGroup(drawn.id)}
+                      trigger={
+                        <button
+                          type="button"
+                          ref={addConditionButtonRef}
+                          data-testid="filter-input"
+                          aria-label="Add a filter"
+                          // Fills the bar when it holds no conditions so the
+                          // placeholder is centred, otherwise stays narrow.
+                          className={`self-stretch min-h-2 text-left outline-none font-body text-sm text-muted-foreground ${
+                            drawn.children.length === 0
+                              ? "flex-1"
+                              : "flex-none w-4"
+                          }`}
+                        >
+                          {drawn.children.length === 0 ? placeholder : ""}
+                        </button>
+                      }
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="absolute right-2 top-1.5 flex items-center gap-0.5">
+              {!keysUnavailable && (
+                <button
+                  type="button"
+                  aria-label={
+                    editingAsText ? "Edit as conditions" : "Edit as text"
+                  }
+                  aria-pressed={editingAsText}
+                  data-testid="filter-toggle-text"
+                  title={editingAsText ? "Edit as conditions" : "Edit as text"}
+                  onClick={toggleTextEditing}
+                  className={`h-6 w-6 inline-flex items-center justify-center rounded hover:bg-accent hover:text-foreground ${
+                    editingAsText
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  <Type className="h-3 w-3" />
+                </button>
+              )}
+
+              {draftText !== "" && (
+                <button
+                  type="button"
+                  aria-label="Clear filter"
+                  data-testid="filter-clear"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={clearFilter}
+                  className="h-6 w-6 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          </div>
+
+          {draftIssueMessage && (
+            <p
+              role="alert"
+              data-testid="filter-issue"
+              className="mt-2 font-body text-xs text-muted-foreground"
+            >
+              {draftIssueMessage}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -649,18 +649,29 @@ export function useSpanMetricsPlotQuery(
 
 const ALERTS_LIMIT = 5;
 
-export function useAlertsOverviewQuery(paginationOffset: number) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useAlertsOverviewQuery(
+  params: FilterParams | null,
+  paginationOffset: number,
+) {
   return useQuery({
     queryKey: [
       "alertsOverview",
-      filters.serialisedFilters,
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
       paginationOffset,
     ] as const,
     placeholderData: keepPreviousData,
     queryFn: () =>
-      fetchAlertsOverviewFromServer(filters, ALERTS_LIMIT, paginationOffset),
-    enabled: filters.ready,
+      fetchAlertsOverviewFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        ALERTS_LIMIT,
+        paginationOffset,
+      ),
+    enabled: params !== null,
+    retry: false,
   });
 }
 

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -995,6 +995,7 @@ paths:
               - spans
               - bug_reports
               - journeys
+              - alerts
         - name: key
           in: query
           required: false
@@ -1118,6 +1119,7 @@ paths:
               - spans
               - bug_reports
               - journeys
+              - alerts
         - name: key_name
           in: query
           required: true
@@ -3988,7 +3990,7 @@ paths:
         - Alerts
       summary: Fetch an app's alerts
       description: |
-        Fetch an app's alerts by applying various optional filters.
+        Fetch an app's alerts. Alerts are scoped by app and time range.
 
         Pass `limit` and `offset` values to paginate results.
       parameters:
@@ -4013,12 +4015,6 @@ paths:
           description: Number of items to return. Used for pagination. Should be used along with `offset`.
           schema:
             type: integer
-        - name: filter_short_code
-          in: query
-          required: false
-          description: Code representing combination of filters.
-          schema:
-            type: string
       responses:
         "200":
           description: Successful response, no errors.


### PR DESCRIPTION
# Description

- add a keyless alerts filter entity so the alerts endpoint, MCP tool and page share the expression filter mechanism, leaving the legacy AppFilter path with one less user
- alerts page reads and writes its state through the URL like the other migrated pages
- FilterBar gains showFilterExpr to hide the expression editor on pages that only scope by app and date range



