### PR TITLE
Replace arrayJoin in session suggestions and round the suggestion window start to the hour

### DIFF
--- a/backend/libs/exprfilter/sessions.go
+++ b/backend/libs/exprfilter/sessions.go
@@ -122,12 +122,13 @@ var sessionsAppFiltersValues = fixedKeyValueSource{
 var sessionsTableValues = fixedKeyValueSource{
 	table: "sessions",
 	columns: map[string]string{
-		userID.Name:             "arrayJoin(user_ids)",
-		sessionCustomEvent.Name: "arrayJoin(unique_custom_type_names)",
-		sessionScreen.Name:      "arrayJoin(" + rawSessionColumnForms.screen + ")",
+		userID.Name:             "user_ids",
+		sessionCustomEvent.Name: "unique_custom_type_names",
+		sessionScreen.Name:      rawSessionColumnForms.screen,
 	},
-	recencyExpr: "max(first_event_timestamp)",
-	timeColumn:  "first_event_timestamp",
+	recencyExpr:  "max(first_event_timestamp)",
+	timeColumn:   "first_event_timestamp",
+	arrayColumns: true,
 }
 
 // Every attribute written in the session counts, whichever event or bug report

--- a/backend/libs/exprfilter/sessions_values_test.go
+++ b/backend/libs/exprfilter/sessions_values_test.go
@@ -67,6 +67,10 @@ func TestSessionValues(t *testing.T) {
 	ctx := context.Background()
 	teamID, appID, patchID := seedSessionEvents(ctx, t)
 
+	// The reads carry the release mode query settings, so a statement that
+	// ClickHouse refuses to cache fails here the same way it fails in production.
+	ctx = WithFilterQuerySettings(ctx, true, false, "session_values")
+
 	byName := IndexKeysByName(SessionsEntity.Keys)
 
 	list := func(t *testing.T, keyName string, valueRequest ValueRequest) []string {

--- a/backend/libs/exprfilter/valuesuggestions.go
+++ b/backend/libs/exprfilter/valuesuggestions.go
@@ -19,12 +19,16 @@ import (
 // read from, and the aggregate expression that dates a value for
 // most-recently-seen-first ordering. timeColumn names the row timestamp of a
 // raw table so the read stays within the suggestion window; a rollup that is
-// small enough to read whole leaves it empty.
+// small enough to read whole leaves it empty. arrayColumns marks a source
+// whose column expressions are arrays, so each element is suggested as its own
+// value; the elements are expanded with an ARRAY JOIN clause because ClickHouse
+// refuses to cache a query that calls its arrayJoin function.
 type fixedKeyValueSource struct {
-	table       string
-	columns     map[string]string
-	recencyExpr string
-	timeColumn  string
+	table        string
+	columns      map[string]string
+	recencyExpr  string
+	timeColumn   string
+	arrayColumns bool
 }
 
 // A suggestion is only a shortcut for typing a value, so a raw table is read
@@ -85,17 +89,22 @@ func suggestFixedKeyValuesFromClickHouse(sources ...fixedKeyValueSource) func(ct
 		// which use the nil UUID. Unset values are excluded.
 		// UUID columns are read as text so searches and returned
 		// values use strings. Ties are ordered alphabetically.
+		from := fixedValues.table
 		valueExpr := column
+		if fixedValues.arrayColumns {
+			from += " ARRAY JOIN " + column + " AS array_value"
+			valueExpr = "array_value"
+		}
 		unsetTest := valueExpr + " <> ''"
 		var unsetArgs []any
 		if key.ValueType == ValueTypeUUID {
-			valueExpr = "toString(" + column + ")"
+			valueExpr = "toString(" + valueExpr + ")"
 			unsetTest = valueExpr + " <> ?"
 			unsetArgs = []any{uuid.Nil.String()}
 		}
 
 		stmt := sqlf.
-			From(fixedValues.table).
+			From(from).
 			Select(valueExpr+" as suggested_value").
 			Select(fixedValues.recencyExpr+" as recency").
 			Where("team_id = toUUID(?)", teamID).

--- a/backend/libs/exprfilter/valuesuggestions.go
+++ b/backend/libs/exprfilter/valuesuggestions.go
@@ -34,9 +34,12 @@ type fixedKeyValueSource struct {
 // A suggestion is only a shortcut for typing a value, so a raw table is read
 // for the last 30 days only; older values can still be typed in. The start of
 // the window is computed here and bound as a parameter because ClickHouse
-// refuses to cache a query that calls its own now() function.
+// refuses to cache a query that calls its own now() function. The driver
+// writes the bound time into the query text, so the start is rounded down to
+// the hour; otherwise the text would change every second and no read would
+// ever find a cached result.
 func suggestionWindowStart() time.Time {
-	return time.Now().Add(-30 * 24 * time.Hour)
+	return time.Now().Add(-30 * 24 * time.Hour).Truncate(time.Hour)
 }
 
 // SuggestKeyValues lists what one key can be set to, narrowed by what has

--- a/backend/libs/exprfilter/valuesuggestions_test.go
+++ b/backend/libs/exprfilter/valuesuggestions_test.go
@@ -141,9 +141,9 @@ func TestSuggestionSQL(t *testing.T) {
 				byName := IndexKeysByName(SessionsEntity.Keys)
 				_, _ = SessionsEntity.SuggestKeyValues(ctx, nil, recorder, teamID, appID, byName["user_id"], ValueRequest{Search: "ana"})
 			},
-			wantSQL: "SELECT arrayJoin(user_ids) as suggested_value, max(first_event_timestamp) as recency" +
-				" FROM sessions" +
-				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND first_event_timestamp >= ? AND arrayJoin(user_ids) <> '' AND arrayJoin(user_ids) ilike ?" +
+			wantSQL: "SELECT array_value as suggested_value, max(first_event_timestamp) as recency" +
+				" FROM sessions ARRAY JOIN user_ids AS array_value" +
+				" WHERE team_id = toUUID(?) AND app_id = toUUID(?) AND first_event_timestamp >= ? AND array_value <> '' AND array_value ilike ?" +
 				" GROUP BY suggested_value ORDER BY recency desc, suggested_value LIMIT ?",
 			wantArgs: []any{teamID, appID, windowStart{}, "%ana%", DefaultValueLimit + 1},
 		},

--- a/backend/libs/exprfilter/valuesuggestions_test.go
+++ b/backend/libs/exprfilter/valuesuggestions_test.go
@@ -226,7 +226,10 @@ func TestSuggestionSQL(t *testing.T) {
 			gotArgs := slices.Clone(recorder.args)
 			for i, arg := range gotArgs {
 				if bound, ok := arg.(time.Time); ok {
-					if drift := time.Since(bound) - 30*24*time.Hour; drift < 0 || drift > time.Minute {
+					if !bound.Equal(bound.Truncate(time.Hour)) {
+						t.Errorf("window start %v is not on the hour", bound)
+					}
+					if drift := time.Since(bound) - 30*24*time.Hour; drift < 0 || drift > time.Hour+time.Minute {
 						t.Errorf("window start %v is not 30 days ago", bound)
 					}
 					gotArgs[i] = windowStart{}


### PR DESCRIPTION
# Description

Session user id, custom event and screen suggestions still failed with error 704 after #4464, because they read their values with the arrayJoin function, which the query cache also refuses. Suggestion reads bounded by the window also never got a cache hit, because the bound window start changed the query text every second.

- Expand the session arrays with an ARRAY JOIN clause instead
- Run the session value tests with the release mode query settings
- Round the suggestion window start down to the hour so repeated reads get cache hits



