### PR TITLE
Replace the legacy filter bar on the apps page with a plain app selector

### DIFF
--- a/frontend/dashboard/__tests__/components/onboarding_test.tsx
+++ b/frontend/dashboard/__tests__/components/onboarding_test.tsx
@@ -214,12 +214,6 @@ import Onboarding from "@/app/components/onboarding";
 
 // --- Helpers ---
 
-const mockInitConfig: any = {
-  urlFilters: {},
-  appVersionsInitialSelectionType: 0,
-  filterSource: 0,
-};
-
 function makeApp(overrides: Partial<MockApp> = {}): MockApp {
   return {
     id: "app-1",
@@ -240,10 +234,7 @@ const {
 function renderOnboarding(props: Partial<{ teamId: string }> = {}) {
   return render(
     <RenderQCProvider client={renderQueryClient}>
-      <Onboarding
-        teamId={props.teamId ?? "team-1"}
-        initConfig={mockInitConfig}
-      />
+      <Onboarding teamId={props.teamId ?? "team-1"} />
     </RenderQCProvider>,
   );
 }
@@ -1786,7 +1777,7 @@ describe("Onboarding — Persistence", () => {
       );
       render(
         <React.StrictMode>
-          <Onboarding teamId="team-1" initConfig={mockInitConfig} />
+          <Onboarding teamId="team-1" />
         </React.StrictMode>,
       );
       const stored = window.localStorage.getItem(STORAGE_KEY);
@@ -1807,7 +1798,7 @@ describe("Onboarding — Persistence", () => {
         }),
       );
       const { rerender } = renderOnboarding();
-      rerender(<Onboarding teamId="team-1" initConfig={mockInitConfig} />);
+      rerender(<Onboarding teamId="team-1" />);
       const stored = window.localStorage.getItem(STORAGE_KEY);
       const parsed = JSON.parse(stored!);
       expect(parsed.step).toBe("verify");

--- a/frontend/dashboard/__tests__/components/onboarding_test.tsx
+++ b/frontend/dashboard/__tests__/components/onboarding_test.tsx
@@ -444,19 +444,18 @@ describe("Onboarding — Step 1: Create app", () => {
   describe("Success path", () => {
     beforeEach(() => {
       const newApp = makeApp({ name: "My App", id: "app-99" });
-      mockMutateAsync.mockResolvedValue(newApp);
-      // refetch resolves immediately; the component then sets the new app
-      // as selected via setSelectedApp.
-      mockRefetchQueries.mockImplementation(async () => {
+      // The mutation refetches the apps list before it settles, so the
+      // list holds the new app by the time the component reads it.
+      mockMutateAsync.mockImplementation(async () => {
         mockApps = [newApp];
-        mockSelectedApp = newApp;
+        return newApp;
       });
       mockSetSelectedApp.mockImplementation((app: MockApp) => {
         mockSelectedApp = app;
       });
     });
 
-    it("refetches the apps query and selects the new app", async () => {
+    it("selects the new app", async () => {
       renderOnboarding({ teamId: "team-42" });
       fireEvent.change(screen.getByTestId("onboarding-app-name-input"), {
         target: { value: "My App" },
@@ -467,13 +466,10 @@ describe("Onboarding — Step 1: Create app", () => {
         );
       });
       await waitFor(() => {
-        expect(mockRefetchQueries).toHaveBeenCalledWith({
-          queryKey: ["filterApps", "team-42"],
-        });
+        expect(mockSetSelectedApp).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "app-99" }),
+        );
       });
-      expect(mockSetSelectedApp).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "app-99" }),
-      );
     });
 
     it("shows positive toast with the app name", async () => {
@@ -584,7 +580,6 @@ describe("Onboarding — Step 1: Create app", () => {
       await waitFor(() => {
         expect(mockToastNegative).toHaveBeenCalled();
       });
-      expect(mockRefetchQueries).not.toHaveBeenCalled();
       expect(mockSetSelectedApp).not.toHaveBeenCalled();
     });
 

--- a/frontend/dashboard/__tests__/pages/apps_test.tsx
+++ b/frontend/dashboard/__tests__/pages/apps_test.tsx
@@ -13,7 +13,6 @@ import {
 
 const mockToastPositive = jest.fn();
 const mockToastNegative = jest.fn();
-const mockRefreshFilters = jest.fn();
 
 const baseMockApp = {
   id: "app-1",
@@ -57,9 +56,6 @@ jest.mock("@/app/api/api_calls", () => ({
     error_spike_min_count_threshold: 100,
     error_spike_min_rate_threshold: 0.5,
   },
-  FilterSource: {
-    Events: "events",
-  },
   emptyAppRetention: {
     retention: 30,
   },
@@ -77,6 +73,10 @@ jest.mock("@/app/api/api_calls", () => ({
 // --- Bridge store: tests control this, query hook mocks read from it ---
 const { create: createBridge } = jest.requireActual("zustand") as any;
 const appsStore = createBridge((set: any) => ({
+  // Apps query state, where "no-apps" is a loaded empty list and an
+  // appsVersion bump stands in for a refetch
+  appsStatus: "pending",
+  appsVersion: 0,
   // Permissions (derived from the authzAndMembers query)
   canCreateApp: false,
   canRenameApp: false,
@@ -155,6 +155,22 @@ function deriveThresholdStatus(state: any) {
 
 jest.mock("@/app/query/hooks", () => ({
   __esModule: true,
+  useAppsQuery: () => {
+    const status = appsStore((s: any) => s.appsStatus);
+    appsStore((s: any) => s.appsVersion);
+    const data =
+      status === "success"
+        ? [getAppPayload()]
+        : status === "no-apps"
+          ? []
+          : undefined;
+    return {
+      data,
+      isPending: status === "pending",
+      isSuccess: status === "success" || status === "no-apps",
+      isError: status === "error",
+    };
+  },
   useAuthzAndMembersQuery: () => {
     const s = appsStore.getState();
     return {
@@ -240,6 +256,16 @@ jest.mock("@/app/query/hooks", () => ({
         if (result && typeof result.then === "function") {
           result.then((success: boolean) => {
             if (success) {
+              mockCurrentApp = {
+                ...mockCurrentApp,
+                api_key: {
+                  ...mockCurrentApp.api_key,
+                  key: "msrsh_rotated_key_checksum",
+                },
+              };
+              appsStore.setState({
+                appsVersion: appsStore.getState().appsVersion + 1,
+              });
               opts?.onSuccess?.();
             } else {
               opts?.onError?.();
@@ -274,8 +300,9 @@ jest.mock("@/app/query/hooks", () => ({
 
 jest.mock("@/app/stores/provider", () => {
   const { create } = jest.requireActual("zustand");
-  const filtersStore = create(() => ({
-    filters: { ready: false, app: null, serialisedFilters: "" },
+  const filtersStore = create((set: any) => ({
+    selectedApp: null,
+    setSelectedApp: (app: any) => set({ selectedApp: app }),
   }));
   return {
     __esModule: true,
@@ -283,37 +310,17 @@ jest.mock("@/app/stores/provider", () => {
   };
 });
 
-jest.mock("@/app/components/filters", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    default: React.forwardRef((_props: any, ref: any) => {
-      const { useFiltersStore } = require("@/app/stores/provider");
-      React.useImperativeHandle(ref, () => ({
-        refresh: () => {
-          mockRefreshFilters();
-          mockCurrentApp = {
-            ...mockCurrentApp,
-            api_key: {
-              ...mockCurrentApp.api_key,
-              key: "msrsh_rotated_key_checksum",
-            },
-          };
-          useFiltersStore.setState({
-            filters: {
-              ready: true,
-              app: getAppPayload(),
-              serialisedFilters: "app=app-1",
-            },
-          });
-        },
-      }));
+jest.mock("@/app/components/onboarding", () => ({
+  __esModule: true,
+  default: () => <div data-testid="onboarding-mock" />,
+}));
 
-      return <div data-testid="filters-mock" />;
-    }),
-    AppVersionsInitialSelectionType: { All: "all" },
-  };
-});
+jest.mock("@/app/components/filter_bar/app_select", () => ({
+  __esModule: true,
+  default: ({ selected }: any) => (
+    <div data-testid="app-select-mock">{selected.name}</div>
+  ),
+}));
 
 jest.mock("@/app/components/button", () => ({
   Button: ({ children, loading, disabled, ...props }: any) => (
@@ -447,13 +454,7 @@ const renderLoadedPage = async () => {
   await renderPage();
 
   await act(async () => {
-    useFiltersStore.setState({
-      filters: {
-        ready: true,
-        app: getAppPayload(),
-        serialisedFilters: "app=app-1",
-      },
-    });
+    useAppsStore.setState({ appsStatus: "success" });
   });
 };
 
@@ -496,11 +497,10 @@ describe("Apps Page", () => {
     const { isCloud } = require("@/app/utils/env_utils");
     isCloud.mockReturnValue(false);
     mockCurrentApp = { ...baseMockApp, api_key: { ...baseMockApp.api_key } };
-    useFiltersStore.setState({
-      filters: { ready: false, app: null, serialisedFilters: "" },
-      appsState: "loaded",
-    });
+    useFiltersStore.setState({ selectedApp: null });
     useAppsStore.setState({
+      appsStatus: "pending",
+      appsVersion: 0,
       canCreateApp: false,
       canRenameApp: false,
       canChangeRetention: false,
@@ -607,11 +607,12 @@ describe("Apps Page", () => {
     expect(screen.queryByText("Operating Systems")).not.toBeInTheDocument();
   });
 
-  it("hides the Create App button when the team has no apps", async () => {
-    useFiltersStore.setState({ appsState: "no-apps" });
+  it("renders onboarding and hides the Create App button when the team has no apps", async () => {
+    useAppsStore.setState({ ...defaultLoadedAppsState, appsStatus: "no-apps" });
 
-    await renderLoadedPage();
+    await renderPage();
 
+    expect(screen.getByTestId("onboarding-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("create-app-mock")).not.toBeInTheDocument();
   });
 
@@ -634,13 +635,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(screen.getAllByTestId("skeleton-mock").length).toBeGreaterThan(0);
@@ -656,13 +651,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(
@@ -699,13 +688,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(screen.getByRole("button", { name: "Rotate" })).toBeDisabled();
@@ -732,13 +715,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await act(async () => {
@@ -771,13 +748,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(screen.getByRole("button", { name: "Rotate" })).toBeDisabled();
@@ -805,13 +776,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(screen.getByRole("button", { name: "Rotate" })).toBeDisabled();
@@ -839,13 +804,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(screen.getByRole("button", { name: "Rotate" })).toBeDisabled();
@@ -886,7 +845,7 @@ describe("Apps Page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("rotates API key successfully, reloads filters, and updates displayed key", async () => {
+  it("rotates API key successfully and updates displayed key", async () => {
     await renderLoadedPage();
     await openRotateDialog();
 
@@ -896,7 +855,6 @@ describe("Apps Page", () => {
 
     expect(useAppsStore.getState().changeAppApiKey).toHaveBeenCalled();
     expect(mockToastPositive).toHaveBeenCalledWith("API key rotated");
-    expect(mockRefreshFilters).toHaveBeenCalled();
     expect(
       await screen.findAllByDisplayValue("msrsh_rotated_key_checksum"),
     ).toHaveLength(2);
@@ -914,13 +872,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRotateDialog();
@@ -930,7 +882,6 @@ describe("Apps Page", () => {
     });
 
     expect(mockToastNegative).toHaveBeenCalledWith("Error rotating API key");
-    expect(mockRefreshFilters).not.toHaveBeenCalled();
   });
 
   it("re-enables the Rotate button after a failed rotation", async () => {
@@ -942,13 +893,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRotateDialog();
@@ -978,13 +923,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRotateDialog();
@@ -1042,7 +981,6 @@ describe("Apps Page", () => {
       "Renamed App",
     );
     expect(mockToastPositive).toHaveBeenCalledWith("App name changed");
-    expect(mockRefreshFilters).toHaveBeenCalled();
     expect(
       screen.queryByRole("button", { name: "Yes, I'm sure" }),
     ).not.toBeInTheDocument();
@@ -1065,13 +1003,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRenameDialog();
@@ -1103,13 +1035,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRenameDialog();
@@ -1130,13 +1056,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRenameDialog();
@@ -1212,13 +1132,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRetentionDialog();
@@ -1254,13 +1168,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     await openRetentionDialog();
@@ -1379,13 +1287,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(
@@ -1402,13 +1304,7 @@ describe("Apps Page", () => {
     await renderPage();
 
     await act(async () => {
-      useFiltersStore.setState({
-        filters: {
-          ready: true,
-          app: getAppPayload(),
-          serialisedFilters: "app=app-1",
-        },
-      });
+      useAppsStore.setState({ appsStatus: "success" });
     });
 
     expect(
@@ -1443,14 +1339,11 @@ describe("Apps Page", () => {
       expect(retentionSave()).not.toBeDisabled();
       expect(thresholdSave()).not.toBeDisabled();
 
-      // A rename lands via a filters refresh: same id, new name.
+      // A rename keeps the app id and changes the name
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: { ...getAppPayload(), name: "Renamed App" },
-            serialisedFilters: "app=app-1",
-          },
+        mockCurrentApp = { ...getAppPayload(), name: "Renamed App" };
+        useAppsStore.setState({
+          appsVersion: useAppsStore.getState().appsVersion + 1,
         });
       });
 
@@ -1468,14 +1361,11 @@ describe("Apps Page", () => {
       expect(retentionSave()).not.toBeDisabled();
       expect(thresholdSave()).not.toBeDisabled();
 
-      // Switch to a different app (new id) via a filters update.
+      // Switch to a different app id
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: { ...getAppPayload(), id: "app-2", name: "Other App" },
-            serialisedFilters: "app=app-2",
-          },
+        mockCurrentApp = { ...getAppPayload(), id: "app-2", name: "Other App" };
+        useAppsStore.setState({
+          appsVersion: useAppsStore.getState().appsVersion + 1,
         });
       });
 
@@ -1503,13 +1393,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       const spinners = screen.getAllByTestId("skeleton-mock");
@@ -1525,13 +1409,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       const errorMessages = screen.getAllByText(
@@ -1656,13 +1534,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       await act(async () => {
@@ -1692,13 +1564,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       await act(async () => {
@@ -1728,13 +1594,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       await act(async () => {
@@ -1764,13 +1624,7 @@ describe("Apps Page", () => {
       await renderPage();
 
       await act(async () => {
-        useFiltersStore.setState({
-          filters: {
-            ready: true,
-            app: getAppPayload(),
-            serialisedFilters: "app=app-1",
-          },
-        });
+        useAppsStore.setState({ appsStatus: "success" });
       });
 
       expect(screen.getByTestId("error-good-threshold-input")).toBeDisabled();

--- a/frontend/dashboard/app/[teamId]/apps/page.tsx
+++ b/frontend/dashboard/app/[teamId]/apps/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import {
   useAppRetentionQuery,
+  useAppsQuery,
   useAppThresholdPrefsQuery,
   useAuthzAndMembersQuery,
   useChangeAppApiKeyMutation,
@@ -12,7 +13,7 @@ import {
 import { useFiltersStore } from "@/app/stores/provider";
 
 import {
-  FilterSource,
+  type App,
   defaultAppThresholdPrefs,
   emptyAppRetention,
 } from "@/app/api/api_calls";
@@ -22,11 +23,11 @@ import DangerConfirmationDialog from "@/app/components/danger_confirmation_dialo
 import DropdownSelect, {
   DropdownSelectType,
 } from "@/app/components/dropdown_select";
-import Filters, {
-  AppVersionsInitialSelectionType,
-} from "@/app/components/filters";
+import AppSelect from "@/app/components/filter_bar/app_select";
+import { resolveApp } from "@/app/components/filter_bar/resolve_filters";
 import InfoTooltip from "@/app/components/info_tooltip";
 import { Input } from "@/app/components/input";
+import Onboarding from "@/app/components/onboarding";
 import SdkConfigNumericInput from "@/app/components/sdk_config_numeric_input";
 import SdkConfigurator from "@/app/components/sdk_configurator";
 import { Skeleton } from "@/app/components/skeleton";
@@ -35,20 +36,22 @@ import { underlineLinkStyle } from "@/app/utils/shared_styles";
 import { formatDateToHumanReadableDateTime } from "@/app/utils/time_utils";
 import { toastNegative, toastPositive } from "@/app/components/toast";
 import Link from "next/link";
-import { use, useRef, useState } from "react";
+import { use, useEffect, useState } from "react";
+
+const noApps: App[] = [];
 
 export default function Apps(props: { params: Promise<{ teamId: string }> }) {
   const params = use(props.params);
-  const filters = useFiltersStore((state) => state.filters);
-  const appsState = useFiltersStore((state) => state.appsState);
-  // The team has no apps yet. Render <Onboarding> through Filters, and hide
-  // the CreateApp button, so the onboarding flow is the only call to action.
-  // After the user creates an app, the apps query resolves to "loaded", and
-  // the page shows its usual app-settings layout.
-  const hasNoApps = appsState === "no-apps";
+  const rememberedAppId = useFiltersStore((state) => state.selectedApp?.id);
+  const setSelectedApp = useFiltersStore((state) => state.setSelectedApp);
 
-  // TanStack Query: reads
-  const appId = filters.ready ? filters.app?.id : undefined;
+  const appsQuery = useAppsQuery(params.teamId);
+  const apps = appsQuery.data ?? noApps;
+  // Use the app remembered from other pages, else the first in the list
+  const app = resolveApp(null, appsQuery.data, rememberedAppId);
+  // A team with no apps gets the onboarding flow instead of app settings
+  const hasNoApps = appsQuery.isSuccess && apps.length === 0;
+  const appId = app?.id;
   const { data: authzAndMembers } = useAuthzAndMembersQuery(params.teamId);
   const { data: appRetention, status: appRetentionStatus } =
     useAppRetentionQuery(appId);
@@ -73,14 +76,14 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
   // Derive page load status from query statuses
   const pageDataLoading =
-    filters.loading ||
-    (filters.ready &&
+    appsQuery.isPending ||
+    (app !== null &&
       (appRetentionStatus === "pending" || sdkConfigStatus === "pending"));
   const pageDataError =
-    filters.ready &&
+    app !== null &&
     (appRetentionStatus === "error" || sdkConfigStatus === "error");
   const pageDataSuccess =
-    filters.ready &&
+    app !== null &&
     appRetentionStatus === "success" &&
     sdkConfigStatus === "success" &&
     sdkConfig;
@@ -113,15 +116,18 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
     editableThresholdPrefs ?? thresholdPrefs ?? defaultAppThresholdPrefs;
   const savedThresholdPrefs = thresholdPrefs ?? defaultAppThresholdPrefs;
 
-  const filtersRef = useRef<any>(null);
+  // Write picked app to store so other pages that read from it stay in sync
+  useEffect(() => {
+    if (app !== null && app.id !== rememberedAppId) {
+      setSelectedApp(app);
+    }
+  }, [app?.id]);
 
-  // Sync the editable name input to the selected app. Keyed on name so a
-  // rename (which updates filters.app in place) re-syncs the input to the
-  // server's stored value.
+  // Reset name input whenever the selected app's name changes
   const [prevAppName, setPrevAppName] = useState<string>("");
-  if (filters.ready && filters.app && filters.app.name !== prevAppName) {
-    setPrevAppName(filters.app.name);
-    setAppName(filters.app.name);
+  if (app !== null && app.name !== prevAppName) {
+    setPrevAppName(app.name);
+    setAppName(app.name);
     setSaveAppNameButtonDisabled(true);
   }
 
@@ -129,8 +135,8 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
   // changes. Keyed on id so renaming the current app doesn't discard
   // in-progress edits.
   const [prevAppId, setPrevAppId] = useState<string>("");
-  if (filters.ready && filters.app && filters.app.id !== prevAppId) {
-    setPrevAppId(filters.app.id);
+  if (app !== null && app.id !== prevAppId) {
+    setPrevAppId(app.id);
     setUpdatedRetention(null);
     setEditableThresholdPrefs(null);
   }
@@ -205,7 +211,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
     }
 
     updateThresholdPrefsMutation.mutate(
-      { appId: filters.app!.id, prefs: currentThresholdPrefs },
+      { appId: app!.id, prefs: currentThresholdPrefs },
       {
         onSuccess: () => {
           setEditableThresholdPrefs(null);
@@ -220,7 +226,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
   const handleSaveAppRetention = async () => {
     updateRetentionMutation.mutate(
-      { appId: filters.app!.id, retention: currentRetention },
+      { appId: app!.id, retention: currentRetention },
       {
         onSuccess: () => {
           toastPositive("Your app settings have been saved");
@@ -234,14 +240,11 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
   const handleChangeAppName = async () => {
     changeAppNameMutation.mutate(
-      { appId: filters.app!.id, appName },
+      { appId: app!.id, appName },
       {
         onSuccess: () => {
           setSaveAppNameButtonDisabled(true);
           toastPositive("App name changed");
-          if (filtersRef.current?.refresh) {
-            filtersRef.current.refresh();
-          }
         },
         onError: () => {
           toastNegative("Error changing app name");
@@ -252,13 +255,10 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
   const handleChangeAppApiKey = async () => {
     changeAppApiKeyMutation.mutate(
-      { appId: filters.app!.id },
+      { appId: app!.id },
       {
         onSuccess: () => {
           toastPositive("API key rotated");
-          if (filtersRef.current?.refresh) {
-            filtersRef.current.refresh();
-          }
         },
         onError: () => {
           toastNegative("Error rotating API key");
@@ -281,24 +281,22 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
     <div className="flex flex-col items-start">
       <div className="py-4" />
       <div className="flex flex-row items-start gap-2 justify-between w-full">
-        <Filters
-          ref={filtersRef}
-          teamId={params.teamId}
-          filterSource={FilterSource.Events}
-          appVersionsInitialSelectionType={AppVersionsInitialSelectionType.All}
-          showNoData={false}
-          showNotOnboarded={hasNoApps}
-          showAppVersions={false}
-          showDates={false}
-        />
+        {appsQuery.isPending && <Skeleton className="h-9 w-37.5" />}
+        {appsQuery.isError && app === null && (
+          <p className="font-body text-sm">
+            Error fetching apps, please refresh page to try again
+          </p>
+        )}
+        {hasNoApps && <Onboarding teamId={params.teamId} />}
+        {app !== null && (
+          <AppSelect apps={apps} selected={app} onChange={setSelectedApp} />
+        )}
 
         {!hasNoApps && (
           <CreateApp
             teamId={params.teamId}
             disabled={!canCreateApp}
-            onSuccess={(app) => {
-              filtersRef.current?.refresh(app.id);
-            }}
+            onSuccess={setSelectedApp}
           />
         )}
       </div>
@@ -399,10 +397,8 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
             body={
               <p className="font-body">
                 Are you sure you want to rename app{" "}
-                <span className="font-display font-bold">
-                  {filters.app!.name}
-                </span>{" "}
-                to <span className="font-display font-bold">{appName}</span>?
+                <span className="font-display font-bold">{app!.name}</span> to{" "}
+                <span className="font-display font-bold">{appName}</span>?
               </p>
             }
             open={appNameConfirmationDialogOpen}
@@ -419,9 +415,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
             body={
               <p className="font-body">
                 Are you sure you want to rotate the API key for app{" "}
-                <span className="font-display font-bold">
-                  {filters.app!.name}
-                </span>
+                <span className="font-display font-bold">{app!.name}</span>
                 ? <br /> <br /> All apps currently using this key won&apos;t be
                 able to send data anymore until they are updated.
               </p>
@@ -441,10 +435,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
             body={
               <p className="font-body">
                 Are you sure you want to change the retention period for app{" "}
-                <span className="font-display font-bold">
-                  {filters.app!.name}
-                </span>{" "}
-                to{" "}
+                <span className="font-display font-bold">{app!.name}</span> to{" "}
                 <span className="font-display font-bold">
                   {currentRetention.retention} days
                 </span>
@@ -466,44 +457,33 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
 
           <div className="font-body">
             <div className="flex flex-col mt-8">
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="font-display text-muted-foreground">
-                    Unique Identifier
-                  </p>
-                )}
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="text-sm mt-0.5">
-                    {filters.app!.unique_identifier}
-                  </p>
-                )}
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="font-display text-muted-foreground mt-6">
-                    Operating Systems
-                  </p>
-                )}
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="text-sm mt-0.5">
-                    {filters.app!.os_names?.join(", ")}
-                  </p>
-                )}
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="font-display text-muted-foreground mt-6">
-                    Created at
-                  </p>
-                )}
-              {filters.app!.unique_identifier &&
-                !!filters.app!.os_names?.length && (
-                  <p className="text-sm mt-0.5">
-                    {formatDateToHumanReadableDateTime(filters.app!.created_at)}
-                  </p>
-                )}
-              {(!filters.app!.unique_identifier ||
-                !filters.app!.os_names?.length) && (
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="font-display text-muted-foreground">
+                  Unique Identifier
+                </p>
+              )}
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="text-sm mt-0.5">{app!.unique_identifier}</p>
+              )}
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="font-display text-muted-foreground mt-6">
+                  Operating Systems
+                </p>
+              )}
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="text-sm mt-0.5">{app!.os_names?.join(", ")}</p>
+              )}
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="font-display text-muted-foreground mt-6">
+                  Created at
+                </p>
+              )}
+              {app!.unique_identifier && !!app!.os_names?.length && (
+                <p className="text-sm mt-0.5">
+                  {formatDateToHumanReadableDateTime(app!.created_at)}
+                </p>
+              )}
+              {(!app!.unique_identifier || !app!.os_names?.length) && (
                 <p className="font-body text-sm">
                   Follow our{" "}
                   <Link className={underlineLinkStyle} href="/docs">
@@ -549,14 +529,14 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
                 data-testid="api-key-input"
                 type="text"
                 readOnly={true}
-                value={filters.app!.api_key.key}
+                value={app!.api_key.key}
                 className="w-96"
               />
               <Button
                 variant="outline"
                 className="mx-4 my-3"
                 onClick={() => {
-                  navigator.clipboard.writeText(filters.app!.api_key.key);
+                  navigator.clipboard.writeText(app!.api_key.key);
                   toastPositive("API key copied to clipboard");
                 }}
               >
@@ -566,9 +546,9 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
             <div className="py-8" />
 
             <SdkConfigurator
-              appId={filters.app!.id}
-              appName={filters.app!.name}
-              osNames={filters.app!.os_names}
+              appId={app!.id}
+              appName={app!.name}
+              osNames={app!.os_names}
               initialConfig={sdkConfig!}
               currentUserCanChangeAppSettings={canWriteSdkConfig}
             />
@@ -795,7 +775,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
                 type="text"
                 value={appName}
                 onChange={(event) => {
-                  event.target.value === filters.app!.name
+                  event.target.value === app!.name
                     ? setSaveAppNameButtonDisabled(true)
                     : setSaveAppNameButtonDisabled(false);
                   setAppName(event.target.value);
@@ -825,7 +805,7 @@ export default function Apps(props: { params: Promise<{ teamId: string }> }) {
               <Input
                 type="text"
                 readOnly={true}
-                value={filters.app!.api_key.key}
+                value={app!.api_key.key}
                 className="w-96"
               />
               <Button

--- a/frontend/dashboard/app/components/filters.tsx
+++ b/frontend/dashboard/app/components/filters.tsx
@@ -925,7 +925,7 @@ const FiltersComponent = forwardRef<
         )}
         {store.appsState === "no-apps" &&
           (showNotOnboarded ? (
-            <Onboarding teamId={teamId} initConfig={initConfig} />
+            <Onboarding teamId={teamId} />
           ) : (
             <p className="font-body">
               Looks like you don&apos;t have any apps yet. Get started by{" "}
@@ -970,7 +970,7 @@ const FiltersComponent = forwardRef<
               )}
               {showNotOnboarded &&
                 store.filterOptionsState === "not-onboarded" && (
-                  <Onboarding teamId={teamId} initConfig={initConfig} />
+                  <Onboarding teamId={teamId} />
                 )}
             </div>
           )}

--- a/frontend/dashboard/app/components/onboarding.tsx
+++ b/frontend/dashboard/app/components/onboarding.tsx
@@ -16,7 +16,6 @@ import {
   useCreateAppMutation,
 } from "../query/hooks";
 import { useQueryClient } from "@tanstack/react-query";
-import { type InitConfig } from "../stores/filters_store";
 import {
   DEFAULT_ONBOARDING_STATE,
   NATIVE_TARGETS,
@@ -43,7 +42,6 @@ const POLL_INTERVAL_MS = 3000;
 
 interface OnboardingProps {
   teamId: string;
-  initConfig: InitConfig;
 }
 
 // The renderable essentials of a code block. The user-facing step title and
@@ -574,7 +572,7 @@ function resolveApiUrl(): string {
   );
 }
 
-export default function Onboarding({ teamId, initConfig }: OnboardingProps) {
+export default function Onboarding({ teamId }: OnboardingProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const filtersStore = useFiltersStore();

--- a/frontend/dashboard/app/components/onboarding.tsx
+++ b/frontend/dashboard/app/components/onboarding.tsx
@@ -15,7 +15,6 @@ import {
   useAuthzAndMembersQuery,
   useCreateAppMutation,
 } from "../query/hooks";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   DEFAULT_ONBOARDING_STATE,
   NATIVE_TARGETS,
@@ -574,7 +573,6 @@ function resolveApiUrl(): string {
 
 export default function Onboarding({ teamId }: OnboardingProps) {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const filtersStore = useFiltersStore();
   const onboardingStore = useOnboardingStore();
   const selectedApp = useFiltersStore((state) => state.selectedApp);
@@ -712,9 +710,6 @@ export default function Onboarding({ teamId }: OnboardingProps) {
     try {
       const app = await createApp.mutateAsync({ teamId, appName: trimmed });
       if (app) {
-        await queryClient.refetchQueries({
-          queryKey: ["filterApps", teamId],
-        });
         filtersStore.setSelectedApp(app);
         onboardingStore.setOnboardingStep(app.id, "integrate");
       }

--- a/frontend/dashboard/app/query/hooks.ts
+++ b/frontend/dashboard/app/query/hooks.ts
@@ -89,6 +89,7 @@ import {
   keepPreviousData,
   useMutation,
   useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
 
 // ─── Filter options & session ────────────────────────────────────────────
@@ -1164,12 +1165,16 @@ export function useSaveNotifPrefsMutation() {
 // ─── Create App ─────────────────────────────────────────────────────────
 
 export function useCreateAppMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: { teamId: string; appName: string }) =>
       createAppFromServer(params.teamId, params.appName),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] });
-    },
+    // Returned so callers run only after the apps list has refetched
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["teams"] }),
+        queryClient.invalidateQueries({ queryKey: ["filterApps"] }),
+      ]),
   });
 }
 
@@ -1254,24 +1259,32 @@ export function useUpdateAppRetentionMutation() {
 }
 
 export function useChangeAppNameMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (params: { appId: string; appName: string }) => {
       await changeAppNameFromServer(params.appId, params.appName);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] });
-    },
+    // Returned so callers run only after the apps list has refetched
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["teams"] }),
+        queryClient.invalidateQueries({ queryKey: ["filterApps"] }),
+      ]),
   });
 }
 
 export function useChangeAppApiKeyMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (params: { appId: string }) => {
       await changeAppApiKeyFromServer(params.appId);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] });
-    },
+    // Returned so callers run only after the apps list has refetched
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["teams"] }),
+        queryClient.invalidateQueries({ queryKey: ["filterApps"] }),
+      ]),
   });
 }
 


### PR DESCRIPTION
# Description

- The apps page fetches the apps list itself and renders the app selector from the expression filter bar, so it no longer depends on the legacy Filters component or its store slice
- A team with no apps gets the onboarding flow rendered directly from the page
- The picked app is written to the store so the other pages open on it
- Create, rename and key rotation invalidate the apps list from the mutation hooks and wait for the refetch before resolving, replacing the imperative refresh handle
- Onboarding drops an unused `initConfig` prop



