### PR TITLE
fix(ios): avoid objc runtime lock deadlock in crash write callback

### DIFF
--- a/ios/DemoApp/DemoApp/Controller/ViewController.swift
+++ b/ios/DemoApp/DemoApp/Controller/ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SwiftUI
+import ObjectiveC
 import Measure
 
 @objc final class ViewController: MsrViewController, UITableViewDelegate, UITableViewDataSource {
@@ -41,7 +42,8 @@ import Measure
                       "Track Handled NSException",
                       "Track Handled NSError",
                       "Track Swift Error (main thread)",
-                      "Track NSException (main thread)"]
+                      "Track NSException (main thread)",
+                      "ObjC Runtime Lock Deadlock"]
 
     let httpEventTypes = ["GET – 200 OK (JSON)",
                           "POST – 201 Created (JSON body)",
@@ -364,8 +366,31 @@ import Measure
                                         reason: "Something happened on main thread",
                                         userInfo: ["key": "value"])
             Measure.trackException(exception, attributes: ["source": .string("swift-main-thread")])
+        case "ObjC Runtime Lock Deadlock":
+            replicateObjCRuntimeLockDeadlock()
         default:
             fatalError("Triggered crash: \(type)")
+        }
+    }
+
+    private func replicateObjCRuntimeLockDeadlock() {
+        let registrarThreadCount = 16
+
+        for threadIndex in 0..<registrarThreadCount {
+            Thread.detachNewThread {
+                var counter = 0
+                while true {
+                    let className = "MSRDeadlockRepro_\(threadIndex)_\(counter)"
+                    if let newClass = objc_allocateClassPair(NSObject.self, className, 0) {
+                        objc_registerClassPair(newClass)
+                    }
+                    counter += 1
+                }
+            }
+        }
+
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.3) {
+            abort()
         }
     }
 }

--- a/ios/DemoApp/Podfile.lock
+++ b/ios/DemoApp/Podfile.lock
@@ -1,31 +1,31 @@
 PODS:
-  - KSCrash (2.5.1):
-    - KSCrash/Installations (= 2.5.1)
-  - KSCrash/Core (2.5.1)
-  - KSCrash/DemangleFilter (2.5.1):
+  - KSCrash (2.6.0):
+    - KSCrash/Installations (= 2.6.0)
+  - KSCrash/Core (2.6.0)
+  - KSCrash/DemangleFilter (2.6.0):
     - KSCrash/Recording
-  - KSCrash/Filters (2.5.1):
+  - KSCrash/Filters (2.6.0):
     - KSCrash/Recording
     - KSCrash/RecordingCore
     - KSCrash/ReportingCore
-  - KSCrash/Installations (2.5.1):
+  - KSCrash/Installations (2.6.0):
     - KSCrash/DemangleFilter
     - KSCrash/Filters
     - KSCrash/Recording
     - KSCrash/Sinks
-  - KSCrash/Recording (2.5.1):
+  - KSCrash/Recording (2.6.0):
     - KSCrash/RecordingCore
-  - KSCrash/RecordingCore (2.5.1):
+  - KSCrash/RecordingCore (2.6.0):
     - KSCrash/Core
-  - KSCrash/ReportingCore (2.5.1):
+  - KSCrash/ReportingCore (2.6.0):
     - KSCrash/Core
-  - KSCrash/Sinks (2.5.1):
+  - KSCrash/Sinks (2.6.0):
     - KSCrash/Filters
     - KSCrash/Recording
-  - measure-sh (0.12.1):
+  - measure-sh (0.13.1):
     - KSCrash (~> 2.5)
-    - measure-sh/WebP (= 0.12.1)
-  - measure-sh/WebP (0.12.1):
+    - measure-sh/WebP (= 0.13.1)
+  - measure-sh/WebP (0.13.1):
     - KSCrash (~> 2.5)
 
 DEPENDENCIES:
@@ -40,8 +40,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
-  measure-sh: 9a9366e427296f6c1577b62fb29aee38dc11cd09
+  KSCrash: 8515730b020ffc714bb10406a3bd289b28a81c6f
+  measure-sh: 70f3604dadfbcd4930c09dc3fa49f81275f8940b
 
 PODFILE CHECKSUM: 828d9701ce9dd588cdabe7bc1a8cb829d2a17f97
 

--- a/ios/MeasureSDK.xcodeproj/project.pbxproj
+++ b/ios/MeasureSDK.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		526D183F2D5A1913009A2E90 /* CrashDataFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17B72D5A1913009A2E90 /* CrashDataFormatter.swift */; };
 		526D18402D5A1913009A2E90 /* CrashDataPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17B82D5A1913009A2E90 /* CrashDataPersistence.swift */; };
 		526D18412D5A1913009A2E90 /* CrashDataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17B92D5A1913009A2E90 /* CrashDataWriter.swift */; };
+		19B2D1AA396746A8BB1A5C06 /* CrashDataBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47407D60AAF344A080F15EF0 /* CrashDataBuffer.swift */; };
 		526D18432D5A1913009A2E90 /* CrashReportingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17BB2D5A1913009A2E90 /* CrashReportingManager.swift */; };
 		526D18442D5A1913009A2E90 /* SystemCrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17BC2D5A1913009A2E90 /* SystemCrashReporter.swift */; };
 		526D18452D5A1913009A2E90 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D17BE2D5A1913009A2E90 /* Attachment.swift */; };
