### PR TITLE
fix(frontend): keep focus in the value input after changing an operator

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
@@ -316,6 +316,26 @@ describe("KeyPicker", () => {
     expect(screen.getByTestId("value-input")).toHaveFocus();
   });
 
+  it("does not take focus back from a value input after an operator was picked", () => {
+    render(
+      <>
+        <input data-testid="value-input" />
+        <OperatorPicker
+          operators={["in", "contains"]}
+          selected="in"
+          operatorLabels={{ in: "is", contains: "contains" }}
+          onSelect={jest.fn()}
+          open
+          trigger={<button>is</button>}
+        />
+      </>,
+    );
+    screen.getByTestId("value-input").focus();
+    fireEvent.click(screen.getByTestId("close-popover"));
+
+    expect(screen.getByTestId("value-input")).toHaveFocus();
+  });
+
   describe("a user-defined key", () => {
     const customKey = key(
       "custom.is_premium",

--- a/frontend/dashboard/app/components/filter_bar/key_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/key_picker.tsx
@@ -52,27 +52,7 @@ export default function KeyPicker({
         // a box built for many.
         className="p-0 w-auto min-w-96 max-w-[min(32rem,calc(100vw-2rem))]"
         align={align}
-        onCloseAutoFocus={
-          focusOnClose &&
-          ((e) => {
-            e.preventDefault();
-            // Radix calls this when the list has finished closing. If the user
-            // picked a key, the bar has by then opened the value picker for the
-            // new condition and its input holds focus, so moving focus to the
-            // caller's control would take it away from that input. Focus is
-            // moved only when nothing outside this list has it, as after the
-            // user pressed Escape.
-            const active = document.activeElement;
-            const content = e.currentTarget as HTMLElement | null;
-            if (
-              active === null ||
-              active === document.body ||
-              content?.contains(active)
-            ) {
-              focusOnClose.current?.focus();
-            }
-          })
-        }
+        onCloseAutoFocus={(e) => settleFocusOnClose(e, focusOnClose)}
       >
         <KeyList
           keys={keys}
@@ -220,6 +200,31 @@ function KeyList({
   );
 }
 
+// Radix runs this when a picker has finished closing, and by default then
+// focuses the picker's trigger. When the user picked a key or an operator,
+// the bar has already opened the value picker for that condition and its
+// input holds focus, and focusing the trigger would take the user's typing
+// away from it. So when focus is already somewhere outside the closed picker,
+// it stays there. Otherwise, as after Escape, focus goes to the control the
+// caller named, or to the trigger when the caller named none.
+function settleFocusOnClose(
+  e: Event,
+  focusOnClose?: React.RefObject<HTMLElement | null>,
+) {
+  const active = document.activeElement;
+  const content = e.currentTarget as HTMLElement | null;
+  const elsewhere =
+    active !== null && active !== document.body && !content?.contains(active);
+  if (elsewhere) {
+    e.preventDefault();
+    return;
+  }
+  if (focusOnClose?.current) {
+    e.preventDefault();
+    focusOnClose.current.focus();
+  }
+}
+
 export function OperatorPicker({
   operators,
   selected,
@@ -247,7 +252,11 @@ export function OperatorPicker({
   return (
     <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent className="p-1 w-48" align="start">
+      <PopoverContent
+        className="p-1 w-48"
+        align="start"
+        onCloseAutoFocus={(e) => settleFocusOnClose(e)}
+      >
         <div className="flex flex-col">
           {operators.map((operator) => (
             <Button


### PR DESCRIPTION
# Description

- Changing an existing chip's operator to a typed one (contains, starts with), or changing its key, opened the value input and then moved focus back to the chip about a second later, so typing went nowhere and Enter reopened the operator menu.
- The operator menu and the key list on an existing chip used Radix's default of focusing their trigger once the close animation ends, which lands after the value input has taken focus. The key list opened from "Add a filter" was fixed in #4440; these two paths had no close handler.
- Both pickers now share one close handler: focus stays where it is when something outside the closing picker already has it, otherwise it goes to the control the bar named, or to the trigger.