### PR TITLE
chore(frontend): restore onboarding on the expression filter pages

### DIFF
--- a/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/filter_bar_test.tsx
@@ -25,6 +25,13 @@ jest.mock("@/app/components/skeleton", () => ({
   Skeleton: () => <div data-testid="skeleton" />,
 }));
 
+jest.mock("@/app/components/onboarding", () => ({
+  __esModule: true,
+  default: ({ teamId }: any) => (
+    <div data-testid="onboarding" data-team={teamId} />
+  ),
+}));
+
 jest.mock("@/app/components/dropdown_select", () => ({
   __esModule: true,
   DropdownSelectType: { SingleString: "SingleString" },
@@ -340,6 +347,8 @@ async function renderBar(
   const bar = () => (
     <FilterBar
       entity="builds"
+      teamId="team-1"
+      status={{ kind: "ready" }}
       value={drawnValue}
       apps={apps}
       keys={keys}
@@ -459,6 +468,56 @@ describe("FilterBar", () => {
 
       expect(screen.queryByTestId("filter-bar")).toBeNull();
       expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
+    });
+
+    it("draws the integration wizard on its own for a team with no apps", async () => {
+      await renderBar(null, {
+        status: { kind: "onboarding", reason: "no-apps" },
+      });
+
+      expect(screen.getByTestId("onboarding")).toHaveAttribute(
+        "data-team",
+        "team-1",
+      );
+      expect(screen.queryByTestId("app-select")).toBeNull();
+      expect(screen.queryByTestId("date-select")).toBeNull();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+    });
+
+    it("points a team with no apps at the apps page when the wizard is not offered", async () => {
+      await renderBar(null, { status: { kind: "no-apps" } });
+
+      expect(
+        screen.getByRole("link", { name: "creating your first app!" }),
+      ).toHaveAttribute("href", "apps");
+      expect(screen.queryByTestId("onboarding")).toBeNull();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+    });
+
+    it("draws the wizard under the app selector for an app with no events", async () => {
+      await renderBar(
+        {},
+        { status: { kind: "onboarding", reason: "not-onboarded" } },
+      );
+
+      expect(screen.getByTestId("app-select")).toHaveAttribute(
+        "data-selected",
+        "Checkout",
+      );
+      expect(screen.getByTestId("onboarding")).toBeInTheDocument();
+      expect(screen.queryByTestId("date-select")).toBeNull();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+    });
+
+    it("sends the app the selector picks while the wizard is up", async () => {
+      const { onChange } = await renderBar(
+        {},
+        { status: { kind: "onboarding", reason: "not-onboarded" } },
+      );
+
+      await click(screen.getByTestId("pick-app-app-2"));
+
+      expect(lastChange(onChange)).toEqual({ appId: "app-2" });
     });
 
     it("draws the app and range it is given", async () => {

--- a/frontend/dashboard/__tests__/components/filter_bar/resolve_filters_test.ts
+++ b/frontend/dashboard/__tests__/components/filter_bar/resolve_filters_test.ts
@@ -102,6 +102,7 @@ function resolve(
     keys: keysLoaded,
     spanNames: null,
     remembered: nothingRemembered,
+    onboarding: false,
     ...overrides,
   });
 }
@@ -450,17 +451,15 @@ describe("resolveFilters", () => {
       expect(resolution.filters).toBeNull();
     });
 
-    it("reports a team with no apps", () => {
+    it("reports a team with no apps to a page without the wizard", () => {
       const resolution = resolve({
         apps: { status: "success", data: [] },
         keys: keysFailed,
         spanNames: namesFailed,
+        onboarding: false,
       });
 
-      expect(resolution.status).toEqual({
-        kind: "error",
-        message: expect.stringContaining("don't have any apps yet"),
-      });
+      expect(resolution.status).toEqual({ kind: "no-apps" });
       expect(resolution.filters).toBeNull();
     });
 
@@ -472,6 +471,60 @@ describe("resolveFilters", () => {
         message: expect.stringContaining("Error fetching filters"),
       });
       expect(resolution.filters?.app).toEqual(apps[0]);
+    });
+  });
+
+  describe("the integration wizard", () => {
+    const notOnboarded = [{ ...apps[0], onboarded: false } as App];
+    const onboarded = [{ ...apps[0], onboarded: true } as App];
+
+    it("takes over for a team with no apps", () => {
+      const resolution = resolve({
+        apps: { status: "success", data: [] },
+        onboarding: true,
+      });
+
+      expect(resolution.status).toEqual({
+        kind: "onboarding",
+        reason: "no-apps",
+      });
+      expect(resolution.filters).toBeNull();
+    });
+
+    it("takes over for an app that has not reported an event, with the app settled", () => {
+      const resolution = resolve({
+        apps: { status: "success", data: notOnboarded },
+        onboarding: true,
+      });
+
+      expect(resolution.status).toEqual({
+        kind: "onboarding",
+        reason: "not-onboarded",
+      });
+      expect(resolution.filters).toEqual({
+        app: notOnboarded[0],
+        filterExpr: null,
+        rootSpanName: null,
+      });
+    });
+
+    it("leaves the filters alone once the app has reported one", () => {
+      const resolution = resolve({
+        apps: { status: "success", data: onboarded },
+        onboarding: true,
+      });
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.app).toEqual(onboarded[0]);
+    });
+
+    it("is skipped on a page that does without it", () => {
+      const resolution = resolve({
+        apps: { status: "success", data: notOnboarded },
+      });
+
+      expect(resolution.status).toEqual({ kind: "ready" });
+      expect(resolution.filters?.app).toEqual(notOnboarded[0]);
     });
   });
 });

