### PR TITLE
Migrate network to expression filters

### DIFF
--- a/backend/agent/agent/toolbox.go
+++ b/backend/agent/agent/toolbox.go
@@ -420,7 +420,7 @@ func commonTools(cfg *Config) []Tool {
 		// get_filter_keys
 		newTool(&mcpsdk.Tool{
 			Name:        "get_filter_keys",
-			Description: "List the filter keys of an entity (spans, bug_reports, journeys or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
+			Description: "List the filter keys of an entity (spans, bug_reports, journeys, network or builds), the vocabulary a filter_expr is written with: each key's name, label, description, key_group, value_type, operators and value_suggestion_mode, plus the key groups present. Call this before writing a filter_expr; get_filter_values lists a key's suggested values.",
 			InputSchema: mcpMustInferSchema[mcpGetFilterKeysInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetFilterKeysInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetFilterKeys(ctx, in)
@@ -496,6 +496,15 @@ func commonTools(cfg *Config) []Tool {
 			InputSchema: mcpMustInferSchema[mcpGetErrorDistributionInput](),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetErrorDistributionInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetErrorDistribution(ctx, in)
+		}),
+
+		// get_error_common_path
+		newTool(&mcpsdk.Tool{
+			Name:        "get_error_common_path",
+			Description: "Get the most common user navigation path leading to a specific error group (crash, exception or ANR)",
+			InputSchema: mcpMustInferSchema[mcpGetErrorCommonPathInput](),
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetErrorCommonPathInput) (*mcpsdk.CallToolResult, any, error) {
+			return cfg.mcpGetErrorCommonPath(ctx, in)
 		}),
 
 		// get_sessions
@@ -615,20 +624,11 @@ func commonTools(cfg *Config) []Tool {
 			return cfg.mcpGetJourney(ctx, in)
 		}),
 
-		// get_error_common_path
-		newTool(&mcpsdk.Tool{
-			Name:        "get_error_common_path",
-			Description: "Get the most common user navigation path leading to a specific error group (crash, exception or ANR)",
-			InputSchema: mcpMustInferSchema[mcpGetErrorCommonPathInput](),
-		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetErrorCommonPathInput) (*mcpsdk.CallToolResult, any, error) {
-			return cfg.mcpGetErrorCommonPath(ctx, in)
-		}),
-
 		// get_network_metrics_trends
 		newTool(&mcpsdk.Tool{
 			Name:        "get_network_metrics_trends",
-			Description: "Get top network endpoints by latency, error rate, and frequency for domain and path pattern",
-			InputSchema: mcpMustInferSchema[mcpGetNetworkTrendsInput](),
+			Description: "Get top network endpoints by latency, error rate, and frequency for domain and path pattern. Covers every request unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.NetworkEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetNetworkTrendsInput](mcpNetworkFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetNetworkTrendsInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetNetworkTrends(ctx, in)
 		}),
@@ -636,8 +636,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_network_status_codes_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_network_status_codes_over_time",
-			Description: "Get HTTP status-class counts over time for the whole app or a selected endpoint.",
-			InputSchema: mcpMustInferSchema[mcpGetAppHttpStatusCodesOverTimeInput](),
+			Description: "Get HTTP status-class counts over time for the whole app or a selected endpoint. Covers every request unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.NetworkEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetAppHttpStatusCodesOverTimeInput](mcpNetworkFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetAppHttpStatusCodesOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetAppStatusCodesOverTime(ctx, in)
 		}),
@@ -645,8 +645,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_network_endpoint_status_codes_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_network_endpoint_status_codes_over_time",
-			Description: "Get exact HTTP status-code counts over time for the whole app or a selected endpoint.",
-			InputSchema: mcpMustInferSchema[mcpGetHttpEndpointStatusCodesOverTimeInput](),
+			Description: "Get exact HTTP status-code counts over time for a selected endpoint. Covers every request unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.NetworkEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetHttpEndpointStatusCodesOverTimeInput](mcpNetworkFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetHttpEndpointStatusCodesOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetHttpEndpointStatusCodesOverTime(ctx, in)
 		}),
@@ -654,8 +654,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_network_latency_over_time
 		newTool(&mcpsdk.Tool{
 			Name:        "get_network_latency_over_time",
-			Description: "Get latency percentiles over time for the whole app or a selected endpoint.",
-			InputSchema: mcpMustInferSchema[mcpGetNetworkLatencyOverTimeInput](),
+			Description: "Get latency percentiles over time for the whole app or a selected endpoint. Covers every request unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.NetworkEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetNetworkLatencyOverTimeInput](mcpNetworkFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetNetworkLatencyOverTimeInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetNetworkLatencyOverTime(ctx, in)
 		}),
