### PR TITLE
refactor(frontend): export the journeys demo as its own component

### DIFF
--- a/frontend/dashboard/__tests__/components/user_journeys_test.tsx
+++ b/frontend/dashboard/__tests__/components/user_journeys_test.tsx
@@ -51,7 +51,7 @@ jest.mock("@nivo/sankey", () => ({
   ),
 }));
 
-import UserJourneys from "@/app/components/user_journeys";
+import UserJourneys, { UserJourneysDemo } from "@/app/components/user_journeys";
 
 describe("UserJourneys", () => {
   beforeEach(() => {
@@ -60,17 +60,17 @@ describe("UserJourneys", () => {
   });
 
   it("renders the title", () => {
-    render(<UserJourneys demo={true} />);
+    render(<UserJourneysDemo />);
     expect(screen.getByText("User Journeys")).toBeInTheDocument();
   });
 
   it("hides the title when asked", () => {
-    render(<UserJourneys demo={true} hideDemoTitle={true} />);
+    render(<UserJourneysDemo hideTitle />);
     expect(screen.queryByText("User Journeys")).not.toBeInTheDocument();
   });
 
   it("draws the demo journey without a search input, a filter bar or the page's hook", () => {
-    render(<UserJourneys demo={true} />);
+    render(<UserJourneysDemo />);
     expect(screen.getByTestId("sankey-node-MainActivity")).toBeInTheDocument();
     expect(
       screen.getByTestId("sankey-node-CheckoutActivity"),
@@ -81,7 +81,7 @@ describe("UserJourneys", () => {
   });
 
   it("starts on the Paths tab", () => {
-    render(<UserJourneys demo={true} />);
+    render(<UserJourneysDemo />);
     expect(screen.getByRole("button", { name: "Paths" })).toHaveClass(
       "bg-accent",
     );
@@ -91,7 +91,7 @@ describe("UserJourneys", () => {
   });
 
   it("switches tabs locally, writing nothing to the URL", () => {
-    render(<UserJourneys demo={true} />);
+    render(<UserJourneysDemo />);
     fireEvent.click(screen.getByRole("button", { name: "Exceptions" }));
 
     expect(screen.getByRole("button", { name: "Exceptions" })).toHaveClass(
@@ -108,7 +108,7 @@ describe("UserJourneys", () => {
   });
 
   it("opens the issue panel on the Exceptions tab, with inert issue buttons", () => {
-    render(<UserJourneys demo={true} />);
+    render(<UserJourneysDemo />);
     fireEvent.click(screen.getByRole("button", { name: "Exceptions" }));
     fireEvent.click(screen.getByTestId("sankey-node-CheckoutActivity"));
 

--- a/frontend/dashboard/app/components/feature_demo_carousel.tsx
+++ b/frontend/dashboard/app/components/feature_demo_carousel.tsx
@@ -7,7 +7,10 @@ import ScaledPreview from "./scaled_preview";
 import TabSelect, { TabSize } from "./tab_select";
 
 const BugReport = dynamic(() => import("./bug_report"), { ssr: false });
-const UserJourneys = dynamic(() => import("./user_journeys"), { ssr: false });
+const UserJourneysDemo = dynamic(
+  () => import("./user_journeys").then((m) => m.UserJourneysDemo),
+  { ssr: false },
+);
 const Overview = dynamic(() => import("./overview"), { ssr: false });
 const TraceDetails = dynamic(() => import("./trace/details"), { ssr: false });
 const SessionReplay = dynamic(() => import("./session_replay"), {
@@ -173,7 +176,7 @@ export default function FeatureDemoCarousel() {
     <ErrorsDetails demo={true} hideDemoTitle={false} key="demo-errors" />,
     <TraceDetails demo={true} hideDemoTitle={false} key="demo-trace" />,
     <BugReport demo={true} hideDemoTitle={false} key="demo-bugreport" />,
-    <UserJourneys demo={true} hideDemoTitle={false} key="demo-journeys" />,
+    <UserJourneysDemo key="demo-journeys" />,
     <NetworkOverview demo={true} hideDemoTitle={false} key="demo-network" />,
   ];
 

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -18,28 +18,13 @@ import { type ComponentProps, type ReactNode, useState } from "react";
 
 const journeyTypeUrlKey = "jt";
 
-// Stands in for the journey query on the marketing pages, where nothing is
-// fetched and the chart draws the demo data as a completed query.
 const demoJourneyQuery = { status: "success" as const, data: demoJourney };
 
-interface UserJourneysProps {
-  params?: { teamId: string };
-  demo?: boolean;
-  hideDemoTitle?: boolean;
-}
-
-export default function UserJourneys({
-  params = { teamId: "demo-team-id" },
-  demo = false,
-  hideDemoTitle = false,
-}: UserJourneysProps) {
-  if (demo) {
-    return <DemoUserJourneys hideTitle={hideDemoTitle} />;
-  }
-  return <TeamUserJourneys teamId={params.teamId} />;
-}
-
-function DemoUserJourneys({ hideTitle }: { hideTitle: boolean }) {
+export function UserJourneysDemo({
+  hideTitle = false,
+}: {
+  hideTitle?: boolean;
+}) {
   const [plotType, setPlotType] = useState(PlotType.Paths);
 
   return (
@@ -49,7 +34,7 @@ function DemoUserJourneys({ hideTitle }: { hideTitle: boolean }) {
       </p>
       <div className="py-4" />
 
-      <JourneyPlot
+      <JourneyWithControls
         plotType={plotType}
         onChangePlotType={setPlotType}
         query={demoJourneyQuery}
@@ -58,7 +43,12 @@ function DemoUserJourneys({ hideTitle }: { hideTitle: boolean }) {
   );
 }
 
-function TeamUserJourneys({ teamId }: { teamId: string }) {
+export default function UserJourneys({
+  params,
+}: {
+  params: { teamId: string };
+}) {
+  const { teamId } = params;
   const searchParams = useSearchParams();
 
   const {
@@ -120,7 +110,7 @@ function TeamUserJourneys({ teamId }: { teamId: string }) {
 
       {readyValue !== null &&
         (status === "success" || status === "pending") && (
-          <JourneyPlot
+          <JourneyWithControls
             plotType={plotType}
             onChangePlotType={(type) => setPageUrlKey(journeyTypeUrlKey, type)}
             search={
@@ -144,7 +134,7 @@ function TeamUserJourneys({ teamId }: { teamId: string }) {
   );
 }
 
-function JourneyPlot({
+function JourneyWithControls({
   plotType,
   onChangePlotType,
   search,

--- a/frontend/dashboard/app/product/user-journeys/user_journeys_demo.tsx
+++ b/frontend/dashboard/app/product/user-journeys/user_journeys_demo.tsx
@@ -2,10 +2,12 @@
 
 import dynamic from "next/dynamic";
 
-const UserJourneys = dynamic(() => import("../../components/user_journeys"), {
-  ssr: false,
-});
+const Demo = dynamic(
+  () =>
+    import("../../components/user_journeys").then((m) => m.UserJourneysDemo),
+  { ssr: false },
+);
 
 export default function UserJourneysDemo() {
-  return <UserJourneys demo={true} hideDemoTitle={true} />;
+  return <Demo hideTitle />;
 }


### PR DESCRIPTION
# Description

- UserJourneys drops the demo flag and the wrapper that switched on it; the plain name is now the live page and takes only params
- the demo markup is exported as UserJourneysDemo, and the landing carousel and the product demo load it directly through next/dynamic
- the chart, its plot type tabs and the search slot become JourneyWithControls, rendered by both the page and the demo so the two cannot drift