--- a/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
+++ b/frontend/dashboard/__tests__/components/filter_bar/use_expr_filter_page_test.tsx
@@ -39,7 +39,8 @@ jest.mock("@/app/query/hooks", () => ({
 
 import { useExprFilterPage } from "@/app/components/filter_bar/use_expr_filter_page";
 
-const app = (id: string, name: string) => ({ id, name }) as App;
+const app = (id: string, name: string, onboarded = true) =>
+  ({ id, name, onboarded }) as App;
 const apps = [app("app-1", "Checkout"), app("app-2", "Wallet")];
 
 const mappingTypeKey = {
@@ -682,6 +683,46 @@ describe("useExprFilterPage", () => {
 
       expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
       expect(page.paginationOffset).toBe(0);
+    });
+  });
+
+  describe("the integration wizard", () => {
+    const fresh = app("app-3", "Fresh", false);
+
+    it("stands in for a team with no apps, with nothing fetched", async () => {
+      appsLoaded([]);
+      await renderPage();
+
+      expect(page.status).toEqual({ kind: "onboarding", reason: "no-apps" });
+      expect(page.value).toBeNull();
+      expect(page.filterParams).toBeNull();
+      expect(mockFiltersStore.store.getState().appsState).toBe("no-apps");
+    });
+
+    it("stands in for an app that has not reported an event, which it still puts on the store", async () => {
+      appsLoaded([fresh]);
+      await renderPage();
+
+      expect(page.status).toEqual({
+        kind: "onboarding",
+        reason: "not-onboarded",
+      });
+      expect(page.value).toMatchObject({ app: fresh, filterExpr: null });
+      expect(page.filterParams).toBeNull();
+      expect(mockFiltersStore.store.getState().selectedApp).toEqual(fresh);
+      expect(mockUseFilterKeysQuery).toHaveBeenLastCalledWith(
+        undefined,
+        "builds",
+        [],
+      );
+    });
+
+    it("is left out on a page that does without it", async () => {
+      appsLoaded([fresh]);
+      await renderPage({ ...paginated, onboarding: false });
+
+      expect(page.status).toEqual({ kind: "ready" });
+      expect(page.filterParams).toMatchObject({ appId: "app-3" });
     });
   });
 });