@@ -663,8 +663,8 @@ func commonTools(cfg *Config) []Tool {
 		// get_network_timeline
 		newTool(&mcpsdk.Tool{
 			Name:        "get_network_timeline",
-			Description: "Get the HTTP request timeline for the whole app or a selected endpoint.",
-			InputSchema: mcpMustInferSchema[mcpGetNetworkTimelineInput](),
+			Description: "Get the per-session HTTP request timeline for the whole app or a selected endpoint. Covers every request unless filter_expr narrows it; " + mcpFilterExprToolsHint(exprfilter.NetworkEntity) + ".",
+			InputSchema: mcpMustInferFilterExprSchema[mcpGetNetworkTimelineInput](mcpNetworkFilterExprGrammar),
 		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, in mcpGetNetworkTimelineInput) (*mcpsdk.CallToolResult, any, error) {
 			return cfg.mcpGetNetworkTimeline(ctx, in)
 		}),
@@ -699,6 +699,7 @@ var (
 	mcpSpansFilterExprGrammar      = mcpFilterExprGrammar(exprfilter.SpansEntity, "version_name:in:[1.2.0,1.1.9] AND span_status:in:error")
 	mcpBugReportsFilterExprGrammar = mcpFilterExprGrammar(exprfilter.BugReportsEntity, "version_name:in:[1.2.0] AND bug_report_status:in:open")
 	mcpJourneysFilterExprGrammar   = mcpFilterExprGrammar(exprfilter.JourneysEntity, "version_name:in:[1.2.0] AND version_code:in:[120]")
+	mcpNetworkFilterExprGrammar    = mcpFilterExprGrammar(exprfilter.NetworkEntity, "version_name:in:[1.2.0] AND http_method:in:get")
 )
 
 // mcpMustInferFilterExprSchema infers a JSON schema from a Go type and sets
@@ -799,12 +800,12 @@ type mcpGetFiltersInput struct {
 }
 type mcpGetFilterKeysInput struct {
 	AppID  string   `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys or builds"`
+	Entity string   `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys, network or builds"`
 	Keys   []string `json:"keys,omitempty" jsonschema:"Key names you already know, for example from the user's request, to include in the result even when the listing is truncated"`
 }
 type mcpGetFilterValuesInput struct {
 	AppID   string `json:"app_id" jsonschema:"UUID of the app to query"`
-	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys or builds"`
+	Entity  string `json:"entity" jsonschema:"The entity the filter is written against: spans, bug_reports, journeys, network or builds"`
 	KeyName string `json:"key_name" jsonschema:"Name of the filter key to list values for, as get_filter_keys returns it"`
 	Search  string `json:"search,omitempty" jsonschema:"Return only values containing this text"`
 	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum number of values to return (default: 50, max: 200)"`
@@ -934,36 +935,47 @@ type mcpUpdateBugReportStatusInput struct {
 }
 
 // Network tool input structs.
-type mcpNetworkFilters struct {
-	mcpCommonFilters
-	HttpMethods []string `json:"http_methods,omitempty" jsonschema:"Filter by HTTP methods (e.g. get, post)"`
-}
 type mcpGetNetworkTrendsInput struct {
-	mcpNetworkFilters
-	Limit int `json:"limit,omitempty" jsonschema:"Maximum number of endpoints to return per category (1-50, default 10)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Limit      int    `json:"limit,omitempty" jsonschema:"Maximum number of endpoints to return per category (1-50, default 10)"`
 }
 type mcpGetAppHttpStatusCodesOverTimeInput struct {
-	mcpNetworkFilters
-	Domain   string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
-	Path     string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
-	Timezone string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Domain     string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
+	Path       string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
+	Timezone   string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
 }
 type mcpGetNetworkLatencyOverTimeInput struct {
-	mcpNetworkFilters
-	Domain   string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
-	Path     string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
-	Timezone string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Domain     string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
+	Path       string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
+	Timezone   string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
 }
 type mcpGetHttpEndpointStatusCodesOverTimeInput struct {
-	mcpNetworkFilters
-	Domain   string `json:"domain,omitempty" jsonschema:"Restrict to a domain (e.g. api.example.com)"`
-	Path     string `json:"path,omitempty" jsonschema:"Restrict to a path across all domains when domain is omitted (e.g. /v1/users)"`
-	Timezone string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Domain     string `json:"domain,omitempty" jsonschema:"Restrict to a domain (e.g. api.example.com)"`
+	Path       string `json:"path,omitempty" jsonschema:"Restrict to a path across all domains when domain is omitted (e.g. /v1/users)"`
+	Timezone   string `json:"timezone" jsonschema:"Timezone for time bucketing (e.g. America/New_York)"`
 }
 type mcpGetNetworkTimelineInput struct {
-	mcpNetworkFilters
-	Domain string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
-	Path   string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
+	AppID      string `json:"app_id" jsonschema:"UUID of the app to query"`
+	From       string `json:"from,omitempty" jsonschema:"Start of time range (RFC3339, default: 7 days ago)"`
+	To         string `json:"to,omitempty" jsonschema:"End of time range (RFC3339, default: now)"`
+	FilterExpr string `json:"filter_expr,omitempty"`
+	Domain     string `json:"domain,omitempty" jsonschema:"Restrict to an exact domain or * wildcard pattern (e.g. api.example.com or *.example.com)"`
+	Path       string `json:"path,omitempty" jsonschema:"Restrict to an exact, * or ** path pattern across all domains when domain is omitted (e.g. /v1/users or /v1/*)"`
 }
 
 // --------------------------------------------------------------------------
@@ -2118,29 +2130,8 @@ func (c *Config) mcpUpdateBugReportStatus(ctx context.Context, in mcpUpdateBugRe
 // Network tool helpers & handlers
 // --------------------------------------------------------------------------
 
-func (c *Config) mcpBuildNetworkFilter(ctx context.Context, appID uuid.UUID, nf mcpNetworkFilters) (*filter.AppFilter, error) {
-	af, err := c.mcpBuildAppFilter(ctx, appID, nf.mcpCommonFilters)
-	if err != nil {
-		return nil, err
-	}
-	if len(nf.HttpMethods) > 0 {
-		af.HttpMethods = nf.HttpMethods
-	}
-	return af, nil
-}
-
 func (c *Config) mcpGetNetworkTrends(ctx context.Context, in mcpGetNetworkTrendsInput) (*mcpsdk.CallToolResult, any, error) {
 	deps := c.Deps
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	af, err := c.mcpBuildNetworkFilter(ctx, appID, in.mcpNetworkFilters)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	limit := in.Limit
 	if limit <= 0 {
 		limit = 10
@@ -2149,7 +2140,12 @@ func (c *Config) mcpGetNetworkTrends(ctx context.Context, in mcpGetNetworkTrends
 		limit = 50
 	}
 
-	result, err := network.FetchTrends(ctx, deps.RchPool, appID, teamID, af, limit)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.NetworkEntity, in.AppID, in.From, in.To, in.FilterExpr, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result, err := network.FetchTrends(ctx, deps.RchPool, appID, teamID, ef, limit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network trends: %v", err)
 	}
@@ -2163,24 +2159,20 @@ func (c *Config) mcpGetAppStatusCodesOverTime(ctx context.Context, in mcpGetAppH
 		return nil, nil, fmt.Errorf("timezone is required for over time tools")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.NetworkEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		ef.Timezone = in.Timezone
+		ef.SetDefaultPlotTimeGroupIfUnset()
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildNetworkFilter(ctx, appID, in.mcpNetworkFilters)
-	if err != nil {
-		return nil, nil, err
-	}
-	af.Timezone = in.Timezone
-	af.SetDefaultPlotTimeGroup()
-
-	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetStatusCodesPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetStatusCodesPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network status overview over time: %v", err)
 	}
@@ -2194,24 +2186,20 @@ func (c *Config) mcpGetNetworkLatencyOverTime(ctx context.Context, in mcpGetNetw
 		return nil, nil, fmt.Errorf("timezone is required for over time tools")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.NetworkEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		ef.Timezone = in.Timezone
+		ef.SetDefaultPlotTimeGroupIfUnset()
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildNetworkFilter(ctx, appID, in.mcpNetworkFilters)
-	if err != nil {
-		return nil, nil, err
-	}
-	af.Timezone = in.Timezone
-	af.SetDefaultPlotTimeGroup()
-
-	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetLatencyPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetLatencyPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network latency over time: %v", err)
 	}
@@ -2228,24 +2216,20 @@ func (c *Config) mcpGetHttpEndpointStatusCodesOverTime(ctx context.Context, in m
 		return nil, nil, fmt.Errorf("timezone is required for over time tools")
 	}
 
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.NetworkEntity, in.AppID, in.From, in.To, in.FilterExpr, func(ef *exprfilter.ExprFilter) {
+		ef.Timezone = in.Timezone
+		ef.SetDefaultPlotTimeGroupIfUnset()
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildNetworkFilter(ctx, appID, in.mcpNetworkFilters)
-	if err != nil {
-		return nil, nil, err
-	}
-	af.Timezone = in.Timezone
-	af.SetDefaultPlotTimeGroup()
-
-	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to compute time group expression: %v", err)
 	}
 
-	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network endpoint status codes over time: %v", err)
 	}
@@ -2255,17 +2239,12 @@ func (c *Config) mcpGetHttpEndpointStatusCodesOverTime(ctx context.Context, in m
 
 func (c *Config) mcpGetNetworkTimeline(ctx context.Context, in mcpGetNetworkTimelineInput) (*mcpsdk.CallToolResult, any, error) {
 	deps := c.Deps
-	appID, teamID, err := c.mcpResolveAppAccess(ctx, in.AppID)
+	appID, teamID, ef, err := c.mcpPrepareExprFilter(ctx, exprfilter.NetworkEntity, in.AppID, in.From, in.To, in.FilterExpr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	af, err := c.mcpBuildNetworkFilter(ctx, appID, in.mcpNetworkFilters)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	result, err := network.FetchTimelinePlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, af)
+	result, err := network.FetchTimelinePlot(ctx, deps.RchPool, appID, teamID, in.Domain, in.Path, ef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get network request timeline: %v", err)
 	}

--- a/backend/agent/mcp/mcp_test.go
+++ b/backend/agent/mcp/mcp_test.go
@@ -4141,6 +4141,111 @@ func TestMCPNetworkSelectionScopes(t *testing.T) {
 	}
 }
 
+func TestMCPNetworkFilterExpr(t *testing.T) {
+	ctx := context.Background()
+	cleanupAll(ctx, t)
+
+	userID := uuid.New()
+	teamID := uuid.New()
+	appID := uuid.New()
+	rawToken := "msr_networkexpr"
+	seedUser(ctx, t, userID.String(), "networkexpr@mcp.test")
+	seedTeam(ctx, t, teamID, "network expr team")
+	seedTeamMembership(ctx, t, teamID, userID.String(), "owner")
+	seedApp(ctx, t, appID, teamID, 30)
+	seedMCPAccessToken(ctx, t, rawToken, userID.String(), "c1", time.Now().Add(90*24*time.Hour))
+
+	now := time.Now().UTC().Truncate(15 * time.Minute)
+	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://a.example.com/one", "GET", 200, 5, now)
+	seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "a.example.com", "/one", 5, 5, 0, 0, now)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	latencyCount := func(t *testing.T, filterExpr string) float64 {
+		t.Helper()
+		args := map[string]any{"app_id": appID.String(), "from": from, "to": to, "timezone": "UTC"}
+		if filterExpr != "" {
+			args["filter_expr"] = filterExpr
+		}
+		resp := callMCPTool(t, rawToken, "get_network_latency_over_time", args)
+		if isToolError(resp) {
+			t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+		}
+		var points []map[string]any
+		if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &points); err != nil {
+			t.Fatalf("response is not a data-point array: %v", err)
+		}
+		var total float64
+		for _, point := range points {
+			total += point["count"].(float64)
+		}
+		return total
+	}
+
+	t.Run("filter_expr narrows the events queries", func(t *testing.T) {
+		if got := latencyCount(t, ""); got != 5 {
+			t.Fatalf("unfiltered count = %v, want 5", got)
+		}
+		if got := latencyCount(t, "version_name:in:v1 AND http_method:in:get"); got != 5 {
+			t.Errorf("matching filter count = %v, want 5", got)
+		}
+		if got := latencyCount(t, "version_name:in:v9"); got != 0 {
+			t.Errorf("count for a version never seen = %v, want 0", got)
+		}
+	})
+
+	t.Run("filter_expr narrows the rollup queries", func(t *testing.T) {
+		points := func(t *testing.T, filterExpr string) int {
+			t.Helper()
+			resp := callMCPTool(t, rawToken, "get_network_timeline", map[string]any{
+				"app_id": appID.String(), "from": from, "to": to, "filter_expr": filterExpr,
+			})
+			if isToolError(resp) {
+				t.Fatalf("unexpected tool error: %s", extractTextContent(t, resp))
+			}
+			var result struct {
+				Points []any `json:"points"`
+			}
+			if err := json.Unmarshal([]byte(extractTextContent(t, resp)), &result); err != nil {
+				t.Fatalf("timeline response is not JSON: %v", err)
+			}
+			return len(result.Points)
+		}
+
+		if got := points(t, "http_method:in:get"); got == 0 {
+			t.Error("want the seeded bucket kept by a matching filter")
+		}
+		if got := points(t, "http_method:in:post"); got != 0 {
+			t.Errorf("timeline points for a method never seen = %d, want 0", got)
+		}
+	})
+
+	t.Run("invalid filter_expr returns the issue", func(t *testing.T) {
+		resp := callMCPTool(t, rawToken, "get_network_metrics_trends", map[string]any{
+			"app_id": appID.String(), "from": from, "to": to, "filter_expr": "span_status:in:error",
+		})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for a key the network entity does not have")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "Unknown key") || !strings.Contains(text, "span_status") {
+			t.Errorf("error text %q should name the unknown key", text)
+		}
+	})
+
+	t.Run("unparseable filter_expr returns the parse error", func(t *testing.T) {
+		resp := callMCPTool(t, rawToken, "get_network_metrics_trends", map[string]any{
+			"app_id": appID.String(), "from": from, "to": to, "filter_expr": "version_name:in:v1 AND",
+		})
+		if !isToolError(resp) {
+			t.Fatal("want tool error for unparseable filter")
+		}
+		if text := extractTextContent(t, resp); !strings.Contains(text, "filter_expr could not be parsed") || !strings.Contains(text, "at position") {
+			t.Errorf("error text %q should report the parse failure and its position", text)
+		}
+	})
+}
+
 func TestMCPGetNetworkTrends(t *testing.T) {
 	ctx := context.Background()
 	setupToolTest := func(t *testing.T, email string) (uuid.UUID, string) {

--- a/backend/agent/mcp/test_helpers_test.go
+++ b/backend/agent/mcp/test_helpers_test.go
@@ -137,6 +137,8 @@ func seedHttpMetrics(
 			[toUInt16(200)] AS status_codes,
 			[('1.0','1')] AS app_versions,
 			[('android','14')] AS os_versions,
+			[''] AS patch_versions,
+			[toUUID('00000000-0000-0000-0000-000000000000')] AS patch_ids,
 			['samsung'] AS device_manufacturers,
 			['galaxy'] AS device_names,
 			['provider'] AS network_providers,

--- a/backend/alerts/network/network.go
+++ b/backend/alerts/network/network.go
@@ -336,6 +336,8 @@ func insertAggregatedMetrics(ctx context.Context, teamID, appID uuid.UUID, from,
 		Select("groupUniqArray(e.status_code)").
 		Select("groupUniqArray(e.`attribute.app_version`)").
 		Select("groupUniqArray(e.`attribute.os_version`)").
+		Select("groupUniqArray(e.`attribute.patch_version`)").
+		Select("groupUniqArray(e.`attribute.patch_id`)").
 		Select("groupUniqArray(e.`attribute.device_manufacturer`)").
 		Select("groupUniqArray(e.`attribute.device_name`)").
 		Select("groupUniqArray(e.`attribute.network_provider`)").

--- a/backend/alerts/network/network_test.go
+++ b/backend/alerts/network/network_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"backend/testinfra"
+
 	"github.com/google/uuid"
 )
 
@@ -218,13 +220,41 @@ func TestGenerateMetrics_InsertsAggregatedMetrics(t *testing.T) {
 
 	now := time.Now().UTC()
 
+	patchID := uuid.New()
 	th.SeedUrlPattern(ctx, t, teamID, appID, "api.example.com", "/api/v1/users")
-	th.SeedHttpEvent(ctx, t, teamID, appID, "https://api.example.com/api/v1/users", "GET", 200, 10, now.Add(-30*time.Minute))
+	th.SeedEventRows(ctx, t, teamID, appID, 10, testinfra.EventRow{
+		Type:           "http",
+		Timestamp:      now.Add(-30 * time.Minute),
+		InsertedAt:     now.Add(-30 * time.Minute),
+		HttpURL:        "https://api.example.com/api/v1/users",
+		HttpMethod:     "GET",
+		HttpStatusCode: 200,
+		HttpStartTime:  1000,
+		HttpEndTime:    1100,
+		PatchID:        patchID,
+		PatchVersion:   "1.0-patch.2",
+	})
 
 	GenerateMetrics(ctx)
 
 	if got := countHttpMetrics(ctx, t, teamID, appID); got == 0 {
 		t.Error("expected http_metrics rows after GenerateMetrics, got 0")
+	}
+
+	var patchVersions []string
+	var patchIDs []uuid.UUID
+	err := th.ChConn.QueryRow(ctx,
+		"SELECT groupUniqArrayArray(patch_versions), groupUniqArrayArray(patch_ids) FROM http_metrics WHERE team_id = ? AND app_id = ?",
+		teamID, appID,
+	).Scan(&patchVersions, &patchIDs)
+	if err != nil {
+		t.Fatalf("query aggregated patches: %v", err)
+	}
+	if len(patchVersions) != 1 || patchVersions[0] != "1.0-patch.2" {
+		t.Errorf("patch versions = %v, want [1.0-patch.2]", patchVersions)
+	}
+	if len(patchIDs) != 1 || patchIDs[0] != patchID {
+		t.Errorf("patch ids = %v, want [%s]", patchIDs, patchID)
 	}
 }
 

--- a/backend/api/handlers/app.go
+++ b/backend/api/handlers/app.go
@@ -3222,109 +3222,17 @@ func (h Handlers) PatchConfig(c *gin.Context) {
 // GetNetworkRequestsEndpoints serves the dashboard's endpoint search.
 func (h Handlers) GetNetworkRequestsEndpoints(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.NetworkEntity,
+		appScope: *measure.ScopeAppRead,
+		logRoot:  logcomment.Network,
+		logName:  "endpoints",
+	})
+	if !ok {
 		return
 	}
 
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "network endpoint search request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
-
-	endpoints, err := network.FetchEndpoints(ctx, deps.RchPool, *app.ID, *team.ID, c.Query("query"), &af)
+	endpoints, err := network.FetchEndpoints(ctx, deps.RchPool, *app.ID, app.TeamId, c.Query("query"), &ef)
 	if err != nil {
 		msg := "failed to get network endpoints"
 		fmt.Println(msg, err)
@@ -3337,84 +3245,19 @@ func (h Handlers) GetNetworkRequestsEndpoints(c *gin.Context) {
 
 func (h Handlers) GetNetworkEndpointLatencyPlot(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:          exprfilter.NetworkEntity,
+		appScope:        *measure.ScopeAppRead,
+		logRoot:         logcomment.Network,
+		logName:         "latency",
+		requireTimezone: true,
+	})
+	if !ok {
 		return
 	}
 
-	domain := c.Query("domain")
-	path := c.Query("path")
-
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "network metrics request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if !af.HasTimezone() {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "missing required field `timezone`",
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	if !af.HasPlotTimeGroup() {
-		af.SetDefaultPlotTimeGroup()
-	}
-
-	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	ef.SetDefaultPlotTimeGroupIfUnset()
+	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		msg := "failed to compute time group expression"
 		fmt.Println(msg, err)
@@ -3422,46 +3265,7 @@ func (h Handlers) GetNetworkEndpointLatencyPlot(c *gin.Context) {
 		return
 	}
 
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
-
-	result, err := network.GetLatencyPlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetLatencyPlot(ctx, deps.RchPool, *app.ID, app.TeamId, c.Query("domain"), c.Query("path"), &ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		msg := "failed to get network latency metrics"
 		fmt.Println(msg, err)
@@ -3474,105 +3278,13 @@ func (h Handlers) GetNetworkEndpointLatencyPlot(c *gin.Context) {
 
 func (h Handlers) GetNetworkRequestsTrends(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "network overview request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.NetworkEntity,
+		appScope: *measure.ScopeAppRead,
+		logRoot:  logcomment.Network,
+		logName:  "trends",
+	})
+	if !ok {
 		return
 	}
 
@@ -3584,7 +3296,7 @@ func (h Handlers) GetNetworkRequestsTrends(c *gin.Context) {
 		trendsLimit = 50
 	}
 
-	result, err := network.FetchTrends(ctx, deps.RchPool, *app.ID, *team.ID, &af, trendsLimit)
+	result, err := network.FetchTrends(ctx, deps.RchPool, *app.ID, app.TeamId, &ef, trendsLimit)
 	if err != nil {
 		msg := "failed to get network overview"
 		fmt.Println(msg, err)
@@ -3597,112 +3309,17 @@ func (h Handlers) GetNetworkRequestsTrends(c *gin.Context) {
 
 func (h Handlers) GetNetworkEndpointTimelinePlot(c *gin.Context) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:   exprfilter.NetworkEntity,
+		appScope: *measure.ScopeAppRead,
+		logRoot:  logcomment.Network,
+		logName:  "timeline",
+	})
+	if !ok {
 		return
 	}
 
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
-	}
-
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "endpoint timeline request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	domain := c.Query("domain")
-	path := c.Query("path")
-
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
-
-	result, err := network.FetchTimelinePlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af)
+	result, err := network.FetchTimelinePlot(ctx, deps.RchPool, *app.ID, app.TeamId, c.Query("domain"), c.Query("path"), &ef)
 	if err != nil {
 		msg := "failed to get endpoint timeline data"
 		fmt.Println(msg, err)
@@ -3723,15 +3340,6 @@ func (h Handlers) GetNetworkEndpointStatusCodesPlot(c *gin.Context) {
 
 func (h Handlers) getNetworkStatusCodesPlot(c *gin.Context, exactCodes bool) {
 	deps := h.Deps
-	ctx := c.Request.Context()
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		msg := `id invalid or missing`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
 	domain := c.Query("domain")
 	path := c.Query("path")
 	if exactCodes && domain == "" && path == "" {
@@ -3739,72 +3347,24 @@ func (h Handlers) getNetworkStatusCodesPlot(c *gin.Context, exactCodes bool) {
 		return
 	}
 
-	af := filter.AppFilter{
-		AppID: id,
-		Limit: filter.DefaultPaginationLimit,
+	logName := "status_codes"
+	if exactCodes {
+		logName = "endpoint_status_codes"
 	}
 
-	if err := c.ShouldBindQuery(&af); err != nil {
-		msg := `failed to parse query parameters`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
+	app, ef, ctx, _, ok := h.prepareExprFilter(c, exprFilterEndpoint{
+		entity:          exprfilter.NetworkEntity,
+		appScope:        *measure.ScopeAppRead,
+		logRoot:         logcomment.Network,
+		logName:         logName,
+		requireTimezone: true,
+	})
+	if !ok {
 		return
 	}
 
-	if err := af.Expand(ctx, deps.PgPool); err != nil {
-		msg := `failed to expand filters`
-		fmt.Println(msg, err)
-		status := http.StatusInternalServerError
-		if errors.Is(err, pgx.ErrNoRows) {
-			status = http.StatusNotFound
-		}
-		c.JSON(status, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	msg := "network status codes plot request validation failed"
-	if err := af.Validate(); err != nil {
-		fmt.Println(msg, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   msg,
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if !af.HasTimezone() {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "missing required field `timezone`",
-		})
-		return
-	}
-
-	if len(af.Versions) > 0 || len(af.VersionCodes) > 0 {
-		if err := af.ValidateVersions(); err != nil {
-			fmt.Println(msg, err)
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   msg,
-				"details": err.Error(),
-			})
-			return
-		}
-	}
-
-	if !af.HasTimeRange() {
-		af.SetDefaultTimeRange()
-	}
-
-	if !af.HasPlotTimeGroup() {
-		af.SetDefaultPlotTimeGroup()
-	}
-
-	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", af.PlotTimeGroup)
+	ef.SetDefaultPlotTimeGroupIfUnset()
+	groupExpr, err := measure.GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		msg := "failed to compute time group expression"
 		fmt.Println(msg, err)
@@ -3812,47 +3372,8 @@ func (h Handlers) getNetworkStatusCodesPlot(c *gin.Context, exactCodes bool) {
 		return
 	}
 
-	app := measure.App{
-		ID: &id,
-	}
-	team, err := app.GetTeam(ctx, deps.PgPool)
-	if err != nil {
-		msg := "failed to get team from app id"
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-	if team == nil {
-		msg := fmt.Sprintf("no team exists for app [%s]", app.ID)
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	userId := c.GetString("userId")
-	okTeam, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeTeamRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	okApp, err := measure.PerformAuthz(deps.PgPool, userId, team.ID.String(), *measure.ScopeAppRead)
-	if err != nil {
-		msg := `failed to perform authorization`
-		fmt.Println(msg, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		return
-	}
-
-	if !okTeam || !okApp {
-		msg := `you are not authorized to access this app`
-		c.JSON(http.StatusForbidden, gin.H{"error": msg})
-		return
-	}
-
 	if exactCodes {
-		result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+		result, err := network.GetEndpointStatusCodesPlot(ctx, deps.RchPool, *app.ID, app.TeamId, domain, path, &ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 		if err != nil {
 			msg := "failed to get network endpoint status codes plot"
 			fmt.Println(msg, err)
@@ -3864,7 +3385,7 @@ func (h Handlers) getNetworkStatusCodesPlot(c *gin.Context, exactCodes bool) {
 		return
 	}
 
-	result, err := network.GetStatusCodesPlot(ctx, deps.RchPool, *app.ID, *team.ID, domain, path, &af, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
+	result, err := network.GetStatusCodesPlot(ctx, deps.RchPool, *app.ID, app.TeamId, domain, path, &ef, groupExpr.BucketExpr, groupExpr.DatetimeFormat)
 	if err != nil {
 		msg := "failed to get network status codes plot"
 		fmt.Println(msg, err)

--- a/backend/libs/exprfilter/columnbinding.go
+++ b/backend/libs/exprfilter/columnbinding.go
@@ -86,6 +86,60 @@ func bindUUIDKey(column string, condition Condition) (*sqlf.Stmt, error) {
 	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
 }
 
+func bindArrayKey(column string, condition Condition) (*sqlf.Stmt, error) {
+	switch condition.Operator {
+	case OperatorIn:
+		return sqlf.New("hasAny("+column+", ?)", condition.TextValues()), nil
+	case OperatorNotIn:
+		return sqlf.New("not hasAny("+column+", ?)", condition.TextValues()), nil
+	}
+
+	text := EscapeLikeWildcards(condition.TextValue())
+	var pattern string
+	switch condition.Operator {
+	case OperatorContains, OperatorNotContains:
+		pattern = "%" + text + "%"
+	case OperatorStartsWith:
+		pattern = text + "%"
+	case OperatorEndsWith:
+		pattern = "%" + text
+	default:
+		return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+	}
+
+	anyMatch := "arrayExists(value -> value ilike ?, " + column + ")"
+	if condition.Operator == OperatorNotContains {
+		return sqlf.New("not "+anyMatch, pattern), nil
+	}
+	return sqlf.New(anyMatch, pattern), nil
+}
+
+// Bound uuids arrive as text, so they are cast before the array functions
+// compare them.
+func bindUUIDArrayKey(column string, condition Condition) (*sqlf.Stmt, error) {
+	switch condition.Operator {
+	case OperatorIn, OperatorNotIn:
+		bound := make([]uuid.UUID, 0, len(condition.Values))
+		for _, text := range condition.TextValues() {
+			id, err := uuid.Parse(text)
+			if err != nil {
+				return nil, fmt.Errorf("Key %q takes uuid values, got %q", condition.KeyName, text)
+			}
+			bound = append(bound, id)
+		}
+		if condition.Operator == OperatorNotIn {
+			return sqlf.New("not hasAny("+column+", cast(?, 'Array(UUID)'))", bound), nil
+		}
+		return sqlf.New("hasAny("+column+", cast(?, 'Array(UUID)'))", bound), nil
+	case OperatorIsSet:
+		return sqlf.New("arrayExists(value -> value <> toUUID(?), "+column+")", uuid.Nil), nil
+	case OperatorIsNotSet:
+		return sqlf.New("has("+column+", toUUID(?))", uuid.Nil), nil
+	}
+
+	return nil, fmt.Errorf("Key %q cannot be filtered with %q", condition.KeyName, condition.Operator)
+}
+
 // bindEnumKeyToCodes builds the columnKeyBinding for an enum key whose column
 // stores integer codes: each value name a condition carries is translated
 // through the mapping before comparison, and a name outside it is refused.

--- a/backend/libs/exprfilter/columnbinding_test.go
+++ b/backend/libs/exprfilter/columnbinding_test.go
@@ -139,3 +139,138 @@ func TestUUIDKeyBinding(t *testing.T) {
 		}
 	})
 }
+
+func TestArrayColumnBindingSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyName  string
+		operator Operator
+		texts    []string
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name: "in keeps a bucket holding any of the values", keyName: "network_type",
+			operator: OperatorIn, texts: []string{"wifi", "cellular"},
+			wantSQL: "hasAny(network_types, ?)", wantArgs: []any{[]string{"wifi", "cellular"}},
+		},
+		{
+			name: "not_in drops a bucket holding any of the values", keyName: "network_type",
+			operator: OperatorNotIn, texts: []string{"wifi"},
+			wantSQL: "not hasAny(network_types, ?)", wantArgs: []any{[]string{"wifi"}},
+		},
+		{
+			name: "contains matches any value in the bucket", keyName: "device_name",
+			operator: OperatorContains, texts: []string{"pix"},
+			wantSQL: "arrayExists(value -> value ilike ?, device_names)", wantArgs: []any{"%pix%"},
+		},
+		{
+			name: "starts_with anchors the start", keyName: "device_name",
+			operator: OperatorStartsWith, texts: []string{"pix"},
+			wantSQL: "arrayExists(value -> value ilike ?, device_names)", wantArgs: []any{"pix%"},
+		},
+		{
+			name: "a wildcard in the typed text is escaped", keyName: "device_name",
+			operator: OperatorContains, texts: []string{"50%"},
+			wantSQL: "arrayExists(value -> value ilike ?, device_names)", wantArgs: []any{`%50\%%`},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values := make([]Value, len(test.texts))
+			for i, text := range test.texts {
+				values[i] = Value{Text: text}
+			}
+
+			stmt, err := NetworkMetricsKeyBindings[test.keyName](Condition{
+				KeyName:  test.keyName,
+				Operator: test.operator,
+				Values:   values,
+			})
+			if err != nil {
+				t.Fatalf("bind %s %s: %v", test.keyName, test.operator, err)
+			}
+			defer stmt.Close()
+
+			if got := stmt.String(); got != test.wantSQL {
+				t.Errorf("\n got %s\nwant %s", got, test.wantSQL)
+			}
+			args := stmt.Args()
+			if len(args) != len(test.wantArgs) {
+				t.Fatalf("want %d arguments, got %#v", len(test.wantArgs), args)
+			}
+			for i, want := range test.wantArgs {
+				if texts, ok := want.([]string); ok {
+					if got, ok := args[i].([]string); !ok || !slices.Equal(got, texts) {
+						t.Errorf("argument %d = %#v, want %#v", i, args[i], want)
+					}
+					continue
+				}
+				if args[i] != want {
+					t.Errorf("argument %d = %#v, want %#v", i, args[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestUUIDArrayKeyBinding(t *testing.T) {
+	bind := NetworkMetricsKeyBindings["patch_id"]
+
+	t.Run("in binds the parsed uuids", func(t *testing.T) {
+		one := uuid.New()
+		stmt, err := bind(Condition{
+			KeyName:  "patch_id",
+			Operator: OperatorIn,
+			Values:   []Value{{Text: one.String()}},
+		})
+		if err != nil {
+			t.Fatalf("bind patch_id in: %v", err)
+		}
+		defer stmt.Close()
+
+		if got := stmt.String(); got != "hasAny(patch_ids, cast(?, 'Array(UUID)'))" {
+			t.Errorf("want the patch id array compared, got %q", got)
+		}
+		if got, ok := stmt.Args()[0].([]uuid.UUID); !ok || !slices.Equal(got, []uuid.UUID{one}) {
+			t.Errorf("want the parsed uuid bound, got %v", stmt.Args()[0])
+		}
+	})
+
+	t.Run("is_set and is_not_set compare against the nil uuid", func(t *testing.T) {
+		isSet, err := bind(Condition{KeyName: "patch_id", Operator: OperatorIsSet})
+		if err != nil {
+			t.Fatalf("bind patch_id is_set: %v", err)
+		}
+		defer isSet.Close()
+		if got := isSet.String(); got != "arrayExists(value -> value <> toUUID(?), patch_ids)" {
+			t.Errorf("want a patched request looked for, got %q", got)
+		}
+		if args := isSet.Args(); len(args) != 1 || args[0] != uuid.Nil {
+			t.Errorf("want the nil uuid bound, got %v", args)
+		}
+
+		isNotSet, err := bind(Condition{KeyName: "patch_id", Operator: OperatorIsNotSet})
+		if err != nil {
+			t.Fatalf("bind patch_id is_not_set: %v", err)
+		}
+		defer isNotSet.Close()
+		if got := isNotSet.String(); got != "has(patch_ids, toUUID(?))" {
+			t.Errorf("want an unpatched request looked for, got %q", got)
+		}
+		if args := isNotSet.Args(); len(args) != 1 || args[0] != uuid.Nil {
+			t.Errorf("want the nil uuid bound, got %v", args)
+		}
+	})
+
+	t.Run("a value that is not a uuid is refused", func(t *testing.T) {
+		if _, err := bind(Condition{
+			KeyName:  "patch_id",
+			Operator: OperatorIn,
+			Values:   []Value{{Text: "not-a-uuid"}},
+		}); err == nil {
+			t.Error("want a value that does not parse as a uuid refused")
+		}
+	})
+}

--- a/backend/libs/exprfilter/entity.go
+++ b/backend/libs/exprfilter/entity.go
@@ -72,6 +72,8 @@ func FindByName(name string) (Entity, error) {
 		return JourneysEntity, nil
 	case AlertsEntity.Name:
 		return AlertsEntity, nil
+	case NetworkEntity.Name:
+		return NetworkEntity, nil
 	}
 
 	return Entity{}, fmt.Errorf("Unknown filter entity %q", name)
@@ -82,6 +84,7 @@ const (
 	KeyGroupVersion   KeyGroup = "Version"
 	KeyGroupBuild     KeyGroup = "Build"
 	KeyGroupSpan      KeyGroup = "Span"
+	KeyGroupRequest   KeyGroup = "Request"
 	KeyGroupBugReport KeyGroup = "Bug Report"
 	KeyGroupSession   KeyGroup = "Session"
 	KeyGroupUser      KeyGroup = "User"
@@ -95,7 +98,7 @@ const (
 // keyGroupOrder is the order the filter bar shows groups in.
 var keyGroupOrder = []KeyGroup{
 	KeyGroupBugReport, KeyGroupVersion, KeyGroupBuild, KeyGroupSpan,
-	KeyGroupOS, KeyGroupDevice, KeyGroupNetwork, KeyGroupLocation,
+	KeyGroupRequest, KeyGroupOS, KeyGroupDevice, KeyGroupNetwork, KeyGroupLocation,
 	KeyGroupUser, KeyGroupSession, KeyGroupCustom,
 }
 
@@ -189,6 +192,17 @@ var (
 		Operators:           []Operator{OperatorIn, OperatorNotIn},
 		ValueSuggestionMode: ValueSuggestionModeFullList,
 		EnumValues:          []string{"unset", "ok", "error"},
+	}
+
+	httpMethod = Key{
+		Name:                "http_method",
+		Label:               "HTTP method",
+		Description:         "The HTTP method of the request.",
+		KeyGroup:            KeyGroupRequest,
+		ValueType:           ValueTypeEnum,
+		Operators:           []Operator{OperatorIn, OperatorNotIn},
+		ValueSuggestionMode: ValueSuggestionModeFullList,
+		EnumValues:          []string{"get", "post", "put", "patch", "delete"},
 	}
 
 	bugReportStatus = Key{

--- a/backend/libs/exprfilter/entity_test.go
+++ b/backend/libs/exprfilter/entity_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity, JourneysEntity, AlertsEntity}
+var allEntities = []Entity{BuildsEntity, SpansEntity, BugReportsEntity, JourneysEntity, AlertsEntity, NetworkEntity}
 
 func sampleValues(t *testing.T, key Key, operator Operator) []Value {
 	t.Helper()
@@ -421,6 +421,123 @@ func TestJourneyEventsKeyBindingsReadTheEventsColumns(t *testing.T) {
 	}
 	if args := onEvents.Args(); len(args) != 2 || !slices.Equal(args[0].([]string), []string{"1.2.0"}) || !slices.Equal(args[1].([]string), []string{"120"}) {
 		t.Errorf("want the version values bound, got %v", args)
+	}
+}
+
+func TestNetworkEntityOffersEveryNetworkKey(t *testing.T) {
+	byName := IndexKeysByName(NetworkEntity.Keys)
+
+	wanted := []string{
+		"version_name", "version_code", "patch_version", "patch_id",
+		"http_method",
+		"os_name", "os_version",
+		"device_name", "device_manufacturer", "locale",
+		"network_type", "network_generation", "network_provider",
+		"country",
+	}
+	for _, name := range wanted {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("want a %q key on the network entity", name)
+		}
+	}
+	if len(NetworkEntity.Keys) != len(wanted) {
+		t.Errorf("want %d network keys, got %d", len(wanted), len(NetworkEntity.Keys))
+	}
+}
+
+func TestNetworkBindKeyRefusesAKeyTheEntityDoesNotHave(t *testing.T) {
+	_, err := NetworkEntity.BindKey(Condition{
+		KeyName:  "span_status",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "error"}},
+	})
+
+	if err == nil {
+		t.Fatal("want a key the network entity does not have refused")
+	}
+	if !strings.Contains(err.Error(), "span_status") {
+		t.Errorf("want the key named, got %q", err)
+	}
+}
+
+func TestNetworkHttpMethodComparesLowercased(t *testing.T) {
+	condition := Condition{
+		KeyName:  "http_method",
+		Operator: OperatorIn,
+		Values:   []Value{{Text: "get"}},
+	}
+
+	onEvents, err := NetworkEntity.BindKey(condition)
+	if err != nil {
+		t.Fatalf("bind http_method: %v", err)
+	}
+	defer onEvents.Close()
+	if got := onEvents.String(); got != "lower(method) in ?" {
+		t.Errorf("want the method column lowercased, got %q", got)
+	}
+
+	onMetrics, err := NetworkMetricsKeyBindings["http_method"](condition)
+	if err != nil {
+		t.Fatalf("bind http_method on the rollup: %v", err)
+	}
+	defer onMetrics.Close()
+	if got := onMetrics.String(); got != "hasAny(arrayMap(method -> lower(method), methods), ?)" {
+		t.Errorf("want the method array lowercased, got %q", got)
+	}
+}
+
+func TestNetworkMetricsKeyBindingsReadTheRollupArrays(t *testing.T) {
+	ef := &ExprFilter{Entity: NetworkEntity, FilterExpr: "version_name:in:1.2.0 AND country:in:US"}
+	if err := ef.BuildExprTree(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	onEvents, err := ef.Predicate(nil)
+	if err != nil {
+		t.Fatalf("predicate on the events table: %v", err)
+	}
+	defer onEvents.Close()
+	if got := onEvents.String(); got != "((tupleElement(`attribute.app_version`, 1) in ?) and (`inet.country_code` in ?))" {
+		t.Errorf("want the event columns compared, got %q", got)
+	}
+
+	onMetrics, err := ef.Predicate(NetworkMetricsKeyBindings)
+	if err != nil {
+		t.Fatalf("predicate on the rollup: %v", err)
+	}
+	defer onMetrics.Close()
+	want := "((hasAny(arrayMap(version -> tupleElement(version, 1), app_versions), ?)) and (hasAny(`inet.country_code`, ?)))"
+	if got := onMetrics.String(); got != want {
+		t.Errorf("\n got %s\nwant %s", got, want)
+	}
+	if args := onMetrics.Args(); len(args) != 2 || !slices.Equal(args[0].([]string), []string{"1.2.0"}) || !slices.Equal(args[1].([]string), []string{"US"}) {
+		t.Errorf("want the condition values bound, got %v", args)
+	}
+}
+
+func TestNetworkMetricsBindEveryOperatorTheKeysOffer(t *testing.T) {
+	for _, key := range NetworkEntity.Keys {
+		t.Run(key.Name, func(t *testing.T) {
+			binding, bound := NetworkMetricsKeyBindings[key.Name]
+			if !bound {
+				t.Fatalf("key %q has no rollup binding", key.Name)
+			}
+			for _, operator := range key.Operators {
+				stmt, err := binding(Condition{
+					KeyName:  key.Name,
+					Operator: operator,
+					Values:   sampleValues(t, key, operator),
+				})
+				if err != nil {
+					t.Errorf("Operator %q: %v", operator, err)
+					continue
+				}
+				if stmt.String() == "" {
+					t.Errorf("Operator %q wrote no SQL", operator)
+				}
+				stmt.Close()
+			}
+		})
 	}
 }
 

--- a/backend/libs/exprfilter/exprfilter.go
+++ b/backend/libs/exprfilter/exprfilter.go
@@ -86,6 +86,12 @@ func (ef *ExprFilter) SetDefaultTimeRangeIfUnset() {
 	ef.To = to
 }
 
+func (ef *ExprFilter) SetDefaultPlotTimeGroupIfUnset() {
+	if ef.PlotTimeGroup == "" {
+		ef.PlotTimeGroup = PlotTimeGroupDays
+	}
+}
+
 func (ef *ExprFilter) BuildExprTree() error {
 	if ef.FilterExpr == "" {
 		ef.ExprTree = nil

--- a/backend/libs/exprfilter/network.go
+++ b/backend/libs/exprfilter/network.go
@@ -1,0 +1,110 @@
+package exprfilter
+
+var NetworkEntity = Entity{
+	Name:                  "network",
+	Keys:                  networkKeys,
+	BindKey:               bindKeysToColumns(httpEventsColumns, networkKeyBindingOverrides),
+	SuggestFixedKeyValues: suggestFixedKeyValuesFromClickHouse(networkFixedKeyValues),
+}
+
+var networkKeys = []Key{
+	versionName,
+	versionCode,
+	patchVersion,
+	patchID,
+	httpMethod,
+	osName,
+	osVersion,
+	deviceName,
+	deviceManufacturer,
+	locale,
+	networkType,
+	networkGeneration,
+	networkProvider,
+	country,
+}
+
+var (
+	httpEventsColumns = map[string]string{
+		versionName.Name:        "tupleElement(`attribute.app_version`, 1)",
+		versionCode.Name:        "tupleElement(`attribute.app_version`, 2)",
+		patchVersion.Name:       "`attribute.patch_version`",
+		patchID.Name:            "`attribute.patch_id`",
+		httpMethod.Name:         "lower(method)",
+		osName.Name:             "tupleElement(`attribute.os_version`, 1)",
+		osVersion.Name:          "tupleElement(`attribute.os_version`, 2)",
+		deviceName.Name:         "`attribute.device_name`",
+		deviceManufacturer.Name: "`attribute.device_manufacturer`",
+		locale.Name:             "`attribute.device_locale`",
+		networkType.Name:        "`attribute.network_type`",
+		networkGeneration.Name:  "`attribute.network_generation`",
+		networkProvider.Name:    "`attribute.network_provider`",
+		country.Name:            "`inet.country_code`",
+	}
+
+	networkFilterColumns = map[string]string{
+		versionName.Name:        "tupleElement(app_version, 1)",
+		versionCode.Name:        "tupleElement(app_version, 2)",
+		patchVersion.Name:       "patch_version",
+		patchID.Name:            "patch_id",
+		osName.Name:             "tupleElement(os_version, 1)",
+		osVersion.Name:          "tupleElement(os_version, 2)",
+		deviceName.Name:         "device_name",
+		deviceManufacturer.Name: "device_manufacturer",
+		locale.Name:             "device_locale",
+		networkType.Name:        "network_type",
+		networkGeneration.Name:  "network_generation",
+		networkProvider.Name:    "network_provider",
+		country.Name:            "country_code",
+	}
+
+	httpMetricsColumns = map[string]string{
+		versionName.Name:        "arrayMap(version -> tupleElement(version, 1), app_versions)",
+		versionCode.Name:        "arrayMap(version -> tupleElement(version, 2), app_versions)",
+		patchVersion.Name:       "patch_versions",
+		patchID.Name:            "patch_ids",
+		httpMethod.Name:         "arrayMap(method -> lower(method), methods)",
+		osName.Name:             "arrayMap(version -> tupleElement(version, 1), os_versions)",
+		osVersion.Name:          "arrayMap(version -> tupleElement(version, 2), os_versions)",
+		deviceName.Name:         "device_names",
+		deviceManufacturer.Name: "device_manufacturers",
+		locale.Name:             "device_locales",
+		networkType.Name:        "network_types",
+		networkGeneration.Name:  "network_generations",
+		networkProvider.Name:    "network_providers",
+		country.Name:            "`inet.country_code`",
+	}
+)
+
+var networkKeyBindingOverrides = map[string]columnKeyBinding{
+	patchID.Name: bindUUIDKey,
+}
+
+// app_filters keeps one row per attribute combination per month, so values
+// seen in the same month order alphabetically.
+var networkFixedKeyValues = fixedKeyValueSource{
+	table:       "app_filters",
+	columns:     networkFilterColumns,
+	recencyExpr: "max(end_of_month)",
+}
+
+var httpMetricsKeyBindingOverrides = map[string]columnKeyBinding{
+	versionName.Name:        bindArrayKey,
+	versionCode.Name:        bindArrayKey,
+	patchVersion.Name:       bindArrayKey,
+	patchID.Name:            bindUUIDArrayKey,
+	httpMethod.Name:         bindArrayKey,
+	osName.Name:             bindArrayKey,
+	osVersion.Name:          bindArrayKey,
+	deviceName.Name:         bindArrayKey,
+	deviceManufacturer.Name: bindArrayKey,
+	locale.Name:             bindArrayKey,
+	networkType.Name:        bindArrayKey,
+	networkGeneration.Name:  bindArrayKey,
+	networkProvider.Name:    bindArrayKey,
+	country.Name:            bindArrayKey,
+}
+
+// NetworkMetricsKeyBindings rebinds the network keys onto the http_metrics
+// rollup, where a bucket matches when any request in it did.
+var NetworkMetricsKeyBindings = bindingForEachKey(networkKeys, bindKeysToColumns(httpMetricsColumns, httpMetricsKeyBindingOverrides))

--- a/backend/libs/exprfilter/network_values_test.go
+++ b/backend/libs/exprfilter/network_values_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package exprfilter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"backend/testinfra"
+
+	"github.com/google/uuid"
+)
+
+func seedNetworkEvents(ctx context.Context, t *testing.T) (teamID, appID uuid.UUID, patchID uuid.UUID) {
+	t.Helper()
+
+	teamID = uuid.New()
+	appID = uuid.New()
+	otherAppID := uuid.New()
+	patchID = uuid.New()
+
+	th.SeedTeam(ctx, t, teamID.String(), "network values team")
+	th.SeedApp(ctx, t, appID.String(), teamID.String(), "network values app", 90)
+	th.SeedApp(ctx, t, otherAppID.String(), teamID.String(), "another network app", 90)
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	request := func(row testinfra.EventRow) testinfra.EventRow {
+		row.Type = "http"
+		row.Timestamp = base
+		row.HttpURL = "https://api.example.com/v1/users"
+		row.HttpMethod = "GET"
+		row.HttpStatusCode = 200
+		row.HttpStartTime = 1000
+		row.HttpEndTime = 1100
+		row.OSName = "Android"
+		row.OSVersion = "14"
+		row.CountryCode = "US"
+		row.NetworkProvider = "carrier"
+		row.NetworkType = "wifi"
+		row.NetworkGeneration = "4g"
+		row.DeviceLocale = "en-US"
+		row.DeviceManufacturer = "TestCo"
+		row.DeviceName = "pixel"
+		return row
+	}
+
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, request(testinfra.EventRow{
+		AppVersion: "1.2.0", AppBuild: "120", PatchID: patchID, PatchVersion: "1.2.0-patch.3",
+	}))
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, request(testinfra.EventRow{
+		AppVersion: "1.1.0", AppBuild: "110",
+	}))
+	th.SeedEventRows(ctx, t, teamID.String(), otherAppID.String(), 1, request(testinfra.EventRow{
+		AppVersion: "9.0.0", AppBuild: "900",
+	}))
+
+	return teamID, appID, patchID
+}
+
+func TestNetworkValues(t *testing.T) {
+	ctx := context.Background()
+	teamID, appID, patchID := seedNetworkEvents(ctx, t)
+
+	byName := IndexKeysByName(NetworkEntity.Keys)
+
+	list := func(t *testing.T, keyName string, valueRequest ValueRequest) []string {
+		t.Helper()
+		valueList, err := NetworkEntity.SuggestKeyValues(ctx, pgPool, chConn, teamID, appID, byName[keyName], valueRequest)
+		if err != nil {
+			t.Fatalf("fetch values: %v", err)
+		}
+		texts := make([]string, len(valueList.Values))
+		for i, value := range valueList.Values {
+			texts[i] = value.Text
+		}
+		return texts
+	}
+
+	t.Run("version names come from the rollup, once each", func(t *testing.T) {
+		if got := list(t, "version_name", ValueRequest{}); len(got) != 2 || got[0] != "1.1.0" || got[1] != "1.2.0" {
+			t.Errorf("want [1.1.0 1.2.0], got %v", got)
+		}
+	})
+
+	t.Run("device attributes come from the rollup", func(t *testing.T) {
+		if got := list(t, "device_name", ValueRequest{}); len(got) != 1 || got[0] != "pixel" {
+			t.Errorf("want [pixel], got %v", got)
+		}
+		if got := list(t, "country", ValueRequest{}); len(got) != 1 || got[0] != "US" {
+			t.Errorf("want [US], got %v", got)
+		}
+	})
+
+	t.Run("patch values leave out the requests without a patch", func(t *testing.T) {
+		if got := list(t, "patch_id", ValueRequest{}); len(got) != 1 || got[0] != patchID.String() {
+			t.Errorf("want the one patch id, got %v", got)
+		}
+		if got := list(t, "patch_version", ValueRequest{}); len(got) != 1 || got[0] != "1.2.0-patch.3" {
+			t.Errorf("want the one patch version, got %v", got)
+		}
+	})
+
+	t.Run("http methods are the key's own values, with no table read", func(t *testing.T) {
+		valueList, err := NetworkEntity.SuggestKeyValues(ctx, nil, nil, teamID, appID, byName["http_method"], ValueRequest{})
+		if err != nil {
+			t.Fatalf("fetch http methods: %v", err)
+		}
+		if len(valueList.Values) != 5 || valueList.Values[0].Text != "get" {
+			t.Errorf("want the five method names, got %v", valueList.Values)
+		}
+	})
+
+	t.Run("another app's requests stay out", func(t *testing.T) {
+		for _, text := range list(t, "version_name", ValueRequest{}) {
+			if text == "9.0.0" {
+				t.Error("want the other app's version left out")
+			}
+		}
+	})
+
+	t.Run("typing narrows the list", func(t *testing.T) {
+		if got := list(t, "version_name", ValueRequest{Search: "1.2"}); len(got) != 1 || got[0] != "1.2.0" {
+			t.Errorf("want [1.2.0], got %v", got)
+		}
+	})
+}

--- a/backend/libs/filter/appfilter.go
+++ b/backend/libs/filter/appfilter.go
@@ -176,10 +176,6 @@ type AppFilter struct {
 	// a bug report to be filtered on.
 	BugReportStatuses []int8 `form:"bug_report_statuses"`
 
-	// HttpMethods is the list of HTTP methods
-	// to be matched & filtered on.
-	HttpMethods []string `form:"http_methods"`
-
 	// FreeText is a free form text string that can be used
 	// to filter over logs, exceptions, events etc
 	FreeText string `form:"free_text"`
@@ -632,12 +628,6 @@ func (af AppFilter) HasFreeText() bool {
 // one bug report statuses are requested.
 func (af AppFilter) HasBugReportStatuses() bool {
 	return len(af.BugReportStatuses) > 0
-}
-
-// HasHttpMethods returns true if at least
-// one HTTP method is requested.
-func (af AppFilter) HasHttpMethods() bool {
-	return len(af.HttpMethods) > 0
 }
 
 // LimitAbs returns the absolute value of limit

--- a/backend/libs/measure/app.go
+++ b/backend/libs/measure/app.go
@@ -2369,12 +2369,8 @@ func (a App) GetMetricsPlotForSpanNameWithFilter(ctx context.Context, rch driver
 		return
 	}
 
-	plotTimeGroup := ef.PlotTimeGroup
-	if plotTimeGroup == "" {
-		plotTimeGroup = exprfilter.PlotTimeGroupDays
-	}
-
-	groupExpr, err := GetPlotTimeGroupExpr("timestamp", plotTimeGroup)
+	ef.SetDefaultPlotTimeGroupIfUnset()
+	groupExpr, err := GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -2671,12 +2667,8 @@ func (a App) GetBugReportInstancesPlot(ctx context.Context, rch driver.Conn, ef 
 		return
 	}
 
-	plotTimeGroup := ef.PlotTimeGroup
-	if plotTimeGroup == "" {
-		plotTimeGroup = exprfilter.PlotTimeGroupDays
-	}
-
-	groupExpr, err := GetPlotTimeGroupExpr("timestamp", plotTimeGroup)
+	ef.SetDefaultPlotTimeGroupIfUnset()
+	groupExpr, err := GetPlotTimeGroupExpr("timestamp", ef.PlotTimeGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/libs/network/network.go
+++ b/backend/libs/network/network.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"backend/libs/chquery"
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
 	"backend/libs/logcomment"
 	"context"
 	"fmt"
@@ -93,97 +93,6 @@ func withQueryName(ctx context.Context, name string) context.Context {
 		"log_comment": lc.MustPut(logcomment.Root, logcomment.Network).String(),
 	}
 	return chquery.WithSettings(ctx, logcomment.Put(settings, lc, logcomment.Name, name))
-}
-
-// applyEventsFilters applies supported
-// AppFilter criteria to http_events.
-func applyEventsFilters(stmt *sqlf.Stmt, af *filter.AppFilter) {
-	if af.HasVersions() {
-		selectedVersions, err := af.VersionPairs()
-		if err == nil {
-			stmt.Where("`attribute.app_version` in (?)", selectedVersions.Parameterize())
-		}
-	}
-
-	if af.HasNetworkTypes() {
-		stmt.Where("`attribute.network_type`").In(af.NetworkTypes)
-	}
-
-	if af.HasNetworkGenerations() {
-		stmt.Where("`attribute.network_generation`").In(af.NetworkGenerations)
-	}
-
-	if af.HasNetworkProviders() {
-		stmt.Where("`attribute.network_provider`").In(af.NetworkProviders)
-	}
-
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err == nil {
-			stmt.Where("`attribute.os_version` in (?)", selectedOSVersions.Parameterize())
-		}
-	}
-
-	if af.HasDeviceManufacturers() {
-		stmt.Where("`attribute.device_manufacturer`").In(af.DeviceManufacturers)
-	}
-
-	if af.HasDeviceNames() {
-		stmt.Where("`attribute.device_name`").In(af.DeviceNames)
-	}
-
-	if af.HasDeviceLocales() {
-		stmt.Where("`attribute.device_locale`").In(af.Locales)
-	}
-
-	if af.HasCountries() {
-		stmt.Where("`inet.country_code`").In(af.Countries)
-	}
-
-	if af.HasHttpMethods() {
-		stmt.Where("method").In(af.HttpMethods)
-	}
-}
-
-// applyMetricsFilters applies supported
-// AppFilter criteria to http_metrics.
-func applyMetricsFilters(stmt *sqlf.Stmt, af *filter.AppFilter) {
-	if af.HasVersions() {
-		selectedVersions, err := af.VersionPairs()
-		if err == nil {
-			stmt.Having("hasAny(groupUniqArrayArray(`app_versions`), [?])", selectedVersions.Parameterize())
-		}
-	}
-	if af.HasOSVersions() {
-		selectedOSVersions, err := af.OSVersionPairs()
-		if err == nil {
-			stmt.Having("hasAny(groupUniqArrayArray(`os_versions`), [?])", selectedOSVersions.Parameterize())
-		}
-	}
-	if af.HasDeviceManufacturers() {
-		stmt.Having("hasAny(groupUniqArrayArray(`device_manufacturers`), ?)", af.DeviceManufacturers)
-	}
-	if af.HasDeviceNames() {
-		stmt.Having("hasAny(groupUniqArrayArray(`device_names`), ?)", af.DeviceNames)
-	}
-	if af.HasNetworkProviders() {
-		stmt.Having("hasAny(groupUniqArrayArray(`network_providers`), ?)", af.NetworkProviders)
-	}
-	if af.HasNetworkTypes() {
-		stmt.Having("hasAny(groupUniqArrayArray(`network_types`), ?)", af.NetworkTypes)
-	}
-	if af.HasNetworkGenerations() {
-		stmt.Having("hasAny(groupUniqArrayArray(`network_generations`), ?)", af.NetworkGenerations)
-	}
-	if af.HasDeviceLocales() {
-		stmt.Having("hasAny(groupUniqArrayArray(`device_locales`), ?)", af.Locales)
-	}
-	if af.HasHttpMethods() {
-		stmt.Having("hasAny(groupUniqArrayArray(`methods`), ?)", af.HttpMethods)
-	}
-	if af.HasCountries() {
-		stmt.Having("hasAny(groupUniqArrayArray(`inet.country_code`), ?)", af.Countries)
-	}
 }
 
 func applyDomainFilter(stmt *sqlf.Stmt, domain string) {
@@ -337,7 +246,7 @@ func applyPathFilter(stmt *sqlf.Stmt, pathPattern string) {
 }
 
 // fetchTrendsCategory returns one endpoint ranking from http_metrics.
-func fetchTrendsCategory(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, af *filter.AppFilter, orderBy string, limit int) ([]TrendMetric, error) {
+func fetchTrendsCategory(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, ef *exprfilter.ExprFilter, orderBy string, limit int) ([]TrendMetric, error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.
 		Select("domain").
@@ -348,14 +257,23 @@ func fetchTrendsCategory(ctx context.Context, ch driver.Conn, appId, teamId uuid
 		From("http_metrics").
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", appId).
-		Where("timestamp >= ?", af.From).
-		Where("timestamp < ?", af.To)
+		Where("timestamp >= ?", ef.From).
+		Where("timestamp < ?", ef.To)
+
+	defer stmt.Close()
+
+	if ef.HasFilterExpr() {
+		predicate, err := ef.Predicate(exprfilter.NetworkMetricsKeyBindings)
+		if err != nil {
+			return nil, err
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
+	}
 
 	stmt.GroupBy("domain, path").
 		OrderBy(orderBy).
 		Limit(limit)
-
-	defer stmt.Close()
 
 	ctx = withQueryName(ctx, "fetch_trends_category")
 
@@ -399,7 +317,7 @@ func scanEndpoints(rows driver.Rows) (endpoints []Endpoint, err error) {
 }
 
 // FetchEndpoints returns matching generated patterns and raw request paths.
-func FetchEndpoints(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, search string, af *filter.AppFilter) (endpoints []Endpoint, err error) {
+func FetchEndpoints(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, search string, ef *exprfilter.ExprFilter) (endpoints []Endpoint, err error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
 
 	// parse the search query
@@ -472,13 +390,22 @@ func FetchEndpoints(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID
 			From("http_events").
 			Where("team_id = toUUID(?)", teamId).
 			Where("app_id = toUUID(?)", appId).
-			Where("timestamp >= ?", af.From).
-			Where("timestamp < ?", af.To)
+			Where("timestamp >= ?", ef.From).
+			Where("timestamp < ?", ef.To)
 		defer stmt.Close()
 
 		condition, args := endpointSearchCondition("domain", "path", input)
 		stmt.Where(condition, args...)
-		applyEventsFilters(stmt, af)
+
+		if ef.HasFilterExpr() {
+			predicate, err := ef.Predicate(nil)
+			if err != nil {
+				return err
+			}
+			defer predicate.Close()
+			stmt.Where(predicate.String(), predicate.Args()...)
+		}
+
 		stmt.GroupBy("domain, path").
 			OrderBy("count() DESC, domain, path").
 			Limit(searchResultsLimit)
@@ -514,22 +441,22 @@ func FetchEndpoints(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID
 }
 
 // FetchTrends returns endpoint rankings by latency, error rate, and frequency.
-func FetchTrends(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, af *filter.AppFilter, limit int) (*TrendsResponse, error) {
+func FetchTrends(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, ef *exprfilter.ExprFilter, limit int) (*TrendsResponse, error) {
 	var result TrendsResponse
 	var trendsGroup errgroup.Group
 
 	trendsGroup.Go(func() (err error) {
-		result.TrendsLatency, err = fetchTrendsCategory(ctx, ch, appId, teamId, af, "p95_latency DESC", limit)
+		result.TrendsLatency, err = fetchTrendsCategory(ctx, ch, appId, teamId, ef, "p95_latency DESC", limit)
 		return
 	})
 
 	trendsGroup.Go(func() (err error) {
-		result.TrendsErrorRate, err = fetchTrendsCategory(ctx, ch, appId, teamId, af, "error_rate DESC", limit)
+		result.TrendsErrorRate, err = fetchTrendsCategory(ctx, ch, appId, teamId, ef, "error_rate DESC", limit)
 		return
 	})
 
 	trendsGroup.Go(func() (err error) {
-		result.TrendsFrequency, err = fetchTrendsCategory(ctx, ch, appId, teamId, af, "frequency DESC", limit)
+		result.TrendsFrequency, err = fetchTrendsCategory(ctx, ch, appId, teamId, ef, "frequency DESC", limit)
 		return
 	})
 
@@ -541,10 +468,10 @@ func FetchTrends(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, a
 }
 
 // GetStatusCodesPlot returns HTTP status-class counts over time for an optional endpoint selection.
-func GetStatusCodesPlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, path string, af *filter.AppFilter, bucketExpr, datetimeFormat string) (result []MetricsDataPoint, err error) {
+func GetStatusCodesPlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, path string, ef *exprfilter.ExprFilter, bucketExpr, datetimeFormat string) (result []MetricsDataPoint, err error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.From("http_events").
-		Select(bucketExpr+" as datetime_bucket", af.Timezone).
+		Select(bucketExpr+" as datetime_bucket", ef.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", datetimeFormat).
 		Select("countIf(status_code_bucket in ('2xx','3xx','4xx','5xx')) as total_count").
 		Select("countIf(status_code_bucket = '2xx') as count_2xx").
@@ -553,15 +480,23 @@ func GetStatusCodesPlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.
 		Select("countIf(status_code_bucket = '5xx') as count_5xx").
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", appId).
-		Where("timestamp >= ?", af.From).
-		Where("timestamp < ?", af.To)
+		Where("timestamp >= ?", ef.From).
+		Where("timestamp < ?", ef.To)
 
 	applyDomainFilter(stmt, domain)
 	applyPathFilter(stmt, path)
-	applyEventsFilters(stmt, af)
+	defer stmt.Close()
+
+	if ef.HasFilterExpr() {
+		predicate, errPredicate := ef.Predicate(nil)
+		if errPredicate != nil {
+			return nil, errPredicate
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
+	}
 
 	stmt.GroupBy("datetime_bucket").OrderBy("datetime_bucket")
-	defer stmt.Close()
 
 	ctx = withQueryName(ctx, "status_codes_plot")
 
@@ -597,27 +532,35 @@ func GetEndpointStatusCodesPlot(
 	ch driver.Conn,
 	appId, teamId uuid.UUID,
 	domain, path string,
-	af *filter.AppFilter,
+	ef *exprfilter.ExprFilter,
 	bucketExpr, datetimeFormat string,
 ) (*EndpointStatusCodesPlotResponse, error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
 	stmt := sqlf.From("http_events").
-		Select(bucketExpr+" as datetime_bucket", af.Timezone).
+		Select(bucketExpr+" as datetime_bucket", ef.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", datetimeFormat).
 		Select("status_code").
 		Select("count() as count").
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", appId).
 		Where("status_code != ?", 0).
-		Where("timestamp >= ?", af.From).
-		Where("timestamp < ?", af.To)
+		Where("timestamp >= ?", ef.From).
+		Where("timestamp < ?", ef.To)
 
 	applyDomainFilter(stmt, domain)
 	applyPathFilter(stmt, path)
-	applyEventsFilters(stmt, af)
+	defer stmt.Close()
+
+	if ef.HasFilterExpr() {
+		predicate, err := ef.Predicate(nil)
+		if err != nil {
+			return nil, err
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
+	}
 
 	stmt.GroupBy("datetime_bucket, status_code").OrderBy("datetime_bucket, status_code")
-	defer stmt.Close()
 
 	rows, err := ch.Query(withQueryName(ctx, "endpoint_status_codes_plot"), stmt.String(), stmt.Args()...)
 	if err != nil {
@@ -678,7 +621,7 @@ func GetLatencyPlot(
 	ch driver.Conn,
 	appId, teamId uuid.UUID,
 	domain, path string,
-	af *filter.AppFilter,
+	ef *exprfilter.ExprFilter,
 	bucketExpr, datetimeFormat string,
 ) ([]MetricsDataPoint, error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
@@ -686,22 +629,30 @@ func GetLatencyPlot(
 	result := make([]MetricsDataPoint, 0)
 
 	stmt := sqlf.From("http_events").
-		Select(bucketExpr+" as datetime_bucket", af.Timezone).
+		Select(bucketExpr+" as datetime_bucket", ef.Timezone).
 		Select("formatDateTime(datetime_bucket, ?) as datetime", datetimeFormat).
 		Select("quantiles(0.50, 0.90, 0.95, 0.99)(latency_ms) as latencies").
 		Select("count() as count").
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", appId).
 		Where("status_code != ?", 0).
-		Where("timestamp >= ?", af.From).
-		Where("timestamp < ?", af.To)
+		Where("timestamp >= ?", ef.From).
+		Where("timestamp < ?", ef.To)
 
 	applyDomainFilter(stmt, domain)
 	applyPathFilter(stmt, path)
-	applyEventsFilters(stmt, af)
+	defer stmt.Close()
+
+	if ef.HasFilterExpr() {
+		predicate, err := ef.Predicate(nil)
+		if err != nil {
+			return nil, err
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
+	}
 
 	stmt.GroupBy("datetime_bucket").OrderBy("datetime_bucket")
-	defer stmt.Close()
 
 	ctx = withQueryName(ctx, "latency_plot")
 
@@ -733,7 +684,7 @@ func GetLatencyPlot(
 
 // FetchTimelinePlot returns five-second, per-session request-count buckets for
 // the whole app or a selected domain and path pattern.
-func FetchTimelinePlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, pathPattern string, af *filter.AppFilter) (*TimelineResponse, error) {
+func FetchTimelinePlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.UUID, domain, pathPattern string, ef *exprfilter.ExprFilter) (*TimelineResponse, error) {
 	ctx = chquery.WithTeamScope(ctx, teamId)
 
 	stmt := sqlf.
@@ -745,20 +696,26 @@ func FetchTimelinePlot(ctx context.Context, ch driver.Conn, appId, teamId uuid.U
 		From("http_metrics").
 		Where("team_id = toUUID(?)", teamId).
 		Where("app_id = toUUID(?)", appId).
-		Where("timestamp >= ?", af.From).
-		Where("timestamp < ?", af.To)
+		Where("timestamp >= ?", ef.From).
+		Where("timestamp < ?", ef.To)
 
 	applyDomainFilter(stmt, domain)
 	applyPathFilter(stmt, pathPattern)
+	defer stmt.Close()
 
-	applyMetricsFilters(stmt, af)
+	if ef.HasFilterExpr() {
+		predicate, err := ef.Predicate(exprfilter.NetworkMetricsKeyBindings)
+		if err != nil {
+			return nil, err
+		}
+		defer predicate.Close()
+		stmt.Where(predicate.String(), predicate.Args()...)
+	}
 
 	// A broad selection may match many patterns; retain the most requested ones.
 	stmt.GroupBy("domain, path").
 		OrderBy("sum(request_count) DESC").
 		Limit(maxTimelineEndpointPatterns)
-
-	defer stmt.Close()
 
 	ctx = withQueryName(ctx, "timeline_plot")
 

--- a/backend/libs/network/network_test.go
+++ b/backend/libs/network/network_test.go
@@ -3,7 +3,8 @@
 package network
 
 import (
-	"backend/libs/filter"
+	"backend/libs/exprfilter"
+	"backend/testinfra"
 	"context"
 	"slices"
 	"testing"
@@ -11,6 +12,27 @@ import (
 
 	"github.com/google/uuid"
 )
+
+func networkExprFilter(t *testing.T, appID, teamID uuid.UUID, from, to time.Time, filterExpr string) *exprfilter.ExprFilter {
+	t.Helper()
+	ef := &exprfilter.ExprFilter{
+		AppID:      appID,
+		TeamID:     teamID,
+		Entity:     exprfilter.NetworkEntity,
+		From:       from,
+		To:         to,
+		Timezone:   "UTC",
+		Limit:      exprfilter.DefaultPaginationLimit,
+		FilterExpr: filterExpr,
+	}
+	if err := ef.BuildExprTree(); err != nil {
+		t.Fatalf("parse %q: %v", filterExpr, err)
+	}
+	if err := ef.Validate(); err != nil {
+		t.Fatalf("validate %q: %v", filterExpr, err)
+	}
+	return ef
+}
 
 // --------------------------------------------------------------------------
 // http_events queries
@@ -25,7 +47,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/pattern")
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/raw-only", "GET", 200, 1, now)
@@ -46,12 +68,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		appFilter := &filter.AppFilter{
-			AppID:    appID,
-			From:     now.Add(-time.Hour),
-			To:       now.Add(time.Hour),
-			Timezone: "UTC",
-		}
+		appFilter := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/fallback", "GET", 200, 1, now)
 
@@ -70,12 +87,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		appFilter := &filter.AppFilter{
-			AppID:    appID,
-			From:     now.Add(-time.Hour),
-			To:       now.Add(time.Hour),
-			Timezone: "UTC",
-		}
+		appFilter := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/known")
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/raw-only", "GET", 200, 1, now)
@@ -95,12 +107,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{
-			AppID:       appID,
-			From:        now.Add(-time.Hour),
-			To:          now.Add(time.Hour),
-			HttpMethods: []string{"GET"},
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "http_method:in:get")
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/visible", "GET", 200, 1, now)
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/post", "POST", 200, 1, now)
@@ -121,7 +128,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/products/*")
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/products/123", "GET", 200, 1, now)
@@ -145,7 +152,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users/*")
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/orders/*")
@@ -171,7 +178,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/stale/*")
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/stale/123", "GET", 200, 1, now.Add(-24*time.Hour))
@@ -192,7 +199,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users/123/profile", "GET", 200, 1, now)
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users/123/settings/profile", "GET", 200, 1, now)
@@ -217,7 +224,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 1, now)
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users/123", "GET", 200, 1, now)
@@ -247,7 +254,7 @@ func TestFetchEndpoints(t *testing.T) {
 		teamID := uuid.New()
 		appID := uuid.New()
 		now := time.Now().UTC()
-		af := &filter.AppFilter{AppID: appID, From: now.Add(-time.Hour), To: now.Add(time.Hour)}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "patterns.example.com", "/v1/known")
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://raw.example.com/v1/raw", "GET", 200, 1, now)
@@ -275,12 +282,7 @@ func TestGetStatusCodesPlot(t *testing.T) {
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/path", "GET", 404, 5, now)
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/path", "GET", 500, 2, now)
 
-	af := &filter.AppFilter{
-		AppID:    appID,
-		From:     now.Add(-1 * time.Hour),
-		To:       now.Add(1 * time.Hour),
-		Timezone: "UTC",
-	}
+	af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 	bucketExpr := "toStartOfHour(timestamp, ?)"
 	datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -325,12 +327,7 @@ func TestGetEndpointStatusCodesPlot(t *testing.T) {
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/path", "GET", 404, 2, now)
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/other", "GET", 500, 7, now)
 
-	af := &filter.AppFilter{
-		AppID:    appID,
-		From:     now.Add(-time.Hour),
-		To:       now.Add(time.Hour),
-		Timezone: "UTC",
-	}
+	af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 	result, err := GetEndpointStatusCodesPlot(
 		ctx,
@@ -379,12 +376,7 @@ func TestGetLatencyPlot(t *testing.T) {
 
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 20, now)
 
-	af := &filter.AppFilter{
-		AppID:    appID,
-		From:     now.Add(-1 * time.Hour),
-		To:       now.Add(1 * time.Hour),
-		Timezone: "UTC",
-	}
+	af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 	bucketExpr := "toStartOfHour(timestamp, ?)"
 	datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -427,12 +419,7 @@ func TestGetLatencyPlot_WildcardMatchesOnePathSegment(t *testing.T) {
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/users/123/orders", "GET", 200, 11, now)
 	seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/users/a/b/orders", "GET", 200, 17, now)
 
-	af := &filter.AppFilter{
-		AppID:    appID,
-		From:     now.Add(-1 * time.Hour),
-		To:       now.Add(1 * time.Hour),
-		Timezone: "UTC",
-	}
+	af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 	result, err := GetLatencyPlot(
 		ctx, deps.ChPool, appID, teamID, "api.example.com", "/users/*/orders", af,
 		"toStartOfHour(timestamp, ?)", "%Y-%m-%d %H:00:00",
@@ -460,13 +447,7 @@ func TestGetLatencyPlot_HttpMethodFilter(t *testing.T) {
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 20, now)
 
-		af := &filter.AppFilter{
-			AppID:       appID,
-			From:        now.Add(-1 * time.Hour),
-			To:          now.Add(1 * time.Hour),
-			Timezone:    "UTC",
-			HttpMethods: []string{"GET"},
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "http_method:in:get")
 
 		bucketExpr := "toStartOfHour(timestamp, ?)"
 		datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -489,13 +470,7 @@ func TestGetLatencyPlot_HttpMethodFilter(t *testing.T) {
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 20, now)
 
-		af := &filter.AppFilter{
-			AppID:       appID,
-			From:        now.Add(-1 * time.Hour),
-			To:          now.Add(1 * time.Hour),
-			Timezone:    "UTC",
-			HttpMethods: []string{"POST"},
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "http_method:in:post")
 
 		bucketExpr := "toStartOfHour(timestamp, ?)"
 		datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -522,14 +497,7 @@ func TestGetLatencyPlot_AppVersionFilter(t *testing.T) {
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 20, now)
 
-		af := &filter.AppFilter{
-			AppID:        appID,
-			From:         now.Add(-1 * time.Hour),
-			To:           now.Add(1 * time.Hour),
-			Timezone:     "UTC",
-			Versions:     []string{"v1"},
-			VersionCodes: []string{"1"},
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "version_name:in:v1 AND version_code:in:1")
 
 		bucketExpr := "toStartOfHour(timestamp, ?)"
 		datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -552,14 +520,7 @@ func TestGetLatencyPlot_AppVersionFilter(t *testing.T) {
 
 		seedHttpEvent(ctx, t, teamID.String(), appID.String(), "https://api.example.com/v1/users", "GET", 200, 20, now)
 
-		af := &filter.AppFilter{
-			AppID:        appID,
-			From:         now.Add(-1 * time.Hour),
-			To:           now.Add(1 * time.Hour),
-			Timezone:     "UTC",
-			Versions:     []string{"v2"},
-			VersionCodes: []string{"2"},
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "version_name:in:v2 AND version_code:in:2")
 
 		bucketExpr := "toStartOfHour(timestamp, ?)"
 		datetimeFormat := "%Y-%m-%d %H:00:00"
@@ -589,15 +550,11 @@ func TestFetchTrends(t *testing.T) {
 		now := time.Now().UTC().Truncate(15 * time.Minute)
 
 		// Endpoint A: high request count, low errors
-		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", 100, 95, 3, 2, now)
+		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", "", uuid.Nil, 100, 95, 3, 2, now)
 		// Endpoint B: low request count, high errors
-		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/orders", 10, 2, 5, 3, now)
+		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/orders", "", uuid.Nil, 10, 2, 5, 3, now)
 
-		af := &filter.AppFilter{
-			AppID: appID,
-			From:  now.Add(-1 * time.Hour),
-			To:    now.Add(1 * time.Hour),
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		resp, err := FetchTrends(ctx, deps.ChPool, appID, teamID, af, 10)
 		if err != nil {
@@ -628,11 +585,7 @@ func TestFetchTrends(t *testing.T) {
 		appID := uuid.New()
 		now := time.Now().UTC()
 
-		af := &filter.AppFilter{
-			AppID: appID,
-			From:  now.Add(-1 * time.Hour),
-			To:    now.Add(1 * time.Hour),
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		resp, err := FetchTrends(ctx, deps.ChPool, appID, teamID, af, 10)
 		if err != nil {
@@ -658,13 +611,9 @@ func TestFetchTimelinePlot_Unscoped(t *testing.T) {
 	appID := uuid.New()
 	now := time.Now().UTC().Truncate(15 * time.Minute)
 
-	seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", 50, 50, 0, 0, now)
+	seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", "", uuid.Nil, 50, 50, 0, 0, now)
 
-	af := &filter.AppFilter{
-		AppID: appID,
-		From:  now.Add(-1 * time.Hour),
-		To:    now.Add(1 * time.Hour),
-	}
+	af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 	resp, err := FetchTimelinePlot(ctx, deps.ChPool, appID, teamID, "", "", af)
 	if err != nil {
@@ -698,13 +647,9 @@ func TestFetchTimelinePlot(t *testing.T) {
 		now := time.Now().UTC().Truncate(15 * time.Minute)
 
 		seedUrlPattern(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users")
-		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", 50, 50, 0, 0, now)
+		seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", "", uuid.Nil, 50, 50, 0, 0, now)
 
-		af := &filter.AppFilter{
-			AppID: appID,
-			From:  now.Add(-1 * time.Hour),
-			To:    now.Add(1 * time.Hour),
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		resp, err := FetchTimelinePlot(ctx, deps.ChPool, appID, teamID, "api.example.com", "/v1/users", af)
 		if err != nil {
@@ -735,11 +680,7 @@ func TestFetchTimelinePlot(t *testing.T) {
 		appID := uuid.New()
 		now := time.Now().UTC()
 
-		af := &filter.AppFilter{
-			AppID: appID,
-			From:  now.Add(-1 * time.Hour),
-			To:    now.Add(1 * time.Hour),
-		}
+		af := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), "")
 
 		resp, err := FetchTimelinePlot(ctx, deps.ChPool, appID, teamID, "nonexistent.com", "/v1/nope", af)
 		if err != nil {
@@ -752,4 +693,113 @@ func TestFetchTimelinePlot(t *testing.T) {
 			t.Errorf("expected no points, got %+v", resp.Points)
 		}
 	})
+}
+
+func TestGetLatencyPlot_PatchFilter(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Hour)
+	patchID := uuid.New()
+
+	// http_events collapses rows sharing a domain and timestamp.
+	seedRequest := func(offset int, patch uuid.UUID, patchVersion string) {
+		th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, testinfra.EventRow{
+			Type:           "http",
+			Timestamp:      now.Add(time.Duration(offset) * time.Second),
+			HttpURL:        "https://api.example.com/v1/users",
+			HttpMethod:     "GET",
+			HttpStatusCode: 200,
+			HttpStartTime:  1000,
+			HttpEndTime:    1100,
+			PatchID:        patch,
+			PatchVersion:   patchVersion,
+		})
+	}
+	seedRequest(0, patchID, "1.0-patch.2")
+	seedRequest(1, patchID, "1.0-patch.2")
+	seedRequest(2, uuid.Nil, "")
+
+	count := func(t *testing.T, filterExpr string) uint64 {
+		t.Helper()
+		ef := networkExprFilter(t, appID, teamID, now.Add(-time.Hour), now.Add(time.Hour), filterExpr)
+		result, err := GetLatencyPlot(
+			ctx, deps.ChPool, appID, teamID, "api.example.com", "/v1/users", ef,
+			"toStartOfHour(timestamp, ?)", "%Y-%m-%d %H:00:00",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 data point for %q, got %d", filterExpr, len(result))
+		}
+		return result[0]["count"].(uint64)
+	}
+
+	if got := count(t, ""); got != 3 {
+		t.Errorf("unfiltered count = %d, want 3", got)
+	}
+	if got := count(t, "patch_id:in:"+patchID.String()); got != 2 {
+		t.Errorf("patch_id count = %d, want 2", got)
+	}
+	if got := count(t, "patch_version:in:1.0-patch.2"); got != 2 {
+		t.Errorf("patch_version count = %d, want 2", got)
+	}
+	if got := count(t, "patch_id:is_not_set"); got != 1 {
+		t.Errorf("is_not_set count = %d, want 1", got)
+	}
+}
+
+func TestHttpMetricsPatchFilter(t *testing.T) {
+	ctx := context.Background()
+	defer cleanupAll(ctx, t)
+
+	teamID := uuid.New()
+	appID := uuid.New()
+	now := time.Now().UTC().Truncate(15 * time.Minute)
+	patchID := uuid.New()
+
+	seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/users", "1.0-patch.2", patchID, 50, 50, 0, 0, now)
+	seedHttpMetrics(ctx, t, teamID.String(), appID.String(), "api.example.com", "/v1/orders", "", uuid.Nil, 20, 20, 0, 0, now)
+
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+
+	timelinePaths := func(t *testing.T, filterExpr string) []string {
+		t.Helper()
+		ef := networkExprFilter(t, appID, teamID, from, to, filterExpr)
+		resp, err := FetchTimelinePlot(ctx, deps.ChPool, appID, teamID, "", "", ef)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		paths := []string{}
+		for _, point := range resp.Points {
+			if !slices.Contains(paths, point.PathPattern) {
+				paths = append(paths, point.PathPattern)
+			}
+		}
+		return paths
+	}
+
+	if got := timelinePaths(t, ""); len(got) != 2 {
+		t.Errorf("unfiltered timeline paths = %v, want both endpoints", got)
+	}
+	if got := timelinePaths(t, "patch_id:in:"+patchID.String()); len(got) != 1 || got[0] != "/v1/users" {
+		t.Errorf("patch_id timeline paths = %v, want [/v1/users]", got)
+	}
+	if got := timelinePaths(t, "patch_version:in:1.0-patch.2"); len(got) != 1 || got[0] != "/v1/users" {
+		t.Errorf("patch_version timeline paths = %v, want [/v1/users]", got)
+	}
+	if got := timelinePaths(t, "patch_id:is_not_set"); len(got) != 1 || got[0] != "/v1/orders" {
+		t.Errorf("is_not_set timeline paths = %v, want [/v1/orders]", got)
+	}
+
+	trends, err := FetchTrends(ctx, deps.ChPool, appID, teamID, networkExprFilter(t, appID, teamID, from, to, "patch_id:in:"+patchID.String()), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trends.TrendsFrequency) != 1 || trends.TrendsFrequency[0].PathPattern != "/v1/users" {
+		t.Errorf("patch_id trends = %v, want only the patched endpoint", trends.TrendsFrequency)
+	}
 }

--- a/backend/libs/network/test_helpers_test.go
+++ b/backend/libs/network/test_helpers_test.go
@@ -12,8 +12,8 @@ import (
 	"backend/testinfra"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/leporo/sqlf"
 	valkey "github.com/valkey-io/valkey-go"
 )
 
@@ -49,8 +49,6 @@ func TestMain(m *testing.M) {
 	vk, vkCleanup := testinfra.SetupValkey(ctx)
 
 	th = testinfra.NewTestHelper(pgPool, chConn, vk)
-
-	sqlf.SetDialect(sqlf.PostgreSQL)
 
 	deps = &testDeps{
 		PgPool:  pgPool,
@@ -95,7 +93,8 @@ func seedUrlPattern(ctx context.Context, t *testing.T, teamID, appID, domain, pa
 func seedHttpMetrics(
 	ctx context.Context,
 	t *testing.T,
-	teamID, appID, domain, path string,
+	teamID, appID, domain, path, patchVersion string,
+	patchID uuid.UUID,
 	requestCount, count2xx, count4xx, count5xx uint64,
 	ts time.Time,
 ) {
@@ -115,6 +114,8 @@ func seedHttpMetrics(
 			[toUInt16(200)] AS status_codes,
 			[('1.0','1')] AS app_versions,
 			[('android','14')] AS os_versions,
+			['%s'] AS patch_versions,
+			[toUUID('%s')] AS patch_ids,
 			['samsung'] AS device_manufacturers,
 			['galaxy'] AS device_names,
 			['provider'] AS network_providers,
@@ -132,6 +133,7 @@ func seedHttpMetrics(
 			(SELECT uniqCombined64State(generateUUIDv4()) FROM numbers(%d))`,
 		teamID, appID, tsStr,
 		domain, path,
+		patchVersion, patchID.String(),
 		requestCount,
 		count2xx,
 		count4xx,

--- a/backend/testinfra/seed.go
+++ b/backend/testinfra/seed.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -232,6 +233,8 @@ type EventRow struct {
 	AppVersion string
 	AppBuild   string
 
+	InsertedAt time.Time
+
 	// Exception/ANR payload, written only for issue events (Type "exception"
 	// or "anr"). Severity, ExceptionsJSON and IsCustom are written only when
 	// set, leaving ClickHouse column defaults otherwise.
@@ -245,6 +248,12 @@ type EventRow struct {
 	// class name is set.
 	LifecycleActivityType      string
 	LifecycleActivityClassName string
+
+	HttpURL        string
+	HttpMethod     string
+	HttpStatusCode int
+	HttpStartTime  uint64
+	HttpEndTime    uint64
 
 	// Description is the bug report text, written only for Type "bug_report".
 	// For those events the seed also writes '[]' into the attachments column,
@@ -362,9 +371,23 @@ func (h *TestHelper) SeedEventRows(ctx context.Context, t *testing.T, teamID, ap
 		vals = append(vals, quote(row.Description), "'[]'")
 	}
 
+	if row.HttpURL != "" {
+		cols = append(cols,
+			"`http.url`", "`http.method`", "`http.status_code`",
+			"`http.start_time`", "`http.end_time`")
+		vals = append(vals,
+			quote(row.HttpURL), quote(row.HttpMethod), strconv.Itoa(row.HttpStatusCode),
+			strconv.FormatUint(row.HttpStartTime, 10), strconv.FormatUint(row.HttpEndTime, 10))
+	}
+
 	if row.LifecycleActivityClassName != "" {
 		cols = append(cols, "`lifecycle_activity.type`", "`lifecycle_activity.class_name`")
 		vals = append(vals, quote(row.LifecycleActivityType), quote(row.LifecycleActivityClassName))
+	}
+
+	if !row.InsertedAt.IsZero() {
+		cols = append(cols, "inserted_at")
+		vals = append(vals, quote(row.InsertedAt.UTC().Format("2006-01-02 15:04:05")))
 	}
 
 	if row.OSName != "" {

--- a/frontend/dashboard/__tests__/api/api_calls_test.ts
+++ b/frontend/dashboard/__tests__/api/api_calls_test.ts
@@ -123,6 +123,9 @@ function errorResponse(status: number = 500, body: any = {}) {
   return mockResponse(false, status, body);
 }
 
+const isoFrom = "2026-04-01T00:00:00.000Z";
+const isoTo = "2026-04-10T00:00:00.000Z";
+
 function makeFilters(overrides: Partial<Filters> = {}): Filters {
   return {
     ...defaultFilters,
@@ -724,15 +727,27 @@ describe("fetchAppHealthPlotFromServer", () => {
 // Network endpoint fetches
 // ========================================================================
 describe("network endpoint fetches", () => {
+  const from = isoFrom;
+  const to = isoTo;
   const scoped = ["example.com", "/api/users"] as const;
 
   it("fetchNetworkEndpointsFromServer hits /networkRequests/endpoints and returns them", async () => {
     const results = [{ domain: "example.com", path_pattern: "/v1/users/*" }];
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results }));
-    const r = await fetchNetworkEndpointsFromServer(makeFilters(), "users");
-    const url = lastFetchUrl();
-    expect(url).toContain("/api/apps/app-a/networkRequests/endpoints");
-    expect(url).toContain("query=users");
+    const r = await fetchNetworkEndpointsFromServer(
+      "app-a",
+      from,
+      to,
+      null,
+      "users",
+    );
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/networkRequests/endpoints");
+    expect(url.searchParams.get("from")).toBe(from);
+    expect(url.searchParams.get("to")).toBe(to);
+    expect(url.searchParams.get("timezone")).toBeTruthy();
+    expect(url.searchParams.get("query")).toBe("users");
+    expect(url.searchParams.has("filter_expr")).toBe(false);
     expect(r).toEqual(results);
   });
 
@@ -741,7 +756,10 @@ describe("network endpoint fetches", () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
 
     await fetchNetworkEndpointsFromServer(
-      makeFilters(),
+      "app-a",
+      from,
+      to,
+      null,
       "users",
       controller.signal,
     );
@@ -751,35 +769,50 @@ describe("network endpoint fetches", () => {
     });
   });
 
-  it("fetchNetworkEndpointsFromServer forwards selected HTTP methods", async () => {
+  it("fetchNetworkEndpointsFromServer sends the filter expression when one is given", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
     await fetchNetworkEndpointsFromServer(
-      makeFilters({
-        httpMethods: { all: false, selected: ["GET", "POST"] as any },
-      }),
+      "app-a",
+      from,
+      to,
+      "http_method:in:get",
       "users",
     );
 
-    expect(lastFetchUrl()).toContain("http_methods=GET");
-    expect(lastFetchUrl()).toContain("http_methods=POST");
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.searchParams.get("filter_expr")).toBe("http_method:in:get");
   });
 
   it("fetchNetworkEndpointsFromServer omits an empty query and tolerates no results", async () => {
     mockApiClientFetch.mockResolvedValueOnce(
       successResponse({ results: null }),
     );
-    const r = await fetchNetworkEndpointsFromServer(makeFilters(), "");
+    const r = await fetchNetworkEndpointsFromServer(
+      "app-a",
+      from,
+      to,
+      null,
+      "",
+    );
     expect(lastFetchUrl()).not.toContain("query=");
     expect(r).toEqual([]);
   });
 
   it("fetchNetworkLatencyPlotFromServer uses the latency path and sends the scope", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ points: [1] }));
-    const r = await fetchNetworkLatencyPlotFromServer(makeFilters(), ...scoped);
-    const url = lastFetchUrl();
-    expect(url).toContain("/api/apps/app-a/networkRequests/plots/latency");
-    expect(url).toContain("domain=example.com");
-    expect(url).toContain("path=%2Fapi%2Fusers");
+    const r = await fetchNetworkLatencyPlotFromServer(
+      "app-a",
+      from,
+      to,
+      "http_method:in:post",
+      ...scoped,
+    );
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/networkRequests/plots/latency");
+    expect(url.searchParams.get("domain")).toBe("example.com");
+    expect(url.searchParams.get("path")).toBe("/api/users");
+    expect(url.searchParams.get("filter_expr")).toBe("http_method:in:post");
+    expect(url.searchParams.get("plot_time_group")).toBe("days");
     expect(r).toEqual({ points: [1] });
   });
 
@@ -788,23 +821,39 @@ describe("network endpoint fetches", () => {
       successResponse({ status_codes: [200], data_points: [{ count_200: 1 }] }),
     );
     const r = await fetchNetworkEndpointStatusCodesPlotFromServer(
-      makeFilters(),
+      "app-a",
+      from,
+      to,
+      null,
       ...scoped,
     );
-    expect(lastFetchUrl()).toContain(
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe(
       "/api/apps/app-a/networkRequests/plots/endpointStatusCodes",
     );
-    expect(lastFetchUrl()).toContain("domain=example.com");
-    expect(lastFetchUrl()).toContain("path=%2Fapi%2Fusers");
+    expect(url.searchParams.get("domain")).toBe("example.com");
+    expect(url.searchParams.get("path")).toBe("/api/users");
+    expect(url.searchParams.get("plot_time_group")).toBe("days");
     expect(r).toEqual({ status_codes: [200], data_points: [{ count_200: 1 }] });
   });
 
   it("fetchNetworkStatusCodesPlotFromServer sends an empty scope for every endpoint", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse([{ code: 200 }]));
-    await fetchNetworkStatusCodesPlotFromServer(makeFilters(), "", "");
-    const url = lastFetchUrl();
-    expect(url).toContain("domain=&");
-    expect(url).toContain("path=");
+    await fetchNetworkStatusCodesPlotFromServer(
+      "app-a",
+      from,
+      to,
+      null,
+      "",
+      "",
+    );
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe(
+      "/api/apps/app-a/networkRequests/plots/statusCodes",
+    );
+    expect(url.searchParams.get("domain")).toBe("");
+    expect(url.searchParams.get("path")).toBe("");
+    expect(url.searchParams.get("plot_time_group")).toBe("days");
   });
 
   it("fetchNetworkTimelinePlotFromServer uses the timeline path and returns the points", async () => {
@@ -812,31 +861,34 @@ describe("network endpoint fetches", () => {
       successResponse({ points: [{ t: 1 }] }),
     );
     const r = await fetchNetworkTimelinePlotFromServer(
-      makeFilters(),
+      "app-a",
+      from,
+      to,
+      null,
       ...scoped,
     );
-    expect(lastFetchUrl()).toContain(
-      "/api/apps/app-a/networkRequests/plots/timeline",
-    );
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/networkRequests/plots/timeline");
+    expect(url.searchParams.has("plot_time_group")).toBe(false);
     expect(r).toEqual({ points: [{ t: 1 }] });
   });
 
   it("fetchNetworkTrendsFromServer uses /networkRequests/trends with trends_limit and throws on failure", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse({ results: [] }));
-    await fetchNetworkTrendsFromServer(makeFilters(), 15);
-    const url = lastFetchUrl();
-    expect(url).toContain("/api/apps/app-a/networkRequests/trends");
-    expect(url).toContain("trends_limit=15");
+    await fetchNetworkTrendsFromServer("app-a", from, to, null, 15);
+    const url = new URL(lastFetchUrl(), "http://localhost");
+    expect(url.pathname).toBe("/api/apps/app-a/networkRequests/trends");
+    expect(url.searchParams.get("trends_limit")).toBe("15");
 
     mockApiClientFetch.mockResolvedValueOnce(errorResponse());
-    await expect(fetchNetworkTrendsFromServer(makeFilters())).rejects.toThrow(
-      ApiError,
-    );
+    await expect(
+      fetchNetworkTrendsFromServer("app-a", from, to, null, 10),
+    ).rejects.toThrow(ApiError);
 
     mockApiClientFetch.mockRejectedValueOnce(new Error("x"));
-    await expect(fetchNetworkTrendsFromServer(makeFilters())).rejects.toThrow(
-      RequestError,
-    );
+    await expect(
+      fetchNetworkTrendsFromServer("app-a", from, to, null, 10),
+    ).rejects.toThrow(RequestError);
   });
 });
 
