### PR TITLE
perf(backend): read value suggestions from raw tables for 30 days only

### DIFF
--- a/backend/libs/exprfilter/bugreports.go
+++ b/backend/libs/exprfilter/bugreports.go
@@ -62,6 +62,7 @@ var bugReportFixedKeyValues = fixedKeyValueSource{
 	table:       "bug_reports",
 	columns:     bugReportsTableColumns,
 	recencyExpr: "max(timestamp)",
+	timeColumn:  "timestamp",
 }
 
 // The custom keys are the user-defined attributes set on the session a

--- a/backend/libs/exprfilter/custom_values_test.go
+++ b/backend/libs/exprfilter/custom_values_test.go
@@ -28,6 +28,7 @@ func seedSpanUDAttrs(ctx context.Context, t *testing.T) (teamID, appID, otherApp
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "free", Timestamp: base})
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "pro", Timestamp: base.Add(10 * time.Minute)})
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "", Timestamp: base.Add(20 * time.Minute)})
+	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "plan", Value: "legacy", Timestamp: base.Add(-40 * 24 * time.Hour)})
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "is_premium", Type: "bool", Value: "true", Timestamp: base})
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "retries", Type: "int64", Value: "3", Timestamp: base})
 	th.SeedSpanUDAttrRow(ctx, t, teamID.String(), appID.String(), testinfra.SpanUDAttrRow{Key: "ratio", Type: "float64", Value: "0.5", Timestamp: base})
@@ -247,6 +248,13 @@ func TestCustomSpanKeyValues(t *testing.T) {
 		}
 		if len(got) != 2 || got[0] != "pro" || got[1] != "free" {
 			t.Errorf("want [pro free], got %v", got)
+		}
+	})
+
+	t.Run("a value last written more than 30 days ago stays out", func(t *testing.T) {
+		got, _ := list(t, plan, ValueRequest{Search: "legacy"})
+		if len(got) != 0 {
+			t.Errorf("want no values, got %v", got)
 		}
 	})
 

--- a/backend/libs/exprfilter/customstore.go
+++ b/backend/libs/exprfilter/customstore.go
@@ -112,7 +112,8 @@ func (s customKeyStore) suggestValues(ctx context.Context, chPool driver.Conn, t
 		Select("value").
 		Select("max(timestamp) as recency").
 		Where("team_id = toUUID(?)", teamID).
-		Where("app_id = toUUID(?)", appID)
+		Where("app_id = toUUID(?)", appID).
+		Where("timestamp >= " + suggestionWindow)
 
 	if s.extraScope != "" {
 		stmt.Where(s.extraScope)

--- a/backend/libs/exprfilter/sessions.go
+++ b/backend/libs/exprfilter/sessions.go
@@ -127,6 +127,7 @@ var sessionsTableValues = fixedKeyValueSource{
 		sessionScreen.Name:      "arrayJoin(" + rawSessionColumnForms.screen + ")",
 	},
 	recencyExpr: "max(first_event_timestamp)",
+	timeColumn:  "first_event_timestamp",
 }
 
 // Every attribute written in the session counts, whichever event or bug report

--- a/backend/libs/exprfilter/sessions_values_test.go
+++ b/backend/libs/exprfilter/sessions_values_test.go
@@ -53,6 +53,9 @@ func seedSessionEvents(ctx context.Context, t *testing.T) (teamID, appID, patchI
 		Type: "custom", CustomName: "checkout_completed", Timestamp: base.Add(20 * time.Minute),
 	})
 	th.SeedScreenViewInSession(ctx, t, teamID.String(), appID.String(), uuid.NewString(), "CheckoutScreen", base.Add(30*time.Minute))
+	th.SeedEventRows(ctx, t, teamID.String(), appID.String(), 1, attributed(testinfra.EventRow{
+		AppVersion: "1.0.0", AppBuild: "100", UserID: "ana-of-old", Timestamp: base.Add(-40 * 24 * time.Hour),
+	}))
 	th.SeedEventRows(ctx, t, teamID.String(), otherAppID.String(), 1, attributed(testinfra.EventRow{
 		AppVersion: "9.0.0", AppBuild: "900", UserID: "other", Timestamp: base,
 	}))
