### PR TITLE
feat(flutter): attach layout snapshots to screen view events

### DIFF
--- a/flutter/packages/measure_dio/test/fake_measure.dart
+++ b/flutter/packages/measure_dio/test/fake_measure.dart
@@ -85,6 +85,8 @@ class FakeMeasure implements MeasureApi {
   void trackScreenViewEvent({
     required String name,
     bool userTriggered = true,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
   }) {}
 
   @override
@@ -230,13 +232,20 @@ class FakeMeasure implements MeasureApi {
   }
 
   @override
-  Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot) async {
+  Future<void> trackClick(
+    ClickData clickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     throw UnimplementedError();
   }
 
   @override
   Future<void> trackLongClick(
-      LongClickData longClickData, SnapshotNode? snapshot) async {
+    LongClickData longClickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     throw UnimplementedError();
   }
 

--- a/flutter/packages/measure_flutter/lib/measure_flutter.dart
+++ b/flutter/packages/measure_flutter/lib/measure_flutter.dart
@@ -435,6 +435,14 @@ class Measure implements MeasureApi {
   ///
   /// **Parameters:**
   /// - [name]: A unique identifier for the screen (e.g., 'HomeScreen', 'ProfilePage')
+  /// - [timestamp]: When the screen was viewed, in milliseconds since epoch.
+  ///   Defaults to the time this method is called.
+  /// - [captureLayoutSnapshot]: Whether to attach a layout snapshot of the
+  ///   screen to the event. The snapshot is taken on the frame after this call,
+  ///   so call this once the screen is on display. Pass false when the screen is
+  ///   still animating into place, such as a tab change part way through its
+  ///   transition, to leave out a snapshot that would show the animation rather
+  ///   than the screen.
   ///
   /// **Example:**
   /// ```dart
@@ -447,12 +455,16 @@ class Measure implements MeasureApi {
     required String name,
     Map<String, AttributeValue> attributes = const {},
     bool userTriggered = true,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
   }) {
     if (_isInitialized) {
       _measure.trackScreenViewEvent(
         name: name,
         userTriggered: userTriggered,
         attributes: attributes,
+        timestamp: timestamp,
+        captureLayoutSnapshot: captureLayoutSnapshot,
       );
     }
   }
@@ -997,9 +1009,13 @@ class Measure implements MeasureApi {
   /// **Note:** Consider using [MeasureWidget] wrapper for automatic
   /// gesture tracking instead of manual tracking.
   @override
-  Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot) async {
+  Future<void> trackClick(
+    ClickData clickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     if (isInitialized) {
-      return _measure.trackClick(clickData, snapshot);
+      return _measure.trackClick(clickData, snapshot, timestamp: timestamp);
     }
   }
 
@@ -1028,9 +1044,17 @@ class Measure implements MeasureApi {
   /// **Note:** Consider using [MeasureWidget] wrapper for automatic
   /// gesture tracking instead of manual tracking.
   @override
-  Future<void> trackLongClick(LongClickData longClickData, SnapshotNode? snapshot) async {
+  Future<void> trackLongClick(
+    LongClickData longClickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     if (isInitialized) {
-      return _measure.trackLongClick(longClickData, snapshot);
+      return _measure.trackLongClick(
+        longClickData,
+        snapshot,
+        timestamp: timestamp,
+      );
     }
   }
 

--- a/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
 import 'package:measure_flutter/src/gestures/scroll_data.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
@@ -15,15 +16,18 @@ class GestureCollector {
   final SignalProcessor _signalProcessor;
   final TimeProvider _timeProvider;
   final LayoutSnapshotCollector _layoutSnapshotCollector;
+  final LayoutSnapshotThrottler _layoutSnapshotThrottler;
   bool _isRegistered = false;
 
   GestureCollector(
     SignalProcessor signalProcessor,
     TimeProvider timeProvider,
     LayoutSnapshotCollector layoutSnapshotCollector,
+    LayoutSnapshotThrottler layoutSnapshotThrottler,
   )   : _signalProcessor = signalProcessor,
         _timeProvider = timeProvider,
-        _layoutSnapshotCollector = layoutSnapshotCollector;
+        _layoutSnapshotCollector = layoutSnapshotCollector,
+        _layoutSnapshotThrottler = layoutSnapshotThrottler;
 
   void register() {
     _isRegistered = true;
@@ -44,11 +48,9 @@ class GestureCollector {
       if (!_isRegistered) {
         return;
       }
-      // Taken before the snapshot is written so that the event carries the
-      // time of the gesture, not the time the attachment finished.
       final eventTimestamp = timestamp ?? _timeProvider.now();
       MsrAttachment? attachment;
-      if (snapshot != null) {
+      if (snapshot != null && _layoutSnapshotThrottler.shouldTakeSnapshot()) {
         attachment = await _layoutSnapshotCollector.createAttachment(snapshot);
       }
       _signalProcessor.trackEvent(
@@ -95,11 +97,9 @@ class GestureCollector {
       if (!_isRegistered) {
         return;
       }
-      // Taken before the snapshot is written so that the event carries the
-      // time of the gesture, not the time the attachment finished.
       final eventTimestamp = timestamp ?? _timeProvider.now();
       MsrAttachment? attachment;
-      if (snapshot != null) {
+      if (snapshot != null && _layoutSnapshotThrottler.shouldTakeSnapshot()) {
         attachment = await _layoutSnapshotCollector.createAttachment(snapshot);
       }
       _signalProcessor.trackEvent(

--- a/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/gesture_collector.dart
@@ -3,37 +3,27 @@ import 'dart:isolate';
 
 import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/events/event_type.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
 import 'package:measure_flutter/src/gestures/scroll_data.dart';
-import 'package:measure_flutter/src/logger/log_level.dart';
-import 'package:measure_flutter/src/logger/logger.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
-import 'package:measure_flutter/src/storage/file_storage.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
-import 'package:measure_flutter/src/utils/id_provider.dart';
 
-import '../isolate/file_processor.dart';
 import 'click_data.dart';
 
 class GestureCollector {
   final SignalProcessor _signalProcessor;
   final TimeProvider _timeProvider;
-  final FileStorage _fileStorage;
-  final Logger _logger;
-  final IdProvider _idProvider;
+  final LayoutSnapshotCollector _layoutSnapshotCollector;
   bool _isRegistered = false;
 
   GestureCollector(
     SignalProcessor signalProcessor,
     TimeProvider timeProvider,
-    FileStorage fileStorage,
-    Logger logger,
-    IdProvider idProvider,
+    LayoutSnapshotCollector layoutSnapshotCollector,
   )   : _signalProcessor = signalProcessor,
         _timeProvider = timeProvider,
-        _fileStorage = fileStorage,
-        _logger = logger,
-        _idProvider = idProvider;
+        _layoutSnapshotCollector = layoutSnapshotCollector;
 
   void register() {
     _isRegistered = true;
@@ -54,14 +44,17 @@ class GestureCollector {
       if (!_isRegistered) {
         return;
       }
+      // Taken before the snapshot is written so that the event carries the
+      // time of the gesture, not the time the attachment finished.
+      final eventTimestamp = timestamp ?? _timeProvider.now();
       MsrAttachment? attachment;
       if (snapshot != null) {
-        attachment = await createAttachment(snapshot);
+        attachment = await _layoutSnapshotCollector.createAttachment(snapshot);
       }
       _signalProcessor.trackEvent(
         data: data,
         type: EventType.gestureClick,
-        timestamp: timestamp ?? _timeProvider.now(),
+        timestamp: eventTimestamp,
         userDefinedAttrs: {},
         userTriggered: isUserTriggered,
         threadName: Isolate.current.debugName ?? "unknown",
@@ -102,14 +95,17 @@ class GestureCollector {
       if (!_isRegistered) {
         return;
       }
+      // Taken before the snapshot is written so that the event carries the
+      // time of the gesture, not the time the attachment finished.
+      final eventTimestamp = timestamp ?? _timeProvider.now();
       MsrAttachment? attachment;
       if (snapshot != null) {
-        attachment = await createAttachment(snapshot);
+        attachment = await _layoutSnapshotCollector.createAttachment(snapshot);
       }
       _signalProcessor.trackEvent(
         data: longClickData,
         type: EventType.gestureLongClick,
-        timestamp: timestamp ?? _timeProvider.now(),
+        timestamp: eventTimestamp,
         userDefinedAttrs: {},
         userTriggered: false,
         threadName: Isolate.current.debugName ?? "unknown",
@@ -117,63 +113,6 @@ class GestureCollector {
       );
     } finally {
       task.finish();
-    }
-  }
-
-  /// Creates an attachment from an already-captured layout snapshot.
-  ///
-  /// Serializes the [snapshot] to JSON and writes it to a file in an isolate.
-  /// Returns an [MsrAttachment] with the file path, or null if the operation fails.
-  Future<MsrAttachment?> createAttachment(SnapshotNode snapshot) async {
-    try {
-      final rootPath = await _fileStorage.getRootPath();
-      if (rootPath == null) {
-        _logger.log(
-          LogLevel.debug,
-          'LayoutSnapshotCollector: Root path is null',
-        );
-        return null;
-      }
-
-      final uuid = _idProvider.uuid();
-      final result = await writeJsonToFileInIsolate(
-        WriteLayoutSnapshotParams(
-          snapshot: snapshot,
-          fileName: uuid,
-          rootPath: rootPath,
-          compress: true,
-        ),
-      );
-
-      final filePath = result.filePath;
-      final fileSize = result.size;
-
-      if (filePath == null || fileSize == null) {
-        _logger.log(
-          LogLevel.debug,
-          'LayoutSnapshotCollector: Failed to write JSON file: ${result.error}',
-        );
-        return null;
-      }
-
-      _logger.log(
-        LogLevel.debug,
-        'LayoutSnapshotCollector: Successfully stored layout snapshot attachment (id: $uuid, size: $fileSize bytes, path: $filePath)',
-      );
-
-      return MsrAttachment.fromPath(
-        path: filePath,
-        type: AttachmentType.layoutSnapshotJson,
-        size: fileSize,
-        uuid: uuid,
-        fileExtension: 'json.gz',
-      );
-    } catch (e) {
-      _logger.log(
-        LogLevel.debug,
-        'LayoutSnapshotCollector: Error capturing layout snapshot: $e',
-      );
-      return null;
     }
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_collector.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/widgets.dart';
+import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/config/config_provider.dart';
+import 'package:measure_flutter/src/gestures/msr_gesture_detector.dart';
+import 'package:measure_flutter/src/isolate/file_processor.dart';
+import 'package:measure_flutter/src/logger/log_level.dart';
+import 'package:measure_flutter/src/logger/logger.dart';
+import 'package:measure_flutter/src/storage/file_storage.dart';
+import 'package:measure_flutter/src/utils/id_provider.dart';
+
+/// Captures layout snapshots and turns them into attachments for other
+/// collectors to add to their events.
+class LayoutSnapshotCollector {
+  final ConfigProvider _configProvider;
+  final FileStorage _fileStorage;
+  final Logger _logger;
+  final IdProvider _idProvider;
+
+  LayoutSnapshotCollector(
+    this._configProvider,
+    this._fileStorage,
+    this._logger,
+    this._idProvider,
+  );
+
+  /// Captures the widget tree once the next frame has been rendered, so that a
+  /// screen which just appeared has been laid out, and returns it as an
+  /// attachment. Returns null when no snapshot could be taken.
+  Future<MsrAttachment?> captureAttachmentAfterNextFrame() async {
+    try {
+      await WidgetsBinding.instance.endOfFrame;
+      final rootElement = layoutSnapshotRootElement;
+      if (rootElement == null) {
+        _logger.log(
+          LogLevel.debug,
+          'LayoutSnapshotCollector: MeasureWidget is not in the widget tree',
+        );
+        return null;
+      }
+      final result = LayoutSnapshotCapture.capture(
+        rootElement,
+        screenBounds: _screenBounds(rootElement),
+        widgetFilter: _configProvider.widgetFilter,
+      );
+      if (result == null) {
+        return null;
+      }
+      return await createAttachment(result.snapshot);
+    } catch (e) {
+      _logger.log(
+        LogLevel.debug,
+        'LayoutSnapshotCollector: Error capturing layout snapshot: $e',
+      );
+      return null;
+    }
+  }
+
+  /// Creates an attachment from an already-captured layout snapshot.
+  ///
+  /// Serializes the [snapshot] to JSON and writes it to a file in an isolate.
+  /// Returns an [MsrAttachment] with the file path, or null if the operation fails.
+  Future<MsrAttachment?> createAttachment(SnapshotNode snapshot) async {
+    try {
+      final rootPath = await _fileStorage.getRootPath();
+      if (rootPath == null) {
+        _logger.log(
+          LogLevel.debug,
+          'LayoutSnapshotCollector: Root path is null',
+        );
+        return null;
+      }
+
+      final uuid = _idProvider.uuid();
+      final result = await writeJsonToFileInIsolate(
+        WriteLayoutSnapshotParams(
+          snapshot: snapshot,
+          fileName: uuid,
+          rootPath: rootPath,
+          compress: true,
+        ),
+      );
+
+      final filePath = result.filePath;
+      final fileSize = result.size;
+
+      if (filePath == null || fileSize == null) {
+        _logger.log(
+          LogLevel.debug,
+          'LayoutSnapshotCollector: Failed to write JSON file: ${result.error}',
+        );
+        return null;
+      }
+
+      _logger.log(
+        LogLevel.debug,
+        'LayoutSnapshotCollector: Successfully stored layout snapshot attachment (id: $uuid, size: $fileSize bytes, path: $filePath)',
+      );
+
+      return MsrAttachment.fromPath(
+        path: filePath,
+        type: AttachmentType.layoutSnapshotJson,
+        size: fileSize,
+        uuid: uuid,
+        fileExtension: 'json.gz',
+      );
+    } catch (e) {
+      _logger.log(
+        LogLevel.debug,
+        'LayoutSnapshotCollector: Error capturing layout snapshot: $e',
+      );
+      return null;
+    }
+  }
+
+  Rect? _screenBounds(Element rootElement) {
+    final renderObject = rootElement.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return null;
+    }
+    final size = renderObject.size;
+    return Rect.fromLTWH(0, 0, size.width, size.height);
+  }
+}

--- a/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_throttler.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_throttler.dart
@@ -1,0 +1,20 @@
+import 'package:measure_flutter/src/time/time_provider.dart';
+
+/// Limits how often layout snapshots are taken by requiring a minimum time
+/// between them. Every call counts as an attempt, so taps closer together than
+/// the delay keep only the first snapshot.
+class LayoutSnapshotThrottler {
+  static const defaultDelayMs = 750;
+
+  final TimeProvider _timeProvider;
+  int _lastAttemptTimestamp = 0;
+
+  LayoutSnapshotThrottler(this._timeProvider);
+
+  bool shouldTakeSnapshot({int delayMs = defaultDelayMs}) {
+    final now = _timeProvider.now();
+    final previous = _lastAttemptTimestamp;
+    _lastAttemptTimestamp = now;
+    return previous == 0 || (now - previous) > delayMs;
+  }
+}

--- a/flutter/packages/measure_flutter/lib/src/gestures/msr_gesture_detector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/msr_gesture_detector.dart
@@ -13,13 +13,23 @@ import 'long_click_data.dart';
 
 const _tapDeltaArea = 20 * 20;
 const _longClickDuration = Duration(milliseconds: 500);
-Element? _clickTrackerElement;
+
+Element? _layoutSnapshotRootElement;
+
+/// The element layout snapshots of a whole screen are captured from, which is
+/// the mounted [MsrGestureDetector] and so requires the app to be wrapped in a
+/// [MeasureWidget]. Null while no detector is mounted, in which case no snapshot
+/// of the screen can be taken.
+///
+/// Gesture snapshots do not read this: a detector captures from its own element,
+/// so that it never depends on which detector registered last.
+Element? get layoutSnapshotRootElement => _layoutSnapshotRootElement;
 
 class MsrGestureDetector extends StatefulWidget {
   final Widget child;
   final Map<Type, String> layoutSnapshotWidgetFilter;
-  final Future<void> Function(ClickData, SnapshotNode?) onClick;
-  final Future<void> Function(LongClickData, SnapshotNode?) onLongClick;
+  final Future<void> Function(ClickData, SnapshotNode?, int) onClick;
+  final Future<void> Function(LongClickData, SnapshotNode?, int) onLongClick;
   final Future<void> Function(ScrollData) onScroll;
 
   const MsrGestureDetector({
@@ -32,21 +42,31 @@ class MsrGestureDetector extends StatefulWidget {
   });
 
   @override
-  StatefulElement createElement() {
-    final element = super.createElement();
-    _clickTrackerElement = element;
-    return element;
-  }
-
-  @override
   MsrGestureDetectorState createState() => MsrGestureDetectorState();
 }
 
 class MsrGestureDetectorState extends State<MsrGestureDetector> {
+  Element? _element;
   int? _lastPointerId;
   Offset? _lastPointerDownLocation;
   Duration? _pointerDownTime;
   bool _isScrolling = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _element = context as Element;
+    _layoutSnapshotRootElement = _element;
+  }
+
+  @override
+  void dispose() {
+    // Another detector may have registered since, and it keeps the slot.
+    if (identical(_layoutSnapshotRootElement, _element)) {
+      _layoutSnapshotRootElement = null;
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -83,6 +103,9 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
   void _onPointerUp(
       PointerUpEvent event, double devicePixelRatio, Size screenSize) {
     try {
+      // Taken here so that the event carries the time of the gesture rather
+      // than the time the layout snapshot finished being captured.
+      final timestamp = Measure.instance.getCurrentTime();
       final location = _lastPointerDownLocation;
       final downTime = _pointerDownTime;
       if (location == null ||
@@ -97,9 +120,9 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
       if (delta.distanceSquared < _tapDeltaArea) {
         if (duration >= _longClickDuration) {
           _handleLongClick(event.position, downTime, event.timeStamp,
-              devicePixelRatio, screenSize);
+              devicePixelRatio, screenSize, timestamp);
         } else {
-          _handleClick(event.position, devicePixelRatio, screenSize);
+          _handleClick(event.position, devicePixelRatio, screenSize, timestamp);
         }
       }
 
@@ -140,12 +163,13 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
     _isScrolling = false;
   }
 
-  void _handleClick(Offset position, double devicePixelRatio, Size screenSize) {
+  void _handleClick(Offset position, double devicePixelRatio, Size screenSize,
+      int timestamp) {
     final screenBounds =
         Rect.fromLTWH(0, 0, screenSize.width, screenSize.height);
 
     final result = LayoutSnapshotCapture.capture(
-      _clickTrackerElement,
+      _element,
       screenBounds: screenBounds,
       detectionPosition: position,
       detectionMode: GestureDetectionMode.click,
@@ -177,6 +201,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
           height: result.gestureElement?.size?.height.toInt(),
         ),
         result.snapshot,
+        timestamp,
       )
           .catchError((error, stackTrace) {
         _logError('onClick', error, stackTrace);
@@ -190,11 +215,12 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
     Duration upTime,
     double devicePixelRatio,
     Size screenSize,
+    int timestamp,
   ) {
     final screenBounds =
         Rect.fromLTWH(0, 0, screenSize.width, screenSize.height);
     final result = LayoutSnapshotCapture.capture(
-      _clickTrackerElement,
+      _element,
       detectionPosition: position,
       detectionMode: GestureDetectionMode.click,
       widgetFilter: Measure.instance.getLayoutSnapshotWidgetFilter(),
@@ -226,6 +252,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
         height: result.gestureElement?.size?.height.toInt(),
       ),
       result.snapshot,
+      timestamp,
     )
         .catchError((error, stackTrace) {
       _logError('onLongClick', error, stackTrace);
@@ -300,7 +327,8 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
 
   /// Finds a scrollable element at the given position.
   (Element?, String?) _findScrollableElement(Offset position) {
-    if (_clickTrackerElement == null) {
+    final rootElement = _element;
+    if (rootElement == null) {
       return (null, null);
     }
 
@@ -317,7 +345,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
       }
       final scrollableType = getScrollableWidgetName(element.widget);
       if (scrollableType != null) {
-        if (_hitTest(element, position, _clickTrackerElement!)) {
+        if (_hitTest(element, position, rootElement)) {
           foundElement = element;
           foundType = scrollableType;
         }
@@ -325,7 +353,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
       element.visitChildElements(traverse);
     }
 
-    traverse(_clickTrackerElement!);
+    traverse(rootElement);
     return (foundElement, foundType);
   }
 

--- a/flutter/packages/measure_flutter/lib/src/measure_api.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_api.dart
@@ -58,6 +58,8 @@ abstract class MeasureApi {
   void trackScreenViewEvent({
     required String name,
     bool userTriggered = true,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
   });
 
   bool shouldTrackHttpRequestBody(String url);
@@ -119,9 +121,17 @@ abstract class MeasureApi {
 
   void setShakeListener(Function? onShake);
 
-  Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot);
+  Future<void> trackClick(
+    ClickData clickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  });
 
-  Future<void> trackLongClick(LongClickData longClickData, SnapshotNode? snapshot);
+  Future<void> trackLongClick(
+    LongClickData longClickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  });
 
   Future<void> trackScroll(ScrollData scrollData);
 

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -5,6 +5,7 @@ import 'package:measure_flutter/src/config/measure_config.dart';
 import 'package:measure_flutter/src/events/custom_event_collector.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/gestures/gesture_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
 import 'package:measure_flutter/src/http/http_collector.dart';
 import 'package:measure_flutter/src/isolate/file_processing_isolate.dart';
 import 'package:measure_flutter/src/isolate/file_processor.dart';
@@ -42,6 +43,7 @@ final class MeasureInitializer {
   late final BugReportCollector _bugReportCollector;
   late final HttpCollector _httpCollector;
   late final GestureCollector _gestureCollector;
+  late final LayoutSnapshotCollector _layoutSnapshotCollector;
   late final ScreenshotCollector _screenshotCollector;
   late final SignalProcessor _signalProcessor;
   late final SpanProcessor _spanProcessor;
@@ -73,6 +75,8 @@ final class MeasureInitializer {
   HttpCollector get httpCollector => _httpCollector;
 
   GestureCollector get gestureCollector => _gestureCollector;
+
+  LayoutSnapshotCollector get layoutSnapshotCollector => _layoutSnapshotCollector;
 
   ScreenshotCollector get screenshotCollector => _screenshotCollector;
 
@@ -150,15 +154,22 @@ final class MeasureInitializer {
       timeProvider: timeProvider,
       methodChannel: _methodChannel,
     );
+    _layoutSnapshotCollector = LayoutSnapshotCollector(
+      _configProvider,
+      _fileStorage,
+      logger,
+      _idProvider,
+    );
     _navigationCollector = NavigationCollector(
       signalProcessor: signalProcessor,
       timeProvider: timeProvider,
+      layoutSnapshotCollector: _layoutSnapshotCollector,
     );
     _httpCollector = HttpCollector(
       signalProcessor: signalProcessor,
       configProvider: configProvider,
     );
-    _gestureCollector = GestureCollector(signalProcessor, timeProvider, _fileStorage, logger, _idProvider);
+    _gestureCollector = GestureCollector(signalProcessor, timeProvider, _layoutSnapshotCollector);
     _shakeDetector = ShakeDetectorImpl(
       methodChannel: _methodChannel,
       methodChannelCallbacks: methodChannelCallbacks,

--- a/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_initializer.dart
@@ -6,6 +6,7 @@ import 'package:measure_flutter/src/events/custom_event_collector.dart';
 import 'package:measure_flutter/src/exception/exception_collector.dart';
 import 'package:measure_flutter/src/gestures/gesture_collector.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/http/http_collector.dart';
 import 'package:measure_flutter/src/isolate/file_processing_isolate.dart';
 import 'package:measure_flutter/src/isolate/file_processor.dart';
@@ -164,12 +165,18 @@ final class MeasureInitializer {
       signalProcessor: signalProcessor,
       timeProvider: timeProvider,
       layoutSnapshotCollector: _layoutSnapshotCollector,
+      layoutSnapshotThrottler: LayoutSnapshotThrottler(_timeProvider),
     );
     _httpCollector = HttpCollector(
       signalProcessor: signalProcessor,
       configProvider: configProvider,
     );
-    _gestureCollector = GestureCollector(signalProcessor, timeProvider, _layoutSnapshotCollector);
+    _gestureCollector = GestureCollector(
+      signalProcessor,
+      timeProvider,
+      _layoutSnapshotCollector,
+      LayoutSnapshotThrottler(_timeProvider),
+    );
     _shakeDetector = ShakeDetectorImpl(
       methodChannel: _methodChannel,
       methodChannelCallbacks: methodChannelCallbacks,

--- a/flutter/packages/measure_flutter/lib/src/measure_internal.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_internal.dart
@@ -128,11 +128,15 @@ final class MeasureInternal {
     required String name,
     required Map<String, AttributeValue> attributes,
     bool userTriggered = true,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
   }) {
     _navigationCollector.trackScreenViewEvent(
       name: name,
       userTriggered: userTriggered,
       attributes: attributes,
+      timestamp: timestamp,
+      captureLayoutSnapshot: captureLayoutSnapshot,
     );
   }
 
@@ -231,17 +235,27 @@ final class MeasureInternal {
     _shakeDetector.setShakeListener(onShake);
   }
 
-  Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot) async {
+  Future<void> trackClick(
+    ClickData clickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     _gestureCollector.trackGestureClick(
       clickData,
       snapshot: snapshot,
+      timestamp: timestamp,
     );
   }
 
-  Future<void> trackLongClick(LongClickData longClickData, SnapshotNode? snapshot) async {
+  Future<void> trackLongClick(
+    LongClickData longClickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     _gestureCollector.trackGestureLongClick(
       longClickData,
       snapshot: snapshot,
+      timestamp: timestamp,
     );
   }
 

--- a/flutter/packages/measure_flutter/lib/src/measure_widget.dart
+++ b/flutter/packages/measure_flutter/lib/src/measure_widget.dart
@@ -59,10 +59,10 @@ class _MeasureWidgetState extends State<MeasureWidget> {
       key: _repaintBoundaryKey,
       child: MsrGestureDetector(
         layoutSnapshotWidgetFilter: Measure.instance.getLayoutSnapshotWidgetFilter(),
-        onClick: (clickData, snapshot) =>
-            Measure.instance.trackClick(clickData, snapshot),
-        onLongClick: (longClickData, snapshot) =>
-            Measure.instance.trackLongClick(longClickData, snapshot),
+        onClick: (clickData, snapshot, timestamp) =>
+            Measure.instance.trackClick(clickData, snapshot, timestamp: timestamp),
+        onLongClick: (longClickData, snapshot, timestamp) => Measure.instance
+            .trackLongClick(longClickData, snapshot, timestamp: timestamp),
         onScroll: (scrollData) => Measure.instance.trackScroll(scrollData),
         child: widget.child,
       ),

--- a/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
@@ -1,4 +1,5 @@
 import 'package:measure_flutter/src/events/event_type.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
@@ -8,11 +9,13 @@ import '../../measure_flutter.dart';
 class NavigationCollector {
   final SignalProcessor signalProcessor;
   final TimeProvider timeProvider;
+  final LayoutSnapshotCollector layoutSnapshotCollector;
   bool _enabled = false;
 
   NavigationCollector({
     required this.signalProcessor,
     required this.timeProvider,
+    required this.layoutSnapshotCollector,
   });
 
   void register() {
@@ -27,17 +30,23 @@ class NavigationCollector {
     required String name,
     required bool userTriggered,
     required Map<String, AttributeValue> attributes,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
   }) async {
     if (!_enabled) {
       return;
     }
-    final data = ScreenViewData(name: name);
+    final eventTimestamp = timestamp ?? timeProvider.now();
+    final attachment = captureLayoutSnapshot
+        ? await layoutSnapshotCollector.captureAttachmentAfterNextFrame()
+        : null;
     return signalProcessor.trackEvent(
-      data: data,
+      data: ScreenViewData(name: name),
       type: EventType.screenView,
-      timestamp: timeProvider.now(),
+      timestamp: eventTimestamp,
       userDefinedAttrs: attributes,
       userTriggered: userTriggered,
+      attachments: attachment != null ? [attachment] : null,
     );
   }
 }

--- a/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/navigation/navigation_collector.dart
@@ -1,5 +1,6 @@
 import 'package:measure_flutter/src/events/event_type.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/method_channel/signal_processor.dart';
 import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
@@ -10,12 +11,14 @@ class NavigationCollector {
   final SignalProcessor signalProcessor;
   final TimeProvider timeProvider;
   final LayoutSnapshotCollector layoutSnapshotCollector;
+  final LayoutSnapshotThrottler layoutSnapshotThrottler;
   bool _enabled = false;
 
   NavigationCollector({
     required this.signalProcessor,
     required this.timeProvider,
     required this.layoutSnapshotCollector,
+    required this.layoutSnapshotThrottler,
   });
 
   void register() {
@@ -37,9 +40,10 @@ class NavigationCollector {
       return;
     }
     final eventTimestamp = timestamp ?? timeProvider.now();
-    final attachment = captureLayoutSnapshot
-        ? await layoutSnapshotCollector.captureAttachmentAfterNextFrame()
-        : null;
+    final attachment =
+        captureLayoutSnapshot && layoutSnapshotThrottler.shouldTakeSnapshot()
+            ? await layoutSnapshotCollector.captureAttachmentAfterNextFrame()
+            : null;
     return signalProcessor.trackEvent(
       data: ScreenViewData(name: name),
       type: EventType.screenView,

--- a/flutter/packages/measure_flutter/lib/src/navigation/navigator_observer.dart
+++ b/flutter/packages/measure_flutter/lib/src/navigation/navigator_observer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../measure_flutter.dart';
@@ -41,6 +43,10 @@ import '../../measure_flutter.dart';
 /// );
 /// ```
 class MsrNavigatorObserver extends NavigatorObserver {
+  /// Grace period added to a route's transition duration before the wait for
+  /// the transition to end is abandoned.
+  static const _transitionTimeoutMargin = Duration(milliseconds: 100);
+
   final MeasureApi _measure;
 
   MsrNavigatorObserver() : _measure = Measure.instance;
@@ -50,22 +56,97 @@ class MsrNavigatorObserver extends NavigatorObserver {
 
   @override
   void didPush(Route route, Route? previousRoute) {
-    _trackScreenView(route.settings.name);
+    _trackScreenView(route.settings.name, route, AnimationStatus.completed);
   }
 
   @override
   void didPop(Route route, Route? previousRoute) {
-    _trackScreenView(previousRoute?.settings.name);
+    _trackScreenView(
+      previousRoute?.settings.name,
+      route,
+      AnimationStatus.dismissed,
+    );
   }
 
   @override
   void didReplace({Route? newRoute, Route? oldRoute}) {
-    _trackScreenView(newRoute?.settings.name);
+    _trackScreenView(
+      newRoute?.settings.name,
+      newRoute,
+      AnimationStatus.completed,
+    );
   }
 
-  void _trackScreenView(String? name) {
-    if (name != null && name.isNotEmpty) {
-      _measure.trackScreenViewEvent(name: name, userTriggered: false);
+  /// Tracks the screen view once [transitioningRoute] reaches [settledStatus].
+  ///
+  /// The layout snapshot attached to the event is captured when the event is
+  /// tracked, so waiting for the transition keeps it from showing the first
+  /// frame of an animation instead of the screen the user lands on. The
+  /// timestamp is taken when the navigation happens, so the event still sits
+  /// where the user navigated on the session timeline.
+  void _trackScreenView(
+    String? name,
+    Route<dynamic>? transitioningRoute,
+    AnimationStatus settledStatus,
+  ) {
+    if (name == null || name.isEmpty) {
+      return;
     }
+    final timestamp = _measure.getCurrentTime();
+    final route =
+        transitioningRoute is TransitionRoute ? transitioningRoute : null;
+    if (route == null || route.animation == null) {
+      _track(name, timestamp);
+      return;
+    }
+    _whenTransitionEnds(route, settledStatus)
+        .then((_) => _track(name, timestamp));
+  }
+
+  /// Completes once [route] has finished animating.
+  ///
+  /// A pushed route reports a settled status for an instant before its
+  /// transition starts, so the wait begins on the next frame, by which point
+  /// the animation reflects the transition that is actually running.
+  Future<void> _whenTransitionEnds(
+    TransitionRoute<dynamic> route,
+    AnimationStatus settledStatus,
+  ) async {
+    await WidgetsBinding.instance.endOfFrame;
+    final animation = route.animation;
+    // A route removed during its transition is left holding an animation that
+    // never moves again, and [Route.navigator] is cleared when it goes.
+    if (animation == null ||
+        route.navigator == null ||
+        animation.status == settledStatus) {
+      return;
+    }
+    final completer = Completer<void>();
+    void onStatusChanged(AnimationStatus status) {
+      if (status == AnimationStatus.completed ||
+          status == AnimationStatus.dismissed) {
+        animation.removeStatusListener(onStatusChanged);
+        completer.complete();
+      }
+    }
+
+    animation.addStatusListener(onStatusChanged);
+    final duration = settledStatus == AnimationStatus.dismissed
+        ? route.reverseTransitionDuration
+        : route.transitionDuration;
+    // A route removed after this point never reaches a settled status, and the
+    // screen view must not be lost with it.
+    await completer.future.timeout(
+      duration + _transitionTimeoutMargin,
+      onTimeout: () => animation.removeStatusListener(onStatusChanged),
+    );
+  }
+
+  void _track(String name, int timestamp) {
+    _measure.trackScreenViewEvent(
+      name: name,
+      userTriggered: false,
+      timestamp: timestamp,
+    );
   }
 }

--- a/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/gestures/click_data.dart';
+import 'package:measure_flutter/src/gestures/gesture_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+import 'package:measure_flutter/src/gestures/long_click_data.dart';
+import 'package:measure_flutter/src/time/time_provider.dart';
+
+import '../utils/fake_signal_processor.dart';
+import '../utils/test_clock.dart';
+
+void main() {
+  group('GestureCollector', () {
+    late FakeSignalProcessor signalProcessor;
+    late TestClock clock;
+    late GestureCollector collector;
+    late _SlowLayoutSnapshotCollector snapshotCollector;
+
+    final snapshot = SnapshotNode(
+      label: 'Button',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      children: [],
+    );
+
+    setUp(() {
+      signalProcessor = FakeSignalProcessor();
+      clock = TestClock.create();
+      snapshotCollector = _SlowLayoutSnapshotCollector(clock);
+      collector = GestureCollector(
+        signalProcessor,
+        FlutterTimeProvider(clock),
+        snapshotCollector,
+      );
+      collector.register();
+    });
+
+    test('stamps a click at the gesture, not after the snapshot is written',
+        () async {
+      final tapTime = clock.epochTime();
+
+      await collector.trackGestureClick(
+        ClickData(
+          target: 'Button',
+          x: 1,
+          y: 1,
+          touchDownTime: null,
+          touchUpTime: null,
+        ),
+        snapshot: snapshot,
+      );
+
+      expect(signalProcessor.trackedEvents.single.timestamp, equals(tapTime));
+    });
+
+    test('stamps a long click at the gesture, not after the snapshot is '
+        'written', () async {
+      final tapTime = clock.epochTime();
+
+      await collector.trackGestureLongClick(
+        LongClickData(
+          target: 'Button',
+          x: 1,
+          y: 1,
+          touchDownTime: null,
+          touchUpTime: null,
+        ),
+        snapshot: snapshot,
+      );
+
+      expect(signalProcessor.trackedEvents.single.timestamp, equals(tapTime));
+    });
+
+    test('keeps the timestamp the caller supplies', () async {
+      await collector.trackGestureClick(
+        ClickData(
+          target: 'Button',
+          x: 1,
+          y: 1,
+          touchDownTime: null,
+          touchUpTime: null,
+        ),
+        snapshot: snapshot,
+        timestamp: 42,
+      );
+
+      expect(signalProcessor.trackedEvents.single.timestamp, equals(42));
+    });
+  });
+}
+
+/// Stands in for the real collector, whose json encode, gzip and file write
+/// take time the event timestamp must not absorb.
+class _SlowLayoutSnapshotCollector implements LayoutSnapshotCollector {
+  _SlowLayoutSnapshotCollector(this._clock);
+
+  final TestClock _clock;
+
+  @override
+  Future<MsrAttachment?> createAttachment(SnapshotNode snapshot) async {
+    _clock.advance(const Duration(milliseconds: 120));
+    return null;
+  }
+
+  @override
+  Future<MsrAttachment?> captureAttachmentAfterNextFrame() async => null;
+}

--- a/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
@@ -5,6 +5,8 @@ import 'package:measure_flutter/src/gestures/gesture_collector.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
+import 'package:measure_flutter/src/gestures/msr_scroll_direction.dart';
+import 'package:measure_flutter/src/gestures/scroll_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
 import '../utils/fake_layout_snapshot_collector.dart';
@@ -12,39 +14,43 @@ import '../utils/fake_signal_processor.dart';
 import '../utils/test_clock.dart';
 
 void main() {
-  group('GestureCollector', () {
-    late FakeSignalProcessor signalProcessor;
-    late TestClock clock;
-    late GestureCollector collector;
-    late _SlowLayoutSnapshotCollector snapshotCollector;
+  late FakeSignalProcessor signalProcessor;
+  late TestClock clock;
+  late GestureCollector collector;
 
-    final snapshot = SnapshotNode(
-      label: 'Button',
-      x: 0,
-      y: 0,
-      width: 10,
-      height: 10,
-      children: [],
-    );
+  final snapshot = SnapshotNode(
+    label: 'Button',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    children: [],
+  );
+  final attachment = MsrAttachment.fromPath(
+    path: 'snapshot-path',
+    type: AttachmentType.layoutSnapshotJson,
+    size: 10,
+    uuid: 'uuid-1',
+    fileExtension: 'json.gz',
+  );
 
-    setUp(() {
-      signalProcessor = FakeSignalProcessor();
-      clock = TestClock.create();
-      snapshotCollector = _SlowLayoutSnapshotCollector(clock);
-      collector = GestureCollector(
-        signalProcessor,
-        FlutterTimeProvider(clock),
-        snapshotCollector,
-        LayoutSnapshotThrottler(FlutterTimeProvider(clock)),
-      );
-      collector.register();
-    });
+  GestureCollector collectorWith(LayoutSnapshotCollector snapshotCollector) {
+    final timeProvider = FlutterTimeProvider(clock);
+    return GestureCollector(
+      signalProcessor,
+      timeProvider,
+      snapshotCollector,
+      LayoutSnapshotThrottler(timeProvider),
+    )..register();
+  }
 
-    test('stamps a click at the gesture, not after the snapshot is written',
-        () async {
-      final tapTime = clock.epochTime();
+  setUp(() {
+    signalProcessor = FakeSignalProcessor();
+    clock = TestClock.create();
+    collector = collectorWith(FakeLayoutSnapshotCollector(attachment: attachment));
+  });
 
-      await collector.trackGestureClick(
+  Future<void> click({int? timestamp}) => collector.trackGestureClick(
         ClickData(
           target: 'Button',
           x: 1,
@@ -53,16 +59,10 @@ void main() {
           touchUpTime: null,
         ),
         snapshot: snapshot,
+        timestamp: timestamp,
       );
 
-      expect(signalProcessor.trackedEvents.single.timestamp, equals(tapTime));
-    });
-
-    test('stamps a long click at the gesture, not after the snapshot is '
-        'written', () async {
-      final tapTime = clock.epochTime();
-
-      await collector.trackGestureLongClick(
+  Future<void> longClick() => collector.trackGestureLongClick(
         LongClickData(
           target: 'Button',
           x: 1,
@@ -73,94 +73,97 @@ void main() {
         snapshot: snapshot,
       );
 
-      expect(signalProcessor.trackedEvents.single.timestamp, equals(tapTime));
+  TrackedEvent lastEvent() => signalProcessor.trackedEvents.last;
+
+  group('gesture events', () {
+    test('stamps a click at the tap, not when its snapshot finished writing',
+        () async {
+      collector = collectorWith(_SlowLayoutSnapshotCollector(clock));
+      final tapTime = clock.epochTime();
+
+      await click();
+
+      expect(lastEvent().timestamp, equals(tapTime));
     });
 
-    test('keeps the timestamp the caller supplies', () async {
-      await collector.trackGestureClick(
-        ClickData(
-          target: 'Button',
-          x: 1,
-          y: 1,
-          touchDownTime: null,
-          touchUpTime: null,
-        ),
-        snapshot: snapshot,
-        timestamp: 42,
-      );
+    test(
+        'stamps a long click at the tap, not when its snapshot finished '
+        'writing', () async {
+      collector = collectorWith(_SlowLayoutSnapshotCollector(clock));
+      final tapTime = clock.epochTime();
 
-      expect(signalProcessor.trackedEvents.single.timestamp, equals(42));
+      await longClick();
+
+      expect(lastEvent().timestamp, equals(tapTime));
+    });
+
+    test('stamps a click at the timestamp the caller supplies', () async {
+      final tapTime = clock.epochTime();
+      clock.advance(const Duration(milliseconds: 300));
+
+      await click(timestamp: tapTime);
+
+      expect(lastEvent().timestamp, equals(tapTime));
+    });
+
+    test('ignores a click while the collector is unregistered', () async {
+      collector.unregister();
+
+      await click();
+
+      expect(signalProcessor.trackedEvents, isEmpty);
+    });
+
+    test('tracks a scroll, which carries no snapshot', () async {
+      collector.trackGestureScroll(ScrollData(
+        target: 'ListView',
+        x: 1,
+        y: 1,
+        endX: 1,
+        endY: 100,
+        touchDownTime: null,
+        touchUpTime: null,
+        direction: MsrScrollDirection.down,
+      ));
+
+      expect(lastEvent().attachments, isNull);
     });
   });
 
-  group('GestureCollector layout snapshot throttling', () {
-    late FakeSignalProcessor signalProcessor;
-    late TestClock clock;
-    late GestureCollector collector;
-
-    final snapshot = SnapshotNode(
-      label: 'Button',
-      x: 0,
-      y: 0,
-      width: 10,
-      height: 10,
-      children: [],
-    );
-    final attachment = MsrAttachment.fromPath(
-      path: 'snapshot-path',
-      type: AttachmentType.layoutSnapshotJson,
-      size: 10,
-      uuid: 'uuid-1',
-      fileExtension: 'json.gz',
-    );
-
-    Future<void> click() => collector.trackGestureClick(
-          ClickData(
-            target: 'Button',
-            x: 1,
-            y: 1,
-            touchDownTime: null,
-            touchUpTime: null,
-          ),
-          snapshot: snapshot,
-        );
-
-    setUp(() {
-      signalProcessor = FakeSignalProcessor();
-      clock = TestClock.create();
-      collector = GestureCollector(
-        signalProcessor,
-        FlutterTimeProvider(clock),
-        FakeLayoutSnapshotCollector(attachment: attachment),
-        LayoutSnapshotThrottler(FlutterTimeProvider(clock)),
-      );
-      collector.register();
-    });
-
-    test('attaches a snapshot to the first click', () async {
+  group('layout snapshots', () {
+    test('attaches a snapshot of the screen to the click', () async {
       await click();
 
-      expect(signalProcessor.trackedEvents.single.attachments?.single,
-          same(attachment));
+      expect(lastEvent().attachments?.single, same(attachment));
     });
 
-    test('leaves out the snapshot of a click within the delay', () async {
+    test('tracks a click within the throttle window without a snapshot',
+        () async {
       await click();
       clock.advance(const Duration(milliseconds: 500));
 
       await click();
 
-      expect(signalProcessor.trackedEvents.last.attachments, isNull);
+      expect(lastEvent().attachments, isNull);
     });
 
-    test('attaches a snapshot again once the delay has elapsed', () async {
+    test('attaches a snapshot again once the throttle window has passed',
+        () async {
       await click();
       clock.advance(const Duration(milliseconds: 751));
 
       await click();
 
-      expect(signalProcessor.trackedEvents.last.attachments?.single,
-          same(attachment));
+      expect(lastEvent().attachments?.single, same(attachment));
+    });
+
+    test('throttles a long click against the same window as a click', () async {
+      await click();
+      clock.advance(const Duration(milliseconds: 500));
+
+      await longClick();
+
+      expect(lastEvent().attachments, isNull);
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/gesture_collector_test.dart
@@ -3,9 +3,11 @@ import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/gestures/click_data.dart';
 import 'package:measure_flutter/src/gestures/gesture_collector.dart';
 import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/gestures/long_click_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
+import '../utils/fake_layout_snapshot_collector.dart';
 import '../utils/fake_signal_processor.dart';
 import '../utils/test_clock.dart';
 
@@ -33,6 +35,7 @@ void main() {
         signalProcessor,
         FlutterTimeProvider(clock),
         snapshotCollector,
+        LayoutSnapshotThrottler(FlutterTimeProvider(clock)),
       );
       collector.register();
     });
@@ -87,6 +90,77 @@ void main() {
       );
 
       expect(signalProcessor.trackedEvents.single.timestamp, equals(42));
+    });
+  });
+
+  group('GestureCollector layout snapshot throttling', () {
+    late FakeSignalProcessor signalProcessor;
+    late TestClock clock;
+    late GestureCollector collector;
+
+    final snapshot = SnapshotNode(
+      label: 'Button',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      children: [],
+    );
+    final attachment = MsrAttachment.fromPath(
+      path: 'snapshot-path',
+      type: AttachmentType.layoutSnapshotJson,
+      size: 10,
+      uuid: 'uuid-1',
+      fileExtension: 'json.gz',
+    );
+
+    Future<void> click() => collector.trackGestureClick(
+          ClickData(
+            target: 'Button',
+            x: 1,
+            y: 1,
+            touchDownTime: null,
+            touchUpTime: null,
+          ),
+          snapshot: snapshot,
+        );
+
+    setUp(() {
+      signalProcessor = FakeSignalProcessor();
+      clock = TestClock.create();
+      collector = GestureCollector(
+        signalProcessor,
+        FlutterTimeProvider(clock),
+        FakeLayoutSnapshotCollector(attachment: attachment),
+        LayoutSnapshotThrottler(FlutterTimeProvider(clock)),
+      );
+      collector.register();
+    });
+
+    test('attaches a snapshot to the first click', () async {
+      await click();
+
+      expect(signalProcessor.trackedEvents.single.attachments?.single,
+          same(attachment));
+    });
+
+    test('leaves out the snapshot of a click within the delay', () async {
+      await click();
+      clock.advance(const Duration(milliseconds: 500));
+
+      await click();
+
+      expect(signalProcessor.trackedEvents.last.attachments, isNull);
+    });
+
+    test('attaches a snapshot again once the delay has elapsed', () async {
+      await click();
+      clock.advance(const Duration(milliseconds: 751));
+
+      await click();
+
+      expect(signalProcessor.trackedEvents.last.attachments?.single,
+          same(attachment));
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
@@ -1,183 +1,121 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:measure_flutter/measure_flutter.dart';
-import 'package:measure_flutter/src/gestures/gesture_collector.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
 import 'package:measure_flutter/src/isolate/file_processor.dart';
-import 'package:measure_flutter/src/method_channel/signal_processor.dart';
-import 'package:measure_flutter/src/time/time_provider.dart';
 
+import '../utils/fake_config_provider.dart';
 import '../utils/fake_file_processing_isolate.dart';
 import '../utils/fake_file_storage.dart';
 import '../utils/fake_id_provider.dart';
-import '../utils/fake_signal_processor.dart';
+import '../utils/measure_test_app.dart';
 import '../utils/noop_logger.dart';
 
 void main() {
-  group('GestureCollector createAttachment', () {
-    late GestureCollector collector;
-    late FakeIdProvider idProvider;
-    late FakeFileStorage fileStorage;
-    late NoopLogger logger;
-    late FakeFileProcessingIsolate fakeWorker;
-    late SignalProcessor signalProcessor;
-    late TimeProvider timeProvider;
+  late LayoutSnapshotCollector collector;
+  late FakeIdProvider idProvider;
+  late FakeFileStorage fileStorage;
+  late NoopLogger logger;
+  late FakeFileProcessingIsolate worker;
 
-    setUp(() {
-      idProvider = FakeIdProvider();
-      fileStorage = FakeFileStorage();
-      logger = NoopLogger();
-      fakeWorker = FakeFileProcessingIsolate();
-      signalProcessor = FakeSignalProcessor();
-      timeProvider = FakeTimeProvider();
+  final snapshot = SnapshotNode(
+    label: 'Parent',
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 200,
+    children: [
+      SnapshotNode(
+        label: 'Child',
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 50,
+        highlighted: true,
+        children: [],
+      ),
+    ],
+  );
 
-      // Initialize the shared worker used by writeJsonToFileInIsolate
-      initializeFileProcessingIsolate(fakeWorker);
+  setUp(() {
+    idProvider = FakeIdProvider();
+    fileStorage = FakeFileStorage();
+    logger = NoopLogger();
+    worker = FakeFileProcessingIsolate();
+    initializeFileProcessingIsolate(worker);
+    collector = LayoutSnapshotCollector(
+      FakeConfigProvider(),
+      fileStorage,
+      logger,
+      idProvider,
+    );
+  });
 
-      collector = GestureCollector(
-        signalProcessor,
-        timeProvider,
+  group('createAttachment', () {
+    test('names the compressed snapshot after its id', () async {
+      final result = await collector.createAttachment(snapshot);
+
+      expect(result, isNotNull);
+      expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
+      expect(result.name, equals('${result.id}.json.gz'));
+      expect(result.path, contains(result.id));
+      expect(result.size, greaterThan(0));
+    });
+
+    test('gives every attachment its own id', () async {
+      final first = await collector.createAttachment(snapshot);
+      final second = await collector.createAttachment(snapshot);
+
+      expect(first!.id, isNot(equals(second!.id)));
+    });
+
+    // Storing a snapshot reaches the file system through an isolate, and no
+    // failure along the way may reach the app.
+    final failures = <String, void Function()>{
+      'the storage root is unavailable': () =>
+          fileStorage.shouldReturnNullPath = true,
+      'the write reports an error': () => worker.shouldReturnError = true,
+      'the write throws': () => worker.shouldThrowException = true,
+    };
+    failures.forEach((cause, arrange) {
+      test('returns null when $cause', () async {
+        arrange();
+
+        expect(await collector.createAttachment(snapshot), isNull);
+      });
+    });
+  });
+
+  group('captureAttachmentAfterNextFrame', () {
+    testWidgets('captures the screen once a frame has been rendered',
+        (tester) async {
+      final future = collector.captureAttachmentAfterNextFrame();
+      await tester.pumpWidget(measureApp(child: const Text('Home')));
+
+      final result = await future;
+
+      expect(result, isNotNull);
+      expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
+    });
+
+    testWidgets('returns null when reading the widget tree throws',
+        (tester) async {
+      final failing = LayoutSnapshotCollector(
+        _ThrowingConfigProvider(),
         fileStorage,
         logger,
         idProvider,
       );
-    });
 
-    test('creates attachment successfully with valid snapshot', () async {
-      final snapshot = SnapshotNode(
-        label: 'TestWidget',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
+      final future = failing.captureAttachmentAfterNextFrame();
+      await tester.pumpWidget(measureApp(child: const Text('Home')));
 
-      final result = await collector.createAttachment(snapshot);
-
-      expect(result, isNotNull);
-      expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
-      expect(result.id, equals('uuid-1'));
-      expect(result.name, equals('uuid-1.json.gz'));
-      expect(result.path, contains('uuid-1'));
-      expect(result.size, greaterThan(0));
-    });
-
-    test('creates attachment with nested children', () async {
-      final snapshot = SnapshotNode(
-        label: 'Parent',
-        x: 0,
-        y: 0,
-        width: 200,
-        height: 200,
-        children: [
-          SnapshotNode(
-            label: 'Child1',
-            x: 10,
-            y: 10,
-            width: 50,
-            height: 50,
-            children: [],
-          ),
-          SnapshotNode(
-            label: 'Child2',
-            x: 70,
-            y: 70,
-            width: 50,
-            height: 50,
-            highlighted: true,
-            children: [],
-          ),
-        ],
-      );
-
-      final result = await collector.createAttachment(snapshot);
-
-      expect(result, isNotNull);
-      expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
-      expect(result.size, greaterThan(0));
-    });
-
-    test('returns null when root path is null', () async {
-      fileStorage.shouldReturnNullPath = true;
-      final snapshot = SnapshotNode(
-        label: 'TestWidget',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
-
-      final result = await collector.createAttachment(snapshot);
-
-      expect(result, isNull);
-    });
-
-    test('returns null when file writing fails', () async {
-      fakeWorker.shouldReturnError = true;
-      final snapshot = SnapshotNode(
-        label: 'TestWidget',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
-
-      final result = await collector.createAttachment(snapshot);
-
-      expect(result, isNull);
-    });
-
-    test('handles exceptions gracefully', () async {
-      fakeWorker.shouldThrowException = true;
-      final snapshot = SnapshotNode(
-        label: 'TestWidget',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
-
-      final result = await collector.createAttachment(snapshot);
-
-      expect(result, isNull);
-    });
-
-    test('generates unique IDs for multiple attachments', () async {
-      final snapshot1 = SnapshotNode(
-        label: 'Widget1',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
-      final snapshot2 = SnapshotNode(
-        label: 'Widget2',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        children: [],
-      );
-
-      final result1 = await collector.createAttachment(snapshot1);
-      final result2 = await collector.createAttachment(snapshot2);
-
-      expect(result1, isNotNull);
-      expect(result2, isNotNull);
-      expect(result1!.id, equals('uuid-1'));
-      expect(result2!.id, equals('uuid-2'));
-      expect(result1.id, isNot(equals(result2.id)));
+      expect(await future, isNull);
     });
   });
 }
 
-class FakeTimeProvider implements TimeProvider {
+class _ThrowingConfigProvider extends FakeConfigProvider {
   @override
-  int now() => 0;
-
-  @override
-  int get elapsedRealtime => 0;
+  Map<Type, String> get widgetFilter => throw StateError('capture failed');
 }

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_root_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_root_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/gestures/msr_gesture_detector.dart';
+
+import '../utils/measure_test_app.dart';
+
+void main() {
+  group('layoutSnapshotRootElement', () {
+    testWidgets('is the mounted detector', (tester) async {
+      await tester.pumpWidget(measureApp());
+
+      expect(layoutSnapshotRootElement,
+          equals(tester.element(find.byType(MsrGestureDetector))));
+    });
+
+    testWidgets('is null once the detector leaves the tree', (tester) async {
+      await tester.pumpWidget(measureApp());
+
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      expect(layoutSnapshotRootElement, isNull);
+    });
+
+    // The replacement mounts before the old detector is unmounted at the end of
+    // the frame, so the departing one must not clear the newcomer.
+    testWidgets('survives one detector replacing another', (tester) async {
+      await tester.pumpWidget(measureApp(detectorKey: const ValueKey('first')));
+
+      await tester.pumpWidget(measureApp(detectorKey: const ValueKey('second')));
+
+      expect(layoutSnapshotRootElement,
+          equals(tester.element(find.byType(MsrGestureDetector))));
+    });
+  });
+}

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_throttler_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_throttler_test.dart
@@ -18,20 +18,30 @@ void main() {
       expect(throttler.shouldTakeSnapshot(), isTrue);
     });
 
-    test('blocks a snapshot taken too soon after the previous one', () {
+    test('blocks a snapshot asked for within the delay', () {
       throttler.shouldTakeSnapshot();
+      clock.advance(const Duration(milliseconds: 500));
 
       expect(throttler.shouldTakeSnapshot(), isFalse);
     });
 
-    test('allows a snapshot once the delay has elapsed', () {
+    test('allows a snapshot once the delay has passed', () {
       throttler.shouldTakeSnapshot();
       clock.advance(const Duration(milliseconds: 751));
 
       expect(throttler.shouldTakeSnapshot(), isTrue);
     });
 
-    test('respects a custom delay', () {
+    test('measures the delay from the last attempt, blocked or not', () {
+      throttler.shouldTakeSnapshot();
+      clock.advance(const Duration(milliseconds: 500));
+      throttler.shouldTakeSnapshot();
+      clock.advance(const Duration(milliseconds: 500));
+
+      expect(throttler.shouldTakeSnapshot(), isFalse);
+    });
+
+    test('takes the delay from the caller', () {
       throttler.shouldTakeSnapshot(delayMs: 100);
       clock.advance(const Duration(milliseconds: 50));
 

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_throttler_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_throttler_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
+import 'package:measure_flutter/src/time/time_provider.dart';
+
+import '../utils/test_clock.dart';
+
+void main() {
+  group('LayoutSnapshotThrottler', () {
+    late TestClock clock;
+    late LayoutSnapshotThrottler throttler;
+
+    setUp(() {
+      clock = TestClock.create();
+      throttler = LayoutSnapshotThrottler(FlutterTimeProvider(clock));
+    });
+
+    test('allows the first snapshot', () {
+      expect(throttler.shouldTakeSnapshot(), isTrue);
+    });
+
+    test('blocks a snapshot taken too soon after the previous one', () {
+      throttler.shouldTakeSnapshot();
+
+      expect(throttler.shouldTakeSnapshot(), isFalse);
+    });
+
+    test('allows a snapshot once the delay has elapsed', () {
+      throttler.shouldTakeSnapshot();
+      clock.advance(const Duration(milliseconds: 751));
+
+      expect(throttler.shouldTakeSnapshot(), isTrue);
+    });
+
+    test('respects a custom delay', () {
+      throttler.shouldTakeSnapshot(delayMs: 100);
+      clock.advance(const Duration(milliseconds: 50));
+
+      expect(throttler.shouldTakeSnapshot(delayMs: 100), isFalse);
+
+      clock.advance(const Duration(milliseconds: 101));
+
+      expect(throttler.shouldTakeSnapshot(delayMs: 100), isTrue);
+    });
+  });
+}

--- a/flutter/packages/measure_flutter/test/gestures/msr_gesture_detector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/msr_gesture_detector_test.dart
@@ -11,15 +11,15 @@ void main() {
   group('MsrGestureDetector', () {
     Widget createTestWidget({
       Widget? child,
-      Future<void> Function(ClickData, SnapshotNode?)? onClick,
-      Future<void> Function(LongClickData, SnapshotNode?)? onLongClick,
+      Future<void> Function(ClickData, SnapshotNode?, int)? onClick,
+      Future<void> Function(LongClickData, SnapshotNode?, int)? onLongClick,
       Future<void> Function(ScrollData)? onScroll,
     }) {
       return MaterialApp(
         home: Scaffold(
           body: MsrGestureDetector(
-            onClick: onClick ?? (data, snapshot) async {},
-            onLongClick: onLongClick ?? (data, snapshot) async {},
+            onClick: onClick ?? (data, snapshot, timestamp) async {},
+            onLongClick: onLongClick ?? (data, snapshot, timestamp) async {},
             onScroll: onScroll ?? (data) async {},
             layoutSnapshotWidgetFilter: {},
             child: child ??
@@ -54,7 +54,7 @@ void main() {
         final clickEvents = <ClickData>[];
 
         await tester.pumpWidget(createTestWidget(
-          onClick: (data, snapshot) async => clickEvents.add(data),
+          onClick: (data, snapshot, timestamp) async => clickEvents.add(data),
         ));
 
         // Tap the button
@@ -73,7 +73,7 @@ void main() {
         final clickEvents = <ClickData>[];
 
         await tester.pumpWidget(createTestWidget(
-          onClick: (data, snapshot) async => clickEvents.add(data),
+          onClick: (data, snapshot, timestamp) async => clickEvents.add(data),
           child: SizedBox(
             width: 200,
             height: 200,
@@ -97,8 +97,8 @@ void main() {
 
         await tester.pumpWidget(
           createTestWidget(
-            onClick: (data, snapshot) async => clickEvents.add(data),
-            onLongClick: (data, snapshot) async => longClickEvents.add(data),
+            onClick: (data, snapshot, timestamp) async => clickEvents.add(data),
+            onLongClick: (data, snapshot, timestamp) async => longClickEvents.add(data),
           ),
         );
 
@@ -141,8 +141,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: MsrGestureDetector(
-              onClick: (data, snapshot) async {},
-              onLongClick: (data, snapshot) async {},
+              onClick: (data, snapshot, timestamp) async {},
+              onLongClick: (data, snapshot, timestamp) async {},
               onScroll: (data) async => scrollEvents.add(data),
               layoutSnapshotWidgetFilter: {},
               child: SizedBox(
@@ -175,8 +175,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: MsrGestureDetector(
-              onClick: (data, snapshot) async {},
-              onLongClick: (data, snapshot) async {},
+              onClick: (data, snapshot, timestamp) async {},
+              onLongClick: (data, snapshot, timestamp) async {},
               onScroll: (data) async {
                 scrollEvents.add(data);
               },
@@ -233,8 +233,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: MsrGestureDetector(
-              onClick: (data, snapshot) async {},
-              onLongClick: (data, snapshot) async {},
+              onClick: (data, snapshot, timestamp) async {},
+              onLongClick: (data, snapshot, timestamp) async {},
               onScroll: (data) async {
                 scrollEvents.add(data);
               },
@@ -272,8 +272,8 @@ void main() {
         final scrollEvents = <ScrollData>[];
 
         await tester.pumpWidget(createTestWidget(
-          onClick: (data, snapshot) async => clickEvents.add(data),
-          onLongClick: (data, snapshot) async => longClickEvents.add(data),
+          onClick: (data, snapshot, timestamp) async => clickEvents.add(data),
+          onLongClick: (data, snapshot, timestamp) async => longClickEvents.add(data),
           onScroll: (data) async => scrollEvents.add(data),
         ));
 
@@ -295,7 +295,7 @@ void main() {
         final clickEvents = <ClickData>[];
 
         await tester.pumpWidget(createTestWidget(
-          onClick: (data, snapshot) async => clickEvents.add(data),
+          onClick: (data, snapshot, timestamp) async => clickEvents.add(data),
         ));
 
         // Start first gesture
@@ -326,10 +326,10 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: MsrGestureDetector(
-              onClick: (data, snapshot) async {
+              onClick: (data, snapshot, timestamp) async {
                 throw Exception('Test exception');
               },
-              onLongClick: (data, snapshot) async {},
+              onLongClick: (data, snapshot, timestamp) async {},
               onScroll: (data) async {},
               layoutSnapshotWidgetFilter: {},
               child: ElevatedButton(
@@ -365,8 +365,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: MsrGestureDetector(
-                onClick: (data, snapshot) async {},
-                onLongClick: (data, snapshot) async {},
+                onClick: (data, snapshot, timestamp) async {},
+                onLongClick: (data, snapshot, timestamp) async {},
                 onScroll: (data) async {
                   scrollEvents.add(data);
                 },
@@ -440,8 +440,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: MsrGestureDetector(
-                onClick: (data, snapshot) async {},
-                onLongClick: (data, snapshot) async {},
+                onClick: (data, snapshot, timestamp) async {},
+                onLongClick: (data, snapshot, timestamp) async {},
                 onScroll: (data) async {
                   scrollEvents.add(data);
                 },
@@ -516,8 +516,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: MsrGestureDetector(
-                onClick: (data, snapshot) async {},
-                onLongClick: (data, snapshot) async {},
+                onClick: (data, snapshot, timestamp) async {},
+                onLongClick: (data, snapshot, timestamp) async {},
                 onScroll: (data) async {
                   scrollEvents.add(data);
                 },

--- a/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_throttler.dart';
 import 'package:measure_flutter/src/navigation/navigation_collector.dart';
 import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
@@ -13,6 +14,7 @@ void main() {
   late NavigationCollector collector;
   late TimeProvider timeProvider;
   late FakeLayoutSnapshotCollector snapshotCollector;
+  late TestClock clock;
 
   final snapshotAttachment = MsrAttachment.fromPath(
     path: 'snapshot-path',
@@ -24,7 +26,8 @@ void main() {
 
   setUp(() {
     signalProcessor = FakeSignalProcessor();
-    timeProvider = FlutterTimeProvider(TestClock.create());
+    clock = TestClock.create();
+    timeProvider = FlutterTimeProvider(clock);
     snapshotCollector = FakeLayoutSnapshotCollector(
       attachment: snapshotAttachment,
     );
@@ -32,6 +35,7 @@ void main() {
       signalProcessor: signalProcessor,
       timeProvider: timeProvider,
       layoutSnapshotCollector: snapshotCollector,
+      layoutSnapshotThrottler: LayoutSnapshotThrottler(timeProvider),
     );
     collector.register();
   });
@@ -75,6 +79,41 @@ void main() {
 
       expect(snapshotCollector.captureCount, equals(0));
       expect(trackedEvent().attachments, isNull);
+    });
+
+    test('leaves out the snapshot of a screen view within the delay', () async {
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: false,
+        attributes: {},
+      );
+      clock.advance(const Duration(milliseconds: 500));
+
+      await collector.trackScreenViewEvent(
+        name: 'CheckoutScreen',
+        userTriggered: false,
+        attributes: {},
+      );
+
+      expect(signalProcessor.trackedEvents.last.attachments, isNull);
+    });
+
+    test('attaches a snapshot again once the delay has elapsed', () async {
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: false,
+        attributes: {},
+      );
+      clock.advance(const Duration(milliseconds: 751));
+
+      await collector.trackScreenViewEvent(
+        name: 'CheckoutScreen',
+        userTriggered: false,
+        attributes: {},
+      );
+
+      expect(signalProcessor.trackedEvents.last.attachments?.single,
+          same(snapshotAttachment));
     });
 
     test('does nothing while unregistered', () async {

--- a/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
@@ -40,92 +40,100 @@ void main() {
     collector.register();
   });
 
-  TrackedEvent trackedEvent() => signalProcessor.trackedEvents.single;
+  Future<void> trackScreenView(
+    String name, {
+    bool userTriggered = false,
+    Map<String, AttributeValue> attributes = const {},
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
+  }) =>
+      collector.trackScreenViewEvent(
+        name: name,
+        userTriggered: userTriggered,
+        attributes: attributes,
+        timestamp: timestamp,
+        captureLayoutSnapshot: captureLayoutSnapshot,
+      );
 
-  group('trackScreenViewEvent', () {
-    test('tracks the screen with its attributes, at the time of the call',
+  TrackedEvent lastEvent() => signalProcessor.trackedEvents.last;
+
+  String screenName(TrackedEvent event) => (event.data as ScreenViewData).name;
+
+  group('screen views', () {
+    test('tracks the screen name, its attributes and who triggered it',
         () async {
       final attributes = {'key': StringAttr('value')};
 
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
+      await trackScreenView(
+        'HomeScreen',
         userTriggered: true,
         attributes: attributes,
       );
 
-      expect((trackedEvent().data as ScreenViewData).name, equals('HomeScreen'));
-      expect(trackedEvent().userTriggered, isTrue);
-      expect(trackedEvent().userDefinedAttrs, equals(attributes));
-      expect(trackedEvent().timestamp, equals(timeProvider.now()));
+      expect(screenName(lastEvent()), equals('HomeScreen'));
+      expect(lastEvent().userTriggered, isTrue);
+      expect(lastEvent().userDefinedAttrs, equals(attributes));
     });
 
-    test('attaches the layout snapshot', () async {
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
-        userTriggered: false,
-        attributes: {},
-      );
+    test('stamps the screen view at the time it is tracked', () async {
+      await trackScreenView('HomeScreen');
 
-      expect(trackedEvent().attachments?.single, same(snapshotAttachment));
+      expect(lastEvent().timestamp, equals(clock.epochTime()));
     });
 
-    test('captures no snapshot when asked not to', () async {
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
-        userTriggered: true,
-        attributes: {},
-        captureLayoutSnapshot: false,
-      );
+    test('stamps the screen view at the timestamp the caller supplies',
+        () async {
+      final navigatedAt = clock.epochTime();
+      clock.advance(const Duration(milliseconds: 300));
 
-      expect(snapshotCollector.captureCount, equals(0));
-      expect(trackedEvent().attachments, isNull);
+      await trackScreenView('HomeScreen', timestamp: navigatedAt);
+
+      expect(lastEvent().timestamp, equals(navigatedAt));
     });
 
-    test('leaves out the snapshot of a screen view within the delay', () async {
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
-        userTriggered: false,
-        attributes: {},
-      );
-      clock.advance(const Duration(milliseconds: 500));
-
-      await collector.trackScreenViewEvent(
-        name: 'CheckoutScreen',
-        userTriggered: false,
-        attributes: {},
-      );
-
-      expect(signalProcessor.trackedEvents.last.attachments, isNull);
-    });
-
-    test('attaches a snapshot again once the delay has elapsed', () async {
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
-        userTriggered: false,
-        attributes: {},
-      );
-      clock.advance(const Duration(milliseconds: 751));
-
-      await collector.trackScreenViewEvent(
-        name: 'CheckoutScreen',
-        userTriggered: false,
-        attributes: {},
-      );
-
-      expect(signalProcessor.trackedEvents.last.attachments?.single,
-          same(snapshotAttachment));
-    });
-
-    test('does nothing while unregistered', () async {
+    test('ignores a screen view while the collector is unregistered', () async {
       collector.unregister();
 
-      await collector.trackScreenViewEvent(
-        name: 'HomeScreen',
-        userTriggered: true,
-        attributes: {},
-      );
+      await trackScreenView('HomeScreen');
 
       expect(signalProcessor.trackedEvents, isEmpty);
+    });
+  });
+
+  group('layout snapshots', () {
+    test('attaches a snapshot of the screen to the screen view', () async {
+      await trackScreenView('HomeScreen');
+
+      expect(lastEvent().attachments?.single, same(snapshotAttachment));
+    });
+
+    test('captures no snapshot when the caller opts out', () async {
+      await trackScreenView('HomeScreen', captureLayoutSnapshot: false);
+
+      expect(lastEvent().attachments, isNull);
+      expect(snapshotCollector.captureCount, isZero);
+    });
+
+    test('tracks a screen view within the throttle window without a snapshot',
+        () async {
+      await trackScreenView('HomeScreen');
+      clock.advance(const Duration(milliseconds: 500));
+
+      await trackScreenView('CheckoutScreen');
+
+      expect(screenName(lastEvent()), equals('CheckoutScreen'));
+      expect(lastEvent().attachments, isNull);
+      expect(snapshotCollector.captureCount, equals(1));
+    });
+
+    test('attaches a snapshot again once the throttle window has passed',
+        () async {
+      await trackScreenView('HomeScreen');
+      clock.advance(const Duration(milliseconds: 751));
+
+      await trackScreenView('CheckoutScreen');
+
+      expect(lastEvent().attachments?.single, same(snapshotAttachment));
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigation_collector_test.dart
@@ -1,65 +1,92 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:measure_flutter/measure_flutter.dart';
 import 'package:measure_flutter/src/navigation/navigation_collector.dart';
+import 'package:measure_flutter/src/navigation/screen_view_data.dart';
 import 'package:measure_flutter/src/time/time_provider.dart';
 
+import '../utils/fake_layout_snapshot_collector.dart';
 import '../utils/fake_signal_processor.dart';
 import '../utils/test_clock.dart';
 
 void main() {
-  group('NavigationCollector', () {
-    late FakeSignalProcessor fakeSignalProcessor;
-    late NavigationCollector navigationCollector;
-    late TimeProvider timeProvider;
+  late FakeSignalProcessor signalProcessor;
+  late NavigationCollector collector;
+  late TimeProvider timeProvider;
+  late FakeLayoutSnapshotCollector snapshotCollector;
 
-    setUp(() {
-      fakeSignalProcessor = FakeSignalProcessor();
-      timeProvider = FlutterTimeProvider(TestClock.create());
-      navigationCollector = NavigationCollector(
-        signalProcessor: fakeSignalProcessor,
-        timeProvider: timeProvider,
+  final snapshotAttachment = MsrAttachment.fromPath(
+    path: 'snapshot-path',
+    type: AttachmentType.layoutSnapshotJson,
+    size: 10,
+    uuid: 'uuid-1',
+    fileExtension: 'json.gz',
+  );
+
+  setUp(() {
+    signalProcessor = FakeSignalProcessor();
+    timeProvider = FlutterTimeProvider(TestClock.create());
+    snapshotCollector = FakeLayoutSnapshotCollector(
+      attachment: snapshotAttachment,
+    );
+    collector = NavigationCollector(
+      signalProcessor: signalProcessor,
+      timeProvider: timeProvider,
+      layoutSnapshotCollector: snapshotCollector,
+    );
+    collector.register();
+  });
+
+  TrackedEvent trackedEvent() => signalProcessor.trackedEvents.single;
+
+  group('trackScreenViewEvent', () {
+    test('tracks the screen with its attributes, at the time of the call',
+        () async {
+      final attributes = {'key': StringAttr('value')};
+
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: true,
+        attributes: attributes,
       );
-      navigationCollector.register();
+
+      expect((trackedEvent().data as ScreenViewData).name, equals('HomeScreen'));
+      expect(trackedEvent().userTriggered, isTrue);
+      expect(trackedEvent().userDefinedAttrs, equals(attributes));
+      expect(trackedEvent().timestamp, equals(timeProvider.now()));
     });
 
-    group('trackScreenViewEvent', () {
-      test('should track screen view event', () async {
-        // Arrange
-        const screenName = 'HomeScreen';
-        const userTriggered = true;
+    test('attaches the layout snapshot', () async {
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: false,
+        attributes: {},
+      );
 
-        // Act
-        await navigationCollector.trackScreenViewEvent(
-          name: screenName,
-          userTriggered: userTriggered,
-          attributes: {},
-        );
+      expect(trackedEvent().attachments?.single, same(snapshotAttachment));
+    });
 
-        // Assert
-        expect(fakeSignalProcessor.trackedScreenViewEvents.length, equals(1));
+    test('captures no snapshot when asked not to', () async {
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: true,
+        attributes: {},
+        captureLayoutSnapshot: false,
+      );
 
-        final trackedEvent = fakeSignalProcessor.trackedScreenViewEvents.first;
-        expect(trackedEvent.name, equals(screenName));
-      });
+      expect(snapshotCollector.captureCount, equals(0));
+      expect(trackedEvent().attachments, isNull);
+    });
 
-      test('should track screen view event with attributes', () async {
-        // Arrange
-        const screenName = 'HomeScreen';
-        const userTriggered = true;
-        final attributes = {"key": StringAttr("value")};
+    test('does nothing while unregistered', () async {
+      collector.unregister();
 
-        // Act
-        await navigationCollector.trackScreenViewEvent(
-          name: screenName,
-          userTriggered: userTriggered,
-          attributes: attributes,
-        );
+      await collector.trackScreenViewEvent(
+        name: 'HomeScreen',
+        userTriggered: true,
+        attributes: {},
+      );
 
-        // Assert
-        expect(fakeSignalProcessor.trackedScreenViewEvents.length, equals(1));
-        final trackedEvent = fakeSignalProcessor.trackedEvents.first;
-        expect(trackedEvent.userDefinedAttrs, equals(attributes));
-      });
+      expect(signalProcessor.trackedEvents, isEmpty);
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/navigation/navigator_observer_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigator_observer_test.dart
@@ -5,178 +5,127 @@ import 'package:measure_flutter/measure_flutter.dart';
 import '../utils/fake_measure.dart';
 
 void main() {
-  group('MsrNavigatorObserver', () {
-    late FakeMeasure fakeMeasure;
-    late MsrNavigatorObserver observer;
+  late FakeMeasure fakeMeasure;
+  late MsrNavigatorObserver observer;
 
-    setUp(() {
-      fakeMeasure = FakeMeasure();
-      observer = MsrNavigatorObserver.withMeasure(fakeMeasure);
+  setUp(() {
+    fakeMeasure = FakeMeasure();
+    observer = MsrNavigatorObserver.withMeasure(fakeMeasure);
+  });
+
+  List<String> trackedNames() =>
+      fakeMeasure.trackedScreenViews.map((call) => call.name).toList();
+
+  // Routes built outside a Navigator are never installed, so they have no
+  // transition to wait on and are tracked as soon as the callback fires.
+  Route<void> route(String? name) => MaterialPageRoute<void>(
+        settings: RouteSettings(name: name),
+        builder: (_) => const SizedBox(),
+      );
+
+  group('the screen a navigation lands on', () {
+    test('is the pushed route, the route revealed by a pop, or the replacement',
+        () {
+      observer.didPush(route('/pushed'), route('/under'));
+      observer.didPop(route('/popped'), route('/revealed'));
+      observer.didReplace(newRoute: route('/new'), oldRoute: route('/old'));
+
+      expect(trackedNames(), equals(['/pushed', '/revealed', '/new']));
     });
 
-    tearDown(() {
+    test('is not tracked when that route has no usable name', () {
+      for (final name in <String?>[null, '']) {
+        observer.didPush(route(name), route('/under'));
+        observer.didPop(route('/popped'), route(name));
+        observer.didReplace(newRoute: route(name), oldRoute: route('/old'));
+      }
+
+      expect(trackedNames(), isEmpty);
+    });
+
+    test('is not tracked when there is no route to land on', () {
+      observer.didPop(route('/popped'), null);
+      observer.didReplace(newRoute: null, oldRoute: route('/old'));
+
+      expect(trackedNames(), isEmpty);
+    });
+  });
+
+  group('route transitions', () {
+    Future<void> pumpApp(WidgetTester tester) {
+      return tester.pumpWidget(MaterialApp(
+        navigatorObservers: [observer],
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  settings: const RouteSettings(name: '/details'),
+                  builder: (_) => const Scaffold(body: Text('Details')),
+                ),
+              ),
+              child: const Text('Push'),
+            ),
+          ),
+        ),
+      ));
+    }
+
+    testWidgets('the initial route is tracked without waiting', (tester) async {
+      await pumpApp(tester);
+
+      expect(trackedNames(), equals(['/']));
+    });
+
+    testWidgets('a push is tracked once its transition has ended, stamped at '
+        'the navigation', (tester) async {
+      await pumpApp(tester);
       fakeMeasure.clear();
+      fakeMeasure.currentTime = 1000;
+
+      await tester.tap(find.text('Push'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(trackedNames(), isEmpty);
+
+      fakeMeasure.currentTime = 9999;
+      await tester.pumpAndSettle();
+
+      expect(trackedNames(), equals(['/details']));
+      expect(fakeMeasure.trackedScreenViews.single.timestamp, equals(1000));
     });
 
-    group('didPush', () {
-      test('should track screen view with route name', () {
-        // Arrange
-        const routeName = '/home';
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: routeName),
-          builder: (context) => Container(),
-        );
-        final previousRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: '/previous'),
-          builder: (context) => Container(),
-        );
+    testWidgets('a pop is tracked once its transition has ended',
+        (tester) async {
+      await pumpApp(tester);
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
+      fakeMeasure.clear();
 
-        // Act
-        observer.didPush(route, previousRoute);
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(trackedNames(), isEmpty);
 
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 1);
-        expect(fakeMeasure.trackedScreenViews.last.name, routeName);
-        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
-      });
+      await tester.pumpAndSettle();
 
-      test('should not track screen view when route name is null', () {
-        // Arrange
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: null),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didPush(route, null);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
+      expect(trackedNames(), equals(['/']));
     });
 
-    group('didPop', () {
-      test('should track screen view with previous route name', () {
-        // Arrange
-        const previousRouteName = '/previous';
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: '/current'),
-          builder: (context) => Container(),
-        );
-        final previousRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: previousRouteName),
-          builder: (context) => Container(),
-        );
+    testWidgets('a route removed mid transition is still tracked',
+        (tester) async {
+      await pumpApp(tester);
+      fakeMeasure.clear();
 
-        // Act
-        observer.didPop(route, previousRoute);
+      await tester.tap(find.text('Push'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      tester.state<NavigatorState>(find.byType(Navigator)).removeRoute(
+            ModalRoute.of(tester.element(find.text('Details')))!,
+          );
+      await tester.pumpAndSettle();
 
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 1);
-        expect(fakeMeasure.trackedScreenViews.last.name, previousRouteName);
-        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
-      });
-
-      test('should not track screen view when previous route is null', () {
-        // Arrange
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: '/current'),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didPop(route, null);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
-
-      test('should not track screen view when previous route is empty', () {
-        // Arrange
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: ''),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didPop(route, null);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
-
-      test('should not track screen view when previous route name is null', () {
-        // Arrange
-        final route = MaterialPageRoute(
-          settings: const RouteSettings(name: '/current'),
-          builder: (context) => Container(),
-        );
-        final previousRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: null),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didPop(route, previousRoute);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
-    });
-
-    group('didReplace', () {
-      test('should track screen view with new route name', () {
-        // Arrange
-        const newRouteName = '/new';
-        final newRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: newRouteName),
-          builder: (context) => Container(),
-        );
-        final oldRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: '/old'),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 1);
-        expect(fakeMeasure.trackedScreenViews.last.name, newRouteName);
-        expect(fakeMeasure.trackedScreenViews.last.userTriggered, false);
-      });
-
-      test('should not track screen view when new route is null', () {
-        // Arrange
-        final oldRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: '/old'),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didReplace(newRoute: null, oldRoute: oldRoute);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
-
-      test('should not track screen view when new route name is null', () {
-        // Arrange
-        final newRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: null),
-          builder: (context) => Container(),
-        );
-        final oldRoute = MaterialPageRoute(
-          settings: const RouteSettings(name: '/old'),
-          builder: (context) => Container(),
-        );
-
-        // Act
-        observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-
-        // Assert
-        expect(fakeMeasure.trackedScreenViews.length, 0);
-      });
+      expect(trackedNames(), equals(['/details']));
     });
   });
 }

--- a/flutter/packages/measure_flutter/test/navigation/navigator_observer_test.dart
+++ b/flutter/packages/measure_flutter/test/navigation/navigator_observer_test.dart
@@ -77,8 +77,9 @@ void main() {
       expect(trackedNames(), equals(['/']));
     });
 
-    testWidgets('a push is tracked once its transition has ended, stamped at '
-        'the navigation', (tester) async {
+    testWidgets(
+        'a push is tracked once its transition has ended, stamped at the navigation',
+        (tester) async {
       await pumpApp(tester);
       fakeMeasure.clear();
       fakeMeasure.currentTime = 1000;

--- a/flutter/packages/measure_flutter/test/utils/fake_layout_snapshot_collector.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_layout_snapshot_collector.dart
@@ -1,0 +1,19 @@
+import 'package:measure_flutter/measure_flutter.dart';
+import 'package:measure_flutter/src/gestures/layout_snapshot_collector.dart';
+
+class FakeLayoutSnapshotCollector implements LayoutSnapshotCollector {
+  MsrAttachment? attachment;
+  int captureCount = 0;
+
+  FakeLayoutSnapshotCollector({this.attachment});
+
+  @override
+  Future<MsrAttachment?> captureAttachmentAfterNextFrame() async {
+    captureCount++;
+    return attachment;
+  }
+
+  @override
+  Future<MsrAttachment?> createAttachment(SnapshotNode snapshot) async =>
+      attachment;
+}

--- a/flutter/packages/measure_flutter/test/utils/fake_measure.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_measure.dart
@@ -9,6 +9,7 @@ import 'package:measure_flutter/src/gestures/scroll_data.dart';
 class FakeMeasure implements MeasureApi {
   final List<ScreenViewCall> trackedScreenViews = [];
   final List<BugReportCall> trackedBugReports = [];
+  int currentTime = 0;
 
   @override
   Future<void> init(
@@ -81,8 +82,13 @@ class FakeMeasure implements MeasureApi {
   }
 
   @override
-  void trackScreenViewEvent({required String name, bool userTriggered = true}) {
-    trackedScreenViews.add(ScreenViewCall(name, userTriggered));
+  void trackScreenViewEvent({
+    required String name,
+    bool userTriggered = true,
+    int? timestamp,
+    bool captureLayoutSnapshot = true,
+  }) {
+    trackedScreenViews.add(ScreenViewCall(name, userTriggered, timestamp));
   }
 
   void clear() {
@@ -145,7 +151,7 @@ class FakeMeasure implements MeasureApi {
 
   @override
   int getCurrentTime() {
-    throw UnimplementedError();
+    return currentTime;
   }
 
   @override
@@ -193,12 +199,20 @@ class FakeMeasure implements MeasureApi {
   }
 
   @override
-  Future<void> trackClick(ClickData clickData, SnapshotNode? snapshot) async {
+  Future<void> trackClick(
+    ClickData clickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     throw UnimplementedError();
   }
 
   @override
-  Future<void> trackLongClick(LongClickData longClickData, SnapshotNode? snapshot) async {
+  Future<void> trackLongClick(
+    LongClickData longClickData,
+    SnapshotNode? snapshot, {
+    int? timestamp,
+  }) async {
     throw UnimplementedError();
   }
 
@@ -231,8 +245,9 @@ class FakeMeasure implements MeasureApi {
 class ScreenViewCall {
   final String name;
   final bool userTriggered;
+  final int? timestamp;
 
-  ScreenViewCall(this.name, this.userTriggered);
+  ScreenViewCall(this.name, this.userTriggered, this.timestamp);
 }
 
 class BugReportCall {

--- a/flutter/packages/measure_flutter/test/utils/measure_test_app.dart
+++ b/flutter/packages/measure_flutter/test/utils/measure_test_app.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:measure_flutter/src/gestures/msr_gesture_detector.dart';
+
+/// An app wrapped the way [MeasureWidget] wraps one, which is what registers
+/// the element whole screen layout snapshots are captured from.
+Widget measureApp({Key? detectorKey, Widget child = const Scaffold()}) {
+  return MaterialApp(
+    home: MsrGestureDetector(
+      key: detectorKey,
+      layoutSnapshotWidgetFilter: const {},
+      onClick: (data, snapshot, timestamp) async {},
+      onLongClick: (data, snapshot, timestamp) async {},
+      onScroll: (data) async {},
+      child: child,
+    ),
+  );
+}

--- a/flutter/packages/measure_flutter/test/utils/measure_test_app.dart
+++ b/flutter/packages/measure_flutter/test/utils/measure_test_app.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:measure_flutter/src/gestures/msr_gesture_detector.dart';
 
-/// An app wrapped the way [MeasureWidget] wraps one, which is what registers
-/// the element whole screen layout snapshots are captured from.
 Widget measureApp({Key? detectorKey, Widget child = const Scaffold()}) {
   return MaterialApp(
     home: MsrGestureDetector(

--- a/frontend/dashboard/content/docs/api-reference.mdx
+++ b/frontend/dashboard/content/docs/api-reference.mdx
@@ -96,7 +96,7 @@ Pass a config object to `init` to customize the SDK. The available options diffe
 | `enableLogging` | `bool` | `false` | Turn on internal SDK logs. |
 | `autoStart` | `bool` | `true` | Start tracking automatically on init. Set to `false` to delay starting collection. |
 | `enableDiagnosticMode` | `bool` | `false` | Write all SDK logs to a file you can attach when reporting an SDK bug. |
-| `widgetFilter` | `Map<Type, String>` | built-in set | Widget types to include in layout snapshots. Generate a fuller list with the `measure_build` package. |
+| `widgetFilter` | `Map<Type, String>` | built-in set | Widget types to include in Layout snapshots on Flutter. Generate a fuller list with the `measure_build` package. |
 
 </Tab>
 <Tab value="React Native">
@@ -630,9 +630,20 @@ Measure.trackScreenView("Home", attributes)
 </Tab>
 </Tabs>
 
+### Layout snapshots on Flutter
+
+A screen view tracked from Flutter carries a [layout snapshot](/docs/session-replay/layout-snapshots) of the widget tree.
+For screen view events tracked manually using `trackScreenViewEvent`, you can disable layout snapshot using `captureLayoutSnapshot` if needed.
+
+```dart
+import 'package:measure_flutter/measure_flutter.dart';
+
+Measure.instance.trackScreenViewEvent(name: "Home", captureLayoutSnapshot: false);
+```
+
 ### Automatic tracking on Flutter
 
-Add `MsrNavigatorObserver` to your app's `navigatorObservers` to track screen views automatically. It works best with named routes.
+Add `MsrNavigatorObserver` to your app's `navigatorObservers` to track screen views automatically. It works best with named routes. The observer tracks a screen once its route transition finishes, and keeps the time of the navigation on the event.
 
 ```dart
 import 'package:flutter/material.dart';

--- a/frontend/dashboard/content/docs/gesture-tracking/index.mdx
+++ b/frontend/dashboard/content/docs/gesture-tracking/index.mdx
@@ -6,7 +6,7 @@ description: "Capture taps, long presses, and scrolls automatically along with t
 
 Measure captures clicks, long clicks, and scrolls automatically, so you can see how users interact with your app without instrumenting every view. Each gesture records the element it was performed on, and clicks include the text visible on that element, so a tap on a button labeled "Checkout" appears in the session with that text.
 
-Clicks also capture a [layout snapshot](/docs/gesture-tracking/layout-snapshots), a wireframe of the screen as it looked when the user tapped.
+Clicks also capture a [layout snapshot](/docs/session-replay/layout-snapshots), a wireframe of the screen as it looked when the user tapped.
 
 ## Android
 

--- a/frontend/dashboard/content/docs/gesture-tracking/meta.json
+++ b/frontend/dashboard/content/docs/gesture-tracking/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Gesture Tracking",
-  "pages": ["layout-snapshots"]
+  "pages": []
 }

--- a/frontend/dashboard/content/docs/navigation-tracking.mdx
+++ b/frontend/dashboard/content/docs/navigation-tracking.mdx
@@ -92,6 +92,8 @@ Widget build(BuildContext context) {
 }
 ```
 
+The observer tracks a screen once its route transition finishes, which keeps the [layout snapshot](/docs/session-replay/layout-snapshots) on the event from showing the animation instead of the screen. The event keeps the time of the navigation.
+
 ### React Native
 
 Screen views aren't recorded automatically because React Native apps use a variety of navigation libraries. For [React Navigation](https://reactnavigation.org/), hook into the `onStateChange` callback of `NavigationContainer`:

--- a/frontend/dashboard/content/docs/session-replay/index.mdx
+++ b/frontend/dashboard/content/docs/session-replay/index.mdx
@@ -4,13 +4,19 @@ seoTitle: "Mobile App Session Replay"
 description: "Replay each session as a chronological sequence of events with CPU and memory usage, screenshots, and layout snapshots."
 ---
 
-A session replay shows everything that happened during a session in order: screen views, gestures, logs, network calls, and errors, alongside charts of [CPU and memory usage](/docs/cpu-memory-monitoring). Screenshots and [layout snapshots](/docs/gesture-tracking/layout-snapshots) capture what was on screen at the time.
+A session replay shows everything that happened during a session in order: screen views, gestures, logs, network calls, and errors, alongside charts of [CPU and memory usage](/docs/cpu-memory-monitoring). Screenshots and [layout snapshots](/docs/session-replay/layout-snapshots) capture what was on screen at the time.
 
 ## What counts as a session
 
 A session is a continuous period of activity in the app. A new one starts when the SDK initializes, or when the app returns to the foreground after more than 30 seconds in the background.
 
 To reference a session from your own logs or backend, read the current session ID with [`getSessionId`](/docs/api-reference#get-session-id).
+
+## Layout snapshots
+
+A layout snapshot is a wireframe of the screen, captured as the user moves through the app. It shows what the user was acting on at a fraction of the cost of capturing, storing, and rendering a screenshot.
+
+See [Layout snapshots](/docs/session-replay/layout-snapshots) for more details on how they work and ways to configure them for each platform.
 
 ## Replay duration
 

--- a/frontend/dashboard/content/docs/session-replay/layout-snapshots.mdx
+++ b/frontend/dashboard/content/docs/session-replay/layout-snapshots.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Layout snapshots"
-seoTitle: "Layout Snapshots for Mobile Gesture Tracking"
-description: "Capture a lightweight wireframe of the screen with every tap to see the UI a gesture acted on."
+seoTitle: "Layout Snapshots for Mobile Session Replay"
+description: "Capture a lightweight wireframe of the screen as the user moves through the app to see the UI behind each event."
 ---
 
-Measure captures a layout snapshot with every click: a wireframe of the screen at the moment of the gesture. A snapshot shows what the user was acting on at a fraction of the cost of capturing, storing, and rendering a screenshot.
+Measure captures a layout snapshot as the user moves through the app: a wireframe of the screen at that moment. A snapshot shows what the user was acting on at a fraction of the cost of capturing, storing, and rendering a screenshot.
 
 | Screenshot                                                  | Layout snapshot                                       |
 |-------------------------------------------------------------|-------------------------------------------------------|
@@ -32,6 +32,13 @@ Layout snapshots with clicks are throttled to one snapshot every 750 ms, and the
 Snapshots capture the full view hierarchy of the screen with no setup. SwiftUI content appears with its underlying system view names rather than your SwiftUI view names.
 
 ## Flutter
+
+A snapshot is captured at each of these moments:
+
+- A click or long press, with the target widget marked.
+- A screen view, whether tracked by `MsrNavigatorObserver` or with `Measure.instance.trackScreenViewEvent`.
+
+Clicks and screen views are throttled separately, each to one snapshot every 750 ms.
 
 A screen can hold thousands of widgets, so snapshots include only common widget types by default and skip the rest:
 

--- a/frontend/dashboard/content/docs/session-replay/meta.json
+++ b/frontend/dashboard/content/docs/session-replay/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Session Replay",
+  "pages": ["layout-snapshots"]
+}

--- a/frontend/dashboard/next.config.mjs
+++ b/frontend/dashboard/next.config.mjs
@@ -134,6 +134,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: "/docs/gesture-tracking/layout-snapshots",
+        destination: "/docs/session-replay/layout-snapshots",
+        permanent: true,
+      },
+      {
         source: "/:teamId/crashes/:rest*",
         destination: "/:teamId/errors/:rest*",
         permanent: true,

--- a/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
+++ b/ios/Sources/MeasureSDK/Swift/Events/InternalSignalCollector.swift
@@ -212,7 +212,7 @@ final class BaseInternalSignalCollector: InternalSignalCollector { // swiftlint:
                     type: .screenView,
                     attributes: evaluatedAttributes,
                     sessionId: sessionId,
-                    attachments: nil,
+                    attachments: attachments,
                     userDefinedAttributes: serializedUserDefinedAttributes,
                     threadName: threadName,
                     needsReporting: signalSampler.shouldTrackJourneyForSession(sessionId: sessionId ?? sessionManager.sessionId),


### PR DESCRIPTION
# Description

Capture layout snapshot for screen view events on Flutter and implement snapshot throttling similar to other SDKs.

## Flutter SDK

- `MsrNavigatorObserver` tracks a layout snapshot once its route transition settles.
- Update public API `trackScreenViewEvent` to take `timestamp` and `captureLayoutSnapshot` (enabled by default).
- Snapshots are throttled to one every 750 ms. Clicks and screen views are throttled in separate windows, mirroring Android.
- Gesture timestamps are taken at pointer up, not after the snapshot is written.
- `MsrGestureDetector` clears the element it captures from when it leaves the tree. It used to hold a defunct element, which stopped snapshots for the rest of the process.

## iOS SDK

- Screen views from cross platform SDKs keep their attachments, which were dropped earlier.

## Related issue

Closes #4430 