@@ -453,6 +454,7 @@
 		526D17B72D5A1913009A2E90 /* CrashDataFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashDataFormatter.swift; sourceTree = "<group>"; };
 		526D17B82D5A1913009A2E90 /* CrashDataPersistence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashDataPersistence.swift; sourceTree = "<group>"; };
 		526D17B92D5A1913009A2E90 /* CrashDataWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashDataWriter.swift; sourceTree = "<group>"; };
+		47407D60AAF344A080F15EF0 /* CrashDataBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashDataBuffer.swift; sourceTree = "<group>"; };
 		526D17BB2D5A1913009A2E90 /* CrashReportingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportingManager.swift; sourceTree = "<group>"; };
 		526D17BC2D5A1913009A2E90 /* SystemCrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCrashReporter.swift; sourceTree = "<group>"; };
 		526D17BE2D5A1913009A2E90 /* Attachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attachment.swift; sourceTree = "<group>"; };
@@ -908,6 +910,7 @@
 				526D17B72D5A1913009A2E90 /* CrashDataFormatter.swift */,
 				526D17B82D5A1913009A2E90 /* CrashDataPersistence.swift */,
 				526D17B92D5A1913009A2E90 /* CrashDataWriter.swift */,
+				47407D60AAF344A080F15EF0 /* CrashDataBuffer.swift */,
 				526D17BB2D5A1913009A2E90 /* CrashReportingManager.swift */,
 				526D17BC2D5A1913009A2E90 /* SystemCrashReporter.swift */,
 			);
@@ -1939,6 +1942,7 @@
 				CFF2E6982F69246A003B5A66 /* Data+Extension.swift in Sources */,
 				CF1BB49E2DCDF99A00588506 /* ShakeBugReportCollector.swift in Sources */,
 				526D18402D5A1913009A2E90 /* CrashDataPersistence.swift in Sources */,
+				19B2D1AA396746A8BB1A5C06 /* CrashDataBuffer.swift in Sources */,
 				526D18862D5A1913009A2E90 /* MeasureQueue.swift in Sources */,
 				526D187F2D5A1913009A2E90 /* UIViewController+Extension.swift in Sources */,
 				526D185D2D5A1913009A2E90 /* GestureEvents.swift in Sources */,
@@ -2875,7 +2879,7 @@
 			repositoryURL = "https://github.com/kstenerud/KSCrash.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.5.1;
+				version = 2.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/PublicApi/Measure.swiftinterface
+++ b/ios/PublicApi/Measure.swiftinterface
@@ -1,6 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
-// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
+// swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Onone -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -module-name Measure
 // swift-module-flags-ignorable: -no-verify-emitted-module-interface -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
 import AVKit
 import CoreData

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataBuffer.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataBuffer.swift
@@ -1,0 +1,33 @@
+//
+//  CrashDataBuffer.swift
+//  MeasureSDK
+//
+//  Created by Adwin Ross on 08/09/26.
+//
+
+import Foundation
+
+struct CrashDataBuffer {
+    private static let capacity = 256
+
+    private var cachedValue: String?
+    private var storage = [CChar](repeating: 0, count: CrashDataBuffer.capacity)
+
+    mutating func update(_ newValue: String?) {
+        guard newValue != cachedValue else { return }
+        cachedValue = newValue
+        let source = newValue ?? ""
+        storage.withUnsafeMutableBufferPointer { buffer in
+            guard let base = buffer.baseAddress else { return }
+            _ = source.withCString { strlcpy(base, $0, CrashDataBuffer.capacity) }
+        }
+    }
+
+    func withCString(_ body: (UnsafePointer<CChar>) -> Void) {
+        storage.withUnsafeBufferPointer { buffer in
+            if let base = buffer.baseAddress {
+                body(base)
+            }
+        }
+    }
+}

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataPersistence.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataPersistence.swift
@@ -5,147 +5,139 @@
 //  Created by Adwin Ross on 19/09/24.
 //
 
+#if canImport(KSCrashRecording)
+import KSCrashRecording
+#elseif canImport(KSCrash)
+import KSCrash
+#endif
 import Foundation
 
 typealias CrashDataAttributes = (attribute: Attributes?, sessionId: String?, isForeground: Bool?)
 
-/// A protocol that defines the interface for managing crash data persistence.
-///
-/// Implementers of this protocol are responsible for managing the lifecycle of crash data, including
-/// preparing crash files, writing crash data, reading it, and clearing the persisted data.
+private let crashReportUserSectionKey = "user"
+
 protocol CrashDataPersistence {
     var attribute: Attributes? { get set }
     var sessionId: String? { get set }
     var isForeground: Bool { get set }
-    func prepareCrashFile()
-    func writeCrashData()
-    func readCrashData() -> CrashDataAttributes
-    func clearCrashData()
+
+    func writeCrashData(plan: UnsafePointer<ExceptionHandlingPlan>, writer: UnsafePointer<ReportWriter>)
+    func readCrashData(from reportDict: [String: Any]) -> CrashDataAttributes
 }
 
