### PR TITLE
feat(android): attach layout snapshots to lifecycle and screen views

### DIFF
--- a/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
+++ b/android/measure-android/measure/src/androidTest/java/sh/measure/android/TestMeasureInitializer.kt
@@ -40,6 +40,8 @@ import sh.measure.android.exporter.NetworkClientImpl
 import sh.measure.android.gestures.GestureCollector
 import sh.measure.android.httpurl.HttpUrlConnectionEventCollector
 import sh.measure.android.httpurl.HttpUrlConnectionEventCollectorImpl
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
+import sh.measure.android.layoutinspector.LayoutSnapshotCollectorImpl
 import sh.measure.android.layoutinspector.LayoutSnapshotThrottler
 import sh.measure.android.lifecycle.AppLifecycleCollector
 import sh.measure.android.lifecycle.AppLifecycleManager
@@ -266,12 +268,19 @@ internal class TestMeasureInitializer(
         exporter = exporter,
         sampler = sampler,
     ),
+    override val layoutSnapshotCollector: LayoutSnapshotCollector = LayoutSnapshotCollectorImpl(
+        logger = logger,
+        resumedActivityProvider = resumedActivityProvider,
+        defaultExecutor = executorServiceRegistry.defaultExecutor(),
+        layoutSnapshotThrottler = LayoutSnapshotThrottler(timeProvider),
+    ),
     override val userTriggeredEventCollector: UserTriggeredEventCollector = UserTriggeredEventCollectorImpl(
         logger = logger,
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         processInfoProvider = processInfoProvider,
         configProvider = configProvider,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     override val unhandledExceptionCollector: UnhandledExceptionCollector = UnhandledExceptionCollector(
         logger = logger,
@@ -343,18 +352,21 @@ internal class TestMeasureInitializer(
         appLifecycleManager = appLifecycleManager,
         configProvider = configProvider,
         tracer = tracer,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     override val appLifecycleCollector: AppLifecycleCollector = AppLifecycleCollector(
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         appLifecycleManager = appLifecycleManager,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     override val gestureCollector: GestureCollector = GestureCollector(
         logger = logger,
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         defaultExecutor = executorServiceRegistry.defaultExecutor(),
-        layoutSnapshotThrottler = LayoutSnapshotThrottler(configProvider, timeProvider),
+        layoutSnapshotThrottler = LayoutSnapshotThrottler(timeProvider),
+        configProvider = configProvider,
     ),
     private val launchTracker: LaunchTracker = LaunchTracker(
         logger,
@@ -446,5 +458,6 @@ internal class TestMeasureInitializer(
         processInfoProvider = processInfoProvider,
         sessionManager = sessionManager,
         spanAttributeProcessors = spanAttributeProcessors,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
 ) : MeasureInitializer

--- a/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/MeasureInitializer.kt
@@ -44,6 +44,8 @@ import sh.measure.android.exporter.NetworkClientImpl
 import sh.measure.android.gestures.GestureCollector
 import sh.measure.android.httpurl.HttpUrlConnectionEventCollector
 import sh.measure.android.httpurl.HttpUrlConnectionEventCollectorImpl
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
+import sh.measure.android.layoutinspector.LayoutSnapshotCollectorImpl
 import sh.measure.android.layoutinspector.LayoutSnapshotThrottler
 import sh.measure.android.lifecycle.ActivityLifecycleCollector
 import sh.measure.android.lifecycle.AppLifecycleCollector
@@ -292,12 +294,19 @@ internal class MeasureInitializerImpl(
         exporter = exporter,
         sampler = sampler,
     ),
+    override val layoutSnapshotCollector: LayoutSnapshotCollector = LayoutSnapshotCollectorImpl(
+        logger = logger,
+        resumedActivityProvider = resumedActivityProvider,
+        defaultExecutor = executorServiceRegistry.defaultExecutor(),
+        layoutSnapshotThrottler = LayoutSnapshotThrottler(timeProvider),
+    ),
     override val userTriggeredEventCollector: UserTriggeredEventCollector = UserTriggeredEventCollectorImpl(
         logger = logger,
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         processInfoProvider = processInfoProvider,
         configProvider = configProvider,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     private val httpEventCollectorFactory: HttpEventCollectorFactory = HttpEventCollectorFactory(
         logger = logger,
@@ -392,18 +401,21 @@ internal class MeasureInitializerImpl(
         appLifecycleManager = appLifecycleManager,
         configProvider = configProvider,
         tracer = tracer,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     override val appLifecycleCollector: AppLifecycleCollector = AppLifecycleCollector(
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         appLifecycleManager = appLifecycleManager,
+        layoutSnapshotCollector = layoutSnapshotCollector,
     ),
     override val gestureCollector: GestureCollector = GestureCollector(
         logger = logger,
         signalProcessor = signalProcessor,
         timeProvider = timeProvider,
         defaultExecutor = executorServiceRegistry.defaultExecutor(),
-        layoutSnapshotThrottler = LayoutSnapshotThrottler(configProvider, timeProvider),
+        layoutSnapshotThrottler = LayoutSnapshotThrottler(timeProvider),
+        configProvider = configProvider,
     ),
     override val spanCollector: SpanCollector = SpanCollector(
         tracer = tracer,
@@ -475,6 +487,7 @@ internal class MeasureInitializerImpl(
         processInfoProvider,
         sessionManager,
         spanAttributeProcessors,
+        layoutSnapshotCollector,
     ),
     override val periodicSignalStoreScheduler: PeriodicSignalStoreScheduler = PeriodicSignalStoreScheduler(
         logger = logger,
@@ -508,6 +521,7 @@ internal interface MeasureInitializer {
     val activityLifecycleCollector: ActivityLifecycleCollector
     val appLifecycleCollector: AppLifecycleCollector
     val gestureCollector: GestureCollector
+    val layoutSnapshotCollector: LayoutSnapshotCollector
     val appLaunchCollector: AppLaunchCollector
     val profileCollector: ProfileCollector
     val networkChangesCollector: NetworkChangesCollector

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
@@ -12,6 +12,7 @@ import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.gestures.ClickData
 import sh.measure.android.gestures.LongClickData
 import sh.measure.android.gestures.ScrollData
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.logs.LogData
@@ -35,6 +36,7 @@ internal class InternalSignalCollector(
     private val processInfoProvider: ProcessInfoProvider,
     private val sessionManager: SessionManager,
     private val spanAttributeProcessors: List<AttributeProcessor>,
+    private val layoutSnapshotCollector: LayoutSnapshotCollector,
 ) {
     fun trackEvent(
         data: MutableMap<String, Any?>,
@@ -117,15 +119,22 @@ internal class InternalSignalCollector(
 
                 EventType.SCREEN_VIEW -> {
                     val extractedData = extractScreenViewData(data)
-                    signalProcessor.track(
-                        data = extractedData,
-                        timestamp = timestamp,
-                        type = eventType,
-                        attributes = attributes,
-                        userDefinedAttributes = userDefinedAttrs,
-                        attachments = eventAttachments,
-                        userTriggered = userTriggered,
-                    )
+                    val callerThreadName = threadName ?: Thread.currentThread().name
+                    layoutSnapshotCollector.captureAttachmentAfterNextDraw { attachment ->
+                        if (attachment != null) {
+                            eventAttachments.add(attachment)
+                        }
+                        signalProcessor.track(
+                            data = extractedData,
+                            timestamp = timestamp,
+                            type = eventType,
+                            attributes = attributes,
+                            userDefinedAttributes = userDefinedAttrs,
+                            attachments = eventAttachments,
+                            threadName = callerThreadName,
+                            userTriggered = userTriggered,
+                        )
+                    }
                 }
 
                 EventType.HTTP -> {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/InternalSignalCollector.kt
@@ -120,10 +120,7 @@ internal class InternalSignalCollector(
                 EventType.SCREEN_VIEW -> {
                     val extractedData = extractScreenViewData(data)
                     val callerThreadName = threadName ?: Thread.currentThread().name
-                    layoutSnapshotCollector.captureAttachmentAfterNextDraw { attachment ->
-                        if (attachment != null) {
-                            eventAttachments.add(attachment)
-                        }
+                    fun trackScreenView() {
                         signalProcessor.track(
                             data = extractedData,
                             timestamp = timestamp,
@@ -134,6 +131,20 @@ internal class InternalSignalCollector(
                             threadName = callerThreadName,
                             userTriggered = userTriggered,
                         )
+                    }
+
+                    val hasLayoutSnapshot = eventAttachments.any {
+                        it.type == AttachmentType.LAYOUT_SNAPSHOT_JSON
+                    }
+                    if (hasLayoutSnapshot) {
+                        trackScreenView()
+                    } else {
+                        layoutSnapshotCollector.captureAttachmentAfterNextDraw { attachment ->
+                            if (attachment != null) {
+                                eventAttachments.add(attachment)
+                            }
+                            trackScreenView()
+                        }
                     }
                 }
 

--- a/android/measure-android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/events/UserTriggeredEventCollector.kt
@@ -6,6 +6,7 @@ import sh.measure.android.bugreport.BugReportData
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.exceptions.ExceptionFactory
 import sh.measure.android.exceptions.ExceptionSeverity
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
 import sh.measure.android.logger.LogLevel
 import sh.measure.android.logger.Logger
 import sh.measure.android.navigation.ScreenViewData
@@ -48,6 +49,7 @@ internal class UserTriggeredEventCollectorImpl(
     private val timeProvider: TimeProvider,
     private val processInfoProvider: ProcessInfoProvider,
     private val configProvider: ConfigProvider,
+    private val layoutSnapshotCollector: LayoutSnapshotCollector,
 ) : UserTriggeredEventCollector {
     private var enabled = AtomicBoolean(false)
 
@@ -194,12 +196,16 @@ internal class UserTriggeredEventCollectorImpl(
         if (!enabled.get()) {
             return
         }
-        signalProcessor.trackUserTriggered(
-            data = ScreenViewData(name = screenName),
-            timestamp = timeProvider.now(),
-            type = EventType.SCREEN_VIEW,
-            userDefinedAttributes = attributes,
-        )
+        val timestamp = timeProvider.now()
+        layoutSnapshotCollector.captureAttachmentAfterPendingLayout { attachment ->
+            signalProcessor.trackUserTriggered(
+                data = ScreenViewData(name = screenName),
+                timestamp = timestamp,
+                type = EventType.SCREEN_VIEW,
+                attachments = listOfNotNull(attachment).toMutableList(),
+                userDefinedAttributes = attributes,
+            )
+        }
         logger.log(LogLevel.Debug, "Screen view event received")
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/gestures/GestureCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/gestures/GestureCollector.kt
@@ -7,6 +7,7 @@ import curtains.OnRootViewsChangedListener
 import curtains.OnTouchEventListener
 import curtains.phoneWindow
 import curtains.touchEventInterceptors
+import sh.measure.android.config.ConfigProvider
 import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
@@ -27,6 +28,7 @@ internal class GestureCollector(
     private val timeProvider: TimeProvider,
     private val defaultExecutor: MeasureExecutorService,
     private val layoutSnapshotThrottler: LayoutSnapshotThrottler,
+    private val configProvider: ConfigProvider,
 ) {
     private val touchListeners = mutableMapOf<Window, OnTouchEventListener>()
     private var rootViewsChangedListener: OnRootViewsChangedListener? = null
@@ -118,7 +120,7 @@ internal class GestureCollector(
         layoutSnapshot: LayoutSnapshot,
     ) {
         val data = ClickData.fromTargetNode(gesture, element)
-        if (layoutSnapshotThrottler.shouldTakeSnapshot()) {
+        if (configProvider.gestureClickTakeSnapshot && layoutSnapshotThrottler.shouldTakeSnapshot()) {
             trackClickWithSnapshotAsync(gesture, data, layoutSnapshot)
         } else {
             trackClick(gesture, data)

--- a/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutSnapshotCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutSnapshotCollector.kt
@@ -1,0 +1,136 @@
+package sh.measure.android.layoutinspector
+
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.Window
+import curtains.Curtains
+import curtains.onNextDraw
+import sh.measure.android.events.Attachment
+import sh.measure.android.events.AttachmentType
+import sh.measure.android.executors.MeasureExecutorService
+import sh.measure.android.isMainThread
+import sh.measure.android.logger.LogLevel
+import sh.measure.android.logger.Logger
+import sh.measure.android.mainHandler
+import sh.measure.android.utils.ResumedActivityProvider
+import java.util.concurrent.RejectedExecutionException
+
+internal interface LayoutSnapshotCollector {
+    fun captureAttachment(onCaptured: (Attachment?) -> Unit)
+    fun captureAttachmentAfterNextDraw(onCaptured: (Attachment?) -> Unit)
+    fun captureAttachmentAfterNextDraw(window: Window, onCaptured: (Attachment?) -> Unit)
+    fun captureAttachmentAfterPendingLayout(onCaptured: (Attachment?) -> Unit)
+}
+
+internal class LayoutSnapshotCollectorImpl(
+    private val logger: Logger,
+    private val resumedActivityProvider: ResumedActivityProvider,
+    private val defaultExecutor: MeasureExecutorService,
+    private val layoutSnapshotThrottler: LayoutSnapshotThrottler,
+) : LayoutSnapshotCollector {
+
+    override fun captureAttachment(onCaptured: (Attachment?) -> Unit) {
+        runOnMainThread {
+            if (!layoutSnapshotThrottler.shouldTakeSnapshot()) {
+                onCaptured(null)
+                return@runOnMainThread
+            }
+            captureAttachmentFrom(Curtains.rootViews.lastOrNull(), onCaptured)
+        }
+    }
+
+    override fun captureAttachmentAfterNextDraw(onCaptured: (Attachment?) -> Unit) {
+        runOnMainThread {
+            val window = resumedActivityProvider.getResumedActivity()?.window
+            if (window == null) {
+                onCaptured(null)
+            } else {
+                captureAttachmentAfterNextDraw(window, onCaptured)
+            }
+        }
+    }
+
+    override fun captureAttachmentAfterNextDraw(window: Window, onCaptured: (Attachment?) -> Unit) {
+        runOnMainThread {
+            if (!layoutSnapshotThrottler.shouldTakeSnapshot()) {
+                onCaptured(null)
+                return@runOnMainThread
+            }
+            // The draw callback runs while the frame is still being drawn, so the capture is
+            // posted to run once the frame is complete.
+            window.onNextDraw {
+                mainHandler.post {
+                    captureAttachmentFrom(window.peekDecorView()?.rootView, onCaptured)
+                }
+            }
+        }
+    }
+
+    override fun captureAttachmentAfterPendingLayout(onCaptured: (Attachment?) -> Unit) {
+        runOnMainThread {
+            val decorView = resumedActivityProvider.getResumedActivity()?.window?.peekDecorView()
+            if (decorView == null) {
+                onCaptured(null)
+                return@runOnMainThread
+            }
+            if (!layoutSnapshotThrottler.shouldTakeSnapshot()) {
+                onCaptured(null)
+                return@runOnMainThread
+            }
+            if (decorView.isLayoutRequested) {
+                onNextLayout(decorView) {
+                    captureAttachmentFrom(decorView.rootView, onCaptured)
+                }
+            } else {
+                captureAttachmentFrom(decorView.rootView, onCaptured)
+            }
+        }
+    }
+
+    private fun onNextLayout(decorView: View, onLaidOut: () -> Unit) {
+        decorView.viewTreeObserver.addOnGlobalLayoutListener(
+            object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    val observer = decorView.viewTreeObserver
+                    if (observer.isAlive) {
+                        observer.removeOnGlobalLayoutListener(this)
+                    }
+                    mainHandler.post(onLaidOut)
+                }
+            },
+        )
+    }
+
+    private fun captureAttachmentFrom(rootView: View?, onCaptured: (Attachment?) -> Unit) {
+        val snapshot = rootView?.let { view ->
+            try {
+                LayoutInspector.capture(view)
+            } catch (e: Exception) {
+                logger.log(LogLevel.Debug, "LayoutSnapshotCollector: unable to parse layout", e)
+                null
+            }
+        }
+        if (snapshot == null || snapshot.totalNodeCount() == 0) {
+            onCaptured(null)
+            return
+        }
+        try {
+            defaultExecutor.submit {
+                val attachment =
+                    snapshot.compressToAttachment(AttachmentType.LAYOUT_SNAPSHOT_JSON)
+                mainHandler.post { onCaptured(attachment) }
+            }
+        } catch (e: RejectedExecutionException) {
+            logger.log(LogLevel.Debug, "LayoutSnapshotCollector: failed to compress layout snapshot", e)
+            onCaptured(null)
+        }
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        if (isMainThread()) {
+            block()
+        } else {
+            mainHandler.post(block)
+        }
+    }
+}

--- a/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutSnapshotThrottler.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/layoutinspector/LayoutSnapshotThrottler.kt
@@ -1,6 +1,5 @@
 package sh.measure.android.layoutinspector
 
-import sh.measure.android.config.ConfigProvider
 import sh.measure.android.utils.TimeProvider
 import java.util.concurrent.atomic.AtomicLong
 
@@ -8,23 +7,19 @@ import java.util.concurrent.atomic.AtomicLong
  * Controls the frequency of layout snapshots by enforcing a minimum time interval between captures.
  */
 internal class LayoutSnapshotThrottler(
-    private val configProvider: ConfigProvider,
     private val timeProvider: TimeProvider,
 ) {
     private val lastSnapshotAttemptTimestamp = AtomicLong(0)
 
     /**
-     * Determines whether a new snapshot should be taken based on the `gestureClickTakeSnapshot`
-     * config and the elapsed time since the last attempt.
+     * Determines whether a new snapshot should be taken based on the elapsed time since the
+     * last attempt.
      *
      * @param delayMs The required delay between snapshots in milliseconds.
      * @return `true` if enough time has elapsed since the last snapshot or if this is the
-     *          first snapshot, false` if the delay hasn't been met.
+     *          first snapshot, `false` if the delay hasn't been met.
      */
     fun shouldTakeSnapshot(delayMs: Int = 750): Boolean {
-        if (!configProvider.gestureClickTakeSnapshot) {
-            return false
-        }
         val now = timeProvider.now()
         val previous = lastSnapshotAttemptTimestamp.getAndSet(now)
         return previous == 0L || (now - previous) > delayMs

--- a/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/AndroidXFragmentNavigationCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/AndroidXFragmentNavigationCollector.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
 import sh.measure.android.navigation.ScreenViewData
 import sh.measure.android.utils.TimeProvider
 import sh.measure.android.utils.isClassAvailable
@@ -19,6 +20,7 @@ import sh.measure.android.utils.isClassAvailable
 internal class AndroidXFragmentNavigationCollector(
     private val signalProcessor: SignalProcessor,
     private val timeProvider: TimeProvider,
+    private val layoutSnapshotCollector: LayoutSnapshotCollector,
 ) : FragmentLifecycleAdapter(),
     NavController.OnDestinationChangedListener {
 
@@ -41,11 +43,15 @@ internal class AndroidXFragmentNavigationCollector(
         arguments: Bundle?,
     ) {
         val displayName = getDisplayName(controller.context, destination.id)
-        signalProcessor.track(
-            type = EventType.SCREEN_VIEW,
-            timestamp = timeProvider.now(),
-            data = ScreenViewData(name = displayName),
-        )
+        val timestamp = timeProvider.now()
+        layoutSnapshotCollector.captureAttachmentAfterNextDraw { attachment ->
+            signalProcessor.track(
+                type = EventType.SCREEN_VIEW,
+                timestamp = timestamp,
+                data = ScreenViewData(name = displayName),
+                attachments = listOfNotNull(attachment).toMutableList(),
+            )
+        }
     }
 
     private fun safelyTrackAndroidxNavChanges(f: Fragment) {

--- a/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/AppLifecycleCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/AppLifecycleCollector.kt
@@ -2,6 +2,7 @@ package sh.measure.android.lifecycle
 
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
 import sh.measure.android.utils.TimeProvider
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -9,6 +10,7 @@ internal class AppLifecycleCollector(
     private val appLifecycleManager: AppLifecycleManager,
     private val signalProcessor: SignalProcessor,
     private val timeProvider: TimeProvider,
+    private val layoutSnapshotCollector: LayoutSnapshotCollector,
 ) : AppLifecycleListener {
     private var isRegistered = AtomicBoolean(false)
 
@@ -33,10 +35,14 @@ internal class AppLifecycleCollector(
     }
 
     override fun onAppBackground() {
-        signalProcessor.track(
-            ApplicationLifecycleData(AppLifecycleType.BACKGROUND),
-            timeProvider.now(),
-            EventType.LIFECYCLE_APP,
-        )
+        val timestamp = timeProvider.now()
+        layoutSnapshotCollector.captureAttachment { attachment ->
+            signalProcessor.track(
+                ApplicationLifecycleData(AppLifecycleType.BACKGROUND),
+                timestamp,
+                EventType.LIFECYCLE_APP,
+                attachments = listOfNotNull(attachment).toMutableList(),
+            )
+        }
     }
 }

--- a/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/DefaultActivityLifecycleCollector.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/lifecycle/DefaultActivityLifecycleCollector.kt
@@ -8,6 +8,7 @@ import curtains.onNextDraw
 import sh.measure.android.config.ConfigProvider
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
 import sh.measure.android.mainHandler
 import sh.measure.android.postAtFrontOfQueueAsync
 import sh.measure.android.tracing.AttributeName
@@ -31,6 +32,7 @@ internal class DefaultActivityLifecycleCollector(
     private val timeProvider: TimeProvider,
     private val configProvider: ConfigProvider,
     private val tracer: Tracer,
+    private val layoutSnapshotCollector: LayoutSnapshotCollector,
 ) : ActivityLifecycleCollector,
     ActivityLifecycleListener {
     private val createdActivities = mutableMapOf<String, Span>()
@@ -38,7 +40,7 @@ internal class DefaultActivityLifecycleCollector(
         FragmentLifecycleCollector(signalProcessor, timeProvider, configProvider, tracer)
     }
     private val androidXFragmentNavigationCollector by lazy {
-        AndroidXFragmentNavigationCollector(signalProcessor, timeProvider)
+        AndroidXFragmentNavigationCollector(signalProcessor, timeProvider, layoutSnapshotCollector)
     }
 
     private var isRegistered = AtomicBoolean(false)
@@ -85,14 +87,18 @@ internal class DefaultActivityLifecycleCollector(
     }
 
     override fun onActivityResumed(activity: Activity) {
-        signalProcessor.track(
-            timestamp = timeProvider.now(),
-            type = EventType.LIFECYCLE_ACTIVITY,
-            data = ActivityLifecycleData(
-                type = ActivityLifecycleType.RESUMED,
-                class_name = activity.javaClass.name,
-            ),
-        )
+        val timestamp = timeProvider.now()
+        layoutSnapshotCollector.captureAttachmentAfterNextDraw(activity.window) { attachment ->
+            signalProcessor.track(
+                timestamp = timestamp,
+                type = EventType.LIFECYCLE_ACTIVITY,
+                data = ActivityLifecycleData(
+                    type = ActivityLifecycleType.RESUMED,
+                    class_name = activity.javaClass.name,
+                ),
+                attachments = listOfNotNull(attachment).toMutableList(),
+            )
+        }
 
         activity.window.onNextDraw {
             mainHandler.postAtFrontOfQueueAsync {

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
@@ -25,6 +25,7 @@ import sh.measure.android.attributes.AttributeValue
 import sh.measure.android.bugreport.BugReportData
 import sh.measure.android.exceptions.ExceptionSeverity
 import sh.measure.android.fakes.FakeConfigProvider
+import sh.measure.android.fakes.FakeLayoutSnapshotCollector
 import sh.measure.android.fakes.FakeProcessInfoProvider
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.NoopLogger
@@ -41,6 +42,7 @@ class InternalSignalCollectorTest {
     private val configProvider = FakeConfigProvider()
     private val processInfoProvider = FakeProcessInfoProvider()
     private val sessionManager = FakeSessionManager()
+    private val layoutSnapshotCollector = FakeLayoutSnapshotCollector()
     private val attributeProcessor = object : AttributeProcessor {
         override fun appendAttributes(attributes: MutableMap<String, Any?>) {
             attributes.put("key-processor", "value-processor")
@@ -53,6 +55,7 @@ class InternalSignalCollectorTest {
         processInfoProvider = processInfoProvider,
         sessionManager = sessionManager,
         spanAttributeProcessors = listOf(attributeProcessor),
+        layoutSnapshotCollector = layoutSnapshotCollector,
     )
 
     @Test
@@ -169,7 +172,7 @@ class InternalSignalCollectorTest {
             attributes = attributes,
             userDefinedAttributes = userDefinedAttrs,
             attachments = mutableListOf(),
-            threadName = null,
+            threadName = Thread.currentThread().name,
             sessionId = null,
             userTriggered = userTriggered,
         )

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/InternalSignalCollectorTest.kt
@@ -145,6 +145,11 @@ class InternalSignalCollectorTest {
 
     @Test
     fun `trackEvent tracks screen view event`() {
+        val nativeSnapshot = TestData.getAttachment(
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+            name = "native.json.gz",
+        )
+        layoutSnapshotCollector.attachment = nativeSnapshot
         val data = mutableMapOf<String, Any?>("name" to "screen_name")
         val type = EventType.SCREEN_VIEW
         val timestamp = 1234567890L
@@ -171,7 +176,53 @@ class InternalSignalCollectorTest {
             type = type,
             attributes = attributes,
             userDefinedAttributes = userDefinedAttrs,
-            attachments = mutableListOf(),
+            attachments = mutableListOf(nativeSnapshot),
+            threadName = Thread.currentThread().name,
+            sessionId = null,
+            userTriggered = userTriggered,
+        )
+    }
+
+    @Test
+    fun `trackEvent skips native layout snapshot when screen view already has one`() {
+        layoutSnapshotCollector.attachment = TestData.getAttachment(
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+            name = "native.json.gz",
+        )
+        val data = mutableMapOf<String, Any?>("name" to "screen_name")
+        val type = EventType.SCREEN_VIEW
+        val timestamp = 1234567890L
+        val attributes = mutableMapOf<String, Any?>()
+        val userDefinedAttrs = mutableMapOf<String, AttributeValue>()
+        val crossPlatformSnapshot = MsrAttachment(
+            name = "flutter.json.gz",
+            path = "flutter-path",
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+        )
+        val attachments = mutableListOf(crossPlatformSnapshot)
+        val userTriggered = false
+
+        internalSignalCollector.trackEvent(
+            data = data,
+            type = type.value,
+            timestamp = timestamp,
+            attributes = attributes,
+            userDefinedAttrs = userDefinedAttrs,
+            attachments = attachments,
+            userTriggered = userTriggered,
+            sessionId = null,
+            threadName = null,
+        )
+
+        verify(signalProcessor).track(
+            data = ScreenViewData("screen_name"),
+            timestamp = timestamp,
+            type = type,
+            attributes = attributes,
+            userDefinedAttributes = userDefinedAttrs,
+            attachments = mutableListOf(
+                crossPlatformSnapshot.toEventAttachment(AttachmentType.LAYOUT_SNAPSHOT_JSON),
+            ),
             threadName = Thread.currentThread().name,
             sessionId = null,
             userTriggered = userTriggered,

--- a/android/measure-android/measure/src/test/java/sh/measure/android/events/UserTriggeredEventCollectorImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/events/UserTriggeredEventCollectorImplTest.kt
@@ -10,8 +10,10 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import sh.measure.android.attributes.StringAttr
+import sh.measure.android.events.AttachmentType
 import sh.measure.android.exceptions.ExceptionData
 import sh.measure.android.fakes.FakeConfigProvider
+import sh.measure.android.fakes.FakeLayoutSnapshotCollector
 import sh.measure.android.fakes.FakeProcessInfoProvider
 import sh.measure.android.fakes.NoopLogger
 import sh.measure.android.fakes.TestData
@@ -27,6 +29,7 @@ class UserTriggeredEventCollectorImplTest {
     private val timeProvider = AndroidTimeProvider(TestClock.create())
     private val processInfoProvider: ProcessInfoProvider = FakeProcessInfoProvider()
     private val configProvider = FakeConfigProvider()
+    private val layoutSnapshotCollector = FakeLayoutSnapshotCollector()
 
     private val userTriggeredEventCollector = UserTriggeredEventCollectorImpl(
         logger,
@@ -34,6 +37,7 @@ class UserTriggeredEventCollectorImplTest {
         timeProvider,
         processInfoProvider,
         configProvider,
+        layoutSnapshotCollector,
     )
 
     @Test
@@ -45,6 +49,24 @@ class UserTriggeredEventCollectorImplTest {
             data = ScreenViewData(name = screenName),
             type = EventType.SCREEN_VIEW,
             timestamp = timeProvider.now(),
+        )
+    }
+
+    @Test
+    fun `attaches layout snapshot to screen view event`() {
+        val snapshot = Attachment(
+            name = "snapshot.json.gz",
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+            bytes = byteArrayOf(1),
+        )
+        layoutSnapshotCollector.attachment = snapshot
+        userTriggeredEventCollector.register()
+        userTriggeredEventCollector.trackScreenView("screen-name", emptyMap())
+        verify(signalProcessor).trackUserTriggered(
+            data = ScreenViewData(name = "screen-name"),
+            type = EventType.SCREEN_VIEW,
+            timestamp = timeProvider.now(),
+            attachments = mutableListOf(snapshot),
         )
     }
 
@@ -472,6 +494,7 @@ class UserTriggeredEventCollectorImplTest {
             timeProvider,
             processInfoProvider,
             configProvider,
+            layoutSnapshotCollector,
         )
 
         collector.register()
@@ -516,6 +539,7 @@ class UserTriggeredEventCollectorImplTest {
             timeProvider,
             processInfoProvider,
             configProvider,
+            layoutSnapshotCollector,
         )
 
         collector.register()
@@ -560,6 +584,7 @@ class UserTriggeredEventCollectorImplTest {
             timeProvider,
             processInfoProvider,
             configProvider,
+            layoutSnapshotCollector,
         )
 
         val requestBody = "{\"name\":\"test\"}"
@@ -605,6 +630,7 @@ class UserTriggeredEventCollectorImplTest {
             timeProvider,
             processInfoProvider,
             configProvider,
+            layoutSnapshotCollector,
         )
 
         val responseBody = "{\"id\":1,\"name\":\"test\"}"

--- a/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeLayoutSnapshotCollector.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/fakes/FakeLayoutSnapshotCollector.kt
@@ -1,0 +1,23 @@
+package sh.measure.android.fakes
+
+import android.view.Window
+import sh.measure.android.events.Attachment
+import sh.measure.android.layoutinspector.LayoutSnapshotCollector
+
+internal class FakeLayoutSnapshotCollector(var attachment: Attachment? = null) : LayoutSnapshotCollector {
+    override fun captureAttachment(onCaptured: (Attachment?) -> Unit) {
+        onCaptured(attachment)
+    }
+
+    override fun captureAttachmentAfterNextDraw(onCaptured: (Attachment?) -> Unit) {
+        onCaptured(attachment)
+    }
+
+    override fun captureAttachmentAfterNextDraw(window: Window, onCaptured: (Attachment?) -> Unit) {
+        onCaptured(attachment)
+    }
+
+    override fun captureAttachmentAfterPendingLayout(onCaptured: (Attachment?) -> Unit) {
+        onCaptured(attachment)
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/layoutinspector/LayoutSnapshotCollectorImplTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/layoutinspector/LayoutSnapshotCollectorImplTest.kt
@@ -1,0 +1,169 @@
+package sh.measure.android.layoutinspector
+
+import android.app.Application
+import android.os.Looper
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.concurrent.futures.ResolvableFuture
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import sh.measure.android.events.Attachment
+import sh.measure.android.events.AttachmentType
+import sh.measure.android.fakes.ImmediateExecutorService
+import sh.measure.android.fakes.NoopLogger
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.ResumedActivityProviderImpl
+import sh.measure.android.utils.TestClock
+import sh.measure.android.utils.forceDrawFrame
+import sh.measure.android.utils.forceLayoutPass
+import java.time.Duration
+
+@RunWith(AndroidJUnit4::class)
+class LayoutSnapshotCollectorImplTest {
+    private val testClock = TestClock.create()
+    private val timeProvider = AndroidTimeProvider(testClock)
+    private val application = InstrumentationRegistry.getInstrumentation().context as Application
+    private val resumedActivityProvider = ResumedActivityProviderImpl(application)
+    private val collector = createCollector()
+    private lateinit var controller: ActivityController<LayoutInspectorTestActivity>
+
+    @Before
+    fun setup() {
+        resumedActivityProvider.register()
+        controller = buildActivity(LayoutInspectorTestActivity::class.java)
+        val activity = controller.get()
+        val content = FrameLayout(activity)
+        content.addView(TextView(activity).apply { text = "hello" })
+        activity.setContentView(content)
+    }
+
+    @Test
+    fun `captureAttachment delivers a compressed snapshot of the top-most window`() {
+        controller.setup()
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachment { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val attachment = captured.single()
+        assertNotNull(attachment)
+        assertEquals(AttachmentType.LAYOUT_SNAPSHOT_JSON, attachment!!.type)
+        assertEquals("snapshot.json.gz", attachment.name)
+    }
+
+    @Test
+    fun `captureAttachmentAfterNextDraw delivers once the resumed window has drawn`() {
+        controller.setup()
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachmentAfterNextDraw { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(emptyList<Attachment?>(), captured)
+
+        controller.forceDrawFrame()
+        assertNotNull(captured.single())
+    }
+
+    @Test
+    fun `captureAttachmentAfterNextDraw delivers null without a resumed activity`() {
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachmentAfterNextDraw { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(listOf(null), captured)
+    }
+
+    @Test
+    fun `captureAttachment skips a snapshot taken too soon after the previous one`() {
+        controller.setup()
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachment { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+        collector.captureAttachment { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertNotNull(captured[0])
+        assertEquals(null, captured[1])
+    }
+
+    @Test
+    fun `captureAttachment takes a snapshot again once the throttle window has elapsed`() {
+        controller.setup()
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachment { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+        testClock.advance(Duration.ofMillis(751))
+        collector.captureAttachment { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertNotNull(captured[0])
+        assertNotNull(captured[1])
+    }
+
+    @Test
+    fun `captureAttachmentAfterPendingLayout waits for a layout which is still pending`() {
+        controller.create().start().resume()
+        assertTrue(controller.get().window.decorView.isLayoutRequested)
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachmentAfterPendingLayout { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(emptyList<Attachment?>(), captured)
+
+        controller.get().window.decorView.layoutNow()
+        controller.forceLayoutPass()
+        assertNotNull(captured.single())
+    }
+
+    @Test
+    fun `captureAttachmentAfterPendingLayout delivers without waiting once laid out`() {
+        controller.setup()
+        controller.get().window.decorView.layoutNow()
+        assertFalse(controller.get().window.decorView.isLayoutRequested)
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachmentAfterPendingLayout { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertNotNull(captured.single())
+    }
+
+    @Test
+    fun `captureAttachmentAfterPendingLayout delivers null without a resumed activity`() {
+        val captured = mutableListOf<Attachment?>()
+
+        collector.captureAttachmentAfterPendingLayout { captured.add(it) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(listOf(null), captured)
+    }
+
+    private fun createCollector() = LayoutSnapshotCollectorImpl(
+        logger = NoopLogger(),
+        resumedActivityProvider = resumedActivityProvider,
+        defaultExecutor = ImmediateExecutorService(ResolvableFuture.create()),
+        layoutSnapshotThrottler = LayoutSnapshotThrottler(timeProvider),
+    )
+
+    private fun View.layoutNow() {
+        measure(
+            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+        )
+        layout(0, 0, measuredWidth, measuredHeight)
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/layoutinspector/LayoutSnapshotThrottlerTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/layoutinspector/LayoutSnapshotThrottlerTest.kt
@@ -1,0 +1,41 @@
+package sh.measure.android.layoutinspector
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import sh.measure.android.utils.AndroidTimeProvider
+import sh.measure.android.utils.TestClock
+import java.time.Duration
+
+class LayoutSnapshotThrottlerTest {
+    private val testClock = TestClock.create()
+    private val timeProvider = AndroidTimeProvider(testClock)
+    private val throttler = LayoutSnapshotThrottler(timeProvider)
+
+    @Test
+    fun `allows the first snapshot`() {
+        assertTrue(throttler.shouldTakeSnapshot())
+    }
+
+    @Test
+    fun `blocks a snapshot taken too soon after the previous one`() {
+        throttler.shouldTakeSnapshot()
+        assertFalse(throttler.shouldTakeSnapshot())
+    }
+
+    @Test
+    fun `allows a snapshot once the delay has elapsed`() {
+        throttler.shouldTakeSnapshot()
+        testClock.advance(Duration.ofMillis(751))
+        assertTrue(throttler.shouldTakeSnapshot())
+    }
+
+    @Test
+    fun `respects a custom delay`() {
+        throttler.shouldTakeSnapshot(delayMs = 100)
+        testClock.advance(Duration.ofMillis(50))
+        assertFalse(throttler.shouldTakeSnapshot(delayMs = 100))
+        testClock.advance(Duration.ofMillis(101))
+        assertTrue(throttler.shouldTakeSnapshot(delayMs = 100))
+    }
+}

--- a/android/measure-android/measure/src/test/java/sh/measure/android/lifecycle/ActivityLifecycleCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/lifecycle/ActivityLifecycleCollectorTest.kt
@@ -19,9 +19,12 @@ import org.robolectric.android.controller.ActivityController
 import sh.measure.android.ChildFragment
 import sh.measure.android.TestFragment
 import sh.measure.android.TestLifecycleActivity
+import sh.measure.android.events.Attachment
+import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
 import sh.measure.android.fakes.FakeConfigProvider
+import sh.measure.android.fakes.FakeLayoutSnapshotCollector
 import sh.measure.android.fakes.FakeSessionManager
 import sh.measure.android.fakes.NoopLogger
 import sh.measure.android.tracing.SpanData
@@ -39,6 +42,7 @@ class ActivityLifecycleCollectorTest {
     private val application = InstrumentationRegistry.getInstrumentation().context as Application
     private val appLifecycleManager = AppLifecycleManager(application)
     private val configProvider = FakeConfigProvider()
+    private val layoutSnapshotCollector = FakeLayoutSnapshotCollector()
     private val tracer =
         TestTracer(signalProcessor, configProvider, logger, timeProvider, sessionManager)
     private var activityLifecycleCollector: DefaultActivityLifecycleCollector = DefaultActivityLifecycleCollector(
@@ -47,6 +51,7 @@ class ActivityLifecycleCollectorTest {
         timeProvider,
         configProvider,
         tracer,
+        layoutSnapshotCollector,
     )
     private lateinit var controller: ActivityController<TestLifecycleActivity>
 
@@ -105,6 +110,26 @@ class ActivityLifecycleCollectorTest {
                 type = ActivityLifecycleType.RESUMED,
                 class_name = TestLifecycleActivity::class.java.name,
             ),
+        )
+    }
+
+    @Test
+    fun `attaches layout snapshot to activity onResume`() {
+        val snapshot = Attachment(
+            name = "snapshot.json.gz",
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+            bytes = byteArrayOf(1),
+        )
+        layoutSnapshotCollector.attachment = snapshot
+        controller.setup()
+        verify(signalProcessor, times(1)).track(
+            timestamp = timeProvider.now(),
+            type = EventType.LIFECYCLE_ACTIVITY,
+            data = ActivityLifecycleData(
+                type = ActivityLifecycleType.RESUMED,
+                class_name = TestLifecycleActivity::class.java.name,
+            ),
+            attachments = mutableListOf(snapshot),
         )
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/lifecycle/AppLifecycleCollectorTest.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/lifecycle/AppLifecycleCollectorTest.kt
@@ -13,8 +13,11 @@ import org.mockito.kotlin.never
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.android.controller.ActivityController
 import sh.measure.android.TestLifecycleActivity
+import sh.measure.android.events.Attachment
+import sh.measure.android.events.AttachmentType
 import sh.measure.android.events.EventType
 import sh.measure.android.events.SignalProcessor
+import sh.measure.android.fakes.FakeLayoutSnapshotCollector
 import sh.measure.android.utils.AndroidTimeProvider
 import sh.measure.android.utils.TestClock
 
@@ -24,10 +27,12 @@ class AppLifecycleCollectorTest {
     private val timeProvider = AndroidTimeProvider(TestClock.create())
     private val application = InstrumentationRegistry.getInstrumentation().context as Application
     private val appLifecycleManager = AppLifecycleManager(application)
+    private val layoutSnapshotCollector = FakeLayoutSnapshotCollector()
     private val appLifecycleCollector: AppLifecycleCollector = AppLifecycleCollector(
         appLifecycleManager,
         signalProcessor,
         timeProvider,
+        layoutSnapshotCollector,
     )
     private lateinit var controller: ActivityController<TestLifecycleActivity>
 
@@ -47,6 +52,25 @@ class AppLifecycleCollectorTest {
             data = ApplicationLifecycleData(
                 type = AppLifecycleType.BACKGROUND,
             ),
+        )
+    }
+
+    @Test
+    fun `attaches layout snapshot to application background event`() {
+        val snapshot = Attachment(
+            name = "snapshot.json.gz",
+            type = AttachmentType.LAYOUT_SNAPSHOT_JSON,
+            bytes = byteArrayOf(1),
+        )
+        layoutSnapshotCollector.attachment = snapshot
+        controller.setup().stop()
+        verify(signalProcessor, times(1)).track(
+            timestamp = timeProvider.now(),
+            type = EventType.LIFECYCLE_APP,
+            data = ApplicationLifecycleData(
+                type = AppLifecycleType.BACKGROUND,
+            ),
+            attachments = mutableListOf(snapshot),
         )
     }
 

--- a/android/measure-android/measure/src/test/java/sh/measure/android/utils/ActivityControllerExt.kt
+++ b/android/measure-android/measure/src/test/java/sh/measure/android/utils/ActivityControllerExt.kt
@@ -13,3 +13,12 @@ fun <T : Activity> ActivityController<T>.forceDrawFrame() {
     decorView.viewTreeObserver.dispatchOnDraw()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 }
+
+/**
+ * Forces a layout pass on the decor view.
+ */
+fun <T : Activity> ActivityController<T>.forceLayoutPass() {
+    val decorView = get().window.decorView
+    decorView.viewTreeObserver.dispatchOnGlobalLayout()
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+}

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -3697,12 +3697,22 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.GestureScroll = &gestureScroll
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleActivity:
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			ev.LifecycleActivity = &lifecycleActivity
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleFragment:
 			ev.LifecycleFragment = &lifecycleFragment
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleApp:
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			ev.LifecycleApp = &lifecycleApp
 			session.Events = append(session.Events, ev)
 		case event.TypeColdLaunch:
@@ -3739,6 +3749,11 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.Navigation = &navigation
 			session.Events = append(session.Events, ev)
 		case event.TypeScreenView:
+			if len(attachments) > 8 {
+				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+					return nil, err
+				}
+			}
 			ev.ScreenView = &screenView
 			session.Events = append(session.Events, ev)
 		case event.TypeBugReport:

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -3049,6 +3049,15 @@ func (a *App) Populate(ctx context.Context, pg *pgxpool.Pool) (err error) {
 	return
 }
 
+// unmarshalAttachments parses the
+// attachments JSON array.
+func unmarshalAttachments(attachments string, dest *[]event.Attachment) error {
+	if len(attachments) <= 8 {
+		return nil
+	}
+	return json.Unmarshal([]byte(attachments), dest)
+}
+
 // GetSessionEvents fetches all the events of an app's session.
 func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId uuid.UUID) (*Session, error) {
 	ctx = chquery.WithTeamScope(ctx, a.TeamId)
@@ -3664,43 +3673,26 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.Log = &logData
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureLongClick:
-			// only unmarshal attachments if more than
-			// 8 characters
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.GestureLongClick = &gestureLongClick
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureClick:
-			// only unmarshal attachments if more than
-			// 8 characters
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
-			}
-			if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
 				return nil, err
 			}
 			ev.GestureClick = &gestureClick
 			session.Events = append(session.Events, ev)
 		case event.TypeGestureScroll:
-			// only unmarshal attachments if more than
-			// 8 characters
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.GestureScroll = &gestureScroll
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleActivity:
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.LifecycleActivity = &lifecycleActivity
 			session.Events = append(session.Events, ev)
@@ -3708,10 +3700,8 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.LifecycleFragment = &lifecycleFragment
 			session.Events = append(session.Events, ev)
 		case event.TypeLifecycleApp:
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.LifecycleApp = &lifecycleApp
 			session.Events = append(session.Events, ev)
@@ -3749,10 +3739,8 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.Navigation = &navigation
 			session.Events = append(session.Events, ev)
 		case event.TypeScreenView:
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.ScreenView = &screenView
 			session.Events = append(session.Events, ev)
@@ -3775,11 +3763,8 @@ func (a *App) GetSessionEvents(ctx context.Context, rch driver.Conn, sessionId u
 			ev.MemoryUsageAbs = &memoryUsageAbs
 			session.Events = append(session.Events, ev)
 		case event.TypeProfile:
-			// only unmarshal attachments if more than 8 characters
-			if len(attachments) > 8 {
-				if err := json.Unmarshal([]byte(attachments), &ev.Attachments); err != nil {
-					return nil, err
-				}
+			if err := unmarshalAttachments(attachments, &ev.Attachments); err != nil {
+				return nil, err
 			}
 			ev.Profile = &profile
 			session.Events = append(session.Events, ev)

--- a/backend/libs/timeline/lifecycle.go
+++ b/backend/libs/timeline/lifecycle.go
@@ -14,7 +14,8 @@ type LifecycleActivity struct {
 	UDAttribute *udattr.UDAttribute `json:"user_defined_attribute"`
 	ThreadName  string              `json:"thread_name"`
 	*event.LifecycleActivity
-	Timestamp time.Time `json:"timestamp"`
+	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
 }
 
 // GetThreadName provides the name of the thread
@@ -102,7 +103,8 @@ type LifecycleApp struct {
 	UDAttribute *udattr.UDAttribute `json:"user_defined_attribute"`
 	ThreadName  string              `json:"thread_name"`
 	*event.LifecycleApp
-	Timestamp time.Time `json:"timestamp"`
+	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
 }
 
 // GetThreadName provides the name of the thread
@@ -127,6 +129,7 @@ func ComputeLifecycleActivities(events []event.EventField) (result []ThreadGroup
 			event.Attribute.ThreadName,
 			event.LifecycleActivity,
 			event.Timestamp,
+			event.Attachments,
 		}
 		result = append(result, activities)
 	}
@@ -195,6 +198,7 @@ func ComputeLifecycleApps(events []event.EventField) (result []ThreadGrouper) {
 			event.Attribute.ThreadName,
 			event.LifecycleApp,
 			event.Timestamp,
+			event.Attachments,
 		}
 		result = append(result, apps)
 	}

--- a/backend/libs/timeline/nav.go
+++ b/backend/libs/timeline/nav.go
@@ -26,7 +26,8 @@ type ScreenView struct {
 	ThreadName    string              `json:"thread_name"`
 	UserTriggered bool                `json:"user_triggered"`
 	*event.ScreenView
-	Timestamp time.Time `json:"timestamp"`
+	Timestamp   time.Time          `json:"timestamp"`
+	Attachments []event.Attachment `json:"attachments"`
 }
 
 // GetThreadName provides the name of the thread
@@ -70,6 +71,7 @@ func ComputeScreenViews(events []event.EventField) (result []ThreadGrouper) {
 			event.UserTriggered,
 			event.ScreenView,
 			event.Timestamp,
+			event.Attachments,
 		}
 		result = append(result, sv)
 	}

--- a/frontend/dashboard/__tests__/components/session_replay_test.tsx
+++ b/frontend/dashboard/__tests__/components/session_replay_test.tsx
@@ -1136,7 +1136,7 @@ describe("idle stretches", () => {
     { event_type: "lifecycle_activity", timestamp: at(1) },
     { event_type: "gesture_click", timestamp: at(2) },
     { event_type: "http", timestamp: at(20) },
-    { event_type: "lifecycle_app", timestamp: at(40) },
+    { event_type: "trim_memory", timestamp: at(40) },
     { event_type: "error", timestamp: at(60), severity: "unhandled" },
     { event_type: "anr", timestamp: at(70) },
     { event_type: "bug_report", timestamp: at(80) },
@@ -1157,12 +1157,32 @@ describe("idle stretches", () => {
   };
 
   it("skips a stretch that carries events but leaves the screen alone", () => {
-    // The events between the gesture and the error are network calls and
-    // lifecycle transitions, none of which put anything new on the screen.
+    // The events between the gesture and the error are a network call and a
+    // memory trim, neither of which puts anything new on the screen.
     const { slice } = sliceAt(3000);
 
     expect(slice.skipToOffsetMs).toBe(59_500);
   });
+
+  it.each(["screen_view", "lifecycle_activity", "lifecycle_app"])(
+    "stops at a %s, which can carry a layout snapshot",
+    (eventType) => {
+      const replay = replayFrom(
+        timelineWith([
+          { event_type: "gesture_click", timestamp: at(0) },
+          {
+            event_type: eventType,
+            timestamp: at(30),
+            name: "Checkout",
+            type: "resumed",
+          },
+          { event_type: "gesture_click", timestamp: at(60) },
+        ]),
+      );
+
+      expect(replay.slices[0].skipToOffsetMs).toBe(29_500);
+    },
+  );
 
   it("plays through a wait short enough to sit out", () => {
     const shortWait = replayFrom(
@@ -1431,8 +1451,10 @@ describe("the machine", () => {
     actor.send({ type: "user.toggle" });
     actor.send({ type: "clock.tick", clockOffsetMs: 1 });
 
-    expect(actor.getSnapshot().context.playheadOffsetMs).toBe(10000);
-    expect(actor.getSnapshot().context.skippedIdleMs).toBe(9999);
+    // The lifecycle event closing the session can carry a layout snapshot, so
+    // the jump stops short of it rather than running to the end.
+    expect(actor.getSnapshot().context.playheadOffsetMs).toBe(9500);
+    expect(actor.getSnapshot().context.skippedIdleMs).toBe(9499);
     expect(actor.getSnapshot().matches({ ready: { notice: "visible" } })).toBe(
       true,
     );

--- a/frontend/dashboard/app/components/session_replay.tsx
+++ b/frontend/dashboard/app/components/session_replay.tsx
@@ -1374,8 +1374,9 @@ function fillIdleSkipTargets(
     // ahead of where this slice began. It can still land past slices in
     // between, since slices are cut at every event while only gestures, errors
     // and bug reports count as activity, and a log or an http call inside the
-    // gap starts a slice the skip carries straight over. Those slices hold no
-    // attachment of their own, so nothing that would be drawn is missed.
+    // gap starts a slice the skip carries straight over. A lifecycle or screen
+    // view event inside the gap can carry a layout snapshot; that frame is the
+    // one on show where the skip lands, so the screen still ends up current.
     slice.skipToOffsetMs = targetOffsetMs;
   });
 }

--- a/frontend/dashboard/app/components/session_replay.tsx
+++ b/frontend/dashboard/app/components/session_replay.tsx
@@ -468,11 +468,17 @@ function isGesture(eventType: string): boolean {
   return (gestureTypes as readonly string[]).includes(eventType);
 }
 
+// Every event which can carry a layout snapshot or a screenshot, since those
+// are the ones which put something new on the screen. An event type which
+// starts carrying one belongs here too.
 const activityEventTypes = [
   ...gestureTypes,
   "error",
   "anr",
   "bug_report",
+  "screen_view",
+  "lifecycle_activity",
+  "lifecycle_app",
 ] as const;
 
 function isActivityEvent(eventType: string): boolean {
@@ -1372,11 +1378,9 @@ function fillIdleSkipTargets(
     // sees a moment of stillness before whatever happens next. The lead is
     // shorter than the gap that counts as idle, so the target always lands
     // ahead of where this slice began. It can still land past slices in
-    // between, since slices are cut at every event while only gestures, errors
-    // and bug reports count as activity, and a log or an http call inside the
-    // gap starts a slice the skip carries straight over. A lifecycle or screen
-    // view event inside the gap can carry a layout snapshot; that frame is the
-    // one on show where the skip lands, so the screen still ends up current.
+    // between, since slices are cut at every event while only the ones which
+    // put something on the screen count as activity, so a log or an http call
+    // inside the gap starts a slice the skip carries straight over.
     slice.skipToOffsetMs = targetOffsetMs;
   });
 }

--- a/frontend/dashboard/content/docs/gesture-tracking/layout-snapshots.mdx
+++ b/frontend/dashboard/content/docs/gesture-tracking/layout-snapshots.mdx
@@ -20,6 +20,15 @@ Snapshots are throttled to at most one every 750 ms, so bursts of taps don't add
 
 Snapshots cover the whole screen with no setup, whether it's built with Views, Jetpack Compose, or a mix of both.
 
+A snapshot is captured at each of these moments, so a session replay has a frame for every screen the user saw and not only the ones they tapped:
+
+- A click, with the tapped element marked.
+- An activity resuming.
+- A screen view, whether tracked automatically or with `Measure.trackScreenView`.
+- The app going to the background.
+
+The resume and screen view snapshots wait for the new screen to draw, so they show what the user saw rather than an empty layout. Clicks are throttled to one snapshot every 750 ms, and the other three moments share a separate 750 ms limit. A throttled event is still tracked, only without its snapshot.
+
 ## iOS
 
 Snapshots capture the full view hierarchy of the screen with no setup. SwiftUI content appears with its underlying system view names rather than your SwiftUI view names.

--- a/frontend/dashboard/content/docs/gesture-tracking/layout-snapshots.mdx
+++ b/frontend/dashboard/content/docs/gesture-tracking/layout-snapshots.mdx
@@ -18,16 +18,14 @@ Snapshots are throttled to at most one every 750 ms, so bursts of taps don't add
 
 ## Android
 
-Snapshots cover the whole screen with no setup, whether it's built with Views, Jetpack Compose, or a mix of both.
-
-A snapshot is captured at each of these moments, so a session replay has a frame for every screen the user saw and not only the ones they tapped:
+Snapshots are collected with Views, Jetpack Compose, or a mix of both. A snapshot is captured at each of these moments:
 
 - A click, with the tapped element marked.
 - An activity resuming.
 - A screen view, whether tracked automatically or with `Measure.trackScreenView`.
 - The app going to the background.
 
-The resume and screen view snapshots wait for the new screen to draw, so they show what the user saw rather than an empty layout. Clicks are throttled to one snapshot every 750 ms, and the other three moments share a separate 750 ms limit. A throttled event is still tracked, only without its snapshot.
+Layout snapshots with clicks are throttled to one snapshot every 750 ms, and the other three moments share a separate 750 ms limit.
 
 ## iOS
 


### PR DESCRIPTION
# Description

Layout snapshots are were captured on clicks only. They are now also captured on activity resume, screen views and app background.

## Android SDK

- App background captures immediately, since no further frame will be drawn.
- Activity resume and screen views wait for the next frame to be drawn.
- `Measure.trackScreenView` waits only when `decorView.isLayoutRequested` otherwise we assume the UI tree is already final.
- Cross platform screen views skip the native capture when the event already carries a layout snapshot.

## Backend

- `GetSessionEvents` unmarshals attachments for `lifecycle_activity`, `lifecycle_app` and `screen_view`.
- Timeline structs for those three adds an `Attachments` field.

## Dashboard

- Idle skip logic now also stops at the new events which include layout snapshots.