### PR TITLE
fix(frontend): keep focus in the value input after picking a filter key

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
@@ -23,8 +23,11 @@ jest.mock("@/app/components/popover", () => {
           {/* Stands in for Radix calling onCloseAutoFocus as the popover closes. */}
           <button
             data-testid="close-popover"
-            onClick={() =>
-              onCloseAutoFocus?.({ preventDefault: () => {} } as any)
+            onClick={(e) =>
+              onCloseAutoFocus?.({
+                preventDefault: () => {},
+                currentTarget: e.currentTarget.parentElement,
+              } as any)
             }
           >
             close
@@ -282,6 +285,35 @@ describe("KeyPicker", () => {
     fireEvent.click(screen.getByTestId("close-popover"));
 
     expect(screen.getByTestId("lands-here")).toHaveFocus();
+  });
+
+  it("does not take focus back from a value input that gained it while the list was closing", () => {
+    function Harness() {
+      const ref = React.useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={ref} data-testid="lands-here">
+            lands here
+          </button>
+          <input data-testid="value-input" />
+          <KeyPicker
+            keys={keys}
+            keyGroups={keyGroups}
+            selected={null}
+            open
+            focusOnClose={ref}
+            onSelect={jest.fn()}
+            trigger={<button>open</button>}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    screen.getByTestId("value-input").focus();
+    fireEvent.click(screen.getByTestId("close-popover"));
+
+    expect(screen.getByTestId("value-input")).toHaveFocus();
   });
 
   describe("a user-defined key", () => {

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -304,7 +304,13 @@ export default function FilterBar({
       : `${first.message} (+${rest.length} more)`;
   }, [draftFilterIssues]);
 
+  const openValuesRowId =
+    pending?.picker?.kind === "values" ? pending.picker.rowId : null;
+
   useEffect(() => {
+    if (focusedId !== null && focusedId === openValuesRowId) {
+      return;
+    }
     focusedControlRef.current?.focus();
   }, [focusedId]);
 
@@ -528,8 +534,7 @@ export default function FilterBar({
     focusedControlRef,
     openKeysGroupId:
       pending?.picker?.kind === "keys" ? pending.picker.groupId : null,
-    openValuesRowId:
-      pending?.picker?.kind === "values" ? pending.picker.rowId : null,
+    openValuesRowId,
     onChangeKey: changeKey,
     onChangeOperator: changeOperator,
     onChangeValues: changeValues,

--- a/frontend/dashboard/app/components/filter_bar/key_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/key_picker.tsx
@@ -56,7 +56,21 @@ export default function KeyPicker({
           focusOnClose &&
           ((e) => {
             e.preventDefault();
-            focusOnClose.current?.focus();
+            // Radix calls this when the list has finished closing. If the user
+            // picked a key, the bar has by then opened the value picker for the
+            // new condition and its input holds focus, so moving focus to the
+            // caller's control would take it away from that input. Focus is
+            // moved only when nothing outside this list has it, as after the
+            // user pressed Escape.
+            const active = document.activeElement;
+            const content = e.currentTarget as HTMLElement | null;
+            if (
+              active === null ||
+              active === document.body ||
+              content?.contains(active)
+            ) {
+              focusOnClose.current?.focus();
+            }
           })
         }
       >


### PR DESCRIPTION
# Description

- Picking a typed-text key such as the bug report description opened the value input, then focus jumped to the new chip's key button about a second later, so typing went nowhere and the next click on the bar opened a fresh key list.
- The closing key list's `onCloseAutoFocus`, which Radix runs once the exit animation ends, and the bar's effect that focuses the control marked as focused both moved focus after the value input had taken it.
- Both now leave focus alone when the row's value picker has it. Escape on the key list still returns focus to the add button.