-/// A concrete implementation of the `CrashDataPersistence` protocol.
-///
-/// `BaseCrashDataPersistence` manages the persistence of crash-related data by saving it into the app's cache.
 final class BaseCrashDataPersistence: CrashDataPersistence {
-    var attribute: Attributes?
-    var sessionId: String?
+    var attribute: Attributes? {
+        didSet { updateBuffers(with: attribute) }
+    }
+    var sessionId: String? {
+        didSet { sessionIdBuffer.update(sessionId) }
+    }
     var isForeground: Bool
-    private let logger: Logger
-    private var crashFileDescriptor: Int32 = -1
-    private let systemFileManager: SystemFileManager
 
-    init(attribute: Attributes? = nil, sessionId: String? = nil, isForeground: Bool = true, logger: Logger, systemFileManager: SystemFileManager) {
+    private var threadNameBuffer = CrashDataBuffer()
+    private var deviceNameBuffer = CrashDataBuffer()
+    private var deviceModelBuffer = CrashDataBuffer()
+    private var deviceManufacturerBuffer = CrashDataBuffer()
+    private var deviceTypeBuffer = CrashDataBuffer()
+    private var deviceLocaleBuffer = CrashDataBuffer()
+    private var osNameBuffer = CrashDataBuffer()
+    private var osVersionBuffer = CrashDataBuffer()
+    private var networkTypeBuffer = CrashDataBuffer()
+    private var networkGenerationBuffer = CrashDataBuffer()
+    private var networkProviderBuffer = CrashDataBuffer()
+    private var installationIdBuffer = CrashDataBuffer()
+    private var userIdBuffer = CrashDataBuffer()
+    private var deviceCpuArchBuffer = CrashDataBuffer()
+    private var appVersionBuffer = CrashDataBuffer()
+    private var appBuildBuffer = CrashDataBuffer()
+    private var measureSdkVersionBuffer = CrashDataBuffer()
+    private var appUniqueIdBuffer = CrashDataBuffer()
+    private var sessionIdBuffer = CrashDataBuffer()
+
+    init(attribute: Attributes? = nil, sessionId: String? = nil, isForeground: Bool = true) {
         self.attribute = attribute
         self.sessionId = sessionId
         self.isForeground = isForeground
-        self.logger = logger
-        self.systemFileManager = systemFileManager
+        updateBuffers(with: attribute)
+        sessionIdBuffer.update(sessionId)
     }
 
-    func prepareCrashFile() {
-        if let crashFilePath = systemFileManager.getCrashFilePath() {
-            if crashFileDescriptor != -1 {
-                close(crashFileDescriptor)
-                crashFileDescriptor = -1
-            }
-
-            crashFileDescriptor = open(crashFilePath.path, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR)
-            if crashFileDescriptor == -1 {
-                logger.internalLog(level: .error, message: "CrashDataPersistence: Failed to open crash log file at \(crashFilePath.path)", error: nil, data: nil)
-            }
-        }
+    private func updateBuffers(with attribute: Attributes?) {
+        threadNameBuffer.update(attribute?.threadName)
+        deviceNameBuffer.update(attribute?.deviceName)
+        deviceModelBuffer.update(attribute?.deviceModel)
+        deviceManufacturerBuffer.update(attribute?.deviceManufacturer)
+        deviceTypeBuffer.update(attribute?.deviceType?.rawValue)
+        deviceLocaleBuffer.update(attribute?.deviceLocale)
+        osNameBuffer.update(attribute?.osName)
+        osVersionBuffer.update(attribute?.osVersion)
+        networkTypeBuffer.update(attribute?.networkType?.rawValue)
+        networkGenerationBuffer.update(attribute?.networkGeneration?.rawValue)
+        networkProviderBuffer.update(attribute?.networkProvider)
+        installationIdBuffer.update(attribute?.installationId)
+        userIdBuffer.update(attribute?.userId)
+        deviceCpuArchBuffer.update(attribute?.deviceCpuArch)
+        appVersionBuffer.update(attribute?.appVersion)
+        appBuildBuffer.update(attribute?.appBuild)
+        measureSdkVersionBuffer.update(attribute?.measureSdkVersion)
+        appUniqueIdBuffer.update(attribute?.appUniqueId)
     }
 
-    func writeCrashData() {
-        if crashFileDescriptor != -1, attribute != nil {
-            let bytes = getAttributesData().cString(using: .utf8)
-            if let bytes = bytes {
-                write(crashFileDescriptor, bytes, strlen(bytes))
-            }
+    func writeCrashData(plan: UnsafePointer<ExceptionHandlingPlan>, writer: UnsafePointer<ReportWriter>) {
+        // Per KSCrash's contract for `crashedDuringExceptionHandling`: record nothing extra
+        // when a crash occurs while already handling another crash.
+        guard !plan.pointee.crashedDuringExceptionHandling, attribute != nil else { return }
+
+        threadNameBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.threadName, $0) }
+        deviceNameBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceName, $0) }
+        deviceModelBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceModel, $0) }
+        deviceManufacturerBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceManufacturer, $0) }
+        deviceTypeBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceType, $0) }
+        deviceLocaleBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceLocale, $0) }
+        osNameBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.osName, $0) }
+        osVersionBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.osVersion, $0) }
+        networkTypeBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.networkType, $0) }
+        networkGenerationBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.networkGeneration, $0) }
+        networkProviderBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.networkProvider, $0) }
+        installationIdBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.installationId, $0) }
+        userIdBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.userId, $0) }
+        deviceCpuArchBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.deviceCpuArch, $0) }
+        appVersionBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.appVersion, $0) }
+        appBuildBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.appBuild, $0) }
+        measureSdkVersionBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.measureSdkVersion, $0) }
+        appUniqueIdBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.appUniqueId, $0) }
+        sessionIdBuffer.withCString { writer.pointee.addStringElement(writer, CrashDataKeys.sessionId, $0) }
+
+        if let deviceIsFoldable = attribute?.deviceIsFoldable {
+            writer.pointee.addBooleanElement(writer, CrashDataKeys.deviceIsFoldable, deviceIsFoldable)
         }
+        if let deviceIsPhysical = attribute?.deviceIsPhysical {
+            writer.pointee.addBooleanElement(writer, CrashDataKeys.deviceIsPhysical, deviceIsPhysical)
+        }
+        if let deviceDensityDpi = attribute?.deviceDensityDpi {
+            writer.pointee.addIntegerElement(writer, CrashDataKeys.deviceDensityDpi, deviceDensityDpi)
+        }
+        if let deviceWidthPx = attribute?.deviceWidthPx {
+            writer.pointee.addIntegerElement(writer, CrashDataKeys.deviceWidthPx, deviceWidthPx)
+        }
+        if let deviceHeightPx = attribute?.deviceHeightPx {
+            writer.pointee.addIntegerElement(writer, CrashDataKeys.deviceHeightPx, deviceHeightPx)
+        }
+        if let deviceDensity = attribute?.deviceDensity {
+            writer.pointee.addIntegerElement(writer, CrashDataKeys.deviceDensity, deviceDensity)
+        }
+        writer.pointee.addBooleanElement(writer, CrashDataKeys.isForeground, isForeground)
     }
 
