### PR TITLE
test(frontend): wrap the offset test's URL change in act

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -611,7 +611,9 @@ describe("useExprFilterPage", () => {
       await renderPage();
       expect(page.paginationOffset).toBe(0);
 
-      mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=abc");
+      await act(async () => {
+        mockRouter.setUrl("?a=app-1&d=Last+6+Hours&po=abc");
+      });
       await renderPage();
       expect(page.paginationOffset).toBe(0);
     });


### PR DESCRIPTION
# Description

- the pagination offset test changes the URL while the first render is still mounted, so the store notification reached React outside act and logged a warning on every run