### PR TITLE
fix(frontend): keep a filter chip when its operator or key is changed first

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -113,35 +113,44 @@ jest.mock("@/app/components/filter_bar/key_picker", () => ({
     <div
       data-testid="key-picker"
       data-groups={keyGroups.join(",")}
-      data-open={open === undefined ? undefined : String(open)}
+      data-open={String(open)}
     >
       {trigger}
-      {keys.map((key: any) => (
-        <button
-          key={key.name}
-          data-testid={`pick-key-${key.name}${selected ? "-in-row" : ""}`}
-          onClick={() => {
-            onSelect(key);
-            onOpenChange?.(false);
-          }}
-        >
-          pick {key.label}
-        </button>
-      ))}
-      {onAddGroup && (
-        <button data-testid="add-group" onClick={() => onAddGroup()}>
-          group
-        </button>
-      )}
-      {onOpenChange && (
-        <button data-testid="close-keys" onClick={() => onOpenChange(false)}>
-          close
-        </button>
+      <button data-testid="open-keys" onClick={() => onOpenChange(true)}>
+        open
+      </button>
+      {/* The real list is drawn only while the picker is open. */}
+      {open && (
+        <>
+          {keys.map((key: any) => (
+            <button
+              key={key.name}
+              data-testid={`pick-key-${key.name}${selected ? "-in-row" : ""}`}
+              onClick={() => onSelect(key)}
+            >
+              pick {key.label}
+            </button>
+          ))}
+          {onAddGroup && (
+            <button data-testid="add-group" onClick={() => onAddGroup()}>
+              group
+            </button>
+          )}
+          <button data-testid="close-keys" onClick={() => onOpenChange(false)}>
+            close
+          </button>
+        </>
       )}
     </div>
   ),
-  OperatorPicker: ({ operators, onSelect, trigger }: any) => (
-    <div data-testid="operator-picker">
+  OperatorPicker: ({
+    operators,
+    onSelect,
+    onOpenChange,
+    open,
+    trigger,
+  }: any) => (
+    <div data-testid="operator-picker" data-open={String(open)}>
       {trigger}
       {operators.map((operator: string) => (
         <button
@@ -152,6 +161,12 @@ jest.mock("@/app/components/filter_bar/key_picker", () => ({
           {operator}
         </button>
       ))}
+      <button data-testid="open-operator" onClick={() => onOpenChange(true)}>
+        open
+      </button>
+      <button data-testid="close-operator" onClick={() => onOpenChange(false)}>
+        close
+      </button>
     </div>
   ),
 }));
@@ -173,11 +188,17 @@ jest.mock("@/app/components/filter_bar/value_picker", () => ({
       >
         choose proguard
       </button>
+      <button data-testid="unpick-value" onClick={() => onChange([], false)}>
+        take every value off
+      </button>
       <button
         data-testid="pick-one-value"
         onClick={() => onChange([{ text: "dsym" }], true)}
       >
         choose dsym and finish
+      </button>
+      <button data-testid="open-values" onClick={() => onOpenChange(true)}>
+        open
       </button>
       <button data-testid="close-values" onClick={() => onOpenChange(false)}>
         close
@@ -378,6 +399,11 @@ function groupPicker(group: HTMLElement) {
   return pickerOf(within(group).getByLabelText("Add a filter to this group"));
 }
 
+// The key picker of the chip whose key segment reads this label.
+function chipKeyPicker(label: string) {
+  return pickerOf(screen.getByText(label));
+}
+
 function valuePickers() {
   return screen.queryAllByTestId("value-picker");
 }
@@ -392,11 +418,24 @@ async function pickValue() {
   await click(screen.getAllByTestId("pick-value").at(-1)!);
 }
 
+// The list of a closed picker is not drawn, so its control is pressed first.
+async function pickFromKeyList(
+  picker: ReturnType<typeof pickerOf>,
+  testId: string,
+) {
+  await click(picker.getByTestId("open-keys"));
+  await click(picker.getByTestId(testId));
+}
+
+async function addGroup(picker = wholeFilterPicker()) {
+  await pickFromKeyList(picker, "add-group");
+}
+
 async function addCondition(
   picker = wholeFilterPicker(),
   keyName = "mapping_type",
 ) {
-  await click(picker.getByTestId(`pick-key-${keyName}`));
+  await pickFromKeyList(picker, `pick-key-${keyName}`);
   await pickValue();
 }
 
@@ -498,7 +537,7 @@ describe("FilterBar", () => {
     it("stands in for the values an operator takes, one or many", async () => {
       await renderBar({ filterExpr: "mapping_type:in:dsym" });
 
-      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-version_name");
       expect(screen.getByText("<values>")).toBeInTheDocument();
 
       await click(screen.getAllByTestId("pick-op-contains")[0]);
@@ -513,7 +552,7 @@ describe("FilterBar", () => {
         "Filter builds…",
       );
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
 
       expect(screen.getByTestId("filter-input")).toHaveTextContent("");
     });
@@ -674,7 +713,10 @@ describe("FilterBar", () => {
         filterExpr: "mapping_type:in:dsym",
       });
 
-      await click(screen.getByTestId("pick-key-patch_id-in-row"));
+      await pickFromKeyList(
+        chipKeyPicker("File type"),
+        "pick-key-patch_id-in-row",
+      );
 
       expect(lastChange(onChange)).toEqual({ filterExpr: "patch_id:is_set" });
       expect(valuePickers()).toHaveLength(0);
@@ -757,7 +799,7 @@ describe("FilterBar", () => {
     it("starts with its key picked and its value picker open, sending nothing", async () => {
       const { onChange } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
 
       expect(onChange).not.toHaveBeenCalled();
       expect(screen.getByText("<values>")).toBeInTheDocument();
@@ -827,7 +869,7 @@ describe("FilterBar", () => {
     it("closes its picker after a value that ends the selection", async () => {
       const { onChange } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await click(screen.getByTestId("pick-one-value"));
 
       expect(lastChange(onChange)).toEqual({
@@ -859,7 +901,7 @@ describe("FilterBar", () => {
         filterExpr: "mapping_type:in:dsym",
       });
 
-      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-version_name");
       expect(valuePickers()[1]).toHaveAttribute("data-open", "true");
 
       await setValue({
@@ -882,10 +924,136 @@ describe("FilterBar", () => {
       });
     });
 
+    it("keeps its place when the operator picker is opened over the value picker", async () => {
+      const { onChange } = await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await click(screen.getByTestId("open-operator"));
+
+      expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+      expect(screen.getByTestId("operator-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("waits for a value again once the operator is changed, and is sent when one is picked", async () => {
+      const { onChange } = await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await click(screen.getByTestId("open-operator"));
+      await click(screen.getByTestId("pick-op-not_in"));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId("operator-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await click(screen.getByTestId("pick-value"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:not_in:dsym",
+      });
+    });
+
+    it("is dropped when the operator picker it was moved to closes", async () => {
+      const { onChange } = await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await click(screen.getByTestId("open-operator"));
+      await click(screen.getByTestId("close-operator"));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByLabelText("Remove condition")).toBeNull();
+    });
+
+    it("keeps its place when the key picker is opened over the value picker", async () => {
+      await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await click(chipKeyPicker("File type").getByTestId("open-keys"));
+
+      expect(screen.getByLabelText("Remove condition")).toBeInTheDocument();
+      expect(
+        screen.getByText("File type").closest("[data-testid='key-picker']"),
+      ).toHaveAttribute("data-open", "true");
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "false",
+      );
+    });
+
+    it("is put back when the value picker reached through the operator picker is dismissed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("open-operator"));
+      await click(screen.getByTestId("pick-op-contains"));
+
+      expect(screen.getByText("<value>")).toBeInTheDocument();
+      expect(screen.getByTestId("value-picker")).toHaveAttribute(
+        "data-open",
+        "true",
+      );
+
+      await click(screen.getByTestId("close-values"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.queryByText("<value>")).toBeNull();
+    });
+
+    it("is put back when the key picker opened over that value picker is dismissed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await click(screen.getByTestId("open-operator"));
+      await click(screen.getByTestId("pick-op-contains"));
+      await click(chipKeyPicker("File type").getByTestId("open-keys"));
+      await click(chipKeyPicker("File type").getByTestId("close-keys"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.queryByText("<value>")).toBeNull();
+    });
+
+    it("is put back when the value it was given is taken off again and the picker dismissed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym",
+      });
+
+      await pickFromKeyList(
+        chipKeyPicker("File type"),
+        "pick-key-version_name-in-row",
+      );
+      await click(screen.getByTestId("pick-value"));
+      await click(screen.getByTestId("unpick-value"));
+      await click(screen.getByTestId("close-values"));
+
+      expect(lastChange(onChange)).toEqual({
+        filterExpr: "mapping_type:in:dsym",
+      });
+      expect(screen.getByText("dsym")).toBeInTheDocument();
+    });
+
     it("is dropped when its value picker closes without a value", async () => {
       const { onChange } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await click(screen.getByTestId("close-values"));
 
       expect(onChange).not.toHaveBeenCalled();
@@ -896,7 +1064,7 @@ describe("FilterBar", () => {
     it("is dropped when the filter changes from outside", async () => {
       const { onChange, setValue } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await setValue({ filterExpr: "version_name:in:1.0" });
 
       expect(onChange).not.toHaveBeenCalled();
@@ -908,7 +1076,7 @@ describe("FilterBar", () => {
     it("is dropped when the range changes from outside", async () => {
       const { onChange, setValue } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await setValue({
         date: toDateSelection({
           dateRange: "Last Week",
@@ -928,7 +1096,7 @@ describe("FilterBar", () => {
         { spanNames: ["span.first", "span.second"] },
       );
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await setValue({ rootSpanName: "span.second" });
 
       expect(onChange).not.toHaveBeenCalled();
@@ -941,7 +1109,7 @@ describe("FilterBar", () => {
         filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
       });
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await click(screen.getAllByTestId("filter-logical-operator")[0]);
 
       expect(lastChange(onChange)).toEqual({
@@ -954,7 +1122,7 @@ describe("FilterBar", () => {
     it("is dropped when another app is picked", async () => {
       const { onChange } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await click(screen.getByTestId("pick-app-app-2"));
 
       expect(lastChange(onChange)).toEqual({
@@ -970,7 +1138,7 @@ describe("FilterBar", () => {
         filterExpr: "version_name:in:1.0",
       });
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await click(screen.getAllByLabelText("Remove condition")[0]);
 
       expect(lastChange(onChange)).toEqual({ filterExpr: null });
@@ -980,8 +1148,8 @@ describe("FilterBar", () => {
     it("is replaced by the next one started", async () => {
       const { onChange } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
-      await click(wholeFilterPicker().getByTestId("pick-key-version_name"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-version_name");
 
       expect(onChange).not.toHaveBeenCalled();
       expect(screen.getAllByLabelText("Remove condition")).toHaveLength(1);
@@ -994,7 +1162,10 @@ describe("FilterBar", () => {
         filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
       });
 
-      await click(screen.getAllByTestId("pick-key-version_name-in-row")[0]);
+      await pickFromKeyList(
+        chipKeyPicker("File type"),
+        "pick-key-version_name-in-row",
+      );
 
       expect(lastChange(onChange)).toEqual({
         filterExpr: "version_name:in:1.0",
@@ -1013,7 +1184,10 @@ describe("FilterBar", () => {
         filterExpr: "mapping_type:in:dsym AND version_name:in:1.0",
       });
 
-      await click(screen.getAllByTestId("pick-key-version_name-in-row")[0]);
+      await pickFromKeyList(
+        chipKeyPicker("File type"),
+        "pick-key-version_name-in-row",
+      );
       await click(screen.getAllByTestId("pick-value")[0]);
 
       expect(lastChange(onChange)).toEqual({
@@ -1063,7 +1237,7 @@ describe("FilterBar", () => {
     it("drops the edit when the filter it sent was discarded", async () => {
       const { setValue } = await renderBar();
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await setValue({ discarded: true });
 
       expect(screen.queryByText("<values>")).toBeNull();
@@ -1076,7 +1250,7 @@ describe("FilterBar", () => {
         { spanNames: null },
       );
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
       await setValue({ rootSpanName: "span.first" });
 
       expect(screen.getByText("<values>")).toBeInTheDocument();
@@ -1088,7 +1262,10 @@ describe("FilterBar", () => {
       });
 
       const group = () => screen.getByRole("group", { name: "Filter group" });
-      await click(within(group()).getByTestId("pick-key-mapping_type-in-row"));
+      await pickFromKeyList(
+        chipKeyPicker("App version"),
+        "pick-key-mapping_type-in-row",
+      );
 
       expect(lastChange(onChange)).toEqual({
         filterExpr: "mapping_type:in:dsym",
@@ -1108,8 +1285,9 @@ describe("FilterBar", () => {
       });
 
       const innermost = () => screen.getAllByRole("group").at(-1)!;
-      await click(
-        within(innermost()).getByTestId("pick-key-mapping_type-in-row"),
+      await pickFromKeyList(
+        chipKeyPicker("App version"),
+        "pick-key-mapping_type-in-row",
       );
 
       expect(lastChange(onChange)).toEqual({
@@ -1132,7 +1310,7 @@ describe("FilterBar", () => {
       });
 
       const group = () => screen.getByRole("group", { name: "Filter group" });
-      await click(groupPicker(group()).getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(groupPicker(group()), "pick-key-mapping_type");
       expect(
         within(group()).getAllByLabelText("Remove condition"),
       ).toHaveLength(2);
@@ -1148,10 +1326,6 @@ describe("FilterBar", () => {
 
   describe("grouping", () => {
     const onlyGroup = () => screen.getByRole("group", { name: "Filter group" });
-
-    async function addGroup(picker = wholeFilterPicker()) {
-      await click(picker.getByTestId("add-group"));
-    }
 
     it("opens the key list for the first condition of a group, sending nothing", async () => {
       const { onChange } = await renderBar();
@@ -1174,6 +1348,30 @@ describe("FilterBar", () => {
       await click(groupPicker(onlyGroup()).getByTestId("close-keys"));
 
       expect(screen.queryByRole("group")).toBeNull();
+    });
+
+    it("offers a nested group from the list of a group that holds a condition", async () => {
+      await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      await addGroup(groupPicker(onlyGroup()));
+
+      expect(screen.getAllByRole("group")).toHaveLength(2);
+    });
+
+    it("keeps a group that already holds a condition when its key list is dismissed", async () => {
+      const { onChange } = await renderBar({
+        filterExpr: "mapping_type:in:dsym AND (version_name:in:1.0)",
+      });
+
+      await click(groupPicker(onlyGroup()).getByTestId("open-keys"));
+      await click(groupPicker(onlyGroup()).getByTestId("close-keys"));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(
+        within(onlyGroup()).getAllByLabelText("Remove condition"),
+      ).toHaveLength(1);
     });
 
     it("sends the group once its first condition has a value", async () => {
@@ -1317,6 +1515,31 @@ describe("FilterBar", () => {
 
       expect(wholePicker()).toHaveAttribute("data-open", "false");
       expect(lastChange(onChange)).toEqual({ filterExpr: null });
+    });
+
+    it("closes once a key is picked from it", async () => {
+      await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+
+      expect(wholePicker()).toHaveAttribute("data-open", "false");
+    });
+
+    it("closes once a group is added from it", async () => {
+      await renderBar();
+
+      await addGroup();
+
+      expect(wholePicker()).toHaveAttribute("data-open", "false");
+    });
+
+    it("stays shut while a condition has a picker of its own open", async () => {
+      await renderBar();
+
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
+      await click(screen.getByTestId("filter-bar"));
+
+      expect(wholePicker()).toHaveAttribute("data-open", "false");
     });
 
     it("leaves the bar alone while the filter is edited as text", async () => {
@@ -1724,13 +1947,28 @@ describe("FilterBar", () => {
     it("declines the edit and names the limit that stopped it", async () => {
       const { onChange } = await renderBar({ filterExpr: full });
 
-      await click(wholeFilterPicker().getByTestId("pick-key-mapping_type"));
+      await pickFromKeyList(wholeFilterPicker(), "pick-key-mapping_type");
 
       expect(mockToastNegative).toHaveBeenCalledWith(
         `A filter can hold at most ${MAX_CONDITIONS} conditions`,
       );
       expect(onChange).not.toHaveBeenCalled();
       expect(screen.queryByText("<values>")).toBeNull();
+    });
+
+    it("keeps the group and its open list when its first condition is declined", async () => {
+      const { onChange } = await renderBar({ filterExpr: full });
+
+      await addGroup();
+      const group = screen.getByRole("group", { name: "Filter group" });
+      await click(groupPicker(group).getByTestId("pick-key-version_name"));
+
+      expect(mockToastNegative).toHaveBeenCalledWith(
+        `A filter can hold at most ${MAX_CONDITIONS} conditions`,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByRole("group")).toBeInTheDocument();
+      expect(groupPicker(group).getByTestId("close-keys")).toBeInTheDocument();
     });
 
     it("says nothing while the filter is still inside every limit", async () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/key_picker_test.tsx
@@ -7,8 +7,12 @@ import React from "react";
 // same.
 jest.mock("@/app/components/popover", () => {
   const PopoverOpen = { current: false };
+  // Radix reports a press outside the popover to this handler; the tests call
+  // it with a press they build themselves.
+  const pointerDownOutside = { current: (_event: any) => {} };
   return {
     __esModule: true,
+    pointerDownOutside,
     Popover: ({ children, open }: any) => {
       PopoverOpen.current = open;
       return <div data-testid="popover">{children}</div>;
@@ -16,8 +20,13 @@ jest.mock("@/app/components/popover", () => {
     PopoverTrigger: ({ children }: any) => (
       <div data-testid="popover-trigger">{children}</div>
     ),
-    PopoverContent: ({ children, onCloseAutoFocus }: any) =>
-      PopoverOpen.current ? (
+    PopoverContent: ({
+      children,
+      onCloseAutoFocus,
+      onPointerDownOutside,
+    }: any) => {
+      pointerDownOutside.current = onPointerDownOutside;
+      return PopoverOpen.current ? (
         <div data-testid="popover-content">
           {children}
           {/* Stands in for Radix calling onCloseAutoFocus as the popover closes. */}
@@ -33,7 +42,8 @@ jest.mock("@/app/components/popover", () => {
             close
           </button>
         </div>
-      ) : null,
+      ) : null;
+    },
   };
 });
 
@@ -124,6 +134,30 @@ function search(text: string) {
   });
 }
 
+const popover = jest.requireMock("@/app/components/popover") as {
+  pointerDownOutside: { current: (event: unknown) => void };
+};
+
+// Hands the picker a press it did not receive itself, the way Radix does, and
+// reports whether the picker asked to stay open.
+function pressOutside(
+  target: Node,
+  press: { button?: number; ctrlKey?: boolean } = {},
+) {
+  const preventDefault = jest.fn();
+  popover.pointerDownOutside.current({
+    detail: { originalEvent: { target, button: 0, ...press } },
+    preventDefault,
+  });
+  return preventDefault;
+}
+
+function chipHoldingASegment() {
+  const chip = document.createElement("div");
+  chip.appendChild(document.createElement("button"));
+  return chip;
+}
+
 describe("KeyPicker", () => {
   it("shows nothing until it is opened", () => {
     render(
@@ -131,6 +165,8 @@ describe("KeyPicker", () => {
         keys={keys}
         keyGroups={keyGroups}
         selected={null}
+        open={false}
+        onOpenChange={jest.fn()}
         onSelect={jest.fn()}
         trigger={<button>open</button>}
       />,
@@ -181,6 +217,7 @@ describe("KeyPicker", () => {
         keyGroups={keyGroups}
         selected={null}
         open
+        onOpenChange={jest.fn()}
         onSelect={jest.fn()}
         trigger={<button>open</button>}
       />,
@@ -193,6 +230,7 @@ describe("KeyPicker", () => {
         keyGroups={["Version"]}
         selected={null}
         open
+        onOpenChange={jest.fn()}
         onSelect={jest.fn()}
         trigger={<button>open</button>}
       />,
@@ -242,6 +280,7 @@ describe("KeyPicker", () => {
         keyGroups={["Build"]}
         selected={null}
         open
+        onOpenChange={jest.fn()}
         onSelect={jest.fn()}
         trigger={<button>open</button>}
       />,
@@ -251,13 +290,27 @@ describe("KeyPicker", () => {
     expect(screen.getByText("Patch id")).toBeInTheDocument();
   });
 
-  it("reports the key that was picked and closes", () => {
+  it("reports the picked key and closes, leaving the close itself unreported", () => {
     const { onSelect, onOpenChange } = openPicker();
 
     fireEvent.click(screen.getByTestId("filter-key-version"));
 
     expect(onSelect).toHaveBeenCalledWith(keys[0]);
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("stays open when the left button goes down inside the chip it was given", () => {
+    const chip = chipHoldingASegment();
+    openPicker({ stayOpenWithin: { current: chip } });
+
+    expect(pressOutside(chip.firstChild!)).toHaveBeenCalled();
+    expect(pressOutside(document.body)).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { button: 2 }),
+    ).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { ctrlKey: true }),
+    ).not.toHaveBeenCalled();
   });
 
   it("hands focus to the control the caller named as it closes", () => {
@@ -273,6 +326,7 @@ describe("KeyPicker", () => {
             keyGroups={keyGroups}
             selected={null}
             open
+            onOpenChange={jest.fn()}
             focusOnClose={ref}
             onSelect={jest.fn()}
             trigger={<button>open</button>}
@@ -301,6 +355,7 @@ describe("KeyPicker", () => {
             keyGroups={keyGroups}
             selected={null}
             open
+            onOpenChange={jest.fn()}
             focusOnClose={ref}
             onSelect={jest.fn()}
             trigger={<button>open</button>}
@@ -326,6 +381,7 @@ describe("KeyPicker", () => {
           operatorLabels={{ in: "is", contains: "contains" }}
           onSelect={jest.fn()}
           open
+          onOpenChange={jest.fn()}
           trigger={<button>is</button>}
         />
       </>,
@@ -379,6 +435,7 @@ describe("OperatorPicker", () => {
         operatorLabels={operatorLabels}
         onSelect={jest.fn()}
         open
+        onOpenChange={jest.fn()}
         trigger={<button>open</button>}
       />,
     );
@@ -395,6 +452,7 @@ describe("OperatorPicker", () => {
         operatorLabels={operatorLabels}
         onSelect={jest.fn()}
         open
+        onOpenChange={jest.fn()}
         trigger={<button>open</button>}
       />,
     );
@@ -412,6 +470,7 @@ describe("OperatorPicker", () => {
         operatorLabels={filterBarOperatorLabels}
         onSelect={jest.fn()}
         open
+        onOpenChange={jest.fn()}
         trigger={<button>open</button>}
       />,
     );
@@ -432,6 +491,7 @@ describe("OperatorPicker", () => {
         operatorLabels={filterBarOperatorLabels}
         onSelect={jest.fn()}
         open
+        onOpenChange={jest.fn()}
         trigger={<button>open</button>}
       />,
     );
@@ -450,7 +510,7 @@ describe("OperatorPicker", () => {
     );
   });
 
-  it("reports the operator that was picked and closes", () => {
+  it("reports the picked operator and closes, leaving the close itself unreported", () => {
     const onSelect = jest.fn();
     const onOpenChange = jest.fn();
     render(
@@ -468,6 +528,31 @@ describe("OperatorPicker", () => {
     fireEvent.click(screen.getByTestId("filter-op-not_in"));
 
     expect(onSelect).toHaveBeenCalledWith("not_in");
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("stays open when the left button goes down inside the chip it was given", () => {
+    const chip = chipHoldingASegment();
+    render(
+      <OperatorPicker
+        operators={["in", "not_in"]}
+        selected="in"
+        operatorLabels={operatorLabels}
+        onSelect={jest.fn()}
+        open
+        onOpenChange={jest.fn()}
+        stayOpenWithin={{ current: chip }}
+        trigger={<button>open</button>}
+      />,
+    );
+
+    expect(pressOutside(chip.firstChild!)).toHaveBeenCalled();
+    expect(pressOutside(document.body)).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { button: 2 }),
+    ).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { ctrlKey: true }),
+    ).not.toHaveBeenCalled();
   });
 });

--- a/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/value_picker_test.tsx
@@ -4,8 +4,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 jest.mock("@/app/components/popover", () => {
   const PopoverOpen = { current: false };
+  // Radix reports a press outside the popover to this handler; the tests call
+  // it with a press they build themselves.
+  const pointerDownOutside = { current: (_event: any) => {} };
   return {
     __esModule: true,
+    pointerDownOutside,
     Popover: ({ children, open }: any) => {
       PopoverOpen.current = open;
       return <div data-testid="popover">{children}</div>;
@@ -13,10 +17,41 @@ jest.mock("@/app/components/popover", () => {
     PopoverTrigger: ({ children }: any) => (
       <div data-testid="popover-trigger">{children}</div>
     ),
-    PopoverContent: ({ children }: any) =>
-      PopoverOpen.current ? (
-        <div data-testid="popover-content">{children}</div>
-      ) : null,
+    PopoverContent: ({
+      children,
+      onCloseAutoFocus,
+      onPointerDownOutside,
+    }: any) => {
+      pointerDownOutside.current = onPointerDownOutside;
+      return PopoverOpen.current ? (
+        <div data-testid="popover-content">
+          {children}
+          {/* Stands in for Radix finishing a close: it offers the close to the
+              handler and, unless the handler takes it, focuses the trigger. */}
+          <button
+            data-testid="close-popover"
+            onClick={(e) => {
+              let taken = false;
+              onCloseAutoFocus?.({
+                preventDefault: () => {
+                  taken = true;
+                },
+                currentTarget: e.currentTarget.parentElement,
+              } as any);
+              if (!taken) {
+                document
+                  .querySelector<HTMLElement>(
+                    "[data-testid='popover-trigger'] button",
+                  )
+                  ?.focus();
+              }
+            }}
+          >
+            close
+          </button>
+        </div>
+      ) : null;
+    },
   };
 });
 
@@ -91,9 +126,54 @@ function renderPicker(props: any = {}) {
   return { onChange, onOpenChange };
 }
 
+const popover = jest.requireMock("@/app/components/popover") as {
+  pointerDownOutside: { current: (event: unknown) => void };
+};
+
+// Hands the picker a press it did not receive itself, the way Radix does, and
+// reports whether the picker asked to stay open.
+function pressOutside(
+  target: Node,
+  press: { button?: number; ctrlKey?: boolean } = {},
+) {
+  const preventDefault = jest.fn();
+  popover.pointerDownOutside.current({
+    detail: { originalEvent: { target, button: 0, ...press } },
+    preventDefault,
+  });
+  return preventDefault;
+}
+
 describe("ValuePicker", () => {
   beforeEach(() => {
     valuesLoaded([{ text: "1.0.0" }, { text: "1.0.1" }]);
+  });
+
+  it("stays open when the left button goes down inside the chip it was given", () => {
+    const chip = document.createElement("div");
+    chip.appendChild(document.createElement("button"));
+    renderPicker({ stayOpenWithin: { current: chip } });
+
+    expect(pressOutside(chip.firstChild!)).toHaveBeenCalled();
+    expect(pressOutside(document.body)).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { button: 2 }),
+    ).not.toHaveBeenCalled();
+    expect(
+      pressOutside(chip.firstChild!, { ctrlKey: true }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("leaves focus with whatever took it while the picker was closing", () => {
+    renderPicker();
+    const elsewhere = document.createElement("input");
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+
+    fireEvent.click(screen.getByTestId("close-popover"));
+
+    expect(elsewhere).toHaveFocus();
+    elsewhere.remove();
   });
 
   it("shows nothing until it is opened", () => {

--- a/frontend/dashboard/app/components/filter_bar/conditions.ts
+++ b/frontend/dashboard/app/components/filter_bar/conditions.ts
@@ -229,6 +229,17 @@ export function dropById(filter: ConditionGroup, id: string): ConditionGroup {
   return replaceById(filter, id, () => null);
 }
 
+// Removes the condition or group with this id only when `shouldDrop` says so
+// about what is found there, and leaves the filter alone when there is nothing
+// with that id.
+export function dropWhen(
+  filter: ConditionGroup,
+  id: string,
+  shouldDrop: (item: ConditionOrGroup) => boolean,
+): ConditionGroup {
+  return replaceById(filter, id, (item) => (shouldDrop(item) ? null : item));
+}
+
 // Reading order, not sibling order.
 export function rowBefore(
   filter: ConditionGroup,

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -30,6 +30,7 @@ import {
   type ConditionOrGroup,
   type ConditionRow,
   dropById,
+  dropWhen,
   isConditionGroup,
   isRowComplete,
   rowBefore,
@@ -83,9 +84,11 @@ interface FilterBarProps {
   onChange: (change: FilterChange) => void;
 }
 
-type OpenPicker =
-  | { kind: "keys"; groupId: string }
-  | { kind: "values"; rowId: string };
+type RowPickerKind = "key" | "operator" | "values";
+
+type OpenRowPicker = { kind: RowPickerKind; rowId: string };
+
+type OpenPicker = { kind: "keys"; groupId: string } | OpenRowPicker;
 
 type PendingEdit = {
   appId: string;
@@ -138,21 +141,6 @@ function settle(edit: PendingEdit, value: FilterSelection): PendingEdit | null {
   return { ...edit, from: edit.to };
 }
 
-function rowIn(tree: ConditionGroup, rowId: string): ConditionRow | null {
-  for (const child of tree.children) {
-    if (child.id === rowId && !isConditionGroup(child)) {
-      return child;
-    }
-    if (isConditionGroup(child)) {
-      const found = rowIn(child, rowId);
-      if (found) {
-        return found;
-      }
-    }
-  }
-  return null;
-}
-
 function withPickerClosed(
   tree: ConditionGroup,
   picker: OpenPicker | null,
@@ -161,12 +149,17 @@ function withPickerClosed(
     return tree;
   }
   if (picker.kind === "keys") {
-    return dropById(tree, picker.groupId);
+    return dropWhen(
+      tree,
+      picker.groupId,
+      (item) => isConditionGroup(item) && item.children.length === 0,
+    );
   }
-  const row = rowIn(tree, picker.rowId);
-  return row !== null && !isRowComplete(row)
-    ? dropById(tree, picker.rowId)
-    : tree;
+  return dropWhen(
+    tree,
+    picker.rowId,
+    (item) => !isConditionGroup(item) && !isRowComplete(item),
+  );
 }
 
 function appendTo(
@@ -304,11 +297,13 @@ export default function FilterBar({
       : `${first.message} (+${rest.length} more)`;
   }, [draftFilterIssues]);
 
-  const openValuesRowId =
-    pending?.picker?.kind === "values" ? pending.picker.rowId : null;
+  const openRowPicker: OpenRowPicker | null =
+    pending?.picker != null && pending.picker.kind !== "keys"
+      ? pending.picker
+      : null;
 
   useEffect(() => {
-    if (focusedId !== null && focusedId === openValuesRowId) {
+    if (focusedId !== null && openRowPicker?.rowId === focusedId) {
       return;
     }
     focusedControlRef.current?.focus();
@@ -345,6 +340,16 @@ export default function FilterBar({
       toastNegative(limit);
       return;
     }
+    // The text to revert to belongs to the edit the user is making on one
+    // condition, so it is kept for as long as the picker stays on that
+    // condition, whichever of its three pickers is the open one.
+    const stayingOnRow =
+      pending?.picker != null &&
+      pending.picker.kind !== "keys" &&
+      picker !== null &&
+      picker.kind !== "keys" &&
+      pending.picker.rowId === picker.rowId;
+    const carriedRevert = stayingOnRow ? pending?.revert : undefined;
     const text = writeFilterExpr(tree);
     if (text !== drawnText) {
       onChange({ filterExpr: text });
@@ -357,7 +362,7 @@ export default function FilterBar({
       from: pending !== null ? pending.from : filterExpr,
       to: text,
       picker,
-      revert,
+      revert: revert !== undefined ? revert : carriedRevert,
     });
   }
 
@@ -404,6 +409,10 @@ export default function FilterBar({
     send(tree, { kind: "keys", groupId: id });
   }
 
+  function openKeys(groupId: string) {
+    send(baseFor(groupId), { kind: "keys", groupId });
+  }
+
   function closeKeys(groupId: string) {
     setEdit((current) =>
       current?.picker?.kind === "keys" && current.picker.groupId === groupId
@@ -422,7 +431,7 @@ export default function FilterBar({
     send(
       updateRow(baseFor(row.id), row.id, { key, operator, values: [] }),
       opensPicker ? { kind: "values", rowId: row.id } : null,
-      opensPicker && isRowComplete(row) ? drawnText : undefined,
+      isRowComplete(row) ? drawnText : undefined,
     );
   }
 
@@ -436,7 +445,7 @@ export default function FilterBar({
     send(
       updateRow(baseFor(row.id), row.id, { operator, values }),
       opensPicker ? { kind: "values", rowId: row.id } : null,
-      opensPicker && isRowComplete(row) ? drawnText : undefined,
+      isRowComplete(row) ? drawnText : undefined,
     );
   }
 
@@ -451,12 +460,16 @@ export default function FilterBar({
     );
   }
 
-  function openValues(row: ConditionRow) {
-    send(baseFor(row.id), { kind: "values", rowId: row.id });
+  function openRowPickerFor(row: ConditionRow, kind: RowPickerKind) {
+    send(baseFor(row.id), { kind, rowId: row.id });
   }
 
-  function closeValues(row: ConditionRow) {
-    if (pending?.picker?.kind !== "values" || pending.picker.rowId !== row.id) {
+  function closeRowPicker(row: ConditionRow) {
+    if (
+      !pending?.picker ||
+      pending.picker.kind === "keys" ||
+      pending.picker.rowId !== row.id
+    ) {
       return;
     }
     if (!isRowComplete(row) && pending.revert !== undefined) {
@@ -534,12 +547,13 @@ export default function FilterBar({
     focusedControlRef,
     openKeysGroupId:
       pending?.picker?.kind === "keys" ? pending.picker.groupId : null,
-    openValuesRowId,
+    openRowPicker,
     onChangeKey: changeKey,
     onChangeOperator: changeOperator,
     onChangeValues: changeValues,
-    onOpenValues: openValues,
-    onCloseValues: closeValues,
+    onOpenRowPicker: openRowPickerFor,
+    onCloseRowPicker: closeRowPicker,
+    onOpenKeys: openKeys,
     onCloseKeys: closeKeys,
     onRemove: removeById,
     onStartRow: startRow,
@@ -592,9 +606,13 @@ export default function FilterBar({
               keysUnavailable ? "opacity-50 select-none" : ""
             } ${!editingAsText && !keysUnavailable ? "cursor-pointer" : ""}`}
             // A click on empty space anywhere in the bar opens the key list.
-            // A click that reaches a button is left to that button.
+            // A click that reaches a button is left to that button. While a
+            // condition has a picker open, the click is ignored: the chip takes
+            // pointer events back from the modal layer, so a press on its border
+            // reaches the bar, and opening the key list then stacks it over the
+            // chip's picker.
             onClick={(e) => {
-              if (editingAsText || keysUnavailable) {
+              if (editingAsText || keysUnavailable || pending?.picker) {
                 return;
               }
               if ((e.target as HTMLElement).closest("button")) {
@@ -637,8 +655,14 @@ export default function FilterBar({
                       open={keyListOpen}
                       onOpenChange={setKeyListOpen}
                       focusOnClose={focusedControlRef}
-                      onSelect={(key) => startRow(drawn.id, key)}
-                      onAddGroup={() => startGroup(drawn.id)}
+                      onSelect={(key) => {
+                        startRow(drawn.id, key);
+                        setKeyListOpen(false);
+                      }}
+                      onAddGroup={() => {
+                        startGroup(drawn.id);
+                        setKeyListOpen(false);
+                      }}
                       trigger={
                         <button
                           type="button"
@@ -721,7 +745,7 @@ interface FilterEditor {
   focusedId: string | null;
   focusedControlRef: RefObject<HTMLButtonElement | null>;
   openKeysGroupId: string | null;
-  openValuesRowId: string | null;
+  openRowPicker: OpenRowPicker | null;
   onChangeKey: (row: ConditionRow, key: FilterKey) => void;
   onChangeOperator: (row: ConditionRow, operator: FilterOperator) => void;
   onChangeValues: (
@@ -729,8 +753,9 @@ interface FilterEditor {
     values: ConditionRow["values"],
     done: boolean,
   ) => void;
-  onOpenValues: (row: ConditionRow) => void;
-  onCloseValues: (row: ConditionRow) => void;
+  onOpenRowPicker: (row: ConditionRow, kind: RowPickerKind) => void;
+  onCloseRowPicker: (row: ConditionRow) => void;
+  onOpenKeys: (groupId: string) => void;
   onCloseKeys: (groupId: string) => void;
   onRemove: (id: string) => void;
   onStartRow: (groupId: string, key: FilterKey) => void;
@@ -790,20 +815,16 @@ function FilterGroup({
         keys={editor.keys}
         keyGroups={editor.keyGroups}
         selected={null}
-        open={pickingFirstKey ? true : undefined}
-        onOpenChange={
-          pickingFirstKey
-            ? (open) => {
-                if (!open) {
-                  editor.onCloseKeys(group.id);
-                }
-              }
-            : undefined
+        open={pickingFirstKey}
+        onOpenChange={(open) =>
+          open ? editor.onOpenKeys(group.id) : editor.onCloseKeys(group.id)
         }
         focusOnClose={editor.focusedControlRef}
         onSelect={(key) => editor.onStartRow(group.id, key)}
         onAddGroup={
-          pickingFirstKey ? undefined : () => editor.onStartGroup(group.id)
+          group.children.length === 0
+            ? undefined
+            : () => editor.onStartGroup(group.id)
         }
         trigger={
           <button
@@ -842,13 +863,32 @@ function FilterRow({
 }) {
   const { keys, keyGroups, appId, entity, focusedId, focusedControlRef } =
     editor;
+  const chipRef = useRef<HTMLSpanElement>(null);
+  const openPickerKind =
+    editor.openRowPicker?.rowId === row.id ? editor.openRowPicker.kind : null;
+  const segmentPicker = (kind: RowPickerKind) => ({
+    open: openPickerKind === kind,
+    onOpenChange: (open: boolean) =>
+      open ? editor.onOpenRowPicker(row, kind) : editor.onCloseRowPicker(row),
+  });
 
   return (
-    <span className="inline-flex items-stretch h-6 max-w-full min-w-0 overflow-hidden rounded-sm border border-input bg-accent/80 font-display text-xs">
+    <span
+      ref={chipRef}
+      // A picker of this chip is a modal popover, which turns off pointer
+      // events on everything behind it. The chip turns them back on for
+      // itself, so a press on one of its other segments reaches that segment
+      // and opens its picker.
+      className={`inline-flex items-stretch h-6 max-w-full min-w-0 overflow-hidden rounded-sm border border-input bg-accent/80 font-display text-xs ${
+        openPickerKind === null ? "" : "pointer-events-auto"
+      }`}
+    >
       <KeyPicker
         keys={keys}
         keyGroups={keyGroups}
         selected={row.key}
+        {...segmentPicker("key")}
+        stayOpenWithin={chipRef}
         onSelect={(key) => editor.onChangeKey(row, key)}
         trigger={
           <button
@@ -865,6 +905,8 @@ function FilterRow({
         operators={row.key.operators}
         selected={row.operator}
         operatorLabels={operatorLabels}
+        {...segmentPicker("operator")}
+        stayOpenWithin={chipRef}
         onSelect={(operator) =>
           editor.onChangeOperator(row, operator as FilterOperator)
         }
@@ -889,14 +931,8 @@ function FilterRow({
           takesOneValue={operatorTakesOneValue(row.operator)}
           selected={row.values}
           onChange={(values, done) => editor.onChangeValues(row, values, done)}
-          open={row.id === editor.openValuesRowId}
-          onOpenChange={(open) => {
-            if (open) {
-              editor.onOpenValues(row);
-            } else {
-              editor.onCloseValues(row);
-            }
-          }}
+          {...segmentPicker("values")}
+          stayOpenWithin={chipRef}
           trigger={
             <button
               type="button"

--- a/frontend/dashboard/app/components/filter_bar/key_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/key_picker.tsx
@@ -7,6 +7,7 @@ import { Button } from "../button";
 import { Input } from "../input";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 import TabSelect from "../tab_select";
+import { keepOpenWithin, settleFocusOnClose } from "./picker_popover";
 
 interface KeyPickerProps {
   keys: FilterKey[];
@@ -15,12 +16,13 @@ interface KeyPickerProps {
   onSelect: (key: FilterKey) => void;
   onAddGroup?: () => void;
   trigger: React.ReactNode;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   align?: "start" | "end";
   // Where focus goes when the list closes, for a caller that wants it
   // somewhere other than the control that opened it.
   focusOnClose?: React.RefObject<HTMLElement | null>;
+  stayOpenWithin?: React.RefObject<HTMLElement | null>;
 }
 
 export default function KeyPicker({
@@ -30,22 +32,16 @@ export default function KeyPicker({
   onSelect,
   onAddGroup,
   trigger,
-  open: controlledOpen,
+  open,
   onOpenChange,
   align = "start",
   focusOnClose,
+  stayOpenWithin,
 }: KeyPickerProps) {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const open = controlledOpen ?? internalOpen;
-  const setOpen = (value: boolean) => {
-    setInternalOpen(value);
-    onOpenChange?.(value);
-  };
-
   return (
     // modal keeps the TAB key inside the open list, and returns focus to
     // whatever opened it when the list closes.
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={onOpenChange} modal>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent
         // Sized to its content, so an entity with few tabs does not open
@@ -53,15 +49,13 @@ export default function KeyPicker({
         className="p-0 w-auto min-w-96 max-w-[min(32rem,calc(100vw-2rem))]"
         align={align}
         onCloseAutoFocus={(e) => settleFocusOnClose(e, focusOnClose)}
+        onPointerDownOutside={keepOpenWithin(stayOpenWithin)}
       >
         <KeyList
           keys={keys}
           keyGroups={keyGroups}
           selected={selected}
-          onSelect={(key) => {
-            onSelect(key);
-            setOpen(false);
-          }}
+          onSelect={onSelect}
         />
 
         {onAddGroup && (
@@ -69,10 +63,7 @@ export default function KeyPicker({
             <button
               type="button"
               data-testid="filter-add-group"
-              onClick={() => {
-                onAddGroup();
-                setOpen(false);
-              }}
+              onClick={onAddGroup}
               className="flex items-center gap-2 w-full text-left px-2 py-1.5 rounded outline-none hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
             >
               <Parentheses className="h-4 w-4 text-muted-foreground" />
@@ -200,62 +191,33 @@ function KeyList({
   );
 }
 
-// Radix runs this when a picker has finished closing, and by default then
-// focuses the picker's trigger. When the user picked a key or an operator,
-// the bar has already opened the value picker for that condition and its
-// input holds focus, and focusing the trigger would take the user's typing
-// away from it. So when focus is already somewhere outside the closed picker,
-// it stays there. Otherwise, as after Escape, focus goes to the control the
-// caller named, or to the trigger when the caller named none.
-function settleFocusOnClose(
-  e: Event,
-  focusOnClose?: React.RefObject<HTMLElement | null>,
-) {
-  const active = document.activeElement;
-  const content = e.currentTarget as HTMLElement | null;
-  const elsewhere =
-    active !== null && active !== document.body && !content?.contains(active);
-  if (elsewhere) {
-    e.preventDefault();
-    return;
-  }
-  if (focusOnClose?.current) {
-    e.preventDefault();
-    focusOnClose.current.focus();
-  }
-}
-
 export function OperatorPicker({
   operators,
   selected,
   operatorLabels,
   onSelect,
   trigger,
-  open: controlledOpen,
+  open,
   onOpenChange,
+  stayOpenWithin,
 }: {
   operators: string[];
   selected: string | null;
   operatorLabels: Record<string, string>;
   onSelect: (operator: string) => void;
   trigger: React.ReactNode;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stayOpenWithin?: React.RefObject<HTMLElement | null>;
 }) {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const open = controlledOpen ?? internalOpen;
-  const setOpen = (value: boolean) => {
-    setInternalOpen(value);
-    onOpenChange?.(value);
-  };
-
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={onOpenChange} modal>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent
         className="p-1 w-48"
         align="start"
         onCloseAutoFocus={(e) => settleFocusOnClose(e)}
+        onPointerDownOutside={keepOpenWithin(stayOpenWithin)}
       >
         <div className="flex flex-col">
           {operators.map((operator) => (
@@ -266,10 +228,7 @@ export function OperatorPicker({
                 selected === operator ? "bg-accent" : ""
               }`}
               data-testid={`filter-op-${operator}`}
-              onClick={() => {
-                onSelect(operator);
-                setOpen(false);
-              }}
+              onClick={() => onSelect(operator)}
             >
               {operatorLabels[operator] ?? operator}
             </Button>

--- a/frontend/dashboard/app/components/filter_bar/picker_popover.ts
+++ b/frontend/dashboard/app/components/filter_bar/picker_popover.ts
@@ -1,0 +1,48 @@
+import type { RefObject } from "react";
+
+// Radix runs this when a picker has finished closing, and by default then
+// focuses the picker's trigger. By then the bar has often opened another
+// picker on the same condition, which already holds focus, and focusing the
+// trigger would take it away. So when focus is already outside the closed
+// picker, it stays there. Otherwise, as after Escape, focus goes to the control
+// the caller named, or to the trigger when the caller named none.
+export function settleFocusOnClose(
+  e: Event,
+  focusOnClose?: RefObject<HTMLElement | null>,
+) {
+  const active = document.activeElement;
+  const content = e.currentTarget as HTMLElement | null;
+  const elsewhere =
+    active !== null && active !== document.body && !content?.contains(active);
+  if (elsewhere) {
+    e.preventDefault();
+    return;
+  }
+  if (focusOnClose?.current) {
+    e.preventDefault();
+    focusOnClose.current.focus();
+  }
+}
+
+// A picker is dismissed by any pointer press outside it. A picker that belongs
+// to a condition chip is given the chip's element as `stayOpenWithin`, and a
+// plain left press anywhere inside that chip does not close the picker, so
+// pressing another segment of the chip opens that segment's picker. Right,
+// middle and ctrl presses still dismiss.
+export function keepOpenWithin(
+  stayOpenWithin: RefObject<HTMLElement | null> | undefined,
+) {
+  return (e: {
+    detail: { originalEvent: PointerEvent };
+    preventDefault: () => void;
+  }) => {
+    const { target, button, ctrlKey } = e.detail.originalEvent;
+    if (
+      button === 0 &&
+      !ctrlKey &&
+      stayOpenWithin?.current?.contains(target as Node)
+    ) {
+      e.preventDefault();
+    }
+  };
+}

--- a/frontend/dashboard/app/components/filter_bar/value_picker.tsx
+++ b/frontend/dashboard/app/components/filter_bar/value_picker.tsx
@@ -12,6 +12,7 @@ import DebounceTextInput from "../debounce_text_input";
 import { Input } from "../input";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 import { Skeleton } from "../skeleton";
+import { keepOpenWithin, settleFocusOnClose } from "./picker_popover";
 
 interface ValuePickerProps {
   appId: string;
@@ -28,8 +29,9 @@ interface ValuePickerProps {
   // `done` marks a pick that ends the selection; the owner of `open` closes.
   onChange: (values: FilterValue[], done: boolean) => void;
   trigger: React.ReactNode;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stayOpenWithin?: React.RefObject<HTMLElement | null>;
 }
 
 export default function ValuePicker({
@@ -43,16 +45,10 @@ export default function ValuePicker({
   selected,
   onChange,
   trigger,
-  open: controlledOpen,
+  open,
   onOpenChange,
+  stayOpenWithin,
 }: ValuePickerProps) {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const open = controlledOpen ?? internalOpen;
-  const setOpen = (value: boolean) => {
-    setInternalOpen(value);
-    onOpenChange?.(value);
-  };
-
   const listed =
     !takesTypedText &&
     (valueSuggestionMode === "full_list" || valueSuggestionMode === "sample");
@@ -64,7 +60,6 @@ export default function ValuePicker({
   const toggle = (value: FilterValue) => {
     if (takesOneValue) {
       onChange([value], true);
-      setInternalOpen(false);
       return;
     }
     if (isSelected(value)) {
@@ -78,11 +73,13 @@ export default function ValuePicker({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={onOpenChange} modal>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent
         className="p-0 w-auto min-w-72 max-w-[min(24rem,calc(100vw-2rem))]"
         align="start"
+        onCloseAutoFocus={(e) => settleFocusOnClose(e)}
+        onPointerDownOutside={keepOpenWithin(stayOpenWithin)}
       >
         {listed ? (
           <ValueList
@@ -99,10 +96,7 @@ export default function ValuePicker({
           <TypedValue
             initial={selected[0]?.text ?? ""}
             valueType={valueType}
-            onApply={(text) => {
-              onChange([{ text }], true);
-              setInternalOpen(false);
-            }}
+            onApply={(text) => onChange([{ text }], true)}
           />
         )}
       </PopoverContent>


### PR DESCRIPTION
# Description

- Clicking a chip's key or operator segment while another of its pickers was open dismissed that picker, which dropped a chip that had no value yet
- The bar now owns the open state of a chip's three pickers, a press inside the chip does not dismiss, and the text a chip reverts to is kept for the whole edit on that chip

## Related issue
Fixes #4444