-    func clearCrashData() {
-        if crashFileDescriptor != -1 {
-            close(crashFileDescriptor)
-            crashFileDescriptor = -1
-        }
-
-        if let crashFilePath = systemFileManager.getCrashFilePath() {
-            let fileManager = FileManager.default
-            if fileManager.fileExists(atPath: crashFilePath.path) {
-                let fileDescriptor = open(crashFilePath.path, O_WRONLY | O_TRUNC)
-                if fileDescriptor != -1 {
-                    close(fileDescriptor)
-                    prepareCrashFile()
-                    logger.internalLog(level: .info, message: "CrashDataPersistence: Crash data file cleared at \(crashFilePath.path)", error: nil, data: nil)
-                } else {
-                    logger.internalLog(level: .error, message: "CrashDataPersistence: Failed to open crash log file for truncation at \(crashFilePath.path)", error: nil, data: nil)
-                }
-            } else {
-                logger.internalLog(level: .error, message: "CrashDataPersistence: No crash data file found to clear at \(crashFilePath.path)", error: nil, data: nil)
-            }
-        }
-    }
-
-    func readCrashData() -> CrashDataAttributes {
-        guard let crashFilePath = systemFileManager.getCrashFilePath() else {
-            logger.internalLog(level: .error, message: "CrashDataPersistence: No crash data file found to read.", error: nil, data: nil)
+    func readCrashData(from reportDict: [String: Any]) -> CrashDataAttributes {
+        guard let crashData = reportDict[crashReportUserSectionKey] as? [String: Any] else {
             return (attribute: nil, sessionId: nil, isForeground: nil)
         }
 
-        do {
-            let crashDataString = try String(contentsOf: crashFilePath, encoding: .utf8)
-
-            guard let data = crashDataString.data(using: .utf8) else {
-                logger.internalLog(level: .error, message: "CrashDataPersistence: Failed to convert crash data string to Data", error: nil, data: nil)
-                return (attribute: nil, sessionId: nil, isForeground: nil)
-            }
-
-            if let crashData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                let sessionId = crashData[CrashDataKeys.sessionId] as? String ?? ""
-                let isForeground = crashData[CrashDataKeys.isForeground] as? Bool
-                let attributes = getAttributes(crashData: crashData)
-                return (attribute: attributes, sessionId: sessionId, isForeground: isForeground)
-            }
-            return (attribute: nil, sessionId: nil, isForeground: nil)
-        } catch {
-            logger.internalLog(level: .error, message: "CrashDataPersistence: Failed to read or parse crash data file at \(crashFilePath.path)", error: error, data: nil)
-            return (attribute: nil, sessionId: nil, isForeground: nil)
-        }
-    }
-
-    private func getAttributesData() -> String {
-        return """
-        {
-            "\(CrashDataKeys.threadName)": "\(attribute?.threadName ?? "")",
-            "\(CrashDataKeys.deviceName)": "\(attribute?.deviceName ?? "")",
-            "\(CrashDataKeys.deviceModel)": "\(attribute?.deviceModel ?? "")",
-            "\(CrashDataKeys.deviceManufacturer)": "\(attribute?.deviceManufacturer ?? "")",
-            "\(CrashDataKeys.deviceType)": "\(attribute?.deviceType?.rawValue ?? "")",
-            "\(CrashDataKeys.deviceIsFoldable)": \(attribute?.deviceIsFoldable ?? false),
-            "\(CrashDataKeys.deviceIsPhysical)": \(attribute?.deviceIsPhysical ?? true),
-            "\(CrashDataKeys.deviceDensityDpi)": \(attribute?.deviceDensityDpi ?? 0),
-            "\(CrashDataKeys.deviceWidthPx)": \(attribute?.deviceWidthPx ?? 0),
-            "\(CrashDataKeys.deviceHeightPx)": \(attribute?.deviceHeightPx ?? 0),
-            "\(CrashDataKeys.deviceDensity)": \(attribute?.deviceDensity ?? 0),
-            "\(CrashDataKeys.deviceLocale)": "\(attribute?.deviceLocale ?? "")",
-            "\(CrashDataKeys.osName)": "\(attribute?.osName ?? "")",
-            "\(CrashDataKeys.osVersion)": "\(attribute?.osVersion ?? "")",
-            "\(CrashDataKeys.networkType)": "\(attribute?.networkType?.rawValue ?? "")",
-            "\(CrashDataKeys.networkGeneration)": "\(attribute?.networkGeneration?.rawValue ?? "")",
-            "\(CrashDataKeys.networkProvider)": "\(attribute?.networkProvider ?? "")",
-            "\(CrashDataKeys.installationId)": "\(attribute?.installationId ?? "")",
-            "\(CrashDataKeys.userId)": "\(attribute?.userId ?? "")",
-            "\(CrashDataKeys.deviceCpuArch)": "\(attribute?.deviceCpuArch ?? "")",
-            "\(CrashDataKeys.appVersion)": "\(attribute?.appVersion ?? "")",
-            "\(CrashDataKeys.appBuild)": "\(attribute?.appBuild ?? "")",
-            "\(CrashDataKeys.measureSdkVersion)": "\(attribute?.measureSdkVersion ?? "")",
-            "\(CrashDataKeys.appUniqueId)": "\(attribute?.appUniqueId ?? "")",
-            "\(CrashDataKeys.isForeground)": \(isForeground),
-            "\(CrashDataKeys.sessionId)": "\(sessionId ?? "")"
-        }
-        """
+        let sessionId = crashData[CrashDataKeys.sessionId] as? String ?? ""
+        let isForeground = crashData[CrashDataKeys.isForeground] as? Bool
+        let attributes = getAttributes(crashData: crashData)
+        return (attribute: attributes, sessionId: sessionId, isForeground: isForeground)
     }
 
     private func getAttributes(crashData: [String: Any]) -> Attributes {

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataWriter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashDataWriter.swift
@@ -5,6 +5,11 @@
 //  Created by Adwin Ross on 19/09/24.
 //
 
+#if canImport(KSCrashRecording)
+import KSCrashRecording
+#elseif canImport(KSCrash)
+import KSCrash
+#endif
 import Foundation
 
 /// A singleton class responsible for writing crash data to a persistent store.
@@ -18,9 +23,7 @@ final class CrashDataWriter {
         self.crashDataPersistence = crashDataPersistence
     }
 
-    func writeCrashData() {
-        if let crashDataPersistence = self.crashDataPersistence {
-            crashDataPersistence.writeCrashData()
-        }
+    func writeCrashData(plan: UnsafePointer<ExceptionHandlingPlan>, writer: UnsafePointer<ReportWriter>) {
+        crashDataPersistence?.writeCrashData(plan: plan, writer: writer)
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/CrashReportingManager.swift
@@ -24,7 +24,6 @@ final class BaseCrashReportingManager: CrashReportManager {
     private let logger: Logger
     private let signalProcessor: SignalProcessor
     private let crashDataPersistence: CrashDataPersistence
-    private let systemFileManager: SystemFileManager
     private let idProvider: IdProvider
     private let sysCtl: SysCtl
     private let configProvider: ConfigProvider
@@ -34,7 +33,6 @@ final class BaseCrashReportingManager: CrashReportManager {
          signalProcessor: SignalProcessor,
          crashDataPersistence: CrashDataPersistence,
          crashReporter: SystemCrashReporter,
-         systemFileManager: SystemFileManager,
          idProvider: IdProvider,
          sysCtl: SysCtl,
          configProvider: ConfigProvider) {
@@ -43,7 +41,6 @@ final class BaseCrashReportingManager: CrashReportManager {
         self.crashDataPersistence = crashDataPersistence
         self.crashReporter = crashReporter
         self.hasPendingCrashReport = crashReporter.hasPendingCrashReport
-        self.systemFileManager = systemFileManager
         self.idProvider = idProvider
         self.sysCtl = sysCtl
         self.configProvider = configProvider
@@ -62,12 +59,11 @@ final class BaseCrashReportingManager: CrashReportManager {
         let exceptionData = processKotlinCrashReport() ?? processCrashReport()
         guard var exception = exceptionData.exception, let date = exceptionData.date else {
             crashReporter.clearCrashData()
-            crashDataPersistence.clearCrashData()
             completion?()
             return
         }
 
-        let crashDataAttributes = crashDataPersistence.readCrashData()
+        let crashDataAttributes = exceptionData.crashDataAttributes
         if let attributes = crashDataAttributes.attribute, let sessionId = crashDataAttributes.sessionId {
             exception.foreground = crashDataAttributes.isForeground
             signalProcessor.track(data: exception,
@@ -83,7 +79,6 @@ final class BaseCrashReportingManager: CrashReportManager {
         }
 
         crashReporter.clearCrashData()
-        crashDataPersistence.clearCrashData()
         completion?()
     }
 
@@ -91,7 +86,7 @@ final class BaseCrashReportingManager: CrashReportManager {
     /// "msr_kmp_kotlin_crash" in the NSException's userInfo. KSCrash stores this as
     /// a string in the report, so a substring check is sufficient.
     /// Returns nil if no Kotlin crash report is found.
-    private func processKotlinCrashReport() -> (exception: Exception?, date: Date?)? {
+    private func processKotlinCrashReport() -> (exception: Exception?, date: Date?, crashDataAttributes: CrashDataAttributes)? {
         for reportDict in crashReporter.loadAllCrashReports() {
             let crashDict = reportDict["crash"] as? [String: Any] ?? [:]
             let errorDict = crashDict["error"] as? [String: Any] ?? [:]
@@ -106,13 +101,14 @@ final class BaseCrashReportingManager: CrashReportManager {
             let exception = formatter.getException()
             let timestamp = (reportDict["report"] as? [String: Any])?["timestamp"] as? TimeInterval
             let date = timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()
-            return (exception, date)
+            let crashDataAttributes = crashDataPersistence.readCrashData(from: reportDict)
+            return (exception, date, crashDataAttributes)
         }
 
         return nil
     }
 
-    private func processCrashReport() -> (exception: Exception?, date: Date?) {
+    private func processCrashReport() -> (exception: Exception?, date: Date?, crashDataAttributes: CrashDataAttributes) {
         do {
             let reportDict = try crashReporter.loadCrashReport()
             let formatter  = CrashDataFormatter(reportDict, sysCtl: sysCtl)
@@ -120,11 +116,12 @@ final class BaseCrashReportingManager: CrashReportManager {
 
             let timestamp = (reportDict["report"] as? [String: Any])?["timestamp"] as? TimeInterval
             let date = timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()
+            let crashDataAttributes = crashDataPersistence.readCrashData(from: reportDict)
 
-            return (exception, date)
+            return (exception, date, crashDataAttributes)
         } catch {
             logger.internalLog(level: .error, message: "CrashReportManager: Error parsing crash report.", error: error, data: nil)
-            return (nil, nil)
+            return (nil, nil, (attribute: nil, sessionId: nil, isForeground: nil))
         }
     }
 }

--- a/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
+++ b/ios/Sources/MeasureSDK/Swift/CrashReporter/SystemCrashReporter.swift
@@ -26,15 +26,13 @@ final class BaseSystemCrashReporter: SystemCrashReporter {
     private static var isKSCrashInstalled = false
 
     private let logger: Logger
-    private let crashDataPersistence: CrashDataPersistence
 
     var hasPendingCrashReport: Bool {
         return KSCrash.shared.reportStore?.reportCount ?? 0 > 0
     }
 
-    init(logger: Logger, crashDataPersistence: CrashDataPersistence) {
+    init(logger: Logger) {
         self.logger = logger
-        self.crashDataPersistence = crashDataPersistence
         do {
             try enable()
         } catch {
@@ -43,8 +41,6 @@ final class BaseSystemCrashReporter: SystemCrashReporter {
     }
 
     func enable() throws {
-        crashDataPersistence.prepareCrashFile()
-
         if Self.isKSCrashInstalled {
             return
         }
@@ -58,8 +54,9 @@ final class BaseSystemCrashReporter: SystemCrashReporter {
             .mainThreadDeadlock,
             .memoryTermination
         ]
-        config.crashNotifyCallback = { _ in
-            CrashDataWriter.shared.writeCrashData()
+
+        config.isWritingReportCallback = { plan, writer in
+            CrashDataWriter.shared.writeCrashData(plan: plan, writer: writer)
         }
 
         do {

--- a/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
+++ b/ios/Sources/MeasureSDK/Swift/Exception/ExceptionGenerator.swift
@@ -86,7 +86,6 @@ final class BaseExceptionGenerator: ExceptionGenerator {
         var result = formatter.getException(severity: .handled, numCode: numCode, code: code, meta: meta, framesToStrip: framesToStrip)
         result.foreground = crashDataPersistence.isForeground
         store.deleteReport(with: Int64(truncating: reportID))
-        crashDataPersistence.clearCrashData()
 
         return result
     }

--- a/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
+++ b/ios/Sources/MeasureSDK/Swift/MeasureInitializer.swift
@@ -287,8 +287,7 @@ final class BaseMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
                                     networkStateAttributeProcessor,
                                     userAttributeProcessor,
                                     sessionAttributeProcessor]
-        self.crashDataPersistence = BaseCrashDataPersistence(logger: logger,
-                                                             systemFileManager: systemFileManager)
+        self.crashDataPersistence = BaseCrashDataPersistence()
         CrashDataWriter.shared.setCrashDataPersistence(crashDataPersistence)
         self.attachmentProcessor = BaseAttachmentProcessor(logger: logger,
                                                            fileManager: systemFileManager,
@@ -323,14 +322,12 @@ final class BaseMeasureInitializer: MeasureInitializer { // swiftlint:disable:th
                                                    measureDispatchQueue: measureDispatchQueue,
                                                    signalSampler: signalSampler,
                                                    exporter: exporter)
-        self.systemCrashReporter = BaseSystemCrashReporter(logger: logger,
-                                                           crashDataPersistence: crashDataPersistence)
+        self.systemCrashReporter = BaseSystemCrashReporter(logger: logger)
         self.sysCtl = BaseSysCtl()
         self.crashReportManager = BaseCrashReportingManager(logger: logger,
                                                             signalProcessor: signalProcessor,
                                                             crashDataPersistence: crashDataPersistence,
                                                             crashReporter: systemCrashReporter,
-                                                            systemFileManager: systemFileManager,
                                                             idProvider: idProvider,
                                                             sysCtl: sysCtl,
                                                             configProvider: configProvider)

--- a/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/Constants.swift
@@ -14,7 +14,6 @@ typealias FloatNumber64 = Float64
 
 let logTag = "com.measure.sh"
 let cacheDirectoryName = "com.measure.sh"
-let crashDataFileName = "crash_data.txt"
 let backgroundQueueLabel = "com.measure.background"
 let periodicEventExporterLabel = "com.measure.periodicEventExporter"
 let userInitiatedQueueLabel = "com.measure.userInitiated"

--- a/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/Utils/SystemFileManager.swift
@@ -12,7 +12,6 @@ enum ConfigFileConstants {
     static let folderName = "measure"
     static let directory: FileManager.SearchPathDirectory = .applicationSupportDirectory
     static let sdkDebugLogsFolderName = "sdk_debug_logs"
-    static let crashDataFolderName = "crash_data"
     static let dynamicConfigFolderName = "dynamic_config"
     static let attachmentsFolderName = "attachments"
 }
@@ -21,7 +20,6 @@ enum ConfigFileConstants {
 protocol SystemFileManager {
     func getDirectoryPath(directory: FileManager.SearchPathDirectory) -> String?
     func getAttachmentDirectoryPath() -> String?
-    func getCrashFilePath() -> URL?
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL?
     func retrieveFile(name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> Data?
     func getDynamicConfigPath() -> String?
@@ -45,20 +43,6 @@ final class BaseSystemFileManager: SystemFileManager {
     init(logger: Logger) {
         self.logger = logger
         self.fileManager = FileManager.default
-    }
-
-    func getCrashFilePath() -> URL? {
-        guard let measureDir = measureDirectory else { return nil }
-        let crashDir = measureDir.appendingPathComponent(ConfigFileConstants.crashDataFolderName)
-        do {
-            if !fileManager.fileExists(atPath: crashDir.path) {
-                try fileManager.createDirectory(at: crashDir, withIntermediateDirectories: true, attributes: nil)
-            }
-        } catch {
-            logger.internalLog(level: .error, message: "SystemFileManager: Failed to create crash report directory.", error: error, data: nil)
-            return nil
-        }
-        return crashDir.appendingPathComponent(crashDataFileName)
     }
 
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL? {

--- a/ios/Tests/MeasureSDKTests/CrashReporter/CrashReportManagerTests.swift
+++ b/ios/Tests/MeasureSDKTests/CrashReporter/CrashReportManagerTests.swift
@@ -13,7 +13,6 @@ final class CrashReportingManagerTests: XCTestCase {
     var signalProcessor: MockSignalProcessor!
     var persistence: MockCrashDataPersistence!
     var logger: MockLogger!
-    var systemFileManager: MockSystemFileManager!
     var idProvider: MockIdProvider!
     var configProvider: MockConfigProvider!
     var crashReportingManager: BaseCrashReportingManager!
@@ -29,7 +28,6 @@ final class CrashReportingManagerTests: XCTestCase {
             isForeground: false
         )
         logger = MockLogger()
-        systemFileManager = MockSystemFileManager()
         idProvider = MockIdProvider()
         configProvider = MockConfigProvider()
         sysCtl = MockSysCtl()
@@ -41,7 +39,6 @@ final class CrashReportingManagerTests: XCTestCase {
         signalProcessor = nil
         persistence = nil
         logger = nil
-        systemFileManager = nil
         idProvider = nil
         configProvider = nil
         sysCtl = nil
@@ -177,12 +174,13 @@ final class CrashReportingManagerTests: XCTestCase {
         XCTAssertTrue(reporter.clearCrashDataCalled)
     }
 
-    func test_trackException_clearsPersistenceDataAfterTracking() {
+    func test_trackException_readsAttributesFromTheLoadedReportDict() {
         reporter.hasPendingCrashReport = true
-        reporter.reportToReturn = makeReportDict()
+        let report = makeReportDict()
+        reporter.reportToReturn = report
         trackException()
-        XCTAssertNil(persistence.attribute)
-        XCTAssertNil(persistence.sessionId)
+        XCTAssertTrue(persistence.readCrashDataCalled)
+        XCTAssertEqual(persistence.lastReadReportDict?.keys.sorted(), report.keys.sorted())
     }
 
     func test_trackException_ClearReporterWhenLoadThrows() {
@@ -192,11 +190,11 @@ final class CrashReportingManagerTests: XCTestCase {
         XCTAssertTrue(reporter.clearCrashDataCalled)
     }
 
-    func test_trackException_ClearPersistenceWhenLoadThrows() {
+    func test_trackException_doesNotReadCrashDataWhenLoadThrows() {
         reporter.hasPendingCrashReport = true
         reporter.reportToReturn = nil
         trackException()
-        XCTAssertNil(persistence.attribute)
+        XCTAssertFalse(persistence.readCrashDataCalled)
     }
 
     func test_trackException_ClearReporterWhenAttributesNil() {
@@ -205,14 +203,6 @@ final class CrashReportingManagerTests: XCTestCase {
         persistence.attribute = nil
         trackException()
         XCTAssertTrue(reporter.clearCrashDataCalled)
-    }
-
-    func test_trackException_ClearPersistenceWhenSessionIdNil() {
-        reporter.hasPendingCrashReport = true
-        reporter.reportToReturn = makeReportDict()
-        persistence.sessionId = nil
-        trackException()
-        XCTAssertNil(persistence.attribute)
     }
 
     func test_trackException_detectsKotlinCrashFromUserInfo() {
@@ -301,7 +291,6 @@ final class CrashReportingManagerTests: XCTestCase {
                                                           signalProcessor: signalProcessor,
                                                           crashDataPersistence: persistence,
                                                           crashReporter: reporter,
-                                                          systemFileManager: systemFileManager,
                                                           idProvider: idProvider,
                                                           sysCtl: sysCtl,
                                                           configProvider: configProvider)

--- a/ios/Tests/MeasureSDKTests/Mocks/MockCrashDataPersistence.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockCrashDataPersistence.swift
@@ -5,6 +5,11 @@
 //  Created by Adwin Ross on 26/09/24.
 //
 
+#if canImport(KSCrashRecording)
+import KSCrashRecording
+#elseif canImport(KSCrash)
+import KSCrash
+#endif
 import Foundation
 @testable import Measure
 
@@ -12,6 +17,10 @@ final class MockCrashDataPersistence: CrashDataPersistence {
     var attribute: Attributes?
     var sessionId: String?
     var isForeground: Bool
+    var writeCrashDataCalled = false
+    var readCrashDataCalled = false
+    /// The last `reportDict` passed to `readCrashData(from:)`, for assertions.
+    var lastReadReportDict: [String: Any]?
 
     init(attribute: Attributes? = nil, sessionId: String? = nil, isForeground: Bool) {
         self.attribute = attribute
@@ -19,14 +28,15 @@ final class MockCrashDataPersistence: CrashDataPersistence {
         self.isForeground = isForeground
     }
 
-    func prepareCrashFile() {}
-    func writeCrashData() {}
-    func readCrashData() -> CrashDataAttributes {
-        return (attribute: attribute, sessionId: sessionId, isForeground: isForeground)
+    func writeCrashData(plan: UnsafePointer<ExceptionHandlingPlan>, writer: UnsafePointer<ReportWriter>) {
+        writeCrashDataCalled = true
     }
-    func clearCrashData() {
-        attribute = nil
-        sessionId = nil
-        isForeground = true
+
+    /// Ignores `reportDict` and simply returns whatever the test configured on this mock -
+    /// real read-from-report parsing is covered by `CrashDataPersistenceTests`.
+    func readCrashData(from reportDict: [String: Any]) -> CrashDataAttributes {
+        readCrashDataCalled = true
+        lastReadReportDict = reportDict
+        return (attribute: attribute, sessionId: sessionId, isForeground: isForeground)
     }
 }

--- a/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockMeasureInitializer.swift
@@ -203,8 +203,7 @@ final class MockMeasureInitializer: MeasureInitializer {
             self.userAttributeProcessor,
             self.sessionAttributeProcessor
         ]
-        self.crashDataPersistence = crashDataPersistence ?? BaseCrashDataPersistence(logger: logger ?? MockLogger(),
-                                                             systemFileManager: self.systemFileManager)
+        self.crashDataPersistence = crashDataPersistence ?? BaseCrashDataPersistence()
         CrashDataWriter.shared.setCrashDataPersistence(self.crashDataPersistence)
         self.attachmentProcessor = attachmentProcessor ?? BaseAttachmentProcessor(logger: self.logger,
                                                            fileManager: self.systemFileManager,
@@ -228,14 +227,12 @@ final class MockMeasureInitializer: MeasureInitializer {
                                                    measureDispatchQueue: self.measureDispatchQueue,
                                                    signalSampler: self.signalSampler,
                                                    exporter: self.exporter)
-        self.systemCrashReporter = systemCrashReporter ?? BaseSystemCrashReporter(logger: self.logger,
-                                                                                  crashDataPersistence: self.crashDataPersistence)
+        self.systemCrashReporter = systemCrashReporter ?? BaseSystemCrashReporter(logger: self.logger)
         self.sysCtl = sysCtl ?? BaseSysCtl()
         self.crashReportManager = crashReportManager ?? BaseCrashReportingManager(logger: self.logger,
                                                                                   signalProcessor: self.signalProcessor,
                                                                                   crashDataPersistence: self.crashDataPersistence,
                                                                                   crashReporter: self.systemCrashReporter,
-                                                                                  systemFileManager: self.systemFileManager,
                                                                                   idProvider: self.idProvider,
                                                                                   sysCtl: self.sysCtl,
                                                                                   configProvider: self.configProvider)

--- a/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
+++ b/ios/Tests/MeasureSDKTests/Mocks/MockSystemFileManager.swift
@@ -9,7 +9,6 @@ import Foundation
 @testable import Measure
 
 final class MockSystemFileManager: SystemFileManager {
-    var crashFilePath: URL?
     var directoryPath: String?
     var attachmentDirectoryPath: String?
     var dynamicConfigPath: String?
@@ -18,10 +17,6 @@ final class MockSystemFileManager: SystemFileManager {
     var logFile: URL?
     var sdkDebugLogFiles: [URL] = []
     var deletedPaths: [String] = []
-
-    func getCrashFilePath() -> URL? {
-        return crashFilePath
-    }
 
     func saveFile(data: Data, name: String, folderName: String?, directory: FileManager.SearchPathDirectory) -> URL? {
         let fileKey = folderName != nil ? "\(folderName!)/\(name)" : name

--- a/ios/Tests/MeasureSDKTests/Utils/SystemFileManagerTests.swift
+++ b/ios/Tests/MeasureSDKTests/Utils/SystemFileManagerTests.swift
@@ -25,21 +25,6 @@ final class SystemFileManagerTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_getCrashFilePath_returnsPathUnderMeasureCrashDataFolder() {
-        let expected = measureURL
-            .appendingPathComponent(ConfigFileConstants.crashDataFolderName)
-            .appendingPathComponent(crashDataFileName)
-
-        XCTAssertEqual(sut.getCrashFilePath(), expected)
-    }
-
-    func test_getCrashFilePath_createsCrashDataDirectory() {
-        _ = sut.getCrashFilePath()
-
-        let crashDir = measureURL.appendingPathComponent(ConfigFileConstants.crashDataFolderName)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: crashDir.path))
-    }
-
     func test_getDynamicConfigPath_returnsPathUnderMeasureDynamicConfigFolder() {
         let expected = measureURL
             .appendingPathComponent(ConfigFileConstants.dynamicConfigFolderName)
@@ -90,7 +75,6 @@ final class SystemFileManagerTests: XCTestCase {
     func test_allPaths_areRootedUnderApplicationSupportMeasure() {
         let expectedRoot = measureURL.path
 
-        XCTAssertTrue(sut.getCrashFilePath()!.path.hasPrefix(expectedRoot))
         XCTAssertTrue(sut.getDynamicConfigPath()!.hasPrefix(expectedRoot))
         XCTAssertTrue(sut.getAttachmentDirectoryPath()!.hasPrefix(expectedRoot))
         XCTAssertTrue(sut.getSdkDebugLogsDirectory()!.path.hasPrefix(expectedRoot))


### PR DESCRIPTION
# Description

Measure's crash-write callback built a JSON string via Swift string interpolation and bridged it to a C string via `.cString(using:)`, which can take the objc runtime lock. KSCrash suspends all threads before invoking this callback, so if another thread was suspended mid-dlopen/objc-class-registration while holding that same lock, the callback deadlocked forever instead of writing a crash report.

  - Migrate from the deprecated `crashNotifyCallback` to `isWritingReportCallback` and write attributes directly into the KSCrash report's own "user" section via the async-safe writer API, instead of a separate hand-rolled JSON file.
  - Cache string attributes in fixed-size C buffers (CrashDataBuffer), updated only when a value actually changes, so the crash-time write path never touches Swift String, Foundation, or the objc runtime.
  - Reconstruct attributes from the report's "user" section on next launch instead of a standalone crash file; drops the now-unused crash-file read/write/clear plumbing in CrashDataPersistence and SystemFileManager.
  - Bump KSCrash to 2.6.0, which removes crashNotifyCallback entirely.

## Related issue
Fixes #4420 