--- a/frontend/dashboard/__tests__/components/network_details_test.tsx
+++ b/frontend/dashboard/__tests__/components/network_details_test.tsx
@@ -113,7 +113,7 @@ jest.mock("@/app/components/network_timeline_plot", () => ({
 import NetworkDetails from "@/app/components/network_details";
 import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const httpMethodKey = {
   name: "http_method",

--- a/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
+++ b/frontend/dashboard/__tests__/integration/onboarding_msw_test.tsx
@@ -1,0 +1,254 @@
+import { mockRouter } from "@/__tests__/helpers/mock_router";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+// --- jsdom polyfills ---
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+}
+
+// --- External dependency mocks ---
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { reset: jest.fn(), capture: jest.fn(), init: jest.fn() },
+}));
+
+jest.mock("next/navigation", () => ({
+  ...require("@/__tests__/helpers/mock_router").nextNavigationMock(),
+  usePathname: () => "/test-team/overview",
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next-themes", () => ({
+  __esModule: true,
+  useTheme: () => ({ theme: "light" }),
+}));
+
+jest.mock("@nivo/line", () => {
+  const LineChartStub = () => <div data-testid="nivo-line-chart" />;
+  return {
+    __esModule: true,
+    ResponsiveLine: LineChartStub,
+    ResponsiveLineCanvas: LineChartStub,
+  };
+});
+
+// --- MSW ---
+
+import { makeAppFixture, makeMetricsFixture } from "../msw/fixtures";
+import { server } from "../msw/server";
+
+jest.spyOn(console, "log").mockImplementation(() => {});
+jest.spyOn(console, "error").mockImplementation(() => {});
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// --- Store/component imports ---
+
+import Overview from "@/app/components/overview";
+import { queryClient } from "@/app/query/query_client";
+import { createFiltersStore } from "@/app/stores/filters_store";
+import { createOnboardingStore } from "@/app/stores/onboarding_store";
+import { QueryClientProvider } from "@tanstack/react-query";
+
+let filtersStore = createFiltersStore();
+let onboardingStore = createOnboardingStore();
+
+jest.mock("@/app/stores/provider", () => {
+  const { useStore } = require("zustand");
+  return {
+    __esModule: true,
+    useFiltersStore: (selector?: any) =>
+      useStore(filtersStore, selector ?? ((s: any) => s)),
+    useOnboardingStore: (selector?: any) =>
+      useStore(onboardingStore, selector ?? ((s: any) => s)),
+    useMeasureStoreRegistry: () => ({ filtersStore, onboardingStore }),
+  };
+});
+
+beforeEach(() => {
+  filtersStore = createFiltersStore();
+  onboardingStore = createOnboardingStore();
+  queryClient.clear();
+  mockRouter.reset();
+  window.localStorage.clear();
+  const { apiClient } = require("@/app/api/api_client");
+  apiClient.init({ replace: jest.fn(), push: jest.fn() });
+});
+
+function renderPage() {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Overview params={{ teamId: "test-team" }} />
+    </QueryClientProvider>,
+  );
+}
+
+// The apps endpoint answers 404 for a team that has no apps.
+function noAppsHandler() {
+  return http.get("*/api/teams/:teamId/apps", () => {
+    return new HttpResponse(null, { status: 404 });
+  });
+}
+
+function appsListHandler(apps: any[]) {
+  return http.get("*/api/teams/:teamId/apps", () => HttpResponse.json(apps));
+}
+
+function recordMetrics() {
+  const sent: string[] = [];
+  server.use(
+    http.get("*/api/apps/:appId/metrics", ({ request }) => {
+      sent.push(request.url);
+      return HttpResponse.json(makeMetricsFixture());
+    }),
+  );
+  return sent;
+}
+
+const freshApp = (overrides: Record<string, any>) =>
+  makeAppFixture({
+    onboarded: false,
+    onboarded_at: null,
+    ...overrides,
+  });
+
+describe("Onboarding (MSW integration)", () => {
+  describe("a team with no apps", () => {
+    it("puts the wizard on the page at its first step, and asks for no metrics", async () => {
+      server.use(noAppsHandler());
+      const metrics = recordMetrics();
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("onboarding-step-create")).toBeTruthy(),
+      );
+      expect(screen.getByTestId("onboarding-app-name-input")).toBeTruthy();
+      expect(screen.queryByTestId("filter-bar")).toBeNull();
+      expect(metrics).toHaveLength(0);
+    });
+
+    it("moves to the integration step once the app is created, with that app's key", async () => {
+      const created = freshApp({
+        id: "app-fresh",
+        name: "Fresh App",
+        api_key: {
+          key: "msr_fresh_key",
+          revoked: false,
+          created_at: "",
+          last_seen: null,
+        },
+      });
+      let exists = false;
+      server.use(
+        http.get("*/api/teams/:teamId/apps", () =>
+          exists
+            ? HttpResponse.json([created])
+            : new HttpResponse(null, { status: 404 }),
+        ),
+        http.post("*/api/teams/:teamId/apps", () => {
+          exists = true;
+          return HttpResponse.json(created);
+        }),
+      );
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("onboarding-step-create")).toBeTruthy(),
+      );
+      fireEvent.change(screen.getByTestId("onboarding-app-name-input"), {
+        target: { value: "Fresh App" },
+      });
+      await act(async () => {
+        fireEvent.submit(
+          screen.getByTestId("onboarding-app-name-input").closest("form")!,
+        );
+      });
+
+      const integrate = await screen.findByTestId("onboarding-step-integrate");
+      expect(within(integrate).getByTestId("step-2-indicator")).toBeTruthy();
+      expect(screen.getByTestId("snippet-manifest").textContent).toContain(
+        "msr_fresh_key",
+      );
+      expect(filtersStore.getState().selectedApp?.id).toBe("app-fresh");
+    });
+  });
+
+  describe("an app that has not reported an event", () => {
+    it("puts the wizard under the app selector, and asks for no metrics", async () => {
+      server.use(
+        appsListHandler([
+          freshApp({
+            id: "app-not-onboarded",
+            name: "My App",
+            api_key: {
+              key: "msr_integration_key",
+              revoked: false,
+              created_at: "",
+              last_seen: null,
+            },
+          }),
+        ]),
+      );
+      const metrics = recordMetrics();
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("onboarding-step-integrate")).toBeTruthy(),
+      );
+      expect(screen.getByRole("button", { name: /My App/ })).toBeTruthy();
+      // The snippet carries the real key only once the page has put the app
+      // on the filters store, which is where the wizard reads it from.
+      expect(screen.getByTestId("snippet-manifest").textContent).toContain(
+        "msr_integration_key",
+      );
+      expect(metrics).toHaveLength(0);
+    });
+  });
+
+  describe("an app that has reported one", () => {
+    it("gets the filters and the page, with no wizard", async () => {
+      const metrics = recordMetrics();
+      renderPage();
+
+      await waitFor(() => expect(screen.getByText("99.1%")).toBeTruthy(), {
+        timeout: 5000,
+      });
+      expect(screen.getByTestId("filter-bar")).toBeTruthy();
+      expect(screen.queryByTestId("onboarding")).toBeNull();
+      expect(metrics).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/alerts_overview_test.tsx
@@ -129,8 +129,8 @@ jest.mock("@/app/utils/time_utils", () => ({
 import AlertsOverview from "@/app/[teamId]/alerts/page";
 
 const mockApps = [
-  { id: "app-1", name: "Sample" },
-  { id: "app-2", name: "Second" },
+  { id: "app-1", name: "Sample", onboarded: true },
+  { id: "app-2", name: "Second", onboarded: true },
 ];
 
 const mockAlertResult = {

--- a/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/bug_reports_overview_test.tsx
@@ -139,7 +139,7 @@ jest.mock("@/app/utils/time_utils", () => ({
 
 import BugReportsOverview from "@/app/[teamId]/bug_reports/page";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const statusKey = {
   name: "bug_report_status",

--- a/frontend/dashboard/__tests__/pages/builds_test.tsx
+++ b/frontend/dashboard/__tests__/pages/builds_test.tsx
@@ -59,6 +59,7 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => ({
       <span data-testid="filter-bar-app">
         {props.value?.app.name ?? "none"}
       </span>
+      <span data-testid="filter-bar-status">{props.status.kind}</span>
       <span data-testid="filter-bar-expr">
         {props.value?.filterExpr ?? "none"}
       </span>
@@ -473,6 +474,17 @@ describe("Builds page", () => {
       renderPage();
 
       expect(mockRouter.urlParams()).toEqual({ ...settled, po: "10" });
+    });
+  });
+
+  describe("a team with no apps", () => {
+    it("is told so in words, since builds are listed without the wizard", () => {
+      mockUseAppsQuery.mockReturnValue({ status: "success", data: [] });
+      renderPage();
+
+      expect(screen.getByTestId("filter-bar-status")).toHaveTextContent(
+        "no-apps",
+      );
     });
   });
 

--- a/frontend/dashboard/__tests__/pages/error_details_test.tsx
+++ b/frontend/dashboard/__tests__/pages/error_details_test.tsx
@@ -174,7 +174,7 @@ jest.mock("@/app/utils/time_utils", () => ({
 
 import ErrorDetailsPage from "@/app/[teamId]/errors/[appId]/[errorGroupId]/[errorGroupName]/page";
 
-const mockApp = { id: "app-1", name: "measure demo" };
+const mockApp = { id: "app-1", name: "measure demo", onboarded: true };
 
 const osNameKey = {
   name: "os_name",

--- a/frontend/dashboard/__tests__/pages/errors_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/errors_overview_test.tsx
@@ -138,7 +138,7 @@ jest.mock("@/app/components/loading_bar", () => () => (
 
 import ErrorsOverviewPage from "@/app/[teamId]/errors/page";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const errorTypeKey = {
   name: "error_type",

--- a/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/journeys_overview_test.tsx
@@ -145,8 +145,8 @@ jest.mock("@/app/components/debounce_text_input", () => ({
 import UserJourneysPage from "@/app/[teamId]/journeys/page";
 import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 
-const mockApp = { id: "app-1", name: "Sample" };
-const mockOtherApp = { id: "app-2", name: "Other" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
+const mockOtherApp = { id: "app-2", name: "Other", onboarded: true };
 
 const versionKey = {
   name: "version_name",

--- a/frontend/dashboard/__tests__/pages/network_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/network_overview_test.tsx
@@ -129,7 +129,7 @@ import NetworkOverview, {
 } from "@/app/components/network_overview";
 import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const httpMethodKey = {
   name: "http_method",

--- a/frontend/dashboard/__tests__/pages/overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/overview_test.tsx
@@ -61,6 +61,9 @@ jest.mock("@/app/components/filter_bar/filter_bar", () => ({
   default: (props: any) => (
     <div data-testid="filter-bar-mock">
       <span data-testid="filter-bar-entity">{props.entity}</span>
+      <span data-testid="filter-bar-status" data-reason={props.status.reason}>
+        {props.status.kind}
+      </span>
       <span data-testid="filter-bar-expr">
         {props.value?.filterExpr ?? "none"}
       </span>
@@ -116,7 +119,7 @@ jest.mock("@/app/components/metrics_overview", () => ({
 import { ApiError, invalidFilterExpr } from "@/app/api/api_error";
 import Overview, { OverviewDemo } from "@/app/components/overview";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const versionNameKey = {
   name: "version_name",
@@ -302,6 +305,19 @@ describe("Overview page", () => {
     expect(screen.getByTestId("filter-bar-issues")).toHaveTextContent(
       'Unknown key "os_name"',
     );
+  });
+
+  describe("a team with no apps", () => {
+    it("hands the bar the wizard to draw, and fetches nothing", () => {
+      mockUseAppsQuery.mockReturnValue({ status: "success", data: [] });
+      renderPage();
+
+      const status = screen.getByTestId("filter-bar-status");
+      expect(status).toHaveTextContent("onboarding");
+      expect(status).toHaveAttribute("data-reason", "no-apps");
+      expect(screen.queryByTestId("app-health-plot-mock")).toBeNull();
+      expect(mockUseMetricsQuery).toHaveBeenLastCalledWith(null);
+    });
   });
 
   describe("a filter it could not settle", () => {

--- a/frontend/dashboard/__tests__/pages/session_replay_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/session_replay_overview_test.tsx
@@ -141,7 +141,7 @@ jest.mock("@/app/utils/time_utils", () => ({
 
 import SessionReplayOverview from "@/app/[teamId]/session_replays/page";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const eventsKey = {
   name: "session_events",

--- a/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
+++ b/frontend/dashboard/__tests__/pages/traces_overview_test.tsx
@@ -144,7 +144,7 @@ jest.mock("@/app/utils/time_utils", () => ({
 
 import TracesOverview from "@/app/[teamId]/traces/page";
 
-const mockApp = { id: "app-1", name: "Sample" };
+const mockApp = { id: "app-1", name: "Sample", onboarded: true };
 
 const spanStatusKey = {
   name: "span_status",

--- a/frontend/dashboard/app/[teamId]/alerts/page.tsx
+++ b/frontend/dashboard/app/[teamId]/alerts/page.tsx
@@ -62,12 +62,14 @@ export default function AlertsOverview(props: {
 
       <FilterBar
         entity="alerts"
+        teamId={params.teamId}
         value={value}
         apps={apps}
         keys={keys}
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         showFilterExpr={false}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
+++ b/frontend/dashboard/app/[teamId]/bug_reports/page.tsx
@@ -78,6 +78,7 @@ export default function BugReportsOverview(props: {
 
       <FilterBar
         entity="bug_reports"
+        teamId={params.teamId}
         placeholder="Filter bug reports…"
         value={value}
         apps={apps}
@@ -85,6 +86,7 @@ export default function BugReportsOverview(props: {
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/builds/builds_results.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/builds_results.tsx
@@ -43,9 +43,8 @@ export default function BuildsResults({
         <p className="text-lg font-display">{status.message}</p>
       )}
 
-      {status.kind !== "error" && query.status === "pending" && (
-        <SkeletonListPage />
-      )}
+      {(status.kind === "loading" || status.kind === "ready") &&
+        query.status === "pending" && <SkeletonListPage />}
 
       {query.status === "error" && !filterExprHasIssues && (
         <p className="text-lg font-display">

--- a/frontend/dashboard/app/[teamId]/builds/page.tsx
+++ b/frontend/dashboard/app/[teamId]/builds/page.tsx
@@ -28,6 +28,7 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
     teamId: params.teamId,
     entity: "builds",
     paginationLimit: PAGINATION_LIMIT,
+    onboarding: false,
   });
 
   const buildsQuery = useBuildsQuery(filterParams, paginationOffset);
@@ -40,6 +41,7 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
 
       <FilterBar
         entity="builds"
+        teamId={params.teamId}
         placeholder="Filter builds…"
         value={value}
         apps={apps}
@@ -47,6 +49,7 @@ export default function Builds(props: { params: Promise<{ teamId: string }> }) {
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={status}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/session_replays/page.tsx
+++ b/frontend/dashboard/app/[teamId]/session_replays/page.tsx
@@ -78,6 +78,7 @@ export default function SessionReplayOverview(props: {
 
       <FilterBar
         entity="sessions"
+        teamId={params.teamId}
         placeholder="Filter sessions…"
         value={value}
         apps={apps}
@@ -85,6 +86,7 @@ export default function SessionReplayOverview(props: {
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/[teamId]/traces/page.tsx
+++ b/frontend/dashboard/app/[teamId]/traces/page.tsx
@@ -79,6 +79,7 @@ export default function TracesOverview(props: {
 
       <FilterBar
         entity="spans"
+        teamId={params.teamId}
         placeholder="Filter traces…"
         value={value}
         apps={apps}
@@ -87,6 +88,7 @@ export default function TracesOverview(props: {
         keysUnavailable={keysUnavailable}
         spanNames={spanNames}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/components/errors_details.tsx
+++ b/frontend/dashboard/app/components/errors_details.tsx
@@ -583,6 +583,7 @@ export const ErrorsDetails: React.FC<ErrorsDetailsProps> = ({
 
       <FilterBar
         entity="error_group_events"
+        teamId={teamId}
         placeholder="Filter events…"
         value={value}
         apps={apps}
@@ -591,6 +592,7 @@ export const ErrorsDetails: React.FC<ErrorsDetailsProps> = ({
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
         showAppSelect={false}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/components/errors_overview.tsx
+++ b/frontend/dashboard/app/components/errors_overview.tsx
@@ -92,6 +92,7 @@ export const ErrorsOverview: React.FC<ErrorsOverviewProps> = ({ teamId }) => {
 
       <FilterBar
         entity="errors"
+        teamId={teamId}
         placeholder="Filter errors…"
         value={value}
         apps={apps}
@@ -99,6 +100,7 @@ export const ErrorsOverview: React.FC<ErrorsOverviewProps> = ({ teamId }) => {
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />

--- a/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
+++ b/frontend/dashboard/app/components/filter_bar/filter_bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Plus, SlidersHorizontal, Type, X } from "lucide-react";
+import Link from "next/link";
 import {
   Fragment,
   type RefObject,
@@ -13,10 +14,13 @@ import { type App } from "../../api/api_calls";
 import type { FilterExprIssue } from "../../api/api_error";
 import { type FilterKey, type FilterOperator } from "../../api/filter_types";
 import { useFilterKeysQuery } from "../../query/hooks";
+import { underlineLinkStyle } from "../../utils/shared_styles";
 import { toastNegative } from "../toast";
+import Onboarding from "../onboarding";
 import { Skeleton } from "../skeleton";
 import DropdownSelect, { DropdownSelectType } from "../dropdown_select";
 import AppSelect from "./app_select";
+import type { FilterStatus } from "./resolve_filters";
 import DateRangeSelect, {
   DateRange,
   type DateSelection,
@@ -69,7 +73,9 @@ export type FilterChange = Partial<{
 
 interface FilterBarProps {
   entity: string;
+  teamId: string;
   placeholder?: string;
+  status: FilterStatus;
   value: FilterSelection | null;
   apps: App[];
   keys: FilterKey[] | null;
@@ -177,7 +183,9 @@ function appendTo(
 
 export default function FilterBar({
   entity,
+  teamId,
   placeholder = "Filter…",
+  status,
   value,
   apps,
   keys,
@@ -308,6 +316,42 @@ export default function FilterBar({
     }
     focusedControlRef.current?.focus();
   }, [focusedId]);
+
+  if (status.kind === "no-apps") {
+    return (
+      <p className="font-body">
+        Looks like you don&apos;t have any apps yet. Get started by{" "}
+        <Link className={underlineLinkStyle} href="apps">
+          creating your first app!
+        </Link>
+      </p>
+    );
+  }
+
+  // A team with no apps, or an app that has not reported an event yet, gets
+  // the integration wizard in place of the filters. The app selector stays so
+  // the user can change apps.
+  if (status.kind === "onboarding") {
+    return (
+      <div className="flex flex-col w-full">
+        {status.reason === "not-onboarded" &&
+          showAppSelect &&
+          value !== null && (
+            <>
+              <div className="flex flex-wrap gap-4 items-center w-full">
+                <AppSelect
+                  apps={apps}
+                  selected={value.app}
+                  onChange={(picked) => onChange({ appId: picked.id })}
+                />
+              </div>
+              <div className="py-4" />
+            </>
+          )}
+        <Onboarding teamId={teamId} />
+      </div>
+    );
+  }
 
   if (value === null || keys === null) {
     return (

--- a/frontend/dashboard/app/components/filter_bar/resolve_filters.ts
+++ b/frontend/dashboard/app/components/filter_bar/resolve_filters.ts
@@ -42,6 +42,8 @@ export type RememberedFilters = {
 export type FilterStatus =
   | { kind: "loading" }
   | { kind: "error"; message: string }
+  | { kind: "no-apps" }
+  | { kind: "onboarding"; reason: "no-apps" | "not-onboarded" }
   | { kind: "ready" };
 
 export type ResolvedFilters = {
@@ -59,8 +61,6 @@ export type FilterResolution = {
 
 const appsErrorMessage =
   "Error fetching apps, please refresh page to try again";
-const noAppsMessage =
-  "Looks like you don't have any apps yet. Get started by creating your first app!";
 const keysErrorMessage =
   "Error fetching filters, please refresh page to try again";
 const spanNamesErrorMessage =
@@ -108,12 +108,16 @@ export function resolveFilters({
   keys,
   spanNames,
   remembered,
+  onboarding,
 }: {
   url: UrlFilters;
   apps: AppsQueryState;
   keys: KeysQueryState;
   spanNames: SpanNamesQueryState | null;
   remembered: RememberedFilters;
+  // Whether the page offers the integration wizard to a team with no apps and
+  // to an app that has not reported an event yet.
+  onboarding: boolean;
 }): FilterResolution {
   const app = resolveApp(url.appId, apps.data, remembered.appId);
   const date = pickDateRange(url.dateRange, remembered.dateRange);
@@ -164,10 +168,24 @@ export function resolveFilters({
     return resolution({ kind: "error", message: appsErrorMessage }, null);
   }
   if (apps.status === "success" && (apps.data ?? []).length === 0) {
-    return resolution({ kind: "error", message: noAppsMessage }, null);
+    return onboarding
+      ? resolution({ kind: "onboarding", reason: "no-apps" }, null)
+      : resolution({ kind: "no-apps" }, null);
   }
   if (app === null) {
     return resolution({ kind: "loading" }, null);
+  }
+  // The filters still carry the app so the bar can offer the app selector
+  // above the wizard.
+  if (onboarding && !app.onboarded) {
+    return resolution(
+      { kind: "onboarding", reason: "not-onboarded" },
+      {
+        app,
+        filterExpr: null,
+        rootSpanName: null,
+      },
+    );
   }
   if (keys.isError) {
     return resolution(

--- a/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
+++ b/frontend/dashboard/app/components/filter_bar/use_expr_filter_page.ts
@@ -114,6 +114,7 @@ export function useExprFilterPage({
   paginationLimit,
   rootSpan = false,
   appId: fixedAppId,
+  onboarding = true,
 }: {
   teamId: string;
   entity: string;
@@ -121,6 +122,9 @@ export function useExprFilterPage({
   rootSpan?: boolean;
   // Fixes the app. The URL app id is overwritten with it.
   appId?: string;
+  // Whether the page offers the integration wizard to a team with no apps and
+  // to an app that has not reported an event yet.
+  onboarding?: boolean;
 }) {
   const searchParams = useSearchParams();
   const search = searchParams.toString();
@@ -160,7 +164,12 @@ export function useExprFilterPage({
         : [],
     [url.filterExpr],
   );
-  const keysQuery = useFilterKeysQuery(app?.id, entity, urlCustomKeyNames);
+  // An app that has not reported yet gets the wizard, so its keys are not read.
+  const keysQuery = useFilterKeysQuery(
+    onboarding && app !== null && !app.onboarded ? undefined : app?.id,
+    entity,
+    urlCustomKeyNames,
+  );
   const spanNamesQuery = useRootSpanNamesQuery(rootSpan ? app : null);
 
   const {
@@ -181,6 +190,7 @@ export function useExprFilterPage({
         endDate: rememberedEndDate,
       },
     },
+    onboarding,
   });
 
   const customDate = dateRange.dateRange === DateRange.Custom;

--- a/frontend/dashboard/app/components/network_details.tsx
+++ b/frontend/dashboard/app/components/network_details.tsx
@@ -83,6 +83,7 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
       <div className="py-4" />
       <FilterBar
         entity="network"
+        teamId={params.teamId}
         placeholder="Filter network requests…"
         value={value}
         apps={apps}
@@ -91,6 +92,7 @@ export default function NetworkDetails({ params }: NetworkDetailsProps) {
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
         showAppSelect={false}
+        status={filterStatus}
         onChange={onChange}
       />
 

--- a/frontend/dashboard/app/components/network_overview.tsx
+++ b/frontend/dashboard/app/components/network_overview.tsx
@@ -246,6 +246,7 @@ export default function NetworkOverview({
 
       <FilterBar
         entity="network"
+        teamId={teamId}
         placeholder="Filter network requests…"
         value={value}
         apps={apps}
@@ -253,6 +254,7 @@ export default function NetworkOverview({
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
 

--- a/frontend/dashboard/app/components/onboarding.tsx
+++ b/frontend/dashboard/app/components/onboarding.tsx
@@ -956,7 +956,7 @@ export default function Onboarding({ teamId }: OnboardingProps) {
               >
                 <p className="font-display text-xl">Crash received.</p>
                 <p className="font-body text-sm text-muted-foreground">
-                  Your first crash made it to Measure.
+                  First crash received!
                 </p>
                 <div>
                   <Button

--- a/frontend/dashboard/app/components/overview.tsx
+++ b/frontend/dashboard/app/components/overview.tsx
@@ -68,6 +68,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
 
       <FilterBar
         entity="app_health"
+        teamId={teamId}
         placeholder="Filter by app version…"
         value={value}
         apps={apps}
@@ -75,6 +76,7 @@ export default function Overview({ params }: { params: { teamId: string } }) {
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
 

--- a/frontend/dashboard/app/components/user_journeys.tsx
+++ b/frontend/dashboard/app/components/user_journeys.tsx
@@ -82,6 +82,7 @@ export default function UserJourneys({
 
       <FilterBar
         entity="journeys"
+        teamId={teamId}
         placeholder="Filter journeys…"
         value={value}
         apps={apps}
@@ -89,6 +90,7 @@ export default function UserJourneys({
         keyGroups={keyGroups}
         keysUnavailable={keysUnavailable}
         filterExprIssues={filterExprIssues}
+        status={filterStatus}
         onChange={onChange}
       />
       <div className="py-4" />


### PR DESCRIPTION
# Description

- Resolve a team with no apps and an app without events into an onboarding status instead of the ready state
- Draw the integration wizard from the filter bar in place of the filters, keeping the app selector for an app without events
- Offer the wizard on every data page, with the builds page keeping its plain no-apps text and link
- Skip the filter keys request for an app that has not reported data yet
- Restore the onboarding integration test on the filter bar flow



