### PR TITLE
chore(rn): prepare release 0.3.1

### DIFF
--- a/frontend/dashboard/content/docs/getting-started/react-native.mdx
+++ b/frontend/dashboard/content/docs/getting-started/react-native.mdx
@@ -14,7 +14,7 @@ native Android and iOS SDKs, so their minimum requirements apply here too.
 | React Native    | `0.73.0` |
 | React           | `18.2.0` |
 | Measure Android | `0.20.0` |
-| Measure iOS     | `0.13.1` |
+| Measure iOS     | `0.13.2` |
 
 ## 1. Get the credentials
 
@@ -31,7 +31,7 @@ create a new app on Measure with a different API key.
 
 ```sh
 # In your project root
-npm install @measuresh/react-native@0.3.0
+npm install @measuresh/react-native@0.3.1
 ```
 
 ## 3. Add the config plugin

--- a/react-native/CHANGELOG.md
+++ b/react-native/CHANGELOG.md
@@ -5,12 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [rn-v0.3.1] - 2026-09-09
+
+### :bug: Bug fixes
+
+
+- (**rn**): Validate dynamic config field types (#4433) by @adwinross in #4433
+
 ## [rn-v0.3.0] - 2026-09-02
 
 ### :books: Documentation
 
 
 - (**rn**): Update link in upload build script (#4258) by @detj in #4258
+
+### :hammer: Misc
+
+
+- (**rn**): Prepare release 0.3.0 (#4369) by @abhaysood in #4369
 
 ### :sparkles: New features
 
@@ -99,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (**rn**): Add exception tracking (#2628) by @adwinross in #2628
 - (**rn**): Add sdk initialization api (#2505) by @adwinross in #2505
 
+[rn-v0.3.1]: https://github.com/measure-sh/measure/compare/rn-v0.3.0..rn-v0.3.1
 [rn-v0.3.0]: https://github.com/measure-sh/measure/compare/rn-v0.2.0..rn-v0.3.0
 [rn-v0.2.0]: https://github.com/measure-sh/measure/compare/rn-v0.1.1..rn-v0.2.0
 [rn-v0.1.1]: https://github.com/measure-sh/measure/compare/rn-v0.1.0..rn-v0.1.1

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@measuresh/react-native",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "measureIosSdk": {
-    "version": "0.13.1",
+    "version": "0.13.2",
     "spmUrl": "https://github.com/measure-sh/measure.git",
-    "revision": "ea9d91aa78cfe25ed10c0be77b81c025c60802aa"
+    "revision": "7e15705ffa563aa376d166d1c4cf5b40964d4fc7"
   },
   "react-native": "lib/module/index.js",
   "description": "Mobile apps break, get to the root cause faster",


### PR DESCRIPTION
This PR prepares the React Native SDK for release version 0.3.1.

Changes:
- Bumped version to 0.3.1
- Updated Measure Android SDK to 0.20.0
- Updated Measure iOS SDK to 0.13.2
- Updated Measure Android Gradle Plugin to 0.14.0
- Updated CHANGELOG.md