### PR TITLE
docs: point documentation links at website

### DIFF
--- a/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
+++ b/android/measure-android/measure/src/main/java/sh/measure/android/Measure.kt
@@ -350,7 +350,7 @@ object Measure {
     /**
      * Starts a new performance tracing span with the specified [name].
      *
-     * @param name The name to identify this span. Follow the [naming convention guide](https://github.com/measure-sh/measure/blob/main/docs/android/features/feature_performance_tracing.md#span-names)
+     * @param name The name to identify this span. Follow the [naming convention guide](https://measure.sh/docs/performance-tracing)
      * for consistent naming practices.
      *
      * @return [Span] A new span instance if the SDK is initialized, or an invalid no-op span if not initialized
@@ -364,7 +364,7 @@ object Measure {
     /**
      * Starts a new performance tracing span with the specified [name] and start [timestamp].
      *
-     * @param name The name to identify this span. Follow the [naming convention guide](https://github.com/measure-sh/measure/blob/main/docs/android/features/feature_performance_tracing.md#span-names)
+     * @param name The name to identify this span. Follow the [naming convention guide](https://measure.sh/docs/performance-tracing)
      * for consistent naming practices.
      * @param timestamp The milliseconds since epoch when the span started. Must be obtained using [getCurrentTime]
      * to minimize clock drift effects.
@@ -383,7 +383,7 @@ object Measure {
     /**
      * Creates a configurable span builder for deferred span creation.
      *
-     * @param name The name to identify this span. Follow the [naming convention guide](https://github.com/measure-sh/measure/blob/main/docs/android/features/feature_performance_tracing.md#span-names)
+     * @param name The name to identify this span. Follow the [naming convention guide](https://measure.sh/docs/performance-tracing)
      * for consistent naming practices.
      *
      * @return [SpanBuilder] A builder instance to configure the span if the SDK is initialized,

--- a/flutter/packages/measure_build/pubspec.yaml
+++ b/flutter/packages/measure_build/pubspec.yaml
@@ -1,6 +1,7 @@
 name: measure_build
 repository: https://github.com/measure-sh/measure/tree/main/flutter/packages/measure_build
 issue_tracker: https://github.com/measure-sh/measure/issues
+documentation: https://measure.sh/docs
 description: A build package for generating code used by the measure_flutter SDK.
 version: 0.1.0
 

--- a/flutter/packages/measure_dio/README.md
+++ b/flutter/packages/measure_dio/README.md
@@ -13,5 +13,5 @@ final dio = Dio();
 dio.interceptors.add(MsrInterceptor());
 ```
 
-Checkout our [documentation](https://github.com/measure-sh/measure/tree/main/docs) for more details
+Checkout our [documentation](https://measure.sh/docs) for more details
 and features.

--- a/flutter/packages/measure_dio/pubspec.yaml
+++ b/flutter/packages/measure_dio/pubspec.yaml
@@ -1,6 +1,7 @@
 name: measure_dio
 repository: https://github.com/measure-sh/measure/tree/main/flutter/packages/measure_dio
 issue_tracker: https://github.com/measure-sh/measure/issues
+documentation: https://measure.sh/docs
 description: Provides interceptors for monitoring http requests made using Dio library using measure.sh.
 version: 0.8.0
 

--- a/flutter/packages/measure_flutter/README.md
+++ b/flutter/packages/measure_flutter/README.md
@@ -93,5 +93,5 @@ For any other HTTP client libraries, you can manually track network requests usi
 
 # Checkout detailed documentation
 
-Checkout our [documentation](https://github.com/measure-sh/measure/tree/main/docs) to learn more
+Checkout our [documentation](https://measure.sh/docs) to learn more
 about Measure.

--- a/flutter/packages/measure_flutter/lib/measure_flutter.dart
+++ b/flutter/packages/measure_flutter/lib/measure_flutter.dart
@@ -79,7 +79,7 @@
 ///
 /// ## Checkout detailed documentation
 ///
-/// Checkout the [documentation](https://github.com/measure-sh/measure/tree/main/docs) to learn more
+/// Checkout the [documentation](https://measure.sh/docs) to learn more
 /// about Measure.
 library;
 

--- a/flutter/packages/measure_flutter/pubspec.yaml
+++ b/flutter/packages/measure_flutter/pubspec.yaml
@@ -1,6 +1,7 @@
 name: measure_flutter
 repository: https://github.com/measure-sh/measure/tree/main/flutter/packages/measure_flutter
 issue_tracker: https://github.com/measure-sh/measure/issues
+documentation: https://measure.sh/docs
 description: Flutter SDK to track crashes, bug reports, performance traces and more using measure.sh, an
   open-source monitoring tool.
 version: 0.8.0


### PR DESCRIPTION
## Description

Everything now points at `https://measure.sh/docs` (verified 200).

- Added `documentation: https://measure.sh/docs` to the `measure_flutter`, `measure_dio` and `measure_build` pubspecs, alongside the existing link fields.
- Replaced the stale link in `measure_flutter/README.md`, `measure_dio/README.md`, and the `measure_flutter.dart` library dartdoc (the last one also renders on the pub.dev API reference page).

## References

Closes #4416