### PR TITLE
fix(ios): use dispatch group to prevent core data deadlock

### DIFF
--- a/ios/Sources/MeasureSDK/Swift/CoreData/CoreDataManager.swift
+++ b/ios/Sources/MeasureSDK/Swift/CoreData/CoreDataManager.swift
@@ -16,13 +16,14 @@ final class BaseCoreDataManager: CoreDataManager {
     private let logger: Logger
     private var persistentContainer: NSPersistentContainer?
     private var _backgroundContext: NSManagedObjectContext?
-    private let readySemaphore = DispatchSemaphore(value: 0)
+    private let readyGroup = DispatchGroup()
     private var initializationFailed = false
     private var didSignalReady = false
     private let readyLock = NSLock()
 
     init(logger: Logger) {
         self.logger = logger
+        readyGroup.enter()
 
         let model: NSManagedObjectModel
 
@@ -86,7 +87,7 @@ final class BaseCoreDataManager: CoreDataManager {
             return _backgroundContext
         }
 
-        readySemaphore.wait()
+        readyGroup.wait()
 
         if initializationFailed {
             logger.log(
@@ -107,6 +108,6 @@ final class BaseCoreDataManager: CoreDataManager {
 
         guard !didSignalReady else { return }
         didSignalReady = true
-        readySemaphore.signal()
+        readyGroup.leave()
     }
 }


### PR DESCRIPTION
# Description

`backgroundContext` gated on a DispatchSemaphore signaled exactly once when the persistent store finished loading. signal() only releases one blocked wait() caller, so a second concurrent caller before the store was ready would block forever. Use DispatchGroup instead, which releases every waiter once the store is ready.

## Related issue
Fixes #4422