@@ -1302,22 +1354,6 @@ describe("applyGenericFiltersToUrl filter branches", () => {
   });
 });
 
-describe("applyHttpMethodsToUrl", () => {
-  it("appends http_methods params for selected methods", async () => {
-    mockApiClientFetch.mockResolvedValueOnce(successResponse([]));
-    await fetchNetworkLatencyPlotFromServer(
-      makeFilters({
-        httpMethods: { all: false, selected: ["get", "post"] as any },
-      }),
-      "example.com",
-      "/path",
-    );
-    const url = lastFetchUrl();
-    expect(url).toContain("http_methods=get");
-    expect(url).toContain("http_methods=post");
-  });
-});
-
 // ========================================================================
 // Expression-filter span fetchers
 // ========================================================================
@@ -1607,25 +1643,38 @@ describe("fetch functions: failure paths", () => {
     ["fetchNotifPrefsFromServer", () => fetchNotifPrefsFromServer()],
     [
       "fetchNetworkEndpointsFromServer",
-      () => fetchNetworkEndpointsFromServer(makeFilters(), "q"),
+      () => fetchNetworkEndpointsFromServer("a", isoFrom, isoTo, null, "q"),
     ],
     [
       "fetchNetworkLatencyPlotFromServer",
-      () => fetchNetworkLatencyPlotFromServer(makeFilters(), "d", "p"),
+      () =>
+        fetchNetworkLatencyPlotFromServer("a", isoFrom, isoTo, null, "d", "p"),
     ],
     [
       "fetchNetworkTimelinePlotFromServer",
-      () => fetchNetworkTimelinePlotFromServer(makeFilters(), "d", "p"),
+      () =>
+        fetchNetworkTimelinePlotFromServer("a", isoFrom, isoTo, null, "d", "p"),
     ],
     [
       "fetchNetworkStatusCodesPlotFromServer",
-      () => fetchNetworkStatusCodesPlotFromServer(makeFilters(), "", ""),
+      () =>
+        fetchNetworkStatusCodesPlotFromServer(
+          "a",
+          isoFrom,
+          isoTo,
+          null,
+          "",
+          "",
+        ),
     ],
     [
       "fetchNetworkEndpointStatusCodesPlotFromServer",
       () =>
         fetchNetworkEndpointStatusCodesPlotFromServer(
-          makeFilters(),
+          "a",
+          isoFrom,
+          isoTo,
+          null,
           "example.com",
           "/api/users",
         ),
@@ -1780,13 +1829,20 @@ describe("additional branch coverage", () => {
 
   it("fetchNetworkTimelinePlotFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    const r = await fetchNetworkTimelinePlotFromServer(makeFilters(), "", "");
+    const r = await fetchNetworkTimelinePlotFromServer(
+      "a",
+      isoFrom,
+      isoTo,
+      null,
+      "",
+      "",
+    );
     expect(r).toBeNull();
   });
 
   it("fetchNetworkTrendsFromServer returns null on a null body", async () => {
     mockApiClientFetch.mockResolvedValueOnce(successResponse(null));
-    const r = await fetchNetworkTrendsFromServer(makeFilters());
+    const r = await fetchNetworkTrendsFromServer("a", isoFrom, isoTo, null, 10);
     expect(r).toBeNull();
   });
 

--- a/frontend/dashboard/__tests__/components/filters_test.tsx
+++ b/frontend/dashboard/__tests__/components/filters_test.tsx
@@ -147,7 +147,6 @@ function defaultProps(overrides: Record<string, any> = {}) {
     showLocales: true,
     showDeviceManufacturers: true,
     showDeviceNames: true,
-    showHttpMethods: false,
     showUdAttrs: false,
     showFreeText: false,
     ...overrides,

--- a/frontend/dashboard/__tests__/components/network_details_test.tsx
+++ b/frontend/dashboard/__tests__/components/network_details_test.tsx
@@ -1,59 +1,108 @@
-import NetworkDetails from "@/app/components/network_details";
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const replace = jest.fn();
-const latencyQuery = jest.fn();
-const statusCodesQuery = jest.fn();
-const timelineQuery = jest.fn();
-const mockFilters = jest.fn((_props: unknown) => <div data-testid="filters" />);
-const mockEndpointStatusCodesPlot = jest.fn((_props: unknown) => (
-  <div data-testid="status-codes-plot" />
-));
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace }),
-  usePathname: () => "/team-1/network/details",
-  useSearchParams: () =>
-    new URLSearchParams("domain=api.example.com&path=/v1/users"),
-}));
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
 