@@ -80,8 +83,8 @@ func TestSessionValues(t *testing.T) {
 	}
 
 	t.Run("version names come from the rollup, once each", func(t *testing.T) {
-		if got := list(t, "version_name", ValueRequest{}); !slices.Equal(got, []string{"1.1.0", "1.2.0"}) {
-			t.Errorf("want [1.1.0 1.2.0], got %v", got)
+		if got := list(t, "version_name", ValueRequest{}); !slices.Equal(got, []string{"1.1.0", "1.2.0", "1.0.0"}) {
+			t.Errorf("want [1.1.0 1.2.0 1.0.0], got %v", got)
 		}
 	})
 
@@ -106,6 +109,15 @@ func TestSessionValues(t *testing.T) {
 	t.Run("user ids come from the sessions table, most recent first", func(t *testing.T) {
 		if got := list(t, "user_id", ValueRequest{}); !slices.Equal(got, []string{"zoe", "ana"}) {
 			t.Errorf("want [zoe ana], got %v", got)
+		}
+	})
+
+	t.Run("a user id last seen more than 30 days ago is not suggested, though its version still is", func(t *testing.T) {
+		if got := list(t, "user_id", ValueRequest{Search: "old"}); len(got) != 0 {
+			t.Errorf("want no user ids, got %v", got)
+		}
+		if got := list(t, "version_name", ValueRequest{Search: "1.0.0"}); !slices.Equal(got, []string{"1.0.0"}) {
+			t.Errorf("want [1.0.0] from the rollup, got %v", got)
 		}
 	})
 

--- a/backend/libs/exprfilter/valuesuggestions.go
+++ b/backend/libs/exprfilter/valuesuggestions.go
@@ -17,12 +17,19 @@ import (
 // fixedKeyValueSource says where an entity's fixed-key value suggestions are
 // read from: a ClickHouse table, the column expression each key's values are
 // read from, and the aggregate expression that dates a value for
-// most-recently-seen-first ordering.
+// most-recently-seen-first ordering. timeColumn names the row timestamp of a
+// raw table so the read stays within the suggestion window; a rollup that is
+// small enough to read whole leaves it empty.
 type fixedKeyValueSource struct {
 	table       string
 	columns     map[string]string
 	recencyExpr string
+	timeColumn  string
 }
+
+// A suggestion is only a shortcut for typing a value, so a raw table is read
+// for the last 30 days only; older values can still be typed in.
+const suggestionWindow = "now() - interval 30 day"
 
 // SuggestKeyValues lists what one key can be set to, narrowed by what has
 // been typed. An enum key answers from its own value list without a read, a
@@ -88,7 +95,13 @@ func suggestFixedKeyValuesFromClickHouse(sources ...fixedKeyValueSource) func(ct
 			Select(valueExpr+" as suggested_value").
 			Select(fixedValues.recencyExpr+" as recency").
 			Where("team_id = toUUID(?)", teamID).
-			Where("app_id = toUUID(?)", appID).
+			Where("app_id = toUUID(?)", appID)
+
+		if fixedValues.timeColumn != "" {
+			stmt.Where(fixedValues.timeColumn + " >= " + suggestionWindow)
+		}
+
+		stmt.
 			Where(unsetTest, unsetArgs...).
 			GroupBy("suggested_value").
 			OrderBy("recency desc, suggested_value").

--- a/backend/libs/exprfilter/valuesuggestions_test.go
+++ b/backend/libs/exprfilter/valuesuggestions_test.go
@@ -78,7 +78,7 @@ func TestSuggestionSQL(t *testing.T) {
 			},
 			wantSQL: "SELECT device_name as suggested_value, max(timestamp) as recency" +
 				" FROM bug_reports" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND device_name <> ''" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND timestamp >= now() - interval 30 day AND device_name <> ''" +
 				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
 			wantArgs: []any{teamID, appID, DefaultValueLimit + 1},
 		},
@@ -90,7 +90,7 @@ func TestSuggestionSQL(t *testing.T) {
 			},
 			wantSQL: "SELECT toString(patch_id) as suggested_value, max(timestamp) as recency" +
 				" FROM bug_reports" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND toString(patch_id) <> ?" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND timestamp >= now() - interval 30 day AND toString(patch_id) <> ?" +
 				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
 			wantArgs: []any{teamID, appID, uuid.Nil.String(), DefaultValueLimit + 1},
 		},
@@ -138,7 +138,7 @@ func TestSuggestionSQL(t *testing.T) {
 			},
 			wantSQL: "SELECT arrayJoin(user_ids) as suggested_value, max(first_event_timestamp) as recency" +
 				" FROM sessions" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND arrayJoin(user_ids) <> '' AND arrayJoin(user_ids) ilike ?" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND first_event_timestamp >= now() - interval 30 day AND arrayJoin(user_ids) <> '' AND arrayJoin(user_ids) ilike ?" +
 				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
 			wantArgs: []any{teamID, appID, "%ana%", DefaultValueLimit + 1},
 		},
@@ -149,7 +149,7 @@ func TestSuggestionSQL(t *testing.T) {
 			},
 			wantSQL: "SELECT value, max(timestamp) as recency" +
 				" FROM span_user_def_attrs" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND key = ? AND type = ? AND value <> ''" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND timestamp >= now() - interval 30 day AND key = ? AND type = ? AND value <> ''" +
 				" GROUP BY value ORDER BY recency desc, value LIMIT ?",
 			wantArgs: []any{teamID, appID, "plan", "string", DefaultValueLimit + 1},
 		},
@@ -160,7 +160,7 @@ func TestSuggestionSQL(t *testing.T) {
 			},
 			wantSQL: "SELECT value, max(timestamp) as recency" +
 				" FROM user_def_attrs" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND bug_report = true AND key = ? AND type = ? AND value <> '' AND value ilike ?" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND timestamp >= now() - interval 30 day AND bug_report = true AND key = ? AND type = ? AND value <> '' AND value ilike ?" +
 				" GROUP BY value ORDER BY recency desc, value LIMIT ?",
 			wantArgs: []any{teamID, appID, "plan", "string", "%fr%", 4},
 		},


### PR DESCRIPTION
# Description

- Sessions, bug reports and custom attribute suggestions scanned the whole table on every keystroke, grouping every distinct value
- The raw-table queries now read the last 30 days; a suggestion is a shortcut for typing, so older values can still be typed in

## Related issue
Closes #4443


