### PR TITLE
fix: use SPDX license name & valid distribution in sdk packages

### DIFF
--- a/android/measure-android/measure/build.gradle.kts
+++ b/android/measure-android/measure/build.gradle.kts
@@ -38,9 +38,9 @@ mavenPublishing {
         url.set("https://github.com/measure-sh/measure")
         licenses {
             license {
-                name.set("The Apache License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
             }
         }
         developers {

--- a/android/measure-gradle-plugin/build.gradle.kts
+++ b/android/measure-gradle-plugin/build.gradle.kts
@@ -47,9 +47,9 @@ mavenPublishing {
         url.set("https://github.com/measure-sh/measure")
         licenses {
             license {
-                name.set("The Apache License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
             }
         }
         developers {

--- a/kmp/measure-kmp/build.gradle.kts
+++ b/kmp/measure-kmp/build.gradle.kts
@@ -92,9 +92,9 @@ mavenPublishing {
         url.set("https://github.com/measure-sh/measure")
         licenses {
             license {
-                name.set("The Apache License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
             }
         }
         developers {

--- a/measure-sh.podspec
+++ b/measure-sh.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
   spec.version      = "0.13.2"
   spec.summary      = "Open source tool to monitor mobile apps"
   spec.homepage     = "https://github.com/measure-sh/measure.git"
-  spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.license      = { :type => "Apache-2.0", :file => "LICENSE" }
   spec.author       = "measure.sh"
   spec.platform     = :ios, "13.0"
   spec.swift_version = "5.10"

--- a/react-native/MeasureReactNative.podspec
+++ b/react-native/MeasureReactNative.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.summary          = "A native bridge for the Measure React Native SDK"
     s.description      = "This pod provides a native bridge for integrating the Measure React Native SDK into iOS applications, allowing developers to utilize Measure's features seamlessly."
     s.homepage         = "https://github.com/measure-sh/measure.git"
-    s.license          = { :type => "Apache 2.0", :file => "LICENSE" }
+    s.license          = { :type => "Apache-2.0", :file => "LICENSE" }
     s.author           = "measure.sh"
     s.source           = { :path => "." }
     s.platform     = :ios, "13.0"


### PR DESCRIPTION
## Summary

This PR corrects the software license metadata across every artifact Measure publishes. The three Maven Central POMs now declare the SPDX identifier `Apache-2.0` as the license name that Maven recommends, so license scanners & policy plugins classify our artifacts without alias rules & the `distribution` element carries `repo` instead of a URL, which is one of the two values that element accepts. The two CocoaPods podspecs move to the same SPDX identifier, matching the Flutter podspec & the npm package that already use it. This is metadata only, so artifact contents & SDK behavior stay the same.

## Tasks

- [x] Fix the Android SDK & Gradle plugin POMs
- [x] Fix the KMP SDK POM
- [x] Fix the iOS & React Native podspecs
- [x] Audit every registry Measure publishes to for the same defect
