### PR TITLE
fix(frontend): build absolute URLs from the deploy's own origin

### DIFF
--- a/frontend/dashboard/__tests__/utils/metadata_test.ts
+++ b/frontend/dashboard/__tests__/utils/metadata_test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "@jest/globals";
 import {
   pageMetadata,
   previewImage,
+  resolveSiteOrigin,
   siteHandle,
   siteMetadata,
+  siteOrigin,
   siteXUrl,
 } from "@/app/utils/metadata";
 
@@ -152,7 +154,25 @@ describe("siteMetadata", () => {
   });
 
   it("resolves relative paths against the site origin", () => {
-    expect(siteMetadata.metadataBase?.toString()).toBe("https://measure.sh/");
+    expect(siteMetadata.metadataBase?.toString()).toBe(`${siteOrigin}/`);
+  });
+});
+
+describe("resolveSiteOrigin", () => {
+  it("falls back to the canonical site when the deploy declares none", () => {
+    expect(resolveSiteOrigin(undefined)).toBe("https://measure.sh");
+  });
+
+  it("uses the declared origin as given", () => {
+    expect(resolveSiteOrigin("https://staging.measure.sh")).toBe(
+      "https://staging.measure.sh",
+    );
+  });
+
+  it("strips a trailing slash, which callers would double up on", () => {
+    expect(resolveSiteOrigin("https://staging.measure.sh/")).toBe(
+      "https://staging.measure.sh",
+    );
   });
 });
 

--- a/frontend/dashboard/app/utils/metadata.ts
+++ b/frontend/dashboard/app/utils/metadata.ts
@@ -1,6 +1,18 @@
 import type { Metadata } from "next";
 
-export const siteOrigin = "https://measure.sh";
+const canonicalOrigin = "https://measure.sh";
+
+/**
+ * resolveSiteOrigin picks the origin absolute URLs are built from, the
+ * canonical site when the deploy declares none. Trailing slashes are
+ * stripped: callers concatenate paths straight onto this.
+ */
+export function resolveSiteOrigin(siteUrl: string | undefined): string {
+  if (!siteUrl) return canonicalOrigin;
+  return siteUrl.replace(/\/+$/, "");
+}
+
+export const siteOrigin = resolveSiteOrigin(process.env.NEXT_PUBLIC_SITE_URL);
 
 const siteName = "measure.sh";
 


### PR DESCRIPTION
## Summary

This PR builds absolute URLs from the origin a deploy actually serves. `siteOrigin` was pinned to the canonical site, so staging emitted production URLs for `og:image`, `og:url`, canonicals & JSON-LD, which left share images unresolvable there & social card validation only possible after a production release. It now reads `NEXT_PUBLIC_SITE_URL`, a variable the staging & production builds already set, falling back to the canonical site.

## Tasks

- [x] Read `NEXT_PUBLIC_SITE_URL` for `siteOrigin`, falling back to the canonical site
- [x] Strip a trailing slash so concatenated paths stay valid
- [x] Cover `resolveSiteOrigin` in `metadata_test`