-jest.mock("@/app/api/api_calls", () => ({
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  FilterSource: { Events: "events" },
+  toastNegative: jest.fn(),
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, loading: true, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
+const pendingQueryState = () => ({
+  data: null as any,
+  status: "pending" as string,
+  error: null as Error | null,
 });
+
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
+const mockUseNetworkLatencyQuery = jest.fn((..._args: unknown[]) =>
+  pendingQueryState(),
+);
+const mockUseNetworkEndpointStatusCodesQuery = jest.fn((..._args: unknown[]) =>
+  pendingQueryState(),
+);
+const mockUseNetworkTimelineQuery = jest.fn((..._args: unknown[]) =>
+  pendingQueryState(),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useNetworkLatencyQuery: (...args: unknown[]) => latencyQuery(...args),
+  paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
+  useNetworkLatencyQuery: (...args: unknown[]) =>
+    mockUseNetworkLatencyQuery(...args),
   useNetworkEndpointStatusCodesQuery: (...args: unknown[]) =>
-    statusCodesQuery(...args),
-  useNetworkTimelineQuery: (...args: unknown[]) => timelineQuery(...args),
+    mockUseNetworkEndpointStatusCodesQuery(...args),
+  useNetworkTimelineQuery: (...args: unknown[]) =>
+    mockUseNetworkTimelineQuery(...args),
 }));
 
-jest.mock("@/app/components/filters", () => ({
+const mockFilterBar = jest.fn();
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   __esModule: true,
-  default: (props: unknown) => mockFilters(props),
-  AppVersionsInitialSelectionType: { All: "all" },
+  default: (props: any) => {
+    mockFilterBar(props);
+    return (
+      <div data-testid="filter-bar-mock">
+        <span data-testid="filter-bar-entity">{props.entity}</span>
+        <span data-testid="filter-bar-issues">
+          {props.filterExprIssues
+            ? props.filterExprIssues
+                .map((issue: { message: string }) => issue.message)
+                .join(", ")
+            : "none"}
+        </span>
+        <button
+          data-testid="filter-bar-apply"
+          onClick={() => props.onChange({ filterExpr: "http_method:in:get" })}
+        >
+          apply
+        </button>
+      </div>
+    );
+  },
+}));
+
+jest.mock("@/app/components/skeleton", () => ({
+  __esModule: true,
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
+  SkeletonPlot: () => <div data-testid="skeleton-plot-mock" />,
 }));
 
 jest.mock("@/app/components/network_latency_plot", () => ({
   __esModule: true,
-  default: () => <div data-testid="latency-plot" />,
+  default: (props: any) => (
+    <div data-testid="latency-plot" data-time-group={props.plotTimeGroup} />
+  ),
 }));
 
+const mockEndpointStatusCodesPlot = jest.fn();
 jest.mock("@/app/components/network_endpoint_status_codes_plot", () => ({
   __esModule: true,
-  default: (props: unknown) => mockEndpointStatusCodesPlot(props),
+  default: (props: any) => {
+    mockEndpointStatusCodesPlot(props);
+    return <div data-testid="status-codes-plot" />;
+  },
 }));
 
 jest.mock("@/app/components/network_timeline_plot", () => ({
@@ -61,128 +110,212 @@ jest.mock("@/app/components/network_timeline_plot", () => ({
   default: () => <div data-testid="timeline-plot" />,
 }));
 
-jest.mock("@/app/components/skeleton", () => ({
-  Skeleton: () => <div data-testid="skeleton" />,
-  SkeletonPlot: () => <div data-testid="skeleton-plot" />,
-}));
+import NetworkDetails from "@/app/components/network_details";
+import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 
-jest.mock("@/app/components/info_tooltip", () => ({
-  __esModule: true,
-  default: () => <div data-testid="info-tooltip" />,
-}));
+const mockApp = { id: "app-1", name: "Sample" };
 
-jest.mock("@/app/utils/time_utils", () => ({
-  getPlotTimeGroupForRange: () => "days",
-}));
+const httpMethodKey = {
+  name: "http_method",
+  label: "HTTP method",
+  key_group: "Request",
+  description: "The HTTP method of the request",
+  value_type: "enum",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
+};
 
-jest.mock("@/app/utils/shared_styles", () => ({
-  underlineLinkStyle: "underline",
-}));
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
+const endpoint = "domain=api.example.com&path=%2Fv1%2Fusers";
+const selection = { domain: "api.example.com", path: "/v1/users" };
+const settled = {
+  a: "app-1",
+  d: "Last 6 Hours",
+  ...selection,
+};
 
 const noData = { data: null, status: "success", error: null };
 
-function setReadyFilters() {
-  useFiltersStore.setState({
-    filters: {
-      ready: true,
-      loading: false,
-      app: { id: "app-1" },
-      serialisedFilters: "a=app-1",
-      startDate: "2024-01-01",
-      endDate: "2024-01-14",
+function renderDetails() {
+  return render(<NetworkDetails params={{ teamId: "team-1" }} />);
+}
+
+function plotsLoaded() {
+  mockUseNetworkLatencyQuery.mockReturnValue({
+    data: [{ datetime: "2026-04-01", p50: 1, p90: 2, p95: 3, p99: 4 }],
+    status: "success",
+    error: null,
+  });
+  mockUseNetworkEndpointStatusCodesQuery.mockReturnValue({
+    data: {
+      status_codes: [200, 404],
+      data_points: [
+        { datetime: "2026-04-01", total_count: 4, count_200: 3, count_404: 1 },
+      ],
     },
+    status: "success",
+    error: null,
+  });
+  mockUseNetworkTimelineQuery.mockReturnValue({
+    data: { interval: 5, points: [{ elapsed: 1, count: 2 }] },
+    status: "success",
+    error: null,
   });
 }
 
 describe("NetworkDetails", () => {
   beforeEach(() => {
-    replace.mockReset();
-    latencyQuery.mockReset();
-    statusCodesQuery.mockReset();
-    timelineQuery.mockReset();
-    mockFilters.mockClear();
+    mockRouter.reset();
+    mockRouter.setUrl(`?${endpoint}`);
+    mockFiltersStore.reset();
+    mockFilterBar.mockClear();
     mockEndpointStatusCodesPlot.mockClear();
-    latencyQuery.mockReturnValue(noData);
-    statusCodesQuery.mockReturnValue(noData);
-    timelineQuery.mockReturnValue(noData);
-    setReadyFilters();
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: [mockApp] });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [httpMethodKey], key_groups: ["Request"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
+    mockUseNetworkLatencyQuery.mockReset();
+    mockUseNetworkLatencyQuery.mockReturnValue(noData);
+    mockUseNetworkEndpointStatusCodesQuery.mockReset();
+    mockUseNetworkEndpointStatusCodesQuery.mockReturnValue(noData);
+    mockUseNetworkTimelineQuery.mockReset();
+    mockUseNetworkTimelineQuery.mockReturnValue(noData);
+  });
+
+  it("renders the filter bar for the network entity, without the app control", () => {
+    renderDetails();
+
+    expect(screen.getByTestId("filter-bar-entity")).toHaveTextContent(
+      "network",
+    );
+    expect(mockFilterBar.mock.calls.at(-1)?.[0]).toMatchObject({
+      showAppSelect: false,
+    });
+  });
+
+  it("scopes every plot to the endpoint the URL names", () => {
+    mockRouter.setUrl(`?${endpoint}&filter_expr=http_method%3Ain%3Aget`);
+    plotsLoaded();
+    renderDetails();
+
+    const params = expect.objectContaining({
+      appId: "app-1",
+      filterExpr: "http_method:in:get",
+    });
+    expect(mockUseNetworkLatencyQuery).toHaveBeenLastCalledWith(
+      params,
+      "api.example.com",
+      "/v1/users",
+    );
+    expect(mockUseNetworkEndpointStatusCodesQuery).toHaveBeenLastCalledWith(
+      params,
+      "api.example.com",
+      "/v1/users",
+    );
+    expect(mockUseNetworkTimelineQuery).toHaveBeenLastCalledWith(
+      params,
+      "api.example.com",
+      "/v1/users",
+    );
+  });
+
+  it("keeps the endpoint in the URL beside what it settled on", () => {
+    plotsLoaded();
+    renderDetails();
+
+    expect(mockRouter.urlParams()).toEqual(settled);
+  });
+
+  it("keeps the endpoint when the filter changes", async () => {
+    plotsLoaded();
+    renderDetails();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("filter-bar-apply"));
+    });
+
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      filter_expr: "http_method:in:get",
+    });
+  });
+
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
+    renderDetails();
+
+    expect(mockUseNetworkLatencyQuery).toHaveBeenLastCalledWith(
+      null,
+      "api.example.com",
+      "/v1/users",
+    );
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
+  });
+
+  it("draws every plot, bucketed for the settled range", () => {
+    plotsLoaded();
+    renderDetails();
+
+    expect(screen.getByTestId("latency-plot")).toHaveAttribute(
+      "data-time-group",
+      "minutes",
+    );
+    expect(screen.getByTestId("status-codes-plot")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-plot")).toBeInTheDocument();
+    expect(mockEndpointStatusCodesPlot.mock.calls.at(-1)?.[0]).toMatchObject({
+      statusCodes: [200, 404],
+      data: [
+        { datetime: "2026-04-01", total_count: 4, count_200: 3, count_404: 1 },
+      ],
+    });
   });
 
   it("shows one empty state when the endpoint has no data", () => {
-    latencyQuery.mockReturnValue({ data: [], status: "success", error: null });
-    render(<NetworkDetails params={{ teamId: "team-1" }} />);
+    mockUseNetworkLatencyQuery.mockReturnValue({
+      data: [],
+      status: "success",
+      error: null,
+    });
+    renderDetails();
 
     expect(
       screen.getAllByText("No data available for the selected filters"),
     ).toHaveLength(1);
     expect(screen.queryByText("Latency")).not.toBeInTheDocument();
-    expect(screen.queryByText("Status Distribution")).not.toBeInTheDocument();
+    expect(screen.queryByText("Status Codes")).not.toBeInTheDocument();
     expect(screen.queryByText("Timeline")).not.toBeInTheDocument();
   });
 
-  it("scopes all plots to the endpoint and synchronizes its URL", async () => {
-    latencyQuery.mockReturnValue({
-      data: [{}],
-      status: "success",
-      error: null,
+  it("hands a refused filter's issues to the bar", () => {
+    mockRouter.setUrl(`?${endpoint}&filter_expr=http_method%3Ain%3Aget`);
+    mockUseNetworkLatencyQuery.mockReturnValue({
+      data: null,
+      status: "error",
+      error: new ApiError(400, invalidFilterExpr, [
+        { message: 'Unknown key "os_name"', span: { start: 0, end: 7 } },
+      ]),
     });
-    statusCodesQuery.mockReturnValue({
-      data: {
-        status_codes: [200, 404],
-        data_points: [
-          {
-            datetime: "2024-01-01",
-            total_count: 4,
-            count_200: 3,
-            count_404: 1,
-          },
-        ],
-      },
-      status: "success",
-      error: null,
-    });
-    timelineQuery.mockReturnValue({
-      data: { points: [{}] },
-      status: "success",
-      error: null,
-    });
+    renderDetails();
 
-    render(<NetworkDetails params={{ teamId: "team-1" }} />);
-
-    expect(latencyQuery).toHaveBeenCalledWith("api.example.com", "/v1/users");
-    expect(statusCodesQuery).toHaveBeenCalledWith(
-      "api.example.com",
-      "/v1/users",
+    expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent(
+      'Unknown key "os_name"',
     );
-    expect(timelineQuery).toHaveBeenCalledWith("api.example.com", "/v1/users");
-    expect(mockFilters.mock.calls.at(-1)?.[0]).toMatchObject({
-      showAppSelector: false,
-      showHttpMethods: true,
-    });
-    expect(
-      screen.queryByTestId("network-endpoint-search"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("network-endpoint-results-label"),
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("latency-plot")).toBeInTheDocument();
-    expect(screen.getByTestId("status-codes-plot")).toBeInTheDocument();
-    expect(screen.getByTestId("timeline-plot")).toBeInTheDocument();
-    expect(screen.getByText("Status Codes")).toBeInTheDocument();
-    expect(mockEndpointStatusCodesPlot.mock.calls.at(-1)?.[0]).toMatchObject({
-      statusCodes: [200, 404],
-      data: [
-        { datetime: "2024-01-01", total_count: 4, count_200: 3, count_404: 1 },
-      ],
-    });
+  });
 
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith(
-        "/team-1/network/details?a=app-1&domain=api.example.com&path=%2Fv1%2Fusers",
-        { scroll: false },
-      );
+  it("says so when a plot request fails", () => {
+    mockUseNetworkLatencyQuery.mockReturnValue({
+      data: null,
+      status: "error",
+      error: new Error("fail"),
     });
+    renderDetails();
+
+    expect(
+      screen.getByText(
+        "Error fetching latency, please change filters & try again",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/dashboard/__tests__/components/network_endpoint_search_test.tsx
+++ b/frontend/dashboard/__tests__/components/network_endpoint_search_test.tsx
@@ -22,14 +22,26 @@ jest.mock("next/navigation", () => ({
 }));
 
 const mockUseNetworkEndpointsQuery = jest.fn(
-  (_query: string, _enabled: boolean) => ({ data: [] as any }),
+  (_params: unknown, _query: string, _enabled: boolean) => ({
+    data: [] as any,
+  }),
 );
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useNetworkEndpointsQuery: (query: string, enabled: boolean) =>
-    mockUseNetworkEndpointsQuery(query, enabled),
+  useNetworkEndpointsQuery: (
+    params: unknown,
+    query: string,
+    enabled: boolean,
+  ) => mockUseNetworkEndpointsQuery(params, query, enabled),
 }));
+
+const filterParams = {
+  appId: "app-1",
+  startDate: "2026-04-01T00:00:00.000Z",
+  endDate: "2026-04-10T00:00:00.000Z",
+  filterExpr: "http_method:in:get",
+};
 
 const initialSuggestions = [
   { domain: "api.example.com", path_pattern: "/v1/users/*" },
@@ -43,7 +55,10 @@ const searchResults = [
 ];
 
 const box = () => screen.getByTestId("network-endpoint-search");
-const renderSearch = () => render(<NetworkEndpointSearch teamId="test-team" />);
+const renderSearch = () =>
+  render(
+    <NetworkEndpointSearch teamId="test-team" filterParams={filterParams} />,
+  );
 
 async function settleSearch(value: string) {
   fireEvent.change(box(), { target: { value } });
@@ -56,9 +71,11 @@ describe("NetworkEndpointSearch", () => {
   beforeEach(() => {
     mockRouterPush.mockReset();
     mockUseNetworkEndpointsQuery.mockReset();
-    mockUseNetworkEndpointsQuery.mockImplementation((query: string) => ({
-      data: query === "" ? initialSuggestions : searchResults,
-    }));
+    mockUseNetworkEndpointsQuery.mockImplementation(
+      (_params: unknown, query: string) => ({
+        data: query === "" ? initialSuggestions : searchResults,
+      }),
+    );
     localStorage.clear();
   });
 
@@ -70,7 +87,11 @@ describe("NetworkEndpointSearch", () => {
       "placeholder",
       "Search endpoints, e.g. /v1/products/*, /v1/**, api.example.com/v1/orders/**",
     );
-    expect(mockUseNetworkEndpointsQuery).toHaveBeenLastCalledWith("", true);
+    expect(mockUseNetworkEndpointsQuery).toHaveBeenLastCalledWith(
+      filterParams,
+      "",
+      true,
+    );
     expect(screen.getAllByTestId("network-endpoint-suggestion")).toHaveLength(
       2,
     );
@@ -93,9 +114,11 @@ describe("NetworkEndpointSearch", () => {
     fireEvent.keyDown(box(), { key: "Enter" });
     expect(mockRouterPush).not.toHaveBeenCalled();
 
-    mockUseNetworkEndpointsQuery.mockImplementation((query: string) => ({
-      data: query === "" ? initialSuggestions : searchResults,
-    }));
+    mockUseNetworkEndpointsQuery.mockImplementation(
+      (_params: unknown, query: string) => ({
+        data: query === "" ? initialSuggestions : searchResults,
+      }),
+    );
     await settleSearch("users");
     fireEvent.keyDown(box(), { key: "Enter" });
 
@@ -127,6 +150,7 @@ describe("NetworkEndpointSearch", () => {
 
     await settleSearch("reviews/*");
     expect(mockUseNetworkEndpointsQuery).toHaveBeenLastCalledWith(
+      filterParams,
       "/reviews/*",
       true,
     );

--- a/frontend/dashboard/__tests__/components/network_trends_test.tsx
+++ b/frontend/dashboard/__tests__/components/network_trends_test.tsx
@@ -24,11 +24,6 @@ jest.mock("next/link", () => ({
   ),
 }));
 
-jest.mock("@/app/components/filters", () => ({
-  __esModule: true,
-  defaultFilters: { ready: false, serialisedFilters: null },
-}));
-
 jest.mock("@/app/components/loading_bar", () => ({
   __esModule: true,
   default: () => <div data-testid="loading-bar">Loading...</div>,
@@ -59,23 +54,18 @@ jest.mock("@/app/utils/shared_styles", () => ({
   underlineLinkStyle: "underline",
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: null },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
-});
-
-const mockUseNetworkTrendsQuery = jest.fn(() => ({
-  data: null as any,
-  status: "pending" as string,
-  error: null as Error | null,
-}));
+const mockUseNetworkTrendsQuery = jest.fn(
+  (_params: unknown, _active: boolean) => ({
+    data: null as any,
+    status: "pending" as string,
+    error: null as Error | null,
+  }),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useNetworkTrendsQuery: () => mockUseNetworkTrendsQuery(),
+  useNetworkTrendsQuery: (params: unknown, active: boolean) =>
+    mockUseNetworkTrendsQuery(params, active),
   TrendsTab: {
     Latency: "Latency",
     ErrorRate: "Error Rate",
@@ -84,7 +74,13 @@ jest.mock("@/app/query/hooks", () => ({
 }));
 
 import NetworkTrends from "@/app/components/network_trends";
-const { useFiltersStore } = require("@/app/stores/provider") as any;
+
+const filterParams = {
+  appId: "app-1",
+  startDate: "2026-04-01T00:00:00.000Z",
+  endDate: "2026-04-10T00:00:00.000Z",
+  filterExpr: null,
+};
 
 function mockTrendsData() {
   return {
@@ -125,10 +121,6 @@ function mockTrendsData() {
   };
 }
 
-function readyFilters() {
-  return { ready: true, app: { id: "app-1" }, serialisedFilters: "a=app-1" };
-}
-
 describe("NetworkTrends", () => {
   beforeEach(() => {
     mockRouterPush.mockReset();
@@ -138,21 +130,17 @@ describe("NetworkTrends", () => {
       status: "pending" as string,
       error: null,
     });
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: null },
-    });
   });
 
   describe("Loading state", () => {
     it("shows loading bar while fetching", async () => {
-      useFiltersStore.setState({ filters: readyFilters() });
       mockUseNetworkTrendsQuery.mockReturnValue({
         data: null,
         status: "pending" as string,
         error: null,
       });
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       expect(screen.getByTestId("loading-bar")).toBeInTheDocument();
     });
@@ -160,14 +148,13 @@ describe("NetworkTrends", () => {
 
   describe("Error state", () => {
     it("shows error message", async () => {
-      useFiltersStore.setState({ filters: readyFilters() });
       mockUseNetworkTrendsQuery.mockReturnValue({
         data: null,
         status: "error",
         error: new Error("fail"),
       });
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(screen.getByText(/Error fetching overview/)).toBeInTheDocument();
@@ -177,14 +164,13 @@ describe("NetworkTrends", () => {
 
   describe("NoData state", () => {
     it("shows no data message", async () => {
-      useFiltersStore.setState({ filters: readyFilters() });
       mockUseNetworkTrendsQuery.mockReturnValue({
         data: null,
         status: "success",
         error: null,
       });
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(screen.getByText(/No data available/)).toBeInTheDocument();
@@ -194,7 +180,6 @@ describe("NetworkTrends", () => {
 
   describe("Success state", () => {
     beforeEach(() => {
-      useFiltersStore.setState({ filters: readyFilters() });
       mockUseNetworkTrendsQuery.mockReturnValue({
         data: mockTrendsData(),
         status: "success",
@@ -204,7 +189,7 @@ describe("NetworkTrends", () => {
 
     it("renders table with endpoint data", async () => {
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -218,7 +203,7 @@ describe("NetworkTrends", () => {
 
     it("shows latency, error rate and frequency columns", async () => {
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(screen.getByText("Latency (p95)")).toBeInTheDocument();
@@ -232,7 +217,7 @@ describe("NetworkTrends", () => {
 
     it("renders tab buttons (Latency, Error Rate, Frequency)", async () => {
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         // Use getAllByText for 'Frequency' since the table header also says 'Frequency'
@@ -246,7 +231,7 @@ describe("NetworkTrends", () => {
 
     it("switches data when tab is clicked", async () => {
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -272,7 +257,7 @@ describe("NetworkTrends", () => {
 
     it("opens endpoint details when its row is clicked", async () => {
       await act(async () => {
-        render(<NetworkTrends teamId="team-1" />);
+        render(<NetworkTrends teamId="team-1" filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -290,7 +275,7 @@ describe("NetworkTrends", () => {
 
     it("links the endpoint text to its details page", async () => {
       await act(async () => {
-        render(<NetworkTrends teamId="team-1" />);
+        render(<NetworkTrends teamId="team-1" filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -306,7 +291,7 @@ describe("NetworkTrends", () => {
 
     it("leaves a modified endpoint click to the browser", async () => {
       await act(async () => {
-        render(<NetworkTrends teamId="team-1" />);
+        render(<NetworkTrends teamId="team-1" filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -325,7 +310,7 @@ describe("NetworkTrends", () => {
 
     it("opens endpoint details on Enter", async () => {
       await act(async () => {
-        render(<NetworkTrends teamId="team-1" />);
+        render(<NetworkTrends teamId="team-1" filterParams={filterParams} />);
       });
       await waitFor(() => {
         expect(
@@ -345,14 +330,13 @@ describe("NetworkTrends", () => {
 
   describe("Docs link", () => {
     it("offers the endpoint patterns tooltip beside the title", async () => {
-      useFiltersStore.setState({ filters: readyFilters() });
       mockUseNetworkTrendsQuery.mockReturnValue({
         data: mockTrendsData(),
         status: "success",
         error: null as Error | null,
       });
       await act(async () => {
-        render(<NetworkTrends />);
+        render(<NetworkTrends filterParams={filterParams} />);
       });
       expect(
         screen
@@ -381,6 +365,7 @@ describe("NetworkTrends", () => {
       expect(screen.getByText("Top Endpoints")).toBeInTheDocument();
       // Demo data should render some endpoints
       expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+      expect(mockUseNetworkTrendsQuery).toHaveBeenLastCalledWith(null, true);
     });
 
     it("does not navigate from a demo row click", async () => {

--- a/frontend/dashboard/__tests__/integration/network_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/network_msw_test.tsx
@@ -1,15 +1,4 @@
-/**
- * Integration tests for Network Overview and Details pages.
- *
- * Covers page/api wiring only: endpoint suggestions, HTTP failure handling
- * for every network endpoint, request paths and query params,
- * URL serialisation, cache behaviour, and re-fetching when filters change.
- * Rendering behaviour is covered by focused page/component tests.
- *
- * Network pages use FilterSource.Events with showNoData=true and
- * showNotOnboarded=true, so filters.ready requires apps+filters and has a
- * dedicated empty state for NoData/NotOnboarded.
- */
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import {
   afterAll,
   afterEach,
@@ -19,23 +8,8 @@ import {
   expect,
   it,
 } from "@jest/globals";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-
-// --- jsdom polyfills ---
-if (typeof globalThis.ResizeObserver === "undefined") {
-  globalThis.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any;
-}
 
 // --- External dependency mocks ---
 
@@ -44,14 +18,10 @@ jest.mock("posthog-js", () => ({
   default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
 }));
 
-const mockRouterReplace = jest.fn();
-const mockRouterPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
-const appFixtureId = "b5f3e8a1-6c2d-4f9a-8e7b-1a2b3c4d5e6f";
+const mockRouterPush = mockRouter.pushMock;
+
 jest.mock("next/navigation", () => ({
-  __esModule: true,
-  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
   usePathname: () => "/test-team/network",
 }));
 
@@ -93,13 +63,25 @@ jest.mock("@nivo/heatmap", () => ({
   ),
 }));
 
+// Radix popovers and cmdk need browser APIs jsdom lacks.
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn(() => false);
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
+
 // --- MSW ---
 import {
-  makeNetworkStatusCodesFixture,
+  makeAppFixture,
+  makeNetworkEndpointLatencyFixture,
   makeNetworkEndpointsFixture,
+  makeNetworkStatusCodesFixture,
   makeNetworkTimelineFixture,
   makeNetworkTrendsFixture,
-  makeFiltersFixture,
 } from "../msw/fixtures";
 import { server } from "../msw/server";
 
@@ -109,20 +91,20 @@ jest.spyOn(console, "error").mockImplementation(() => {});
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
-  mockRouterReplace.mockClear();
   mockRouterPush.mockClear();
 });
 afterAll(() => server.close());
 
 // --- Store/component imports ---
+import NetworkDetails from "@/app/components/network_details";
 import NetworkOverview from "@/app/components/network_overview";
+import { queryClient } from "@/app/query/query_client";
 import { createFiltersStore } from "@/app/stores/filters_store";
 import { createOnboardingStore } from "@/app/stores/onboarding_store";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 let filtersStore = createFiltersStore();
 let onboardingStore = createOnboardingStore();
-let testQueryClient: QueryClient;
 
 jest.mock("@/app/stores/provider", () => {
   const { useStore } = require("zustand");
@@ -136,293 +118,322 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
+const appId = makeAppFixture().id;
+
 beforeEach(() => {
   filtersStore = createFiltersStore();
   onboardingStore = createOnboardingStore();
-  testQueryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  filtersStore.getState().reset();
-  for (const key of [...mockSearchParams.keys()]) mockSearchParams.delete(key);
+  queryClient.clear();
+  mockRouter.reset();
   const { apiClient } = require("@/app/api/api_client");
   apiClient.init({ replace: jest.fn(), push: jest.fn() });
-  // Clear localStorage for recent searches
-  try {
-    localStorage.clear();
-  } catch {}
+  localStorage.clear();
 });
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(
-    <QueryClientProvider client={testQueryClient}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   );
 }
 
-// ====================================================================
-// NETWORK OVERVIEW
-// ====================================================================
-describe("Network Overview (MSW integration)", () => {
-  async function renderAndWaitForData() {
-    renderWithProviders(<NetworkOverview params={{ teamId: "test-team" }} />);
+function record(path: string, respond?: () => any) {
+  const sent: URL[] = [];
+  server.use(
+    http.get(`*/api/apps/:appId/${path}`, ({ request }) => {
+      sent.push(new URL(request.url));
+      return respond === undefined ? undefined : HttpResponse.json(respond());
+    }),
+  );
+  return sent;
+}
+
+const lastWrittenUrl = () => new URLSearchParams(window.location.search);
+
+describe("Network overview (MSW integration)", () => {
+  function renderPage() {
+    return renderWithProviders(<NetworkOverview params={{ teamId: "123" }} />);
+  }
+
+  async function waitForPlots() {
     await waitFor(
-      () => {
-        // Wait for the endpoint ranking to appear
-        expect(screen.getByText("Top Endpoints")).toBeTruthy();
+      () => expect(screen.getByTestId("nivo-heatmap")).toBeTruthy(),
+      {
+        timeout: 5000,
       },
-      { timeout: 5000 },
     );
   }
 
-  // ================================================================
-  // PAGE LOAD
-  // ================================================================
-  describe("page load", () => {
-    it("lists the app's endpoints from the API", async () => {
-      await renderAndWaitForData();
-      await waitFor(() => {
-        expect(screen.getByText("api.example.com/v1/checkout")).toBeTruthy();
-      });
+  describe("opening the page", () => {
+    it("draws the plots and the ranking the server sent", async () => {
+      renderPage();
+      await waitForPlots();
+
+      expect(screen.getByTestId("nivo-line-chart")).toBeTruthy();
+      expect(screen.getByText("Top Endpoints")).toBeTruthy();
+      expect(screen.getByText("api.example.com/v1/checkout")).toBeTruthy();
     });
 
-    it("shows the shared empty state when the app has no data", async () => {
-      server.use(
-        http.get("*/api/apps/:appId/filters", () =>
-          HttpResponse.json(makeFiltersFixture({ versions: null })),
-        ),
+    it("asks for every endpoint over the range it settled on", async () => {
+      const sent = record("networkRequests/plots/statusCodes", () =>
+        makeNetworkStatusCodesFixture(),
       );
+      renderPage();
+      await waitForPlots();
 
-      renderWithProviders(<NetworkOverview params={{ teamId: "test-team" }} />);
+      expect(sent).toHaveLength(1);
+      expect(sent[0].pathname).toBe(
+        `/api/apps/${appId}/networkRequests/plots/statusCodes`,
+      );
+      expect(sent[0].searchParams.get("from")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("to")).toMatch(/Z$/);
+      expect(sent[0].searchParams.get("timezone")).toBeTruthy();
+      expect(sent[0].searchParams.get("plot_time_group")).toBe("minutes");
+      expect(sent[0].searchParams.get("domain")).toBe("");
+      expect(sent[0].searchParams.get("path")).toBe("");
+      expect(sent[0].searchParams.has("filter_expr")).toBe(false);
+      expect(sent[0].searchParams.has("http_methods")).toBe(false);
+      expect(sent[0].searchParams.has("filter_short_code")).toBe(false);
+    });
 
-      await waitFor(() => {
-        expect(
-          screen.getByText("No data received for this app yet"),
-        ).toBeTruthy();
-      });
-      expect(screen.queryByText("Status Distribution")).toBeNull();
+    it("asks for the ranking with a limit and no time group", async () => {
+      const sent = record("networkRequests/trends", () =>
+        makeNetworkTrendsFixture(),
+      );
+      renderPage();
+      await waitForPlots();
+
+      expect(sent[0].searchParams.get("trends_limit")).toBe("10");
+      expect(sent[0].searchParams.has("plot_time_group")).toBe(false);
+    });
+
+    it("asks the keys endpoint for the network entity", async () => {
+      const sent = record("filters/keys");
+      renderPage();
+      await waitForPlots();
+
+      await waitFor(() => expect(sent.length).toBeGreaterThan(0));
+      expect(sent[0].searchParams.get("entity")).toBe("network");
+    });
+
+    it("records the app and range it settled on in the URL, with no offset", async () => {
+      renderPage();
+      await waitForPlots();
+
+      const written = lastWrittenUrl();
+      expect(written.get("a")).toBe(appId);
+      expect(written.get("d")).toBe("Last 6 Hours");
+      expect(written.has("po")).toBe(false);
+      expect(written.has("hm")).toBe(false);
     });
   });
 
-  // ================================================================
-  // TRENDS TABLE
-  // ================================================================
-  describe("trends table", () => {
-    it("shows error when trends API returns 500", async () => {
+  describe("a link carrying a filter", () => {
+    it("filters every request by it", async () => {
+      mockRouter.setUrl(
+        `filter_expr=${encodeURIComponent("http_method:in:get")}`,
+      );
+      const statusCodes = record("networkRequests/plots/statusCodes", () =>
+        makeNetworkStatusCodesFixture(),
+      );
+      const timeline = record("networkRequests/plots/timeline", () =>
+        makeNetworkTimelineFixture(),
+      );
+      const trends = record("networkRequests/trends", () =>
+        makeNetworkTrendsFixture(),
+      );
+      renderPage();
+      await waitForPlots();
+
+      for (const sent of [statusCodes, timeline, trends]) {
+        expect(sent[0].searchParams.get("filter_expr")).toBe(
+          "http_method:in:get",
+        );
+      }
+      expect(lastWrittenUrl().get("filter_expr")).toBe("http_method:in:get");
+    });
+  });
+
+  describe("the endpoint search", () => {
+    it("opens the endpoint it is given, keeping the filter in the URL", async () => {
+      mockRouter.setUrl(
+        `filter_expr=${encodeURIComponent("http_method:in:get")}`,
+      );
+      const sent = record("networkRequests/endpoints", () =>
+        makeNetworkEndpointsFixture(),
+      );
+      renderPage();
+      await waitForPlots();
+
+      fireEvent.focus(screen.getByTestId("network-endpoint-search"));
+      await waitFor(() =>
+        expect(
+          screen.getAllByTestId("network-endpoint-suggestion"),
+        ).toHaveLength(3),
+      );
+      expect(sent[0].searchParams.get("filter_expr")).toBe(
+        "http_method:in:get",
+      );
+
+      fireEvent.click(screen.getAllByTestId("network-endpoint-suggestion")[0]);
+      const opened = new URL(
+        mockRouterPush.mock.calls.at(-1)![0] as string,
+        "http://localhost",
+      );
+      expect(opened.pathname).toBe("/123/network/details");
+      expect(Object.fromEntries(opened.searchParams)).toEqual({
+        a: appId,
+        d: "Last 6 Hours",
+        filter_expr: "http_method:in:get",
+        domain: "api.example.com",
+        path: "/v1/users/*/profile",
+        from: "search",
+      });
+    });
+  });
+
+  describe("when the server fails", () => {
+    it("says so for each plot", async () => {
       server.use(
+        http.get("*/api/apps/:appId/networkRequests/plots/statusCodes", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+        http.get("*/api/apps/:appId/networkRequests/plots/timeline", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
         http.get("*/api/apps/:appId/networkRequests/trends", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       );
-      renderWithProviders(<NetworkOverview params={{ teamId: "test-team" }} />);
-      await waitFor(
-        () => {
-          expect(screen.getByText(/Error fetching overview/)).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-    });
-  });
+      renderPage();
 
-  // ================================================================
-  // STATUS DISTRIBUTION PLOT
-  // ================================================================
-  describe("status distribution plot", () => {
-    it("shows error when status plot API returns 500", async () => {
+      expect(
+        await screen.findByText(/Error fetching status distribution/),
+      ).toBeTruthy();
+      expect(screen.getByText(/Error fetching requests timeline/)).toBeTruthy();
+      expect(screen.getByText(/Error fetching overview/)).toBeTruthy();
+    });
+
+    it("shows a refused filter's issue in the bar, not the error message", async () => {
+      mockRouter.setUrl(
+        `filter_expr=${encodeURIComponent("http_method:in:get")}`,
+      );
       server.use(
         http.get("*/api/apps/:appId/networkRequests/plots/statusCodes", () => {
+          return HttpResponse.json(
+            {
+              error: "invalid_filter_expr",
+              filter_expr_issues: [
+                {
+                  message: 'Key "http_method" has no value "get"',
+                  span: { start: 0, end: 18 },
+                },
+              ],
+            },
+            { status: 400 },
+          );
+        }),
+      );
+      renderPage();
+
+      expect((await screen.findByTestId("filter-issue")).textContent).toContain(
+        'Key "http_method" has no value "get"',
+      );
+    });
+
+    it("says so when the team's apps cannot be fetched", async () => {
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       );
-      renderWithProviders(<NetworkOverview params={{ teamId: "test-team" }} />);
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(/Error fetching status distribution/),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
+      renderPage();
+
+      expect(await screen.findByText(/Error fetching apps/)).toBeTruthy();
     });
   });
 
-  // ================================================================
-  // TIMELINE PLOT
-  // ================================================================
-  describe("timeline plot", () => {
-    it("shows error when timeline API returns 500", async () => {
+  describe("when the server answers with nothing", () => {
+    it("says there is no data for the filter", async () => {
       server.use(
-        http.get("*/api/apps/:appId/networkRequests/plots/timeline", () => {
-          return new HttpResponse(null, { status: 500 });
-        }),
-      );
-      renderWithProviders(<NetworkOverview params={{ teamId: "test-team" }} />);
-      await waitFor(
-        () => {
-          expect(
-            screen.getByText(/Error fetching requests timeline/),
-          ).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-    });
-  });
-
-  // ================================================================
-  // URL SYNC
-  // ================================================================
-  describe("URL sync", () => {
-    it("serialises filters into URL", async () => {
-      await renderAndWaitForData();
-      expect(mockRouterReplace).toHaveBeenCalled();
-      const url =
-        mockRouterReplace.mock.calls[
-          mockRouterReplace.mock.calls.length - 1
-        ][0];
-      expect(url).toContain("a=");
-      expect(url).toContain("sd=");
-    });
-  });
-
-  // ================================================================
-  // API PATHS
-  // ================================================================
-  describe("API paths", () => {
-    it("fetches the endpoint list from /networkRequests/endpoints", async () => {
-      const paths: string[] = [];
-      server.use(
-        http.get(
-          "*/api/apps/:appId/networkRequests/endpoints",
-          ({ request }) => {
-            paths.push(new URL(request.url).pathname);
-            return HttpResponse.json(makeNetworkEndpointsFixture());
-          },
+        http.get("*/api/apps/:appId/networkRequests/plots/statusCodes", () =>
+          HttpResponse.json([]),
+        ),
+        http.get("*/api/apps/:appId/networkRequests/plots/timeline", () =>
+          HttpResponse.json({ interval: 5, points: [] }),
         ),
       );
-      await renderAndWaitForData();
-      fireEvent.focus(screen.getByTestId("network-endpoint-search"));
-      await waitFor(() => {
+      renderPage();
+
+      await waitFor(() =>
         expect(
-          paths.some((p) => p.includes("/networkRequests/endpoints")),
-        ).toBe(true);
-      });
-    });
-
-    it("fetches trends from /networkRequests/trends", async () => {
-      const paths: string[] = [];
-      server.use(
-        http.get("*/api/apps/:appId/networkRequests/trends", ({ request }) => {
-          paths.push(new URL(request.url).pathname);
-          return HttpResponse.json(makeNetworkTrendsFixture());
-        }),
+          screen.getAllByText("No data available for the selected filters")
+            .length,
+        ).toBeGreaterThan(0),
       );
-      await renderAndWaitForData();
-      expect(paths.some((p) => p.includes("/networkRequests/trends"))).toBe(
-        true,
-      );
-    });
-  });
-
-  describe("endpoint selection", () => {
-    it("opens the selected endpoint's detail route", async () => {
-      await renderAndWaitForData();
-      fireEvent.focus(screen.getByTestId("network-endpoint-search"));
-      await waitFor(() => {
-        expect(
-          screen.getAllByTestId("network-endpoint-suggestion"),
-        ).toHaveLength(3);
-      });
-      fireEvent.click(screen.getAllByTestId("network-endpoint-suggestion")[0]);
-      expect(mockRouterPush).toHaveBeenCalledWith(
-        "/test-team/network/details?domain=api.example.com&path=%2Fv1%2Fusers%2F*%2Fprofile&from=search",
-      );
-    });
-  });
-
-  // ================================================================
-  // CACHING
-  // ================================================================
-  describe("caching", () => {
-    it("re-render with same filters re-fetches the status plot (gcTime: 0 evicts on unmount)", async () => {
-      let fetchCount = 0;
-      server.use(
-        http.get("*/api/apps/:appId/networkRequests/plots/statusCodes", () => {
-          fetchCount++;
-          return HttpResponse.json(makeNetworkStatusCodesFixture());
-        }),
-      );
-      const { unmount } = render(
-        <QueryClientProvider client={testQueryClient}>
-          <NetworkOverview params={{ teamId: "test-team" }} />
-        </QueryClientProvider>,
-      );
-      await waitFor(
-        () => {
-          expect(screen.getByText("Top Endpoints")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      const initial = fetchCount;
-
-      unmount();
-      render(
-        <QueryClientProvider client={testQueryClient}>
-          <NetworkOverview params={{ teamId: "test-team" }} />
-        </QueryClientProvider>,
-      );
-      await waitFor(
-        () => {
-          expect(screen.getByText("Top Endpoints")).toBeTruthy();
-        },
-        { timeout: 5000 },
-      );
-      expect(fetchCount).toBeGreaterThan(initial);
-    });
-  });
-
-  // ================================================================
-  // FILTER CHANGE RE-FETCH
-  // ================================================================
-  describe("filter change re-fetch", () => {
-    it("date range change re-fetches the status plot and timeline", async () => {
-      let statusPlotFetches = 0;
-      let timelineFetches = 0;
-      server.use(
-        http.get("*/api/apps/:appId/networkRequests/plots/statusCodes", () => {
-          statusPlotFetches++;
-          return HttpResponse.json(makeNetworkStatusCodesFixture());
-        }),
-        http.get("*/api/apps/:appId/networkRequests/plots/timeline", () => {
-          timelineFetches++;
-          return HttpResponse.json(makeNetworkTimelineFixture());
-        }),
-      );
-
-      await renderAndWaitForData();
-      const initialStatus = statusPlotFetches;
-      const initialTimeline = timelineFetches;
-
-      // Change date range to trigger re-fetch
-      const now = new Date();
-      await act(async () => {
-        filtersStore.getState().setSelectedDateRange("Last Week");
-        filtersStore
-          .getState()
-          .setSelectedStartDate(
-            new Date(now.getTime() - 7 * 86400000).toISOString(),
-          );
-        filtersStore.getState().setSelectedEndDate(now.toISOString());
-      });
-
-      await waitFor(
-        () => {
-          expect(statusPlotFetches).toBeGreaterThan(initialStatus);
-        },
-        { timeout: 5000 },
-      );
-      expect(timelineFetches).toBeGreaterThan(initialTimeline);
+      expect(screen.queryByTestId("nivo-heatmap")).toBeNull();
     });
   });
 });
 
-// ====================================================================
-// NETWORK DETAILS
-// ====================================================================
+describe("Network details (MSW integration)", () => {
+  const endpoint = "domain=api.example.com&path=%2Fv1%2Fusers";
+
+  function renderPage() {
+    return renderWithProviders(<NetworkDetails params={{ teamId: "123" }} />);
+  }
+
+  async function waitForPlots() {
+    await waitFor(
+      () => expect(screen.getByTestId("nivo-heatmap")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+  }
+
+  beforeEach(() => {
+    mockRouter.setUrl(`?${endpoint}`);
+  });
+
+  it("asks every plot for the endpoint the URL names", async () => {
+    mockRouter.setUrl(
+      `?${endpoint}&filter_expr=${encodeURIComponent("http_method:in:get")}`,
+    );
+    const latency = record("networkRequests/plots/latency", () =>
+      makeNetworkEndpointLatencyFixture(),
+    );
+    const timeline = record("networkRequests/plots/timeline", () =>
+      makeNetworkTimelineFixture(),
+    );
+    renderPage();
+    await waitForPlots();
+
+    for (const sent of [latency, timeline]) {
+      expect(sent[0].searchParams.get("domain")).toBe("api.example.com");
+      expect(sent[0].searchParams.get("path")).toBe("/v1/users");
+      expect(sent[0].searchParams.get("filter_expr")).toBe(
+        "http_method:in:get",
+      );
+    }
+    expect(latency[0].searchParams.get("plot_time_group")).toBe("minutes");
+    expect(timeline[0].searchParams.has("plot_time_group")).toBe(false);
+  });
+
+  it("keeps the endpoint in the URL beside what it settled on", async () => {
+    renderPage();
+    await waitForPlots();
+
+    const written = lastWrittenUrl();
+    expect(written.get("domain")).toBe("api.example.com");
+    expect(written.get("path")).toBe("/v1/users");
+    expect(written.get("a")).toBe(appId);
+    expect(written.get("d")).toBe("Last 6 Hours");
+  });
+
+  it("draws the latency, status code and timeline plots", async () => {
+    renderPage();
+    await waitForPlots();
+
+    expect(screen.getByText("Latency")).toBeTruthy();
+    expect(screen.getByText("Status Codes")).toBeTruthy();
+    expect(screen.getAllByTestId("nivo-line-chart")).toHaveLength(2);
+  });
+});

--- a/frontend/dashboard/__tests__/msw/fixtures.ts
+++ b/frontend/dashboard/__tests__/msw/fixtures.ts
@@ -1524,6 +1524,56 @@ export function makeJourneysFilterKeysFixture(
   };
 }
 
+// --- Filter keys for the network entity ---
+
+export function makeNetworkFilterKeysFixture(
+  overrides: Record<string, any> = {},
+) {
+  return {
+    keys: [
+      {
+        name: "http_method",
+        label: "HTTP method",
+        description: "The HTTP method of the request.",
+        key_group: "Request",
+        value_type: "enum",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+        enum_values: ["get", "post", "put", "patch", "delete"],
+      },
+      {
+        name: "version_name",
+        label: "App version",
+        description: "The app version the request was made on",
+        key_group: "Version",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "os_name",
+        label: "OS name",
+        description: "The operating system's name",
+        key_group: "OS",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+      {
+        name: "network_type",
+        label: "Network type",
+        description: "The kind of network the request went over",
+        key_group: "Network",
+        value_type: "string",
+        value_suggestion_mode: "full_list",
+        operators: ["in", "not_in"],
+      },
+    ],
+    key_groups: ["Request", "Version", "OS", "Device", "Network", "Location"],
+    ...overrides,
+  };
+}
+
 // --- Filter values (GET /apps/:appId/filters/values) ---
 
 export function makeFilterValuesFixture(overrides: Record<string, any> = {}) {

--- a/frontend/dashboard/__tests__/msw/handlers.ts
+++ b/frontend/dashboard/__tests__/msw/handlers.ts
@@ -29,6 +29,7 @@ import {
   makeExceptionInstanceFixture,
   makeExceptionsOverviewFixture,
   makeFilterKeysFixture,
+  makeNetworkFilterKeysFixture,
   makeFilterValuesFixture,
   makeFiltersFixture,
   makeHealthPlotFixture,
@@ -419,6 +420,9 @@ export const handlers = [
     }
     if (entity === "journeys") {
       return HttpResponse.json(makeJourneysFilterKeysFixture());
+    }
+    if (entity === "network") {
+      return HttpResponse.json(makeNetworkFilterKeysFixture());
     }
     if (entity === "alerts") {
       return HttpResponse.json({

--- a/frontend/dashboard/__tests__/pages/network_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/network_overview_test.tsx
@@ -1,167 +1,153 @@
-import NetworkOverview from "@/app/components/network_overview";
+import { mockFiltersStore } from "@/__tests__/helpers/mock_filters_store";
+import { mockRouter } from "@/__tests__/helpers/mock_router";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
-// Global router mocks
-const replaceMock = jest.fn();
-const pushMock = jest.fn();
+jest.mock("next/navigation", () =>
+  require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+);
 
-// Mock next/navigation hooks
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-    push: pushMock,
-  }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => "/test-team/network",
-}));
+jest.mock("@/app/stores/provider", () =>
+  require("@/__tests__/helpers/mock_filters_store").filtersProviderMock(),
+);
 
-// Mock API calls
-jest.mock("@/app/api/api_calls", () => ({
+jest.mock("@/app/components/toast", () => ({
   __esModule: true,
-  FilterSource: { Events: "events" },
+  toastNegative: jest.fn(),
 }));
 
-jest.mock("@/app/stores/provider", () => {
-  const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, serialisedFilters: "" },
-  }));
-  return { __esModule: true, useFiltersStore: filtersStore };
+const pendingQueryState = () => ({
+  data: null as any,
+  status: "pending" as string,
+  error: null as Error | null,
 });
 
-const mockUseNetworkLatencyQuery = jest.fn(() => ({
-  data: null as any,
-  status: "pending" as string,
-  error: null as Error | null,
-}));
-
-const mockUseNetworkStatusPlotQuery = jest.fn(() => ({
-  data: null as any,
-  status: "pending" as string,
-  error: null as Error | null,
-}));
-
-const mockUseNetworkTimelineQuery = jest.fn(() => ({
-  data: null as any,
-  status: "pending" as string,
-  error: null as Error | null,
-}));
+const mockUseAppsQuery = jest.fn();
+const mockUseFilterKeysQuery = jest.fn();
+const mockUseNetworkStatusCodesQuery = jest.fn((..._args: unknown[]) =>
+  pendingQueryState(),
+);
+const mockUseNetworkTimelineQuery = jest.fn((..._args: unknown[]) =>
+  pendingQueryState(),
+);
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
-  useNetworkLatencyQuery: () => mockUseNetworkLatencyQuery(),
-  useNetworkStatusCodesQuery: () => mockUseNetworkStatusPlotQuery(),
-  useNetworkTimelineQuery: () => mockUseNetworkTimelineQuery(),
+  paginationOffsetUrlKey: "po",
+  useAppsQuery: (teamId: string) => mockUseAppsQuery(teamId),
+  useFilterKeysQuery: (
+    appId: string | undefined,
+    entity: string,
+    keyNames: string[],
+  ) => mockUseFilterKeysQuery(appId, entity, keyNames),
+  useRootSpanNamesQuery: () => ({
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+  }),
+  useNetworkStatusCodesQuery: (...args: unknown[]) =>
+    mockUseNetworkStatusCodesQuery(...args),
+  useNetworkTimelineQuery: (...args: unknown[]) =>
+    mockUseNetworkTimelineQuery(...args),
 }));
 
-// Mock Filters component
-jest.mock("@/app/components/filters", () => ({
+jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   __esModule: true,
-  default: () => <div data-testid="filters-mock" />,
-  AppVersionsInitialSelectionType: { Latest: "latest", All: "all" },
-}));
-
-const { useFiltersStore } = require("@/app/stores/provider") as any;
-
-// Mock time utils
-jest.mock("@/app/utils/time_utils", () => ({
-  getPlotTimeGroupForRange: jest.fn(() => "days"),
-}));
-
-// Mock child components
-jest.mock("@/app/components/skeleton", () => ({
-  Skeleton: ({ className, ...props }: any) => (
-    <div data-testid="skeleton-mock" className={className} {...props} />
+  default: (props: any) => (
+    <div data-testid="filter-bar-mock">
+      <span data-testid="filter-bar-entity">{props.entity}</span>
+      <span data-testid="filter-bar-expr">
+        {props.value?.filterExpr ?? "none"}
+      </span>
+      <span data-testid="filter-bar-issues">
+        {props.filterExprIssues
+          ? props.filterExprIssues
+              .map((issue: { message: string }) => issue.message)
+              .join(", ")
+          : "none"}
+      </span>
+      <button
+        data-testid="filter-bar-apply"
+        onClick={() => props.onChange({ filterExpr: "http_method:in:get" })}
+      >
+        apply
+      </button>
+    </div>
   ),
-  SkeletonPlot: () => <div data-testid="skeleton-plot-mock">Loading...</div>,
-  SkeletonTable: () => <div data-testid="skeleton-table-mock" />,
+}));
+
+jest.mock("@/app/components/skeleton", () => ({
+  __esModule: true,
+  SkeletonListPage: () => <div data-testid="skeleton-list-page-mock" />,
+  SkeletonPlot: () => <div data-testid="skeleton-plot-mock" />,
+}));
+
+jest.mock("@/app/components/network_endpoint_search", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div
+      data-testid="endpoint-search-mock"
+      data-app={props.filterParams?.appId ?? "none"}
+    />
+  ),
 }));
 
 jest.mock("@/app/components/network_status_distribution_plot", () => ({
   __esModule: true,
-  default: () => (
-    <div data-testid="status-distribution-plot-mock">
-      StatusDistributionPlot
-    </div>
+  default: (props: any) => (
+    <div
+      data-testid="status-distribution-plot-mock"
+      data-time-group={props.plotTimeGroup}
+      data-points={props.data.length}
+    />
   ),
 }));
 
 jest.mock("@/app/components/network_timeline_plot", () => ({
   __esModule: true,
-  default: () => (
-    <div data-testid="network-timeline-plot-mock">NetworkTimelinePlot</div>
+  default: (props: any) => (
+    <div
+      data-testid="network-timeline-plot-mock"
+      data-points={props.data.points.length}
+    />
   ),
-  NetworkTimelineData: {},
-  NetworkTimelineDataPoint: {},
-}));
-
-jest.mock("@/app/components/network_endpoint_search", () => ({
-  __esModule: true,
-  default: () => <div data-testid="endpoint-search-mock" />,
-}));
-
-jest.mock("@/app/components/network_latency_plot", () => ({
-  __esModule: true,
-  default: () => <div data-testid="latency-plot-mock">LatencyPlot</div>,
 }));
 
 jest.mock("@/app/components/network_trends", () => ({
   __esModule: true,
   default: (props: any) => (
-    <div data-testid="network-trends-mock">NetworkTrends</div>
+    <div
+      data-testid="network-trends-mock"
+      data-app={props.filterParams?.appId ?? "none"}
+    />
   ),
 }));
 
-jest.mock("@/app/components/badge", () => ({
-  Badge: (props: any) => <span {...props}>{props.children}</span>,
-}));
+import NetworkOverview, {
+  NetworkOverviewDemo,
+} from "@/app/components/network_overview";
+import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 
-jest.mock("@/app/components/button", () => ({
-  Button: (props: any) => <button {...props}>{props.children}</button>,
-}));
+const mockApp = { id: "app-1", name: "Sample" };
 
-jest.mock("@/app/components/tooltip", () => ({
-  Tooltip: (props: any) => <div>{props.children}</div>,
-  TooltipContent: (props: any) => <div>{props.children}</div>,
-  TooltipTrigger: (props: any) => <div>{props.children}</div>,
-}));
-
-jest.mock("next/link", () => ({
-  __esModule: true,
-  default: ({ href, children, className }: any) => (
-    <a href={href} className={className}>
-      {children}
-    </a>
-  ),
-}));
-
-jest.mock("@/app/utils/shared_styles", () => ({
-  underlineLinkStyle: "underline-link",
-}));
-
-const readyFilters = {
-  ready: true,
-  serialisedFilters: "updated",
-  app: { id: "app1" },
-  startDate: "2024-01-01",
-  endDate: "2024-01-14",
+const httpMethodKey = {
+  name: "http_method",
+  label: "HTTP method",
+  key_group: "Request",
+  description: "The HTTP method of the request",
+  value_type: "enum",
+  value_suggestion_mode: "full_list",
+  operators: ["in", "not_in"],
 };
 
-// Helper to set queries to a fully successful state
-function setupSuccessfulQueryState() {
-  mockUseNetworkLatencyQuery.mockReturnValue({
-    data: [
-      { datetime: "2024-01-01", p50: 1, p90: 2, p95: 3, p99: 4, count: 5 },
-    ],
-    status: "success",
-    error: null as Error | null,
-  });
-  mockUseNetworkStatusPlotQuery.mockReturnValue({
+const settled = { a: "app-1", d: "Last 6 Hours" };
+
+function statusCodesLoaded() {
+  mockUseNetworkStatusCodesQuery.mockReturnValue({
     data: [
       {
-        datetime: "2024-01-01",
+        datetime: "2026-04-01",
         total_count: 100,
         count_2xx: 90,
         count_3xx: 2,
@@ -170,8 +156,11 @@ function setupSuccessfulQueryState() {
       },
     ],
     status: "success",
-    error: null as Error | null,
+    error: null,
   });
+}
+
+function timelineLoaded() {
   mockUseNetworkTimelineQuery.mockReturnValue({
     data: {
       interval: 5,
@@ -185,187 +174,190 @@ function setupSuccessfulQueryState() {
       ],
     },
     status: "success",
-    error: null as Error | null,
+    error: null,
   });
 }
 
-describe("NetworkOverview - Demo mode", () => {
+describe("NetworkOverviewDemo", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
-    pushMock.mockClear();
-    mockUseNetworkLatencyQuery.mockReset();
-    mockUseNetworkStatusPlotQuery.mockReset();
+    mockRouter.reset();
+    mockFiltersStore.reset();
+    mockUseAppsQuery.mockReset();
+    mockUseNetworkStatusCodesQuery.mockReset();
     mockUseNetworkTimelineQuery.mockReset();
-    mockUseNetworkLatencyQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
-    mockUseNetworkStatusPlotQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
-    mockUseNetworkTimelineQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
   });
 
-  it("renders title and sections in demo mode without fetching APIs", () => {
-    render(<NetworkOverview demo={true} />);
+  it("draws the demo sections without a filter bar or any query", () => {
+    render(<NetworkOverviewDemo />);
 
     expect(screen.getByText("Network Performance")).toBeInTheDocument();
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
     expect(
       screen.getByTestId("status-distribution-plot-mock"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Timeline")).toBeInTheDocument();
-    expect(screen.queryByTestId("filters-mock")).not.toBeInTheDocument();
-  });
-
-  it("renders NetworkTrends in demo mode", () => {
-    render(<NetworkOverview demo={true} />);
     expect(screen.getByTestId("network-trends-mock")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("network-timeline-plot-mock"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("filter-bar-mock")).toBeNull();
+    expect(screen.queryByTestId("endpoint-search-mock")).toBeNull();
+    expect(mockUseAppsQuery).not.toHaveBeenCalled();
+    expect(mockUseNetworkStatusCodesQuery).not.toHaveBeenCalled();
   });
 
-  it("does not render Filters in demo mode", () => {
-    render(<NetworkOverview demo={true} />);
-    expect(screen.queryByTestId("filters-mock")).not.toBeInTheDocument();
-  });
-
-  it("hides title and beta badge when hideDemoTitle is true", () => {
-    render(<NetworkOverview demo={true} hideDemoTitle={true} />);
+  it("hides the title when asked", () => {
+    render(<NetworkOverviewDemo hideTitle />);
     expect(screen.queryByText("Network Performance")).not.toBeInTheDocument();
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
   });
 });
 
-describe("NetworkOverview", () => {
+describe("NetworkOverview page", () => {
+  function renderPage() {
+    return render(<NetworkOverview params={{ teamId: "123" }} />);
+  }
+
   beforeEach(() => {
-    replaceMock.mockClear();
-    pushMock.mockClear();
-    mockUseNetworkLatencyQuery.mockReset();
-    mockUseNetworkStatusPlotQuery.mockReset();
+    mockRouter.reset();
+    mockFiltersStore.reset();
+    mockUseAppsQuery.mockReturnValue({ status: "success", data: [mockApp] });
+    mockUseFilterKeysQuery.mockReturnValue({
+      data: { keys: [httpMethodKey], key_groups: ["Request"] },
+      isPending: false,
+      isError: false,
+      isPlaceholderData: false,
+    });
+    mockUseNetworkStatusCodesQuery.mockReset();
+    mockUseNetworkStatusCodesQuery.mockReturnValue(pendingQueryState());
     mockUseNetworkTimelineQuery.mockReset();
-    mockUseNetworkLatencyQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
-    mockUseNetworkStatusPlotQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
-    mockUseNetworkTimelineQuery.mockReturnValue({
-      data: null,
-      status: "pending" as string,
-      error: null,
-    });
-    useFiltersStore.setState({
-      filters: { ready: false, serialisedFilters: "" },
-    });
+    mockUseNetworkTimelineQuery.mockReturnValue(pendingQueryState());
   });
 
-  it("renders Filters component and does not render main UI when filters are not ready", () => {
-    render(<NetworkOverview params={{ teamId: "123" }} />);
+  it("renders the filter bar for the network entity", () => {
+    renderPage();
 
-    expect(screen.getByTestId("filters-mock")).toBeInTheDocument();
-    expect(screen.queryByText("Status Distribution")).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("network-domains-mock"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows skeletons while filters are loading", async () => {
-    render(<NetworkOverview params={{ teamId: "123" }} />);
-
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: false,
-          loading: true,
-          serialisedFilters: "",
-        },
-      });
-    });
-
-    expect(screen.getAllByTestId("skeleton-plot-mock").length).toBeGreaterThan(
-      0,
+    expect(screen.getByTestId("filter-bar-entity")).toHaveTextContent(
+      "network",
+    );
+    expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+      "app-1",
+      "network",
+      [],
     );
   });
 
-  it("renders main content once filters are ready and updates URL", async () => {
-    setupSuccessfulQueryState();
-    render(<NetworkOverview params={{ teamId: "123" }} />);
+  it("fetches nothing until it settles on an app and a range", () => {
+    mockUseAppsQuery.mockReturnValue({ status: "pending", data: undefined });
+    renderPage();
 
-    await act(async () => {
-      useFiltersStore.setState({ filters: readyFilters });
-    });
-
-    // URL should be updated
-    expect(replaceMock).toHaveBeenCalledWith("/test-team/network?updated", {
-      scroll: false,
-    });
-
-    // Unscoped: the search, the status plot, the ranking and the timeline.
-    expect(screen.getByTestId("endpoint-search-mock")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("status-distribution-plot-mock"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("network-trends-mock")).toBeInTheDocument();
-    expect(screen.getByText("Timeline")).toBeInTheDocument();
+    expect(mockUseNetworkStatusCodesQuery).toHaveBeenLastCalledWith(
+      null,
+      "",
+      "",
+    );
+    expect(mockUseNetworkTimelineQuery).toHaveBeenLastCalledWith(null, "", "");
+    expect(screen.getByTestId("skeleton-list-page-mock")).toBeInTheDocument();
+    expect(screen.queryByText("Status Distribution")).toBeNull();
   });
 
-  it("shows status plot error message when status codes API fails", async () => {
-    mockUseNetworkStatusPlotQuery.mockReturnValue({
+  it("asks for every endpoint, filtered by what it settled on", () => {
+    mockRouter.setUrl("?filter_expr=http_method%3Ain%3Aget");
+    statusCodesLoaded();
+    timelineLoaded();
+    renderPage();
+
+    const params = expect.objectContaining({
+      appId: "app-1",
+      filterExpr: "http_method:in:get",
+    });
+    expect(mockUseNetworkStatusCodesQuery).toHaveBeenLastCalledWith(
+      params,
+      "",
+      "",
+    );
+    expect(mockUseNetworkTimelineQuery).toHaveBeenLastCalledWith(
+      params,
+      "",
+      "",
+    );
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      filter_expr: "http_method:in:get",
+    });
+  });
+
+  it("hands the endpoint search and the ranking the filter it settled on", () => {
+    statusCodesLoaded();
+    timelineLoaded();
+    renderPage();
+
+    expect(screen.getByTestId("endpoint-search-mock")).toHaveAttribute(
+      "data-app",
+      "app-1",
+    );
+    expect(screen.getByTestId("network-trends-mock")).toHaveAttribute(
+      "data-app",
+      "app-1",
+    );
+  });
+
+  it("draws the plots the server sent, bucketed for the settled range", () => {
+    statusCodesLoaded();
+    timelineLoaded();
+    renderPage();
+
+    const statusPlot = screen.getByTestId("status-distribution-plot-mock");
+    expect(statusPlot).toHaveAttribute("data-points", "1");
+    expect(statusPlot).toHaveAttribute("data-time-group", "minutes");
+    expect(screen.getByTestId("network-timeline-plot-mock")).toHaveAttribute(
+      "data-points",
+      "1",
+    );
+  });
+
+  it("refetches for the filter the bar applies", async () => {
+    statusCodesLoaded();
+    timelineLoaded();
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("filter-bar-apply"));
+    });
+
+    expect(mockRouter.urlParams()).toEqual({
+      ...settled,
+      filter_expr: "http_method:in:get",
+    });
+    expect(mockUseNetworkStatusCodesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ filterExpr: "http_method:in:get" }),
+      "",
+      "",
+    );
+  });
+
+  it("says so when the status codes request fails", () => {
+    mockUseNetworkStatusCodesQuery.mockReturnValue({
       data: null,
       status: "error",
       error: new Error("fail"),
     });
-    render(<NetworkOverview params={{ teamId: "123" }} />);
-
-    await act(async () => {
-      useFiltersStore.setState({ filters: readyFilters });
-    });
+    timelineLoaded();
+    renderPage();
 
     expect(
       screen.getByText(
         "Error fetching status distribution, please change filters & try again",
       ),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent("none");
   });
 
-  it("shows no data message when status codes API returns no data", async () => {
-    mockUseNetworkStatusPlotQuery.mockReturnValue({
-      data: null,
-      status: "success",
-      error: null,
-    });
-    render(<NetworkOverview params={{ teamId: "123" }} />);
-
-    await act(async () => {
-      useFiltersStore.setState({ filters: readyFilters });
-    });
-
-    expect(
-      screen.getAllByText("No data available for the selected filters").length,
-    ).toBeGreaterThan(0);
-  });
-
-  it("shows timeline error message when timeline API fails", async () => {
+  it("says so when the timeline request fails", () => {
+    statusCodesLoaded();
     mockUseNetworkTimelineQuery.mockReturnValue({
       data: null,
       status: "error",
       error: new Error("fail"),
     });
-    render(<NetworkOverview params={{ teamId: "123" }} />);
-
-    await act(async () => {
-      useFiltersStore.setState({ filters: readyFilters });
-    });
+    renderPage();
 
     expect(
       screen.getByText(
@@ -374,30 +366,66 @@ describe("NetworkOverview", () => {
     ).toBeInTheDocument();
   });
 
-  it("updates URL when filters change", async () => {
-    setupSuccessfulQueryState();
-    render(<NetworkOverview params={{ teamId: "123" }} />);
-
-    await act(async () => {
-      useFiltersStore.setState({ filters: readyFilters });
+  it("hands a refused filter's issues to the bar", () => {
+    mockRouter.setUrl("?filter_expr=http_method%3Ain%3Aget");
+    mockUseNetworkStatusCodesQuery.mockReturnValue({
+      data: null,
+      status: "error",
+      error: new ApiError(400, invalidFilterExpr, [
+        { message: 'Unknown key "os_name"', span: { start: 0, end: 7 } },
+      ]),
     });
+    timelineLoaded();
+    renderPage();
 
-    expect(replaceMock).toHaveBeenCalledWith("/test-team/network?updated", {
-      scroll: false,
-    });
-
-    // Change filters
-    await act(async () => {
-      useFiltersStore.setState({
-        filters: { ...readyFilters, serialisedFilters: "updated2" },
-      });
-    });
-
-    expect(replaceMock).toHaveBeenLastCalledWith(
-      "/test-team/network?updated2",
-      {
-        scroll: false,
-      },
+    expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent(
+      'Unknown key "os_name"',
     );
+  });
+
+  it("says there is no data when both requests come back empty", () => {
+    mockUseNetworkStatusCodesQuery.mockReturnValue({
+      data: null,
+      status: "success",
+      error: null,
+    });
+    mockUseNetworkTimelineQuery.mockReturnValue({
+      data: null,
+      status: "success",
+      error: null,
+    });
+    renderPage();
+
+    expect(
+      screen.getAllByText("No data available for the selected filters"),
+    ).toHaveLength(2);
+  });
+
+  describe("a filter it could not settle", () => {
+    beforeEach(() => {
+      mockRouter.setUrl("?a=app-1&d=Last+6+Hours");
+      mockUseAppsQuery.mockReturnValue({ status: "error", data: undefined });
+    });
+
+    it("is said by the page, in place of the plots", () => {
+      renderPage();
+
+      expect(
+        screen.getByText(
+          "Error fetching apps, please refresh page to try again",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Status Distribution")).toBeNull();
+    });
+
+    it("stops the page fetching anything", () => {
+      renderPage();
+
+      expect(mockUseNetworkStatusCodesQuery).toHaveBeenLastCalledWith(
+        null,
+        "",
+        "",
+      );
+    });
   });
 });

--- a/frontend/dashboard/__tests__/stores/filters_store_test.ts
+++ b/frontend/dashboard/__tests__/stores/filters_store_test.ts
@@ -4,7 +4,6 @@ import {
   App,
   AppVersion,
   FilterSource,
-  HttpMethod,
   OsVersion,
   SessionType,
 } from "@/app/api/api_calls";
@@ -63,7 +62,6 @@ const baseConfig = {
   showLocales: true,
   showDeviceManufacturers: true,
   showDeviceNames: true,
-  showHttpMethods: true,
   showUdAttrs: true,
   showFreeText: true,
 };
@@ -327,16 +325,6 @@ describe("applyFilterOptions", () => {
       SessionType.FatalErrors,
       SessionType.ANRs,
     ]);
-  });
-
-  it("honors URL http methods when valid", () => {
-    const patch = applyFilterOptions(
-      emptyOptions(),
-      app,
-      initConfig({ httpMethods: [HttpMethod.GET] }),
-      state(),
-    );
-    expect(patch.selectedHttpMethods).toEqual([HttpMethod.GET]);
   });
 
   it("honors URL freeText", () => {

--- a/frontend/dashboard/app/api/api_calls.ts
+++ b/frontend/dashboard/app/api/api_calls.ts
@@ -52,14 +52,6 @@ export enum SessionType {
   Background = "Background Sessions",
 }
 
-export enum HttpMethod {
-  GET = "get",
-  POST = "post",
-  PUT = "put",
-  PATCH = "patch",
-  DELETE = "delete",
-}
-
 export type Team = {
   id: string;
   name: string;
@@ -637,7 +629,6 @@ export type Filters = {
   endDate: string;
   versions: { selected: AppVersion[]; all: boolean };
   sessionTypes: { selected: SessionType[]; all: boolean };
-  httpMethods: { selected: HttpMethod[]; all: boolean };
   osVersions: { selected: OsVersion[]; all: boolean };
   countries: { selected: string[]; all: boolean };
   networkProviders: { selected: string[]; all: boolean };
@@ -667,7 +658,6 @@ export const defaultFilters: Filters = {
   endDate: "",
   versions: { selected: [], all: false },
   sessionTypes: { selected: [], all: false },
-  httpMethods: { selected: [], all: false },
   osVersions: { selected: [], all: false },
   countries: { selected: [], all: false },
   networkProviders: { selected: [], all: false },
@@ -898,29 +888,6 @@ function appendSessionTypesToUrl(url: string, filters: Filters): string {
     if (severities.size > 0) {
       u.searchParams.append("severity", Array.from(severities).join(","));
     }
-  }
-  return u.toString();
-}
-
-// Adds the network page's endpoint selection to a plot request. Empty values are sent as
-// empty, which the server reads as "every domain" or "every path".
-function appendEndpointSelectionToUrl(
-  url: string,
-  domain: string,
-  path: string,
-): string {
-  const u = new URL(url, window.location.origin);
-  u.searchParams.set("domain", domain);
-  u.searchParams.set("path", path);
-  return u.toString();
-}
-
-function appendHttpMethodsToUrl(url: string, filters: Filters): string {
-  const u = new URL(url, window.location.origin);
-  if (!filters.httpMethods.all && filters.httpMethods.selected.length > 0) {
-    filters.httpMethods.selected.forEach((v) => {
-      u.searchParams.append("http_methods", v);
-    });
   }
   return u.toString();
 }
@@ -1932,46 +1899,78 @@ export const updateSdkConfigFromServer = async (
 
 export type NetworkEndpoint = { domain: string; path_pattern: string };
 
+function networkRequestParams(
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
+): URLSearchParams {
+  const params = new URLSearchParams({
+    from: formatUserInputDateToServerFormat(startDate),
+    to: formatUserInputDateToServerFormat(endDate),
+    timezone: getTimeZoneForServer(),
+  });
+  if (filterExpr) {
+    params.set("filter_expr", filterExpr);
+  }
+  return params;
+}
+
+// An empty domain or path is sent as is and means every domain or path.
+function networkPlotParams(
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
+  domain: string,
+  path: string,
+): URLSearchParams {
+  const params = networkRequestParams(startDate, endDate, filterExpr);
+  params.set("domain", domain);
+  params.set("path", path);
+  return params;
+}
+
 export const fetchNetworkEndpointsFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   query: string,
   signal?: AbortSignal,
 ): Promise<NetworkEndpoint[]> => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/endpoints?`;
-
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl = appendHttpMethodsToUrl(apiUrl, filters);
-
-  const u = new URL(apiUrl, window.location.origin);
+  const params = networkRequestParams(startDate, endDate, filterExpr);
   if (query !== "") {
-    u.searchParams.append("query", query);
+    params.set("query", query);
   }
 
-  const data = await request(u.toString(), {
-    failsWith: "Failed to fetch network endpoints",
-    signal,
-  });
+  const data = await request(
+    `/api/apps/${appId}/networkRequests/endpoints?${params.toString()}`,
+    { failsWith: "Failed to fetch network endpoints", signal },
+  );
 
   return (data?.results as NetworkEndpoint[] | null) ?? [];
 };
 
-// The three plots below take the page's endpoint selection. An empty domain covers every
-// domain, and an empty path every path within one.
 export const fetchNetworkLatencyPlotFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   domain: string,
   path: string,
 ) => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/plots/latency?`;
+  const params = networkPlotParams(
+    startDate,
+    endDate,
+    filterExpr,
+    domain,
+    path,
+  );
+  params.set("plot_time_group", getPlotTimeGroupForRange(startDate, endDate));
 
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl = appendPlotTimeGroupToUrl(apiUrl, filters);
-  apiUrl = appendHttpMethodsToUrl(apiUrl, filters);
-  apiUrl = appendEndpointSelectionToUrl(apiUrl, domain, path);
-
-  const data = await request(apiUrl, {
-    failsWith: "Failed to fetch network latency plot",
-  });
+  const data = await request(
+    `/api/apps/${appId}/networkRequests/plots/latency?${params.toString()}`,
+    { failsWith: "Failed to fetch network latency plot" },
+  );
 
   return data === null || (Array.isArray(data) && data.length === 0)
     ? null
@@ -1979,20 +1978,26 @@ export const fetchNetworkLatencyPlotFromServer = async (
 };
 
 export const fetchNetworkStatusCodesPlotFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   domain: string,
   path: string,
 ) => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/plots/statusCodes?`;
+  const params = networkPlotParams(
+    startDate,
+    endDate,
+    filterExpr,
+    domain,
+    path,
+  );
+  params.set("plot_time_group", getPlotTimeGroupForRange(startDate, endDate));
 
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl = appendPlotTimeGroupToUrl(apiUrl, filters);
-  apiUrl = appendHttpMethodsToUrl(apiUrl, filters);
-  apiUrl = appendEndpointSelectionToUrl(apiUrl, domain, path);
-
-  const data = await request(apiUrl, {
-    failsWith: "Failed to fetch network status codes plot",
-  });
+  const data = await request(
+    `/api/apps/${appId}/networkRequests/plots/statusCodes?${params.toString()}`,
+    { failsWith: "Failed to fetch network status codes plot" },
+  );
 
   if (data === null || (Array.isArray(data) && data.length === 0)) {
     return null;
@@ -2002,20 +2007,26 @@ export const fetchNetworkStatusCodesPlotFromServer = async (
 };
 
 export const fetchNetworkEndpointStatusCodesPlotFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   domain: string,
   path: string,
 ) => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/plots/endpointStatusCodes?`;
+  const params = networkPlotParams(
+    startDate,
+    endDate,
+    filterExpr,
+    domain,
+    path,
+  );
+  params.set("plot_time_group", getPlotTimeGroupForRange(startDate, endDate));
 
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl = appendPlotTimeGroupToUrl(apiUrl, filters);
-  apiUrl = appendHttpMethodsToUrl(apiUrl, filters);
-  apiUrl = appendEndpointSelectionToUrl(apiUrl, domain, path);
-
-  const data = await request(apiUrl, {
-    failsWith: "Failed to fetch network endpoint status codes plot",
-  });
+  const data = await request(
+    `/api/apps/${appId}/networkRequests/plots/endpointStatusCodes?${params.toString()}`,
+    { failsWith: "Failed to fetch network endpoint status codes plot" },
+  );
 
   if (data === null || !data.data_points || data.data_points.length === 0) {
     return null;
@@ -2025,19 +2036,25 @@ export const fetchNetworkEndpointStatusCodesPlotFromServer = async (
 };
 
 export const fetchNetworkTimelinePlotFromServer = async (
-  filters: Filters,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
   domain: string,
   path: string,
 ) => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/plots/timeline?`;
+  const params = networkPlotParams(
+    startDate,
+    endDate,
+    filterExpr,
+    domain,
+    path,
+  );
 
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl = appendHttpMethodsToUrl(apiUrl, filters);
-  apiUrl = appendEndpointSelectionToUrl(apiUrl, domain, path);
-
-  const data = await request(apiUrl, {
-    failsWith: "Failed to fetch network timeline plot",
-  });
+  const data = await request(
+    `/api/apps/${appId}/networkRequests/plots/timeline?${params.toString()}`,
+    { failsWith: "Failed to fetch network timeline plot" },
+  );
 
   if (data === null || !data.points || data.points.length === 0) {
     return null;
@@ -2047,17 +2064,17 @@ export const fetchNetworkTimelinePlotFromServer = async (
 };
 
 export const fetchNetworkTrendsFromServer = async (
-  filters: Filters,
-  trendsLimit: number = 10,
+  appId: string,
+  startDate: string,
+  endDate: string,
+  filterExpr: string | null,
+  trendsLimit: number,
 ) => {
-  var apiUrl = `/api/apps/${filters.app!.id}/networkRequests/trends?`;
+  const params = networkRequestParams(startDate, endDate, filterExpr);
+  params.set("trends_limit", String(trendsLimit));
 
-  apiUrl = await applyGenericFiltersToUrl(apiUrl, filters, null, null);
-  apiUrl += `&trends_limit=${trendsLimit}`;
-
-  const data = await request(apiUrl, {
-    failsWith: "Failed to fetch network trends",
-  });
-
-  return data;
+  return await request(
+    `/api/apps/${appId}/networkRequests/trends?${params.toString()}`,
+    { failsWith: "Failed to fetch network trends" },
+  );
 };

--- a/frontend/dashboard/app/components/feature_demo_carousel.tsx
+++ b/frontend/dashboard/app/components/feature_demo_carousel.tsx
@@ -23,9 +23,10 @@ const ErrorsDetails = dynamic(
     ),
   { ssr: false },
 );
-const NetworkOverview = dynamic(() => import("./network_overview"), {
-  ssr: false,
-});
+const NetworkOverviewDemo = dynamic(
+  () => import("./network_overview").then((m) => m.NetworkOverviewDemo),
+  { ssr: false },
+);
 
 // Each demo renders at its own natural height; sizing the frame per feature
 // keeps short demos from ending in dead space while the tall dashboards stay
@@ -177,7 +178,7 @@ export default function FeatureDemoCarousel() {
     <TraceDetails demo={true} hideDemoTitle={false} key="demo-trace" />,
     <BugReport demo={true} hideDemoTitle={false} key="demo-bugreport" />,
     <UserJourneysDemo key="demo-journeys" />,
-    <NetworkOverview demo={true} hideDemoTitle={false} key="demo-network" />,
+    <NetworkOverviewDemo key="demo-network" />,
   ];
 
   return (

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -76,6 +76,7 @@ interface FilterBarProps {
   keysUnavailable: boolean;
   spanNames?: string[] | null;
   filterExprIssues?: FilterExprIssue[] | null;
+  showAppSelect?: boolean;
   // False hides the filter expression editor and keeps the app and date
   // range controls.
   showFilterExpr?: boolean;
@@ -191,6 +192,7 @@ export default function FilterBar({
   keysUnavailable,
   spanNames,
   filterExprIssues,
+  showAppSelect = true,
   showFilterExpr = true,
   onChange,
 }: FilterBarProps) {
@@ -309,7 +311,7 @@ export default function FilterBar({
   if (value === null || keys === null) {
     return (
       <div className="flex flex-wrap gap-4 items-center w-full">
-        <Skeleton className="h-9 w-37.5" />
+        {showAppSelect && <Skeleton className="h-9 w-37.5" />}
         <Skeleton className="h-9 w-37.5" />
         {showFilterExpr && <Skeleton className="h-9 flex-1 min-w-64" />}
       </div>
@@ -542,7 +544,9 @@ export default function FilterBar({
 
   return (
     <div className="flex flex-wrap gap-4 items-start w-full">
-      <AppSelect apps={apps} selected={app} onChange={setApp} />
+      {showAppSelect && (
+        <AppSelect apps={apps} selected={app} onChange={setApp} />
+      )}
       <DateRangeSelect
         selection={value.date}
         onChange={(selection) =>

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -17,13 +17,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  App,
-  AppVersion,
-  FilterSource,
-  HttpMethod,
-  SessionType,
-} from "../api/api_calls";
+import { App, AppVersion, FilterSource, SessionType } from "../api/api_calls";
 import { useAppsQuery, useFilterOptionsQuery } from "../query/hooks";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -93,7 +87,6 @@ interface FiltersProps {
   showLocales?: boolean;
   showDeviceManufacturers?: boolean;
   showDeviceNames?: boolean;
-  showHttpMethods?: boolean;
   showUdAttrs?: boolean;
   showFreeText?: boolean;
   showErrorType?: boolean;
@@ -216,14 +209,6 @@ export function deserializeUrlFilters(queryString: string): URLFilters {
               return { key, type, op, value: val } as UdAttrMatcher;
             })
             .filter((m) => m.key && m.type && m.op && m.value);
-          break;
-
-        case "httpMethods":
-          result[originalKey] = value
-            .split(",")
-            .filter((s): s is HttpMethod =>
-              Object.values(HttpMethod).includes(s as HttpMethod),
-            );
           break;
 
         case "sessionTypes":
@@ -493,7 +478,6 @@ const FiltersComponent = forwardRef<
       showLocales = false,
       showDeviceManufacturers = false,
       showDeviceNames = false,
-      showHttpMethods = false,
       showUdAttrs = false,
       showFreeText = false,
       showErrorType = false,
@@ -547,7 +531,6 @@ const FiltersComponent = forwardRef<
         showLocales,
         showDeviceManufacturers,
         showDeviceNames,
-        showHttpMethods,
         showUdAttrs,
         showFreeText,
       });
@@ -568,7 +551,6 @@ const FiltersComponent = forwardRef<
       showLocales,
       showDeviceManufacturers,
       showDeviceNames,
-      showHttpMethods,
       showUdAttrs,
       showFreeText,
     ]);
@@ -734,7 +716,6 @@ const FiltersComponent = forwardRef<
     // confirms.
     type PendingModalFilters = {
       selectedSessionTypes: SessionType[];
-      selectedHttpMethods: HttpMethod[];
       selectedOsVersions: typeof store.selectedOsVersions;
       selectedCountries: string[];
       selectedNetworkProviders: string[];
@@ -748,7 +729,6 @@ const FiltersComponent = forwardRef<
     const [pendingModalFilters, setPendingModalFilters] =
       useState<PendingModalFilters>(() => ({
         selectedSessionTypes: store.selectedSessionTypes,
-        selectedHttpMethods: store.selectedHttpMethods,
         selectedOsVersions: store.selectedOsVersions,
         selectedCountries: store.selectedCountries,
         selectedNetworkProviders: store.selectedNetworkProviders,
@@ -770,7 +750,6 @@ const FiltersComponent = forwardRef<
       if (moreFiltersOpen) {
         setPendingModalFilters({
           selectedSessionTypes: store.selectedSessionTypes,
-          selectedHttpMethods: store.selectedHttpMethods,
           selectedOsVersions: store.selectedOsVersions,
           selectedCountries: store.selectedCountries,
           selectedNetworkProviders: store.selectedNetworkProviders,
@@ -787,7 +766,6 @@ const FiltersComponent = forwardRef<
     // Commit the pending snapshot to the store and close the modal.
     const saveMoreFilters = () => {
       store.setSelectedSessionTypes(pendingModalFilters.selectedSessionTypes);
-      store.setSelectedHttpMethods(pendingModalFilters.selectedHttpMethods);
       store.setSelectedOsVersions(pendingModalFilters.selectedOsVersions);
       store.setSelectedCountries(pendingModalFilters.selectedCountries);
       store.setSelectedNetworkProviders(
@@ -831,7 +809,6 @@ const FiltersComponent = forwardRef<
     // (no loaded data) so the skeleton can reserve the trigger's slot.
     const hasMoreFiltersConfig =
       showSessionTypes ||
-      showHttpMethods ||
       showOsVersions ||
       showCountries ||
       showNetworkProviders ||
@@ -868,7 +845,6 @@ const FiltersComponent = forwardRef<
     // trigger so it never opens an empty modal.
     const hasMoreFilters =
       showSessionTypes ||
-      showHttpMethods ||
       (showOsVersions && store.osVersions.length > 0) ||
       (showCountries && store.countries.length > 0) ||
       (showNetworkProviders && store.networkProviders.length > 0) ||
@@ -898,23 +874,6 @@ const FiltersComponent = forwardRef<
           : resetAction(() =>
               store.setSelectedSessionTypes(defaultSessionTypes),
             ),
-      });
-    }
-    if (showHttpMethods && store.selectedHttpMethods.length > 0) {
-      filterChips.push({
-        key: "httpMethods",
-        ...chipLabels(
-          "HTTP Method",
-          store.selectedHttpMethods.map((m) => m.toUpperCase()),
-        ),
-        action:
-          store.selectedHttpMethods.length === Object.values(HttpMethod).length
-            ? undefined
-            : resetAction(() =>
-                store.setSelectedHttpMethods(
-                  Object.values(HttpMethod) as HttpMethod[],
-                ),
-              ),
       });
     }
     if (showOsVersions && store.selectedOsVersions.length > 0) {
@@ -1087,21 +1046,6 @@ const FiltersComponent = forwardRef<
               setPendingModalFilters((p) => ({
                 ...p,
                 selectedSessionTypes: items as SessionType[],
-              }))
-            }
-          />
-        )}
-        {showHttpMethods && (
-          <StringMultiRow
-            rowKey="httpMethods"
-            title="HTTP Method"
-            items={Object.values(HttpMethod)}
-            selected={pendingModalFilters.selectedHttpMethods}
-            getLabel={(item) => item.toUpperCase()}
-            onChange={(items) =>
-              setPendingModalFilters((p) => ({
-                ...p,
-                selectedHttpMethods: items as HttpMethod[],
               }))
             }
           />

--- a/frontend/dashboard/app/components/network_details.tsx
+++ b/frontend/dashboard/app/components/network_details.tsx
@@ -1,41 +1,56 @@
 "use client";
 
-import { FilterSource } from "@/app/api/api_calls";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import { filterExprIssuesIn } from "@/app/api/api_error";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import InfoTooltip from "@/app/components/info_tooltip";
 import NetworkEndpointStatusCodesPlot from "@/app/components/network_endpoint_status_codes_plot";
 import NetworkLatencyPlot from "@/app/components/network_latency_plot";
 import NetworkTimelinePlot from "@/app/components/network_timeline_plot";
-import { Skeleton, SkeletonPlot } from "@/app/components/skeleton";
+import { SkeletonListPage, SkeletonPlot } from "@/app/components/skeleton";
 import {
-  useNetworkLatencyQuery,
   useNetworkEndpointStatusCodesQuery,
+  useNetworkLatencyQuery,
   useNetworkTimelineQuery,
 } from "@/app/query/hooks";
-import { useFiltersStore } from "@/app/stores/provider";
 import { underlineLinkStyle } from "@/app/utils/shared_styles";
 import { getPlotTimeGroupForRange } from "@/app/utils/time_utils";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 
 interface NetworkDetailsProps {
   params: { teamId: string };
 }
 
 export default function NetworkDetails({ params }: NetworkDetailsProps) {
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const filters = useFiltersStore((state) => state.filters);
   const domain = searchParams.get("domain") ?? "";
   const path = searchParams.get("path") ?? "";
 
-  const latencyQuery = useNetworkLatencyQuery(domain, path);
-  const statusCodesQuery = useNetworkEndpointStatusCodesQuery(domain, path);
-  const timelineQuery = useNetworkTimelineQuery(domain, path);
+  const {
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status: filterStatus,
+    filterParams,
+    onChange,
+  } = useExprFilterPage({ teamId: params.teamId, entity: "network" });
+  const readyValue = filterStatus.kind === "ready" ? value : null;
+
+  const latencyQuery = useNetworkLatencyQuery(filterParams, domain, path);
+  const statusCodesQuery = useNetworkEndpointStatusCodesQuery(
+    filterParams,
+    domain,
+    path,
+  );
+  const timelineQuery = useNetworkTimelineQuery(filterParams, domain, path);
+
+  const filterExprIssues =
+    filterExprIssuesIn(latencyQuery.error) ??
+    filterExprIssuesIn(statusCodesQuery.error) ??
+    filterExprIssuesIn(timelineQuery.error);
 
   const latencyStatus =
     latencyQuery.status === "success" &&
@@ -52,8 +67,8 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
       : timelineQuery.status;
 
   const plotTimeGroup = getPlotTimeGroupForRange(
-    filters.startDate,
-    filters.endDate,
+    readyValue?.date.startDate ?? "",
+    readyValue?.date.endDate ?? "",
   );
   const shouldRenderLatencyPlot = latencyStatus === "success";
   const shouldRenderStatusCodesPlot = statusCodesStatus === "success";
@@ -63,47 +78,37 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
     statusCodesStatus === "nodata" &&
     timelineStatus === "nodata";
 
-  useEffect(() => {
-    if (!filters.ready) {
-      return;
-    }
-
-    const query = new URLSearchParams(filters.serialisedFilters!);
-    query.set("domain", domain);
-    query.set("path", path);
-    router.replace(`${pathname}?${query.toString()}`, { scroll: false });
-  }, [domain, filters.ready, filters.serialisedFilters, path, pathname]);
-
   return (
     <div className="flex flex-col items-start w-full">
       <div className="py-4" />
-      <Filters
-        teamId={params.teamId}
-        filterSource={FilterSource.Events}
-        appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-        showAppSelector={false}
-        showOsVersions={true}
-        showCountries={true}
-        showNetworkTypes={true}
-        showNetworkProviders={true}
-        showNetworkGenerations={true}
-        showLocales={true}
-        showDeviceManufacturers={true}
-        showDeviceNames={true}
-        showHttpMethods={true}
+      <FilterBar
+        entity="network"
+        placeholder="Filter network requests…"
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
+        filterExprIssues={filterExprIssues}
+        showAppSelect={false}
+        onChange={onChange}
       />
 
-      {filters.loading && (
-        <div className="mt-6 flex flex-col w-full">
-          <Skeleton className="h-9 w-full" />
-          <div className="py-6" />
-          <SkeletonPlot />
-          <div className="py-6" />
-          <SkeletonPlot />
-        </div>
+      {filterStatus.kind === "error" && (
+        <>
+          <div className="py-4" />
+          <p className="text-lg font-display">{filterStatus.message}</p>
+        </>
       )}
 
-      {filters.ready && (
+      {filterStatus.kind === "loading" && (
+        <>
+          <div className="py-4" />
+          <SkeletonListPage />
+        </>
+      )}
+
+      {readyValue !== null && (
         <>
           <div className="py-4" />
           {hasNoData ? (

--- a/frontend/dashboard/app/components/network_endpoint_search.tsx
+++ b/frontend/dashboard/app/components/network_endpoint_search.tsx
@@ -8,7 +8,7 @@ import {
   CommandList,
 } from "@/app/components/command";
 import { Input } from "@/app/components/input";
-import { useNetworkEndpointsQuery } from "@/app/query/hooks";
+import { type FilterParams, useNetworkEndpointsQuery } from "@/app/query/hooks";
 import {
   addRecentSearch,
   getRecentSearches,
@@ -48,10 +48,12 @@ function normalizeEndpointSearch(endpoint: string): string {
 
 interface NetworkEndpointSearchProps {
   teamId: string;
+  filterParams: FilterParams | null;
 }
 
 export default function NetworkEndpointSearch({
   teamId,
+  filterParams,
 }: NetworkEndpointSearchProps) {
   const router = useRouter();
   const currentSearchParams = useSearchParams();
@@ -69,6 +71,7 @@ export default function NetworkEndpointSearch({
 
   const normalizedDebouncedQuery = normalizeEndpointSearch(debouncedQuery);
   const endpointsQuery = useNetworkEndpointsQuery(
+    filterParams,
     normalizedDebouncedQuery,
     open,
   );

--- a/frontend/dashboard/app/components/network_overview.tsx
+++ b/frontend/dashboard/app/components/network_overview.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { FilterSource } from "@/app/api/api_calls";
-
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import { filterExprIssuesIn } from "@/app/api/api_error";
+import FilterBar from "@/app/components/filter_bar/filter_bar";
+import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 import InfoTooltip from "@/app/components/info_tooltip";
 import NetworkEndpointSearch from "@/app/components/network_endpoint_search";
 import NetworkStatusDistributionPlot from "@/app/components/network_status_distribution_plot";
@@ -13,28 +11,16 @@ import NetworkTimelinePlot, {
   NetworkTimelineDataPoint,
 } from "@/app/components/network_timeline_plot";
 import NetworkTrends from "@/app/components/network_trends";
-import {
-  Skeleton,
-  SkeletonPlot,
-  SkeletonTable,
-} from "@/app/components/skeleton";
+import { SkeletonListPage, SkeletonPlot } from "@/app/components/skeleton";
 import {
   useNetworkStatusCodesQuery,
   useNetworkTimelineQuery,
 } from "@/app/query/hooks";
-import { useFiltersStore } from "@/app/stores/provider";
 import { underlineLinkStyle } from "@/app/utils/shared_styles";
 import { getPlotTimeGroupForRange } from "@/app/utils/time_utils";
 import { DateTime } from "luxon";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect } from "react";
-
-interface NetworkOverviewProps {
-  params?: { teamId: string };
-  demo?: boolean;
-  hideDemoTitle?: boolean;
-}
+import type { ComponentProps, ReactNode } from "react";
 
 function generateDemoStatusData() {
   const now = DateTime.now().toUTC();
@@ -182,218 +168,259 @@ function generateDemoTimelineData(): NetworkTimelineData {
   return { interval: 5, points };
 }
 
+type PlotStatus = "pending" | "success" | "error" | "nodata";
+
 const demoStatusData = generateDemoStatusData();
 const demoTimelineData = generateDemoTimelineData();
 
-export default function NetworkOverview({
-  params,
-  demo = false,
-  hideDemoTitle = false,
-}: NetworkOverviewProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const filters = useFiltersStore((state) => state.filters);
-
-  const statusCodesQuery = useNetworkStatusCodesQuery("", "");
-  const timelineQuery = useNetworkTimelineQuery("", "");
-
-  // In demo mode, use static data instead of store data
-  const statusPlotStatus = demo
-    ? ("success" as const)
-    : statusCodesQuery.status === "success" && statusCodesQuery.data === null
-      ? ("nodata" as const)
-      : statusCodesQuery.status;
-  const statusPlotData = demo ? demoStatusData : (statusCodesQuery.data ?? []);
-  const timelinePlotStatus = demo
-    ? ("success" as const)
-    : timelineQuery.status === "success" && timelineQuery.data === null
-      ? ("nodata" as const)
-      : timelineQuery.status;
-  const timelinePlotData = demo
-    ? demoTimelineData
-    : (timelineQuery.data ?? null);
-
-  const plotTimeGroup = demo
-    ? "days"
-    : getPlotTimeGroupForRange(filters.startDate, filters.endDate);
-  const shouldRenderStatusPlot = demo
-    ? true
-    : statusPlotStatus === "success" && statusPlotData.length > 0;
-  const shouldRenderTimeline = demo
-    ? true
-    : timelinePlotStatus === "success" &&
-      timelinePlotData !== null &&
-      timelinePlotData.points.length > 0;
-
-  // Sync filters to URL
-  useEffect(() => {
-    if (demo) return;
-    if (!filters.ready) return;
-    router.replace(`${pathname}?${filters.serialisedFilters!}`, {
-      scroll: false,
-    });
-  }, [filters.ready, filters.serialisedFilters, pathname]);
-
+export function NetworkOverviewDemo({
+  hideTitle = false,
+}: {
+  hideTitle?: boolean;
+}) {
   return (
     <div className="flex flex-col items-start">
       <p className="font-display text-4xl max-w-6xl text-center">
-        {demo ? (hideDemoTitle ? "" : "Network Performance") : ""}
+        {hideTitle ? "" : "Network Performance"}
       </p>
-      {!hideDemoTitle && <div className="py-4" />}
+      {!hideTitle && <div className="py-4" />}
+      <div className="py-8" />
 
-      {!demo && params && (
-        <Filters
-          teamId={params.teamId}
-          filterSource={FilterSource.Events}
-          appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-          showOsVersions={true}
-          showCountries={true}
-          showNetworkTypes={true}
-          showNetworkProviders={true}
-          showNetworkGenerations={true}
-          showLocales={true}
-          showDeviceManufacturers={true}
-          showDeviceNames={true}
-          showHttpMethods={true}
-        />
-      )}
+      <NetworkOverviewSections
+        statusPlotStatus="success"
+        statusPlotData={demoStatusData}
+        plotTimeGroup="days"
+        trends={<NetworkTrends demo />}
+        timelinePlotStatus="success"
+        timelinePlotData={demoTimelineData}
+        timelineTooltip="Distribution of when endpoint patterns are typically called in a session."
+      />
+    </div>
+  );
+}
 
-      {!demo && filters.loading && (
-        <div className="flex flex-col w-full">
-          <div className="py-4" />
-          <Skeleton className="h-9 w-full" />
-          <div className="py-6" />
-          <div className="flex font-body items-center justify-center w-full h-144">
-            <SkeletonPlot />
-          </div>
-          <div className="py-6" />
-          <div className="flex font-body items-center justify-center w-full h-144">
-            <SkeletonPlot />
-          </div>
-          <div className="py-8" />
-          <Skeleton className="h-6 w-36" />
-          <SkeletonTable rows={5} columns={4} />
-        </div>
-      )}
+export default function NetworkOverview({
+  params,
+}: {
+  params: { teamId: string };
+}) {
+  const { teamId } = params;
+  const {
+    value,
+    apps,
+    keys,
+    keyGroups,
+    keysUnavailable,
+    status: filterStatus,
+    filterParams,
+    onChange,
+  } = useExprFilterPage({ teamId, entity: "network" });
+  const readyValue = filterStatus.kind === "ready" ? value : null;
 
-      {(demo || filters.ready) && (
+  const statusCodesQuery = useNetworkStatusCodesQuery(filterParams, "", "");
+  const timelineQuery = useNetworkTimelineQuery(filterParams, "", "");
+
+  const filterExprIssues =
+    filterExprIssuesIn(statusCodesQuery.error) ??
+    filterExprIssuesIn(timelineQuery.error);
+
+  const statusPlotStatus =
+    statusCodesQuery.status === "success" && statusCodesQuery.data === null
+      ? ("nodata" as const)
+      : statusCodesQuery.status;
+  const statusPlotData = statusCodesQuery.data ?? [];
+  const timelinePlotStatus =
+    timelineQuery.status === "success" && timelineQuery.data === null
+      ? ("nodata" as const)
+      : timelineQuery.status;
+  const timelinePlotData = timelineQuery.data ?? null;
+
+  const plotTimeGroup = getPlotTimeGroupForRange(
+    readyValue?.date.startDate ?? "",
+    readyValue?.date.endDate ?? "",
+  );
+
+  return (
+    <div className="flex flex-col items-start">
+      <div className="py-4" />
+
+      <FilterBar
+        entity="network"
+        placeholder="Filter network requests…"
+        value={value}
+        apps={apps}
+        keys={keys}
+        keyGroups={keyGroups}
+        keysUnavailable={keysUnavailable}
+        filterExprIssues={filterExprIssues}
+        onChange={onChange}
+      />
+
+      {filterStatus.kind === "error" && (
         <>
-          {!demo && params && (
-            <>
-              <div className="py-8" />
-              <div className="flex items-center gap-2">
-                <p className="font-display text-xl">Explore Endpoints</p>
-                <InfoTooltip
-                  content={
-                    <>
-                      <Link
-                        href="/docs/network-monitoring/endpoint-patterns#searching-for-endpoints"
-                        className={underlineLinkStyle}
-                      >
-                        Learn more
-                      </Link>{" "}
-                      about endpoint search and using wildcards.
-                    </>
-                  }
-                />
-              </div>
-              <div className="py-4" />
-              <NetworkEndpointSearch
-                key={params.teamId}
-                teamId={params.teamId}
-              />
-            </>
-          )}
+          <div className="py-4" />
+          <p className="text-lg font-display">{filterStatus.message}</p>
+        </>
+      )}
+
+      {filterStatus.kind === "loading" && (
+        <>
+          <div className="py-4" />
+          <SkeletonListPage />
+        </>
+      )}
+
+      {readyValue !== null && (
+        <>
+          <div className="py-8" />
+          <div className="flex items-center gap-2">
+            <p className="font-display text-xl">Explore Endpoints</p>
+            <InfoTooltip
+              content={
+                <>
+                  <Link
+                    href="/docs/network-monitoring/endpoint-patterns#searching-for-endpoints"
+                    className={underlineLinkStyle}
+                  >
+                    Learn more
+                  </Link>{" "}
+                  about endpoint search and using wildcards.
+                </>
+              }
+            />
+          </div>
+          <div className="py-4" />
+          <NetworkEndpointSearch
+            key={teamId}
+            teamId={teamId}
+            filterParams={filterParams}
+          />
 
           <div className="py-8" />
 
-          {/* Status Distribution Section */}
-          <div className="w-full">
-            <p className="font-display text-xl">Status Distribution</p>
-            <div className="py-2" />
-            <div className="flex font-body items-center justify-center w-full h-144">
-              {(statusPlotStatus === "pending" ||
-                (statusPlotStatus === "success" &&
-                  !shouldRenderStatusPlot)) && <SkeletonPlot />}
-              {shouldRenderStatusPlot && (
-                <NetworkStatusDistributionPlot
-                  data={statusPlotData}
-                  plotTimeGroup={plotTimeGroup}
-                />
-              )}
-              {statusPlotStatus === "nodata" && (
-                <p className="font-body text-sm">
-                  No data available for the selected filters
-                </p>
-              )}
-              {statusPlotStatus === "error" && (
-                <p className="font-body text-sm">
-                  Error fetching status distribution, please change filters &
-                  try again
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div className="py-8" />
-
-          {/* Top Endpoints Section */}
-          <div className="w-full">
-            <NetworkTrends teamId={params?.teamId} active demo={demo} />
-          </div>
-
-          <div className="py-10" />
-
-          {/* Request Timeline Section */}
-          <div className="w-full">
-            <div className="flex items-center gap-2">
-              <p className="font-display text-xl">Timeline</p>
-              <InfoTooltip
-                content={
-                  <>
-                    Distribution of when endpoint patterns are typically called
-                    in a session.
-                    {!demo && (
-                      <>
-                        {" "}
-                        <Link
-                          href="/docs/network-monitoring/endpoint-patterns#request-timeline"
-                          className={underlineLinkStyle}
-                        >
-                          Learn more
-                        </Link>{" "}
-                        about how the timeline is generated
-                      </>
-                    )}
-                  </>
-                }
+          <NetworkOverviewSections
+            statusPlotStatus={statusPlotStatus}
+            statusPlotData={statusPlotData}
+            plotTimeGroup={plotTimeGroup}
+            trends={
+              <NetworkTrends
+                teamId={teamId}
+                filterParams={filterParams}
+                active
               />
-            </div>
-            {shouldRenderTimeline && (
-              <div className="py-8">
-                <NetworkTimelinePlot data={timelinePlotData!} />
-              </div>
-            )}
-            {!shouldRenderTimeline && (
-              <div className="flex font-body items-center justify-center w-full h-144">
-                {timelinePlotStatus === "pending" && <SkeletonPlot />}
-                {(timelinePlotStatus === "nodata" ||
-                  timelinePlotStatus === "success") && (
-                  <p className="font-body text-sm">
-                    No data available for the selected filters
-                  </p>
-                )}
-                {timelinePlotStatus === "error" && (
-                  <p className="font-body text-sm">
-                    Error fetching requests timeline, please change filters &
-                    try again
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
+            }
+            timelinePlotStatus={timelinePlotStatus}
+            timelinePlotData={timelinePlotData}
+            timelineTooltip={
+              <>
+                Distribution of when endpoint patterns are typically called in a
+                session.{" "}
+                <Link
+                  href="/docs/network-monitoring/endpoint-patterns#request-timeline"
+                  className={underlineLinkStyle}
+                >
+                  Learn more
+                </Link>{" "}
+                about how the timeline is generated
+              </>
+            }
+          />
         </>
       )}
     </div>
+  );
+}
+
+function NetworkOverviewSections({
+  statusPlotStatus,
+  statusPlotData,
+  plotTimeGroup,
+  trends,
+  timelinePlotStatus,
+  timelinePlotData,
+  timelineTooltip,
+}: {
+  statusPlotStatus: PlotStatus;
+  statusPlotData: ComponentProps<typeof NetworkStatusDistributionPlot>["data"];
+  plotTimeGroup: ComponentProps<
+    typeof NetworkStatusDistributionPlot
+  >["plotTimeGroup"];
+  trends: ReactNode;
+  timelinePlotStatus: PlotStatus;
+  timelinePlotData: NetworkTimelineData | null;
+  timelineTooltip: ReactNode;
+}) {
+  const shouldRenderStatusPlot =
+    statusPlotStatus === "success" && statusPlotData.length > 0;
+  const shouldRenderTimeline =
+    timelinePlotStatus === "success" &&
+    timelinePlotData !== null &&
+    timelinePlotData.points.length > 0;
+
+  return (
+    <>
+      <div className="w-full">
+        <p className="font-display text-xl">Status Distribution</p>
+        <div className="py-2" />
+        <div className="flex font-body items-center justify-center w-full h-144">
+          {(statusPlotStatus === "pending" ||
+            (statusPlotStatus === "success" && !shouldRenderStatusPlot)) && (
+            <SkeletonPlot />
+          )}
+          {shouldRenderStatusPlot && (
+            <NetworkStatusDistributionPlot
+              data={statusPlotData}
+              plotTimeGroup={plotTimeGroup}
+            />
+          )}
+          {statusPlotStatus === "nodata" && (
+            <p className="font-body text-sm">
+              No data available for the selected filters
+            </p>
+          )}
+          {statusPlotStatus === "error" && (
+            <p className="font-body text-sm">
+              Error fetching status distribution, please change filters & try
+              again
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="py-8" />
+
+      <div className="w-full">{trends}</div>
+
+      <div className="py-10" />
+
+      <div className="w-full">
+        <div className="flex items-center gap-2">
+          <p className="font-display text-xl">Timeline</p>
+          <InfoTooltip content={timelineTooltip} />
+        </div>
+        {shouldRenderTimeline && (
+          <div className="py-8">
+            <NetworkTimelinePlot data={timelinePlotData!} />
+          </div>
+        )}
+        {!shouldRenderTimeline && (
+          <div className="flex font-body items-center justify-center w-full h-144">
+            {timelinePlotStatus === "pending" && <SkeletonPlot />}
+            {(timelinePlotStatus === "nodata" ||
+              timelinePlotStatus === "success") && (
+              <p className="font-body text-sm">
+                No data available for the selected filters
+              </p>
+            )}
+            {timelinePlotStatus === "error" && (
+              <p className="font-body text-sm">
+                Error fetching requests timeline, please change filters & try
+                again
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/frontend/dashboard/app/components/network_trends.tsx
+++ b/frontend/dashboard/app/components/network_trends.tsx
@@ -11,7 +11,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/components/table";
-import { TrendsTab, useNetworkTrendsQuery } from "@/app/query/hooks";
+import {
+  type FilterParams,
+  TrendsTab,
+  useNetworkTrendsQuery,
+} from "@/app/query/hooks";
 import { numberToKMB } from "@/app/utils/number_utils";
 import { underlineLinkStyle } from "@/app/utils/shared_styles";
 import { formatMillisToHumanReadable } from "@/app/utils/time_utils";
@@ -146,18 +150,20 @@ const demoTrends = generateDemoTrends();
 
 interface NetworkTrendsProps {
   teamId?: string;
+  filterParams?: FilterParams | null;
   demo?: boolean;
   active?: boolean;
 }
 
 export default function NetworkTrends({
   teamId,
+  filterParams = null,
   demo = false,
   active = true,
 }: NetworkTrendsProps) {
   const router = useRouter();
   const currentSearchParams = useSearchParams();
-  const trendsQuery = useNetworkTrendsQuery(active);
+  const trendsQuery = useNetworkTrendsQuery(filterParams, active);
 
   const [selectedTab, setSelectedTab] = useState<TrendsTab>(TrendsTab.Latency);
 

--- a/frontend/dashboard/app/product/network-performance/network_demo.tsx
+++ b/frontend/dashboard/app/product/network-performance/network_demo.tsx
@@ -2,11 +2,14 @@
 
 import dynamic from "next/dynamic";
 
-const NetworkOverview = dynamic(
-  () => import("../../components/network_overview"),
+const Demo = dynamic(
+  () =>
+    import("../../components/network_overview").then(
+      (m) => m.NetworkOverviewDemo,
+    ),
   { ssr: false },
 );
 
 export default function NetworkDemo() {
-  return <NetworkOverview demo={true} hideDemoTitle={true} />;
+  return <Demo hideTitle />;
 }

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -490,84 +490,174 @@ export function useJourneyQuery(params: FilterParams | null) {
 
 const NETWORK_TRENDS_LIMIT = 10;
 
-export function useNetworkEndpointsQuery(query: string, enabled: boolean) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useNetworkEndpointsQuery(
+  params: FilterParams | null,
+  query: string,
+  enabled: boolean,
+) {
   return useQuery({
-    queryKey: ["networkEndpoints", filters.serialisedFilters, query] as const,
+    queryKey: [
+      "networkEndpoints",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+      query,
+    ] as const,
     queryFn: ({ signal }) =>
-      fetchNetworkEndpointsFromServer(filters, query, signal),
-    enabled: enabled && filters.ready && !!filters.app,
+      fetchNetworkEndpointsFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        query,
+        signal,
+      ),
+    enabled: enabled && params !== null,
+    retry: false,
   });
 }
 
-export function useNetworkLatencyQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters);
-  return useQuery({
-    queryKey: [
-      "networkLatency",
-      filters.serialisedFilters,
-      domain,
-      path,
-    ] as const,
-    queryFn: () => fetchNetworkLatencyPlotFromServer(filters, domain, path),
-    // Latency only renders once a domain or path scope is picked, so a page
-    // without either has nothing to fetch.
-    enabled: filters.ready && !!filters.app && (domain !== "" || path !== ""),
-  });
-}
-
-export function useNetworkStatusCodesQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters);
-  return useQuery({
-    queryKey: [
-      "networkStatusCodes",
-      filters.serialisedFilters,
-      domain,
-      path,
-    ] as const,
-    queryFn: () => fetchNetworkStatusCodesPlotFromServer(filters, domain, path),
-    enabled: filters.ready && !!filters.app,
-  });
-}
-
-export function useNetworkEndpointStatusCodesQuery(
+export function useNetworkLatencyQuery(
+  params: FilterParams | null,
   domain: string,
   path: string,
 ) {
-  const filters = useFiltersStore((s) => s.filters);
   return useQuery({
     queryKey: [
-      "networkEndpointStatusCodes",
-      filters.serialisedFilters,
+      "networkLatency",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
       domain,
       path,
     ] as const,
     queryFn: () =>
-      fetchNetworkEndpointStatusCodesPlotFromServer(filters, domain, path),
-    enabled: filters.ready && !!filters.app && (domain !== "" || path !== ""),
+      fetchNetworkLatencyPlotFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        domain,
+        path,
+      ),
+    // Latency only renders once a domain or path scope is picked, so a page
+    // without either has nothing to fetch.
+    enabled: params !== null && (domain !== "" || path !== ""),
+    retry: false,
   });
 }
 
-export function useNetworkTimelineQuery(domain: string, path: string) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useNetworkStatusCodesQuery(
+  params: FilterParams | null,
+  domain: string,
+  path: string,
+) {
   return useQuery({
     queryKey: [
-      "networkTimeline",
-      filters.serialisedFilters,
+      "networkStatusCodes",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
       domain,
       path,
     ] as const,
-    queryFn: () => fetchNetworkTimelinePlotFromServer(filters, domain, path),
-    enabled: filters.ready && !!filters.app,
+    queryFn: () =>
+      fetchNetworkStatusCodesPlotFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        domain,
+        path,
+      ),
+    enabled: params !== null,
+    retry: false,
   });
 }
 
-export function useNetworkTrendsQuery(active: boolean) {
-  const filters = useFiltersStore((s) => s.filters);
+export function useNetworkEndpointStatusCodesQuery(
+  params: FilterParams | null,
+  domain: string,
+  path: string,
+) {
   return useQuery({
-    queryKey: ["networkTrends", filters.serialisedFilters] as const,
-    queryFn: () => fetchNetworkTrendsFromServer(filters, NETWORK_TRENDS_LIMIT),
-    enabled: filters.ready && active,
+    queryKey: [
+      "networkEndpointStatusCodes",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+      domain,
+      path,
+    ] as const,
+    queryFn: () =>
+      fetchNetworkEndpointStatusCodesPlotFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        domain,
+        path,
+      ),
+    enabled: params !== null && (domain !== "" || path !== ""),
+    retry: false,
+  });
+}
+
+export function useNetworkTimelineQuery(
+  params: FilterParams | null,
+  domain: string,
+  path: string,
+) {
+  return useQuery({
+    queryKey: [
+      "networkTimeline",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+      domain,
+      path,
+    ] as const,
+    queryFn: () =>
+      fetchNetworkTimelinePlotFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        domain,
+        path,
+      ),
+    enabled: params !== null,
+    retry: false,
+  });
+}
+
+export function useNetworkTrendsQuery(
+  params: FilterParams | null,
+  active: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      "networkTrends",
+      params?.appId,
+      params?.startDate,
+      params?.endDate,
+      params?.filterExpr,
+    ] as const,
+    queryFn: () =>
+      fetchNetworkTrendsFromServer(
+        params!.appId,
+        params!.startDate,
+        params!.endDate,
+        params!.filterExpr,
+        NETWORK_TRENDS_LIMIT,
+      ),
+    enabled: active && params !== null,
+    retry: false,
   });
 }
 

--- a/frontend/dashboard/app/stores/filters_store.ts
+++ b/frontend/dashboard/app/stores/filters_store.ts
@@ -7,7 +7,6 @@ import {
   defaultFilters,
   Filters,
   FilterSource,
-  HttpMethod,
   OsVersion,
   saveListFiltersToServer,
   SessionType,
@@ -40,7 +39,6 @@ export type FilterConfig = {
   showLocales: boolean;
   showDeviceManufacturers: boolean;
   showDeviceNames: boolean;
-  showHttpMethods: boolean;
   showUdAttrs: boolean;
   showFreeText: boolean;
 };
@@ -52,7 +50,6 @@ export type URLFilters = {
   dateRange?: string;
   versions?: number[];
   sessionTypes?: SessionType[];
-  httpMethods?: HttpMethod[];
   osVersions?: number[];
   countries?: number[];
   networkProviders?: number[];
@@ -89,13 +86,6 @@ export type FilterOptionsData = {
   userDefAttrOps: Map<string, string[]>;
 };
 
-const allHttpMethods = [
-  HttpMethod.GET,
-  HttpMethod.POST,
-  HttpMethod.PUT,
-  HttpMethod.PATCH,
-  HttpMethod.DELETE,
-];
 const allSessionTypes = [
   SessionType.FatalErrors,
   SessionType.UnhandledErrors,
@@ -121,7 +111,6 @@ const urlFiltersKeyMap = {
   endDate: "ed",
   versions: "v",
   sessionTypes: "st",
-  httpMethods: "hm",
   osVersions: "os",
   countries: "c",
   networkProviders: "np",
@@ -219,9 +208,6 @@ function serializeUrlFilters(
       case "deviceNames":
         if (!config.showDeviceNames) return;
         break;
-      case "httpMethods":
-        if (!config.showHttpMethods) return;
-        break;
       case "udAttrMatchers":
         if (!config.showUdAttrs) return;
         break;
@@ -270,10 +256,6 @@ function serializeUrlFilters(
               `${encodeURIComponent(m.key)}~${encodeURIComponent(m.type)}~${encodeURIComponent(m.op)}~${encodeURIComponent(m.value)}`,
           )
           .join("|");
-        break;
-      case "httpMethods":
-        if ((value as string[]).length === 0) return;
-        serializedValue = (value as string[]).join(",");
         break;
       case "sessionTypes":
         if ((value as SessionType[]).length === 0) return;
@@ -355,7 +337,6 @@ interface FiltersStoreState {
   // every Filters mount via applyFilterOptions.
   selectedVersions: AppVersion[];
   selectedSessionTypes: SessionType[];
-  selectedHttpMethods: HttpMethod[];
   selectedOsVersions: OsVersion[];
   selectedCountries: string[];
   selectedNetworkProviders: string[];
@@ -389,7 +370,6 @@ interface FiltersStoreActions {
   setSelectedEndDate: (date: string) => void;
   setSelectedVersions: (versions: AppVersion[]) => void;
   setSelectedSessionTypes: (types: SessionType[]) => void;
-  setSelectedHttpMethods: (methods: HttpMethod[]) => void;
   setSelectedOsVersions: (versions: OsVersion[]) => void;
   setSelectedCountries: (countries: string[]) => void;
   setSelectedNetworkProviders: (providers: string[]) => void;
@@ -442,7 +422,6 @@ const initialState: FiltersStoreState = {
   selectedEndDate: "",
   selectedVersions: [],
   selectedSessionTypes: defaultSessionTypes,
-  selectedHttpMethods: allHttpMethods,
   selectedOsVersions: [],
   selectedCountries: [],
   selectedNetworkProviders: [],
@@ -493,7 +472,6 @@ function computeFilters(state: FiltersStoreState): Filters {
       ),
     ),
     sessionTypes: state.selectedSessionTypes,
-    httpMethods: state.selectedHttpMethods,
     osVersions: state.selectedOsVersions.map((os) =>
       state.osVersions.findIndex(
         (o) => o.name === os.name && o.version === os.version,
@@ -540,10 +518,6 @@ function computeFilters(state: FiltersStoreState): Filters {
     sessionTypes: {
       selected: state.selectedSessionTypes,
       all: state.selectedSessionTypes.length === allSessionTypes.length,
-    },
-    httpMethods: {
-      selected: state.selectedHttpMethods,
-      all: state.selectedHttpMethods.length === allHttpMethods.length,
     },
     osVersions: {
       selected: state.selectedOsVersions,
@@ -693,17 +667,6 @@ export function applyFilterOptions(
     selectedUdAttrMatchers = [];
   }
 
-  let selectedHttpMethods: HttpMethod[];
-  if (isUrlMatch && urlFilters.httpMethods) {
-    selectedHttpMethods = urlFilters.httpMethods
-      .filter((s: string) =>
-        Object.values(HttpMethod).includes(s as HttpMethod),
-      )
-      .map((s: string) => s as HttpMethod);
-  } else {
-    selectedHttpMethods = allHttpMethods;
-  }
-
   let selectedSessionTypes: SessionType[];
   if (isUrlMatch && urlFilters.sessionTypes) {
     selectedSessionTypes = urlFilters.sessionTypes
@@ -765,7 +728,6 @@ export function applyFilterOptions(
     selectedDeviceManufacturers,
     selectedDeviceNames,
     selectedUdAttrMatchers,
-    selectedHttpMethods,
     selectedSessionTypes,
     selectedFreeText,
     selectedErrorTypes,
@@ -879,7 +841,6 @@ export function createFiltersStore() {
           selectedDeviceManufacturers: [],
           selectedDeviceNames: [],
           selectedSessionTypes: [],
-          selectedHttpMethods: [],
           selectedUdAttrMatchers: [],
           selectedFreeText: "",
           selectedErrorTypes: ["error", "anr"],
@@ -934,8 +895,6 @@ export function createFiltersStore() {
       setSelectedEndDate: (date) => set({ selectedEndDate: date }),
       setSelectedVersions: (versions) => set({ selectedVersions: versions }),
       setSelectedSessionTypes: (types) => set({ selectedSessionTypes: types }),
-      setSelectedHttpMethods: (methods) =>
-        set({ selectedHttpMethods: methods }),
       setSelectedOsVersions: (versions) =>
         set({ selectedOsVersions: versions }),
       setSelectedCountries: (countries) =>

--- a/frontend/dashboard/content/docs/mcp.mdx
+++ b/frontend/dashboard/content/docs/mcp.mdx
@@ -47,7 +47,7 @@ Get available filter options (versions, OS, countries, devices, etc.) for an app
 
 ### `get_filter_keys`
 
-List the filter keys of an entity (spans, bug_reports, journeys or builds): the vocabulary a filter expression is written with.
+List the filter keys of an entity (spans, bug_reports, journeys, network or builds): the vocabulary a filter expression is written with.
 
 ### `get_filter_values`
 
@@ -136,3 +136,23 @@ Get alerts for an app, ordered by most recent first.
 ### `get_journey`
 
 Get user journeys for an app as a graph of screens.
+
+### `get_network_metrics_trends`
+
+Get top network endpoints for an app by latency, error rate and frequency.
+
+### `get_network_status_codes_over_time`
+
+Get time-series of HTTP status class counts (2xx, 3xx, 4xx, 5xx) for an app or a specific endpoint.
+
+### `get_network_endpoint_status_codes_over_time`
+
+Get time-series of exact HTTP status code counts for a specific endpoint.
+
+### `get_network_latency_over_time`
+
+Get time-series of p50/p90/p95/p99 latency for an app or a specific endpoint.
+
+### `get_network_timeline`
+
+Get time-series of network requests per session, bucketed by time since session start, for an app or a specific endpoint.

--- a/frontend/dashboard/content/openapi/dashboard.yaml
+++ b/frontend/dashboard/content/openapi/dashboard.yaml
@@ -996,6 +996,7 @@ paths:
               - bug_reports
               - journeys
               - alerts
+              - network
         - name: key
           in: query
           required: false
@@ -1120,6 +1121,7 @@ paths:
               - bug_reports
               - journeys
               - alerts
+              - network
         - name: key_name
           in: query
           required: true
@@ -4547,6 +4549,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - name: query
           in: query
           required: false
@@ -4613,6 +4616,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - name: trends_limit
           in: query
           required: false
@@ -4713,9 +4717,8 @@ paths:
         Fetch HTTP status-class counts over time for the app, or an optional
         endpoint selection.
 
-        Both `versions` & `version_codes` should be present if any one of them
-        is present. `from` & `to` will default to a last seven days time range if
-        not supplied.
+        `from` & `to` will default to a last seven days time range if not
+        supplied.
       parameters:
         - name: id
           in: path
@@ -4738,62 +4741,9 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - $ref: "#/components/parameters/Timezone"
         - $ref: "#/components/parameters/PlotTimeGroup"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version code identifier strings.
-          schema:
-            type: string
-        - name: os_versions
-          in: query
-          required: false
-          description: List of comma separated OS version identifier strings.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated locale identifier strings.
-          schema:
-            type: string
-        - name: http_methods
-          in: query
-          required: false
-          description: List of comma separated HTTP method strings.
-          schema:
-            type: string
       responses:
         "200":
           description: Successful response, no errors.
@@ -4850,9 +4800,8 @@ paths:
       description: |
         Fetch latency percentiles for the app, or an optional endpoint selection.
 
-        Both `versions` & `version_codes` should be present if any one of them
-        is present. `from` & `to` will default to a last seven days time range if
-        not supplied. Latency values (`p50`, `p90`, `p95`, `p99`) are in
+        `from` & `to` will default to a last seven days time range if not
+        supplied. Latency values (`p50`, `p90`, `p95`, `p99`) are in
         milliseconds and may be null.
       parameters:
         - name: id
@@ -4876,62 +4825,9 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - $ref: "#/components/parameters/Timezone"
         - $ref: "#/components/parameters/PlotTimeGroup"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version code identifier strings.
-          schema:
-            type: string
-        - name: os_versions
-          in: query
-          required: false
-          description: List of comma separated OS version identifier strings.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated locale identifier strings.
-          schema:
-            type: string
-        - name: http_methods
-          in: query
-          required: false
-          description: List of comma separated HTTP method strings.
-          schema:
-            type: string
       responses:
         "200":
           description: Successful response, no errors.
@@ -4998,9 +4894,8 @@ paths:
         endpoint selection. At least one of `domain` or `path` is required.
         When `domain` is omitted, `path` matches across all domains.
 
-        Both `versions` & `version_codes` should be present if any one of them
-        is present. `from` & `to` will default to a last seven days time range if
-        not supplied. `status_codes` lists all distinct HTTP status codes
+        `from` & `to` will default to a last seven days time range if not
+        supplied. `status_codes` lists all distinct HTTP status codes
         observed. `data_points` contains per-bucket counts keyed by exact
         status code (e.g., `count_200`, `count_404`), not by status class.
       parameters:
@@ -5025,62 +4920,9 @@ paths:
             type: string
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - $ref: "#/components/parameters/Timezone"
         - $ref: "#/components/parameters/PlotTimeGroup"
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version code identifier strings.
-          schema:
-            type: string
-        - name: os_versions
-          in: query
-          required: false
-          description: List of comma separated OS version identifier strings.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated locale identifier strings.
-          schema:
-            type: string
-        - name: http_methods
-          in: query
-          required: false
-          description: List of comma separated HTTP method strings.
-          schema:
-            type: string
       responses:
         "200":
           description: Successful response, no errors.
@@ -5144,9 +4986,8 @@ paths:
       description: |
         Fetch the request timeline for the app or an optional endpoint selection.
 
-        Both `versions` & `version_codes` should be present if any one of them
-        is present. `from` & `to` will default to a last seven days time range if
-        not supplied. Results include up to 10 endpoint patterns. `interval` is the time
+        `from` & `to` will default to a last seven days time range if not
+        supplied. Results include up to 10 endpoint patterns. `interval` is the time
         bucket size in seconds. `elapsed` represents seconds of elapsed time
         within sessions. `count` is the average request count per session for
         that endpoint in that bucket.
@@ -5160,6 +5001,7 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/From"
         - $ref: "#/components/parameters/To"
+        - $ref: "#/components/parameters/FilterExpr"
         - name: domain
           in: query
           required: false
@@ -5170,72 +5012,6 @@ paths:
           in: query
           required: false
           description: Exact path or a `*` or trailing `**` pattern. Without a domain, searches every domain.
-          schema:
-            type: string
-        - name: versions
-          in: query
-          required: false
-          description: List of comma separated version identifier strings.
-          schema:
-            type: string
-        - name: version_codes
-          in: query
-          required: false
-          description: List of comma separated version code identifier strings.
-          schema:
-            type: string
-        - name: os_versions
-          in: query
-          required: false
-          description: List of comma separated OS version identifier strings.
-          schema:
-            type: string
-        - name: device_manufacturers
-          in: query
-          required: false
-          description: List of comma separated device manufacturer identifier strings.
-          schema:
-            type: string
-        - name: device_names
-          in: query
-          required: false
-          description: List of comma separated device name identifier strings.
-          schema:
-            type: string
-        - name: network_providers
-          in: query
-          required: false
-          description: List of comma separated network provider identifier strings.
-          schema:
-            type: string
-        - name: network_types
-          in: query
-          required: false
-          description: List of comma separated network type identifier strings.
-          schema:
-            type: string
-        - name: network_generations
-          in: query
-          required: false
-          description: List of comma separated network generation identifier strings.
-          schema:
-            type: string
-        - name: locales
-          in: query
-          required: false
-          description: List of comma separated locale identifier strings.
-          schema:
-            type: string
-        - name: http_methods
-          in: query
-          required: false
-          description: List of comma separated HTTP method strings.
-          schema:
-            type: string
-        - name: countries
-          in: query
-          required: false
-          description: List of comma separated country code identifier strings.
           schema:
             type: string
       responses:

--- a/self-host/clickhouse/20260908100000_alter_http_events_table.sql
+++ b/self-host/clickhouse/20260908100000_alter_http_events_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table http_events
+  add column if not exists `attribute.patch_version` LowCardinality(String) comment 'OTA patch version' CODEC(ZSTD(3)) after `attribute.app_version`,
+  add column if not exists `attribute.patch_id` UUID comment 'OTA patch id' CODEC(ZSTD(3)) after `attribute.patch_version`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table http_events
+  drop column if exists `attribute.patch_id`,
+  drop column if exists `attribute.patch_version`
+settings mutations_sync = 2;

--- a/self-host/clickhouse/20260908100100_alter_http_events_mv.sql
+++ b/self-host/clickhouse/20260908100100_alter_http_events_mv.sql
@@ -1,0 +1,103 @@
+-- migrate:up
+alter table http_events_mv
+modify query
+select
+    `team_id`,
+    `app_id`,
+    `id` as `event_id`,
+    `session_id` as `session_id`,
+    protocol(`http.url`) as `protocol`,
+    port(`http.url`) as `port`,
+    domain(`http.url`) as `domain`,
+    path(`http.url`) as `path`,
+    `http.url` as `url`,
+    `http.method` as `method`,
+    `http.status_code` as `status_code`,
+    multiIf(
+        `http.status_code` >= 500, '5xx',
+        `http.status_code` >= 400, '4xx',
+        `http.status_code` >= 300, '3xx',
+        `http.status_code` >= 200, '2xx',
+        `http.status_code` >= 100, '1xx',
+        'unknown'
+    ) as `status_code_bucket`,
+    `http.failure_reason` as `failure_reason`,
+    `http.failure_description` as `failure_description`,
+    `timestamp` as `timestamp`,
+    `inserted_at` as `inserted_at`,
+    `http.end_time` as `end_time`,
+    `http.start_time` as `start_time`,
+    `http.end_time` - `http.start_time` as `latency_ms`,
+    -- Old SDK versions (Android <0.16.2 and iOS <0.9.2) do not send
+    -- session_start_time, set the elapsed time for such events to 0
+    if(`attribute.session_start_time` > toDateTime(0),
+      toUnixTimestamp64Milli(`timestamp`) - toUnixTimestamp64Milli(`attribute.session_start_time`),
+      0) as `session_elapsed_ms`,
+    (`attribute.app_version`, `attribute.app_build`) as `attribute.app_version`,
+    `attribute.patch_version` as `attribute.patch_version`,
+    `attribute.patch_id` as `attribute.patch_id`,
+    (`attribute.os_name`, `attribute.os_version`) as `attribute.os_version`,
+    `attribute.network_provider` as `attribute.network_provider`,
+    `attribute.network_type` as `attribute.network_type`,
+    `attribute.network_generation` as `attribute.network_generation`,
+    `attribute.device_locale` as `attribute.device_locale`,
+    `attribute.device_manufacturer` as `attribute.device_manufacturer`,
+    `attribute.device_name` as `attribute.device_name`,
+    `inet.country_code` as `inet.country_code`
+FROM
+    events
+WHERE
+    type = 'http'
+    AND domain != ''
+;
+
+-- migrate:down
+alter table http_events_mv
+modify query
+select
+    `team_id`,
+    `app_id`,
+    `id` as `event_id`,
+    `session_id` as `session_id`,
+    protocol(`http.url`) as `protocol`,
+    port(`http.url`) as `port`,
+    domain(`http.url`) as `domain`,
+    path(`http.url`) as `path`,
+    `http.url` as `url`,
+    `http.method` as `method`,
+    `http.status_code` as `status_code`,
+    multiIf(
+        `http.status_code` >= 500, '5xx',
+        `http.status_code` >= 400, '4xx',
+        `http.status_code` >= 300, '3xx',
+        `http.status_code` >= 200, '2xx',
+        `http.status_code` >= 100, '1xx',
+        'unknown'
+    ) as `status_code_bucket`,
+    `http.failure_reason` as `failure_reason`,
+    `http.failure_description` as `failure_description`,
+    `timestamp` as `timestamp`,
+    `inserted_at` as `inserted_at`,
+    `http.end_time` as `end_time`,
+    `http.start_time` as `start_time`,
+    `http.end_time` - `http.start_time` as `latency_ms`,
+    -- Old SDK versions (Android <0.16.2 and iOS <0.9.2) do not send
+    -- session_start_time, set the elapsed time for such events to 0
+    if(`attribute.session_start_time` > toDateTime(0),
+      toUnixTimestamp64Milli(`timestamp`) - toUnixTimestamp64Milli(`attribute.session_start_time`),
+      0) as `session_elapsed_ms`,
+    (`attribute.app_version`, `attribute.app_build`) as `attribute.app_version`,
+    (`attribute.os_name`, `attribute.os_version`) as `attribute.os_version`,
+    `attribute.network_provider` as `attribute.network_provider`,
+    `attribute.network_type` as `attribute.network_type`,
+    `attribute.network_generation` as `attribute.network_generation`,
+    `attribute.device_locale` as `attribute.device_locale`,
+    `attribute.device_manufacturer` as `attribute.device_manufacturer`,
+    `attribute.device_name` as `attribute.device_name`,
+    `inet.country_code` as `inet.country_code`
+FROM
+    events
+WHERE
+    type = 'http'
+    AND domain != ''
+;

--- a/self-host/clickhouse/20260908100200_alter_http_metrics_table.sql
+++ b/self-host/clickhouse/20260908100200_alter_http_metrics_table.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table http_metrics
+  add column if not exists `patch_versions` SimpleAggregateFunction(groupUniqArrayArray, Array(String)) comment 'list of all unique OTA patch versions' after `os_versions`,
+  add column if not exists `patch_ids` SimpleAggregateFunction(groupUniqArrayArray, Array(UUID)) comment 'list of all unique OTA patch ids' after `patch_versions`
+settings mutations_sync = 2;
+
+-- migrate:down
+alter table http_metrics
+  drop column if exists `patch_ids`,
+  drop column if exists `patch_versions`
+settings mutations_sync = 2;


### PR DESCRIPTION
# Description

- move the network endpoints, MCP tools and pages onto the expression filter mechanism with a new network entity
- add patch version and patch id to the http tables so network requests can be filtered by patch
- apply the filter to the top endpoints table, which ignored it before
- hide the app selector on the network details page through a new FilterBar option


