### PR TITLE
fix(flutter): record layout snapshots in device pixels

### DIFF
--- a/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_capture.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_capture.dart
@@ -35,6 +35,7 @@ class _CaptureState {
   final GestureDetectionMode? detectionMode;
   final Element rootElement;
   final Map<Type, String>? widgetFilter;
+  final double devicePixelRatio;
 
   Element? gestureElement;
   String? gestureElementType;
@@ -49,6 +50,7 @@ class _CaptureState {
     this.detectionPosition,
     this.detectionMode,
     this.widgetFilter,
+    required this.devicePixelRatio,
   });
 }
 
@@ -60,6 +62,7 @@ class LayoutSnapshotCapture {
     Offset? detectionPosition,
     GestureDetectionMode? detectionMode,
     Map<Type, String>? widgetFilter,
+    required double devicePixelRatio,
   }) {
     Timeline.startSync('msr-layoutSnapshot-capture');
     try {
@@ -73,6 +76,7 @@ class LayoutSnapshotCapture {
         detectionPosition: detectionPosition,
         detectionMode: detectionMode,
         widgetFilter: widgetFilter,
+        devicePixelRatio: devicePixelRatio,
       );
 
       final nodes = _recursiveTraverse(rootElement, state);
@@ -154,7 +158,10 @@ class LayoutSnapshotCapture {
     // 2. This is the detected gesture element
     // 3. Widget matches filter
     if (isGestureElement || (isInScreenBounds && matchedType != null)) {
-      return [_createNode(element, children, isGestureElement, matchedType, bounds)];
+      return [
+        _createNode(element, children, isGestureElement, matchedType, bounds,
+            state.devicePixelRatio)
+      ];
     }
 
     // Otherwise promote children
@@ -277,15 +284,16 @@ class LayoutSnapshotCapture {
     bool isGestureElement,
     String? widgetName,
     Rect bounds,
+    double devicePixelRatio,
   ) {
     final widget = element.widget;
     return SnapshotNode(
       label: widgetName ?? widget.runtimeType.toString(),
       type: getWidgetElementType(widget),
-      x: bounds.left,
-      y: bounds.top,
-      width: bounds.width,
-      height: bounds.height,
+      x: bounds.left * devicePixelRatio,
+      y: bounds.top * devicePixelRatio,
+      width: bounds.width * devicePixelRatio,
+      height: bounds.height * devicePixelRatio,
       highlighted: isGestureElement,
       scrollable: getScrollableWidgetName(widget) != null,
       children: children,

--- a/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_collector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/layout_snapshot_collector.dart
@@ -41,6 +41,7 @@ class LayoutSnapshotCollector {
         rootElement,
         screenBounds: _screenBounds(rootElement),
         widgetFilter: _configProvider.widgetFilter,
+        devicePixelRatio: MediaQuery.of(rootElement).devicePixelRatio,
       );
       if (result == null) {
         return null;

--- a/flutter/packages/measure_flutter/lib/src/gestures/msr_gesture_detector.dart
+++ b/flutter/packages/measure_flutter/lib/src/gestures/msr_gesture_detector.dart
@@ -174,6 +174,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
       detectionPosition: position,
       detectionMode: GestureDetectionMode.click,
       widgetFilter: Measure.instance.getLayoutSnapshotWidgetFilter(),
+      devicePixelRatio: devicePixelRatio,
     );
 
     if (result != null) {
@@ -225,6 +226,7 @@ class MsrGestureDetectorState extends State<MsrGestureDetector> {
       detectionMode: GestureDetectionMode.click,
       widgetFilter: Measure.instance.getLayoutSnapshotWidgetFilter(),
       screenBounds: screenBounds,
+      devicePixelRatio: devicePixelRatio,
     );
 
     if (result == null ||

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_capture_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_capture_test.dart
@@ -6,7 +6,7 @@ import 'package:measure_flutter/src/gestures/snapshot_node.dart';
 void main() {
   group('LayoutSnapshotCapture', () {
     testWidgets('returns null for null element', (WidgetTester tester) async {
-      final result = LayoutSnapshotCapture.capture(null);
+      final result = LayoutSnapshotCapture.capture(null, devicePixelRatio: 1);
 
       expect(result, isNull);
     });
@@ -32,7 +32,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // With ancestor support, MaterialApp is now the root with Scaffold nested inside
@@ -70,6 +70,7 @@ void main() {
         element,
         detectionPosition: buttonCenter,
         detectionMode: GestureDetectionMode.click,
+        devicePixelRatio: 1,
       );
 
       // We detect the inner most widget which can take the gesture,
@@ -104,6 +105,7 @@ void main() {
         element,
         detectionPosition: listViewCenter,
         detectionMode: GestureDetectionMode.scroll,
+        devicePixelRatio: 1,
       );
 
       expect(result, isNotNull);
@@ -141,7 +143,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // With ancestor support, MaterialApp is the root with nested structure inside
@@ -189,6 +191,7 @@ void main() {
       final result = LayoutSnapshotCapture.capture(
         element,
         screenBounds: screenBounds,
+        devicePixelRatio: 1,
       );
 
       expect(result, isNotNull);
@@ -231,7 +234,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // Visible button should be captured
@@ -266,7 +269,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // Visible button should be captured
@@ -301,7 +304,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // Visible button should be captured
@@ -330,7 +333,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       final buttonSnapshot = _findWidgetByType(result!.snapshot, 'ElevatedButton');
@@ -340,6 +343,31 @@ void main() {
       expect(buttonSnapshot.height, greaterThan(0));
       expect(buttonSnapshot.x, greaterThanOrEqualTo(0));
       expect(buttonSnapshot.y, greaterThanOrEqualTo(0));
+    });
+
+    testWidgets('reports bounds in device pixels', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(child: Text('Scaled')),
+          ),
+        ),
+      );
+
+      final textRect = tester.getRect(find.text('Scaled'));
+      final element = tester.element(find.byType(MaterialApp));
+
+      final result = LayoutSnapshotCapture.capture(
+        element,
+        devicePixelRatio: 3,
+      );
+
+      final textSnapshot = _findWidgetByType(result!.snapshot, 'Text');
+      expect(textSnapshot, isNotNull);
+      expect(textSnapshot!.x, textRect.left * 3);
+      expect(textSnapshot.y, textRect.top * 3);
+      expect(textSnapshot.width, textRect.width * 3);
+      expect(textSnapshot.height, textRect.height * 3);
     });
 
     testWidgets('uses framework widgets when widgets filter input is null', (WidgetTester tester) async {
@@ -363,6 +391,7 @@ void main() {
       final result = LayoutSnapshotCapture.capture(
         element,
         widgetFilter: null,
+        devicePixelRatio: 1,
       );
 
       expect(result, isNotNull);
@@ -393,6 +422,7 @@ void main() {
       final result = LayoutSnapshotCapture.capture(
         element,
         widgetFilter: {},
+        devicePixelRatio: 1,
       );
 
       expect(result, isNotNull);
@@ -429,6 +459,7 @@ void main() {
         widgetFilter: {
           _CustomWidget: 'CustomWidget',
         },
+        devicePixelRatio: 1,
       );
 
       expect(result, isNotNull);
@@ -468,7 +499,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       // The home route's button should be filtered out
@@ -492,7 +523,7 @@ void main() {
       );
 
       final element = tester.element(find.byType(MaterialApp));
-      final result = LayoutSnapshotCapture.capture(element);
+      final result = LayoutSnapshotCapture.capture(element, devicePixelRatio: 1);
 
       expect(result, isNotNull);
       final buttonSnapshot = _findWidgetByType(result!.snapshot, 'ElevatedButton');

--- a/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
+++ b/flutter/packages/measure_flutter/test/gestures/layout_snapshot_collector_test.dart
@@ -98,6 +98,20 @@ void main() {
       expect(result!.type, equals(AttachmentType.layoutSnapshotJson));
     });
 
+    testWidgets('captures the screen in device pixels', (tester) async {
+      tester.view.devicePixelRatio = 2;
+      addTearDown(() => tester.view.devicePixelRatio = 1);
+
+      final future = collector.captureAttachmentAfterNextFrame();
+      await tester.pumpWidget(measureApp(child: const Text('Home')));
+      await future;
+
+      final textRect = tester.getRect(find.text('Home'));
+      final captured = worker.lastSnapshot!;
+      expect(captured.width, textRect.width * 2);
+      expect(captured.height, textRect.height * 2);
+    });
+
     testWidgets('returns null when reading the widget tree throws',
         (tester) async {
       final failing = LayoutSnapshotCollector(

--- a/flutter/packages/measure_flutter/test/utils/fake_file_processing_isolate.dart
+++ b/flutter/packages/measure_flutter/test/utils/fake_file_processing_isolate.dart
@@ -6,6 +6,7 @@ import 'package:measure_flutter/src/isolate/file_processing_isolate.dart';
 class FakeFileProcessingIsolate implements FileProcessingIsolate {
   bool shouldReturnError = false;
   bool shouldThrowException = false;
+  SnapshotNode? lastSnapshot;
 
   @override
   Future<void> init() async {
@@ -32,6 +33,7 @@ class FakeFileProcessingIsolate implements FileProcessingIsolate {
       return const FileProcessingResult(error: 'Write failed');
     }
 
+    lastSnapshot = snapshot;
     final filePath = '$rootPath/$fileName';
     final jsonString = snapshot.toJson().toString();
     final size = jsonString.length;


### PR DESCRIPTION
# Description

Snapshot bounds used logical points, while gesture coordinates used device pixels. This mismatch placed touch indicators outside their snapshots. This change scales snapshot bounds by the device pixel ratio and makes the ratio required. Previously, the screen view path defaulted to 1, causing the mismatch.

## Related issue
Fixes #4239 

